### PR TITLE
Added small tweaks to enable SSSD to be compiled with the musl libc

### DIFF
--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -27,6 +27,9 @@
 #include <tevent.h>
 #include <ldb.h>
 #include <ldb_errors.h>
+#ifndef gid_t
+#include <unistd.h>
+#endif
 
 #include "config.h"
 

--- a/src/monitor/monitor_netlink.c
+++ b/src/monitor/monitor_netlink.c
@@ -26,6 +26,9 @@
 #include <sys/types.h>
 #include <sys/ioctl.h>
 #define __USE_GNU /* needed for struct ucred */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE /* needed by musl to enable struct ucred */
+#endif
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>

--- a/src/monitor/monitor_netlink.c
+++ b/src/monitor/monitor_netlink.c
@@ -25,10 +25,6 @@
 #include <tevent.h>
 #include <sys/types.h>
 #include <sys/ioctl.h>
-#define __USE_GNU /* needed for struct ucred */
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE /* needed by musl to enable struct ucred */
-#endif
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -37,7 +33,7 @@
 
 #include "monitor/monitor.h"
 #include "util/util.h"
-
+#include "config.h"
 #ifdef HAVE_LIBNL
 #include <linux/if.h>
 #include <linux/socket.h>

--- a/src/resolv/async_resolv.h
+++ b/src/resolv/async_resolv.h
@@ -28,6 +28,9 @@
 
 #include <netdb.h>
 #include <ares.h>
+#ifndef MIN
+#include <sys/param.h>
+#endif
 
 #include "config.h"
 #include "confdb/confdb.h"

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -53,6 +53,10 @@
 #include "util/sss_format.h"
 #include "util/debug.h"
 
+#ifndef ALLPERMS
+#define ALLPERMS (S_ISUID|S_ISGID|S_ISVTX|S_IRWXU|S_IRWXG|S_IRWXO)
+#endif
+
 #define _(STRING) gettext (STRING)
 
 #define ENUM_INDICATOR "*"


### PR DESCRIPTION
By checking for if a feature that wants to be used exists, and if it doesn't, add the header that adds the macro or type definition.

I've tested to compile and run this on an amd64 system and it compiles fine. I haven't been able to find anything that breaks from these changes and as they are surrounded by ifndefs, it shouldn't impact when being used with a libc that defines for example ALLPERMS or MIN, as the includes won't be added then.
