### PR TITLE
Miscellanous patches for the sssd-secrets responder

### DIFF
--- a/src/responder/secrets/providers.c
+++ b/src/responder/secrets/providers.c
@@ -24,7 +24,8 @@
 #include "responder/secrets/secsrv_proxy.h"
 #include <jansson.h>
 
-int sec_map_url_to_user_path(struct sec_req_ctx *secreq, char **mapped_path)
+static int sec_map_url_to_user_path(struct sec_req_ctx *secreq,
+                                    char **mapped_path)
 {
     uid_t c_euid;
 

--- a/src/responder/secrets/secsrv.c
+++ b/src/responder/secrets/secsrv.c
@@ -35,7 +35,7 @@ static int sec_get_config(struct sec_ctx *sctx)
     int ret;
 
     ret = confdb_get_int(sctx->rctx->cdb,
-                         CONFDB_SEC_CONF_ENTRY,
+                         sctx->rctx->confdb_service_path,
                          CONFDB_SERVICE_FD_LIMIT,
                          DEFAULT_SEC_FD_LIMIT,
                          &sctx->fd_limit);


### PR DESCRIPTION
The first patch just makes an internal function static. The other just
makes the use of a config section more uniform. We could go one way or
the other, I don't really mind which, but we shouldn't use two ways to
access the same data.