### PR TITLE
Fix initgroups with nested groups

### DIFF
--- a/src/providers/ldap/sdap_async_initgroups.c
+++ b/src/providers/ldap/sdap_async_initgroups.c
@@ -1414,7 +1414,7 @@ sdap_initgr_nested_get_membership_diff(TALLOC_CTX *mem_ctx,
                group_name, parents_count);
 
     if (parents_count > 0) {
-        ret = sysdb_attrs_primary_name_list(dom, tmp_ctx,
+        ret = sysdb_attrs_primary_fqdn_list(dom, tmp_ctx,
                                             ldap_parentlist,
                                             parents_count,
                                             opts->group_map[SDAP_AT_GROUP_NAME].name,


### PR DESCRIPTION
I think this is a leftover from the change to use fully-qualified names in
sysdb. To verify this you can create a nested group in IPA. Without this patch
the id command will only show the groups the user is a direct member of. With
the patch the indirect groups memberships should be shown as well.