### PR TITLE
MAN: Document the ldap_user_gid_number option

### DIFF
--- a/src/man/sssd-ldap.5.xml
+++ b/src/man/sssd-ldap.5.xml
@@ -299,6 +299,21 @@
                 </varlistentry>
 
                 <varlistentry>
+                    <term>ldap_user_primary_group (string)</term>
+                    <listitem>
+                        <para>
+                            Active Directory primary group attribute
+                            for ID-mapping. Note that this attribute should
+                            only be set manually if you are running the
+                            <quote>ldap</quote> provider with ID mapping.
+                        </para>
+                        <para>
+                            Default: unset (LDAP), primaryGroupID (AD)
+                        </para>
+                    </listitem>
+                </varlistentry>
+
+                <varlistentry>
                     <term>ldap_user_gecos (string)</term>
                     <listitem>
                         <para>


### PR DESCRIPTION
Some users, mostly those who cannot join the Linux machines to their AD domain resort to using the LDAP provider with ID mapping.

But in order for that to work correctly, the ldap_user_gid_number option must be set correctly, otherwise SSSD complains about not finding the primary GID:
(Fri Aug 26 13:34:10 2016) [sssd[be[dev]]] [sdap_save_user] (0x0020): Cannot get the GID for [someuser] in domain [extdev].