### PR TITLE
SECRETS: Don't remove a container when it has children

### DIFF
--- a/src/responder/secrets/local.c
+++ b/src/responder/secrets/local.c
@@ -168,6 +168,7 @@ char *local_dn_to_path(TALLOC_CTX *mem_ctx,
 }
 
 #define LOCAL_SIMPLE_FILTER "(type=simple)"
+#define LOCAL_CONTAINER_FILTER "(type=container)"
 
 int local_db_get_simple(TALLOC_CTX *mem_ctx,
                         struct local_context *lctx,
@@ -306,7 +307,7 @@ int local_db_check_containers(TALLOC_CTX *mem_ctx,
 
         /* and check the parent container exists */
         ret = ldb_search(lctx->ldb, mem_ctx, &res, dn, LDB_SCOPE_BASE,
-                         attrs, LOCAL_SIMPLE_FILTER);
+                         attrs, LOCAL_CONTAINER_FILTER);
         if (ret != LDB_SUCCESS) return ENOENT;
         if (res->count != 1) return ENOENT;
         talloc_free(res);


### PR DESCRIPTION
Let's return and log an error in case the container to be removed has
children.

The approach taken introduced at least one new search in every delete
operation. As far as I understand searching in the BASE scope is quite
cheap and that's the reason I decided to just do the search in the
ONELEVEL scope when the deleted dn is for sure a container.

While the first patch is not needed for solving this issue, it's needed for adding something to a container.

The easiest way to test would be:
- Create a container: curl -H "Content-Type: application/json" --unix-socket /var/run/secrets.socket -XPOST http://localhost/secrets/bar/
- Create a container inside the firstly created container: curl -H "Content-Type: application/json" --unix-socket /var/run/secrets.socket -XPOST http://localhost/secrets/bar/foo/
- Add a secret to the container: curl -H "Content-Type: application/json" --unix-socket /var/run/secrets.socket -XPUT http://localhost/secrets/bar/foo/test -d'{"type":"simple","value":"foosecret"}'
- Try to remove the container bar: curl -H "Content-Type: application/json" --unix-socket /var/run/secrets.socket -XDELETE http://localhost/secrets/bar/

With the patch you won't be able to remove unless it has no children. Without, you will be able to remove the container.