### PR TITLE
failover: proceed normally when no new server is found

### DIFF
--- a/src/providers/fail_over.c
+++ b/src/providers/fail_over.c
@@ -1274,6 +1274,8 @@ resolve_srv_send(TALLOC_CTX *mem_ctx, struct tevent_context *ev,
     state->fo_ctx = ctx;
     state->meta = server->srv_data->meta;
 
+    DEBUG(SSSDBG_IMPORTANT_INFO, "RESOLV SRV SEND\n");
+
     status = get_srv_data_status(server->srv_data);
     DEBUG(SSSDBG_FUNC_DATA, "The status of SRV lookup is %s\n",
           str_srv_data_status(status));
@@ -1355,6 +1357,8 @@ resolve_srv_done(struct tevent_req *subreq)
     char *dns_domain = NULL;
     int ret;
     uint32_t ttl;
+
+    DEBUG(SSSDBG_IMPORTANT_INFO, "RESOLV SRV DONE\n");
 
     ret = state->fo_ctx->srv_recv_fn(state, subreq, &dns_domain, &ttl,
                                      &primary_servers, &num_primary_servers,

--- a/src/providers/ldap/sdap_async_connection.c
+++ b/src/providers/ldap/sdap_async_connection.c
@@ -1509,6 +1509,9 @@ static int sdap_cli_resolve_next(struct tevent_req *req)
     subreq = be_resolve_server_send(state, state->ev,
                                     state->be, state->service->name,
                                     state->srv == NULL ? true : false);
+    subreq = be_resolve_server_send(state, state->ev,
+                                    state->be, state->service->name,
+                                    state->srv == NULL ? true : false);
     if (!subreq) {
         return ENOMEM;
     }


### PR DESCRIPTION
https://fedorahosted.org/sssd/ticket/3131

I couldn't reproduce manually so I used the second patch as a by-code reproducer. If you apply the patch then sssd will try to resolve meta server twice simultaneously and triggering the problematic code path. You can search for RESOLV SRV DONE in logs.