### PR TITLE
MEMBEROF: Don't resolve members if they are removed

### DIFF
--- a/src/providers/ldap/sdap_async_groups.c
+++ b/src/providers/ldap/sdap_async_groups.c
@@ -878,6 +878,8 @@ static int sdap_save_grpmem(TALLOC_CTX *memctx,
     size_t nuserdns = 0;
     struct sss_domain_info *group_dom = NULL;
     int ret;
+    const char *remove_attrs[] = {SYSDB_MEMBER, SYSDB_ORIG_MEMBER, SYSDB_GHOST,
+                                  NULL};
 
     if (dom->ignore_group_members) {
         DEBUG(SSSDBG_CRIT_FAILURE,
@@ -962,6 +964,13 @@ static int sdap_save_grpmem(TALLOC_CTX *memctx,
     if (el->num_values == 0 && nuserdns == 0) {
         DEBUG(SSSDBG_TRACE_FUNC,
               "No members for group [%s]\n", group_name);
+
+        ret = sysdb_remove_attrs(group_dom, group_name, SYSDB_MEMBER_GROUP,
+                                 discard_const(remove_attrs));
+        if (ret != EOK) {
+            DEBUG(SSSDBG_OP_FAILURE, "sysdb_remove_attrs failed.\n");
+            goto fail;
+        }
     } else {
         DEBUG(SSSDBG_TRACE_FUNC,
               "Adding member users to group [%s]\n", group_name);


### PR DESCRIPTION
## TOPIC
If we need remove ghost (SYSDB_GHOST, DB_GHOST) attribute
from group we use empty structure.

This doesn't mean that there is pointer to NULL but
it means that there is zero elements.
Ghost attribute is array not string.

Resolves:
https://fedorahosted.org/sssd/ticket/2940

## REPRODUCER

preparing:
```
ipa user-add --first=Adam --last=Adam --email=adam@persei.cz adam
ipa group-add group_1
ipa group-add-member --users=adam group_1
ipa group-add group_2
```
reproducer (possible repeat):
```
systemctl daemon-reload
sudo su -c "truncate -s0 /var/log/sssd/*.log"
sudo su -c "rm -f /var/lib/sss/db/*" 
sudo su -c "rm -f /var/lib/sss/mc/*"
sudo systemctl restart sssd.service

ipa group-add-member --groups=group_1 group_2
sss_cache -UG
sudo su -c "truncate -s0 /var/log/sssd/*.log"
getent group group_2

ipa group-remove-member --groups=group_1 group_2
sss_cache -UG
sudo su -c "truncate -s0 /var/log/sssd/*.log"
getent group group_2
```
