### PR TITLE
Attempting to create a qualified name from a NULL pointer broke sss_groupadd

### DIFF
--- a/src/tools/sss_sync_ops.c
+++ b/src/tools/sss_sync_ops.c
@@ -657,7 +657,7 @@ int groupadd(struct ops_ctx *data)
     int ret;
 
     data->sysdb_fqname = sss_create_internal_fqname(data,
-                                                    data->sysdb_fqname,
+                                                    data->name,
                                                     data->domain->name);
     if (data->sysdb_fqname == NULL) {
         return ENOMEM;


### PR DESCRIPTION
The log said:
(Tue Sep  6 15:18:31:935105 2016) [sss_groupadd] [sysdb_timestamp_cache_connect] (0x0400): No timestamp cache for LOCAL
(Tue Sep  6 15:18:31:935255 2016) [sss_groupadd] [sss_names_init_from_args] (0x0100): Using re [(?P<name>[^@]+)@?(?P<domain>[^@]*$)].
(Tue Sep  6 15:18:31:935277 2016) [sss_groupadd] [sss_fqnames_init] (0x0100): Using fq format [%1$s@%2$s].
(Tue Sep  6 15:18:31:935392 2016) [sss_groupadd] [parse_name_domain] (0x0200): Parsed username: group10000
(Tue Sep  6 15:18:31:935418 2016) [sss_groupadd] [ldb] (0x4000): start ldb transaction (nesting: 0)
(Tue Sep  6 15:18:31:935504 2016) [sss_groupadd] [ldb] (0x4000): cancel ldb transaction (nesting: 0)
(Tue Sep  6 15:18:31:935629 2016) [sss_groupadd] [main] (0x0020): sysdb operation failed (12)[Cannot allocate memory]