### PR TITLE
TOOLS: sss_groupshow did not work

### DIFF
--- a/src/tools/sss_groupshow.c
+++ b/src/tools/sss_groupshow.c
@@ -318,7 +318,7 @@ int group_show(TALLOC_CTX *mem_ctx,
                struct sysdb_ctx *sysdb,
                struct sss_domain_info *domain,
                bool   recursive,
-               const char *name,
+               const char *shortname,
                struct group_info **res)
 {
     struct group_info *root;
@@ -326,11 +326,20 @@ int group_show(TALLOC_CTX *mem_ctx,
     struct ldb_message *msg = NULL;
     const char **group_members = NULL;
     int nmembers = 0;
+    char *sysdb_fqname = NULL;
     int ret;
     int i;
 
+    sysdb_fqname = sss_create_internal_fqname(mem_ctx,
+                                              shortname,
+                                              domain->name);
+    if (sysdb_fqname == NULL) {
+        return ENOMEM;
+    }
+
     /* First, search for the root group */
-    ret = sysdb_search_group_by_name(mem_ctx, domain, name, attrs, &msg);
+    ret = sysdb_search_group_by_name(mem_ctx, domain, sysdb_fqname, attrs,
+                                     &msg);
     if (ret) {
         DEBUG(SSSDBG_OP_FAILURE,
               "Search failed: %s (%d)\n", strerror(ret), ret);

--- a/src/tools/sss_sync_ops.c
+++ b/src/tools/sss_sync_ops.c
@@ -657,7 +657,7 @@ int groupadd(struct ops_ctx *data)
     int ret;
 
     data->sysdb_fqname = sss_create_internal_fqname(data,
-                                                    data->sysdb_fqname,
+                                                    data->name,
                                                     data->domain->name);
     if (data->sysdb_fqname == NULL) {
         return ENOMEM;


### PR DESCRIPTION
sss_groupshow used shortname to search
in sysdb database. We have to u e sysdb_fqname
(aka internal_fqname) format for all sysdb
oprations.

Resolves:
https://fedorahosted.org/sssd/ticket/3175