### PR TITLE
KRB5: Send the output username, not internal fqname to krb5_child

### DIFF
--- a/src/providers/krb5/krb5_access.c
+++ b/src/providers/krb5/krb5_access.c
@@ -51,6 +51,7 @@ struct tevent_req *krb5_access_send(TALLOC_CTX *mem_ctx,
     int ret;
     const char **attrs;
     struct ldb_result *res;
+    struct sss_domain_info *dom;
 
     req = tevent_req_create(mem_ctx, &state, struct krb5_access_state);
     if (req == NULL) {
@@ -64,8 +65,13 @@ struct tevent_req *krb5_access_send(TALLOC_CTX *mem_ctx,
     state->krb5_ctx = krb5_ctx;
     state->access_allowed = false;
 
-    ret = krb5_setup(state, pd, krb5_ctx, be_ctx->domain->case_sensitive,
-                     &state->kr);
+    ret = get_domain_or_subdomain(be_ctx, pd->domain, &dom);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "get_domain_or_subdomain failed.\n");
+        goto done;
+    }
+
+    ret = krb5_setup(state, pd, dom, krb5_ctx, &state->kr);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "krb5_setup failed.\n");
         goto done;

--- a/src/providers/krb5/krb5_auth.h
+++ b/src/providers/krb5/krb5_auth.h
@@ -57,11 +57,14 @@ struct krb5child_req {
     bool send_pac;
 
     const char *user;
+    const char *kuserok_user;
 };
 
-errno_t krb5_setup(TALLOC_CTX *mem_ctx, struct pam_data *pd,
-                   struct krb5_ctx *krb5_ctx, bool case_sensitive,
-                   struct krb5child_req **krb5_req);
+errno_t krb5_setup(TALLOC_CTX *mem_ctx,
+                   struct pam_data *pd,
+                   struct sss_domain_info *dom,
+                   struct krb5_ctx *krb5_ctx,
+                   struct krb5child_req **_krb5_req);
 
 struct tevent_req *
 krb5_pam_handler_send(TALLOC_CTX *mem_ctx,

--- a/src/providers/krb5/krb5_child_handler.c
+++ b/src/providers/krb5/krb5_child_handler.c
@@ -161,7 +161,7 @@ static errno_t create_send_buffer(struct krb5child_req *kr,
     }
 
     if (kr->pd->cmd == SSS_PAM_ACCT_MGMT) {
-        username_len = strlen(kr->pd->user);
+        username_len = strlen(kr->kuserok_user);
         buf->size += sizeof(uint32_t) + username_len;
     }
 
@@ -217,7 +217,7 @@ static errno_t create_send_buffer(struct krb5child_req *kr,
 
     if (kr->pd->cmd == SSS_PAM_ACCT_MGMT) {
         SAFEALIGN_SET_UINT32(&buf->data[rp], username_len, &rp);
-        safealign_memcpy(&buf->data[rp], kr->pd->user, username_len, &rp);
+        safealign_memcpy(&buf->data[rp], kr->kuserok_user, username_len, &rp);
     }
 
     *io_buf = buf;


### PR DESCRIPTION
Resolves:
    https://fedorahosted.org/sssd/ticket/3172

krb5_child calls krb5_kuserok() during the access phase which checks if
a particular user is allowed to authenticate as a particular principal.
We used to pass the internal fqname to krb5_kuserok() which broke the
functionality and all users were denied access.

This patch changes that to send the 'output' username to krb5_child,
because that's the username the system receives through getpwnam() or
getpwuid() anyway. The patch also adds a new structure member fo the
krb5child_req structure to avoid reusing the pd->user variable but have
an explicit one that serves as the input for the child process.