### PR TITLE
IFP: expose user and group unique IDs through DBus

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -224,6 +224,7 @@
                         SYSDB_OVERRIDE_DN, \
                         SYSDB_OVERRIDE_OBJECT_DN, \
                         SYSDB_DEFAULT_OVERRIDE_NAME, \
+                        SYSDB_UUID, \
                         NULL}
 
 #define SYSDB_GRSRC_ATTRS {SYSDB_NAME, SYSDB_GIDNUM, \
@@ -235,6 +236,7 @@
                            SYSDB_OVERRIDE_DN, \
                            SYSDB_OVERRIDE_OBJECT_DN, \
                            SYSDB_DEFAULT_OVERRIDE_NAME, \
+                           SYSDB_UUID, \
                            NULL}
 
 #define SYSDB_NETGR_ATTRS {SYSDB_NAME, SYSDB_NETGROUP_TRIPLE, \

--- a/src/responder/ifp/ifp_groups.c
+++ b/src/responder/ifp/ifp_groups.c
@@ -751,6 +751,25 @@ void ifp_groups_group_get_gid_number(struct sbus_request *sbus_req,
     return;
 }
 
+void ifp_groups_group_get_unique_id(struct sbus_request *sbus_req,
+                                    void *data,
+                                    const char **_out)
+{
+    struct ldb_message *msg;
+    struct sss_domain_info *domain;
+    errno_t ret;
+
+    ret = ifp_groups_group_get(sbus_req, data, NULL, &domain, &msg);
+    if (ret != EOK) {
+        *_out = 0;
+        return;
+    }
+
+    *_out = sss_view_ldb_msg_find_attr_as_string(domain, msg, SYSDB_UUID, 0);
+
+    return;
+}
+
 static errno_t
 ifp_groups_group_get_members(TALLOC_CTX *mem_ctx,
                              struct sbus_request *sbus_req,

--- a/src/responder/ifp/ifp_groups.h
+++ b/src/responder/ifp/ifp_groups.h
@@ -64,6 +64,10 @@ void ifp_groups_group_get_gid_number(struct sbus_request *sbus_req,
                                      void *data,
                                      uint32_t *_out);
 
+void ifp_groups_group_get_unique_id(struct sbus_request *sbus_req,
+                                    void *data,
+                                    const char **_out);
+
 void ifp_groups_group_get_users(struct sbus_request *sbus_req,
                                 void *data,
                                 const char ***_out,

--- a/src/responder/ifp/ifp_iface.c
+++ b/src/responder/ifp/ifp_iface.c
@@ -104,6 +104,7 @@ struct iface_ifp_users_user iface_ifp_users_user = {
     .get_gecos = ifp_users_user_get_gecos,
     .get_homeDirectory = ifp_users_user_get_home_directory,
     .get_loginShell = ifp_users_user_get_login_shell,
+    .get_uniqueID = ifp_users_user_get_unique_id,
     .get_groups = ifp_users_user_get_groups,
     .get_extraAttributes = ifp_users_user_get_extra_attributes
 };
@@ -121,6 +122,7 @@ struct iface_ifp_groups_group iface_ifp_groups_group = {
     .UpdateMemberList = ifp_groups_group_update_member_list,
     .get_name = ifp_groups_group_get_name,
     .get_gidNumber = ifp_groups_group_get_gid_number,
+    .get_uniqueID = ifp_groups_group_get_unique_id,
     .get_users = ifp_groups_group_get_users,
     .get_groups = ifp_groups_group_get_groups
 };

--- a/src/responder/ifp/ifp_iface.xml
+++ b/src/responder/ifp/ifp_iface.xml
@@ -186,6 +186,7 @@
         <property name="gecos" type="s" access="read" />
         <property name="homeDirectory" type="s" access="read" />
         <property name="loginShell" type="s" access="read" />
+        <property name="uniqueID" type="s" access="read" />
         <property name="groups" type="ao" access="read" />
         <property name="extraAttributes" type="a{sas}" access="read" />
     </interface>
@@ -221,6 +222,7 @@
 
         <property name="name" type="s" access="read" />
         <property name="gidNumber" type="u" access="read" />
+        <property name="uniqueID" type="s" access="read" />
         <property name="users" type="ao" access="read" />
         <property name="groups" type="ao" access="read" />
     </interface>

--- a/src/responder/ifp/ifp_iface_generated.c
+++ b/src/responder/ifp/ifp_iface_generated.c
@@ -976,6 +976,15 @@ const struct sbus_property_meta iface_ifp_users_user__properties[] = {
         NULL, /* no invoker */
     },
     {
+        "uniqueID", /* name */
+        "s", /* type */
+        SBUS_PROPERTY_READABLE,
+        offsetof(struct iface_ifp_users_user, get_uniqueID),
+        sbus_invoke_get_s,
+        0, /* not writable */
+        NULL, /* no invoker */
+    },
+    {
         "groups", /* name */
         "ao", /* type */
         SBUS_PROPERTY_READABLE,
@@ -1161,6 +1170,15 @@ const struct sbus_property_meta iface_ifp_groups_group__properties[] = {
         SBUS_PROPERTY_READABLE,
         offsetof(struct iface_ifp_groups_group, get_gidNumber),
         sbus_invoke_get_u,
+        0, /* not writable */
+        NULL, /* no invoker */
+    },
+    {
+        "uniqueID", /* name */
+        "s", /* type */
+        SBUS_PROPERTY_READABLE,
+        offsetof(struct iface_ifp_groups_group, get_uniqueID),
+        sbus_invoke_get_s,
         0, /* not writable */
         NULL, /* no invoker */
     },

--- a/src/responder/ifp/ifp_iface_generated.h
+++ b/src/responder/ifp/ifp_iface_generated.h
@@ -88,6 +88,7 @@
 #define IFACE_IFP_USERS_USER_GECOS "gecos"
 #define IFACE_IFP_USERS_USER_HOMEDIRECTORY "homeDirectory"
 #define IFACE_IFP_USERS_USER_LOGINSHELL "loginShell"
+#define IFACE_IFP_USERS_USER_UNIQUEID "uniqueID"
 #define IFACE_IFP_USERS_USER_GROUPS "groups"
 #define IFACE_IFP_USERS_USER_EXTRAATTRIBUTES "extraAttributes"
 
@@ -103,6 +104,7 @@
 #define IFACE_IFP_GROUPS_GROUP_UPDATEMEMBERLIST "UpdateMemberList"
 #define IFACE_IFP_GROUPS_GROUP_NAME "name"
 #define IFACE_IFP_GROUPS_GROUP_GIDNUMBER "gidNumber"
+#define IFACE_IFP_GROUPS_GROUP_UNIQUEID "uniqueID"
 #define IFACE_IFP_GROUPS_GROUP_USERS "users"
 #define IFACE_IFP_GROUPS_GROUP_GROUPS "groups"
 
@@ -294,6 +296,7 @@ struct iface_ifp_users_user {
     void (*get_gecos)(struct sbus_request *, void *data, const char **);
     void (*get_homeDirectory)(struct sbus_request *, void *data, const char **);
     void (*get_loginShell)(struct sbus_request *, void *data, const char **);
+    void (*get_uniqueID)(struct sbus_request *, void *data, const char **);
     void (*get_groups)(struct sbus_request *, void *data, const char ***, int *);
     void (*get_extraAttributes)(struct sbus_request *, void *data, hash_table_t **);
 };
@@ -328,6 +331,7 @@ struct iface_ifp_groups_group {
     int (*UpdateMemberList)(struct sbus_request *req, void *data);
     void (*get_name)(struct sbus_request *, void *data, const char **);
     void (*get_gidNumber)(struct sbus_request *, void *data, uint32_t*);
+    void (*get_uniqueID)(struct sbus_request *, void *data, const char **);
     void (*get_users)(struct sbus_request *, void *data, const char ***, int *);
     void (*get_groups)(struct sbus_request *, void *data, const char ***, int *);
 };

--- a/src/responder/ifp/ifp_users.c
+++ b/src/responder/ifp/ifp_users.c
@@ -774,6 +774,13 @@ void ifp_users_user_get_login_shell(struct sbus_request *sbus_req,
     ifp_users_get_as_string(sbus_req, data, SYSDB_SHELL, _out);
 }
 
+void ifp_users_user_get_unique_id(struct sbus_request *sbus_req,
+                                  void *data,
+                                  const char **_out)
+{
+    ifp_users_get_as_string(sbus_req, data, SYSDB_UUID, _out);
+}
+
 void ifp_users_user_get_groups(struct sbus_request *sbus_req,
                                void *data,
                                const char ***_out,

--- a/src/responder/ifp/ifp_users.h
+++ b/src/responder/ifp/ifp_users.h
@@ -84,6 +84,10 @@ void ifp_users_user_get_login_shell(struct sbus_request *sbus_req,
                                     void *data,
                                     const char **_out);
 
+void ifp_users_user_get_unique_id(struct sbus_request *sbus_req,
+                                  void *data,
+                                  const char **_out);
+
 void ifp_users_user_get_groups(struct sbus_request *sbus_req,
                                void *data,
                                const char ***_out,


### PR DESCRIPTION
This adds a uniqueID property on User and Group InfoPipe objects. It has a
useful value on AD- and IPA-backed domains. For Active Directory, this is the
GUID.