### PR TITLE
LDAP: Return partial results from adminlimit exceeded

### DIFF
--- a/src/providers/ldap/sdap_async.c
+++ b/src/providers/ldap/sdap_async.c
@@ -1526,7 +1526,8 @@ static void sdap_get_generic_op_finished(struct sdap_op *op,
                   sss_ldap_err2string(result), result,
                   errmsg ? errmsg : "no errmsg set");
 
-        if (result == LDAP_SIZELIMIT_EXCEEDED) {
+        if (result == LDAP_SIZELIMIT_EXCEEDED
+                || result == LDAP_ADMINLIMIT_EXCEEDED) {
             /* Try to return what we've got */
 
             if ( ! (state->flags & SDAP_SRCH_FLG_SIZELIMIT_SILENT)) {


### PR DESCRIPTION
In commit c420ce830ac0b0b288a2a887ec2cfce5c748018c we changed a way how we 'try a next server' in order to fix https://fedorahosted.org/sssd/ticket/3009.

But since this change, results that return adminlimit exceeded (11) also
mark the connection as offline. I think the best way is to special-case
the LDAP error.