### PR TITLE
sss_groupshow does not work with mpg

### DIFF
--- a/src/tests/intg/test_local_domain.py
+++ b/src/tests/intg/test_local_domain.py
@@ -118,6 +118,28 @@ def assert_nonexistent_group(name):
         grp.getgrnam(name)
 
 
+def test_groupshow_mpg(local_domain_only):
+    """
+    Regression test for ticket
+    https://fedorahosted.org/sssd/ticket/3184
+    """
+    subprocess.check_call(["sss_useradd", "foo", "-M"])
+
+    # The user's mpg has to be found (should return 0)
+    subprocess.check_call(["sss_groupshow", "foo"])
+
+
+def test_groupshow_mpg_fqdn(local_domain_only_fqdn):
+    """
+    Regression test for ticket (fq variant)
+    https://fedorahosted.org/sssd/ticket/3184
+    """
+    subprocess.check_call(["sss_useradd", "foo@LOCAL", "-M"])
+
+    # The user's mpg has to be found (should return 0)
+    subprocess.check_call(["sss_groupshow", "foo@LOCAL"])
+
+
 def test_wrong_LC_ALL(local_domain_only):
     """
     Regression test for ticket

--- a/src/tools/sss_groupshow.c
+++ b/src/tools/sss_groupshow.c
@@ -553,13 +553,14 @@ int group_show_recurse(TALLOC_CTX *mem_ctx,
 
 static int group_show_mpg(TALLOC_CTX *mem_ctx,
                           struct sss_domain_info *domain,
-                          const char *name,
+                          const char *shortname,
                           struct group_info **res)
 {
     const char *attrs[] = GROUP_SHOW_MPG_ATTRS;
     struct ldb_message *msg;
     struct group_info *info;
     int ret;
+    char *sysdb_fqname;
 
     info = talloc_zero(mem_ctx, struct group_info);
     if (!info) {
@@ -567,7 +568,14 @@ static int group_show_mpg(TALLOC_CTX *mem_ctx,
         goto fail;
     }
 
-    ret = sysdb_search_user_by_name(info, domain, name, attrs, &msg);
+    sysdb_fqname = sss_create_internal_fqname(mem_ctx,
+                                              shortname,
+                                              domain->name);
+    if (sysdb_fqname == NULL) {
+        return ENOMEM;
+    }
+
+    ret = sysdb_search_user_by_name(info, domain, sysdb_fqname, attrs, &msg);
     if (ret) {
         DEBUG(SSSDBG_OP_FAILURE,
               "Search failed: %s (%d)\n", strerror(ret), ret);


### PR DESCRIPTION
We recently fixed this with normal groups. The MPG code path was still using shortname in sysdb search operation.

Upstream ticket:
https://fedorahosted.org/sssd/ticket/3184