### PR TITLE
KRB5: Fixing FQ name of user in krb5_setup()

### DIFF
--- a/src/providers/krb5/krb5_auth.c
+++ b/src/providers/krb5/krb5_auth.c
@@ -207,7 +207,13 @@ errno_t krb5_setup(TALLOC_CTX *mem_ctx,
     if (ret == EOK) {
         DEBUG(SSSDBG_TRACE_FUNC, "Setting mapped name to: %s\n", mapped_name);
         kr->user = mapped_name;
-        kr->kuserok_user = mapped_name;
+
+        kr->kuserok_user = sss_output_name(kr, kr->user,
+                                           dom->case_sensitive, 0);
+        if (kr->kuserok_user == NULL) {
+            ret = ENOMEM;
+            goto done;
+        }
     } else if (ret == ENOENT) {
         DEBUG(SSSDBG_TRACE_ALL, "No mapping for: %s\n", pd->user);
         kr->user = pd->user;

--- a/src/providers/krb5/krb5_init_shared.c
+++ b/src/providers/krb5/krb5_init_shared.c
@@ -94,6 +94,7 @@ errno_t krb5_child_init(struct krb5_ctx *krb5_auth_ctx,
     ret = parse_krb5_map_user(krb5_auth_ctx,
                               dp_opt_get_cstring(krb5_auth_ctx->opts,
                                                  KRB5_MAP_USER),
+                              bectx->domain->name,
                               &krb5_auth_ctx->name_to_primary);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "parse_krb5_map_user failed: %s:[%d]\n",

--- a/src/providers/krb5/krb5_utils.c
+++ b/src/providers/krb5/krb5_utils.c
@@ -521,7 +521,9 @@ done:
 }
 
 errno_t
-parse_krb5_map_user(TALLOC_CTX *mem_ctx, const char *krb5_map_user,
+parse_krb5_map_user(TALLOC_CTX *mem_ctx,
+                    const char *krb5_map_user,
+                    const char *dom_name,
                     struct map_id_name_to_krb_primary **_name_to_primary)
 {
     int size;
@@ -570,6 +572,28 @@ parse_krb5_map_user(TALLOC_CTX *mem_ctx, const char *krb5_map_user,
         }
     }
 
+    /* conversion names to fully-qualified names */
+    for (int i = 0; i < size; i++) {
+        name_to_primary[i].id_name = sss_create_internal_fqname(
+                                                     name_to_primary,
+                                                     name_to_primary[i].id_name,
+                                                     dom_name);
+        if (name_to_primary[i].id_name == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE, "sss_create_internal_fqname failed\n");
+            ret = ENOMEM;
+            goto done;
+        }
+
+        name_to_primary[i].krb_primary = sss_create_internal_fqname(
+                                                 name_to_primary,
+                                                 name_to_primary[i].krb_primary,
+                                                 dom_name);
+        if (name_to_primary[i].krb_primary == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE, "sss_create_internal_fqname failed\n");
+            ret = ENOMEM;
+            goto done;
+        }
+    }
     ret = EOK;
 
 done:

--- a/src/providers/krb5/krb5_utils.h
+++ b/src/providers/krb5/krb5_utils.h
@@ -51,7 +51,9 @@ errno_t get_domain_or_subdomain(struct be_ctx *be_ctx,
                                 struct sss_domain_info **dom);
 
 errno_t
-parse_krb5_map_user(TALLOC_CTX *mem_ctx, const char *krb5_map_user,
+parse_krb5_map_user(TALLOC_CTX *mem_ctx,
+                    const char *krb5_map_user,
+                    const char *dom_name,
                     struct map_id_name_to_krb_primary **_name_to_primary);
 
 #endif /* __KRB5_UTILS_H__ */

--- a/src/tests/krb5_utils-tests.c
+++ b/src/tests/krb5_utils-tests.c
@@ -614,25 +614,25 @@ START_TEST(test_parse_krb5_map_user)
     /* empty input */
     {
         check_leaks_push(mem_ctx);
-        ret = parse_krb5_map_user(mem_ctx, NULL, &name_to_primary);
+        ret = parse_krb5_map_user(mem_ctx, NULL, DOMAIN_NAME, &name_to_primary);
         fail_unless(ret == EOK);
         fail_unless(name_to_primary[0].id_name == NULL &&
                     name_to_primary[0].krb_primary == NULL);
         talloc_free(name_to_primary);
 
-        ret = parse_krb5_map_user(mem_ctx, "", &name_to_primary);
+        ret = parse_krb5_map_user(mem_ctx, "", DOMAIN_NAME, &name_to_primary);
         fail_unless(ret == EOK);
         fail_unless(name_to_primary[0].id_name == NULL &&
                     name_to_primary[0].krb_primary == NULL);
         talloc_free(name_to_primary);
 
-        ret = parse_krb5_map_user(mem_ctx, ",", &name_to_primary);
+        ret = parse_krb5_map_user(mem_ctx, ",", DOMAIN_NAME, &name_to_primary);
         fail_unless(ret == EOK);
         fail_unless(name_to_primary[0].id_name == NULL &&
                     name_to_primary[0].krb_primary == NULL);
         talloc_free(name_to_primary);
 
-        ret = parse_krb5_map_user(mem_ctx, ",,", &name_to_primary);
+        ret = parse_krb5_map_user(mem_ctx, ",,", DOMAIN_NAME, &name_to_primary);
         fail_unless(ret == EOK);
         fail_unless(name_to_primary[0].id_name == NULL &&
                     name_to_primary[0].krb_primary == NULL);
@@ -645,14 +645,16 @@ START_TEST(test_parse_krb5_map_user)
         check_leaks_push(mem_ctx);
         const char *p = "pája:preichl,joe:juser,jdoe:ßlack";
         const char *p2 = " pája  : preichl , joe:\njuser,jdoe\t:   ßlack ";
-        const char *expected[] = {"pája", "preichl", "joe", "juser", "jdoe", "ßlack"};
-        ret = parse_krb5_map_user(mem_ctx, p, &name_to_primary);
+        const char *expected[] = {"pája@testdomain", "preichl@"DOMAIN_NAME,
+                                  "joe@testdomain", "juser@testdomain",
+                                  "jdoe@testdomain", "ßlack@testdomain"};
+        ret = parse_krb5_map_user(mem_ctx, p, DOMAIN_NAME, &name_to_primary);
         fail_unless(ret == EOK);
         compare_map_id_name_to_krb_primary(name_to_primary, expected,
                                          sizeof(expected)/sizeof(const char*)/2);
         talloc_free(name_to_primary);
 
-        ret = parse_krb5_map_user(mem_ctx, p2, &name_to_primary);
+        ret = parse_krb5_map_user(mem_ctx, p2, DOMAIN_NAME, &name_to_primary);
         fail_unless(ret == EOK);
         compare_map_id_name_to_krb_primary(name_to_primary,  expected,
                                          sizeof(expected)/sizeof(const char*)/2);
@@ -663,22 +665,27 @@ START_TEST(test_parse_krb5_map_user)
     {
         check_leaks_push(mem_ctx);
 
-        ret = parse_krb5_map_user(mem_ctx, ":", &name_to_primary);
+        ret = parse_krb5_map_user(mem_ctx, ":", DOMAIN_NAME, &name_to_primary);
         fail_unless(ret == EINVAL);
 
-        ret = parse_krb5_map_user(mem_ctx, "joe:", &name_to_primary);
+        ret = parse_krb5_map_user(mem_ctx, "joe:", DOMAIN_NAME,
+                                  &name_to_primary);
         fail_unless(ret == EINVAL);
 
-        ret = parse_krb5_map_user(mem_ctx, ":joe", &name_to_primary);
+        ret = parse_krb5_map_user(mem_ctx, ":joe", DOMAIN_NAME,
+                                  &name_to_primary);
         fail_unless(ret == EINVAL);
 
-        ret = parse_krb5_map_user(mem_ctx, "joe:,", &name_to_primary);
+        ret = parse_krb5_map_user(mem_ctx, "joe:,", DOMAIN_NAME,
+                                  &name_to_primary);
         fail_unless(ret == EINVAL);
 
-        ret = parse_krb5_map_user(mem_ctx, ",joe", &name_to_primary);
+        ret = parse_krb5_map_user(mem_ctx, ",joe", DOMAIN_NAME,
+                                  &name_to_primary);
         fail_unless(ret == EINVAL);
 
-        ret = parse_krb5_map_user(mem_ctx, "joe:j:user", &name_to_primary);
+        ret = parse_krb5_map_user(mem_ctx, "joe:j:user", DOMAIN_NAME,
+                                  &name_to_primary);
         fail_unless(ret == EINVAL);
 
         fail_unless(check_leaks_pop(mem_ctx));


### PR DESCRIPTION
This patch fixes creation of FQ username if krb5_map_user option
ise used.

Resolves:
https://fedorahosted.org/sssd/ticket/3188