### PR TITLE
Requesting a pull to SSSD:master from fidencio:wip/#3138

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -175,6 +175,7 @@ endif
 endif
 if BUILD_SECRETS
 sssdlibexec_PROGRAMS += sssd_secrets
+sssdlibexec_PROGRAMS += sssd_update_confdb
 endif
 
 if BUILD_PAC_RESPONDER
@@ -474,6 +475,7 @@ AM_CPPFLAGS = \
     -DSSS_PAC_SOCKET_NAME=\"$(pipepath)/pac\" \
     -DSSS_PAM_PRIV_SOCKET_NAME=\"$(pipepath)/private/pam\" \
     -DSSS_SEC_SOCKET_NAME=\"$(runstatedir)/secrets.socket\" \
+    -DSSS_UPDATE_CONFDB_SOCKET_NAME=\"$(runstatedir)/update-confdb.socket\" \
     -DSSS_SUDO_SOCKET_NAME=\"$(pipepath)/sudo\" \
     -DSSS_AUTOFS_SOCKET_NAME=\"$(pipepath)/autofs\" \
     -DSSS_SSH_SOCKET_NAME=\"$(pipepath)/ssh\" \
@@ -1390,6 +1392,17 @@ sssd_secrets_LDADD = \
     $(SSSD_LIBS) \
     $(SYSTEMD_DAEMON_LIBS) \
     $(CARES_LIBS) \
+    $(SSSD_INTERNAL_LTLIBS) \
+    $(NULL)
+
+sssd_update_confdb_SOURCES = \
+    src/responder/update_confdb/update_confdb.c \
+    $(SSSD_RESPONDER_OBJ) \
+    $(SSSD_TOOLS_OBJ) \
+    $(NULL)
+sssd_update_confdb_LDADD = \
+    $(SSSD_LIBS) \
+    $(SYSTEMD_DAEMON_LIBS) \
     $(SSSD_INTERNAL_LTLIBS) \
     $(NULL)
 endif
@@ -3896,6 +3909,8 @@ if HAVE_SYSTEMD_UNIT
         src/sysv/systemd/sssd.service \
         src/sysv/systemd/sssd-secrets.socket \
         src/sysv/systemd/sssd-secrets.service \
+        src/sysv/systemd/sssd-update-confdb.socket \
+        src/sysv/systemd/sssd-update-confdb.service \
         $(NULL)
 if WITH_JOURNALD
     systemdconf_DATA += \
@@ -3949,6 +3964,8 @@ EXTRA_DIST += \
     src/sysv/systemd/journal.conf.in \
     src/sysv/systemd/sssd-secrets.socket.in \
     src/sysv/systemd/sssd-secrets.service.in \
+    src/sysv/systemd/sssd-update-confdb.socket.in \
+    src/sysv/systemd/sssd-update-confdb.service.in \
     $(NULL)
 
 src/sysv/systemd/sssd.service: src/sysv/systemd/sssd.service.in Makefile
@@ -3964,6 +3981,14 @@ src/sysv/systemd/sssd-secrets.socket: src/sysv/systemd/sssd-secrets.socket.in Ma
 	$(replace_script)
 
 src/sysv/systemd/sssd-secrets.service: src/sysv/systemd/sssd-secrets.service.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+
+src/sysv/systemd/sssd-update-confdb.socket: src/sysv/systemd/sssd-update-confdb.socket.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+
+src/sysv/systemd/sssd-update-confdb.service: src/sysv/systemd/sssd-update-confdb.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
 	$(replace_script)
 
@@ -4184,6 +4209,8 @@ endif
 	rm -f $(builddir)/src/sysv/systemd/sssd.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.service
+	rm -f $(builddir)/src/sysv/systemd/sssd-update-confdb.socket
+	rm -f $(builddir)/src/sysv/systemd/sssd-update-confdb.service
 	rm -f $(builddir)/src/sysv/systemd/journal.conf
 
 CLEANFILES += *.X */*.X */*/*.X

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -1140,7 +1140,6 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d / -s /sbin/nologin -c "Us
 %postun common
 %systemd_postun_with_restart sssd.service
 %systemd_postun_with_restart sssd-secrets.socket
-%systemd_postun_with_restart sssd-secrets.service
 
 %else
 # sysv

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -799,6 +799,8 @@ done
 %{_unitdir}/sssd.service
 %{_unitdir}/sssd-secrets.socket
 %{_unitdir}/sssd-secrets.service
+%{_unitdir}/sssd-update-confdb.socket
+%{_unitdir}/sssd-update-confdb.service
 %else
 %{_initrddir}/%{name}
 %endif
@@ -811,6 +813,7 @@ done
 %{_libexecdir}/%{servicename}/sssd_secrets
 %{_libexecdir}/%{servicename}/sssd_ssh
 %{_libexecdir}/%{servicename}/sssd_sudo
+%{_libexecdir}/%{servicename}/sssd_update_confdb
 %{_libexecdir}/%{servicename}/p11_child
 
 %dir %{_libdir}/%{name}
@@ -1131,14 +1134,17 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d / -s /sbin/nologin -c "Us
 # systemd
 %post common
 %systemd_post sssd.service
+%systemd_post sssd-update-confdb.socket
 %systemd_post sssd-secrets.socket
 
 %preun common
 %systemd_preun sssd.service
+%systemd_preun sssd-update-confdb.socket
 %systemd_preun sssd-secrets.socket
 
 %postun common
 %systemd_postun_with_restart sssd.service
+%systemd_postun_with_restart sssd-update-confdb.socket
 %systemd_postun_with_restart sssd-secrets.socket
 
 %else

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -224,6 +224,8 @@
 /* Secrets Service */
 #define CONFDB_SEC_CONF_ENTRY "config/secrets"
 
+/* Update confdb Service */
+#define CONFDB_UPDATE_CONF_ENTRY "config/updateconfdb"
 
 struct confdb_ctx;
 struct config_file_ctx;

--- a/src/responder/secrets/secsrv.c
+++ b/src/responder/secrets/secsrv.c
@@ -28,7 +28,18 @@
 #include "responder/secrets/secsrv.h"
 #include "resolv/async_resolv.h"
 
+#include "util/sss_sockets.h"
+
 #define DEFAULT_SEC_FD_LIMIT 2048
+
+struct sec_update_confdb_state {
+    struct TALLOC_CTX *mem_ctx;
+    struct tevent_context *ev;
+    struct confdb_ctx *cdb;
+
+    int sd;
+    struct tevent_fd *fde;
+};
 
 static int sec_get_config(struct sec_ctx *sctx)
 {
@@ -137,6 +148,271 @@ fail:
     return ret;
 }
 
+static int sec_update_confdb_state_destructor(void *data)
+{
+    struct sec_update_confdb_state *state;
+
+    state = talloc_get_type(data, struct sec_update_confdb_state);
+
+    if (!state) return 0 ;
+
+    if (state->sd != -1) {
+        DEBUG(SSSDBG_TRACE_FUNC, "closing socket [%d]\n", state->sd);
+        close(state->sd);
+        state->sd = -1;
+    }
+
+    state->mem_ctx = NULL;
+    state->ev = NULL;
+    state->cdb = NULL;
+
+    return 0;
+}
+
+static int sec_update_confdb_fd_send_data(int fd)
+{
+    char data = '1';
+    ssize_t len;
+
+    errno = 0;
+    len = send(fd, &data, 1, 0);
+    if (len == -1) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+            return EAGAIN;
+        } else {
+            return errno;
+        }
+    }
+
+    if (len == 0) {
+        return EIO;
+    }
+
+    return EOK;
+}
+
+static void sec_update_confdb_fd_send(void *data)
+{
+    struct tevent_req *req;
+    struct sec_update_confdb_state *state;
+    int ret;
+
+    req = talloc_get_type(data, struct tevent_req);
+    state = tevent_req_data(req, struct sec_update_confdb_state);
+
+    ret = sec_update_confdb_fd_send_data(state->sd);
+    if (ret == EAGAIN) {
+        /* not all data was sent, loop again */
+        return;
+    }
+
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Failed to send data, aborting client!\n");
+
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    /* ok all sent */
+    TEVENT_FD_NOT_WRITEABLE(state->fde);
+    TEVENT_FD_READABLE(state->fde);
+}
+
+static int sec_update_confdb_fd_recv_data(int fd)
+{
+    char data;
+    ssize_t len;
+
+    errno = 0;
+    len = recv(fd, &data, 1, 0);
+    if (len == -1) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+            return EAGAIN;
+        } else {
+            return errno;
+        }
+    }
+
+    if (len == 0) {
+        return ENODATA;
+    }
+
+    return EOK;
+}
+
+static void sec_update_confdb_fd_recv(void *data)
+{
+    struct tevent_req *req;
+    struct sec_update_confdb_state *state;
+    int ret;
+
+    req = talloc_get_type(data, struct tevent_req);
+    state = tevent_req_data(req, struct sec_update_confdb_state);
+
+    ret = sec_update_confdb_fd_recv_data(state->sd);
+
+    switch(ret) {
+        case ENODATA:
+            DEBUG(SSSDBG_TRACE_ALL,
+                  "Client closed connection\n");
+            tevent_req_error(req, EIO);
+            return;
+        case EAGAIN:
+            DEBUG(SSSDBG_TRACE_ALL,
+                  "Interrupted before any data could be read, retry later\n");
+            return;
+        case EOK:
+            /* all fine */
+            break;
+        default:
+            DEBUG(SSSDBG_FATAL_FAILURE,
+                  "Failed to receive data (%d, %s), aborting client\n",
+                  ret, strerror(ret));
+            tevent_req_error(req, ret);
+            return;
+    }
+
+
+    TEVENT_FD_NOT_READABLE(state->fde);
+
+    ret = sec_process_init(state->mem_ctx, state->ev, state->cdb);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+                "sec_process_init failed: [%d]: %s.\n",
+                ret, strerror(ret));
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    tevent_req_done(req);
+}
+
+static void sec_update_confdb_fd_handler(struct tevent_context *ev,
+                                         struct tevent_fd *fde,
+                                         uint16_t flags, void *data)
+{
+    if (flags & TEVENT_FD_READ) {
+        sec_update_confdb_fd_recv(data);
+        return;
+    }
+
+    if (flags & TEVENT_FD_WRITE) {
+        sec_update_confdb_fd_send(data);
+        return;
+    }
+}
+
+static void sec_update_confdb_connect_done(struct tevent_req *subreq)
+{
+    struct tevent_req *req;
+    struct sec_update_confdb_state *state;
+    int ret;
+
+    req = tevent_req_callback_data(subreq, struct tevent_req);
+    state = tevent_req_data(req, struct sec_update_confdb_state);
+
+    ret = sssd_async_socket_init_recv(subreq, &state->sd);
+    talloc_zfree(subreq);
+
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "sssd_async_socket_init request failed: [%d]: %s.\n",
+              ret, strerror(ret));
+
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    /* EOK */
+
+    state->fde = tevent_add_fd(state->ev, state, state->sd,
+                               TEVENT_FD_WRITE,
+                               sec_update_confdb_fd_handler, req);
+    if (!state->fde) {
+        tevent_req_error(req, EIO);
+        return;
+    }
+
+    tevent_req_done(req);
+}
+
+static struct tevent_req *
+sec_update_confdb_connect(TALLOC_CTX *mem_ctx,
+                          struct tevent_context *ev,
+                          struct confdb_ctx *cdb,
+                          struct sockaddr_storage *addr,
+                          int addr_len, int timeout)
+{
+    struct tevent_req *req, *subreq;
+    struct sec_update_confdb_state *state;
+
+    req = tevent_req_create(mem_ctx, &state, struct sec_update_confdb_state);
+    if (!req) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "tevent_req_create failed.\n");
+        return NULL;
+    }
+
+    talloc_set_destructor((TALLOC_CTX *)state, sec_update_confdb_state_destructor);
+
+    state->mem_ctx = mem_ctx;
+    state->ev = ev;
+    state->cdb = cdb;
+    state->sd = -1;
+
+    subreq = sssd_async_socket_init_send(state, ev, addr, addr_len, timeout);
+    if (!subreq) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "sssd_async_socket_init_send failed.\n");
+
+        tevent_req_error(req, ENOMEM);
+        tevent_req_post(req, ev);
+
+        goto end;
+    }
+
+    tevent_req_set_callback(subreq, sec_update_confdb_connect_done, req);
+
+end:
+    return req;
+}
+
+static int sec_update_confdb(TALLOC_CTX *mem_ctx,
+                             struct tevent_context *ev,
+                             struct confdb_ctx *cdb)
+{
+    struct tevent_req *req;
+    struct sockaddr_storage *sockaddr;
+
+    sockaddr = talloc_zero(mem_ctx, struct sockaddr_storage);
+    if (sockaddr == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "talloc_zero failed.\n");
+        return ENOMEM;
+    }
+
+    /* Updating confdb will be done in a few steps:
+     *
+     * 1) Connect to the update-confdb.socket
+     * 2) Send a single byte to update-confdb.socket,
+     *    which will actually trigger the update.
+     * 3) Receive a single byte as a confirmation that
+     *    the update happened without issues
+     * 4) Finish the initialization using the up-to-date
+     *    values from the confdb.
+     */
+
+    ((struct sockaddr_un *)sockaddr)->sun_family = AF_UNIX;
+    memcpy(&((struct sockaddr_un *) sockaddr)->sun_path,
+           SSS_UPDATE_CONFDB_SOCKET_NAME,
+           strlen(SSS_UPDATE_CONFDB_SOCKET_NAME));
+
+    req = sec_update_confdb_connect(mem_ctx, ev, cdb, sockaddr,
+                                    SUN_LEN((struct sockaddr_un *) sockaddr),
+                                    CONFDB_RESPONDER_CLI_IDLE_DEFAULT_TIMEOUT);
+
+    if (!req) return ENOMEM;
+
+    return EOK;
+}
+
 int main(int argc, const char *argv[])
 {
     int opt;
@@ -187,9 +463,9 @@ int main(int argc, const char *argv[])
               "Could not set up to exit when parent process does\n");
     }
 
-    ret = sec_process_init(main_ctx,
-                           main_ctx->event_ctx,
-                           main_ctx->confdb_ctx);
+    ret = sec_update_confdb(main_ctx,
+                            main_ctx->event_ctx,
+                            main_ctx->confdb_ctx);
     if (ret != EOK) return 3;
 
     /* loop on main */

--- a/src/responder/update_confdb/update_confdb.c
+++ b/src/responder/update_confdb/update_confdb.c
@@ -1,0 +1,307 @@
+/*
+    Authors:
+        Fabiano Fidêncio <fidencio@redhat.com>
+
+    Copyright (C) 2016 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <popt.h>
+
+#include "util/util.h"
+#include "confdb/confdb_setup.h"
+#include "responder/common/responder.h"
+
+
+/* Dummy, not used here but required to link to other responder files */
+struct cli_protocol_version *register_cli_protocol_version(void)
+{
+    return NULL;
+}
+
+static errno_t update_confdb_update(struct cli_ctx *cctx)
+{
+    TALLOC_CTX *tmp_ctx;
+    struct confdb_ctx *confdb;
+    char *path;
+    errno_t ret;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    path = talloc_asprintf(tmp_ctx, "%s/%s", DB_PATH, CONFDB_FILE);
+    if (path == NULL) {
+        return ENOMEM;
+    }
+
+    ret = confdb_setup(tmp_ctx, path, SSSD_CONFIG_FILE, CONFDB_DEFAULT_CONFIG_DIR, &confdb);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to setup ConfDB [%d]: %s\n",
+              ret, strerror(ret));
+        goto done;
+    }
+
+    ret = EOK;
+
+    TEVENT_FD_WRITEABLE(cctx->cfde);
+
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+static int update_confdb_send_data(int fd)
+{
+    char data = '1';
+    ssize_t len;
+
+    errno = 0;
+    len = send(fd, &data, 1, 0);
+    if (len == -1) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+            return EAGAIN;
+        } else {
+            return errno;
+        }
+    }
+
+    if (len == 0) {
+        return EIO;
+    }
+
+    return EOK;
+}
+
+static void update_confdb_send(struct cli_ctx *cctx)
+{
+    int ret;
+
+    ret = update_confdb_send_data(cctx->cfd);
+    if (ret == EAGAIN) {
+        /* not all data was sent, loop again */
+        return;
+    }
+
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Failed to send data, aborting client!\n");
+        talloc_free(cctx);
+
+        return;
+    }
+
+    /* ok all sent */
+    TEVENT_FD_NOT_WRITEABLE(cctx->cfde);
+    TEVENT_FD_READABLE(cctx->cfde);
+
+    exit(0);
+}
+
+static int update_confdb_recv_data(int fd)
+{
+    char data;
+    ssize_t len;
+
+    errno = 0;
+    len = recv(fd, &data, 1, 0);
+    if (len == -1) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+            return EAGAIN;
+        } else {
+            return errno;
+        }
+    }
+
+    if (len == 0) {
+        return ENODATA;
+    }
+
+    return EOK;
+}
+
+static void update_confdb_recv(struct cli_ctx *cctx)
+{
+    int ret;
+
+    ret = update_confdb_recv_data(cctx->cfd);
+    switch(ret) {
+    case ENODATA:
+        DEBUG(SSSDBG_TRACE_ALL,
+              "Client closed connection\n");
+        talloc_free(cctx);
+        return;
+    case EAGAIN:
+        DEBUG(SSSDBG_TRACE_ALL,
+              "Interrupted before any data could be read, retry later\n");
+        return;
+    case EOK:
+        /* all fine */
+        break;
+    default:
+        DEBUG(SSSDBG_FATAL_FAILURE,
+              "Failed to receive data (%d, %s), aborting client!\n",
+              ret, strerror(ret));
+        talloc_free(cctx);
+        return;
+    }
+
+    TEVENT_FD_NOT_READABLE(cctx->cfde);
+    update_confdb_update(cctx);
+
+    return;
+}
+
+static void update_confdb_fd_handler(struct tevent_context *ev,
+                                     struct tevent_fd *fde,
+                                     uint16_t flags, void *ptr)
+{
+    errno_t ret;
+    struct cli_ctx *cctx = talloc_get_type(ptr, struct cli_ctx);
+
+    /* Always reset the idle timer on any activity */
+    ret = reset_idle_timer(cctx);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Could not create idle timer for client. "
+              "This connection may not auto-terminate\n");
+        /* Non-fatal, continue */
+    }
+
+    if (flags & TEVENT_FD_READ) {
+        update_confdb_recv(cctx);
+        return;
+    }
+
+    if (flags & TEVENT_FD_WRITE) {
+        update_confdb_send(cctx);
+        return;
+    }
+}
+
+static int update_confdb_connection_setup(struct cli_ctx *cctx)
+{
+    cctx->cfd_handler = update_confdb_fd_handler;
+
+    return EOK;
+}
+
+static int update_confdb_ctx_destructor(void *ptr)
+{
+    struct resp_ctx *rctx = talloc_get_type(ptr, struct resp_ctx);
+
+    /* mark that we are shutting down the service, so it is propagated
+     * into underlying contexts that are freed right before rctx */
+    DEBUG(SSSDBG_TRACE_FUNC, "Service is being shutdown\n");
+    rctx->shutting_down = true;
+
+    return 0;
+}
+
+static int update_confdb_process_init(TALLOC_CTX *mem_ctx,
+                                      struct tevent_context *ev,
+                                      struct confdb_ctx *cdb)
+{
+    struct resp_ctx *rctx;
+    int ret;
+
+    rctx = talloc_zero(mem_ctx, struct resp_ctx);
+    if (rctx == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "fatal error initializing resp_ctx\n");
+
+        return ENOMEM;
+    }
+
+    rctx->ev = ev;
+    rctx->cdb = cdb;
+    rctx->sock_name = SSS_UPDATE_CONFDB_SOCKET_NAME;
+    rctx->shutting_down = false;
+    rctx->client_idle_timeout = CONFDB_RESPONDER_CLI_IDLE_DEFAULT_TIMEOUT;
+
+    talloc_set_destructor((TALLOC_CTX *)rctx, update_confdb_ctx_destructor);
+
+    ret = activate_unix_sockets(rctx, update_confdb_connection_setup);
+    if (ret != EOK) {
+        goto fail;
+    }
+
+    DEBUG(SSSDBG_TRACE_FUNC, "Update ConfDB socket activation complete\n");
+
+    return EOK;
+
+fail:
+    talloc_free(rctx);
+    return ret;
+}
+
+int main (int argc, const char *argv[])
+{
+    int opt;
+    poptContext pc;
+    struct main_context *main_ctx;
+    int ret;
+
+    struct poptOption long_options[] = {
+        POPT_AUTOHELP
+        SSSD_MAIN_OPTS
+        POPT_TABLEEND
+    };
+
+    /* Set debug level to invalid value so we can decide if -d 0 was used. */
+    debug_level = SSSDBG_INVALID;
+
+    pc = poptGetContext(argv[0], argc, argv, long_options, 0);
+    while((opt = poptGetNextOpt(pc)) != -1) {
+        switch(opt) {
+        default:
+            fprintf(stderr, "\nInvalid option %s: %s\n\n",
+                    poptBadOption(pc, 0), poptStrerror(opt));
+            poptPrintUsage(pc, stderr, 0);
+            return 1;
+        }
+    }
+
+    poptFreeContext(pc);
+
+    DEBUG_INIT(debug_level);
+
+    /* set up things like debug, signals, daemonizations, etc ... */
+    debug_log_file = "sssd_update_confdb";
+
+    ret = server_setup("update_confdb", 0, 0, 0,
+                       CONFDB_UPDATE_CONF_ENTRY, &main_ctx);
+    if (ret != EOK) {
+        return 2;
+    }
+
+    ret = die_if_parent_died();
+    if (ret != EOK) {
+        /* This is not fatal, don't return. */
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Could not set up to exit when parent process does\n");
+    }
+
+    ret = update_confdb_process_init(main_ctx,
+                                     main_ctx->event_ctx,
+                                     main_ctx->confdb_ctx);
+    if (ret != EOK) {
+        return 3;
+    }
+
+    /* loop on main */
+    server_loop(main_ctx);
+
+    return 0;
+}

--- a/src/sysv/systemd/sssd-update-confdb.service.in
+++ b/src/sysv/systemd/sssd-update-confdb.service.in
@@ -1,0 +1,8 @@
+[Unit]
+Description=SSSD Update ConfDB Service
+
+[Install]
+Also=sssd-update-confdb.socket
+
+[Service]
+ExecStart=@libexecdir@/sssd/sssd_update_confdb --debug-to-files

--- a/src/sysv/systemd/sssd-update-confdb.socket.in
+++ b/src/sysv/systemd/sssd-update-confdb.socket.in
@@ -1,0 +1,8 @@
+[Unit]
+Description=SSSD Update ConfDB socket
+
+[Socket]
+ListenStream=@localstatedir@/run/update-confdb.socket
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
This patch series is intended to solve #3138 by adding a new service
that updates the confdb. As part of the series this service is used by
secrets service.

I only ran CI locally and the two secrets tests have been failing. /o\

Also, I've noticed some weird behavior, where the sssd-update-confdb
service starts for apparently no reason, when upgrading fedora
packages.

Anyways, these pieces of code really need some detailed review as it
was the first time I've been "seriously" playing with TEvent requests.
So, please, consider it more like an RFC than a well finished and
polished code.

Best Regards,
