### PR TITLE
sss_cache: improve option argument handling

### DIFF
--- a/src/man/sss_cache.8.xml
+++ b/src/man/sss_cache.8.xml
@@ -30,7 +30,8 @@
         <para>
             <command>sss_cache</command> invalidates records in SSSD cache.
             Invalidated records are forced to be reloaded from server as soon
-            as related SSSD backend is online.
+            as related SSSD backend is online. Options that invalidate a single
+            object only accept a single provided argument.
         </para>
     </refsect1>
 

--- a/src/tools/sss_cache.c
+++ b/src/tools/sss_cache.c
@@ -745,6 +745,14 @@ static errno_t init_context(int argc, const char *argv[],
         BAD_POPT_PARAMS(pc, poptStrerror(ret), ret, fini);
     }
 
+    if (poptGetArg(pc)) {
+        BAD_POPT_PARAMS(pc,
+                _("Unexpected argument(s) provided, options that "
+                  "invalidate a single object only accept a single "
+                  "provided argument.\n"),
+                  ret, fini);
+    }
+
     if (idb == INVALIDATE_NONE && !values.user && !values.group &&
         !values.netgroup && !values.service && !values.map &&
         !values.ssh_host && !values.sudo_rule) {


### PR DESCRIPTION
Print informational message and exit when multiple arguments are
provided for single-argument options with sss_cache

Resolves:
https://fedorahosted.org/sssd/ticket/3180