### PR TITLE
Add DEBUG messages to the sssd-secrets responder

### DIFF
--- a/src/responder/secrets/providers.c
+++ b/src/responder/secrets/providers.c
@@ -180,6 +180,8 @@ static struct sec_http_status_format_table {
       "The requested resource already exists." },
     { 500, "Internal Server Error",
       "The server encountered an internal error." },
+    { 504, "Gateway timeout",
+      "No response from a proxy server." },
 };
 
 int sec_http_status_reply(TALLOC_CTX *mem_ctx, struct sec_data *reply,
@@ -348,6 +350,8 @@ enum sec_http_status_codes sec_errno_to_http_status(errno_t err)
         return STATUS_406;
     case EEXIST:
         return STATUS_409;
+    case ERR_SEC_NO_PROXY:
+        return STATUS_504;
     default:
         return STATUS_500;
     }

--- a/src/responder/secrets/proxy.c
+++ b/src/responder/secrets/proxy.c
@@ -613,7 +613,7 @@ static int proxy_http_req_state_destroy(void *data)
 static int proxy_wire_send(int fd, struct proxy_http_request *req)
 {
     struct sec_data data;
-    size_t ret;
+    int ret;
 
     data.data = req->data->data + req->written;
     data.length = req->data->length - req->written;
@@ -621,7 +621,7 @@ static int proxy_wire_send(int fd, struct proxy_http_request *req)
     ret = sec_send_data(fd, &data);
     if (ret != EOK && ret != EAGAIN) {
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "sec_send_data failed [%zu]: %s\n", ret, sss_strerror(ret));
+              "sec_send_data failed [%d]: %s\n", ret, sss_strerror(ret));
         return ret;
     }
 

--- a/src/responder/secrets/proxy.c
+++ b/src/responder/secrets/proxy.c
@@ -494,7 +494,7 @@ static void proxy_http_req_connect_step(struct tevent_req *req)
 
     if (!state->hostent->addr_list[state->hostidx]) {
         DEBUG(SSSDBG_CRIT_FAILURE, "No more addresses to try.\n");
-        ret = ENXIO;
+        ret = ERR_SEC_NO_PROXY;
         goto done;
     }
 

--- a/src/responder/secrets/secsrv_cmd.c
+++ b/src/responder/secrets/secsrv_cmd.c
@@ -304,7 +304,7 @@ static int sec_on_body(http_parser *parser,
     return 0;
 }
 
-static int sec_get_parsed_filed(TALLOC_CTX *mem_ctx, int field,
+static int sec_get_parsed_field(TALLOC_CTX *mem_ctx, int field,
                                 struct http_parser_url *parsed,
                                 char *source_buf,
                                 char **dest)
@@ -338,7 +338,7 @@ static int sec_on_message_complete(http_parser *parser)
     }
 
     if (parsed.field_set & (1 << UF_SCHEMA)) {
-        ret = sec_get_parsed_filed(req, UF_SCHEMA, &parsed,
+        ret = sec_get_parsed_field(req, UF_SCHEMA, &parsed,
                                    req->request_url,
                                    &req->parsed_url.schema);
         if (ret) {
@@ -350,7 +350,7 @@ static int sec_on_message_complete(http_parser *parser)
     }
 
     if (parsed.field_set & (1 << UF_HOST)) {
-        ret = sec_get_parsed_filed(req, UF_HOST, &parsed,
+        ret = sec_get_parsed_field(req, UF_HOST, &parsed,
                                    req->request_url,
                                    &req->parsed_url.host);
         if (ret) {
@@ -367,7 +367,7 @@ static int sec_on_message_complete(http_parser *parser)
     }
 
     if (parsed.field_set & (1 << UF_PATH)) {
-        ret = sec_get_parsed_filed(req, UF_PATH, &parsed,
+        ret = sec_get_parsed_field(req, UF_PATH, &parsed,
                                    req->request_url,
                                    &req->parsed_url.path);
         if (ret) {
@@ -379,7 +379,7 @@ static int sec_on_message_complete(http_parser *parser)
     }
 
     if (parsed.field_set & (1 << UF_QUERY)) {
-        ret = sec_get_parsed_filed(req, UF_QUERY, &parsed,
+        ret = sec_get_parsed_field(req, UF_QUERY, &parsed,
                                    req->request_url,
                                    &req->parsed_url.query);
         if (ret) {
@@ -391,7 +391,7 @@ static int sec_on_message_complete(http_parser *parser)
     }
 
     if (parsed.field_set & (1 << UF_FRAGMENT)) {
-        ret = sec_get_parsed_filed(req, UF_FRAGMENT, &parsed,
+        ret = sec_get_parsed_field(req, UF_FRAGMENT, &parsed,
                                    req->request_url,
                                    &req->parsed_url.fragment);
         if (ret) {
@@ -404,7 +404,7 @@ static int sec_on_message_complete(http_parser *parser)
     }
 
     if (parsed.field_set & (1 << UF_USERINFO)) {
-        ret = sec_get_parsed_filed(req, UF_USERINFO, &parsed,
+        ret = sec_get_parsed_field(req, UF_USERINFO, &parsed,
                                    req->request_url,
                                    &req->parsed_url.userinfo);
         if (ret) {

--- a/src/responder/secrets/secsrv_private.h
+++ b/src/responder/secrets/secsrv_private.h
@@ -47,6 +47,7 @@ enum sec_http_status_codes {
     STATUS_406,
     STATUS_409,
     STATUS_500,
+    STATUS_504,
 };
 
 struct sec_proto_ctx {

--- a/src/util/util_errors.c
+++ b/src/util/util_errors.c
@@ -99,6 +99,7 @@ struct err_string error_to_str[] = {
     { "The user is not handled by SSSD" }, /* ERR_NON_SSSD_USER */
     { "The internal name format cannot be parsed" }, /* ERR_WRONG_NAME_FORMAT */
     { "The maximum level of nested containers has been reached" }, /* ERR_SEC_INVALID_CONTAINERS_NEST_LEVEL */
+    { "No proxy server for secrets available"}, /* ERR_SEC_NO_PROXY */
     { "ERR_LAST" } /* ERR_LAST */
 };
 

--- a/src/util/util_errors.h
+++ b/src/util/util_errors.h
@@ -121,6 +121,7 @@ enum sssd_errors {
     ERR_NON_SSSD_USER,
     ERR_WRONG_NAME_FORMAT,
     ERR_SEC_INVALID_CONTAINERS_NEST_LEVEL,
+    ERR_SEC_NO_PROXY,
     ERR_LAST            /* ALWAYS LAST */
 };
 


### PR DESCRIPTION
This patchset decorates sssd-secrets with DEBUG messages so that errors are
easier to discover and by default (up to debug_level=3) the usual operations
don't emit any errors.

Also adds two trivial fixes that fix minor code-style issues.