### PR TITLE
IPA: Initialize has_changes boolean control value

### DIFF
--- a/src/providers/ipa/ipa_subdomains.c
+++ b/src/providers/ipa/ipa_subdomains.c
@@ -485,6 +485,11 @@ static errno_t ipa_subdomains_refresh(struct ipa_subdomains_ctx *ctx,
     memset(handled, 0, sizeof(bool) * count);
     h = 0;
 
+    if (changes == NULL) {
+        return EINVAL;
+    }
+    *changes = false;
+
     /* check existing subdomains */
     for (dom = get_next_domain(parent, SSS_GND_DESCEND);
          dom && IS_SUBDOMAIN(dom); /* if we get back to a parent, stop */
@@ -1087,7 +1092,7 @@ static void ipa_subdomains_slave_search_done(struct tevent_req *subreq)
     struct tevent_req *req;
     struct sysdb_attrs **reply;
     size_t reply_count;
-    bool has_changes;
+    bool has_changes = false;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);


### PR DESCRIPTION
without this patch, valgrind was reporting:
    ==30955== Conditional jump or move depends on uninitialised value(s)
    ==30955==    at 0xDBBACC3: ipa_subdomains_slave_search_done (ipa_subdomains.c:1111)
    ==30955==    by 0xE73B34D: sdap_search_bases_ex_done (sdap_ops.c:222)
    ==30955==    by 0xE6FFA98: sdap_get_generic_done (sdap_async.c:1872)
    ==30955==    by 0xE6FF4E2: generic_ext_search_handler (sdap_async.c:1689)
    ==30955==    by 0xE6FF840: sdap_get_and_parse_generic_done (sdap_async.c:1797)
    ==30955==    by 0xE6FEFB5: sdap_get_generic_op_finished (sdap_async.c:1579)
    ==30955==    by 0xE6FB1D2: sdap_process_message (sdap_async.c:353)
    ==30955==    by 0xE6FAD51: sdap_process_result (sdap_async.c:197)
    ==30955==    by 0xE6FAA14: sdap_ldap_next_result (sdap_async.c:145)
    ==30955==    by 0x8E157FF: tevent_common_loop_timer_delay (tevent_timed.c:341)
    ==30955==    by 0x8E16809: epoll_event_loop_once (tevent_epoll.c:911)
    ==30955==    by 0x8E14F09: std_event_loop_once (tevent_standard.c:114)
    ==30955==