### PR TITLE
RESPONDER: Enable sudoRule in case insen. domains (1.13)

### DIFF
--- a/src/db/sysdb_sudo.h
+++ b/src/db/sysdb_sudo.h
@@ -97,14 +97,15 @@ errno_t sysdb_sudo_filter_rules_by_time(TALLOC_CTX *mem_ctx,
                                         struct sysdb_attrs ***_rules);
 
 errno_t
-sysdb_get_sudo_filter(TALLOC_CTX *mem_ctx, const char *username,
-                      uid_t uid, char **groupnames, unsigned int flags,
-                      char **_filter);
+sysdb_get_sudo_filter(TALLOC_CTX *mem_ctx, const char *username, char **aliases,
+                      uid_t uid, char **groupnames, bool case_sensitive_domain,
+                      unsigned int flags, char **_filter);
 
 errno_t
 sysdb_get_sudo_user_info(TALLOC_CTX *mem_ctx,
                          struct sss_domain_info *domain,
                          const char *username, uid_t *_uid,
+                         char ***_aliases,
                          char ***groupnames);
 
 errno_t sysdb_sudo_set_last_full_refresh(struct sss_domain_info *domain,


### PR DESCRIPTION
This ptach is valid only for SSSD-1-13. It adds value 'ALL' to
sudoRule attribute "sudoUser". So if we have case insensitive domain
such sudo rule will be work for right users.

Resolves:
https://fedorahosted.org/sssd/ticket/3203

---

This is simple patch for solving the ticket.
Another solution is backport pbrezina patches what I didn't try yet.
If you prefer backport please tell me.
