### PR TITLE
TESTS: Remove a leftover debug message

### DIFF
--- a/src/tests/intg/test_secrets.py
+++ b/src/tests/intg/test_secrets.py
@@ -149,7 +149,6 @@ def test_crd_ops(setup_for_secrets, secrets_cli):
 
     with pytest.raises(HTTPError) as err507:
         cli.set_secret(str(MAX_SECRETS), sec_value)
-        print >>stderr,str(err507.value)
     assert str(err507.value).startswith("507")
 
 


### PR DESCRIPTION
The debug message was introduced when I was testing 65a38b8c9, but ended
up not removed before submitting the patch.

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>