### PR TITLE
MAN: Wrong defaults for AD provider

### DIFF
--- a/src/man/sssd-ldap.5.xml
+++ b/src/man/sssd-ldap.5.xml
@@ -267,7 +267,8 @@
                             user's login name.
                         </para>
                         <para>
-                            Default: uid
+                            Default: uid (rfc2307, rfc2307bis and IPA),
+                                     sAMAccountName (AD)
                         </para>
                     </listitem>
                 </varlistentry>
@@ -875,7 +876,8 @@
                             the group name.
                         </para>
                         <para>
-                            Default: cn
+                            Default: cn (rfc2307, rfc2307bis and IPA),
+                                     sAMAccountName (AD)
                         </para>
                     </listitem>
                 </varlistentry>


### PR DESCRIPTION
ldap_user_name and ldap_group_name have
different defalts then what the man page
states.

Resolves:
https://fedorahosted.org/sssd/ticket/3022