### PR TITLE
libwbclient-sssd: update interface to version 0.13

### DIFF
--- a/src/conf_macros.m4
+++ b/src/conf_macros.m4
@@ -727,10 +727,10 @@ AC_DEFUN([WITH_LIBWBCLIENT],
     if test x"$with_libwbclient" = xyes; then
         AC_DEFINE(BUILD_LIBWBCLIENT, 1, [whether to build SSSD implementation of libwbclient])
 
-        libwbclient_version="0.12"
+        libwbclient_version="0.13"
         AC_SUBST(libwbclient_version)
 
-        libwbclient_version_info="12:0:12"
+        libwbclient_version_info="13:0:13"
         AC_SUBST(libwbclient_version_info)
     fi
     AM_CONDITIONAL([BUILD_LIBWBCLIENT], [test x"$with_libwbclient" = xyes])

--- a/src/sss_client/libwbclient/wbc_ctx_sssd.c
+++ b/src/sss_client/libwbclient/wbc_ctx_sssd.c
@@ -167,6 +167,13 @@ wbcErr wbcCtxSidsToUnixIds(struct wbcContext *ctx,
     WBC_SSSD_NOT_IMPLEMENTED;
 }
 
+wbcErr wbcCtxUnixIdsToSids(struct wbcContext *ctx,
+                           const struct wbcUnixId *ids, uint32_t num_ids,
+                           struct wbcDomainSid *sids)
+{
+    WBC_SSSD_NOT_IMPLEMENTED;
+}
+
 wbcErr wbcCtxAllocateUid(struct wbcContext *ctx, uid_t *puid)
 {
     WBC_SSSD_NOT_IMPLEMENTED;

--- a/src/sss_client/libwbclient/wbc_idmap_sssd.c
+++ b/src/sss_client/libwbclient/wbc_idmap_sssd.c
@@ -202,3 +202,29 @@ wbcErr wbcSidsToUnixIds(const struct wbcDomainSid *sids, uint32_t num_sids,
 
     return WBC_ERR_SUCCESS;
 }
+
+wbcErr wbcUnixIdsToSids(const struct wbcUnixId *ids, uint32_t num_ids,
+                        struct wbcDomainSid *sids)
+{
+    size_t c;
+    wbcErr wbc_status;
+
+    for (c = 0; c < num_ids; c++) {
+        switch (ids[c].type) {
+        case WBC_ID_TYPE_UID:
+            wbc_status = wbcUidToSid(ids[c].id.uid, &sids[c]);
+            break;
+        case WBC_ID_TYPE_GID:
+            wbc_status = wbcGidToSid(ids[c].id.gid, &sids[c]);
+            break;
+        default:
+            wbc_status = WBC_ERR_INVALID_PARAM;
+        }
+
+        if (!WBC_ERROR_IS_OK(wbc_status)) {
+            sids[c] = (struct wbcDomainSid) {0};
+        };
+    }
+
+    return WBC_ERR_SUCCESS;
+}

--- a/src/sss_client/libwbclient/wbclient.exports
+++ b/src/sss_client/libwbclient/wbclient.exports
@@ -144,3 +144,9 @@ WBCLIENT_0.12 {
         wbcCtxPingDc;
         wbcCtxPingDc2;
 } WBCLIENT_0.11;
+
+WBCLIENT_0.13 {
+    global:
+        wbcUnixIdsToSids;
+        wbcCtxUnixIdsToSids;
+} WBCLIENT_0.12;

--- a/src/sss_client/libwbclient/wbclient_sssd.h
+++ b/src/sss_client/libwbclient/wbclient_sssd.h
@@ -73,9 +73,10 @@ const char *wbcErrorString(wbcErr error);
  *  0.10: Added wbcPingDc2()
  *  0.11: Extended wbcAuthenticateUserEx to provide PAC parsing
  *  0.12: Added wbcCtxCreate and friends
+ *  0.13: Added wbcCtxUnixIdsToSids and wbcUnixIdsToSids
  **/
 #define WBCLIENT_MAJOR_VERSION 0
-#define WBCLIENT_MINOR_VERSION 12
+#define WBCLIENT_MINOR_VERSION 13
 #define WBCLIENT_VENDOR_VERSION "Samba libwbclient"
 struct wbcLibraryDetails {
     uint16_t major_version;
@@ -1029,6 +1030,35 @@ wbcErr wbcCtxSidsToUnixIds(struct wbcContext *ctx,
  **/
 wbcErr wbcSidsToUnixIds(const struct wbcDomainSid *sids, uint32_t num_sids,
                         struct wbcUnixId *ids);
+
+/**
+ * @brief Convert a list of unix ids to sids
+ *
+ * @param *ctx        wbclient Context
+ * @param ids         Pointer to an array of UNIX IDs to convert
+ * @param num_ids     Number of UNIX IDs
+ * @param ids         Preallocated output array for translated SIDs
+ *
+ * @return #wbcErr
+ *
+ **/
+wbcErr wbcCtxUnixIdsToSids(struct wbcContext *ctx,
+                           const struct wbcUnixId *ids, uint32_t num_ids,
+                           struct wbcDomainSid *sids);
+
+/**
+ * @brief Convert a list of unix ids to sids
+ *
+ * @param ids         Pointer to an array of UNIX IDs to convert
+ * @param num_ids     Number of UNIX IDs
+ * @param ids         Preallocated output array for translated SIDs
+ *
+ * @return #wbcErr
+ *
+ **/
+wbcErr wbcUnixIdsToSids(const struct wbcUnixId *ids, uint32_t num_ids,
+                        struct wbcDomainSid *sids);
+
 
 /**
  * @brief Obtain a new uid from Winbind


### PR DESCRIPTION
This patch adds wbcCtxUnixIdsToSids() and wbcUnixIdsToSids() to SSSD's
libwbclient and implements the latter.

Resolves https://fedorahosted.org/sssd/ticket/3181