### PR TITLE
sss_client: Defer thread cancellation until completion of nss/pam operations

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -771,10 +771,6 @@ endif
 
 CLIENT_LIBS = $(LTLIBINTL)
 
-if HAVE_PTHREAD
-CLIENT_LIBS += -lpthread
-endif
-
 if WITH_JOURNALD
 SYSLOG_LIBS = $(JOURNALD_LIBS)
 endif


### PR DESCRIPTION
https://fedorahosted.org/sssd/ticket/3156

The client code is not cancellation-safe, an application which has cancelled an NSS operation
will experience subtle bugs, hence thread cancellation is deferred until completion of client
operations.
