### PR TITLE
BUILD: Fix build without /sbin/service installed on the build host

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -296,6 +296,9 @@ Requires: python3-sssdconfig = %{version}-%{release}
 Requires: python2-sss = %{version}-%{release}
 Requires: python2-sssdconfig = %{version}-%{release}
 %endif
+%if (0%{?use_systemd} == 0)
+Requires: /sbin/service
+%endif
 
 %description tools
 Provides userspace tools for manipulating users, groups, and nested groups in

--- a/src/external/service.m4
+++ b/src/external/service.m4
@@ -7,7 +7,7 @@ AC_DEFUN([CHECK_SERVICE_EXECUTABLE],
         AC_MSG_RESULT(yes)
       else
         AC_MSG_RESULT([no])
-        AC_MSG_ERROR([the service executable is not available])
+        AC_MSG_WARN([the service executable is not available])
       fi
     ]
 )

--- a/src/external/service.m4
+++ b/src/external/service.m4
@@ -1,5 +1,5 @@
 AC_DEFUN([CHECK_SERVICE_EXECUTABLE],
-    [ AC_PATH_PROG(SERVICE, service)
+    [ AC_PATH_PROG([SERVICE], [service], [], [/sbin:/usr/sbin])
       AC_MSG_CHECKING(for the executable \"service\")
       if test -x "$SERVICE"; then
         AC_DEFINE(HAVE_SERVICE, 1, [Whether the service command is available])

--- a/src/tools/sssctl/sssctl.c
+++ b/src/tools/sssctl/sssctl.c
@@ -128,7 +128,7 @@ static errno_t sssctl_manage_service(enum sssctl_svc_action action)
     case SSSCTL_SVC_RESTART:
         return sssctl_systemd_restart();
     }
-#elif HAVE_SERVICE
+#elif defined(HAVE_SERVICE)
     switch (action) {
     case SSSCTL_SVC_START:
         return sssctl_run_command(SERVICE_PATH" sssd start");


### PR DESCRIPTION
There were some issues in the sssctl-related patches that we pushed
recently. First, the build failed if no service binary was around, which
is wrong, we should just proceed and build without the sssctl functionality.

Second, we should make sure that on RHEL-6, /sbin/service is around during
both build and runtime.