### PR TITLE
sssctl: Flags for commadn initialization

### DIFF
--- a/src/tools/common/sss_tools.h
+++ b/src/tools/common/sss_tools.h
@@ -45,16 +45,22 @@ typedef errno_t
                 struct sss_tool_ctx *tool_ctx,
                 void *pvt);
 
-#define SSS_TOOL_COMMAND(cmd, msg, err, fn) {cmd, _(msg), err, fn}
-#define SSS_TOOL_COMMAND_NOMSG(cmd, err, fn) {cmd, NULL, err, fn}
-#define SSS_TOOL_DELIMITER(message) {"", _(message), 0, NULL}
-#define SSS_TOOL_LAST {NULL, NULL, 0, NULL}
+#define SSS_TOOL_COMMAND_FLAGS(cmd, msg, err, fn, flags) \
+    {cmd, _(msg), err, fn, flags}
+#define SSS_TOOL_COMMAND(cmd, msg, err, fn) \
+    {cmd, _(msg), err, fn, 0}
+#define SSS_TOOL_COMMAND_NOMSG(cmd, err, fn) {cmd, NULL, err, fn, 0}
+#define SSS_TOOL_DELIMITER(message) {"", _(message), 0, NULL, 0}
+#define SSS_TOOL_LAST {NULL, NULL, 0, NULL, 0}
+
+#define SSS_TOOL_FLAG_SKIP_CMD_INIT 0x01
 
 struct sss_route_cmd {
     const char *command;
     const char *description;
     errno_t handles_init_err;
     sss_route_fn fn;
+    int flags;
 };
 
 void sss_tool_usage(const char *tool_name,

--- a/src/tools/sssctl/sssctl.c
+++ b/src/tools/sssctl/sssctl.c
@@ -276,7 +276,7 @@ int main(int argc, const char **argv)
         SSS_TOOL_COMMAND("logs-fetch", "Archive SSSD log files in tarball", 0, sssctl_logs_fetch),
 #ifdef HAVE_LIBINI_CONFIG_V1_3
         SSS_TOOL_DELIMITER("Configuration files tools:"),
-        SSS_TOOL_COMMAND("config-check", "Perform static analysis of SSSD configuration", 0, sssctl_config_check),
+        SSS_TOOL_COMMAND_FLAGS("config-check", "Perform static analysis of SSSD configuration", 0, sssctl_config_check, SSS_TOOL_FLAG_SKIP_CMD_INIT),
 #endif
         SSS_TOOL_LAST
     };


### PR DESCRIPTION
Allow passing flags for command specific
initialization. Currently only one flag is
available to skip the confdb initialization
which is required to improce config-check command.

Resolves:
https://fedorahosted.org/sssd/ticket/3209