### PR TITLE
[RFC] Use GNULIB's compiler warning code

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -103,12 +103,7 @@ if WANT_AUX_INFO
     AM_CFLAGS += -aux-info $@.X
 endif
 if HAVE_GCC
-    AM_CFLAGS += -Wall -Wshadow -Wstrict-prototypes -Wpointer-arith \
-                 -Wcast-qual -Wcast-align -Wwrite-strings -Wundef \
-                 -Werror-implicit-function-declaration -Winit-self \
-                 -Wmissing-include-dirs \
-                 -fno-strict-aliasing \
-                 -std=gnu99
+    AM_CFLAGS += $(WARN_CFLAGS)
 endif
 
 pkgconfig_DATA =

--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,11 @@ m4_ifdef([AC_USE_SYSTEM_EXTENSIONS],
     [AC_USE_SYSTEM_EXTENSIONS],
     [AC_GNU_SOURCE])
 
+m4_include([src/warnings.m4])
+m4_include([src/manywarnings.m4])
+m4_include([src/sssd-compile-warnings.m4])
+SSSD_COMPILE_WARNINGS
+
 CFLAGS="$CFLAGS -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE"
 
 

--- a/contrib/ci/configure.sh
+++ b/contrib/ci/configure.sh
@@ -38,6 +38,7 @@ if [[ "$DISTRO_BRANCH" == -redhat-redhatenterprise*-6.*- ||
         "--disable-cifs-idmap-plugin"
         "--with-syslog=syslog"
         "--without-python3-bindings"
+        "--enable-werror=no"
     )
 fi
 

--- a/contrib/ci/run
+++ b/contrib/ci/run
@@ -28,7 +28,7 @@ export LC_ALL=C
 . misc.sh
 
 declare -r DEBUG_CFLAGS="-g3 -O2"
-declare -r COVERAGE_CFLAGS="-g3 -O0 --coverage"
+declare -r COVERAGE_CFLAGS="-g3 --coverage -O0 -Wp,-U_FORTIFY_SOURCE"
 declare -r ARCH=`uname -m`
 declare -r CPU_NUM=`getconf _NPROCESSORS_ONLN`
 declare -r TITLE_WIDTH=24

--- a/src/lib/sifp/sss_sifp_parser.c
+++ b/src/lib/sifp/sss_sifp_parser.c
@@ -283,7 +283,8 @@ sss_sifp_parse_basic(sss_sifp_ctx *ctx,
                     uint64_t, uint64_t, uint64, done);
         break;
     case DBUS_TYPE_STRING:
-    case DBUS_TYPE_OBJECT_PATH: ;
+    case DBUS_TYPE_OBJECT_PATH:
+    {
         const char *val = NULL;
 
         dbus_message_iter_get_basic(iter, &val);
@@ -306,6 +307,7 @@ sss_sifp_parse_basic(sss_sifp_ctx *ctx,
 
         ret = SSS_SIFP_OK;
         break;
+    }
     default:
         ret = SSS_SIFP_INVALID_ARGUMENT;
         break;

--- a/src/manywarnings.m4
+++ b/src/manywarnings.m4
@@ -1,0 +1,274 @@
+# manywarnings.m4 serial 8
+dnl Copyright (C) 2008-2016 Free Software Foundation, Inc.
+dnl This file is free software; the Free Software Foundation
+dnl gives unlimited permission to copy and/or distribute it,
+dnl with or without modifications, as long as this notice is preserved.
+
+dnl From Simon Josefsson
+
+# gl_MANYWARN_COMPLEMENT(OUTVAR, LISTVAR, REMOVEVAR)
+# --------------------------------------------------
+# Copy LISTVAR to OUTVAR except for the entries in REMOVEVAR.
+# Elements separated by whitespace.  In set logic terms, the function
+# does OUTVAR = LISTVAR \ REMOVEVAR.
+AC_DEFUN([gl_MANYWARN_COMPLEMENT],
+[
+  gl_warn_set=
+  set x $2; shift
+  for gl_warn_item
+  do
+    case " $3 " in
+      *" $gl_warn_item "*)
+        ;;
+      *)
+        gl_warn_set="$gl_warn_set $gl_warn_item"
+        ;;
+    esac
+  done
+  $1=$gl_warn_set
+])
+
+# gl_MANYWARN_ALL_GCC(VARIABLE)
+# -----------------------------
+# Add all documented GCC warning parameters to variable VARIABLE.
+# Note that you need to test them using gl_WARN_ADD if you want to
+# make sure your gcc understands it.
+AC_DEFUN([gl_MANYWARN_ALL_GCC],
+[
+  dnl First, check for some issues that only occur when combining multiple
+  dnl gcc warning categories.
+  AC_REQUIRE([AC_PROG_CC])
+  if test -n "$GCC"; then
+
+    dnl Check if -W -Werror -Wno-missing-field-initializers is supported
+    dnl with the current $CC $CFLAGS $CPPFLAGS.
+    AC_MSG_CHECKING([whether -Wno-missing-field-initializers is supported])
+    AC_CACHE_VAL([gl_cv_cc_nomfi_supported], [
+      gl_save_CFLAGS="$CFLAGS"
+      CFLAGS="$CFLAGS -W -Werror -Wno-missing-field-initializers"
+      AC_COMPILE_IFELSE(
+        [AC_LANG_PROGRAM([[]], [[]])],
+        [gl_cv_cc_nomfi_supported=yes],
+        [gl_cv_cc_nomfi_supported=no])
+      CFLAGS="$gl_save_CFLAGS"])
+    AC_MSG_RESULT([$gl_cv_cc_nomfi_supported])
+
+    if test "$gl_cv_cc_nomfi_supported" = yes; then
+      dnl Now check whether -Wno-missing-field-initializers is needed
+      dnl for the { 0, } construct.
+      AC_MSG_CHECKING([whether -Wno-missing-field-initializers is needed])
+      AC_CACHE_VAL([gl_cv_cc_nomfi_needed], [
+        gl_save_CFLAGS="$CFLAGS"
+        CFLAGS="$CFLAGS -W -Werror"
+        AC_COMPILE_IFELSE(
+          [AC_LANG_PROGRAM(
+             [[void f (void)
+               {
+                 typedef struct { int a; int b; } s_t;
+                 s_t s1 = { 0, };
+               }
+             ]],
+             [[]])],
+          [gl_cv_cc_nomfi_needed=no],
+          [gl_cv_cc_nomfi_needed=yes])
+        CFLAGS="$gl_save_CFLAGS"
+      ])
+      AC_MSG_RESULT([$gl_cv_cc_nomfi_needed])
+    fi
+
+    dnl Next, check if -Werror -Wuninitialized is useful with the
+    dnl user's choice of $CFLAGS; some versions of gcc warn that it
+    dnl has no effect if -O is not also used
+    AC_MSG_CHECKING([whether -Wuninitialized is supported])
+    AC_CACHE_VAL([gl_cv_cc_uninitialized_supported], [
+      gl_save_CFLAGS="$CFLAGS"
+      CFLAGS="$CFLAGS -Werror -Wuninitialized"
+      AC_COMPILE_IFELSE(
+        [AC_LANG_PROGRAM([[]], [[]])],
+        [gl_cv_cc_uninitialized_supported=yes],
+        [gl_cv_cc_uninitialized_supported=no])
+      CFLAGS="$gl_save_CFLAGS"])
+    AC_MSG_RESULT([$gl_cv_cc_uninitialized_supported])
+
+  fi
+
+  # List all gcc warning categories.
+  # To compare this list to your installed GCC's, run this Bash command:
+  #
+  # comm -3 \
+  #  <(sed -n 's/^  *\(-[^ ]*\) .*/\1/p' manywarnings.m4 | sort) \
+  #  <(gcc --help=warnings | sed -n 's/^  \(-[^ ]*\) .*/\1/p' | sort |
+  #      grep -v -x -f <(
+  #         awk '/^[^#]/ {print $1}' ../build-aux/gcc-warning.spec))
+
+  gl_manywarn_set=
+  for gl_manywarn_item in \
+    -W \
+    -Wabi \
+    -Waddress \
+    -Waggressive-loop-optimizations \
+    -Wall \
+    -Wattributes \
+    -Wbad-function-cast \
+    -Wbool-compare \
+    -Wbuiltin-macro-redefined \
+    -Wcast-align \
+    -Wchar-subscripts \
+    -Wchkp \
+    -Wclobbered \
+    -Wcomment \
+    -Wcomments \
+    -Wcoverage-mismatch \
+    -Wcpp \
+    -Wdate-time \
+    -Wdeprecated \
+    -Wdeprecated-declarations \
+    -Wdesignated-init \
+    -Wdisabled-optimization \
+    -Wdiscarded-array-qualifiers \
+    -Wdiscarded-qualifiers \
+    -Wdiv-by-zero \
+    -Wdouble-promotion \
+    -Wduplicated-cond \
+    -Wempty-body \
+    -Wendif-labels \
+    -Wenum-compare \
+    -Wextra \
+    -Wformat-contains-nul \
+    -Wformat-extra-args \
+    -Wformat-nonliteral \
+    -Wformat-security \
+    -Wformat-signedness \
+    -Wformat-y2k \
+    -Wformat-zero-length \
+    -Wframe-address \
+    -Wfree-nonheap-object \
+    -Whsa \
+    -Wignored-attributes \
+    -Wignored-qualifiers \
+    -Wimplicit \
+    -Wimplicit-function-declaration \
+    -Wimplicit-int \
+    -Wincompatible-pointer-types \
+    -Winit-self \
+    -Winline \
+    -Wint-conversion \
+    -Wint-to-pointer-cast \
+    -Winvalid-memory-model \
+    -Winvalid-pch \
+    -Wjump-misses-init \
+    -Wlogical-not-parentheses \
+    -Wlogical-op \
+    -Wmain \
+    -Wmaybe-uninitialized \
+    -Wmemset-transposed-args \
+    -Wmisleading-indentation \
+    -Wmissing-braces \
+    -Wmissing-declarations \
+    -Wmissing-field-initializers \
+    -Wmissing-include-dirs \
+    -Wmissing-parameter-type \
+    -Wmissing-prototypes \
+    -Wmultichar \
+    -Wnarrowing \
+    -Wnested-externs \
+    -Wnonnull \
+    -Wnonnull-compare \
+    -Wnull-dereference \
+    -Wodr \
+    -Wold-style-declaration \
+    -Wold-style-definition \
+    -Wopenmp-simd \
+    -Woverflow \
+    -Woverlength-strings \
+    -Woverride-init \
+    -Wpacked \
+    -Wpacked-bitfield-compat \
+    -Wparentheses \
+    -Wpointer-arith \
+    -Wpointer-sign \
+    -Wpointer-to-int-cast \
+    -Wpragmas \
+    -Wreturn-local-addr \
+    -Wreturn-type \
+    -Wscalar-storage-order \
+    -Wsequence-point \
+    -Wshadow \
+    -Wshift-count-negative \
+    -Wshift-count-overflow \
+    -Wshift-negative-value \
+    -Wsizeof-array-argument \
+    -Wsizeof-pointer-memaccess \
+    -Wstack-protector \
+    -Wstrict-aliasing \
+    -Wstrict-overflow \
+    -Wstrict-prototypes \
+    -Wsuggest-attribute=const \
+    -Wsuggest-attribute=format \
+    -Wsuggest-attribute=noreturn \
+    -Wsuggest-attribute=pure \
+    -Wsuggest-final-methods \
+    -Wsuggest-final-types \
+    -Wswitch \
+    -Wswitch-bool \
+    -Wswitch-default \
+    -Wsync-nand \
+    -Wsystem-headers \
+    -Wtautological-compare \
+    -Wtrampolines \
+    -Wtrigraphs \
+    -Wtype-limits \
+    -Wuninitialized \
+    -Wunknown-pragmas \
+    -Wunsafe-loop-optimizations \
+    -Wunused \
+    -Wunused-but-set-parameter \
+    -Wunused-but-set-variable \
+    -Wunused-function \
+    -Wunused-label \
+    -Wunused-local-typedefs \
+    -Wunused-macros \
+    -Wunused-parameter \
+    -Wunused-result \
+    -Wunused-value \
+    -Wunused-variable \
+    -Wvarargs \
+    -Wvariadic-macros \
+    -Wvector-operation-performance \
+    -Wvla \
+    -Wvolatile-register-var \
+    -Wwrite-strings \
+    \
+    ; do
+    gl_manywarn_set="$gl_manywarn_set $gl_manywarn_item"
+  done
+
+  # gcc --help=warnings outputs an unusual form for these options; list
+  # them here so that the above 'comm' command doesn't report a false match.
+  gl_manywarn_set="$gl_manywarn_set -Warray-bounds=2"
+  gl_manywarn_set="$gl_manywarn_set -Wnormalized=nfc"
+  gl_manywarn_set="$gl_manywarn_set -Wshift-overflow=2"
+  gl_manywarn_set="$gl_manywarn_set -Wunused-const-variable=2"
+
+  # These are needed for older GCC versions.
+  if test -n "$GCC"; then
+    case `($CC --version) 2>/dev/null` in
+      'gcc (GCC) '[[0-3]].* | \
+      'gcc (GCC) '4.[[0-7]].*)
+        gl_manywarn_set="$gl_manywarn_set -fdiagnostics-show-option"
+        gl_manywarn_set="$gl_manywarn_set -funit-at-a-time"
+          ;;
+    esac
+  fi
+
+  # Disable specific options as needed.
+  if test "$gl_cv_cc_nomfi_needed" = yes; then
+    gl_manywarn_set="$gl_manywarn_set -Wno-missing-field-initializers"
+  fi
+
+  if test "$gl_cv_cc_uninitialized_supported" = no; then
+    gl_manywarn_set="$gl_manywarn_set -Wno-uninitialized"
+  fi
+
+  $1=$gl_manywarn_set
+])

--- a/src/resolv/async_resolv.c
+++ b/src/resolv/async_resolv.c
@@ -2247,7 +2247,9 @@ static int reply_weight_rearrange(int len,
             new_end = r;
         }
     }
-    new_end->next = NULL;
+    if (new_end) {
+        new_end->next = NULL;
+    }
 
     /* return the rearranged list */
     *start = new_start;

--- a/src/responder/nss/nss_iface.c
+++ b/src/responder/nss/nss_iface.c
@@ -32,7 +32,7 @@ static struct sbus_iface_map iface_map[] = {
     { NULL, NULL }
 };
 
-struct sbus_iface_map *nss_get_sbus_interface()
+struct sbus_iface_map *nss_get_sbus_interface(void)
 {
     return iface_map;
 }

--- a/src/sssd-compile-warnings.m4
+++ b/src/sssd-compile-warnings.m4
@@ -1,0 +1,99 @@
+dnl
+dnl Enable all known GCC compiler warnings, except for those
+dnl we can't yet cope with
+dnl
+AC_DEFUN([SSSD_COMPILE_WARNINGS],[
+    dnl ******************************
+    dnl More compiler warnings
+    dnl ******************************
+
+    AC_ARG_ENABLE([werror],
+                  AS_HELP_STRING([--enable-werror], [Use -Werror (if supported)]),
+                  [set_werror="$enableval"],
+                  [if test -d $srcdir/.git; then
+                     is_git_version=true
+                     set_werror=yes
+                   else
+                     set_werror=no
+                   fi])
+
+    # List of warnings that are not relevant/wanted
+
+    dontwarn=$1
+
+    # In case these warnings are enabled we will break the build on every single
+    # system used by our CI
+    dontwarn="$dontwarn -Wcpp"
+    dontwarn="$dontwarn -Winline"
+    dontwarn="$dontwarn -Wsystem-headers"
+
+    # We have no intention to fix these warnings
+
+    # If we enable this warning, complitaion will break on RHEL6
+    dontwarn="$dontwarn -Woverlength-strings"
+
+    # Enable this again as soon as GCC is updated on RHEL6
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=34114
+    dontwarn="$dontwarn -Wunsafe-loop-optimizations"
+
+    # These are the warnings that, currently, we cannot cope with
+    dontwarn="$dontwarn -Warray-bounds"
+    dontwarn="$dontwarn -Wbad-function-cast"
+    dontwarn="$dontwarn -Wformat-nonliteral"
+    dontwarn="$dontwarn -Wformat-signedness"
+    dontwarn="$dontwarn -Wformat-y2k"
+    dontwarn="$dontwarn -Wlogical-op"
+    dontwarn="$dontwarn -Wmissing-prototypes"
+    dontwarn="$dontwarn -Wmissing-declarations"
+    dontwarn="$dontwarn -Wpacked"
+    dontwarn="$dontwarn -Wsign-compare"
+    dontwarn="$dontwarn -Wstrict-overflow"
+    dontwarn="$dontwarn -Wsuggest-attribute=pure"
+    dontwarn="$dontwarn -Wsuggest-attribute=const"
+    dontwarn="$dontwarn -Wsuggest-attribute=format"
+    dontwarn="$dontwarn -Wsuggest-attribute=noreturn"
+    dontwarn="$dontwarn -Wswitch-default"
+    dontwarn="$dontwarn -Wunused-parameter"
+    dontwarn="$dontwarn -Wunused-macros"
+    dontwarn="$dontwarn -Wvla"
+
+    # Get all possible GCC warnings
+    gl_MANYWARN_ALL_GCC([maybewarn])
+
+    # Remove the ones we don't want, blacklisted earlier
+    gl_MANYWARN_COMPLEMENT([wantwarn], [$maybewarn], [$dontwarn])
+
+    # Check for $CC support of each warning
+    for w in $wantwarn; do
+      gl_WARN_ADD([$w])
+    done
+
+    # GNULIB uses '-W' (aka -Wextra) which includes a bunch of stuff.
+    # Unfortunately, this means you can't simply use '-Wsign-compare'
+    # with gl_MANYWARN_COMPLEMENT
+    # So we have -W enabled, and then have to explicitly turn off ...
+    gl_WARN_ADD([-Wno-array-bounds])
+    gl_WARN_ADD([-Wno-sign-compare])
+    gl_WARN_ADD([-Wno-unused-parameter])
+
+    # Use improved glibc headers
+    AH_VERBATIM([FORTIFY_SOURCE],
+    [/* Enable compile-time and run-time bounds-checking, and some warnings,
+        without upsetting newer glibc. */
+     #if !defined _FORTIFY_SOURCE && defined __OPTIMIZE__ && __OPTIMIZE__
+     # define _FORTIFY_SOURCE 2
+     #endif
+    ])
+
+    # Extra special flags
+    gl_WARN_ADD([-fno-strict-aliasing])
+    gl_WARN_ADD([-std=gnu99])
+    gl_WARN_ADD([-Werror-implicit-declaration])
+
+    if test "$set_werror" = "yes"
+    then
+      gl_WARN_ADD([-Werror])
+    fi
+
+    AC_SUBST([WARN_CFLAGS])
+])

--- a/src/tests/krb5_child-test.c
+++ b/src/tests/krb5_child-test.c
@@ -210,8 +210,18 @@ create_dummy_req(TALLOC_CTX *mem_ctx, const char *user,
 
     /* The Kerberos context */
     kr->krb5_ctx = create_dummy_krb5_ctx(kr, realm);
+    if (!kr->krb5_ctx) {
+        DEBUG(SSSDBG_FATAL_FAILURE,
+              "Failed to create dummy krb5_ctx\n");
+        goto fail;
+    }
     /* PAM Data structure */
     kr->pd = create_dummy_pam_data(kr, user, password);
+    if (!kr->pd) {
+        DEBUG(SSSDBG_FATAL_FAILURE,
+              "Failed to create dummy pam_data");
+        goto fail;
+    }
 
     ret = krb5_get_simple_upn(kr, kr->krb5_ctx, NULL, kr->pd->user, NULL,
                               &kr->upn);

--- a/src/tests/sbus_codegen_tests.c
+++ b/src/tests/sbus_codegen_tests.c
@@ -115,15 +115,15 @@ END_TEST
 
 START_TEST(test_signals)
 {
-    const struct sbus_signal_meta *signal;
+    const struct sbus_signal_meta *sig;
     const struct sbus_arg_meta *arg;
 
-    signal = sbus_meta_find_signal(&com_planetexpress_Ship_meta, "BecameSentient");
-    ck_assert(signal != NULL);
-    ck_assert_str_eq(signal->name, "BecameSentient");
-    ck_assert(signal->args != NULL);
+    sig = sbus_meta_find_signal(&com_planetexpress_Ship_meta, "BecameSentient");
+    ck_assert(sig != NULL);
+    ck_assert_str_eq(sig->name, "BecameSentient");
+    ck_assert(sig->args != NULL);
 
-    arg = find_arg(signal->args, "gender");
+    arg = find_arg(sig->args, "gender");
     ck_assert(arg != NULL);
     ck_assert_str_eq(arg->name, "gender");
     ck_assert_str_eq(arg->type, "s");

--- a/src/tools/sssctl/sssctl_cache.c
+++ b/src/tools/sssctl/sssctl_cache.c
@@ -31,10 +31,10 @@
 #define NOT_FOUND_MSG(obj) _(obj " %s is not present in cache.\n")
 
 #define SSSCTL_CACHE_NAME   {_("Name"), SYSDB_NAME, get_attr_name}
-#define SSSCTL_CACHE_CREATE {_("Cache entry creation date"), SYSDB_CREATE_TIME, attr_time}
-#define SSSCTL_CACHE_UPDATE {_("Cache entry last update time"), SYSDB_LAST_UPDATE, attr_time}
-#define SSSCTL_CACHE_EXPIRE {_("Cache entry expiration time"), SYSDB_CACHE_EXPIRE, attr_expire}
-#define SSSCTL_CACHE_IFP    {_("Cached in InfoPipe"), SYSDB_IFP_CACHED, attr_yesno}
+#define SSSCTL_CACHE_CREATE {_("Cache entry creation date"), SYSDB_CREATE_TIME, get_attr_time}
+#define SSSCTL_CACHE_UPDATE {_("Cache entry last update time"), SYSDB_LAST_UPDATE, get_attr_time}
+#define SSSCTL_CACHE_EXPIRE {_("Cache entry expiration time"), SYSDB_CACHE_EXPIRE, get_attr_expire}
+#define SSSCTL_CACHE_IFP    {_("Cached in InfoPipe"), SYSDB_IFP_CACHED, get_attr_yesno}
 #define SSSCTL_CACHE_NULL   {NULL, NULL, NULL}
 
 enum cache_object {
@@ -123,11 +123,11 @@ static errno_t get_attr_name(TALLOC_CTX *mem_ctx,
     return EOK;
 }
 
-static errno_t attr_time(TALLOC_CTX *mem_ctx,
-                         struct sysdb_attrs *entry,
-                         struct sss_domain_info *dom,
-                         const char *attr,
-                         const char **_value)
+static errno_t get_attr_time(TALLOC_CTX *mem_ctx,
+                             struct sysdb_attrs *entry,
+                             struct sss_domain_info *dom,
+                             const char *attr,
+                             const char **_value)
 {
     uint32_t value;
     errno_t ret;
@@ -140,11 +140,11 @@ static errno_t attr_time(TALLOC_CTX *mem_ctx,
     return time_to_string(mem_ctx, value, _value);
 }
 
-static errno_t attr_expire(TALLOC_CTX *mem_ctx,
-                           struct sysdb_attrs *entry,
-                           struct sss_domain_info *dom,
-                           const char *attr,
-                           const char **_value)
+static errno_t get_attr_expire(TALLOC_CTX *mem_ctx,
+                               struct sysdb_attrs *entry,
+                               struct sss_domain_info *dom,
+                               const char *attr,
+                               const char **_value)
 {
     uint32_t value;
     errno_t ret;
@@ -187,11 +187,11 @@ static errno_t attr_initgr(TALLOC_CTX *mem_ctx,
     return time_to_string(mem_ctx, value, _value);
 }
 
-static errno_t attr_yesno(TALLOC_CTX *mem_ctx,
-                          struct sysdb_attrs *entry,
-                          struct sss_domain_info *dom,
-                          const char *attr,
-                          const char **_value)
+static errno_t get_attr_yesno(TALLOC_CTX *mem_ctx,
+                              struct sysdb_attrs *entry,
+                              struct sss_domain_info *dom,
+                              const char *attr,
+                              const char **_value)
 {
     errno_t ret;
     bool val;

--- a/src/tools/sssctl/sssctl_cache.c
+++ b/src/tools/sssctl/sssctl_cache.c
@@ -30,7 +30,7 @@
 
 #define NOT_FOUND_MSG(obj) _(obj " %s is not present in cache.\n")
 
-#define SSSCTL_CACHE_NAME   {_("Name"), SYSDB_NAME, attr_name}
+#define SSSCTL_CACHE_NAME   {_("Name"), SYSDB_NAME, get_attr_name}
 #define SSSCTL_CACHE_CREATE {_("Cache entry creation date"), SYSDB_CREATE_TIME, attr_time}
 #define SSSCTL_CACHE_UPDATE {_("Cache entry last update time"), SYSDB_LAST_UPDATE, attr_time}
 #define SSSCTL_CACHE_EXPIRE {_("Cache entry expiration time"), SYSDB_CACHE_EXPIRE, attr_expire}
@@ -87,11 +87,11 @@ static errno_t time_to_string(TALLOC_CTX *mem_ctx,
     return EOK;
 }
 
-static errno_t attr_name(TALLOC_CTX *mem_ctx,
-                           struct sysdb_attrs *entry,
-                           struct sss_domain_info *dom,
-                           const char *attr,
-                           const char **_value)
+static errno_t get_attr_name(TALLOC_CTX *mem_ctx,
+                             struct sysdb_attrs *entry,
+                             struct sss_domain_info *dom,
+                             const char *attr,
+                             const char **_value)
 {
     errno_t ret;
     const char *orig_name;

--- a/src/tools/tools_util.c
+++ b/src/tools/tools_util.c
@@ -73,18 +73,17 @@ static int setup_db(struct tools_ctx *ctx)
 void usage(poptContext pc, const char *error)
 {
     size_t lentmp;
-    char nl[2] = "";
 
     poptPrintUsage(pc, stderr, 0);
 
     if (error) {
         lentmp = strlen(error);
         if ((lentmp > 0) && (error[lentmp - 1] != '\n')) {
-            nl[0]='\n';
-            nl[1]='\0';
+            fprintf(stderr, "%s\n", error);
+            return;
         }
 
-        fprintf(stderr, "%s%s", error, nl);
+        fprintf(stderr, "%s", error);
     }
 }
 

--- a/src/warnings.m4
+++ b/src/warnings.m4
@@ -1,0 +1,79 @@
+# warnings.m4 serial 11
+dnl Copyright (C) 2008-2016 Free Software Foundation, Inc.
+dnl This file is free software; the Free Software Foundation
+dnl gives unlimited permission to copy and/or distribute it,
+dnl with or without modifications, as long as this notice is preserved.
+
+dnl From Simon Josefsson
+
+# gl_AS_VAR_APPEND(VAR, VALUE)
+# ----------------------------
+# Provide the functionality of AS_VAR_APPEND if Autoconf does not have it.
+m4_ifdef([AS_VAR_APPEND],
+[m4_copy([AS_VAR_APPEND], [gl_AS_VAR_APPEND])],
+[m4_define([gl_AS_VAR_APPEND],
+[AS_VAR_SET([$1], [AS_VAR_GET([$1])$2])])])
+
+
+# gl_COMPILER_OPTION_IF(OPTION, [IF-SUPPORTED], [IF-NOT-SUPPORTED],
+#                       [PROGRAM = AC_LANG_PROGRAM()])
+# -----------------------------------------------------------------
+# Check if the compiler supports OPTION when compiling PROGRAM.
+#
+# FIXME: gl_Warn must be used unquoted until we can assume Autoconf
+# 2.64 or newer.
+AC_DEFUN([gl_COMPILER_OPTION_IF],
+[AS_VAR_PUSHDEF([gl_Warn], [gl_cv_warn_[]_AC_LANG_ABBREV[]_$1])dnl
+AS_VAR_PUSHDEF([gl_Flags], [_AC_LANG_PREFIX[]FLAGS])dnl
+AS_LITERAL_IF([$1],
+  [m4_pushdef([gl_Positive], m4_bpatsubst([$1], [^-Wno-], [-W]))],
+  [gl_positive="$1"
+case $gl_positive in
+  -Wno-*) gl_positive=-W`expr "X$gl_positive" : 'X-Wno-\(.*\)'` ;;
+esac
+m4_pushdef([gl_Positive], [$gl_positive])])dnl
+AC_CACHE_CHECK([whether _AC_LANG compiler handles $1], m4_defn([gl_Warn]), [
+  gl_save_compiler_FLAGS="$gl_Flags"
+  gl_AS_VAR_APPEND(m4_defn([gl_Flags]),
+    [" $gl_unknown_warnings_are_errors ]m4_defn([gl_Positive])["])
+  AC_LINK_IFELSE([m4_default([$4], [AC_LANG_PROGRAM([])])],
+                 [AS_VAR_SET(gl_Warn, [yes])],
+                 [AS_VAR_SET(gl_Warn, [no])])
+  gl_Flags="$gl_save_compiler_FLAGS"
+])
+AS_VAR_IF(gl_Warn, [yes], [$2], [$3])
+m4_popdef([gl_Positive])dnl
+AS_VAR_POPDEF([gl_Flags])dnl
+AS_VAR_POPDEF([gl_Warn])dnl
+])
+
+# gl_UNKNOWN_WARNINGS_ARE_ERRORS
+# ------------------------------
+# Clang doesn't complain about unknown warning options unless one also
+# specifies -Wunknown-warning-option -Werror.  Detect this.
+AC_DEFUN([gl_UNKNOWN_WARNINGS_ARE_ERRORS],
+[gl_COMPILER_OPTION_IF([-Werror -Wunknown-warning-option],
+   [gl_unknown_warnings_are_errors='-Wunknown-warning-option -Werror'],
+   [gl_unknown_warnings_are_errors=])])
+
+# gl_WARN_ADD(OPTION, [VARIABLE = WARN_CFLAGS],
+#             [PROGRAM = AC_LANG_PROGRAM()])
+# ---------------------------------------------
+# Adds parameter to WARN_CFLAGS if the compiler supports it when
+# compiling PROGRAM.  For example, gl_WARN_ADD([-Wparentheses]).
+#
+# If VARIABLE is a variable name, AC_SUBST it.
+AC_DEFUN([gl_WARN_ADD],
+[AC_REQUIRE([gl_UNKNOWN_WARNINGS_ARE_ERRORS])
+gl_COMPILER_OPTION_IF([$1],
+  [gl_AS_VAR_APPEND(m4_if([$2], [], [[WARN_CFLAGS]], [[$2]]), [" $1"])],
+  [],
+  [$3])
+m4_ifval([$2],
+         [AS_LITERAL_IF([$2], [AC_SUBST([$2])])],
+         [AC_SUBST([WARN_CFLAGS])])dnl
+])
+
+# Local Variables:
+# mode: autoconf
+# End:


### PR DESCRIPTION
This patch series was sent to the sssd-devel and some discussions
already happened there[0](https://lists.fedorahosted.org/archives/list/sssd-devel@lists.fedorahosted.org/thread/CTGR5CYV2PT3PLFLIRBCRTJP5ZW2XBMO/#CTGR5CYV2PT3PLFLIRBCRTJP5ZW2XBMO). I've decided to open the PR because there
are some few patches that can be pushed even if we decide to not use
the "many warnings" patches.

Let's keep track of those patches (and discussions related to them) in
the github, in this way we can avoid them to get lost. :-)

Best Regards,

Changes:

683f72d (Fabiano Fidêncio, 10 weeks ago)
   BUILD: Make use of GNULIB's compiler warning code

   As GNULIB has the 'manywarnings' module, which basically turns on every GCC
   warning, let's make use of it. We can easily blacklist the warnings we
   cannot cope with, but the main goal should be to have enabled every
   possible GCC warning.

   When new GCC warnings are created the 'manywarnings' file can be refreshed
   from upstream GNULIB.

   Signed-off-by: Fabiano Fidêncio fidencio@redhat.com

f59828a (Fabiano Fidêncio, 5 days ago)
   NSS: Fix "old-style-definition" warning caught by GCC

   Signed-off-by: Fabiano Fidêncio fidencio@redhat.com

f22aff7 (Fabiano Fidêncio, 5 days ago)
   SIFP: Fix a "jump-misses-init" warning caught by GCC

   Signed-off-by: Fabiano Fidêncio fidencio@redhat.com

58609d3 (Fabiano Fidêncio, 5 days ago)
   RESOLV: Fix a "-Werror=null-dereference" caught by GCC

   Signed-off-by: Fabiano Fidêncio fidencio@redhat.com

bd1d7fd (Fabiano Fidêncio, 5 days ago)
   RESOLV: Simplify reply_weight_rearrange() a little bit

   Signed-off-by: Fabiano Fidêncio fidencio@redhat.com
