### PR TITLE
CI: Remove dlopen-test from valgrind blacklist

### DIFF
--- a/contrib/ci/run
+++ b/contrib/ci/run
@@ -187,8 +187,8 @@ function build_debug()
 {
     # Extended glob pattern matching tests to run under Valgrind.
     # NOTE: The particular pattern below is inverted
-    declare -r valgrind_test_pattern="\
-        !(*.py|*/dlopen-tests|*/whitespace_test|*/double_semicolon_test)"
+    declare valgrind_test_pattern="!(*.py|*/whitespace_test|"
+    declare -r valgrind_test_pattern+="*/double_semicolon_test)"
     export CFLAGS="$DEBUG_CFLAGS"
     declare test_dir
     declare test_dir_distcheck


### PR DESCRIPTION
Dlopen test was added to blacklist due to following reason:
> Disable running dlopen-tests under Valgrind as their use of dlclose
> makes Valgrind drop symbols and produce meaningless backtraces, which
> cannot be matched with specific suppressions.

It's true that dlclose makes meaningless backtraces but it can
catch real leaks.