### PR TITLE
Fixes in the config API related to secrets responder

### DIFF
--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -8,7 +8,7 @@ section = autofs
 section = ssh
 section = pac
 section = ifp
-section_re = ^secrets\(/users/\([0-9]\+\)\?\)\?$
+section_re = ^secrets\(/users/[0-9]\+\)\?$
 section_re = ^domain/.*$
 
 [rule/allowed_sssd_options]
@@ -213,7 +213,7 @@ option = user_attributes
 
 [rule/allowed_sec_options]
 validator = ini_allowed_options
-section_re = ^secrets\(/users/\([0-9]\+\)\?\)\?$
+section_re = ^secrets\(/users/[0-9]\+\)\?$
 
 option = timeout
 option = debug

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -8,7 +8,8 @@ section = autofs
 section = ssh
 section = pac
 section = ifp
-section_re = ^secrets\(/users/[0-9]\+\)\?$
+section = secrets
+section_re = ^secrets/users/[0-9]\+$
 section_re = ^domain/.*$
 
 [rule/allowed_sssd_options]
@@ -211,9 +212,10 @@ option = description
 option = allowed_uids
 option = user_attributes
 
+# Secrets service
 [rule/allowed_sec_options]
 validator = ini_allowed_options
-section_re = ^secrets\(/users/[0-9]\+\)\?$
+section_re = ^secrets$
 
 option = timeout
 option = debug
@@ -226,12 +228,15 @@ option = reconnection_retries
 option = fd_limit
 option = client_idle_timeout
 option = description
-
-# Secrets service
-option = provider
 option = containers_nest_level
 option = max_secrets
+
+[rule/allowed_sec_users_options]
+validator = ini_allowed_options
+section_re = ^secrets/users/[0-9]\+$
+
 # Secrets service - proxy
+option = provider
 option = proxy_url
 option = auth_type
 option = auth_header_name


### PR DESCRIPTION
Those fixes were suggested by Lukaš in the following thread:
https://lists.fedorahosted.org/archives/list/sssd-devel@lists.fedorahosted.org/message/ZMJSE5ZSICLPNN5M6OOWNRWMG7LBQQIH/

Changes:

28fa419 (Fabiano Fidêncio, 11 minutes ago)
   SECRETS: Add allowed_sec_users_options

   There are options (the proxying related ones) that only apply to the
   secrets' subsections. In order to make config API able to catch those,
   let's create a new section called allowed_sec_users_options) and move there
   these proxying options.

   Signed-off-by: Fabiano Fidêncio fidencio@redhat.com

2aed214 (Fabiano Fidêncio, 2 hours ago)
   SECRETS: Fix secrets rule in the allowed sections

   We have been matching an invalid subsection of the secrets' section, like:
   [secrets/users]

   Let's ensure that we only match the following cases:
   [secrets]
   [secrets/users/[0-9]+?]

   Signed-off-by: Fabiano Fidêncio fidencio@redhat.com
