### PR TITLE
BUILD: Fix build without samba

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -257,7 +257,6 @@ if HAVE_CMOCKA
         test_sbus_opath \
         test_fo_srv \
         pam-srv-tests \
-        test_ad_subdom \
         test_ipa_subdom_util \
         test_tools_colondb \
         test_krb5_wait_queue \
@@ -284,6 +283,7 @@ non_interactive_cmocka_based_tests += \
     ad_access_filter_tests \
     ad_gpo_tests \
     ad_common_tests \
+    test_ad_subdom \
     test_ipa_subdom_server \
     $(NULL)
 endif


### PR DESCRIPTION
The test test_ad_subdom shoudl bw compiled only if samba build is enabled.

In file included from src/tests/cmocka/test_ad_subdomains.c:39:0:
./src/providers/ad/ad_subdomains.c:35:17: fatal error: ndr.h: No such file or directory
 #include <ndr.h>
                 ^
compilation terminated.