### PR TITLE
BUILD: Accept krb5 1.15 for building the PAC plugin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4151,7 +4151,9 @@ install-data-hook:
 	if [ ! $(krb5rcachedir) = "__LIBKRB5_DEFAULTS__" ]; then \
         $(MKDIR_P) $(DESTDIR)/$(krb5rcachedir) ; \
 	fi
+if BUILD_SAMBA
 	mv $(DESTDIR)/$(winbindplugindir)/winbind_idmap_sss.so $(DESTDIR)/$(winbindplugindir)/sss.so
+endif
 
 uninstall-hook:
 	if [ -f $(abs_builddir)/src/config/.files2 ]; then \
@@ -4173,7 +4175,9 @@ if BUILD_PYTHON3_BINDINGS
 	cd $(DESTDIR)$(py3execdir) && \
 		rm -f pysss.so pyhbac.so pysss_murmur.so pysss_nss_idmap.so
 endif
+if BUILD_SAMBA
 	rm $(DESTDIR)/$(winbindplugindir)/sss.so
+endif
 
 clean-local:
 if BUILD_PYTHON2_BINDINGS

--- a/src/external/pac_responder.m4
+++ b/src/external/pac_responder.m4
@@ -16,7 +16,8 @@ then
         Kerberos\ 5\ release\ 1.11* | \
         Kerberos\ 5\ release\ 1.12* | \
         Kerberos\ 5\ release\ 1.13* | \
-        Kerberos\ 5\ release\ 1.14*)
+        Kerberos\ 5\ release\ 1.14* | \
+        Kerberos\ 5\ release\ 1.15*)
             krb5_version_ok=yes
             AC_MSG_RESULT([yes])
             ;;


### PR DESCRIPTION
Fedora rawhide has krb5-1.15-1.fc26.beta1.0 since Friday.
@sumit-bose Could you related internal code in krb5-1.15?

http://koji.fedoraproject.org/koji/buildinfo?buildID=811563