### PR TITLE
Minor Dynamic DNS fixes

### DIFF
--- a/src/providers/be_dyndns.c
+++ b/src/providers/be_dyndns.c
@@ -435,10 +435,14 @@ nsupdate_msg_create_common(TALLOC_CTX *mem_ctx, const char *realm,
         /* Add the server, realm and headers */
         update_msg = talloc_asprintf(tmp_ctx, "server %s\n%s",
                                      servername, realm_directive);
-    } else {
+    } else if (realm != NULL) {
         DEBUG(SSSDBG_FUNC_DATA,
               "Creating update message for realm [%s].\n", realm);
         /* Add the realm headers */
+        update_msg = talloc_asprintf(tmp_ctx, "%s", realm_directive);
+    } else {
+        DEBUG(SSSDBG_FUNC_DATA,
+              "Creating update message for auto-discovered realm.\n");
         update_msg = talloc_asprintf(tmp_ctx, "%s", realm_directive);
     }
     talloc_free(realm_directive);

--- a/src/providers/ldap/sdap_dyndns.c
+++ b/src/providers/ldap/sdap_dyndns.c
@@ -381,9 +381,6 @@ sdap_dyndns_update_done(struct tevent_req *subreq)
                 return;
             }
         }
-
-        tevent_req_error(req, ret);
-        return;
     }
 
     if (state->update_ptr == false) {


### PR DESCRIPTION
To provide a bit more information, one of the fixes is to correct NULL being printed here(https://fedorahosted.org/sssd/ticket/3220):

   [nsupdate_msg_create_common](0x0200): Creating update message for realm [(null)].

For the other(https://bugzilla.redhat.com/show_bug.cgi?id=1386748), It is not uncommon for nsupdate to successfully update DNS records but report the error below which results in return(2) to be called inside nsupdate code

```
TSIG error with server: tsig verify failure
```

It is easy to reproduce with AD DNS changing Dynamic DNS to 'Nonsecure and secure' on the Zone Properties.

This patch allows PTR records to continue when this happens, however in this case our debug log messages still report failure and I think some improvement should be made here(not sure how exactly though)

```
[child_sig_handler] (0x1000): Waiting for child [3710].
[nsupdate_child_handler] (0x0040): Dynamic DNS child failed with status [512]
[child_sig_handler] (0x0020): child [3710] failed with status [2].
[be_nsupdate_done] (0x0040): nsupdate child execution failed [1432158238]: Dynamic DNS update failed
```

It would be nice to correct this at the nsupdate level if this is not the expected behavior also.
