### PR TITLE
MAN: Document different defaults for IPA and AD providers

### DIFF
--- a/src/man/include/ad_modified_defaults.xml
+++ b/src/man/include/ad_modified_defaults.xml
@@ -1,0 +1,63 @@
+<refsect1 id='modified-default-options'>
+    <title>MODIFIED DEFAULT OPTIONS</title>
+    <para>
+        Certain option defaults do not match their respective backend
+        provider defaults, these option names and AD provider-specific
+        defaults are listed below:
+    </para>
+    <refsect2 id='krb5_modifications'>
+        <title>KRB5 Provider</title>
+        <itemizedlist>
+            <listitem>
+                <para>
+                    krb5_validate = true
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    krb5_use_enterprise_principal = true
+                </para>
+            </listitem>
+        </itemizedlist>
+    </refsect2>
+    <refsect2 id='ldap_modifications'>
+        <title>LDAP Provider</title>
+        <itemizedlist>
+            <listitem>
+                <para>
+                    ldap_schema = ad
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    ldap_force_upper_case_realm = true
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    ldap_id_mapping = true
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    ldap_sasl_mech = gssapi
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    ldap_referrals = false
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    ldap_account_expire_policy = ad
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    ldap_use_tokengroups = true
+                </para>
+            </listitem>
+        </itemizedlist>
+    </refsect2>
+</refsect1>

--- a/src/man/include/ipa_modified_defaults.xml
+++ b/src/man/include/ipa_modified_defaults.xml
@@ -1,0 +1,128 @@
+<refsect1 id='modified-default-options'>
+    <title>MODIFIED DEFAULT OPTIONS</title>
+    <para>
+        Certain option defaults do not match their respective backend
+        provider defaults, these option names and IPA provider-specific
+        defaults are listed below:
+    </para>
+    <refsect2 id='krb5_modifications'>
+        <title>KRB5 Provider</title>
+        <itemizedlist>
+            <listitem>
+                <para>
+                    krb5_validate = true
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    krb5_use_fast = try
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    krb5_canonicalize = true
+                </para>
+            </listitem>
+        </itemizedlist>
+    </refsect2>
+    <refsect2 id='ldap_general_modifications'>
+        <title>LDAP Provider - General</title>
+        <itemizedlist>
+            <listitem>
+                <para>
+                    ldap_schema = ipa_v1
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    ldap_force_upper_case_realm = true
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    ldap_sasl_mech = GSSAPI
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    ldap_sasl_minssf = 56
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    ldap_account_expire_policy = ipa
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    ldap_use_tokengroups = true
+                </para>
+            </listitem>
+        </itemizedlist>
+    </refsect2>
+    <refsect2 id='ldap_user_modifications'>
+        <title>LDAP Provider - User options</title>
+        <itemizedlist>
+            <listitem>
+                <para>
+                    ldap_user_member_of = memberOf
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    ldap_user_uuid = ipaUniqueID
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    ldap_user_ssh_public_key = ipaSshPubKey
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    ldap_user_auth_type = ipaUserAuthType
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    ldap_user_certificate = userCertificate;binary
+                </para>
+            </listitem>
+        </itemizedlist>
+    </refsect2>
+    <refsect2 id='ldap_group_modifications'>
+        <title>LDAP Provider - Group options</title>
+        <itemizedlist>
+            <listitem>
+                <para>
+                    ldap_group_object_class = ipaUserGroup
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    ldap_group_object_class_alt = posixGroup
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    ldap_group_member = member
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    ldap_group_uuid = ipaUniqueID
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    ldap_group_objectsid = ipaNTSecurityIdentifier
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    ldap_group_external_member = ipaExternalMember
+                </para>
+            </listitem>
+        </itemizedlist>
+    </refsect2>
+</refsect1>

--- a/src/man/po/po4a.cfg
+++ b/src/man/po/po4a.cfg
@@ -45,3 +45,4 @@
 [type:docbook] include/override_homedir.xml $lang:$(builddir)/$lang/include/override_homedir.xml opt:"-k 0"
 [type:docbook] include/homedir_substring.xml $lang:$(builddir)/$lang/include/homedir_substring.xml opt:"-k 0"
 [type:docbook] include/ad_modified_defaults.xml $lang:$(builddir)/$lang/include/ad_modified_defaults.xml opt:"-k 0"
+[type:docbook] include/ipa_modified_defaults.xml $lang:$(builddir)/$lang/include/ipa_modified_defaults.xml opt:"-k 0"

--- a/src/man/po/po4a.cfg
+++ b/src/man/po/po4a.cfg
@@ -44,3 +44,4 @@
 [type:docbook] include/autofs_restart.xml $lang:$(builddir)/$lang/include/autofs_restart.xml opt:"-k 0"
 [type:docbook] include/override_homedir.xml $lang:$(builddir)/$lang/include/override_homedir.xml opt:"-k 0"
 [type:docbook] include/homedir_substring.xml $lang:$(builddir)/$lang/include/homedir_substring.xml opt:"-k 0"
+[type:docbook] include/ad_modified_defaults.xml $lang:$(builddir)/$lang/include/ad_modified_defaults.xml opt:"-k 0"

--- a/src/man/sssd-ad.5.xml
+++ b/src/man/sssd-ad.5.xml
@@ -48,7 +48,7 @@
             addition servers from trusted domains are always auto-discovered.
         </para>
         <para>
-            The AD provider accepts the same options used by the
+            The AD provider enables SSSD to use the
             <citerefentry>
                 <refentrytitle>sssd-ldap</refentrytitle>
                 <manvolnum>5</manvolnum>
@@ -56,12 +56,19 @@
             <citerefentry>
                 <refentrytitle>sssd-krb5</refentrytitle>
                 <manvolnum>5</manvolnum>
-            </citerefentry> authentication provider with some exceptions described
-            below.
+            </citerefentry> authentication provider with optimizations for
+            Active Directory environments. The AD provider accepts the same
+            options used by the sssd-ldap and sssd-krb5 providers with some
+            exceptions. However, it is neither necessary nor recommended to
+            set these options.
         </para>
         <para>
-            However, it is neither necessary nor recommended to set these
-            options. The AD provider can also be used as an access, chpass,
+            The AD provider primarily copies the traditional ldap and krb5
+            provider default options with some exceptions, the differences
+            are listed in the <quote>MODIFIED DEFAULT OPTIONS</quote> section.
+        </para>
+        <para>
+            The AD provider can also be used as an access, chpass,
             sudo and autofs provider. No configuration of the access provider
             is required on the client side.
         </para>
@@ -943,25 +950,6 @@ ad_gpo_map_deny = +my_pam_service
                 <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="include/homedir_substring.xml" />
 
                 <varlistentry>
-                    <term>krb5_use_enterprise_principal (boolean)</term>
-                    <listitem>
-                        <para>
-                            Specifies if the user principal should be treated
-                            as enterprise principal. See section 5 of RFC 6806
-                            for more details about enterprise principals.
-                        </para>
-
-                        <para>
-                            Default: true
-                        </para>
-                        <para>
-                             Note that this default differs from the
-                             traditional Kerberos provider back end.
-                        </para>
-                    </listitem>
-                </varlistentry>
-
-                <varlistentry>
                     <term>krb5_confd_path (string)</term>
                     <listitem>
                         <para>
@@ -981,6 +969,8 @@ ad_gpo_map_deny = +my_pam_service
             </variablelist>
         </para>
     </refsect1>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="include/ad_modified_defaults.xml" />
 
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="include/failover.xml" />
 

--- a/src/man/sssd-ipa.5.xml
+++ b/src/man/sssd-ipa.5.xml
@@ -40,7 +40,7 @@
             directly from the server.
         </para>
         <para>
-            The IPA provider accepts the same options used by the
+            The IPA provider enables SSSD to use the
             <citerefentry>
                 <refentrytitle>sssd-ldap</refentrytitle>
                 <manvolnum>5</manvolnum>
@@ -48,15 +48,20 @@
             <citerefentry>
                 <refentrytitle>sssd-krb5</refentrytitle>
                 <manvolnum>5</manvolnum>
-            </citerefentry> authentication provider with some exceptions described
-            below.
+            </citerefentry> authentication provider with optimizations for IPA
+            environments. The IPA provider accepts the same options used by the
+            sssd-ldap and sssd-krb5 providers with some exceptions. However, it is
+            neither necessary nor recommended to set these options.
         </para>
         <para>
-            However, it is neither necessary nor recommended to set these options.
-            IPA provider can also be used as an access and chpass provider. As an
-            access provider it uses HBAC (host-based access control) rules. Please
-            refer to freeipa.org for more information about HBAC. No configuration
-            of access provider is required on the client side.
+            The IPA provider primarily copies the traditional ldap and krb5 provider
+            default options with some exceptions, the differences are listed in the
+            <quote>MODIFIED DEFAULT OPTIONS</quote> section.
+        </para>
+        <para>
+            As an access provider, the IPA provider uses HBAC (host-based access control)
+            rules. Please refer to freeipa.org for more information about HBAC. No
+            configuration of access provider is required on the client side.
         </para>
         <para>
             The IPA provider will use the PAC responder if the Kerberos tickets
@@ -395,23 +400,6 @@
                 </varlistentry>
 
                 <varlistentry>
-                    <term>krb5_validate (boolean)</term>
-                    <listitem>
-                        <para>
-                            Verify with the help of krb5_keytab that the TGT
-                            obtained has not been spoofed.
-                        </para>
-                        <para>
-                            Default: true
-                        </para>
-                        <para>
-                             Note that this default differs from the
-                             traditional Kerberos provider back end.
-                        </para>
-                    </listitem>
-                </varlistentry>
-
-                <varlistentry>
                     <term>krb5_realm (string)</term>
                     <listitem>
                         <para>
@@ -422,56 +410,6 @@
                             The name of the Kerberos realm has a special
                             meaning in IPA - it is converted into the base
                             DN to use for performing LDAP operations.
-                        </para>
-                    </listitem>
-                </varlistentry>
-
-                <varlistentry>
-                    <term>krb5_canonicalize (boolean)</term>
-                    <listitem>
-                        <para>
-                            Specifies if the host and user principal should be
-                            canonicalized when connecting to IPA LDAP and also for AS
-                            requests. This feature is available with MIT
-                            Kerberos >= 1.7
-                        </para>
-
-                        <para>
-                            Default: true
-                        </para>
-                    </listitem>
-                </varlistentry>
-
-                <varlistentry>
-                    <term>krb5_use_fast (string)</term>
-                    <listitem>
-                        <para>
-                            Enables flexible authentication secure tunneling
-                            (FAST) for Kerberos pre-authentication. The
-                            following options are supported:
-                        </para>
-                        <para>
-                            <emphasis>never</emphasis> use FAST.
-                        </para>
-                        <para>
-                            <emphasis>try</emphasis> to use FAST. If the server
-                            does not support FAST, continue the
-                            authentication without it. This is
-                            equivalent to not setting this option at all.
-                        </para>
-                        <para>
-                            <emphasis>demand</emphasis> to use FAST. The
-                            authentication fails if the server does not
-                            require fast.
-                        </para>
-                        <para>
-                            Default: try
-                        </para>
-                        <para>
-                            NOTE: SSSD supports FAST only with
-                            MIT Kerberos version 1.8 and later. If SSSD is used
-                            with an older version of MIT Kerberos, using this
-                            option is a configuration error.
                         </para>
                     </listitem>
                 </varlistentry>
@@ -685,6 +623,8 @@
             </para>
         </refsect2>
     </refsect1>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="include/ipa_modified_defaults.xml" />
 
     <refsect1 id='subdomains_provider'>
         <title>SUBDOMAINS PROVIDER</title>


### PR DESCRIPTION
Update man pages for any AD provider config options that differ from
ldap/krb5 provider back-end defaults.

Resolves:
https://fedorahosted.org/sssd/ticket/3214

I would appreciate any suggestions on improving the wording, I was hoping to be informative but concise.
