### PR TITLE
krb5: Use command line arguments instead env vars for krb5_child

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -262,6 +262,7 @@ if HAVE_CMOCKA
         test_dp_builtin \
         test_ipa_dn \
         simple-access-tests \
+        krb5_common_test \
         $(NULL)
 
 if HAVE_LIBRESOLV
@@ -3026,6 +3027,23 @@ simple_access_tests_LDFLAGS = \
 simple_access_tests_LDADD = \
     $(CMOCKA_LIBS) \
     $(SSSD_LIBS) \
+    $(SSSD_INTERNAL_LTLIBS) \
+    libsss_test_common.la \
+    libdlopen_test_providers.la \
+    $(NULL)
+
+krb5_common_test_SOURCES = \
+    src/tests/cmocka/test_krb5_common.c \
+    $(NULL)
+krb5_common_test_CFLAGS = \
+    $(KRB5_CFLAGS) \
+    $(AM_CFLAGS) \
+    $(NULL)
+krb5_common_test_LDADD = \
+    $(CMOCKA_LIBS) \
+    $(POPT_LIBS) \
+    $(TALLOC_LIBS) \
+    libsss_krb5_common.la \
     $(SSSD_INTERNAL_LTLIBS) \
     libsss_test_common.la \
     libdlopen_test_providers.la \

--- a/src/providers/krb5/krb5_auth.h
+++ b/src/providers/krb5/krb5_auth.h
@@ -38,6 +38,15 @@
 
 #define ILLEGAL_PATH_PATTERN "//|/\\./|/\\.\\./"
 
+#define CHILD_OPT_FAST_CCACHE_UID "fast-ccache-uid"
+#define CHILD_OPT_FAST_CCACHE_GID "fast-ccache-gid"
+#define CHILD_OPT_REALM "realm"
+#define CHILD_OPT_LIFETIME "lifetime"
+#define CHILD_OPT_RENEWABLE_LIFETIME "renewable-lifetime"
+#define CHILD_OPT_USE_FAST "use-fast"
+#define CHILD_OPT_FAST_PRINCIPAL "fast-principal"
+#define CHILD_OPT_CANONICALIZE "canonicalize"
+
 struct krb5child_req {
     struct pam_data *pd;
     struct krb5_ctx *krb5_ctx;

--- a/src/providers/krb5/krb5_common.c
+++ b/src/providers/krb5/krb5_common.c
@@ -113,6 +113,7 @@ static errno_t sss_get_system_ccname_template(TALLOC_CTX *mem_ctx,
 
     ret = profile_get_string(p, "libdefaults", "default_ccache_name",
                              NULL, NULL, &value);
+    profile_release(p);
     if (ret) goto done;
 
     if (!value) {
@@ -362,13 +363,7 @@ errno_t sss_krb5_get_options(TALLOC_CTX *memctx, struct confdb_ctx *cdb,
     int ret;
     struct dp_option *opts;
 
-    opts = talloc_zero(memctx, struct dp_option);
-    if (opts == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "talloc_zero failed.\n");
-        return ENOMEM;
-    }
-
-    ret = dp_get_options(opts, cdb, conf_path, default_krb5_opts,
+    ret = dp_get_options(memctx, cdb, conf_path, default_krb5_opts,
                          KRB5_OPTS, &opts);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "dp_get_options failed.\n");

--- a/src/providers/krb5/krb5_common.c
+++ b/src/providers/krb5/krb5_common.c
@@ -38,31 +38,38 @@
 #include <profile.h>
 #endif
 
-errno_t check_and_export_lifetime(struct dp_option *opts, const int opt_id,
-                                  const char *env_name)
+static errno_t check_lifetime(TALLOC_CTX *mem_ctx, struct dp_option *opts,
+                              const int opt_id, char **lifetime_str)
 {
     int ret;
-    char *str;
+    char *str = NULL;
     krb5_deltat lifetime;
-    bool free_str = false;
 
     str = dp_opt_get_string(opts, opt_id);
     if (str == NULL || *str == '\0') {
         DEBUG(SSSDBG_FUNC_DATA, "No lifetime configured.\n");
+        *lifetime_str = NULL;
         return EOK;
     }
 
     if (isdigit(str[strlen(str)-1])) {
-        str = talloc_asprintf(opts, "%ss", str);
+        str = talloc_asprintf(mem_ctx, "%ss", str);
         if (str == NULL) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "talloc_asprintf failed\n");
-            return ENOMEM;
+            DEBUG(SSSDBG_CRIT_FAILURE, "talloc_asprintf failed.\n");
+            ret = ENOMEM;
+            goto done;
         }
-        free_str = true;
 
         ret = dp_opt_set_string(opts, opt_id, str);
         if (ret != EOK) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "dp_opt_set_string failed\n");
+            DEBUG(SSSDBG_CRIT_FAILURE, "dp_opt_set_string failed.\n");
+            goto done;
+        }
+    } else {
+        str = talloc_strdup(mem_ctx, str);
+        if (str == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "talloc_strdup failed.\n");
+            ret = ENOMEM;
             goto done;
         }
     }
@@ -74,17 +81,12 @@ errno_t check_and_export_lifetime(struct dp_option *opts, const int opt_id,
         goto done;
     }
 
-    ret = setenv(env_name, str, 1);
-    if (ret != EOK) {
-        ret = errno;
-        DEBUG(SSSDBG_OP_FAILURE, "setenv [%s] failed.\n", env_name);
-        goto done;
-    }
+    *lifetime_str = str;
 
     ret = EOK;
 
 done:
-    if (free_str) {
+    if (ret != EOK) {
         talloc_free(str);
     }
 
@@ -157,17 +159,19 @@ static void sss_check_cc_template(const char *cc_template)
     }
 }
 
-errno_t check_and_export_options(struct dp_option *opts,
-                                 struct sss_domain_info *dom,
-                                 struct krb5_ctx *krb5_ctx)
+errno_t sss_krb5_check_options(struct dp_option *opts,
+                               struct sss_domain_info *dom,
+                               struct krb5_ctx *krb5_ctx)
 {
     TALLOC_CTX *tmp_ctx = NULL;
     int ret;
     const char *realm;
     const char *dummy;
-    char *use_fast_str;
-    char *fast_principal;
     char *ccname;
+
+    if (opts == NULL || dom == NULL || krb5_ctx == NULL) {
+        return EINVAL;
+    }
 
     tmp_ctx = talloc_new(NULL);
     if (!tmp_ctx) {
@@ -185,15 +189,14 @@ errno_t check_and_export_options(struct dp_option *opts,
         realm = dom->name;
     }
 
-    ret = setenv(SSSD_KRB5_REALM, realm, 1);
-    if (ret != EOK) {
+    krb5_ctx->realm = talloc_strdup(krb5_ctx, realm);
+    if (krb5_ctx->realm == NULL) {
         DEBUG(SSSDBG_OP_FAILURE,
-              "setenv %s failed, authentication might fail.\n",
-                  SSSD_KRB5_REALM);
+              "Failed to set realm, krb5_child might not work as expected.\n");
     }
 
-    ret = check_and_export_lifetime(opts, KRB5_RENEWABLE_LIFETIME,
-                                    SSSD_KRB5_RENEWABLE_LIFETIME);
+    ret = check_lifetime(krb5_ctx, opts, KRB5_RENEWABLE_LIFETIME,
+                         &krb5_ctx->rlife_str);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Failed to check value of krb5_renewable_lifetime. [%d][%s]\n",
@@ -201,8 +204,8 @@ errno_t check_and_export_options(struct dp_option *opts,
         goto done;
     }
 
-    ret = check_and_export_lifetime(opts, KRB5_LIFETIME,
-                                    SSSD_KRB5_LIFETIME);
+    ret = check_lifetime(krb5_ctx, opts, KRB5_LIFETIME,
+                         &krb5_ctx->lifetime_str);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Failed to check value of krb5_lifetime. [%d][%s]\n",
@@ -211,29 +214,17 @@ errno_t check_and_export_options(struct dp_option *opts,
     }
 
 
-    use_fast_str = dp_opt_get_string(opts, KRB5_USE_FAST);
-    if (use_fast_str != NULL) {
-        ret = check_fast(use_fast_str, &krb5_ctx->use_fast);
+    krb5_ctx->use_fast_str = dp_opt_get_cstring(opts, KRB5_USE_FAST);
+    if (krb5_ctx->use_fast_str != NULL) {
+        ret = check_fast(krb5_ctx->use_fast_str, &krb5_ctx->use_fast);
         if (ret != EOK) {
             DEBUG(SSSDBG_CRIT_FAILURE, "check_fast failed.\n");
             goto done;
         }
 
         if (krb5_ctx->use_fast) {
-            ret = setenv(SSSD_KRB5_USE_FAST, use_fast_str, 1);
-            if (ret != EOK) {
-                DEBUG(SSSDBG_OP_FAILURE,
-                      "setenv [%s] failed.\n", SSSD_KRB5_USE_FAST);
-            } else {
-                fast_principal = dp_opt_get_string(opts, KRB5_FAST_PRINCIPAL);
-                if (fast_principal != NULL) {
-                    ret = setenv(SSSD_KRB5_FAST_PRINCIPAL, fast_principal, 1);
-                    if (ret != EOK) {
-                        DEBUG(SSSDBG_OP_FAILURE,
-                              "setenv [%s] failed.\n", SSSD_KRB5_FAST_PRINCIPAL);
-                    }
-                }
-            }
+                krb5_ctx->fast_principal = dp_opt_get_cstring(opts,
+                                                           KRB5_FAST_PRINCIPAL);
         }
     }
 
@@ -241,15 +232,10 @@ errno_t check_and_export_options(struct dp_option *opts,
      * enterprise principal in an AS request but requires the canonicalize
      * flags to be set. To be on the safe side we always enable
      * canonicalization if enterprise principals are used. */
+    krb5_ctx->canonicalize = false;
     if (dp_opt_get_bool(opts, KRB5_CANONICALIZE)
             || dp_opt_get_bool(opts, KRB5_USE_ENTERPRISE_PRINCIPAL)) {
-        ret = setenv(SSSD_KRB5_CANONICALIZE, "true", 1);
-    } else {
-        ret = setenv(SSSD_KRB5_CANONICALIZE, "false", 1);
-    }
-    if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "setenv [%s] failed.\n", SSSD_KRB5_CANONICALIZE);
+        krb5_ctx->canonicalize = true;
     }
 
     dummy = dp_opt_get_cstring(opts, KRB5_KDC);
@@ -370,8 +356,8 @@ errno_t krb5_try_kdcip(struct confdb_ctx *cdb, const char *conf_path,
     return EOK;
 }
 
-errno_t krb5_get_options(TALLOC_CTX *memctx, struct confdb_ctx *cdb,
-                         const char *conf_path, struct dp_option **_opts)
+errno_t sss_krb5_get_options(TALLOC_CTX *memctx, struct confdb_ctx *cdb,
+                             const char *conf_path, struct dp_option **_opts)
 {
     int ret;
     struct dp_option *opts;

--- a/src/providers/krb5/krb5_common.h
+++ b/src/providers/krb5/krb5_common.h
@@ -33,14 +33,6 @@
 #include "util/util.h"
 #include "util/sss_krb5.h"
 
-#define SSSD_KRB5_KDC "SSSD_KRB5_KDC"
-#define SSSD_KRB5_REALM "SSSD_KRB5_REALM"
-#define SSSD_KRB5_RENEWABLE_LIFETIME "SSSD_KRB5_RENEWABLE_LIFETIME"
-#define SSSD_KRB5_LIFETIME "SSSD_KRB5_LIFETIME"
-#define SSSD_KRB5_USE_FAST "SSSD_KRB5_USE_FAST"
-#define SSSD_KRB5_FAST_PRINCIPAL "SSSD_KRB5_FAST_PRINCIPAL"
-#define SSSD_KRB5_CANONICALIZE "SSSD_KRB5_CANONICALIZE"
-
 #define KDCINFO_TMPL PUBCONF_PATH"/kdcinfo.%s"
 #define KPASSWDINFO_TMPL PUBCONF_PATH"/kpasswdinfo.%s"
 
@@ -100,7 +92,9 @@ struct krb5_ctx {
     /* in seconds */
     krb5_deltat starttime;
     krb5_deltat lifetime;
+    char *lifetime_str;
     krb5_deltat rlife;
+    char *rlife_str;
 
     int forwardable;
     int proxiable;
@@ -136,6 +130,13 @@ struct krb5_ctx {
     enum krb5_config_type config_type;
 
     struct map_id_name_to_krb_primary *name_to_primary;
+
+    char *realm;
+
+    const char *use_fast_str;
+    const char *fast_principal;
+
+    bool canonicalize;
 };
 
 struct remove_info_files_ctx {
@@ -145,15 +146,15 @@ struct remove_info_files_ctx {
     const char *kpasswd_service_name;
 };
 
-errno_t check_and_export_options(struct dp_option *opts,
-                                 struct sss_domain_info *dom,
-                                 struct krb5_ctx *krb5_ctx);
+errno_t sss_krb5_check_options(struct dp_option *opts,
+                               struct sss_domain_info *dom,
+                               struct krb5_ctx *krb5_ctx);
 
 errno_t krb5_try_kdcip(struct confdb_ctx *cdb, const char *conf_path,
                        struct dp_option *opts, int opt_id);
 
-errno_t krb5_get_options(TALLOC_CTX *memctx, struct confdb_ctx *cdb,
-                         const char *conf_path, struct dp_option **_opts);
+errno_t sss_krb5_get_options(TALLOC_CTX *memctx, struct confdb_ctx *cdb,
+                             const char *conf_path, struct dp_option **_opts);
 
 errno_t write_krb5info_file(const char *realm, const char *kdc,
                             const char *service);
@@ -221,4 +222,7 @@ krb5_error_code copy_keytab_into_memory(TALLOC_CTX *mem_ctx, krb5_context kctx,
                                         const char *inp_keytab_file,
                                         char **_mem_name,
                                         krb5_keytab *_mem_keytab);
+
+errno_t set_extra_args(TALLOC_CTX *mem_ctx, struct krb5_ctx *krb5_ctx,
+                       const char ***krb5_child_extra_args);
 #endif /* __KRB5_COMMON_H__ */

--- a/src/providers/krb5/krb5_init.c
+++ b/src/providers/krb5/krb5_init.c
@@ -136,7 +136,7 @@ errno_t sssm_krb5_init(TALLOC_CTX *mem_ctx,
         return ENOMEM;
     }
 
-    ret = krb5_get_options(ctx, be_ctx->cdb, be_ctx->conf_path, &ctx->opts);
+    ret = sss_krb5_get_options(ctx, be_ctx->cdb, be_ctx->conf_path, &ctx->opts);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to get krb5 options [%d]: %s\n",
               ret, sss_strerror(ret));

--- a/src/providers/krb5/krb5_init_shared.c
+++ b/src/providers/krb5/krb5_init_shared.c
@@ -64,10 +64,10 @@ errno_t krb5_child_init(struct krb5_ctx *krb5_auth_ctx,
         }
     }
 
-    ret = check_and_export_options(krb5_auth_ctx->opts, bectx->domain,
-                                   krb5_auth_ctx);
+    ret = sss_krb5_check_options(krb5_auth_ctx->opts, bectx->domain,
+                                 krb5_auth_ctx);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "check_and_export_opts failed.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "krb5_check_options failed.\n");
         goto done;
     }
 

--- a/src/tests/cmocka/test_krb5_common.c
+++ b/src/tests/cmocka/test_krb5_common.c
@@ -1,0 +1,297 @@
+/*
+    SSSD
+
+    krb5_common - Test for some krb5 utility functions
+
+    Authors:
+        Sumit Bose <sbose@redhat.com>
+
+    Copyright (C) 2016 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <popt.h>
+#include <stdbool.h>
+
+#include "tests/cmocka/common_mock.h"
+#include "tests/common.h"
+
+#include "src/providers/krb5/krb5_common.h"
+
+#define TEST_REALM "MY.REALM"
+#define TEST_FAST_PRINC "fast_princ@" TEST_REALM
+#define TEST_FAST_STR "dummy"
+#define TEST_LIFE_STR "dummy-life"
+#define TEST_RLIFE_STR "dummy-rlife"
+
+#define TESTS_PATH "tp_" BASE_FILE_STEM
+#define TEST_CONF_DB "test_krb5_common_conf.ldb"
+#define TEST_DOM_NAME "test.krb5.common"
+#define TEST_ID_PROVIDER "ldap"
+
+struct test_ctx {
+    struct sss_test_ctx *tctx;
+};
+
+static int test_setup(void **state)
+{
+    struct test_ctx *test_ctx;
+
+    assert_true(leak_check_setup());
+
+    test_ctx = talloc_zero(global_talloc_context, struct test_ctx);
+    assert_non_null(test_ctx);
+
+    test_ctx->tctx = create_dom_test_ctx(test_ctx, TESTS_PATH, TEST_CONF_DB,
+                                         TEST_DOM_NAME,
+                                         TEST_ID_PROVIDER, NULL);
+    assert_non_null(test_ctx->tctx);
+
+    check_leaks_push(test_ctx);
+    *state = test_ctx;
+
+    return 0;
+}
+
+static int test_teardown(void **state)
+{
+    struct test_ctx *test_ctx = talloc_get_type(*state, struct test_ctx);
+
+    assert_true(check_leaks_pop(test_ctx));
+    talloc_free(test_ctx);
+    assert_true(leak_check_teardown());
+    return 0;
+}
+
+void test_set_extra_args(void **state)
+{
+    int ret;
+    struct krb5_ctx *krb5_ctx;
+    char *uid_opt;
+    char *gid_opt;
+    const char **krb5_child_extra_args;
+
+    ret = set_extra_args(NULL, NULL, NULL);
+    assert_int_equal(ret, EINVAL);
+
+    krb5_ctx = talloc_zero(global_talloc_context, struct krb5_ctx);
+    assert_non_null(krb5_ctx);
+    uid_opt = talloc_asprintf(krb5_ctx, "--fast-ccache-uid=%"SPRIuid, getuid());
+    assert_non_null(uid_opt);
+
+    gid_opt = talloc_asprintf(krb5_ctx, "--fast-ccache-gid=%"SPRIgid, getgid());
+    assert_non_null(gid_opt);
+
+    ret = set_extra_args(global_talloc_context, krb5_ctx,
+                         &krb5_child_extra_args);
+    assert_int_equal(ret, EOK);
+    assert_string_equal(krb5_child_extra_args[0], uid_opt);
+    assert_string_equal(krb5_child_extra_args[1], gid_opt);
+    assert_null(krb5_child_extra_args[2]);
+    talloc_free(krb5_child_extra_args);
+
+    krb5_ctx->canonicalize = true;
+    ret = set_extra_args(global_talloc_context, krb5_ctx,
+                         &krb5_child_extra_args);
+    assert_int_equal(ret, EOK);
+    assert_string_equal(krb5_child_extra_args[0], uid_opt);
+    assert_string_equal(krb5_child_extra_args[1], gid_opt);
+    assert_string_equal(krb5_child_extra_args[2], "--canonicalize");
+    assert_null(krb5_child_extra_args[3]);
+    talloc_free(krb5_child_extra_args);
+
+    krb5_ctx->realm = discard_const(TEST_REALM);
+    ret = set_extra_args(global_talloc_context, krb5_ctx,
+                         &krb5_child_extra_args);
+    assert_int_equal(ret, EOK);
+    assert_string_equal(krb5_child_extra_args[0], uid_opt);
+    assert_string_equal(krb5_child_extra_args[1], gid_opt);
+    assert_string_equal(krb5_child_extra_args[2], "--realm=" TEST_REALM);
+    assert_string_equal(krb5_child_extra_args[3], "--canonicalize");
+    assert_null(krb5_child_extra_args[4]);
+    talloc_free(krb5_child_extra_args);
+
+    /* --fast-principal will be only set if FAST is used */
+    krb5_ctx->fast_principal = discard_const(TEST_FAST_PRINC);
+    ret = set_extra_args(global_talloc_context, krb5_ctx,
+                         &krb5_child_extra_args);
+    assert_int_equal(ret, EOK);
+    assert_string_equal(krb5_child_extra_args[0], uid_opt);
+    assert_string_equal(krb5_child_extra_args[1], gid_opt);
+    assert_string_equal(krb5_child_extra_args[2], "--realm=" TEST_REALM);
+    assert_string_equal(krb5_child_extra_args[3], "--canonicalize");
+    assert_null(krb5_child_extra_args[4]);
+    talloc_free(krb5_child_extra_args);
+
+    krb5_ctx->use_fast_str = discard_const(TEST_FAST_STR);
+    ret = set_extra_args(global_talloc_context, krb5_ctx,
+                         &krb5_child_extra_args);
+    assert_int_equal(ret, EOK);
+    assert_string_equal(krb5_child_extra_args[0], uid_opt);
+    assert_string_equal(krb5_child_extra_args[1], gid_opt);
+    assert_string_equal(krb5_child_extra_args[2], "--realm=" TEST_REALM);
+    assert_string_equal(krb5_child_extra_args[3], "--use-fast=" TEST_FAST_STR);
+    assert_string_equal(krb5_child_extra_args[4],
+                        "--fast-principal=" TEST_FAST_PRINC);
+    assert_string_equal(krb5_child_extra_args[5], "--canonicalize");
+    assert_null(krb5_child_extra_args[6]);
+    talloc_free(krb5_child_extra_args);
+
+    krb5_ctx->lifetime_str = discard_const(TEST_LIFE_STR);
+    krb5_ctx->rlife_str = discard_const(TEST_RLIFE_STR);
+    ret = set_extra_args(global_talloc_context, krb5_ctx,
+                         &krb5_child_extra_args);
+    assert_int_equal(ret, EOK);
+    assert_string_equal(krb5_child_extra_args[0], uid_opt);
+    assert_string_equal(krb5_child_extra_args[1], gid_opt);
+    assert_string_equal(krb5_child_extra_args[2], "--realm=" TEST_REALM);
+    assert_string_equal(krb5_child_extra_args[3], "--lifetime=" TEST_LIFE_STR);
+    assert_string_equal(krb5_child_extra_args[4],
+                        "--renewable-lifetime=" TEST_RLIFE_STR);
+    assert_string_equal(krb5_child_extra_args[5], "--use-fast=" TEST_FAST_STR);
+    assert_string_equal(krb5_child_extra_args[6],
+                        "--fast-principal=" TEST_FAST_PRINC);
+    assert_string_equal(krb5_child_extra_args[7], "--canonicalize");
+    assert_null(krb5_child_extra_args[8]);
+    talloc_free(krb5_child_extra_args);
+
+    talloc_free(krb5_ctx);
+}
+
+void test_sss_krb5_check_options(void **state)
+{
+    int ret;
+    struct dp_option *opts;
+    struct test_ctx *test_ctx = talloc_get_type(*state, struct test_ctx);
+    struct krb5_ctx *krb5_ctx;
+
+    ret = sss_krb5_check_options(NULL, NULL, NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_krb5_get_options(test_ctx, test_ctx->tctx->confdb,
+                               "[domain/" TEST_DOM_NAME "]", &opts);
+    assert_int_equal(ret, EOK);
+    assert_non_null(opts);
+
+    krb5_ctx = talloc_zero(test_ctx, struct krb5_ctx);
+    assert_non_null(krb5_ctx);
+
+    ret = sss_krb5_check_options(opts, test_ctx->tctx->dom, krb5_ctx);
+    assert_int_equal(ret, EOK);
+    assert_string_equal(krb5_ctx->realm, TEST_DOM_NAME);
+
+    /* check check_lifetime() indirectly */
+    ret = dp_opt_set_string(opts, KRB5_LIFETIME, "123");
+    assert_int_equal(ret, EOK);
+    ret = sss_krb5_check_options(opts, test_ctx->tctx->dom, krb5_ctx);
+    assert_int_equal(ret, EOK);
+    assert_string_equal(krb5_ctx->lifetime_str, "123s");
+
+    ret = dp_opt_set_string(opts, KRB5_LIFETIME, "abc");
+    assert_int_equal(ret, EOK);
+    ret = sss_krb5_check_options(opts, test_ctx->tctx->dom, krb5_ctx);
+    assert_int_equal(ret, EINVAL);
+
+    ret = dp_opt_set_string(opts, KRB5_LIFETIME, "s");
+    assert_int_equal(ret, EOK);
+    ret = sss_krb5_check_options(opts, test_ctx->tctx->dom, krb5_ctx);
+    assert_int_equal(ret, EINVAL);
+
+    ret = dp_opt_set_string(opts, KRB5_LIFETIME, "1d");
+    assert_int_equal(ret, EOK);
+    ret = sss_krb5_check_options(opts, test_ctx->tctx->dom, krb5_ctx);
+    assert_int_equal(ret, EOK);
+    assert_string_equal(krb5_ctx->lifetime_str, "1d");
+
+    ret = dp_opt_set_string(opts, KRB5_LIFETIME, "7d 0h 0m 0s");
+    assert_int_equal(ret, EOK);
+    ret = sss_krb5_check_options(opts, test_ctx->tctx->dom, krb5_ctx);
+    assert_int_equal(ret, EOK);
+    assert_string_equal(krb5_ctx->lifetime_str, "7d 0h 0m 0s");
+
+    /* check canonicalize */
+    assert_false(krb5_ctx->canonicalize);
+
+    ret = dp_opt_set_bool(opts, KRB5_USE_ENTERPRISE_PRINCIPAL, true);
+    assert_int_equal(ret, EOK);
+    ret = sss_krb5_check_options(opts, test_ctx->tctx->dom, krb5_ctx);
+    assert_int_equal(ret, EOK);
+    assert_true(krb5_ctx->canonicalize);
+
+    ret = dp_opt_set_bool(opts, KRB5_USE_ENTERPRISE_PRINCIPAL, false);
+    assert_int_equal(ret, EOK);
+    ret = dp_opt_set_bool(opts, KRB5_CANONICALIZE, true);
+    assert_int_equal(ret, EOK);
+    ret = sss_krb5_check_options(opts, test_ctx->tctx->dom, krb5_ctx);
+    assert_int_equal(ret, EOK);
+    assert_true(krb5_ctx->canonicalize);
+
+    talloc_free(krb5_ctx);
+    talloc_free(opts);
+}
+
+int main(int argc, const char *argv[])
+{
+    int rv;
+    int no_cleanup = 0;
+    poptContext pc;
+    int opt;
+    struct poptOption long_options[] = {
+        POPT_AUTOHELP
+        SSSD_DEBUG_OPTS
+        {"no-cleanup", 'n', POPT_ARG_NONE, &no_cleanup, 0,
+         _("Do not delete the test database after a test run"), NULL },
+        POPT_TABLEEND
+    };
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_set_extra_args,
+                                        test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_sss_krb5_check_options,
+                                        test_setup, test_teardown),
+    };
+
+    /* Set debug level to invalid value so we can deside if -d 0 was used. */
+    debug_level = SSSDBG_INVALID;
+
+    pc = poptGetContext(argv[0], argc, argv, long_options, 0);
+    while((opt = poptGetNextOpt(pc)) != -1) {
+        switch(opt) {
+        default:
+            fprintf(stderr, "\nInvalid option %s: %s\n\n",
+                    poptBadOption(pc, 0), poptStrerror(opt));
+            poptPrintUsage(pc, stderr, 0);
+            return 1;
+        }
+    }
+    poptFreeContext(pc);
+
+    DEBUG_CLI_INIT(debug_level);
+
+    tests_set_cwd();
+    test_dom_suite_cleanup(TESTS_PATH, TEST_CONF_DB, TEST_DOM_NAME);
+    test_dom_suite_setup(TESTS_PATH);
+
+    rv = cmocka_run_group_tests(tests, NULL, NULL);
+    if (rv == 0 && !no_cleanup) {
+        test_dom_suite_cleanup(TESTS_PATH, TEST_CONF_DB, TEST_DOM_NAME);
+    }
+
+    return rv;
+}


### PR DESCRIPTION
The first patch resolves https://fedorahosted.org/sssd/ticket/697. The third
patch adds some checks for functions I added or extended. As a result I found
two memory leaks which are fixed by the second patch.