### PR TITLE
MONITOR: Do not set up watchdog for monitor

### DIFF
--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -2603,6 +2603,8 @@ int main(int argc, const char *argv[])
 
     /* we want a pid file check */
     flags |= FLAGS_PID_FILE;
+    /* the monitor should not run a watchdog on itself */
+    flags |= FLAGS_NO_WATCHDOG;
 
     /* Open before server_setup() does to have logging
      * during configuration checking */

--- a/src/util/server.c
+++ b/src/util/server.c
@@ -666,10 +666,13 @@ int server_setup(const char *name, int flags,
                                      ret, strerror(ret));
         return ret;
     }
-    ret = setup_watchdog(ctx->event_ctx, watchdog_interval);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Watchdog setup failed.\n");
-        return ret;
+
+    if ((flags & FLAGS_NO_WATCHDOG) == 0) {
+        ret = setup_watchdog(ctx->event_ctx, watchdog_interval);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "Watchdog setup failed.\n");
+            return ret;
+        }
     }
 
     sss_log(SSS_LOG_INFO, "Starting up");

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -88,6 +88,7 @@
 #define FLAGS_INTERACTIVE 0x0002
 #define FLAGS_PID_FILE 0x0004
 #define FLAGS_GEN_CONF 0x0008
+#define FLAGS_NO_WATCHDOG 0x0010
 
 #define PIPE_INIT { -1, -1 }
 


### PR DESCRIPTION
It makes little sense to set up watchdog for monitor because there is no
entity that would restart the monitor. Therefore we should disable the
watchdog for monitor process.

Resolves:
https://fedorahosted.org/sssd/ticket/3232