### PR TITLE
AD_PROVIDER: Enabled subdomains (1.13)

### DIFF
--- a/src/config/SSSDConfig/__init__.py.in
+++ b/src/config/SSSDConfig/__init__.py.in
@@ -185,6 +185,7 @@ option_strings = {
 
     # [provider/ad]
     'ad_domain' : _('Active Directory domain'),
+    'ad_enabled_domains' : _('Enabled Active Directory domains'),
     'ad_server' : _('Active Directory server address'),
     'ad_backup_server' : _('Active Directory backup server address'),
     'ad_hostname' : _('Active Directory client hostname'),

--- a/src/config/etc/sssd.api.d/sssd-ad.conf
+++ b/src/config/etc/sssd.api.d/sssd-ad.conf
@@ -1,5 +1,6 @@
 [provider/ad]
 ad_domain = str, None, false
+ad_enabled_domains = str, None, false
 ad_server = str, None, false
 ad_backup_server = str, None, false
 ad_hostname = str, None, false

--- a/src/man/sssd-ad.5.xml
+++ b/src/man/sssd-ad.5.xml
@@ -114,6 +114,33 @@ ldap_id_mapping = False
                 </varlistentry>
 
                 <varlistentry>
+                    <term>ad_enabled_domains (string)</term>
+                    <listitem>
+                        <para>
+                            A comma-separated list of enabled Active Directory domains.
+                            If provided, SSSD will ignore any domains not listed in this
+                            option. If left unset, all domains from the AD forest will
+                            be available.
+                        </para>
+                        <para>
+                            For proper operation, this option must be specified in all
+                            lower-case and as the fully qualified domain name of the
+                            Active Directory domain. For example:
+                            <programlisting>
+ad_enabled_domains = sales.example.com, eng.example.com
+                            </programlisting>
+                        </para>
+                        <para>
+                            The short domain name (also known as the NetBIOS or the flat
+                            name) will be autodetected by SSSD.
+                        </para>
+                        <para>
+                            Default: Not set
+                        </para>
+                    </listitem>
+                </varlistentry>
+
+                <varlistentry>
                     <term>ad_server, ad_backup_server (string)</term>
                     <listitem>
                         <para>

--- a/src/providers/ad/ad_common.h
+++ b/src/providers/ad/ad_common.h
@@ -42,6 +42,7 @@ struct ad_options;
 
 enum ad_basic_opt {
     AD_DOMAIN = 0,
+    AD_ENABLED_DOMAINS,
     AD_SERVER,
     AD_BACKUP_SERVER,
     AD_HOSTNAME,

--- a/src/providers/ad/ad_opts.c
+++ b/src/providers/ad/ad_opts.c
@@ -28,6 +28,7 @@
 
 struct dp_option ad_basic_opts[] = {
     { "ad_domain", DP_OPT_STRING, NULL_STRING, NULL_STRING },
+    { "ad_enabled_domains", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "ad_server", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "ad_backup_server", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "ad_hostname", DP_OPT_STRING, NULL_STRING, NULL_STRING },

--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -165,6 +165,16 @@ done:
     return ret;
 }
 
+static bool is_domain_enabled(const char *domain,
+                              const char **enabled_doms)
+{
+   if (enabled_doms == NULL) {
+        return true;
+    }
+
+    return string_in_list(domain, discard_const_p(char *, enabled_doms), false);
+}
+
 static errno_t
 ad_subdom_ad_ctx_new(struct be_ctx *be_ctx,
                      struct ad_id_ctx *id_ctx,
@@ -1023,6 +1033,7 @@ static errno_t ad_subdomains_get_slave(struct ad_subdomains_req_ctx *ctx)
 
 static errno_t ad_subdomains_process(TALLOC_CTX *mem_ctx,
                                      struct sss_domain_info *domain,
+                                     const char **enabled_domains_list,
                                      size_t nsd, struct sysdb_attrs **sd,
                                      struct sysdb_attrs *root,
                                      size_t *_nsd_out,
@@ -1031,9 +1042,10 @@ static errno_t ad_subdomains_process(TALLOC_CTX *mem_ctx,
     size_t i, sdi;
     struct sysdb_attrs **sd_out;
     const char *sd_name;
+    const char *root_name;
     errno_t ret;
 
-    if (root == NULL) {
+    if (root == NULL && enabled_domains_list == NULL) {
         /* We are connected directly to the root domain. The 'sd'
          * list is complete and we can just use it
          */
@@ -1060,6 +1072,13 @@ static errno_t ad_subdomains_process(TALLOC_CTX *mem_ctx,
             goto fail;
         }
 
+        if (is_domain_enabled(sd_name, enabled_domains_list) == false) {
+            DEBUG(SSSDBG_TRACE_FUNC, "Disabling subdomain %s\n", sd_name);
+            continue;
+        } else {
+            DEBUG(SSSDBG_TRACE_FUNC, "Enabling subdomain %s\n", sd_name);
+        }
+
         if (strcasecmp(sd_name, domain->name) == 0) {
             DEBUG(SSSDBG_TRACE_INTERNAL,
                   "Not including primary domain %s in the subdomain list\n",
@@ -1072,9 +1091,23 @@ static errno_t ad_subdomains_process(TALLOC_CTX *mem_ctx,
     }
 
     /* Now include the root */
-    sd_out[sdi] = talloc_steal(sd_out, root);
+    if (root != NULL) {
+        ret = sysdb_attrs_get_string(root, AD_AT_TRUST_PARTNER, &root_name);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_OP_FAILURE, "sysdb_attrs_get_string failed.\n");
+            goto fail;
+        }
 
-    *_nsd_out = sdi+1;
+        if (is_domain_enabled(root_name, enabled_domains_list) == true) {
+            sd_out[sdi] = talloc_steal(sd_out, root);
+            sdi++;
+        } else {
+            DEBUG(SSSDBG_TRACE_FUNC, "Disabling forest root domain %s\n",
+                                     root_name);
+        }
+    }
+
+    *_nsd_out = sdi;
     *_sd_out = sd_out;
     return EOK;
 
@@ -1142,6 +1175,7 @@ static void ad_subdomains_get_slave_domain_done(struct tevent_req *req)
      * subdomains
      */
     ret = ad_subdomains_process(ctx, ctx->sd_ctx->be_ctx->domain,
+                                ctx->sd_ctx->ad_enabled_domains,
                                 ctx->reply_count, ctx->reply,
                                 ctx->root_domain_attrs, &nsubdoms, &subdoms);
     if (ret != EOK) {


### PR DESCRIPTION
This is backport of https://fedorahosted.org/sssd/ticket/2828 to 1.13.