### PR TITLE
IPA/AD: check auth ctx before using it

### DIFF
--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -618,14 +618,23 @@ static errno_t ad_subdom_reinit(struct ad_subdomains_ctx *subdoms_ctx)
 {
     const char *path;
     errno_t ret;
-    bool canonicalize;
+    bool canonicalize = false;
 
     path = dp_opt_get_string(subdoms_ctx->ad_id_ctx->ad_options->basic,
                              AD_KRB5_CONFD_PATH);
 
-    canonicalize = dp_opt_get_bool(
+    if (subdoms_ctx->ad_id_ctx->ad_options->auth_ctx != NULL
+            && subdoms_ctx->ad_id_ctx->ad_options->auth_ctx->opts != NULL) {
+        canonicalize = dp_opt_get_bool(
                              subdoms_ctx->ad_id_ctx->ad_options->auth_ctx->opts,
                              KRB5_CANONICALIZE);
+    } else {
+        DEBUG(SSSDBG_CONF_SETTINGS, "Auth provider data is not available, "
+                                    "most probably because the auth provider "
+                                    "is not 'ad'. Kerberos configuration "
+                                    "snippet to set the 'canonicalize' option "
+                                    "will not be created.\n");
+    }
 
     ret = sss_write_krb5_conf_snippet(path, canonicalize);
     if (ret != EOK) {


### PR DESCRIPTION
In e6b6b9fa79c67d7d2698bc7e33d2e2f6bb53d483 a feature was introduced to
set the 'canonicalize' option in the system-wide Kerberos configuration
according to the settings in SSSD if the AD or IPA provider were used.
Unfortunately the patch implied that the auth provider is the same as
the id provider which might not always be the case. A different auth
provider caused a crash in the backend which is fixed by this patch.

Resolves https://fedorahosted.org/sssd/ticket/3234

I tried to add an integration test to see if SSSD can start with a mixed
configuration but the AD provider tries to set some SASL parameters which
requires e.g. an existing keytab which is afaik currently not available in the
integration test. Since this issue it easy to reproduce manually (start SSSD
with id_provder=ad and auth_provider=krb5) I hope it is acceptable that an
integration test can be added later when the infrastructure for AD provider
tests is available?