### PR TITLE
KRB5: Remove spurious warning in logs

### DIFF
--- a/src/providers/krb5/krb5_utils.c
+++ b/src/providers/krb5/krb5_utils.c
@@ -539,7 +539,7 @@ parse_krb5_map_user(TALLOC_CTX *mem_ctx,
     }
 
     if (krb5_map_user == NULL || strlen(krb5_map_user) == 0) {
-        DEBUG(SSSDBG_FUNC_DATA, "Warning: krb5_map_user is empty!\n");
+        DEBUG(SSSDBG_CONF_SETTINGS, "krb5_map_user is empty!\n");
         size = 0;
     } else {
         ret = split_on_separator(tmp_ctx, krb5_map_user, ',', true, true,


### PR DESCRIPTION
The option krb5_map_user is empty by default.
Therefore we should not confuse users wih warning

(Fri Nov 15 09:58:49 2016) [sssd[be[example.com]]] [parse_krb5_map_user]
(0x0200): Warning: krb5_map_user is empty!