### PR TITLE
Socket-activation of SSSD responders

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3940,6 +3940,12 @@ if BUILD_PAC_RESPONDER
         src/sysv/systemd/sssd-pac.service \
         $(NULL)
 endif
+if BUILD_SSH
+    systemdunit_DATA += \
+        src/sysv/systemd/sssd-ssh.socket \
+        src/sysv/systemd/sssd-ssh.service \
+        $(NULL)
+endif
 if WITH_JOURNALD
     systemdconf_DATA += \
         src/sysv/systemd/journal.conf
@@ -4012,6 +4018,12 @@ EXTRA_DIST += \
     src/sysv/systemd/sssd-pac.service.in \
     $(NULL)
 endif
+if BUILD_SSH
+EXTRA_DIST += \
+    src/sysv/systemd/sssd-ssh.socket.in \
+    src/sysv/systemd/sssd-ssh.service.in \
+    $(NULL)
+endif
 
 src/sysv/systemd/sssd.service: src/sysv/systemd/sssd.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
@@ -4065,6 +4077,16 @@ src/sysv/systemd/sssd-pac.socket: src/sysv/systemd/sssd-pac.socket.in Makefile
 	$(replace_script)
 
 src/sysv/systemd/sssd-pac.service: src/sysv/systemd/sssd-pac.service.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+endif
+
+if BUILD_SSH
+src/sysv/systemd/sssd-ssh.socket: src/sysv/systemd/sssd-ssh.socket.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+
+src/sysv/systemd/sssd-ssh.service: src/sysv/systemd/sssd-ssh.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
 	$(replace_script)
 endif
@@ -4297,6 +4319,8 @@ endif
 	rm -f $(builddir)/src/sysv/systemd/sssd-pam.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-pam-priv.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-pam.service
+	rm -f $(builddir)/src/sysv/systemd/sssd-ssh.socket
+	rm -f $(builddir)/src/sysv/systemd/sssd-ssh.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.service
 	rm -f $(builddir)/src/sysv/systemd/journal.conf

--- a/Makefile.am
+++ b/Makefile.am
@@ -88,6 +88,14 @@ polkitdir = @polkitdir@
 pamconfdir = $(sysconfdir)/pam.d
 systemtap_tapdir = @tapset_dir@
 
+if HAVE_SYSTEMD_UNIT
+ifp_exec = $(sssdlibexecdir)/sssd_ifp --uid 0 --gid 0 --debug-to-files
+ifp_systemdservice = SystemdService=sssd-ifp.service
+else
+ifp_exec = $(sssdlibexecdir)/sss_signal
+ifp_systemdservice =
+endif
+
 secdbpath = @secdbpath@
 
 UNICODE_LIBS=@UNICODE_LIBS@
@@ -1391,6 +1399,24 @@ dist_dbusservice_DATA = \
 if BUILD_CONFIG_LIB
 sssd_ifp_LDADD += libsss_config.la
 endif
+
+EXTRA_DIST += \
+    src/responder/ifp/org.freedesktop.sssd.infopipe.service.in \
+    $(NULL)
+
+ifp_edit_cmd = $(SED) \
+        -e 's|@ifp_exec[@]|$(ifp_exec)|g' \
+        -e 's|@ifp_systemdservice[@]|$(ifp_systemdservice)|g'
+
+ifp_replace_script = \
+    @rm -f $@ $@.tmp; \
+    srcdir=''; \
+        test -f ./$@.in || srcdir=$(srcdir)/; \
+        $(ifp_edit_cmd) $${srcdir}$@.in >$@.tmp; \
+    mv $@.tmp $@
+
+src/responder/ifp/org.freedesktop.sssd.infopipe.service: src/responder/ifp/org.freedesktop.sssd.infopipe.service.in Makefile
+	$(ifp_replace_script)
 
 endif
 
@@ -3934,6 +3960,11 @@ if BUILD_AUTOFS
         src/sysv/systemd/sssd-autofs.service \
         $(NULL)
 endif
+if BUILD_IFP
+    systemdunit_DATA += \
+        src/sysv/systemd/sssd-ifp.service \
+        $(NULL)
+endif
 if BUILD_PAC_RESPONDER
     systemdunit_DATA += \
         src/sysv/systemd/sssd-pac.socket \
@@ -4018,6 +4049,11 @@ EXTRA_DIST += \
     src/sysv/systemd/sssd-autofs.service.in \
     $(NULL)
 endif
+if BUILD_IFP
+EXTRA_DIST += \
+    src/sysv/systemd/sssd-ifp.service.in \
+    $(NULL)
+endif
 if BUILD_PAC_RESPONDER
 EXTRA_DIST += \
     src/sysv/systemd/sssd-pac.socket.in \
@@ -4081,6 +4117,12 @@ src/sysv/systemd/sssd-autofs.socket: src/sysv/systemd/sssd-autofs.socket.in Make
 src/sysv/systemd/sssd-autofs.service: src/sysv/systemd/sssd-autofs.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
 	$(replace_script)
+endif
+
+if BUILD_IFP
+src/sysv/systemd/sssd-ifp.service: src/sysv/systemd/sssd-ifp.service.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(ifp_replace_script)
 endif
 
 if BUILD_PAC_RESPONDER
@@ -4331,9 +4373,11 @@ endif
 		rm -Rf $$doc; \
 	done;
 	rm -Rf ldb_mod_test_dir
+	rm -f $(builddir)/src/responder/ifp/org.freedesktop.sssd.infopipe.service
 	rm -f $(builddir)/src/sysv/systemd/sssd.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-autofs.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-autofs.service
+	rm -f $(builddir)/src/sysv/systemd/sssd-ifp.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-nss.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-nss.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-pac.socket

--- a/Makefile.am
+++ b/Makefile.am
@@ -3946,6 +3946,12 @@ if BUILD_SSH
         src/sysv/systemd/sssd-ssh.service \
         $(NULL)
 endif
+if BUILD_SUDO
+    systemdunit_DATA += \
+        src/sysv/systemd/sssd-sudo.socket \
+        src/sysv/systemd/sssd-sudo.service \
+        $(NULL)
+endif
 if WITH_JOURNALD
     systemdconf_DATA += \
         src/sysv/systemd/journal.conf
@@ -4024,6 +4030,12 @@ EXTRA_DIST += \
     src/sysv/systemd/sssd-ssh.service.in \
     $(NULL)
 endif
+if BUILD_SUDO
+EXTRA_DIST += \
+    src/sysv/systemd/sssd-sudo.socket.in \
+    src/sysv/systemd/sssd-sudo.service.in \
+    $(NULL)
+endif
 
 src/sysv/systemd/sssd.service: src/sysv/systemd/sssd.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
@@ -4087,6 +4099,16 @@ src/sysv/systemd/sssd-ssh.socket: src/sysv/systemd/sssd-ssh.socket.in Makefile
 	$(replace_script)
 
 src/sysv/systemd/sssd-ssh.service: src/sysv/systemd/sssd-ssh.service.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+endif
+
+if BUILD_SUDO
+src/sysv/systemd/sssd-sudo.socket: src/sysv/systemd/sssd-sudo.socket.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+
+src/sysv/systemd/sssd-sudo.service: src/sysv/systemd/sssd-sudo.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
 	$(replace_script)
 endif
@@ -4321,6 +4343,8 @@ endif
 	rm -f $(builddir)/src/sysv/systemd/sssd-pam.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-ssh.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-ssh.service
+	rm -f $(builddir)/src/sysv/systemd/sssd-sudo.socket
+	rm -f $(builddir)/src/sysv/systemd/sssd-sudo.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.service
 	rm -f $(builddir)/src/sysv/systemd/journal.conf

--- a/Makefile.am
+++ b/Makefile.am
@@ -3922,6 +3922,9 @@ if HAVE_SYSTEMD_UNIT
         src/sysv/systemd/sssd.service \
         src/sysv/systemd/sssd-nss.socket \
         src/sysv/systemd/sssd-nss.service \
+        src/sysv/systemd/sssd-pam.socket \
+        src/sysv/systemd/sssd-pam-priv.socket \
+        src/sysv/systemd/sssd-pam.service \
         src/sysv/systemd/sssd-secrets.socket \
         src/sysv/systemd/sssd-secrets.service \
         $(NULL)
@@ -3990,6 +3993,9 @@ EXTRA_DIST += \
     src/sysv/systemd/journal.conf.in \
     src/sysv/systemd/sssd-nss.socket.in \
     src/sysv/systemd/sssd-nss.service.in \
+    src/sysv/systemd/sssd-pam.socket.in \
+    src/sysv/systemd/sssd-pam-priv.socket.in \
+    src/sysv/systemd/sssd-pam.service.in \
     src/sysv/systemd/sssd-secrets.socket.in \
     src/sysv/systemd/sssd-secrets.service.in \
     $(NULL)
@@ -4020,6 +4026,18 @@ src/sysv/systemd/sssd-nss.socket: src/sysv/systemd/sssd-nss.socket.in Makefile
 	$(replace_script)
 
 src/sysv/systemd/sssd-nss.service: src/sysv/systemd/sssd-nss.service.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+
+src/sysv/systemd/sssd-pam.socket: src/sysv/systemd/sssd-pam.socket.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+
+src/sysv/systemd/sssd-pam-priv.socket: src/sysv/systemd/sssd-pam-priv.socket.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+
+src/sysv/systemd/sssd-pam.service: src/sysv/systemd/sssd-pam.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
 	$(replace_script)
 
@@ -4276,6 +4294,9 @@ endif
 	rm -f $(builddir)/src/sysv/systemd/sssd-nss.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-pac.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-pac.service
+	rm -f $(builddir)/src/sysv/systemd/sssd-pam.socket
+	rm -f $(builddir)/src/sysv/systemd/sssd-pam-priv.socket
+	rm -f $(builddir)/src/sysv/systemd/sssd-pam.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.service
 	rm -f $(builddir)/src/sysv/systemd/journal.conf

--- a/Makefile.am
+++ b/Makefile.am
@@ -3931,6 +3931,12 @@ if BUILD_AUTOFS
         src/sysv/systemd/sssd-autofs.service \
         $(NULL)
 endif
+if BUILD_PAC_RESPONDER
+    systemdunit_DATA += \
+        src/sysv/systemd/sssd-pac.socket \
+        src/sysv/systemd/sssd-pac.service \
+        $(NULL)
+endif
 if WITH_JOURNALD
     systemdconf_DATA += \
         src/sysv/systemd/journal.conf
@@ -3994,6 +4000,12 @@ EXTRA_DIST += \
     src/sysv/systemd/sssd-autofs.service.in \
     $(NULL)
 endif
+if BUILD_PAC_RESPONDER
+EXTRA_DIST += \
+    src/sysv/systemd/sssd-pac.socket.in \
+    src/sysv/systemd/sssd-pac.service.in \
+    $(NULL)
+endif
 
 src/sysv/systemd/sssd.service: src/sysv/systemd/sssd.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
@@ -4025,6 +4037,16 @@ src/sysv/systemd/sssd-autofs.socket: src/sysv/systemd/sssd-autofs.socket.in Make
 	$(replace_script)
 
 src/sysv/systemd/sssd-autofs.service: src/sysv/systemd/sssd-autofs.service.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+endif
+
+if BUILD_PAC_RESPONDER
+src/sysv/systemd/sssd-pac.socket: src/sysv/systemd/sssd-pac.socket.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+
+src/sysv/systemd/sssd-pac.service: src/sysv/systemd/sssd-pac.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
 	$(replace_script)
 endif
@@ -4252,6 +4274,8 @@ endif
 	rm -f $(builddir)/src/sysv/systemd/sssd-autofs.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-nss.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-nss.service
+	rm -f $(builddir)/src/sysv/systemd/sssd-pac.socket
+	rm -f $(builddir)/src/sysv/systemd/sssd-pac.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.service
 	rm -f $(builddir)/src/sysv/systemd/journal.conf

--- a/Makefile.am
+++ b/Makefile.am
@@ -3920,6 +3920,8 @@ systemdconf_DATA =
 if HAVE_SYSTEMD_UNIT
     systemdunit_DATA += \
         src/sysv/systemd/sssd.service \
+        src/sysv/systemd/sssd-nss.socket \
+        src/sysv/systemd/sssd-nss.service \
         src/sysv/systemd/sssd-secrets.socket \
         src/sysv/systemd/sssd-secrets.service \
         $(NULL)
@@ -3980,6 +3982,8 @@ replace_script = \
 EXTRA_DIST += \
     src/sysv/systemd/sssd.service.in \
     src/sysv/systemd/journal.conf.in \
+    src/sysv/systemd/sssd-nss.socket.in \
+    src/sysv/systemd/sssd-nss.service.in \
     src/sysv/systemd/sssd-secrets.socket.in \
     src/sysv/systemd/sssd-secrets.service.in \
     $(NULL)
@@ -3996,6 +4000,14 @@ src/sysv/systemd/sssd.service: src/sysv/systemd/sssd.service.in Makefile
 	$(replace_script)
 
 src/sysv/systemd/journal.conf: src/sysv/systemd/journal.conf.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+
+src/sysv/systemd/sssd-nss.socket: src/sysv/systemd/sssd-nss.socket.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+
+src/sysv/systemd/sssd-nss.service: src/sysv/systemd/sssd-nss.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
 	$(replace_script)
 
@@ -4238,6 +4250,8 @@ endif
 	rm -f $(builddir)/src/sysv/systemd/sssd.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-autofs.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-autofs.service
+	rm -f $(builddir)/src/sysv/systemd/sssd-nss.socket
+	rm -f $(builddir)/src/sysv/systemd/sssd-nss.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.service
 	rm -f $(builddir)/src/sysv/systemd/journal.conf

--- a/Makefile.am
+++ b/Makefile.am
@@ -3923,6 +3923,12 @@ if HAVE_SYSTEMD_UNIT
         src/sysv/systemd/sssd-secrets.socket \
         src/sysv/systemd/sssd-secrets.service \
         $(NULL)
+if BUILD_AUTOFS
+    systemdunit_DATA += \
+        src/sysv/systemd/sssd-autofs.socket \
+        src/sysv/systemd/sssd-autofs.service \
+        $(NULL)
+endif
 if WITH_JOURNALD
     systemdconf_DATA += \
         src/sysv/systemd/journal.conf
@@ -3961,6 +3967,7 @@ edit_cmd = $(SED) \
         -e 's|@environment_file[@]|$(environment_file)|g' \
         -e 's|@localstatedir[@]|$(localstatedir)|g' \
         -e 's|@libexecdir[@]|$(libexecdir)|g' \
+        -e 's|@pipepath[@]|$(pipepath)|g' \
         -e 's|@prefix[@]|$(prefix)|g'
 
 replace_script = \
@@ -3977,6 +3984,13 @@ EXTRA_DIST += \
     src/sysv/systemd/sssd-secrets.service.in \
     $(NULL)
 
+if BUILD_AUTOFS
+EXTRA_DIST += \
+    src/sysv/systemd/sssd-autofs.socket.in \
+    src/sysv/systemd/sssd-autofs.service.in \
+    $(NULL)
+endif
+
 src/sysv/systemd/sssd.service: src/sysv/systemd/sssd.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
 	$(replace_script)
@@ -3992,6 +4006,16 @@ src/sysv/systemd/sssd-secrets.socket: src/sysv/systemd/sssd-secrets.socket.in Ma
 src/sysv/systemd/sssd-secrets.service: src/sysv/systemd/sssd-secrets.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
 	$(replace_script)
+
+if BUILD_AUTOFS
+src/sysv/systemd/sssd-autofs.socket: src/sysv/systemd/sssd-autofs.socket.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+
+src/sysv/systemd/sssd-autofs.service: src/sysv/systemd/sssd-autofs.service.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+endif
 
 SSSD_USER_DIRS = \
     $(DESTDIR)$(dbpath) \
@@ -4212,6 +4236,8 @@ endif
 	done;
 	rm -Rf ldb_mod_test_dir
 	rm -f $(builddir)/src/sysv/systemd/sssd.service
+	rm -f $(builddir)/src/sysv/systemd/sssd-autofs.socket
+	rm -f $(builddir)/src/sysv/systemd/sssd-autofs.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.service
 	rm -f $(builddir)/src/sysv/systemd/journal.conf

--- a/configure.ac
+++ b/configure.ac
@@ -477,7 +477,6 @@ AC_CONFIG_FILES([Makefile contrib/sssd.spec src/examples/rwtab src/doxy.config
                  src/lib/sifp/sss_simpleifp.pc
                  src/lib/sifp/sss_simpleifp.doxy
                  src/config/setup.py
-                 src/responder/ifp/org.freedesktop.sssd.infopipe.service
                  src/systemtap/sssd.stp
                  src/config/SSSDConfig/__init__.py])
 AC_OUTPUT

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -802,6 +802,8 @@ done
 %{_unitdir}/sssd.service
 %{_unitdir}/sssd-autofs.socket
 %{_unitdir}/sssd-autofs.service
+%{_unitdir}/sssd-nss.socket
+%{_unitdir}/sssd-nss.service
 %{_unitdir}/sssd-secrets.socket
 %{_unitdir}/sssd-secrets.service
 %else

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -809,6 +809,8 @@ done
 %{_unitdir}/sssd-pam.socket
 %{_unitdir}/sssd-pam-priv.socket
 %{_unitdir}/sssd-pam.service
+%{_unitdir}/sssd-ssh.socket
+%{_unitdir}/sssd-ssh.service
 %{_unitdir}/sssd-secrets.socket
 %{_unitdir}/sssd-secrets.service
 %else

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -800,6 +800,8 @@ done
 %{_sbindir}/sssd
 %if (0%{?use_systemd} == 1)
 %{_unitdir}/sssd.service
+%{_unitdir}/sssd-autofs.socket
+%{_unitdir}/sssd-autofs.service
 %{_unitdir}/sssd-secrets.socket
 %{_unitdir}/sssd-secrets.service
 %else

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -806,6 +806,9 @@ done
 %{_unitdir}/sssd-nss.service
 %{_unitdir}/sssd-pac.socket
 %{_unitdir}/sssd-pac.service
+%{_unitdir}/sssd-pam.socket
+%{_unitdir}/sssd-pam-priv.socket
+%{_unitdir}/sssd-pam.service
 %{_unitdir}/sssd-secrets.socket
 %{_unitdir}/sssd-secrets.service
 %else

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -811,6 +811,8 @@ done
 %{_unitdir}/sssd-pam.service
 %{_unitdir}/sssd-ssh.socket
 %{_unitdir}/sssd-ssh.service
+%{_unitdir}/sssd-sudo.socket
+%{_unitdir}/sssd-sudo.service
 %{_unitdir}/sssd-secrets.socket
 %{_unitdir}/sssd-secrets.service
 %else

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -804,6 +804,8 @@ done
 %{_unitdir}/sssd-autofs.service
 %{_unitdir}/sssd-nss.socket
 %{_unitdir}/sssd-nss.service
+%{_unitdir}/sssd-pac.socket
+%{_unitdir}/sssd-pac.service
 %{_unitdir}/sssd-secrets.socket
 %{_unitdir}/sssd-secrets.service
 %else

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -802,6 +802,7 @@ done
 %{_unitdir}/sssd.service
 %{_unitdir}/sssd-autofs.socket
 %{_unitdir}/sssd-autofs.service
+%{_unitdir}/sssd-ifp.service
 %{_unitdir}/sssd-nss.socket
 %{_unitdir}/sssd-nss.service
 %{_unitdir}/sssd-pac.socket

--- a/src/man/Makefile.am
+++ b/src/man/Makefile.am
@@ -32,7 +32,10 @@ GPO_CONDS = ;gpo_default_enforcing
 else
 GPO_CONDS = ;gpo_default_permissive
 endif
-CONDS = with_false$(SUDO_CONDS)$(AUTOFS_CONDS)$(SSH_CONDS)$(PAC_RESPONDER_CONDS)$(IFP_CONDS)$(GPO_CONDS)$(SEC_CONDS)
+if HAVE_SYSTEMD_UNIT
+SYSTEMD_CONDS = ;have_systemd
+endif
+CONDS = with_false$(SUDO_CONDS)$(AUTOFS_CONDS)$(SSH_CONDS)$(PAC_RESPONDER_CONDS)$(IFP_CONDS)$(GPO_CONDS)$(SEC_CONDS)$(SYSTEMD_CONDS)
 
 
 #Special Rules:

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -202,6 +202,9 @@
                             <para>
                                 Comma separated list of services that are
                                 started when sssd itself starts.
+                                <phrase condition="have_systemd">The list
+                                of services is optional for SSSD 1.15.0 or
+                                later.</phrase>
                             </para>
                             <para>
                                 Supported services: nss, pam

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -227,6 +227,7 @@ static int client_registration(struct sbus_request *dbus_req, void *data)
     struct mt_svc *svc;
     DBusError dbus_error;
     dbus_uint16_t svc_ver;
+    dbus_uint16_t svc_type;
     char *svc_name;
     dbus_bool_t dbret;
     int ret;
@@ -245,6 +246,7 @@ static int client_registration(struct sbus_request *dbus_req, void *data)
     dbret = dbus_message_get_args(dbus_req->message, &dbus_error,
                                   DBUS_TYPE_STRING, &svc_name,
                                   DBUS_TYPE_UINT16, &svc_ver,
+                                  DBUS_TYPE_UINT16, &svc_type,
                                   DBUS_TYPE_INVALID);
     if (!dbret) {
         DEBUG(SSSDBG_CRIT_FAILURE,

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -91,11 +91,6 @@ int cmdline_debug_microseconds;
 
 struct svc_spy;
 
-enum mt_svc_type {
-    MT_SVC_SERVICE,
-    MT_SVC_PROVIDER
-};
-
 struct mt_svc {
     struct mt_svc *prev;
     struct mt_svc *next;

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -778,21 +778,28 @@ done:
     return ret;
 }
 
-static char *check_services(char **services)
+static char *check_service(char *service)
 {
     const char * const *known_services = get_known_services();
-    int i;
-    int ii;
 
-    /* Check if services we are about to start are in the list if known */
-    for (i = 0; services[i]; i++) {
-        for (ii=0; known_services[ii]; ii++) {
-            if (strcasecmp(services[i], known_services[ii]) == 0) {
-                break;
-            }
+    for (int i = 0; known_services[i] != NULL; i++) {
+        if (strcasecmp(service, known_services[i]) == 0) {
+            break;
         }
 
-        if (known_services[ii] == NULL) {
+        if (known_services[i] == NULL) {
+            return service;
+        }
+    }
+
+    return NULL;
+}
+
+static char *check_services(char **services)
+{
+    /* Check if services we are about to start are in the list if known */
+    for (int i = 0; services[i]; i++) {
+        if (check_service(services[i]) != NULL) {
             return services[i];
         }
     }

--- a/src/monitor/monitor_interfaces.h
+++ b/src/monitor/monitor_interfaces.h
@@ -35,6 +35,11 @@
 
 #define SSSD_SERVICE_PIPE "private/sbus-monitor"
 
+enum mt_svc_type {
+    MT_SVC_SERVICE,
+    MT_SVC_PROVIDER
+};
+
 int monitor_get_sbus_address(TALLOC_CTX *mem_ctx, char **address);
 int monitor_common_send_id(struct sbus_connection *conn,
                            const char *name, uint16_t version);

--- a/src/monitor/monitor_interfaces.h
+++ b/src/monitor/monitor_interfaces.h
@@ -42,7 +42,7 @@ enum mt_svc_type {
 
 int monitor_get_sbus_address(TALLOC_CTX *mem_ctx, char **address);
 int monitor_common_send_id(struct sbus_connection *conn,
-                           const char *name, uint16_t version);
+                           const char *name, uint16_t version, uint16_t type);
 int monitor_common_res_init(struct sbus_request *dbus_req, void *data);
 
 errno_t sss_monitor_init(TALLOC_CTX *mem_ctx,
@@ -50,5 +50,6 @@ errno_t sss_monitor_init(TALLOC_CTX *mem_ctx,
                          struct mon_cli_iface *mon_iface,
                          const char *svc_name,
                          uint16_t svc_version,
+                         uint16_t svc_type,
                          void *pvt,
                          struct sbus_connection **mon_conn);

--- a/src/monitor/monitor_sbus.c
+++ b/src/monitor/monitor_sbus.c
@@ -110,7 +110,7 @@ done:
 }
 
 int monitor_common_send_id(struct sbus_connection *conn,
-                           const char *name, uint16_t version)
+                           const char *name, uint16_t version, uint16_t type)
 {
     DBusMessage *msg;
     dbus_bool_t ret;
@@ -131,6 +131,7 @@ int monitor_common_send_id(struct sbus_connection *conn,
     ret = dbus_message_append_args(msg,
                                    DBUS_TYPE_STRING, &name,
                                    DBUS_TYPE_UINT16, &version,
+                                   DBUS_TYPE_UINT16, &type,
                                    DBUS_TYPE_INVALID);
     if (!ret) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Failed to build message\n");
@@ -162,6 +163,7 @@ errno_t sss_monitor_init(TALLOC_CTX *mem_ctx,
                          struct mon_cli_iface *mon_iface,
                          const char *svc_name,
                          uint16_t svc_version,
+                         uint16_t svc_type,
                          void *pvt,
                          struct sbus_connection **mon_conn)
 {
@@ -191,7 +193,7 @@ errno_t sss_monitor_init(TALLOC_CTX *mem_ctx,
     }
 
     /* Identify ourselves to the monitor */
-    ret = monitor_common_send_id(conn, svc_name, svc_version);
+    ret = monitor_common_send_id(conn, svc_name, svc_version, svc_type);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Failed to identify to the monitor!\n");
         return ret;

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -408,7 +408,7 @@ errno_t be_process_init(TALLOC_CTX *mem_ctx,
 
     ret = sss_monitor_init(be_ctx, be_ctx->ev, &monitor_be_methods,
                            be_ctx->identity, DATA_PROVIDER_VERSION,
-                           be_ctx, &be_ctx->mon_conn);
+                           MT_SVC_PROVIDER, be_ctx, &be_ctx->mon_conn);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Unable to initialize monitor connection\n");
         goto done;

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -1062,7 +1062,7 @@ int sss_process_init(TALLOC_CTX *mem_ctx,
     }
 
     /* after all initializations we are ready to listen on our socket */
-    ret = set_unix_socket(rctx, conn_setup);
+    ret = activate_unix_sockets(rctx, conn_setup);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "fatal error initializing socket\n");
         goto fail;

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -1024,8 +1024,8 @@ int sss_process_init(TALLOC_CTX *mem_ctx,
     }
 
     ret = sss_monitor_init(rctx, rctx->ev, monitor_intf,
-                           svc_name, svc_version, rctx,
-                           &rctx->mon_conn);
+                           svc_name, svc_version, MT_SVC_SERVICE,
+                           rctx, &rctx->mon_conn);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "fatal error setting up message bus\n");
         goto fail;

--- a/src/responder/ifp/org.freedesktop.sssd.infopipe.service.in
+++ b/src/responder/ifp/org.freedesktop.sssd.infopipe.service.in
@@ -1,4 +1,5 @@
 [D-BUS Service]
 Name=org.freedesktop.sssd.infopipe
-Exec=@libexecdir@/sssd/sss_signal
+Exec=@ifp_exec@
 User=root
+@ifp_systemdservice@

--- a/src/sysv/systemd/sssd-autofs.service.in
+++ b/src/sysv/systemd/sssd-autofs.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=SSSD AutoFS Service responder
+Documentation=man:sssd.conf(5)
+Requires=sssd.service
+PartOf=sssd.service
+After=sssd.service
+
+[Install]
+Also=sssd-autofs.socket
+
+[Service]
+ExecStart=@libexecdir@/sssd/sssd_autofs --uid 0 --gid 0 --debug-to-files

--- a/src/sysv/systemd/sssd-autofs.socket.in
+++ b/src/sysv/systemd/sssd-autofs.socket.in
@@ -1,0 +1,9 @@
+[Unit]
+Description=SSSD AutoFS Service responder socket
+Documentation=man:sssd.conf(5)
+
+[Socket]
+ListenStream=@pipepath@/autofs
+
+[Install]
+WantedBy=sockets.target

--- a/src/sysv/systemd/sssd-ifp.service.in
+++ b/src/sysv/systemd/sssd-ifp.service.in
@@ -1,0 +1,11 @@
+[Unit]
+Description=SSSD IFP Service responder
+Documentation=man:sssd.conf(5)
+Requires=sssd.service
+PartOf=sssd.service
+After=sssd.service
+
+[Service]
+Type=dbus
+BusName=org.freedesktop.sssd.infopipe
+ExecStart=@ifp_exec@

--- a/src/sysv/systemd/sssd-nss.service.in
+++ b/src/sysv/systemd/sssd-nss.service.in
@@ -1,0 +1,13 @@
+[Unit]
+Description=SSSD NSS Service responder
+Documentation=man:sssd.conf(5)
+Requires=sssd.service
+PartOf=sssd.service
+After=sssd.service
+
+[Install]
+Also=sssd-nss.socket
+
+[Service]
+ExecStart=@libexecdir@/sssd/sssd_nss --uid 0 --gid 0 --debug-to-files
+

--- a/src/sysv/systemd/sssd-nss.socket.in
+++ b/src/sysv/systemd/sssd-nss.socket.in
@@ -1,0 +1,9 @@
+[Unit]
+Description=SSSD NSS Service responder socket
+Documentation=man:sssd.conf(5)
+
+[Socket]
+ListenStream=@pipepath@/nss
+
+[Install]
+WantedBy=sockets.target

--- a/src/sysv/systemd/sssd-pac.service.in
+++ b/src/sysv/systemd/sssd-pac.service.in
@@ -1,0 +1,13 @@
+[Unit]
+Description=SSSD PAC Service responder
+Documentation=man:sssd.conf(5)
+Requires=sssd.service
+PartOf=sssd.service
+After=sssd.service
+
+[Install]
+Also=sssd-pac.socket
+
+[Service]
+ExecStart=@libexecdir@/sssd/sssd_pac --uid 0 --gid 0 --debug-to-files
+

--- a/src/sysv/systemd/sssd-pac.socket.in
+++ b/src/sysv/systemd/sssd-pac.socket.in
@@ -1,0 +1,9 @@
+[Unit]
+Description=SSSD PAC Service responder socket
+Documentation=man:sssd.conf(5)
+
+[Socket]
+ListenStream=@pipepath@/pac
+
+[Install]
+WantedBy=sockets.target

--- a/src/sysv/systemd/sssd-pam-priv.socket.in
+++ b/src/sysv/systemd/sssd-pam-priv.socket.in
@@ -1,0 +1,9 @@
+[Unit]
+Description=SSSD PAM Service responder private socket
+Documentation=man:sssd.conf(5)
+
+[Socket]
+ListenStream=@pipepath@/private/pam
+
+[Install]
+WantedBy=sockets.target

--- a/src/sysv/systemd/sssd-pam.service.in
+++ b/src/sysv/systemd/sssd-pam.service.in
@@ -1,0 +1,13 @@
+[Unit]
+Description=SSSD PAM Service responder
+Documentation=man:sssd.conf(5)
+Requires=sssd.service
+PartOf=sssd.service
+After=sssd.service
+
+[Install]
+Also=sssd-pam.socket sssd-pam-priv.socket
+
+[Service]
+ExecStart=@libexecdir@/sssd/sssd_pam --uid 0 --gid 0 --debug-to-files
+

--- a/src/sysv/systemd/sssd-pam.socket.in
+++ b/src/sysv/systemd/sssd-pam.socket.in
@@ -1,0 +1,9 @@
+[Unit]
+Description=SSSD PAM Service responder socket
+Documentation=man:sssd.conf(5)
+
+[Socket]
+ListenStream=@pipepath@/pam
+
+[Install]
+WantedBy=sockets.target

--- a/src/sysv/systemd/sssd-ssh.service.in
+++ b/src/sysv/systemd/sssd-ssh.service.in
@@ -1,0 +1,13 @@
+[Unit]
+Description=SSSD SSH Service responder
+Documentation=man:sssd.conf(5)
+Requires=sssd.service
+PartOf=sssd.service
+After=sssd.service
+
+[Install]
+Also=sssd-ssh.socket
+
+[Service]
+ExecStart=@libexecdir@/sssd/sssd_ssh --uid 0 --gid 0 --debug-to-files
+

--- a/src/sysv/systemd/sssd-ssh.socket.in
+++ b/src/sysv/systemd/sssd-ssh.socket.in
@@ -1,0 +1,9 @@
+[Unit]
+Description=SSSD SSH Service responder socket
+Documentation=man:sssd.conf(5)
+
+[Socket]
+ListenStream=@pipepath@/ssh
+
+[Install]
+WantedBy=sockets.target

--- a/src/sysv/systemd/sssd-sudo.service.in
+++ b/src/sysv/systemd/sssd-sudo.service.in
@@ -1,0 +1,13 @@
+[Unit]
+Description=SSSD Sudo Service responder
+Documentation=man:sssd.conf(5)
+Requires=sssd.service
+PartOf=sssd.service
+After=sssd.service
+
+[Install]
+Also=sssd-sudo.socket
+
+[Service]
+ExecStart=@libexecdir@/sssd/sssd_sudo --uid 0 --gid 0 --debug-to-files
+

--- a/src/sysv/systemd/sssd-sudo.socket.in
+++ b/src/sysv/systemd/sssd-sudo.socket.in
@@ -1,0 +1,9 @@
+[Unit]
+Description=SSSD Sudo Service responder socket
+Documentation=man:sssd.conf(5)
+
+[Socket]
+ListenStream=@pipepath@/sudo
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
This series fixes [#2243](https://fedorahosted.org/sssd/ticket/2243) and [#3129](https://fedorahosted.org/sssd/ticket/3129), following what was discussed in the [ML](https://lists.fedorahosted.org/archives/list/sssd-devel@lists.fedorahosted.org/message/H6JOF5SGGSIJUIWYNANDA73ODHWBS7J2/) and summed up at [this](https://fedorahosted.org/sssd/wiki/DesignDocs/SocketActivatableResponders) design document.

The approach taken was the less intrusive possible and keeps the backward compatibility.