### PR TITLE
UTIL: Fix implicit declaration of function 'htobe32'

### DIFF
--- a/src/util/cert/libcrypto/cert.c
+++ b/src/util/cert/libcrypto/cert.c
@@ -22,6 +22,7 @@
 #include <openssl/pem.h>
 
 #include "util/util.h"
+#include "util/sss_endian.h"
 
 errno_t sss_cert_der_to_pem(TALLOC_CTX *mem_ctx, const uint8_t *der_blob,
                             size_t der_size, char **pem, size_t *pem_size)

--- a/src/util/cert/nss/cert.c
+++ b/src/util/cert/nss/cert.c
@@ -31,6 +31,7 @@
 #include "util/crypto/sss_crypto.h"
 #include "util/crypto/nss/nss_util.h"
 #include "util/cert.h"
+#include "util/sss_endian.h"
 
 #define NS_CERT_HEADER "-----BEGIN CERTIFICATE-----"
 #define NS_CERT_TRAILER "-----END CERTIFICATE-----"


### PR DESCRIPTION
Include internal wrapper header file for endian related functions.

  CC       src/util/cert/nss/libsss_cert_la-cert.lo
src/util/cert/nss/cert.c: In function 'cert_to_ssh_key':
src/util/cert/nss/cert.c:358: error: implicit declaration of function 'htobe32'
gmake[2]: *** [Makefile:12421: src/util/cert/nss/libsss_cert_la-cert.lo] Error 1
gmake[2]: Leaving directory '/root/sssd_from_git'
gmake[1]: *** [Makefile:20050: all-recursive] Error 1
gmake[1]: Leaving directory '/root/sssd_from_git'
gmake: *** [Makefile:7116: all] Error 2