### PR TITLE
sssctl: Fix missing declaration

### DIFF
--- a/src/tools/sssctl/sssctl.c
+++ b/src/tools/sssctl/sssctl.c
@@ -20,6 +20,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <sys/wait.h>
 
 #include "util/util.h"
 #include "tools/sssctl/sssctl.h"


### PR DESCRIPTION
The WEXITSTATUS is defined in stdlib.h on linux.
There is a nice comment in stdlib.h:
  /* Define the macros <sys/wait.h> also would define this way.  */

It's better to not rely on this and use more platfom friendly
way with including "sys/wait.h".

I found this macro mentioned only in the manual page for wait(2)
and there is mentioned just the "sys/wait.h" and not "stdlib.h"

src/tools/sssctl/sssctl.c: In function 'sssctl_run_command':
src/tools/sssctl/sssctl.c:110: error: implicit declaration of function
'WEXITSTATUS'
gmake[2]: *** [Makefile:22383: src/tools/sssctl/sssctl-sssctl.o] Error 1