### PR TITLE
UTIL: Fix compilation of sss_utf8 with libunistring

### DIFF
--- a/src/util/sss_utf8.c
+++ b/src/util/sss_utf8.c
@@ -26,6 +26,7 @@
 #include <errno.h>
 
 #ifdef HAVE_LIBUNISTRING
+#include <stdlib.h>
 #include <unistr.h>
 #include <unicase.h>
 #elif defined(HAVE_GLIB2)


### PR DESCRIPTION
The internal header file "util/util.h" was removed from sss_utf8.h
as part of commit de5fa34860886ad68fba5e739987e16c342e8f14.
It was neccessary to ensure libipa_hbac can be build with C90
compatible compiler.

This header file includes many system header file and after
this change caused missing declaration of the function free()

src/util/sss_utf8.c: In function ‘sss_utf8_free’:
src/util/sss_utf8.c:40:12: error: implicit declaration of function ‘free’
  [-Werror=implicit-function-declaration]
     return free(ptr);
            ^~~~
src/util/sss_utf8.c:40:12: warning: incompatible implicit declaration
                                    of built-in function ‘free’
src/util/sss_utf8.c:40:12: note: include ‘<stdlib.h>’ or provide
                                 a declaration of ‘free’
cc1: some warnings being treated as errors