### PR TITLE
Enable {socket,dbus}-activation for responders

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3947,6 +3947,12 @@ if BUILD_AUTOFS
         src/sysv/systemd/sssd-autofs.service \
         $(NULL)
 endif
+if BUILD_PAC_RESPONDER
+    systemdunit_DATA += \
+        src/sysv/systemd/sssd-pac.socket \
+        src/sysv/systemd/sssd-pac.service \
+        $(NULL)
+endif
 if WITH_JOURNALD
     systemdconf_DATA += \
         src/sysv/systemd/journal.conf
@@ -4012,6 +4018,12 @@ EXTRA_DIST += \
     src/sysv/systemd/sssd-autofs.service.in \
     $(NULL)
 endif
+if BUILD_PAC_RESPONDER
+EXTRA_DIST += \
+    src/sysv/systemd/sssd-pac.socket.in \
+    src/sysv/systemd/sssd-pac.service.in \
+    $(NULL)
+endif
 
 src/sysv/systemd/sssd.service: src/sysv/systemd/sssd.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
@@ -4043,6 +4055,16 @@ src/sysv/systemd/sssd-autofs.socket: src/sysv/systemd/sssd-autofs.socket.in Make
 	$(replace_script)
 
 src/sysv/systemd/sssd-autofs.service: src/sysv/systemd/sssd-autofs.service.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+endif
+
+if BUILD_PAC_RESPONDER
+src/sysv/systemd/sssd-pac.socket: src/sysv/systemd/sssd-pac.socket.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+
+src/sysv/systemd/sssd-pac.service: src/sysv/systemd/sssd-pac.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
 	$(replace_script)
 endif
@@ -4270,6 +4292,8 @@ endif
 	rm -f $(builddir)/src/sysv/systemd/sssd-autofs.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-nss.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-nss.service
+	rm -f $(builddir)/src/sysv/systemd/sssd-pac.socket
+	rm -f $(builddir)/src/sysv/systemd/sssd-pac.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.service
 	rm -f $(builddir)/src/sysv/systemd/journal.conf

--- a/Makefile.am
+++ b/Makefile.am
@@ -3938,6 +3938,9 @@ if HAVE_SYSTEMD_UNIT
         src/sysv/systemd/sssd.service \
         src/sysv/systemd/sssd-nss.socket \
         src/sysv/systemd/sssd-nss.service \
+        src/sysv/systemd/sssd-pam.socket \
+        src/sysv/systemd/sssd-pam-priv.socket \
+        src/sysv/systemd/sssd-pam.service \
         src/sysv/systemd/sssd-secrets.socket \
         src/sysv/systemd/sssd-secrets.service \
         $(NULL)
@@ -4008,6 +4011,9 @@ EXTRA_DIST += \
     src/sysv/systemd/journal.conf.in \
     src/sysv/systemd/sssd-nss.socket.in \
     src/sysv/systemd/sssd-nss.service.in \
+    src/sysv/systemd/sssd-pam.socket.in \
+    src/sysv/systemd/sssd-pam-priv.socket.in \
+    src/sysv/systemd/sssd-pam.service.in \
     src/sysv/systemd/sssd-secrets.socket.in \
     src/sysv/systemd/sssd-secrets.service.in \
     $(NULL)
@@ -4038,6 +4044,18 @@ src/sysv/systemd/sssd-nss.socket: src/sysv/systemd/sssd-nss.socket.in Makefile
 	$(replace_script)
 
 src/sysv/systemd/sssd-nss.service: src/sysv/systemd/sssd-nss.service.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+
+src/sysv/systemd/sssd-pam.socket: src/sysv/systemd/sssd-pam.socket.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+
+src/sysv/systemd/sssd-pam-priv.socket: src/sysv/systemd/sssd-pam-priv.socket.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+
+src/sysv/systemd/sssd-pam.service: src/sysv/systemd/sssd-pam.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
 	$(replace_script)
 
@@ -4294,6 +4312,9 @@ endif
 	rm -f $(builddir)/src/sysv/systemd/sssd-nss.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-pac.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-pac.service
+	rm -f $(builddir)/src/sysv/systemd/sssd-pam.socket
+	rm -f $(builddir)/src/sysv/systemd/sssd-pam-priv.socket
+	rm -f $(builddir)/src/sysv/systemd/sssd-pam.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.service
 	rm -f $(builddir)/src/sysv/systemd/journal.conf

--- a/Makefile.am
+++ b/Makefile.am
@@ -3939,6 +3939,12 @@ if HAVE_SYSTEMD_UNIT
         src/sysv/systemd/sssd-secrets.socket \
         src/sysv/systemd/sssd-secrets.service \
         $(NULL)
+if BUILD_AUTOFS
+    systemdunit_DATA += \
+        src/sysv/systemd/sssd-autofs.socket \
+        src/sysv/systemd/sssd-autofs.service \
+        $(NULL)
+endif
 if WITH_JOURNALD
     systemdconf_DATA += \
         src/sysv/systemd/journal.conf
@@ -3976,8 +3982,11 @@ edit_cmd = $(SED) \
         -e 's|@sbindir[@]|$(sbindir)|g' \
         -e 's|@environment_file[@]|$(environment_file)|g' \
         -e 's|@localstatedir[@]|$(localstatedir)|g' \
+        -e 's|@logpath[@]|$(logpath)|g' \
         -e 's|@libexecdir[@]|$(libexecdir)|g' \
-        -e 's|@prefix[@]|$(prefix)|g'
+        -e 's|@pipepath[@]|$(pipepath)|g' \
+        -e 's|@prefix[@]|$(prefix)|g' \
+        -e 's|@SSSD_USER[@]|$(SSSD_USER)|g'
 
 replace_script = \
     @rm -f $@ $@.tmp; \
@@ -3992,6 +4001,13 @@ EXTRA_DIST += \
     src/sysv/systemd/sssd-secrets.socket.in \
     src/sysv/systemd/sssd-secrets.service.in \
     $(NULL)
+
+if BUILD_AUTOFS
+EXTRA_DIST += \
+    src/sysv/systemd/sssd-autofs.socket.in \
+    src/sysv/systemd/sssd-autofs.service.in \
+    $(NULL)
+endif
 
 src/sysv/systemd/sssd.service: src/sysv/systemd/sssd.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
@@ -4008,6 +4024,16 @@ src/sysv/systemd/sssd-secrets.socket: src/sysv/systemd/sssd-secrets.socket.in Ma
 src/sysv/systemd/sssd-secrets.service: src/sysv/systemd/sssd-secrets.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
 	$(replace_script)
+
+if BUILD_AUTOFS
+src/sysv/systemd/sssd-autofs.socket: src/sysv/systemd/sssd-autofs.socket.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+
+src/sysv/systemd/sssd-autofs.service: src/sysv/systemd/sssd-autofs.service.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+endif
 
 SSSD_USER_DIRS = \
     $(DESTDIR)$(dbpath) \
@@ -4228,6 +4254,8 @@ endif
 	done;
 	rm -Rf ldb_mod_test_dir
 	rm -f $(builddir)/src/sysv/systemd/sssd.service
+	rm -f $(builddir)/src/sysv/systemd/sssd-autofs.socket
+	rm -f $(builddir)/src/sysv/systemd/sssd-autofs.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.service
 	rm -f $(builddir)/src/sysv/systemd/journal.conf

--- a/Makefile.am
+++ b/Makefile.am
@@ -88,6 +88,16 @@ polkitdir = @polkitdir@
 pamconfdir = $(sysconfdir)/pam.d
 systemtap_tapdir = @tapset_dir@
 
+if HAVE_SYSTEMD_UNIT
+ifp_exec_cmd = $(sssdlibexecdir)/sssd_ifp --uid 0 --gid 0 --debug-to-files --dbus-activated
+ifp_systemdservice = SystemdService=sssd-ifp.service
+ifp_restart = Restart=on-failure
+else
+ifp_exec_cmd = $(sssdlibexecdir)/sss_signal
+ifp_systemdservice =
+ifp_restart =
+endif
+
 secdbpath = @secdbpath@
 
 UNICODE_LIBS=@UNICODE_LIBS@
@@ -1377,6 +1387,26 @@ dist_dbuspolicy_DATA = \
     src/responder/ifp/org.freedesktop.sssd.infopipe.conf
 dist_dbusservice_DATA = \
     src/responder/ifp/org.freedesktop.sssd.infopipe.service
+
+EXTRA_DIST += \
+    src/responder/ifp/org.freedesktop.sssd.infopipe.service.in \
+    $(NULL)
+
+ifp_edit_cmd = $(SED) \
+        -e 's|@ifp_exec_cmd[@]|$(ifp_exec_cmd)|g' \
+        -e 's|@ifp_systemdservice[@]|$(ifp_systemdservice)|g' \
+        -e 's|@ifp_restart[@]|$(ifp_restart)|g'
+
+ifp_replace_script = \
+    @rm -f $@ $@.tmp; \
+    srcdir=''; \
+        test -f ./$@.in || srcdir=$(srcdir)/; \
+        $(ifp_edit_cmd) $${srcdir}$@.in >$@.tmp; \
+    mv $@.tmp $@
+
+src/responder/ifp/org.freedesktop.sssd.infopipe.service: src/responder/ifp/org.freedesktop.sssd.infopipe.service.in Makefile
+	$(ifp_replace_script)
+
 endif
 
 if BUILD_SECRETS
@@ -3950,6 +3980,11 @@ if BUILD_AUTOFS
         src/sysv/systemd/sssd-autofs.service \
         $(NULL)
 endif
+if BUILD_IFP
+    systemdunit_DATA += \
+        src/sysv/systemd/sssd-ifp.service \
+        $(NULL)
+endif
 if BUILD_PAC_RESPONDER
     systemdunit_DATA += \
         src/sysv/systemd/sssd-pac.socket \
@@ -4036,6 +4071,11 @@ EXTRA_DIST += \
     src/sysv/systemd/sssd-autofs.service.in \
     $(NULL)
 endif
+if BUILD_IFP
+EXTRA_DIST += \
+    src/sysv/systemd/sssd-ifp.service.in \
+    $(NULL)
+endif
 if BUILD_PAC_RESPONDER
 EXTRA_DIST += \
     src/sysv/systemd/sssd-pac.socket.in \
@@ -4099,6 +4139,12 @@ src/sysv/systemd/sssd-autofs.socket: src/sysv/systemd/sssd-autofs.socket.in Make
 src/sysv/systemd/sssd-autofs.service: src/sysv/systemd/sssd-autofs.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
 	$(replace_script)
+endif
+
+if BUILD_IFP
+src/sysv/systemd/sssd-ifp.service: src/sysv/systemd/sssd-ifp.service.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(ifp_replace_script)
 endif
 
 if BUILD_PAC_RESPONDER
@@ -4349,9 +4395,11 @@ endif
 		rm -Rf $$doc; \
 	done;
 	rm -Rf ldb_mod_test_dir
+	rm -f $(builddir)/src/responder/ifp/org.freedesktop.sssd.infopipe.service
 	rm -f $(builddir)/src/sysv/systemd/sssd.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-autofs.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-autofs.service
+	rm -f $(builddir)/src/sysv/systemd/sssd-ifp.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-nss.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-nss.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-pac.socket

--- a/Makefile.am
+++ b/Makefile.am
@@ -3956,6 +3956,12 @@ if BUILD_PAC_RESPONDER
         src/sysv/systemd/sssd-pac.service \
         $(NULL)
 endif
+if BUILD_SSH
+    systemdunit_DATA += \
+        src/sysv/systemd/sssd-ssh.socket \
+        src/sysv/systemd/sssd-ssh.service \
+        $(NULL)
+endif
 if WITH_JOURNALD
     systemdconf_DATA += \
         src/sysv/systemd/journal.conf
@@ -4030,6 +4036,12 @@ EXTRA_DIST += \
     src/sysv/systemd/sssd-pac.service.in \
     $(NULL)
 endif
+if BUILD_SSH
+EXTRA_DIST += \
+    src/sysv/systemd/sssd-ssh.socket.in \
+    src/sysv/systemd/sssd-ssh.service.in \
+    $(NULL)
+endif
 
 src/sysv/systemd/sssd.service: src/sysv/systemd/sssd.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
@@ -4083,6 +4095,16 @@ src/sysv/systemd/sssd-pac.socket: src/sysv/systemd/sssd-pac.socket.in Makefile
 	$(replace_script)
 
 src/sysv/systemd/sssd-pac.service: src/sysv/systemd/sssd-pac.service.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+endif
+
+if BUILD_SSH
+src/sysv/systemd/sssd-ssh.socket: src/sysv/systemd/sssd-ssh.socket.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+
+src/sysv/systemd/sssd-ssh.service: src/sysv/systemd/sssd-ssh.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
 	$(replace_script)
 endif
@@ -4315,6 +4337,8 @@ endif
 	rm -f $(builddir)/src/sysv/systemd/sssd-pam.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-pam-priv.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-pam.service
+	rm -f $(builddir)/src/sysv/systemd/sssd-ssh.socket
+	rm -f $(builddir)/src/sysv/systemd/sssd-ssh.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.service
 	rm -f $(builddir)/src/sysv/systemd/journal.conf

--- a/Makefile.am
+++ b/Makefile.am
@@ -3962,6 +3962,12 @@ if BUILD_SSH
         src/sysv/systemd/sssd-ssh.service \
         $(NULL)
 endif
+if BUILD_SUDO
+    systemdunit_DATA += \
+        src/sysv/systemd/sssd-sudo.socket \
+        src/sysv/systemd/sssd-sudo.service \
+        $(NULL)
+endif
 if WITH_JOURNALD
     systemdconf_DATA += \
         src/sysv/systemd/journal.conf
@@ -4042,6 +4048,12 @@ EXTRA_DIST += \
     src/sysv/systemd/sssd-ssh.service.in \
     $(NULL)
 endif
+if BUILD_SUDO
+EXTRA_DIST += \
+    src/sysv/systemd/sssd-sudo.socket.in \
+    src/sysv/systemd/sssd-sudo.service.in \
+    $(NULL)
+endif
 
 src/sysv/systemd/sssd.service: src/sysv/systemd/sssd.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
@@ -4105,6 +4117,16 @@ src/sysv/systemd/sssd-ssh.socket: src/sysv/systemd/sssd-ssh.socket.in Makefile
 	$(replace_script)
 
 src/sysv/systemd/sssd-ssh.service: src/sysv/systemd/sssd-ssh.service.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+endif
+
+if BUILD_SUDO
+src/sysv/systemd/sssd-sudo.socket: src/sysv/systemd/sssd-sudo.socket.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+
+src/sysv/systemd/sssd-sudo.service: src/sysv/systemd/sssd-sudo.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
 	$(replace_script)
 endif
@@ -4339,6 +4361,8 @@ endif
 	rm -f $(builddir)/src/sysv/systemd/sssd-pam.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-ssh.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-ssh.service
+	rm -f $(builddir)/src/sysv/systemd/sssd-sudo.socket
+	rm -f $(builddir)/src/sysv/systemd/sssd-sudo.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.service
 	rm -f $(builddir)/src/sysv/systemd/journal.conf

--- a/Makefile.am
+++ b/Makefile.am
@@ -3936,6 +3936,8 @@ systemdconf_DATA =
 if HAVE_SYSTEMD_UNIT
     systemdunit_DATA += \
         src/sysv/systemd/sssd.service \
+        src/sysv/systemd/sssd-nss.socket \
+        src/sysv/systemd/sssd-nss.service \
         src/sysv/systemd/sssd-secrets.socket \
         src/sysv/systemd/sssd-secrets.service \
         $(NULL)
@@ -3998,6 +4000,8 @@ replace_script = \
 EXTRA_DIST += \
     src/sysv/systemd/sssd.service.in \
     src/sysv/systemd/journal.conf.in \
+    src/sysv/systemd/sssd-nss.socket.in \
+    src/sysv/systemd/sssd-nss.service.in \
     src/sysv/systemd/sssd-secrets.socket.in \
     src/sysv/systemd/sssd-secrets.service.in \
     $(NULL)
@@ -4014,6 +4018,14 @@ src/sysv/systemd/sssd.service: src/sysv/systemd/sssd.service.in Makefile
 	$(replace_script)
 
 src/sysv/systemd/journal.conf: src/sysv/systemd/journal.conf.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+
+src/sysv/systemd/sssd-nss.socket: src/sysv/systemd/sssd-nss.socket.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+
+src/sysv/systemd/sssd-nss.service: src/sysv/systemd/sssd-nss.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
 	$(replace_script)
 
@@ -4256,6 +4268,8 @@ endif
 	rm -f $(builddir)/src/sysv/systemd/sssd.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-autofs.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-autofs.service
+	rm -f $(builddir)/src/sysv/systemd/sssd-nss.socket
+	rm -f $(builddir)/src/sysv/systemd/sssd-nss.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.service
 	rm -f $(builddir)/src/sysv/systemd/journal.conf

--- a/configure.ac
+++ b/configure.ac
@@ -464,7 +464,6 @@ AC_CONFIG_FILES([Makefile contrib/sssd.spec src/examples/rwtab src/doxy.config
                  src/lib/sifp/sss_simpleifp.pc
                  src/lib/sifp/sss_simpleifp.doxy
                  src/config/setup.py
-                 src/responder/ifp/org.freedesktop.sssd.infopipe.service
                  src/systemtap/sssd.stp
                  src/config/SSSDConfig/__init__.py])
 AC_OUTPUT

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -801,6 +801,8 @@ done
 %{_unitdir}/sssd.service
 %{_unitdir}/sssd-autofs.socket
 %{_unitdir}/sssd-autofs.service
+%{_unitdir}/sssd-nss.socket
+%{_unitdir}/sssd-nss.service
 %{_unitdir}/sssd-secrets.socket
 %{_unitdir}/sssd-secrets.service
 %else
@@ -1136,17 +1138,21 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d / -s /sbin/nologin -c "Us
 %post common
 %systemd_post sssd.service
 %systemd_post sssd-autofs.socket
+%systemd_post sssd-nss.socket
 %systemd_post sssd-secrets.socket
 
 %preun common
 %systemd_preun sssd.service
 %systemd_preun sssd-autofs.socket
+%systemd_preun sssd-nss.socket
 %systemd_preun sssd-secrets.socket
 
 %postun common
 %systemd_postun_with_restart sssd.service
 %systemd_postun_with_restart sssd-autofs.socket
 %systemd_postun_with_restart sssd-autofs.service
+%systemd_postun_with_restart sssd-nss.socket
+%systemd_postun_with_restart sssd-nss.service
 %systemd_postun_with_restart sssd-secrets.socket
 %systemd_postun_with_restart sssd-secrets.service
 

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -801,6 +801,7 @@ done
 %{_unitdir}/sssd.service
 %{_unitdir}/sssd-autofs.socket
 %{_unitdir}/sssd-autofs.service
+%{_unitdir}/sssd-ifp.service
 %{_unitdir}/sssd-nss.socket
 %{_unitdir}/sssd-nss.service
 %{_unitdir}/sssd-pac.socket

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -803,6 +803,8 @@ done
 %{_unitdir}/sssd-autofs.service
 %{_unitdir}/sssd-nss.socket
 %{_unitdir}/sssd-nss.service
+%{_unitdir}/sssd-pac.socket
+%{_unitdir}/sssd-pac.service
 %{_unitdir}/sssd-secrets.socket
 %{_unitdir}/sssd-secrets.service
 %else
@@ -1139,12 +1141,14 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d / -s /sbin/nologin -c "Us
 %systemd_post sssd.service
 %systemd_post sssd-autofs.socket
 %systemd_post sssd-nss.socket
+%systemd_post sssd-pac.socket
 %systemd_post sssd-secrets.socket
 
 %preun common
 %systemd_preun sssd.service
 %systemd_preun sssd-autofs.socket
 %systemd_preun sssd-nss.socket
+%systemd_preun sssd-pac.socket
 %systemd_preun sssd-secrets.socket
 
 %postun common
@@ -1153,6 +1157,8 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d / -s /sbin/nologin -c "Us
 %systemd_postun_with_restart sssd-autofs.service
 %systemd_postun_with_restart sssd-nss.socket
 %systemd_postun_with_restart sssd-nss.service
+%systemd_postun_with_restart sssd-pac.socket
+%systemd_postun_with_restart sssd-pac.service
 %systemd_postun_with_restart sssd-secrets.socket
 %systemd_postun_with_restart sssd-secrets.service
 

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -799,6 +799,8 @@ done
 %{_sbindir}/sssd
 %if (0%{?use_systemd} == 1)
 %{_unitdir}/sssd.service
+%{_unitdir}/sssd-autofs.socket
+%{_unitdir}/sssd-autofs.service
 %{_unitdir}/sssd-secrets.socket
 %{_unitdir}/sssd-secrets.service
 %else
@@ -1133,14 +1135,18 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d / -s /sbin/nologin -c "Us
 # systemd
 %post common
 %systemd_post sssd.service
+%systemd_post sssd-autofs.socket
 %systemd_post sssd-secrets.socket
 
 %preun common
 %systemd_preun sssd.service
+%systemd_preun sssd-autofs.socket
 %systemd_preun sssd-secrets.socket
 
 %postun common
 %systemd_postun_with_restart sssd.service
+%systemd_postun_with_restart sssd-autofs.socket
+%systemd_postun_with_restart sssd-autofs.service
 %systemd_postun_with_restart sssd-secrets.socket
 %systemd_postun_with_restart sssd-secrets.service
 

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -805,6 +805,9 @@ done
 %{_unitdir}/sssd-nss.service
 %{_unitdir}/sssd-pac.socket
 %{_unitdir}/sssd-pac.service
+%{_unitdir}/sssd-pam.socket
+%{_unitdir}/sssd-pam-priv.socket
+%{_unitdir}/sssd-pam.service
 %{_unitdir}/sssd-secrets.socket
 %{_unitdir}/sssd-secrets.service
 %else
@@ -1142,6 +1145,8 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d / -s /sbin/nologin -c "Us
 %systemd_post sssd-autofs.socket
 %systemd_post sssd-nss.socket
 %systemd_post sssd-pac.socket
+%systemd_post sssd-pam.socket
+%systemd_post sssd-pam-priv.socket
 %systemd_post sssd-secrets.socket
 
 %preun common
@@ -1149,6 +1154,8 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d / -s /sbin/nologin -c "Us
 %systemd_preun sssd-autofs.socket
 %systemd_preun sssd-nss.socket
 %systemd_preun sssd-pac.socket
+%systemd_preun sssd-pam.socket
+%systemd_preun sssd-pam-priv.socket
 %systemd_preun sssd-secrets.socket
 
 %postun common
@@ -1159,6 +1166,9 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d / -s /sbin/nologin -c "Us
 %systemd_postun_with_restart sssd-nss.service
 %systemd_postun_with_restart sssd-pac.socket
 %systemd_postun_with_restart sssd-pac.service
+%systemd_postun_with_restart sssd-pam.socket
+%systemd_postun_with_restart sssd-pam-priv.socket
+%systemd_postun_with_restart sssd-pam.service
 %systemd_postun_with_restart sssd-secrets.socket
 %systemd_postun_with_restart sssd-secrets.service
 

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -810,6 +810,8 @@ done
 %{_unitdir}/sssd-pam.service
 %{_unitdir}/sssd-ssh.socket
 %{_unitdir}/sssd-ssh.service
+%{_unitdir}/sssd-sudo.socket
+%{_unitdir}/sssd-sudo.service
 %{_unitdir}/sssd-secrets.socket
 %{_unitdir}/sssd-secrets.service
 %else
@@ -1151,6 +1153,7 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d / -s /sbin/nologin -c "Us
 %systemd_post sssd-pam-priv.socket
 %systemd_post sssd-secrets.socket
 %systemd_post sssd-ssh.socket
+%systemd_post sssd-sudo.socket
 
 %preun common
 %systemd_preun sssd.service
@@ -1161,6 +1164,7 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d / -s /sbin/nologin -c "Us
 %systemd_preun sssd-pam-priv.socket
 %systemd_preun sssd-secrets.socket
 %systemd_preun sssd-ssh.socket
+%systemd_preun sssd-sudo.socket
 
 %postun common
 %systemd_postun_with_restart sssd.service
@@ -1177,6 +1181,8 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d / -s /sbin/nologin -c "Us
 %systemd_postun_with_restart sssd-secrets.service
 %systemd_postun_with_restart sssd-ssh.socket
 %systemd_postun_with_restart sssd-ssh.service
+%systemd_postun_with_restart sssd-sudo.socket
+%systemd_postun_with_restart sssd-sudo.service
 
 %else
 # sysv

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -808,6 +808,8 @@ done
 %{_unitdir}/sssd-pam.socket
 %{_unitdir}/sssd-pam-priv.socket
 %{_unitdir}/sssd-pam.service
+%{_unitdir}/sssd-ssh.socket
+%{_unitdir}/sssd-ssh.service
 %{_unitdir}/sssd-secrets.socket
 %{_unitdir}/sssd-secrets.service
 %else
@@ -1148,6 +1150,7 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d / -s /sbin/nologin -c "Us
 %systemd_post sssd-pam.socket
 %systemd_post sssd-pam-priv.socket
 %systemd_post sssd-secrets.socket
+%systemd_post sssd-ssh.socket
 
 %preun common
 %systemd_preun sssd.service
@@ -1157,6 +1160,7 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d / -s /sbin/nologin -c "Us
 %systemd_preun sssd-pam.socket
 %systemd_preun sssd-pam-priv.socket
 %systemd_preun sssd-secrets.socket
+%systemd_preun sssd-ssh.socket
 
 %postun common
 %systemd_postun_with_restart sssd.service
@@ -1171,6 +1175,8 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d / -s /sbin/nologin -c "Us
 %systemd_postun_with_restart sssd-pam.service
 %systemd_postun_with_restart sssd-secrets.socket
 %systemd_postun_with_restart sssd-secrets.service
+%systemd_postun_with_restart sssd-ssh.socket
+%systemd_postun_with_restart sssd-ssh.service
 
 %else
 # sysv

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -86,6 +86,8 @@
 #define CONFDB_RESPONDER_CLI_IDLE_TIMEOUT "client_idle_timeout"
 #define CONFDB_RESPONDER_CLI_IDLE_DEFAULT_TIMEOUT 60
 #define CONFDB_RESPONDER_LOCAL_NEG_TIMEOUT "local_negative_timeout"
+#define CONFDB_RESPONDER_IDLE_TIMEOUT "responder_idle_timeout"
+#define CONFDB_RESPONDER_IDLE_DEFAULT_TIMEOUT 300
 
 /* NSS */
 #define CONFDB_NSS_CONF_ENTRY "config/nss"

--- a/src/config/SSSDConfig/__init__.py.in
+++ b/src/config/SSSDConfig/__init__.py.in
@@ -50,6 +50,7 @@ option_strings = {
     'reconnection_retries' : _('Number of times to attempt connection to Data Providers'),
     'fd_limit' : _('The number of file descriptors that may be opened by this responder'),
     'client_idle_timeout' : _('Idle time before automatic disconnection of a client'),
+    'responder_idle_timeout' : _('Idle time before automatic shutdown of the responder'),
 
     # [sssd]
     'services' : _('SSSD Services to start'),

--- a/src/config/SSSDConfigTest.py
+++ b/src/config/SSSDConfigTest.py
@@ -308,6 +308,7 @@ class SSSDConfigTestSSSDService(unittest.TestCase):
             'reconnection_retries',
             'fd_limit',
             'client_idle_timeout',
+            'responder_idle_timeout',
             'description',
             'certificate_verification',
             'override_space',

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -57,6 +57,7 @@ option = reconnection_retries
 option = fd_limit
 option = client_idle_timeout
 option = description
+option = responder_idle_timeout
 
 # Name service
 option = user_attributes
@@ -94,6 +95,7 @@ option = reconnection_retries
 option = fd_limit
 option = client_idle_timeout
 option = description
+option = responder_idle_timeout
 
 # Authentication service
 option = offline_credentials_expiration
@@ -127,6 +129,7 @@ option = reconnection_retries
 option = fd_limit
 option = client_idle_timeout
 option = description
+option = responder_idle_timeout
 
 # sudo service
 option = sudo_timed
@@ -147,6 +150,7 @@ option = reconnection_retries
 option = fd_limit
 option = client_idle_timeout
 option = description
+option = responder_idle_timeout
 
 # autofs service
 option = autofs_negative_timeout
@@ -166,6 +170,7 @@ option = reconnection_retries
 option = fd_limit
 option = client_idle_timeout
 option = description
+option = responder_idle_timeout
 
 # ssh service
 option = ssh_hash_known_hosts
@@ -187,6 +192,7 @@ option = reconnection_retries
 option = fd_limit
 option = client_idle_timeout
 option = description
+option = responder_idle_timeout
 
 # PAC responder
 option = allowed_uids
@@ -207,6 +213,7 @@ option = reconnection_retries
 option = fd_limit
 option = client_idle_timeout
 option = description
+option = responder_idle_timeout
 
 # InfoPipe responder
 option = allowed_uids

--- a/src/config/etc/sssd.api.conf
+++ b/src/config/etc/sssd.api.conf
@@ -13,6 +13,7 @@ command = str, None, false
 reconnection_retries = int, None, false
 fd_limit = int, None, false
 client_idle_timeout = int, None, false
+responder_idle_timeout = int, None, false
 description = str, None, false
 
 [sssd]

--- a/src/man/Makefile.am
+++ b/src/man/Makefile.am
@@ -32,7 +32,10 @@ GPO_CONDS = ;gpo_default_enforcing
 else
 GPO_CONDS = ;gpo_default_permissive
 endif
-CONDS = with_false$(SUDO_CONDS)$(AUTOFS_CONDS)$(SSH_CONDS)$(PAC_RESPONDER_CONDS)$(IFP_CONDS)$(GPO_CONDS)$(SEC_CONDS)
+if HAVE_SYSTEMD_UNIT
+SYSTEMD_CONDS = ;have_systemd
+endif
+CONDS = with_false$(SUDO_CONDS)$(AUTOFS_CONDS)$(SSH_CONDS)$(PAC_RESPONDER_CONDS)$(IFP_CONDS)$(GPO_CONDS)$(SEC_CONDS)$(SYSTEMD_CONDS)
 
 
 #Special Rules:

--- a/src/man/sssd-sudo.5.xml
+++ b/src/man/sssd-sudo.5.xml
@@ -107,6 +107,12 @@ sudo_provider = ldap
 ldap_uri = ldap://example.com
 ldap_sudo_search_base = ou=sudoers,dc=example,dc=com
 </programlisting>
+            <phrase condition="have_systemd">
+                It's important to note that on platforms where systemd is supported
+                there's no need to add the "sudo" provider to the list of services,
+                as it became optional. However, sssd-sudo.socket must be enabled
+                instead.
+            </phrase>
         </para>
         <para>
             When SSSD is configured to use IPA as the ID provider, the

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -371,6 +371,19 @@
                                 The user to drop the privileges to where
                                 appropriate to avoid running as the
                                 root user.
+                                <phrase condition="have_systemd">
+                                    This option does not work when running socket-activated
+                                    services, as the user set up to run the processes is
+                                    set up during compilation time.
+
+                                    The way to override the systemd unit files is by creating
+                                    the appropriate files in /etc/systemd/system/.
+
+                                    Keep in mind that any change in the socket user, group or
+                                    permissions may result in a non-usable SSSD. The same may
+                                    occur in case of changes of the user running the NSS
+                                    responder.
+                                </phrase>
                             </para>
                             <para>
                                 Default: not set, process will run as root

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -623,6 +623,28 @@
                         </para>
                     </listitem>
                 </varlistentry>
+                <varlistentry>
+                    <term>responder_idle_timeout</term>
+                    <listitem>
+                        <para>
+                            This option specifies the number of seconds that
+                            an SSSD responder process can be up without being
+                            used. This value is limited in order to avoid
+                            resource exhaustion on the system.
+                            The minimum acceptable value for this option is 60
+                            seconds.
+                            Setting this option to 0 (zero) means that no
+                            timeout will be set up to the responder.
+
+                            This option only has effect when SSSD is built with
+                            systemd support and when services are either socket
+                            or dbus activated.
+                        </para>
+                        <para>
+                            Default: 300
+                        </para>
+                    </listitem>
+                </varlistentry>
             </variablelist>
         </refsect2>
 

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -202,6 +202,11 @@
                             <para>
                                 Comma separated list of services that are
                                 started when sssd itself starts.
+                                <phrase condition="have_systemd">
+                                    The services' list is optional on platforms
+                                    where systemd is supported, as they will either
+                                    be socket or dbus activated when needed.
+                                </phrase>
                             </para>
                             <para>
                                 Supported services: nss, pam
@@ -210,6 +215,13 @@
                                 <phrase condition="with_ssh">, ssh</phrase>
                                 <phrase condition="with_pac_responder">, pac</phrase>
                                 <phrase condition="with_ifp">, ifp</phrase>
+                            </para>
+                            <para>
+                                <phrase condition="have_systemd">
+                                    By default, all services are disabled and the administrator
+                                    must enable the ones allowed to be used by executing:
+                                    "systemctl enable sssd-@service@.socket".
+                                </phrase>
                             </para>
                         </listitem>
                     </varlistentry>

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -95,11 +95,6 @@ int cmdline_debug_microseconds;
 
 struct svc_spy;
 
-enum mt_svc_type {
-    MT_SVC_SERVICE,
-    MT_SVC_PROVIDER
-};
-
 struct mt_svc {
     struct mt_svc *prev;
     struct mt_svc *next;

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -806,21 +806,29 @@ done:
     return ret;
 }
 
-static char *check_services(char **services)
+static char *check_service(char *service)
 {
     const char * const *known_services = get_known_services();
     int i;
-    int ii;
 
-    /* Check if services we are about to start are in the list if known */
-    for (i = 0; services[i]; i++) {
-        for (ii=0; known_services[ii]; ii++) {
-            if (strcasecmp(services[i], known_services[ii]) == 0) {
-                break;
-            }
+    for (i = 0; known_services[i] != NULL; i++) {
+        if (strcasecmp(service, known_services[i]) == 0) {
+            break;
         }
+    }
 
-        if (known_services[ii] == NULL) {
+    if (known_services[i] == NULL) {
+        return service;
+    }
+
+    return NULL;
+}
+
+static char *check_services(char **services)
+{
+    /* Check if services we are about to start are in the list if known */
+    for (int i = 0; services[i]; i++) {
+        if (check_service(services[i]) != NULL) {
             return services[i];
         }
     }

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -232,6 +232,7 @@ static int client_registration(struct sbus_request *dbus_req, void *data)
     struct mt_svc *svc;
     DBusError dbus_error;
     dbus_uint16_t svc_ver;
+    dbus_uint16_t svc_type;
     char *svc_name;
     dbus_bool_t dbret;
     int ret;
@@ -250,6 +251,7 @@ static int client_registration(struct sbus_request *dbus_req, void *data)
     dbret = dbus_message_get_args(dbus_req->message, &dbus_error,
                                   DBUS_TYPE_STRING, &svc_name,
                                   DBUS_TYPE_UINT16, &svc_ver,
+                                  DBUS_TYPE_UINT16, &svc_type,
                                   DBUS_TYPE_INVALID);
     if (!dbret) {
         DEBUG(SSSDBG_CRIT_FAILURE,

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -644,7 +644,7 @@ static int monitor_dbus_init(struct mt_ctx *ctx)
      * lose any access.
      */
     ret = sbus_new_server(ctx, ctx->ev, monitor_address, ctx->uid, ctx->gid,
-                          false, &ctx->sbus_srv, monitor_service_init, ctx);
+                          false, &ctx->sbus_srv, monitor_service_init, ctx, NULL);
 
     talloc_free(monitor_address);
 

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -428,12 +428,14 @@ static int mark_service_as_started(struct mt_svc *svc)
             goto done;
         }
 
-        ctx->services_started = true;
+        if (ctx->services != NULL) {
+            ctx->services_started = true;
 
-        DEBUG(SSSDBG_CONF_SETTINGS, "Now starting services!\n");
-        /* then start all services */
-        for (i = 0; ctx->services[i]; i++) {
-            add_new_service(ctx, ctx->services[i], 0);
+            DEBUG(SSSDBG_CONF_SETTINGS, "Now starting services!\n");
+            /* then start all services */
+            for (i = 0; ctx->services[i]; i++) {
+                add_new_service(ctx, ctx->services[i], 0);
+            }
         }
     }
 
@@ -498,6 +500,10 @@ static void services_startup_timeout(struct tevent_context *ev,
 {
     struct mt_ctx *ctx = talloc_get_type(ptr, struct mt_ctx);
     int i;
+
+    if (ctx->services == NULL) {
+        return;
+    }
 
     DEBUG(SSSDBG_TRACE_FUNC, "Handling timeout\n");
 
@@ -826,6 +832,10 @@ static char *check_service(char *service)
 
 static char *check_services(char **services)
 {
+    if (services == NULL) {
+        return NULL;
+    }
+
     /* Check if services we are about to start are in the list if known */
     for (int i = 0; services[i]; i++) {
         if (check_service(services[i]) != NULL) {
@@ -900,8 +910,11 @@ static int get_monitor_config(struct mt_ctx *ctx)
 
     ctx->started_services = 0;
     ctx->num_services = 0;
-    for (i = 0; ctx->services[i] != NULL; i++) {
-        ctx->num_services++;
+
+    if (ctx->services != NULL) {
+        for (i = 0; ctx->services[i] != NULL; i++) {
+            ctx->num_services++;
+        }
     }
 
     ret = get_service_user(ctx);
@@ -2250,7 +2263,7 @@ static int monitor_process_init(struct mt_ctx *ctx,
         if (ret != EOK) {
             return ret;
         }
-    } else {
+    } else if (ctx->services != NULL) {
         int i;
 
         ctx->services_started = true;

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -114,6 +114,7 @@ struct mt_svc {
     int kill_time;
 
     bool svc_started;
+    bool socket_activated; /* also used for dbus-activated services */
 
     int restarts;
     time_t last_restart;
@@ -185,6 +186,8 @@ static int add_new_provider(struct mt_ctx *ctx,
                             const char *name,
                             int restarts);
 
+static char *check_service(char *service);
+
 static int mark_service_as_started(struct mt_svc *svc);
 
 static int monitor_cleanup(void);
@@ -223,13 +226,91 @@ struct mon_init_conn {
 
 static int add_svc_conn_spy(struct mt_svc *svc);
 
+static int service_not_found(char *svc_name,
+                             struct mt_svc **_svc)
+{
+    DEBUG(SSSDBG_FATAL_FAILURE,
+         "Unable to find peer [%s] in list of services,"
+         " killing connection!\n", svc_name);
+
+    *_svc = NULL;
+    return ENOENT;
+}
+
+#ifdef HAVE_SYSTEMD
+static int socket_activated_service_not_found(struct mon_init_conn *mini,
+                                              char *svc_name,
+                                              bool is_provider,
+                                              struct mt_svc **_svc)
+{
+    struct mt_svc *svc = NULL;
+    int ret;
+
+    if (is_provider) {
+        return service_not_found(svc_name, _svc);
+    }
+
+    /* As the service is a responder and wasn't part of the services' list, it means
+     * the service has been socket/dbus activated and has to be configured and added
+     * to the services' list now */
+
+    *_svc = NULL;
+
+    if (check_service(svc_name) != NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Invalid service %s\n", svc_name);
+        return EINVAL;
+    }
+
+    mini->ctx->services_started = true;
+    mini->ctx->num_services++;
+
+    ret = get_service_config(mini->ctx, svc_name, &svc);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE,
+                "Unable to get the configuration for the service: %s\n",
+                svc_name);
+        return ret;
+    }
+    svc->restarts = 0;
+    svc->socket_activated = true;
+
+    DLIST_ADD(mini->ctx->svc_list, svc);
+
+    *_svc = svc;
+    return EOK;
+}
+#endif
+
+static int get_service_in_the_list(struct mon_init_conn *mini,
+                                   char *svc_name,
+                                   bool is_provider,
+                                   struct mt_svc **_svc)
+{
+    struct mt_svc *svc;
+
+    for (svc = mini->ctx->svc_list; svc != NULL; svc = svc->next) {
+        if (strcasecmp(svc->identity, svc_name) == 0) {
+            svc->socket_activated = false;
+            *_svc = svc;
+            return EOK;
+        }
+    }
+
+#if HAVE_SYSTEMD
+    return socket_activated_service_not_found(mini, svc_name, is_provider,
+                                              _svc);
+#else
+    return service_not_found(svc_name, _svc);
+#endif
+}
+
 /* registers a new client.
  * if operation is successful also sends back the Monitor version */
 static int client_registration(struct sbus_request *dbus_req, void *data)
 {
     dbus_uint16_t version = MONITOR_VERSION;
     struct mon_init_conn *mini;
-    struct mt_svc *svc;
+    struct mt_svc *svc = NULL;
     DBusError dbus_error;
     dbus_uint16_t svc_ver;
     dbus_uint16_t svc_type;
@@ -267,22 +348,18 @@ static int client_registration(struct sbus_request *dbus_req, void *data)
           "Received ID registration: (%s,%d)\n", svc_name, svc_ver);
 
     /* search this service in the list */
-    svc = mini->ctx->svc_list;
-    while (svc) {
-        ret = strcasecmp(svc->identity, svc_name);
-        if (ret == 0) {
-            break;
-        }
-        svc = svc->next;
-    }
-    if (!svc) {
-        DEBUG(SSSDBG_FATAL_FAILURE,
-              "Unable to find peer [%s] in list of services,"
-                  " killing connection!\n", svc_name);
+    ret = get_service_in_the_list(mini, svc_name, svc_type == MT_SVC_PROVIDER,
+                                  &svc);
+    if (ret != EOK) {
         sbus_disconnect(dbus_req->conn);
         sbus_request_finish(dbus_req, NULL);
         /* FIXME: should we just talloc_zfree(conn) ? */
-        goto done;
+
+        if (ret == ENOENT) {
+            goto done;
+        }
+
+        return ret;
     }
 
     /* Fill in svc structure with connection data */
@@ -445,6 +522,12 @@ static int mark_service_as_started(struct mt_svc *svc)
 
     /* create the pid file if all services are alive */
     if (!ctx->pid_file_created && ctx->started_services == ctx->num_services) {
+        if (svc->socket_activated) {
+             /* There's no reason for trying to terminate the parent process
+              * when the responder was socket-activated. */
+            goto done;
+        }
+
         DEBUG(SSSDBG_TRACE_FUNC,
               "All services have successfully started, creating pid file\n");
         ret = pidfile(PID_PATH, MONITOR_NAME);
@@ -890,10 +973,19 @@ static int get_monitor_config(struct mt_ctx *ctx)
                                     CONFDB_MONITOR_CONF_ENTRY,
                                     CONFDB_MONITOR_ACTIVE_SERVICES,
                                     &ctx->services);
+
+#ifdef HAVE_SYSTEMD
+    if (ret != EOK && ret != ENOENT) {
+        DEBUG(SSSDBG_FATAL_FAILURE,
+              "Failed to get the explicitly configured services!\n");
+        return EINVAL;
+    }
+#else
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "No services configured!\n");
         return EINVAL;
     }
+#endif
 
     ret = add_implicit_services(ctx->cdb, ctx, &ctx->services);
     if (ret != EOK) {

--- a/src/monitor/monitor_interfaces.h
+++ b/src/monitor/monitor_interfaces.h
@@ -50,4 +50,5 @@ errno_t sss_monitor_init(TALLOC_CTX *mem_ctx,
                          uint16_t svc_version,
                          uint16_t svc_type,
                          void *pvt,
+                         time_t *last_request_time,
                          struct sbus_connection **mon_conn);

--- a/src/monitor/monitor_interfaces.h
+++ b/src/monitor/monitor_interfaces.h
@@ -35,6 +35,11 @@
 
 #define SSSD_SERVICE_PIPE "private/sbus-monitor"
 
+enum mt_svc_type {
+    MT_SVC_SERVICE,
+    MT_SVC_PROVIDER
+};
+
 int monitor_get_sbus_address(TALLOC_CTX *mem_ctx, char **address);
 int monitor_common_send_id(struct sbus_connection *conn,
                            const char *name, uint16_t version);

--- a/src/monitor/monitor_interfaces.h
+++ b/src/monitor/monitor_interfaces.h
@@ -41,8 +41,6 @@ enum mt_svc_type {
 };
 
 int monitor_get_sbus_address(TALLOC_CTX *mem_ctx, char **address);
-int monitor_common_send_id(struct sbus_connection *conn,
-                           const char *name, uint16_t version, uint16_t type);
 int monitor_common_res_init(struct sbus_request *dbus_req, void *data);
 
 errno_t sss_monitor_init(TALLOC_CTX *mem_ctx,

--- a/src/monitor/monitor_interfaces.h
+++ b/src/monitor/monitor_interfaces.h
@@ -42,7 +42,7 @@ enum mt_svc_type {
 
 int monitor_get_sbus_address(TALLOC_CTX *mem_ctx, char **address);
 int monitor_common_send_id(struct sbus_connection *conn,
-                           const char *name, uint16_t version);
+                           const char *name, uint16_t version, uint16_t type);
 int monitor_common_res_init(struct sbus_request *dbus_req, void *data);
 
 errno_t sss_monitor_init(TALLOC_CTX *mem_ctx,
@@ -50,5 +50,6 @@ errno_t sss_monitor_init(TALLOC_CTX *mem_ctx,
                          struct mon_cli_iface *mon_iface,
                          const char *svc_name,
                          uint16_t svc_version,
+                         uint16_t svc_type,
                          void *pvt,
                          struct sbus_connection **mon_conn);

--- a/src/monitor/monitor_sbus.c
+++ b/src/monitor/monitor_sbus.c
@@ -167,6 +167,7 @@ errno_t sss_monitor_init(TALLOC_CTX *mem_ctx,
                          uint16_t svc_version,
                          uint16_t svc_type,
                          void *pvt,
+                         time_t *last_request_time,
                          struct sbus_connection **mon_conn)
 {
     errno_t ret;
@@ -180,7 +181,7 @@ errno_t sss_monitor_init(TALLOC_CTX *mem_ctx,
         return ret;
     }
 
-    ret = sbus_client_init(mem_ctx, ev, sbus_address, &conn);
+    ret = sbus_client_init(mem_ctx, ev, sbus_address, last_request_time, &conn);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Failed to connect to monitor services.\n");
         talloc_free(sbus_address);

--- a/src/monitor/monitor_sbus.c
+++ b/src/monitor/monitor_sbus.c
@@ -110,7 +110,7 @@ done:
 }
 
 int monitor_common_send_id(struct sbus_connection *conn,
-                           const char *name, uint16_t version)
+                           const char *name, uint16_t version, uint16_t type)
 {
     DBusMessage *msg;
     dbus_bool_t ret;
@@ -131,6 +131,7 @@ int monitor_common_send_id(struct sbus_connection *conn,
     ret = dbus_message_append_args(msg,
                                    DBUS_TYPE_STRING, &name,
                                    DBUS_TYPE_UINT16, &version,
+                                   DBUS_TYPE_UINT16, &type,
                                    DBUS_TYPE_INVALID);
     if (!ret) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Failed to build message\n");
@@ -162,6 +163,7 @@ errno_t sss_monitor_init(TALLOC_CTX *mem_ctx,
                          struct mon_cli_iface *mon_iface,
                          const char *svc_name,
                          uint16_t svc_version,
+                         uint16_t svc_type,
                          void *pvt,
                          struct sbus_connection **mon_conn)
 {
@@ -191,7 +193,7 @@ errno_t sss_monitor_init(TALLOC_CTX *mem_ctx,
     }
 
     /* Identify ourselves to the monitor */
-    ret = monitor_common_send_id(conn, svc_name, svc_version);
+    ret = monitor_common_send_id(conn, svc_name, svc_version, svc_type);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Failed to identify to the monitor!\n");
         return ret;

--- a/src/monitor/monitor_sbus.c
+++ b/src/monitor/monitor_sbus.c
@@ -109,8 +109,10 @@ done:
     dbus_message_unref(reply);
 }
 
-int monitor_common_send_id(struct sbus_connection *conn,
-                           const char *name, uint16_t version, uint16_t type)
+static int monitor_common_send_id(struct sbus_connection *conn,
+                                  const char *name,
+                                  uint16_t version,
+                                  uint16_t type)
 {
     DBusMessage *msg;
     dbus_bool_t ret;

--- a/src/providers/data_provider/dp.c
+++ b/src/providers/data_provider/dp.c
@@ -42,7 +42,7 @@ static errno_t dp_init_dbus_server(struct data_provider *provider)
     ret = sbus_new_server(provider, provider->ev, sbus_address,
                           provider->uid, provider->gid, true,
                           &provider->srv_conn,
-                          dp_client_init, provider);
+                          dp_client_init, provider, NULL);
     talloc_free(sbus_address);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Could not set up sbus server.\n");

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -408,7 +408,8 @@ errno_t be_process_init(TALLOC_CTX *mem_ctx,
 
     ret = sss_monitor_init(be_ctx, be_ctx->ev, &monitor_be_methods,
                            be_ctx->identity, DATA_PROVIDER_VERSION,
-                           MT_SVC_PROVIDER, be_ctx, &be_ctx->mon_conn);
+                           MT_SVC_PROVIDER, be_ctx, NULL,
+                           &be_ctx->mon_conn);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Unable to initialize monitor connection\n");
         goto done;

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -408,7 +408,7 @@ errno_t be_process_init(TALLOC_CTX *mem_ctx,
 
     ret = sss_monitor_init(be_ctx, be_ctx->ev, &monitor_be_methods,
                            be_ctx->identity, DATA_PROVIDER_VERSION,
-                           be_ctx, &be_ctx->mon_conn);
+                           MT_SVC_PROVIDER, be_ctx, &be_ctx->mon_conn);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Unable to initialize monitor connection\n");
         goto done;

--- a/src/providers/proxy/proxy_child.c
+++ b/src/providers/proxy/proxy_child.c
@@ -440,7 +440,7 @@ static int proxy_cli_init(struct pc_ctx *ctx)
         return ENOMEM;
     }
 
-    ret = sbus_client_init(ctx, ctx->ev, sbus_address, &ctx->conn);
+    ret = sbus_client_init(ctx, ctx->ev, sbus_address, NULL, &ctx->conn);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "sbus_client_init failed.\n");
         return ret;

--- a/src/providers/proxy/proxy_init.c
+++ b/src/providers/proxy/proxy_init.c
@@ -179,7 +179,7 @@ static errno_t proxy_setup_sbus(TALLOC_CTX *mem_ctx,
     }
 
     ret = sbus_new_server(mem_ctx, be_ctx->ev, sbus_address, 0, be_ctx->gid,
-                          false, &ctx->sbus_srv, proxy_client_init, ctx);
+                          false, &ctx->sbus_srv, proxy_client_init, ctx, NULL);
     talloc_free(sbus_address);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Could not set up sbus server.\n");

--- a/src/responder/autofs/autofssrv.c
+++ b/src/responder/autofs/autofssrv.c
@@ -194,6 +194,7 @@ int main(int argc, const char *argv[])
         POPT_AUTOHELP
         SSSD_MAIN_OPTS
         SSSD_SERVER_OPTS(uid, gid)
+        SSSD_RESPONDER_OPTS
         POPT_TABLEEND
     };
 

--- a/src/responder/common/responder.h
+++ b/src/responder/common/responder.h
@@ -108,6 +108,10 @@ struct resp_ctx {
     int domains_timeout;
     int client_idle_timeout;
 
+    time_t last_request_time;
+    int idle_timeout;
+    struct tevent_timer *idle;
+
     struct sss_cmd_table *sss_cmds;
     const char *sss_pipe_name;
     const char *confdb_service_path;

--- a/src/responder/common/responder.h
+++ b/src/responder/common/responder.h
@@ -152,6 +152,7 @@ struct cli_ctx {
     void *state_ctx;
 
     struct tevent_timer *idle;
+    time_t last_request_time;
 };
 
 struct sss_cmd_table {

--- a/src/responder/common/responder.h
+++ b/src/responder/common/responder.h
@@ -128,6 +128,7 @@ struct resp_ctx {
 
     bool shutting_down;
     bool socket_activated;
+    bool dbus_activated;
 };
 
 struct cli_creds;

--- a/src/responder/common/responder.h
+++ b/src/responder/common/responder.h
@@ -317,11 +317,11 @@ bool sss_utf8_check(const uint8_t *s, size_t n);
 
 void responder_set_fd_limit(rlim_t fd_limit);
 
-errno_t reset_idle_timer(struct cli_ctx *cctx);
-void idle_handler(struct tevent_context *ev,
-                  struct tevent_timer *te,
-                  struct timeval current_time,
-                  void *data);
+errno_t reset_client_idle_timer(struct cli_ctx *cctx);
+void client_idle_handler(struct tevent_context *ev,
+                         struct tevent_timer *te,
+                         struct timeval current_time,
+                         void *data);
 
 #define GET_DOMAINS_DEFAULT_TIMEOUT 60
 

--- a/src/responder/common/responder.h
+++ b/src/responder/common/responder.h
@@ -127,6 +127,7 @@ struct resp_ctx {
     void *pvt_ctx;
 
     bool shutting_down;
+    bool socket_activated;
 };
 
 struct cli_creds;

--- a/src/responder/common/responder.h
+++ b/src/responder/common/responder.h
@@ -318,10 +318,6 @@ bool sss_utf8_check(const uint8_t *s, size_t n);
 void responder_set_fd_limit(rlim_t fd_limit);
 
 errno_t reset_client_idle_timer(struct cli_ctx *cctx);
-void client_idle_handler(struct tevent_context *ev,
-                         struct tevent_timer *te,
-                         struct timeval current_time,
-                         void *data);
 
 #define GET_DOMAINS_DEFAULT_TIMEOUT 60
 

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -952,6 +952,7 @@ int sss_process_init(TALLOC_CTX *mem_ctx,
     rctx->confdb_service_path = confdb_service_path;
     rctx->shutting_down = false;
     rctx->socket_activated = is_socket_activated();
+    rctx->dbus_activated = is_dbus_activated();
 
     talloc_set_destructor((TALLOC_CTX*)rctx, sss_responder_ctx_destructor);
 
@@ -1089,8 +1090,9 @@ int sss_process_init(TALLOC_CTX *mem_ctx,
 
     DEBUG(SSSDBG_TRACE_FUNC,
           "Responder initialization complete (%s)\n",
-          rctx->socket_activated ? "socket-activated" :
-                                   "explicitly configured");
+          rctx->socket_activated  ? "socket-activated" :
+                                    rctx->dbus_activated ? "dbus-activated" :
+                                                            "explicitly configured");
 
     *responder_ctx = rctx;
     return EOK;

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -951,6 +951,7 @@ int sss_process_init(TALLOC_CTX *mem_ctx,
     rctx->priv_lfd = priv_pipe_fd;
     rctx->confdb_service_path = confdb_service_path;
     rctx->shutting_down = false;
+    rctx->socket_activated = is_socket_activated();
 
     talloc_set_destructor((TALLOC_CTX*)rctx, sss_responder_ctx_destructor);
 
@@ -1086,7 +1087,10 @@ int sss_process_init(TALLOC_CTX *mem_ctx,
         goto fail;
     }
 
-    DEBUG(SSSDBG_TRACE_FUNC, "Responder Initialization complete\n");
+    DEBUG(SSSDBG_TRACE_FUNC,
+          "Responder initialization complete (%s)\n",
+          rctx->socket_activated ? "socket-activated" :
+                                   "explicitly configured");
 
     *responder_ctx = rctx;
     return EOK;

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -1022,8 +1022,8 @@ int sss_process_init(TALLOC_CTX *mem_ctx,
     }
 
     ret = sss_monitor_init(rctx, rctx->ev, monitor_intf,
-                           svc_name, svc_version, rctx,
-                           &rctx->mon_conn);
+                           svc_name, svc_version, MT_SVC_SERVICE,
+                           rctx, &rctx->mon_conn);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "fatal error setting up message bus\n");
         goto fail;

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -574,6 +574,7 @@ static int sss_dp_init(struct resp_ctx *rctx,
     }
     ret = sbus_client_init(rctx, rctx->ev,
                            be_conn->sbus_address,
+                           NULL,
                            &be_conn->conn);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Failed to connect to monitor services.\n");
@@ -1023,7 +1024,7 @@ int sss_process_init(TALLOC_CTX *mem_ctx,
 
     ret = sss_monitor_init(rctx, rctx->ev, monitor_intf,
                            svc_name, svc_version, MT_SVC_SERVICE,
-                           rctx, &rctx->mon_conn);
+                           rctx, NULL, &rctx->mon_conn);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "fatal error setting up message bus\n");
         goto fail;

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -517,6 +517,23 @@ static void accept_fd_handler(struct tevent_context *ev,
     return;
 }
 
+static void client_idle_handler(struct tevent_context *ev,
+                                struct tevent_timer *te,
+                                struct timeval current_time,
+                                void *data)
+{
+    /* This connection is idle. Terminate it */
+    struct cli_ctx *cctx =
+            talloc_get_type(data, struct cli_ctx);
+
+    DEBUG(SSSDBG_TRACE_INTERNAL,
+          "Terminating idle client [%p][%d]\n",
+           cctx, cctx->cfd);
+
+    /* The cli_ctx destructor will handle the rest */
+    talloc_free(cctx);
+}
+
 errno_t reset_client_idle_timer(struct cli_ctx *cctx)
 {
     struct timeval tv =
@@ -532,23 +549,6 @@ errno_t reset_client_idle_timer(struct cli_ctx *cctx)
            cctx, cctx->cfd);
 
     return EOK;
-}
-
-void client_idle_handler(struct tevent_context *ev,
-                         struct tevent_timer *te,
-                         struct timeval current_time,
-                         void *data)
-{
-    /* This connection is idle. Terminate it */
-    struct cli_ctx *cctx =
-            talloc_get_type(data, struct cli_ctx);
-
-    DEBUG(SSSDBG_TRACE_INTERNAL,
-          "Terminating idle client [%p][%d]\n",
-           cctx, cctx->cfd);
-
-    /* The cli_ctx destructor will handle the rest */
-    talloc_free(cctx);
 }
 
 static int sss_dp_init(struct resp_ctx *rctx,

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -350,12 +350,97 @@ static void client_recv(struct cli_ctx *cctx)
     return;
 }
 
+static errno_t schedule_responder_idle_timer(struct resp_ctx *rctx);
+
+static void responder_idle_handler(struct tevent_context *ev,
+                                   struct tevent_timer *te,
+                                   struct timeval current_time,
+                                   void *data)
+{
+    struct resp_ctx *rctx;
+    time_t now;
+
+    rctx = talloc_get_type(data, struct resp_ctx);
+
+    now = time(NULL);
+    if (rctx->last_request_time > now) {
+        DEBUG(SSSDBG_IMPORTANT_INFO,
+              "Time shift detected, re-scheduling the responder timeout\n");
+        goto end;
+    }
+
+    if ((now - rctx->last_request_time) > rctx->idle_timeout) {
+        /* This responder is idle. Terminate it */
+        DEBUG(SSSDBG_TRACE_INTERNAL,
+              "Terminating idle responder [%p]\n", rctx);
+
+        talloc_free(rctx);
+
+        orderly_shutdown(0);
+    }
+
+    DEBUG(SSSDBG_TRACE_INTERNAL,
+          "Re-scheduling the idle timeout for the responder [%p]\n", rctx);
+
+end:
+    schedule_responder_idle_timer(rctx);
+}
+
+static errno_t schedule_responder_idle_timer(struct resp_ctx *rctx)
+{
+    struct timeval tv;
+
+    tv = tevent_timeval_current_ofs(rctx->idle_timeout/2, 0);
+
+    talloc_zfree(rctx->idle);
+    rctx->idle = tevent_add_timer(rctx->ev,
+                                  rctx,
+                                  tv,
+                                  responder_idle_handler,
+                                  rctx);
+    if (rctx->idle == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Failed to allocate time event: responder [%p] shutdown timeout\n",
+              rctx);
+        return ENOMEM;
+    }
+
+    DEBUG(SSSDBG_TRACE_INTERNAL,
+          "Re-scheduling the idle timeout for the responder [%p]\n", rctx);
+
+    return EOK;
+}
+
+static errno_t setup_responder_idle_timer(struct resp_ctx *rctx)
+{
+    errno_t ret;
+
+    rctx->last_request_time = time(NULL);
+
+    ret = schedule_responder_idle_timer(rctx);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_TRACE_INTERNAL,
+              "Error scheduling the idle timeout for the responder [%p]: "
+              "%d [%s]\n",
+              rctx, ret, sss_strerror(ret));
+        return ret;
+    }
+
+    DEBUG(SSSDBG_TRACE_INTERNAL,
+          "Setting up the idle timeout for the responder [%p]\n", rctx);
+
+    return EOK;
+}
+
 static void client_fd_handler(struct tevent_context *ev,
                               struct tevent_fd *fde,
                               uint16_t flags, void *ptr)
 {
     errno_t ret;
     struct cli_ctx *cctx = talloc_get_type(ptr, struct cli_ctx);
+
+    /* Always reset the idle timer on any activity */
+    cctx->rctx->last_request_time = time(NULL);
 
     /* Always reset the idle timer on any activity */
     ret = reset_client_idle_timer(cctx);
@@ -971,6 +1056,47 @@ int sss_process_init(TALLOC_CTX *mem_ctx,
         rctx->client_idle_timeout = 10;
     }
 
+    if (rctx->socket_activated || rctx->dbus_activated) {
+        ret = confdb_get_int(rctx->cdb, rctx->confdb_service_path,
+                             CONFDB_RESPONDER_IDLE_TIMEOUT,
+                             CONFDB_RESPONDER_IDLE_DEFAULT_TIMEOUT,
+                             &rctx->idle_timeout);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "Cannot get the responder idle timeout [%d]: %s\n",
+                   ret, sss_strerror(ret));
+            goto fail;
+        }
+
+        /* Idle timeout set to 0 means that no timeout will be set up to
+         * the responder */
+        if (rctx->idle_timeout == 0) {
+            DEBUG(SSSDBG_TRACE_INTERNAL,
+                  "Responder idle timeout won't be set up as the "
+                  "responder_idle_timeout is set to 0");
+        } else {
+            /* Ensure that the responder timeout is at least sixty seconds */
+            if (rctx->idle_timeout < 60) {
+                DEBUG(SSSDBG_TRACE_INTERNAL,
+                      "responder_idle_timeout is set to a value lower than "
+                      "the minimum allowed (60s).\n"
+                      "The minimum allowed value will be used.");
+
+                rctx->idle_timeout = 60;
+            }
+
+            ret = setup_responder_idle_timer(rctx);
+            if (ret != EOK) {
+                DEBUG(SSSDBG_MINOR_FAILURE,
+                      "An error ocurrend when setting up the responder's idle "
+                      "timeout for the responder [%p]: %s [%d].\n"
+                      "The responder won't be automatically shutdown after %d "
+                      "seconds inactive. \n",
+                      rctx, sss_strerror(ret), ret, rctx->idle_timeout);
+            }
+        }
+    }
+
     ret = confdb_get_int(rctx->cdb, rctx->confdb_service_path,
                          CONFDB_RESPONDER_GET_DOMAINS_TIMEOUT,
                          GET_DOMAINS_DEFAULT_TIMEOUT, &rctx->domains_timeout);
@@ -1024,7 +1150,8 @@ int sss_process_init(TALLOC_CTX *mem_ctx,
 
     ret = sss_monitor_init(rctx, rctx->ev, monitor_intf,
                            svc_name, svc_version, MT_SVC_SERVICE,
-                           rctx, NULL, &rctx->mon_conn);
+                           rctx, &rctx->last_request_time,
+                           &rctx->mon_conn);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "fatal error setting up message bus\n");
         goto fail;

--- a/src/responder/ifp/ifpsrv.c
+++ b/src/responder/ifp/ifpsrv.c
@@ -138,7 +138,7 @@ sysbus_init(TALLOC_CTX *mem_ctx,
     /* Integrate with tevent loop */
     ret = sbus_init_connection(system_bus, ev, conn,
                                SBUS_CONN_TYPE_SYSBUS,
-                               &system_bus->conn);
+                               NULL, &system_bus->conn);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Could not integrate D-BUS into mainloop.\n");

--- a/src/responder/ifp/ifpsrv.c
+++ b/src/responder/ifp/ifpsrv.c
@@ -364,6 +364,7 @@ int main(int argc, const char *argv[])
         POPT_AUTOHELP
         SSSD_MAIN_OPTS
         SSSD_SERVER_OPTS(uid, gid)
+        SSSD_RESPONDER_OPTS
         POPT_TABLEEND
     };
 

--- a/src/responder/ifp/ifpsrv.c
+++ b/src/responder/ifp/ifpsrv.c
@@ -138,7 +138,7 @@ sysbus_init(TALLOC_CTX *mem_ctx,
     /* Integrate with tevent loop */
     ret = sbus_init_connection(system_bus, ev, conn,
                                SBUS_CONN_TYPE_SYSBUS,
-                               NULL, &system_bus->conn);
+                               NULL, NULL, &system_bus->conn);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Could not integrate D-BUS into mainloop.\n");

--- a/src/responder/ifp/org.freedesktop.sssd.infopipe.service.in
+++ b/src/responder/ifp/org.freedesktop.sssd.infopipe.service.in
@@ -1,4 +1,5 @@
 [D-BUS Service]
 Name=org.freedesktop.sssd.infopipe
-Exec=@libexecdir@/sssd/sss_signal
+Exec=@ifp_exec_cmd@
 User=root
+@ifp_systemdservice@

--- a/src/responder/nss/nsssrv.c
+++ b/src/responder/nss/nsssrv.c
@@ -513,6 +513,7 @@ int main(int argc, const char *argv[])
         POPT_AUTOHELP
         SSSD_MAIN_OPTS
         SSSD_SERVER_OPTS(uid, gid)
+        SSSD_RESPONDER_OPTS
         POPT_TABLEEND
     };
 

--- a/src/responder/pac/pacsrv.c
+++ b/src/responder/pac/pacsrv.c
@@ -218,6 +218,7 @@ int main(int argc, const char *argv[])
         POPT_AUTOHELP
         SSSD_MAIN_OPTS
         SSSD_SERVER_OPTS(uid, gid)
+        SSSD_RESPONDER_OPTS
         POPT_TABLEEND
     };
 

--- a/src/responder/pam/pamsrv.c
+++ b/src/responder/pam/pamsrv.c
@@ -326,8 +326,8 @@ int main(int argc, const char *argv[])
     int ret;
     uid_t uid;
     gid_t gid;
-    int pipe_fd;
-    int priv_pipe_fd;
+    int pipe_fd = -1;
+    int priv_pipe_fd = -1;
 
     struct poptOption long_options[] = {
         POPT_AUTOHELP

--- a/src/responder/pam/pamsrv.c
+++ b/src/responder/pam/pamsrv.c
@@ -359,23 +359,25 @@ int main(int argc, const char *argv[])
     /* set up things like debug, signals, daemonization, etc... */
     debug_log_file = "sssd_pam";
 
-    /* Crate pipe file descriptors here before privileges are dropped
-     * in server_setup() */
-    ret = create_pipe_fd(SSS_PAM_SOCKET_NAME, &pipe_fd, SCKT_RSP_UMASK);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_FATAL_FAILURE,
-              "create_pipe_fd failed [%d]: %s.\n",
-              ret, sss_strerror(ret));
-        return 2;
-    }
+    if (!is_socket_activated()) {
+        /* Crate pipe file descriptors here before privileges are dropped
+         * in server_setup() */
+        ret = create_pipe_fd(SSS_PAM_SOCKET_NAME, &pipe_fd, SCKT_RSP_UMASK);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_FATAL_FAILURE,
+                  "create_pipe_fd failed [%d]: %s.\n",
+                  ret, sss_strerror(ret));
+            return 2;
+        }
 
-    ret = create_pipe_fd(SSS_PAM_PRIV_SOCKET_NAME, &priv_pipe_fd,
-                         DFL_RSP_UMASK);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_FATAL_FAILURE,
-              "create_pipe_fd failed (priviledged pipe) [%d]: %s.\n",
-              ret, sss_strerror(ret));
-        return 2;
+        ret = create_pipe_fd(SSS_PAM_PRIV_SOCKET_NAME, &priv_pipe_fd,
+                DFL_RSP_UMASK);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_FATAL_FAILURE,
+                  "create_pipe_fd failed (priviledged pipe) [%d]: %s.\n",
+                  ret, sss_strerror(ret));
+            return 2;
+        }
     }
 
     ret = server_setup("sssd[pam]", 0, uid, gid, CONFDB_PAM_CONF_ENTRY, &main_ctx);

--- a/src/responder/pam/pamsrv.c
+++ b/src/responder/pam/pamsrv.c
@@ -333,6 +333,7 @@ int main(int argc, const char *argv[])
         POPT_AUTOHELP
         SSSD_MAIN_OPTS
         SSSD_SERVER_OPTS(uid, gid)
+        SSSD_RESPONDER_OPTS
         POPT_TABLEEND
     };
 

--- a/src/responder/secrets/secsrv.c
+++ b/src/responder/secrets/secsrv.c
@@ -136,6 +136,8 @@ static int sec_process_init(TALLOC_CTX *mem_ctx,
     rctx->sock_name = SSS_SEC_SOCKET_NAME;
     rctx->confdb_service_path = CONFDB_SEC_CONF_ENTRY;
     rctx->shutting_down = false;
+    rctx->lfd = -1;
+    rctx->priv_lfd = -1;
 
     talloc_set_destructor((TALLOC_CTX*)rctx, sec_responder_ctx_destructor);
 

--- a/src/responder/secrets/secsrv_cmd.c
+++ b/src/responder/secrets/secsrv_cmd.c
@@ -584,7 +584,7 @@ static void sec_fd_handler(struct tevent_context *ev,
     struct cli_ctx *cctx = talloc_get_type(ptr, struct cli_ctx);
 
     /* Always reset the idle timer on any activity */
-    ret = reset_idle_timer(cctx);
+    ret = reset_client_idle_timer(cctx);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Could not create idle timer for client. "

--- a/src/responder/ssh/sshsrv.c
+++ b/src/responder/ssh/sshsrv.c
@@ -186,6 +186,7 @@ int main(int argc, const char *argv[])
         POPT_AUTOHELP
         SSSD_MAIN_OPTS
         SSSD_SERVER_OPTS(uid, gid)
+        SSSD_RESPONDER_OPTS
         POPT_TABLEEND
     };
 

--- a/src/responder/sudo/sudosrv.c
+++ b/src/responder/sudo/sudosrv.c
@@ -176,6 +176,7 @@ int main(int argc, const char *argv[])
         POPT_AUTOHELP
         SSSD_MAIN_OPTS
         SSSD_SERVER_OPTS(uid, gid)
+        SSSD_RESPONDER_OPTS
         POPT_TABLEEND
     };
 

--- a/src/sbus/sbus_client.c
+++ b/src/sbus/sbus_client.c
@@ -27,6 +27,7 @@
 int sbus_client_init(TALLOC_CTX *mem_ctx,
                      struct tevent_context *ev,
                      const char *server_address,
+                     time_t *last_request_time,
                      struct sbus_connection **_conn)
 {
     struct sbus_connection *conn = NULL;
@@ -63,7 +64,8 @@ int sbus_client_init(TALLOC_CTX *mem_ctx,
         return EIO;
     }
 
-    ret = sbus_new_connection(mem_ctx, ev, server_address, &conn);
+    ret = sbus_new_connection(mem_ctx, ev, server_address,
+                              last_request_time, &conn);
     if (ret != EOK) {
         goto fail;
     }

--- a/src/sbus/sbus_client.h
+++ b/src/sbus/sbus_client.h
@@ -28,6 +28,7 @@
 int sbus_client_init(TALLOC_CTX *mem_ctx,
                      struct tevent_context *ev,
                      const char *server_address,
+                     time_t *last_request_time,
                      struct sbus_connection **_conn);
 
 #endif /* SBUS_CLIENT_H_ */

--- a/src/sbus/sssd_dbus.h
+++ b/src/sbus/sssd_dbus.h
@@ -74,12 +74,6 @@ struct sbus_request;
 typedef int (*sbus_msg_handler_fn)(struct sbus_request *dbus_req,
                                    void *handler_data);
 
-/*
- * sbus_conn_destructor_fn
- * Function to be called when a connection is finalized
- */
-typedef int (*sbus_conn_destructor_fn)(void *);
-
 typedef void (*sbus_conn_reconn_callback_fn)(struct sbus_connection *, int, void *);
 
 /*
@@ -141,7 +135,9 @@ int sbus_new_server(TALLOC_CTX *mem_ctx,
                     uid_t uid, gid_t gid,
                     bool use_symlink,
                     struct sbus_connection **server,
-                    sbus_server_conn_init_fn init_fn, void *init_pvt_data);
+                    sbus_server_conn_init_fn init_fn,
+                    void *init_pvt_data,
+                    void *client_destructor_data);
 
 /* Connection Functions */
 
@@ -175,6 +171,7 @@ int sbus_init_connection(TALLOC_CTX *ctx,
                          DBusConnection *dbus_conn,
                          int connection_type,
                          time_t *last_request_time,
+                         void *destructor_data,
                          struct sbus_connection **_conn);
 
 DBusConnection *sbus_get_connection(struct sbus_connection *conn);
@@ -449,5 +446,11 @@ sbus_signal_listen(struct sbus_connection *conn,
                    const char *signal,
                    sbus_incoming_signal_fn handler_fn,
                    void *handler_data);
+
+/* This function returns the destructor data passed when in starting
+ * a new dbus server/connection. Its use, for now, must be restricted
+ * to {dbus,socket}-activated services in order to proper shut them
+ * down, unregistering them in the monitor. */
+void *sbus_connection_get_destructor_data(struct sbus_connection *conn);
 
 #endif /* _SSSD_DBUS_H_*/

--- a/src/sbus/sssd_dbus.h
+++ b/src/sbus/sssd_dbus.h
@@ -155,6 +155,7 @@ int sbus_new_server(TALLOC_CTX *mem_ctx,
 int sbus_new_connection(TALLOC_CTX *ctx,
                         struct tevent_context *ev,
                         const char *address,
+                        time_t *last_request_time,
                         struct sbus_connection **conn);
 
 /* sbus_add_connection
@@ -173,6 +174,7 @@ int sbus_init_connection(TALLOC_CTX *ctx,
                          struct tevent_context *ev,
                          DBusConnection *dbus_conn,
                          int connection_type,
+                         time_t *last_request_time,
                          struct sbus_connection **_conn);
 
 DBusConnection *sbus_get_connection(struct sbus_connection *conn);

--- a/src/sbus/sssd_dbus_connection.c
+++ b/src/sbus/sssd_dbus_connection.c
@@ -148,6 +148,7 @@ int sbus_init_connection(TALLOC_CTX *ctx,
                          struct tevent_context *ev,
                          DBusConnection *dbus_conn,
                          int connection_type,
+                         time_t *last_request_time,
                          struct sbus_connection **_conn)
 {
     struct sbus_connection *conn;
@@ -161,6 +162,7 @@ int sbus_init_connection(TALLOC_CTX *ctx,
     conn->type = SBUS_CONNECTION;
     conn->dbus.conn = dbus_conn;
     conn->connection_type = connection_type;
+    conn->last_request_time = last_request_time;
 
     ret = sbus_opath_hash_init(conn, conn, &conn->managed_paths);
     if (ret != EOK) {
@@ -259,7 +261,8 @@ static int sbus_conn_set_fns(struct sbus_connection *conn)
 }
 
 int sbus_new_connection(TALLOC_CTX *ctx, struct tevent_context *ev,
-                        const char *address, struct sbus_connection **_conn)
+                        const char *address, time_t *last_request_time,
+                        struct sbus_connection **_conn)
 {
     struct sbus_connection *conn;
     DBusConnection *dbus_conn;
@@ -278,7 +281,8 @@ int sbus_new_connection(TALLOC_CTX *ctx, struct tevent_context *ev,
         return EIO;
     }
 
-    ret = sbus_init_connection(ctx, ev, dbus_conn, SBUS_CONN_TYPE_SHARED, &conn);
+    ret = sbus_init_connection(ctx, ev, dbus_conn, SBUS_CONN_TYPE_SHARED,
+                               last_request_time, &conn);
     if (ret != EOK) {
         /* FIXME: release resources */
     }

--- a/src/sbus/sssd_dbus_interface.c
+++ b/src/sbus/sssd_dbus_interface.c
@@ -1089,6 +1089,10 @@ sbus_message_handler(DBusConnection *dbus_conn,
     }
     tevent_req_set_callback(req, sbus_message_handler_got_caller_id, sbus_req);
 
+    if (conn->last_request_time != NULL) {
+        *conn->last_request_time = time(NULL);
+    }
+
     return DBUS_HANDLER_RESULT_HANDLED;
 
 fail: ;

--- a/src/sbus/sssd_dbus_private.h
+++ b/src/sbus/sssd_dbus_private.h
@@ -69,6 +69,9 @@ struct sbus_connection {
 
     /* responder related stuff */
     time_t *last_request_time;
+
+    /* client related stuff */
+    void *client_destructor_data;
 };
 
 /* =Standard=interfaces=================================================== */

--- a/src/sbus/sssd_dbus_private.h
+++ b/src/sbus/sssd_dbus_private.h
@@ -66,6 +66,9 @@ struct sbus_connection {
 
     /* watches list */
     struct sbus_watch_ctx *watch_list;
+
+    /* responder related stuff */
+    time_t *last_request_time;
 };
 
 /* =Standard=interfaces=================================================== */

--- a/src/sbus/sssd_dbus_server.c
+++ b/src/sbus/sssd_dbus_server.c
@@ -53,7 +53,7 @@ static void sbus_server_init_new_connection(DBusServer *dbus_server,
 
     DEBUG(SSSDBG_FUNC_DATA,"Adding connection %p.\n", dbus_conn);
     ret = sbus_init_connection(server, server->ev, dbus_conn,
-                               SBUS_CONN_TYPE_PRIVATE, &conn);
+                               SBUS_CONN_TYPE_PRIVATE, NULL, &conn);
     if (ret != 0) {
         dbus_connection_close(dbus_conn);
         DEBUG(SSSDBG_FUNC_DATA, "Closing connection (failed setup)\n");

--- a/src/sbus/sssd_dbus_server.c
+++ b/src/sbus/sssd_dbus_server.c
@@ -30,6 +30,11 @@
 
 static int sbus_server_destructor(void *ctx);
 
+struct new_connection_data {
+    struct sbus_connection *server;
+    void *client_destructor_data;
+};
+
 /*
  * new_connection_callback
  * Actions to be run upon each new client connection
@@ -41,19 +46,20 @@ static void sbus_server_init_new_connection(DBusServer *dbus_server,
                                             DBusConnection *dbus_conn,
                                             void *data)
 {
-    struct sbus_connection *server;
+    struct new_connection_data *ncd;
     struct sbus_connection *conn;
     int ret;
 
     DEBUG(SSSDBG_FUNC_DATA,"Entering.\n");
-    server = talloc_get_type(data, struct sbus_connection);
-    if (!server) {
+    ncd = talloc_get_type(data, struct new_connection_data);
+    if (!ncd) {
         return;
     }
 
     DEBUG(SSSDBG_FUNC_DATA,"Adding connection %p.\n", dbus_conn);
-    ret = sbus_init_connection(server, server->ev, dbus_conn,
-                               SBUS_CONN_TYPE_PRIVATE, NULL, &conn);
+    ret = sbus_init_connection(ncd->server, ncd->server->ev, dbus_conn,
+                               SBUS_CONN_TYPE_PRIVATE, NULL,
+                               ncd->client_destructor_data, &conn);
     if (ret != 0) {
         dbus_connection_close(dbus_conn);
         DEBUG(SSSDBG_FUNC_DATA, "Closing connection (failed setup)\n");
@@ -69,7 +75,7 @@ static void sbus_server_init_new_connection(DBusServer *dbus_server,
      * This function (or its callbacks) should also
      * set up connection-specific methods.
      */
-    ret = server->srv_init_fn(conn, server->srv_init_data);
+    ret = ncd->server->srv_init_fn(conn, ncd->server->srv_init_data);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,"Initialization failed!\n");
         dbus_connection_close(dbus_conn);
@@ -186,7 +192,8 @@ int sbus_new_server(TALLOC_CTX *mem_ctx,
                     bool use_symlink,
                     struct sbus_connection **_server,
                     sbus_server_conn_init_fn init_fn,
-                    void *init_pvt_data)
+                    void *init_pvt_data,
+                    void *client_destructor_data)
 {
     struct sbus_connection *server;
     DBusServer *dbus_server;
@@ -199,6 +206,7 @@ int sbus_new_server(TALLOC_CTX *mem_ctx,
     const char *socket_address;
     struct stat stat_buf;
     TALLOC_CTX *tmp_ctx;
+    struct new_connection_data *ncd;
 
     *_server = NULL;
 
@@ -309,10 +317,21 @@ int sbus_new_server(TALLOC_CTX *mem_ctx,
         }
     }
 
+    /* This structure must be alive while server is alive. That's the
+     * reason for using server as its talloc context.
+     */
+    ncd = talloc_zero((TALLOC_CTX *)server, struct new_connection_data);
+    if (!ncd) {
+        ret = ENOMEM;
+        goto done;
+    }
+    ncd->server = server;
+    ncd->client_destructor_data = client_destructor_data;
+
     /* Set up D-BUS new connection handler */
     dbus_server_set_new_connection_function(server->dbus.server,
                                             sbus_server_init_new_connection,
-                                            server, NULL);
+                                            ncd, NULL);
 
     /* Set up DBusWatch functions */
     dbret = dbus_server_set_watch_functions(server->dbus.server,

--- a/src/sysv/systemd/sssd-autofs.service.in
+++ b/src/sysv/systemd/sssd-autofs.service.in
@@ -1,0 +1,16 @@
+[Unit]
+Description=SSSD AutoFS Service responder
+Documentation=man:sssd.conf(5)
+After=sssd.service
+BindsTo=sssd.service
+
+[Install]
+Also=sssd-autofs.socket
+
+[Service]
+ExecStartPre=-/bin/chown @SSSD_USER@:@SSSD_USER@ @logpath@/sssd_autofs.log
+ExecStart=@libexecdir@/sssd/sssd_autofs --debug-to-files --socket-activated
+Restart=on-failure
+User=@SSSD_USER@
+Group=@SSSD_USER@
+PermissionsStartOnly=true

--- a/src/sysv/systemd/sssd-autofs.socket.in
+++ b/src/sysv/systemd/sssd-autofs.socket.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=SSSD AutoFS Service responder socket
+Documentation=man:sssd.conf(5)
+BindsTo=sssd.service
+
+[Socket]
+ListenStream=@pipepath@/autofs
+SocketUser=@SSSD_USER@
+SocketGroup=@SSSD_USER@
+
+[Install]
+WantedBy=sssd.service

--- a/src/sysv/systemd/sssd-ifp.service.in
+++ b/src/sysv/systemd/sssd-ifp.service.in
@@ -1,0 +1,11 @@
+[Unit]
+Description=SSSD IFP Service responder
+Documentation=man:sssd-ifp(5)
+After=sssd.service
+BindsTo=sssd.service
+
+[Service]
+Type=dbus
+BusName=org.freedesktop.sssd.infopipe
+ExecStart=@ifp_exec_cmd@
+@ifp_restart@

--- a/src/sysv/systemd/sssd-nss.service.in
+++ b/src/sysv/systemd/sssd-nss.service.in
@@ -1,0 +1,13 @@
+[Unit]
+Description=SSSD NSS Service responder
+Documentation=man:sssd.conf(5)
+After=sssd.service
+BindsTo=sssd.service
+
+[Install]
+Also=sssd-nss.socket
+
+[Service]
+ExecStartPre=-/bin/chown root:root @logpath@/sssd_nss.log
+ExecStart=@libexecdir@/sssd/sssd_nss --debug-to-files --socket-activated
+Restart=on-failure

--- a/src/sysv/systemd/sssd-nss.socket.in
+++ b/src/sysv/systemd/sssd-nss.socket.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=SSSD NSS Service responder socket
+Documentation=man:sssd.conf(5)
+BindsTo=sssd.service
+
+[Socket]
+ListenStream=@pipepath@/nss
+SocketUser=@SSSD_USER@
+SocketGroup=@SSSD_USER@
+
+[Install]
+WantedBy=sssd.service

--- a/src/sysv/systemd/sssd-pac.service.in
+++ b/src/sysv/systemd/sssd-pac.service.in
@@ -1,0 +1,16 @@
+[Unit]
+Description=SSSD PAC Service responder
+Documentation=man:sssd.conf(5)
+After=sssd.service
+BindsTo=sssd.service
+
+[Install]
+Also=sssd-pac.socket
+
+[Service]
+ExecStartPre=-/bin/chown @SSSD_USER@:@SSSD_USER@ @logpath@/sssd_pac.log
+ExecStart=@libexecdir@/sssd/sssd_pac --debug-to-files --socket-activated
+Restart=on-failure
+User=@SSSD_USER@
+Group=@SSSD_USER@
+PermissionsStartOnly=true

--- a/src/sysv/systemd/sssd-pac.socket.in
+++ b/src/sysv/systemd/sssd-pac.socket.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=SSSD PAC Service responder socket
+Documentation=man:sssd.conf(5)
+BindsTo=sssd.service
+
+[Socket]
+ListenStream=@pipepath@/pac
+SocketUser=@SSSD_USER@
+SocketGroup=@SSSD_USER@
+
+[Install]
+WantedBy=sssd.service

--- a/src/sysv/systemd/sssd-pam-priv.socket.in
+++ b/src/sysv/systemd/sssd-pam-priv.socket.in
@@ -1,0 +1,15 @@
+[Unit]
+Description=SSSD PAM Service responder private socket
+Documentation=man:sssd.conf(5)
+BindsTo=sssd.service
+BindsTo=sssd-pam.socket
+
+[Socket]
+Service=sssd-pam.service
+ListenStream=@pipepath@/private/pam
+SocketUser=root
+SocketGroup=root
+SocketMode=0600
+
+[Install]
+WantedBy=sssd.service

--- a/src/sysv/systemd/sssd-pam.service.in
+++ b/src/sysv/systemd/sssd-pam.service.in
@@ -1,0 +1,16 @@
+[Unit]
+Description=SSSD PAM Service responder
+Documentation=man:sssd.conf(5)
+After=sssd.service
+BindsTo=sssd.service
+
+[Install]
+Also=sssd-pam.socket sssd-pam-priv.socket
+
+[Service]
+ExecStartPre=-/bin/chown @SSSD_USER@:@SSSD_USER@ @logpath@/sssd_pam.log
+ExecStart=@libexecdir@/sssd/sssd_pam --debug-to-files --socket-activated
+Restart=on-failure
+User=@SSSD_USER@
+Group=@SSSD_USER@
+PermissionsStartOnly=true

--- a/src/sysv/systemd/sssd-pam.socket.in
+++ b/src/sysv/systemd/sssd-pam.socket.in
@@ -1,0 +1,13 @@
+[Unit]
+Description=SSSD PAM Service responder socket
+Documentation=man:sssd.conf(5)
+BindsTo=sssd.service
+BindsTo=sssd-pam-priv.socket
+
+[Socket]
+ListenStream=@pipepath@/pam
+SocketUser=root
+SocketGroup=root
+
+[Install]
+WantedBy=sssd.service

--- a/src/sysv/systemd/sssd-ssh.service.in
+++ b/src/sysv/systemd/sssd-ssh.service.in
@@ -1,0 +1,16 @@
+[Unit]
+Description=SSSD SSH Service responder
+Documentation=man:sssd.conf(5)
+After=sssd.service
+BindsTo=sssd.service
+
+[Install]
+Also=sssd-ssh.socket
+
+[Service]
+ExecStartPre=-/bin/chown @SSSD_USER@:@SSSD_USER@ @logpath@/sssd_ssh.log
+ExecStart=@libexecdir@/sssd/sssd_ssh --debug-to-files --socket-activated
+Restart=on-failure
+User=@SSSD_USER@
+Group=@SSSD_USER@
+PermissionsStartOnly=true

--- a/src/sysv/systemd/sssd-ssh.socket.in
+++ b/src/sysv/systemd/sssd-ssh.socket.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=SSSD SSH Service responder socket
+Documentation=man:sssd.conf(5)
+BindsTo=sssd.service
+
+[Socket]
+ListenStream=@pipepath@/ssh
+SocketUser=@SSSD_USER@
+SocketGroup=@SSSD_USER@
+
+[Install]
+WantedBy=sssd.service

--- a/src/sysv/systemd/sssd-sudo.service.in
+++ b/src/sysv/systemd/sssd-sudo.service.in
@@ -1,0 +1,16 @@
+[Unit]
+Description=SSSD Sudo Service responder
+Documentation=man:sssd.conf(5) man:sssd-sudo(5)
+After=sssd.service
+BindsTo=sssd.service
+
+[Install]
+Also=sssd-sudo.socket
+
+[Service]
+ExecStartPre=-/bin/chown @SSSD_USER@:@SSSD_USER@ @logpath@/sssd_sudo.log
+ExecStart=@libexecdir@/sssd/sssd_sudo --debug-to-files --socket-activated
+Restart=on-failure
+User=@SSSD_USER@
+Group=@SSSD_USER@
+PermissionsStartOnly=true

--- a/src/sysv/systemd/sssd-sudo.socket.in
+++ b/src/sysv/systemd/sssd-sudo.socket.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=SSSD Sudo Service responder socket
+Documentation=man:sssd.conf(5)
+BindsTo=sssd.service
+
+[Socket]
+ListenStream=@pipepath@/sudo
+SocketUser=@SSSD_USER@
+SocketGroup=@SSSD_USER@
+
+[Install]
+WantedBy=sssd.service

--- a/src/tests/common_dbus.c
+++ b/src/tests/common_dbus.c
@@ -113,7 +113,8 @@ mock_server_child(void *data)
     loop = tevent_context_init(ctx);
 
     verify_eq (sbus_new_server(ctx, loop, mock->dbus_address, geteuid(), getegid(),
-                               false, &server, on_accept_connection, mock), EOK);
+                               false, &server, on_accept_connection, mock,
+                               NULL), EOK);
 
     tevent_add_fd(loop, ctx, mock->sync_fds[1], TEVENT_FD_READ,
                   on_sync_fd_written, &stop_server);

--- a/src/util/server.c
+++ b/src/util/server.c
@@ -461,17 +461,19 @@ int server_setup(const char *name, int flags,
     char *locale;
     int watchdog_interval;
 
-    ret = chown_debug_file(NULL, uid, gid);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_MINOR_FAILURE,
-              "Cannot chown the debug files, debugging might not work!\n");
-    }
+    if (!is_socket_activated()) {
+        ret = chown_debug_file(NULL, uid, gid);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "Cannot chown the debug files, debugging might not work!\n");
+        }
 
-    ret = become_user(uid, gid);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_FUNC_DATA,
-              "Cannot become user [%"SPRIuid"][%"SPRIgid"].\n", uid, gid);
-        return ret;
+        ret = become_user(uid, gid);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_FUNC_DATA,
+                  "Cannot become user [%"SPRIuid"][%"SPRIgid"].\n", uid, gid);
+            return ret;
+        }
     }
 
     debug_prg_name = strdup(name);

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -33,6 +33,7 @@
 #include "util/sss_utf8.h"
 
 int socket_activated = 0;
+int dbus_activated = 0;
 
 int split_on_separator(TALLOC_CTX *mem_ctx, const char *str,
                        const char sep, bool trim, bool skip_empty,
@@ -1284,6 +1285,15 @@ bool is_socket_activated(void)
 {
 #ifdef HAVE_SYSTEMD
     return !!socket_activated;
+#else
+    return false;
+#endif
+}
+
+bool is_dbus_activated(void)
+{
+#ifdef HAVE_SYSTEMD
+    return !!dbus_activated;
 #else
     return false;
 #endif

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -32,6 +32,8 @@
 #include "util/util.h"
 #include "util/sss_utf8.h"
 
+int socket_activated = 0;
+
 int split_on_separator(TALLOC_CTX *mem_ctx, const char *str,
                        const char sep, bool trim, bool skip_empty,
                        char ***_list, int *size)
@@ -1276,4 +1278,13 @@ bool is_user_or_group_name(const char *sudo_user_value)
 
     /* Now it's either a username or a groupname */
     return true;
+}
+
+bool is_socket_activated(void)
+{
+#ifdef HAVE_SYSTEMD
+    return !!socket_activated;
+#else
+    return false;
+#endif
 }

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -83,6 +83,16 @@
         {"gid", 0, POPT_ARG_INT, &gid, 0, \
           _("The group ID to run the server as"), NULL},
 
+extern int socket_activated;
+
+#ifdef HAVE_SYSTEMD
+#define SSSD_RESPONDER_OPTS \
+        {"socket-activated", 0, POPT_ARG_NONE, &socket_activated, 0, \
+          _("Informs that the responder has been socket-activated"), NULL },
+#else
+#define SSSD_RESPONDER_OPTS
+#endif
+
 #define FLAGS_NONE 0x0000
 #define FLAGS_DAEMON 0x0001
 #define FLAGS_INTERACTIVE 0x0002
@@ -378,6 +388,9 @@ errno_t sss_hash_create_ex(TALLOC_CTX *mem_ctx,
 
 /* Returns true if sudoUser value is a username or a groupname */
 bool is_user_or_group_name(const char *sudo_user_value);
+
+/* Returns true if the responder has been socket-activated */
+bool is_socket_activated(void);
 
 /**
  * @brief Add two list of strings

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -84,11 +84,14 @@
           _("The group ID to run the server as"), NULL},
 
 extern int socket_activated;
+extern int dbus_activated;
 
 #ifdef HAVE_SYSTEMD
 #define SSSD_RESPONDER_OPTS \
         {"socket-activated", 0, POPT_ARG_NONE, &socket_activated, 0, \
-          _("Informs that the responder has been socket-activated"), NULL },
+          _("Informs that the responder has been socket-activated"), NULL }, \
+        {"dbus-activated", 0, POPT_ARG_NONE, &dbus_activated, 0, \
+          _("Informs that the responder has been dbus-activated"), NULL },
 #else
 #define SSSD_RESPONDER_OPTS
 #endif
@@ -391,6 +394,9 @@ bool is_user_or_group_name(const char *sudo_user_value);
 
 /* Returns true if the responder has been socket-activated */
 bool is_socket_activated(void);
+
+/* Returns true if the responder has been dbus-activated */
+bool is_dbus_activated(void);
 
 /**
  * @brief Add two list of strings


### PR DESCRIPTION
This series fixes [#2243](https://fedorahosted.org/sssd/ticket/2243), [#3129](https://fedorahosted.org/sssd/ticket/3129) and [#3245](https://fedorahosted.org/sssd/ticket/3245) following what was discussed in the [ML](https://lists.fedorahosted.org/archives/list/sssd-devel@lists.fedorahosted.org/message/H6JOF5SGGSIJUIWYNANDA73ODHWBS7J2/) and summed up at [this](https://fedorahosted.org/sssd/wiki/DesignDocs/SocketActivatableResponders) design document.

The approach taken was the less intrusive possible and keeps the backward compatibility.

[PR#84](https://github.com/SSSD/sssd/pull/84) was closed due to my lack of skills with github. :-\