### PR TITLE
CONFDB: Supress clang false passitive warnings

### DIFF
--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -448,8 +448,8 @@ int confdb_get_int(struct confdb_ctx *cdb,
 
         errno = 0;
         val = strtol(values[0], NULL, 0);
-        if (errno) {
-            ret = errno;
+        ret = errno;
+        if (ret != 0) {
             goto failed;
         }
 
@@ -504,8 +504,8 @@ long confdb_get_long(struct confdb_ctx *cdb,
 
         errno = 0;
         val = strtol(values[0], NULL, 0);
-        if (errno) {
-            ret = errno;
+        ret = errno;
+        if (ret != 0) {
             goto failed;
         }
 


### PR DESCRIPTION
The errno is macro expandee into '(*__errno_location ())'.
The reason is that errno is private in glibc and and the
function __errno_location return address of private errno.

  sh$ objdump -T /lib64/libc.so.6 | grep errno
  00000010 g    D  .tbss  00000004  GLIBC_PRIVATE errno
  000208a0 g    DF .text  00000011  GLIBC_2.2.5 __errno_location
  001366b0 g    DF .text  0000005f  GLIBC_2.2.5 clnt_sperrno
  00136710 g    DF .text  00000074  GLIBC_2.2.5 clnt_perrno
  00000064 g    D  .tbss  00000004  GLIBC_PRIVATE __h_errno
  0011aad0 g    DF .text  00000011  GLIBC_2.2.5 __h_errno_location

It looks like clang static analyzer assume that value can be
changed due to function call.

  errno = 0;
  val = strtol(values[0], NULL, 0);
  // Taking true branch => assuming "errno != 0"
  if (errno) {
      ret = errno;
      // errno was stored to ret but clang later assumes
      // that ret can be 0
      goto failed;