### PR TITLE
IFP: Remove "ChangeDebugTemporarily" method

### DIFF
--- a/src/responder/ifp/ifp_components.h
+++ b/src/responder/ifp/ifp_components.h
@@ -44,10 +44,6 @@ int ifp_find_backend_by_name(struct sbus_request *dbus_req,
 
 /* org.freedesktop.sssd.infopipe.Components */
 
-int ifp_component_change_debug_level_tmp(struct sbus_request *dbus_req,
-                                         void *data,
-                                         uint32_t arg_new_level);
-
 void ifp_component_get_name(struct sbus_request *dbus_req,
                             void *data,
                             const char **_out);

--- a/src/responder/ifp/ifp_iface.c
+++ b/src/responder/ifp/ifp_iface.c
@@ -47,7 +47,6 @@ struct iface_ifp iface_ifp = {
 
 struct iface_ifp_components iface_ifp_components = {
     { &iface_ifp_components_meta, 0 },
-    .ChangeDebugLevelTemporarily = ifp_component_change_debug_level_tmp,
     .get_name = ifp_component_get_name,
     .get_debug_level = ifp_component_get_debug_level,
     .get_enabled = ifp_component_get_enabled,

--- a/src/responder/ifp/ifp_iface.xml
+++ b/src/responder/ifp/ifp_iface.xml
@@ -63,10 +63,6 @@
     <interface name="org.freedesktop.sssd.infopipe.Components">
         <annotation name="org.freedesktop.DBus.GLib.CSymbol" value="iface_ifp_components"/>
 
-        <method name="ChangeDebugLevelTemporarily">
-            <arg name="new_level" type="u" direction="in" />
-        </method>
-
         <property name="name" type="s" access="read" />
         <property name="debug_level" type="u" access="read" />
         <property name="enabled" type="b" access="read" />

--- a/src/responder/ifp/ifp_iface_generated.c
+++ b/src/responder/ifp/ifp_iface_generated.c
@@ -263,27 +263,8 @@ const struct sbus_interface_meta iface_ifp_meta = {
     sbus_invoke_get_all, /* GetAll invoker */
 };
 
-/* arguments for org.freedesktop.sssd.infopipe.Components.ChangeDebugLevelTemporarily */
-const struct sbus_arg_meta iface_ifp_components_ChangeDebugLevelTemporarily__in[] = {
-    { "new_level", "u" },
-    { NULL, }
-};
-
-int iface_ifp_components_ChangeDebugLevelTemporarily_finish(struct sbus_request *req)
-{
-   return sbus_request_return_and_finish(req,
-                                         DBUS_TYPE_INVALID);
-}
-
 /* methods for org.freedesktop.sssd.infopipe.Components */
 const struct sbus_method_meta iface_ifp_components__methods[] = {
-    {
-        "ChangeDebugLevelTemporarily", /* name */
-        iface_ifp_components_ChangeDebugLevelTemporarily__in,
-        NULL, /* no out_args */
-        offsetof(struct iface_ifp_components, ChangeDebugLevelTemporarily),
-        invoke_u_method,
-    },
     { NULL, }
 };
 

--- a/src/responder/ifp/ifp_iface_generated.h
+++ b/src/responder/ifp/ifp_iface_generated.h
@@ -27,7 +27,6 @@
 
 /* constants for org.freedesktop.sssd.infopipe.Components */
 #define IFACE_IFP_COMPONENTS "org.freedesktop.sssd.infopipe.Components"
-#define IFACE_IFP_COMPONENTS_CHANGEDEBUGLEVELTEMPORARILY "ChangeDebugLevelTemporarily"
 #define IFACE_IFP_COMPONENTS_NAME "name"
 #define IFACE_IFP_COMPONENTS_DEBUG_LEVEL "debug_level"
 #define IFACE_IFP_COMPONENTS_ENABLED "enabled"
@@ -169,16 +168,12 @@ int iface_ifp_ListDomains_finish(struct sbus_request *req, const char *arg_domai
 /* vtable for org.freedesktop.sssd.infopipe.Components */
 struct iface_ifp_components {
     struct sbus_vtable vtable; /* derive from sbus_vtable */
-    int (*ChangeDebugLevelTemporarily)(struct sbus_request *req, void *data, uint32_t arg_new_level);
     void (*get_name)(struct sbus_request *, void *data, const char **);
     void (*get_debug_level)(struct sbus_request *, void *data, uint32_t*);
     void (*get_enabled)(struct sbus_request *, void *data, bool*);
     void (*get_type)(struct sbus_request *, void *data, const char **);
     void (*get_providers)(struct sbus_request *, void *data, const char ***, int *);
 };
-
-/* finish function for ChangeDebugLevelTemporarily */
-int iface_ifp_components_ChangeDebugLevelTemporarily_finish(struct sbus_request *req);
 
 /* vtable for org.freedesktop.sssd.infopipe.Domains */
 struct iface_ifp_domains {


### PR DESCRIPTION
This method has been only used by OpenLMI, which has been deprecated and
its support dropped from SSSD on commit 99b2352.

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>