### PR TITLE
SIFP: Fix warning format-security

### DIFF
--- a/src/lib/sifp/sss_sifp_utils.c
+++ b/src/lib/sifp/sss_sifp_utils.c
@@ -41,7 +41,7 @@ void sss_sifp_set_io_error(sss_sifp_ctx *ctx, DBusError *error)
 {
     dbus_error_free(ctx->io_error);
     dbus_error_init(ctx->io_error);
-    dbus_set_error(ctx->io_error, error->name, error->message);
+    dbus_set_error(ctx->io_error, error->name, "%s", error->message);
 }
 
 char * sss_sifp_strdup(sss_sifp_ctx *ctx, const char *str)


### PR DESCRIPTION
dbus-1.11.8 added attributes for format string check to
few functions in public header files. And therefore there is a warning.

src/lib/sifp/sss_sifp_utils.c: In function ‘sss_sifp_set_io_error’:
src/lib/sifp/sss_sifp_utils.c:44:5: error: format not a string literal
and no format arguments [-Werror=format-security]
     dbus_set_error(ctx->io_error, error->name, error->message);
          ^~~~~~~~~~~~~~