### PR TITLE
sudo: do not store usn if no rules are found

### DIFF
--- a/src/providers/ldap/sdap_sudo_shared.c
+++ b/src/providers/ldap/sdap_sudo_shared.c
@@ -129,7 +129,7 @@ sdap_sudo_new_usn(TALLOC_CTX *mem_ctx,
     char *newusn;
 
     /* We increment USN number so that we can later use simplify filter
-     * (just usn >= last+1 instaed of usn >= last && usn != last).
+     * (just usn >= last+1 instead of usn >= last && usn != last).
      */
     usn++;
 
@@ -171,6 +171,13 @@ sdap_sudo_set_usn(struct sdap_server_opts *srv_opts,
         ret = errno;
         DEBUG(SSSDBG_MINOR_FAILURE, "Unable to convert USN %s [%d]: %s\n",
               usn, ret, sss_strerror(ret));
+        return;
+    }
+
+    if (usn_number == 0) {
+        /* Zero means that there were no rules on the server, so we have
+         * nothing to store. */
+        DEBUG(SSSDBG_TRACE_FUNC, "SUDO USN value is empty.\n");
         return;
     }
 


### PR DESCRIPTION
When ldap doesn't contain any sudorule during the initial full refresh,
usn is set to 1 instead of remaining unset and we are trying to
search modifyTimestamp>=1 during smart refresh which doesn't return any result
on openldap servers.

How to test:
Run sssd with no rules in ldap. Without the patch,
full refresh stores usn=1 and smart refresh run
search usn>=1. With this patch no usn is stored
and smart refresh run generic request without
usn part.

Resolves:
https://fedorahosted.org/sssd/ticket/3257