### PR TITLE
Add a new "files" provider

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -519,6 +519,7 @@ SSSD_CACHE_REQ_OBJ = \
 SSSD_RESPONDER_IFACE_OBJ = \
     src/responder/common/iface/responder_iface.c \
     src/responder/common/iface/responder_domain.c \
+    src/responder/common/iface/responder_ncache.c \
     src/responder/common/iface/responder_iface_generated.c \
     $(NULL)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1464,6 +1464,7 @@ sssd_be_SOURCES = \
     src/providers/data_provider/dp_iface_backend.c \
     src/providers/data_provider/dp_iface_failover.c \
     src/providers/data_provider/dp_client.c \
+    src/providers/data_provider/dp_resp_client.c \
     src/providers/data_provider/dp_iface_generated.c \
     src/providers/data_provider/dp_request.c \
     src/providers/data_provider/dp_request_reply.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -1279,6 +1279,7 @@ sssd_SOURCES = \
     src/confdb/confdb_setup.c \
     src/monitor/monitor_iface_generated.c \
     src/util/nscd.c \
+    src/util/inotify.c \
     $(NULL)
 sssd_LDADD = \
     $(SSSD_LIBS) \

--- a/Makefile.am
+++ b/Makefile.am
@@ -284,6 +284,10 @@ if BUILD_IFP
 non_interactive_cmocka_based_tests += ifp_tests
 endif   # BUILD_IFP
 
+if HAVE_INOTIFY
+non_interactive_cmocka_based_tests += test_inotify
+endif   # HAVE_INOTIFY
+
 if BUILD_SAMBA
 non_interactive_cmocka_based_tests += \
     ad_access_filter_tests \
@@ -642,6 +646,7 @@ dist_noinst_HEADERS = \
     src/util/util_safealign.h \
     src/util/util_sss_idmap.h \
     src/util/util_creds.h \
+    src/util/inotify.h \
     src/monitor/monitor.h \
     src/monitor/monitor_interfaces.h \
     src/monitor/monitor_iface_generated.h \
@@ -3165,6 +3170,21 @@ krb5_common_test_LDADD = \
     $(SSSD_INTERNAL_LTLIBS) \
     libsss_test_common.la \
     libdlopen_test_providers.la \
+    $(NULL)
+
+test_inotify_SOURCES = \
+    src/util/inotify.c \
+    src/tests/cmocka/test_inotify.c \
+    $(NULL)
+test_inotify_CFLAGS = \
+    $(AM_CFLAGS) \
+    $(NULL)
+test_inotify_LDADD = \
+    $(CMOCKA_LIBS) \
+    $(SSSD_LIBS) \
+    $(SSSD_INTERNAL_LTLIBS) \
+    $(LIBADD_DL) \
+    libsss_test_common.la \
     $(NULL)
 
 endif # HAVE_CMOCKA

--- a/Makefile.am
+++ b/Makefile.am
@@ -516,6 +516,12 @@ SSSD_CACHE_REQ_OBJ = \
 	src/responder/common/cache_req/plugins/cache_req_host_by_name.c \
 	$(NULL)
 
+SSSD_RESPONDER_IFACE_OBJ = \
+    src/responder/common/iface/responder_iface.c \
+    src/responder/common/iface/responder_domain.c \
+    src/responder/common/iface/responder_iface_generated.c \
+    $(NULL)
+
 SSSD_RESPONDER_OBJ = \
     src/responder/common/negcache_files.c \
     src/responder/common/negcache.c \
@@ -530,6 +536,7 @@ SSSD_RESPONDER_OBJ = \
     src/responder/common/data_provider/rdp_client.c \
     src/monitor/monitor_iface_generated.c \
     src/providers/data_provider_req.c \
+    $(SSSD_RESPONDER_IFACE_OBJ) \
     $(SSSD_CACHE_REQ_OBJ) \
     $(NULL)
 
@@ -640,6 +647,8 @@ dist_noinst_HEADERS = \
     src/responder/common/responder.h \
     src/responder/common/responder_packet.h \
     src/responder/common/responder_sbus.h \
+    src/responder/common/iface/responder_iface.h \
+    src/responder/common/iface/responder_iface_generated.h \
     src/responder/common/cache_req/cache_req.h \
     src/responder/common/cache_req/cache_req_plugin.h \
     src/responder/common/cache_req/cache_req_private.h \
@@ -1221,7 +1230,9 @@ CODEGEN_XML = \
     $(srcdir)/src/providers/data_provider/dp_iface.xml \
     $(srcdir)/src/providers/proxy/proxy_iface.xml \
     $(srcdir)/src/responder/ifp/ifp_iface.xml \
-    $(srcdir)/src/responder/nss/nss_iface.xml
+    $(srcdir)/src/responder/nss/nss_iface.xml \
+    $(srcdir)/src/responder/common/iface/responder_iface.xml \
+    $(NULL)
 
 SBUS_CODEGEN = src/sbus/sbus_codegen
 
@@ -2038,7 +2049,9 @@ responder_socket_access_tests_SOURCES = \
     src/responder/common/responder_packet.c \
     src/responder/common/responder_cmd.c \
     src/responder/common/data_provider/rdp_message.c \
-    src/responder/common/data_provider/rdp_client.c
+    src/responder/common/data_provider/rdp_client.c \
+    $(SSSD_RESPONDER_IFACE_OBJ) \
+    $(NULL)
 responder_socket_access_tests_CFLAGS = \
     $(AM_CFLAGS) \
     $(CHECK_CFLAGS)
@@ -2125,6 +2138,7 @@ TEST_MOCK_RESP_OBJ = \
      src/responder/common/data_provider/rdp_client.c \
      src/responder/common/responder_utils.c \
      $(SSSD_CACHE_REQ_OBJ) \
+     $(SSSD_RESPONDER_IFACE_OBJ) \
      $(NULL)
 
 TEST_MOCK_PROVIDER_OBJ = \

--- a/Makefile.am
+++ b/Makefile.am
@@ -339,13 +339,20 @@ sssdlib_LTLIBRARIES = \
     libsss_ldap.la \
     libsss_krb5.la \
     libsss_proxy.la \
-    libsss_simple.la
+    libsss_simple.la \
+    $(NULL)
 
 if BUILD_SAMBA
 sssdlib_LTLIBRARIES += \
     libsss_ipa.la \
     libsss_ad.la
 endif
+
+if HAVE_INOTIFY
+sssdlib_LTLIBRARIES += \
+    libsss_files.la \
+    $(NULL)
+endif # HAVE_INOTIFY
 
 ldblib_LTLIBRARIES = \
     memberof.la
@@ -771,6 +778,7 @@ dist_noinst_HEADERS = \
     src/providers/ad/ad_subdomains.h \
     src/providers/proxy/proxy.h \
     src/providers/proxy/proxy_iface_generated.h \
+    src/providers/files/files_private.h \
     src/tools/tools_util.h \
     src/tools/sss_sync_ops.h \
     src/resolv/async_resolv.h \
@@ -1853,6 +1861,7 @@ if BUILD_SEMANAGE
     FILES_TESTS_LIBS += $(SEMANAGE_LIBS)
 endif
 
+if HAVE_INOTIFY
 files_tests_SOURCES = \
     src/tests/files-tests.c \
     src/util/check_and_open.c \
@@ -1866,6 +1875,7 @@ files_tests_LDADD = \
     $(FILES_TESTS_LIBS) \
     libsss_test_common.la \
     $(SSSD_INTERNAL_LTLIBS)
+endif   # HAVE_INOTIFY
 
 SSSD_RESOLV_TESTS_OBJ = \
     $(SSSD_RESOLV_OBJ)
@@ -3509,6 +3519,23 @@ libsss_proxy_la_LIBADD = \
 libsss_proxy_la_LDFLAGS = \
     -avoid-version \
     -module
+
+libsss_files_la_SOURCES = \
+    src/providers/files/files_init.c \
+    src/providers/files/files_id.c \
+    src/providers/files/files_ops.c \
+    src/util/inotify.c \
+    $(NULL)
+libsss_files_la_CFLAGS = \
+    $(AM_CFLAGS) \
+    $(NULL)
+libsss_files_la_LIBADD = \
+    $(PAM_LIBS) \
+    $(NULL)
+libsss_files_la_LDFLAGS = \
+    -avoid-version \
+    -module \
+    $(NULL)
 
 libsss_simple_la_SOURCES = \
     src/providers/simple/simple_access_check.c \

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -848,6 +848,9 @@ done
 %{_sbindir}/sss_cache
 %{_libexecdir}/%{servicename}/sss_signal
 
+# The files provider is intentionally packaged in -common
+%{_libdir}/%{name}/libsss_files.so
+
 %dir %{sssdstatedir}
 %dir %{_localstatedir}/cache/krb5rcache
 %attr(700,sssd,sssd) %dir %{dbpath}

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -850,6 +850,7 @@ done
 
 # The files provider is intentionally packaged in -common
 %{_libdir}/%{name}/libsss_files.so
+%{_mandir}/man5/sssd-files.5*
 
 %dir %{sssdstatedir}
 %dir %{_localstatedir}/cache/krb5rcache

--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -900,13 +900,6 @@ static int confdb_get_domain_internal(struct confdb_ctx *cdb,
         goto done;
     }
 
-    if (strcasecmp(domain->provider, "files") == 0) {
-        /* The files provider is not valid anymore */
-        DEBUG(SSSDBG_FATAL_FAILURE, "The \"files\" provider is invalid\n");
-        ret = EINVAL;
-        goto done;
-    }
-
     if (strcasecmp(domain->provider, "local") == 0) {
         /* If this is the local provider, we need to ensure that
          * no other provider was specified for other types, since

--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -966,6 +966,13 @@ static int confdb_get_domain_internal(struct confdb_ctx *cdb,
         }
     }
 
+    if (strcasecmp(domain->provider, "files") == 0) {
+        /* The password field must be reported as 'x', else pam_unix won't
+         * authenticate this entry. See man pwconv(8) for more details.
+         */
+        domain->pwfield = "x";
+    }
+
     if (!domain->enumerate) {
         DEBUG(SSSDBG_TRACE_FUNC, "No enumeration for [%s]!\n", domain->name);
     }

--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -828,6 +828,7 @@ static int confdb_get_domain_internal(struct confdb_ctx *cdb,
     char *default_domain;
     bool fqnames_default = false;
     int memcache_timeout;
+    bool enum_default;
 
     tmp_ctx = talloc_new(mem_ctx);
     if (!tmp_ctx) return ENOMEM;
@@ -954,14 +955,17 @@ static int confdb_get_domain_internal(struct confdb_ctx *cdb,
                   "Interpreting as true\n", domain->name);
         domain->enumerate = true;
     } else { /* assume the new format */
+        enum_default = strcasecmp(domain->provider, "files") == 0 ? true : false;
+
         ret = get_entry_as_bool(res->msgs[0], &domain->enumerate,
-                                CONFDB_DOMAIN_ENUMERATE, 0);
+                                CONFDB_DOMAIN_ENUMERATE, enum_default);
         if(ret != EOK) {
             DEBUG(SSSDBG_FATAL_FAILURE,
                   "Invalid value for %s\n", CONFDB_DOMAIN_ENUMERATE);
             goto done;
         }
     }
+
     if (!domain->enumerate) {
         DEBUG(SSSDBG_TRACE_FUNC, "No enumeration for [%s]!\n", domain->name);
     }

--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -1325,6 +1325,16 @@ static int confdb_get_domain_internal(struct confdb_ctx *cdb,
     }
 
     tmp = ldb_msg_find_attr_as_string(res->msgs[0],
+                                      CONFDB_NSS_PWFIELD, NULL);
+    if (tmp != NULL) {
+        domain->pwfield = talloc_strdup(domain, tmp);
+        if (!domain->pwfield) {
+            ret = ENOMEM;
+            goto done;
+        }
+    }
+
+    tmp = ldb_msg_find_attr_as_string(res->msgs[0],
                                       CONFDB_SUBDOMAIN_ENUMERATE,
                                       CONFDB_DEFAULT_SUBDOMAIN_ENUMERATE);
     if (tmp != NULL) {

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -248,6 +248,10 @@ enum sss_domain_state {
      * return cached data
      */
     DOM_INACTIVE,
+    /** Domain is being updated. Responders should ignore cached data and
+     * always contact the DP
+     */
+    DOM_INCONSISTENT,
 };
 
 /**

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -270,6 +270,7 @@ struct sss_domain_info {
     bool ignore_group_members;
     uint32_t id_min;
     uint32_t id_max;
+    const char *pwfield;
 
     bool cache_credentials;
     uint32_t cache_credentials_min_ff_length;

--- a/src/examples/sssd.conf
+++ b/src/examples/sssd.conf
@@ -1,5 +1,4 @@
 [sssd]
-config_file_version = 2
 services = nss, pam
 domains = shadowutils
 
@@ -8,8 +7,7 @@ domains = shadowutils
 [pam]
 
 [domain/shadowutils]
-id_provider = proxy
-proxy_lib_name = files
+id_provider = files
 
 auth_provider = proxy
 proxy_pam_target = sssd-shadowutils

--- a/src/external/inotify.m4
+++ b/src/external/inotify.m4
@@ -29,4 +29,6 @@ int main () {
     AS_IF([test x"$inotify_works" = xyes],
           [AC_DEFINE_UNQUOTED([HAVE_INOTIFY], [1], [Inotify works])])
     AC_SUBST(INOTIFY_LIBS)
+
+    AM_CONDITIONAL([HAVE_INOTIFY], [test x"$inotify_works" = xyes])
 ])

--- a/src/man/Makefile.am
+++ b/src/man/Makefile.am
@@ -84,6 +84,10 @@ if BUILD_NFS_IDMAP
 man_MANS += sss_rpcidmapd.5
 endif
 
+if HAVE_INOTIFY
+man_MANS += sssd-files.5
+endif
+
 SUFFIXES = .1.xml .1 .3.xml .3 .5.xml .5 .8.xml .8
 .1.xml.1:
 	$(XMLLINT) $(XMLLINT_FLAGS) $<

--- a/src/man/po/po4a.cfg
+++ b/src/man/po/po4a.cfg
@@ -28,6 +28,7 @@
 [type:docbook] sss_ssh_knownhostsproxy.1.xml $lang:$(builddir)/$lang/sss_ssh_knownhostsproxy.1.xml
 [type:docbook] idmap_sss.8.xml $lang:$(builddir)/$lang/idmap_sss.8.xml
 [type:docbook] sssctl.8.xml $lang:$(builddir)/$lang/sssctl.8.xml
+[type:docbook] sssd-files.5.xml $lang:$(builddir)/$lang/sssd-files.5.xml
 [type:docbook] sssd-secrets.5.xml $lang:$(builddir)/$lang/sssd-secrets.5.xml
 [type:docbook] include/service_discovery.xml $lang:$(builddir)/$lang/include/service_discovery.xml opt:"-k 0"
 [type:docbook] include/upstream.xml $lang:$(builddir)/$lang/include/upstream.xml opt:"-k 0"

--- a/src/man/sssd-files.5.xml
+++ b/src/man/sssd-files.5.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DocBook V4.4//EN"
+"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
+<reference>
+<title>SSSD Manual pages</title>
+<refentry>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="include/upstream.xml" />
+
+    <refmeta>
+        <refentrytitle>sssd-files</refentrytitle>
+        <manvolnum>5</manvolnum>
+        <refmiscinfo class="manual">File Formats and Conventions</refmiscinfo>
+    </refmeta>
+
+    <refnamediv id='name'>
+        <refname>sssd-files</refname>
+        <refpurpose>SSSD files provider</refpurpose>
+    </refnamediv>
+
+    <refsect1 id='description'>
+        <title>DESCRIPTION</title>
+        <para>
+            This manual page describes the files provider
+            for
+            <citerefentry>
+                <refentrytitle>sssd</refentrytitle>
+                <manvolnum>8</manvolnum>
+            </citerefentry>.
+            For a detailed syntax reference, refer to the <quote>FILE FORMAT</quote> section of the
+            <citerefentry>
+                <refentrytitle>sssd.conf</refentrytitle>
+                <manvolnum>5</manvolnum>
+            </citerefentry> manual page.
+        </para>
+        <para>
+            The files provider mirrors the content of the
+            <citerefentry>
+                <refentrytitle>passwd</refentrytitle>
+                <manvolnum>5</manvolnum>
+            </citerefentry>
+            and
+            <citerefentry>
+                <refentrytitle>group</refentrytitle>
+                <manvolnum>5</manvolnum>
+            </citerefentry>
+            files. The purpose of the files provider is to make the users
+            and groups traditionally only accessible with NSS interfaces
+            also available through the SSSD interfaces such as
+            <citerefentry>
+                <refentrytitle>sssd-ifp</refentrytitle>
+                <manvolnum>5</manvolnum>
+            </citerefentry>.
+        </para>
+    </refsect1>
+
+    <refsect1 id='configuration-options'>
+        <title>CONFIGURATION OPTIONS</title>
+        <para>
+            The files provider has no specific options of its own, however,
+            generic SSSD domain options can be set where applicable.
+            Refer to the section <quote>DOMAIN SECTIONS</quote> of the
+            <citerefentry>
+                <refentrytitle>sssd.conf</refentrytitle>
+                <manvolnum>5</manvolnum>
+            </citerefentry> manual page for details on the configuration
+            of an SSSD domain.
+        </para>
+    </refsect1>
+
+    <refsect1 id='example'>
+        <title>EXAMPLE</title>
+        <para>
+            The following example assumes that SSSD is correctly
+            configured and files is one of the domains in the
+            <replaceable>[sssd]</replaceable> section.
+        </para>
+        <para>
+<programlisting>
+[domain/files]
+id_provider = files
+</programlisting>
+        </para>
+    </refsect1>
+
+	<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="include/seealso.xml" />
+
+</refentry>
+</reference>

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -936,6 +936,23 @@ fallback_homedir = /home/%u
                         </para>
                     </listitem>
                 </varlistentry>
+                <varlistentry>
+                    <term>pwfield (string)</term>
+                    <listitem>
+                        <para>
+                            The value that NSS operations that return
+                            users or groups will return for the
+                            <quote>password</quote> field.
+                        </para>
+                        <para>
+                            This option can also be set per-domain.
+                        </para>
+                        <para>
+                            Default: <quote>*</quote> (remote domains)
+                            or <quote>x</quote> (the files domain)
+                        </para>
+                    </listitem>
+                </varlistentry>
             </variablelist>
         </refsect2>
         <refsect2 id='PAM'>

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -2296,19 +2296,6 @@ static int monitor_process_init(struct mt_ctx *ctx,
     ret = sss_sigchld_init(ctx, ctx->ev, &ctx->sigchld_ctx);
     if (ret != EOK) return ret;
 
-#if 0
-    This feature is incomplete and can leave the SSSD in a bad state if the
-    config file is changed while the SSSD is running.
-
-    Uncomment this once the backends are honoring reloadConfig()
-
-    /* Watch for changes to the confdb config file */
-    ret = monitor_config_file(ctx, ctx, config_file, monitor_signal_reconf,
-                              true);
-    if (ret != EOK) {
-        return ret;
-    }
-#endif
     /* Watch for changes to the DNS resolv.conf */
     ret = monitor_config_file(ctx, ctx, RESOLV_CONF_PATH,
                               monitor_update_resolv, false);

--- a/src/monitor/monitor.h
+++ b/src/monitor/monitor.h
@@ -32,9 +32,6 @@
 
 struct config_file_ctx;
 
-typedef int (*monitor_reconf_fn) (struct config_file_ctx *file_ctx,
-                                  const char *filename);
-
 struct mt_ctx;
 
 /* from monitor_netlink.c */

--- a/src/providers/data_provider.h
+++ b/src/providers/data_provider.h
@@ -229,6 +229,11 @@ int dp_get_sbus_address(TALLOC_CTX *mem_ctx,
                         char **address, const char *domain_name);
 
 
+/* Reserved filter name for request which waits until the files provider finishes mirroring
+ * the file content
+ */
+#define DP_REQ_OPT_FILES_INITGR     "files_initgr_request"
+
 /* Helpers */
 
 #define NULL_STRING { .string = NULL }

--- a/src/providers/data_provider/dp.h
+++ b/src/providers/data_provider/dp.h
@@ -171,4 +171,8 @@ void dp_sbus_reset_users_ncache(struct data_provider *provider,
 void dp_sbus_reset_groups_ncache(struct data_provider *provider,
                                  struct sss_domain_info *dom);
 
+void dp_sbus_reset_users_memcache(struct data_provider *provider);
+void dp_sbus_reset_groups_memcache(struct data_provider *provider);
+void dp_sbus_reset_initgr_memcache(struct data_provider *provider);
+
 #endif /* _DP_H_ */

--- a/src/providers/data_provider/dp.h
+++ b/src/providers/data_provider/dp.h
@@ -161,4 +161,9 @@ bool dp_method_enabled(struct data_provider *provider,
 void dp_terminate_domain_requests(struct data_provider *provider,
                                   const char *domain);
 
+void dp_sbus_domain_active(struct data_provider *provider,
+                           struct sss_domain_info *dom);
+void dp_sbus_domain_inconsistent(struct data_provider *provider,
+                                 struct sss_domain_info *dom);
+
 #endif /* _DP_H_ */

--- a/src/providers/data_provider/dp.h
+++ b/src/providers/data_provider/dp.h
@@ -166,4 +166,9 @@ void dp_sbus_domain_active(struct data_provider *provider,
 void dp_sbus_domain_inconsistent(struct data_provider *provider,
                                  struct sss_domain_info *dom);
 
+void dp_sbus_reset_users_ncache(struct data_provider *provider,
+                                struct sss_domain_info *dom);
+void dp_sbus_reset_groups_ncache(struct data_provider *provider,
+                                 struct sss_domain_info *dom);
+
 #endif /* _DP_H_ */

--- a/src/providers/data_provider/dp_resp_client.c
+++ b/src/providers/data_provider/dp_resp_client.c
@@ -1,0 +1,93 @@
+/*
+   SSSD
+
+   Data Provider Responder client - DP calls responder interface
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+#include <talloc.h>
+#include <tevent.h>
+
+#include "confdb/confdb.h"
+#include "sbus/sssd_dbus.h"
+#include "providers/data_provider.h"
+#include "providers/data_provider/dp_private.h"
+#include "responder/common/iface/responder_iface.h"
+#include "src/responder/nss/nss_iface.h"
+
+static void send_msg_to_all_clients(struct data_provider *provider,
+                                    struct DBusMessage *msg)
+{
+    struct dp_client *cli;
+    int i;
+
+    for (i = 0; provider->clients[i] != NULL; i++) {
+        cli = provider->clients[i];
+        if (cli != NULL) {
+           sbus_conn_send_reply(dp_client_conn(cli), msg);
+        }
+    }
+}
+
+static void dp_sbus_set_domain_state(struct data_provider *provider,
+                                     struct sss_domain_info *dom,
+                                     enum sss_domain_state state)
+{
+    DBusMessage *msg;
+    const char *method = NULL;
+
+    switch (state) {
+    case DOM_ACTIVE:
+        DEBUG(SSSDBG_TRACE_FUNC, "Ordering responders to enable domain %s\n",
+              dom->name);
+        method = IFACE_RESPONDER_DOMAIN_SETACTIVE;
+        break;
+    case DOM_INCONSISTENT:
+        DEBUG(SSSDBG_TRACE_FUNC, "Ordering responders to disable domain %s\n",
+              dom->name);
+        method = IFACE_RESPONDER_DOMAIN_SETINCONSISTENT;
+        break;
+    default:
+        /* No other methods provided at the moment */
+        return;
+    }
+
+    sss_domain_set_state(dom, state);
+
+    msg = sbus_create_message(NULL, NULL, RESPONDER_PATH,
+                              IFACE_RESPONDER_DOMAIN, method,
+                              DBUS_TYPE_STRING, &dom->name);
+    if (msg == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory?!\n");
+        return;
+    }
+
+    send_msg_to_all_clients(provider, msg);
+    dbus_message_unref(msg);
+    return;
+}
+
+void dp_sbus_domain_active(struct data_provider *provider,
+                           struct sss_domain_info *dom)
+{
+    return dp_sbus_set_domain_state(provider, dom, DOM_ACTIVE);
+}
+
+void dp_sbus_domain_inconsistent(struct data_provider *provider,
+                                 struct sss_domain_info *dom)
+{
+    return dp_sbus_set_domain_state(provider, dom, DOM_INCONSISTENT);
+}

--- a/src/providers/data_provider/dp_resp_client.c
+++ b/src/providers/data_provider/dp_resp_client.c
@@ -154,3 +154,38 @@ void dp_sbus_reset_groups_ncache(struct data_provider *provider,
     return dp_sbus_reset_ncache(provider, dom,
                                 IFACE_RESPONDER_NCACHE_RESETGROUPS);
 }
+
+static void dp_sbus_reset_memcache(struct data_provider *provider,
+                                   const char *method)
+{
+    DBusMessage *msg;
+
+    msg = sbus_create_message(NULL, NULL, NSS_MEMORYCACHE_PATH,
+                              IFACE_NSS_MEMORYCACHE, method);
+    if (msg == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory?!\n");
+        return;
+    }
+
+    send_msg_to_selected_clients(provider, msg, user_clients);
+    dbus_message_unref(msg);
+    return;
+}
+
+void dp_sbus_reset_users_memcache(struct data_provider *provider)
+{
+    return dp_sbus_reset_memcache(provider,
+                                  IFACE_NSS_MEMORYCACHE_INVALIDATEALLUSERS);
+}
+
+void dp_sbus_reset_groups_memcache(struct data_provider *provider)
+{
+    return dp_sbus_reset_memcache(provider,
+                                  IFACE_NSS_MEMORYCACHE_INVALIDATEALLGROUPS);
+}
+
+void dp_sbus_reset_initgr_memcache(struct data_provider *provider)
+{
+    return dp_sbus_reset_memcache(provider,
+                          IFACE_NSS_MEMORYCACHE_INVALIDATEALLINITGROUPS);
+}

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -166,8 +166,10 @@ static void be_mark_subdom_offline(struct sss_domain_info *subdom,
     tv = tevent_timeval_current_ofs(reset_status_timeout, 0);
 
     switch (subdom->state) {
+    case DOM_INCONSISTENT:
     case DOM_DISABLED:
-        DEBUG(SSSDBG_MINOR_FAILURE, "Won't touch disabled subdomain\n");
+        DEBUG(SSSDBG_MINOR_FAILURE,
+              "Won't touch disabled or inconsistent subdomain\n");
         return;
     case DOM_INACTIVE:
         DEBUG(SSSDBG_TRACE_ALL, "Subdomain already inactive\n");

--- a/src/providers/files/files_id.c
+++ b/src/providers/files/files_id.c
@@ -1,0 +1,179 @@
+/*
+    SSSD
+
+    files_id.c - Identity operaions on the files provider
+
+    Copyright (C) 2016 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "providers/data_provider/dp.h"
+#include "providers/files/files_private.h"
+
+struct files_account_info_handler_state {
+    struct dp_reply_std reply;
+
+    struct files_id_ctx *id_ctx;
+};
+
+struct tevent_req *
+files_account_info_handler_send(TALLOC_CTX *mem_ctx,
+                                struct files_id_ctx *id_ctx,
+                                struct dp_id_data *data,
+                                struct dp_req_params *params)
+{
+    struct files_account_info_handler_state *state;
+    struct tevent_req *req;
+    struct tevent_req **update_req = NULL;
+    bool needs_update;
+    errno_t ret;
+
+    req = tevent_req_create(mem_ctx, &state,
+                            struct files_account_info_handler_state);
+    if (req == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "tevent_req_create() failed\n");
+        return NULL;
+    }
+    state->id_ctx = id_ctx;
+
+    switch (data->entry_type & BE_REQ_TYPE_MASK) {
+    case BE_REQ_USER:
+        if (data->filter_type != BE_FILTER_ENUM) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Unexpected user filter type: %d\n", data->filter_type);
+            ret = EINVAL;
+            goto immediate;
+        }
+        update_req = &id_ctx->users_req;
+        needs_update = id_ctx->updating_passwd ? true : false;
+        break;
+    case BE_REQ_GROUP:
+        if (data->filter_type != BE_FILTER_ENUM) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Unexpected group filter type: %d\n", data->filter_type);
+            ret = EINVAL;
+            goto immediate;
+        }
+        update_req = &id_ctx->groups_req;
+        needs_update = id_ctx->updating_groups ? true : false;
+        break;
+    case BE_REQ_INITGROUPS:
+        if (data->filter_type != BE_FILTER_NAME) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Unexpected initgr filter type: %d\n", data->filter_type);
+            ret = EINVAL;
+            goto immediate;
+        }
+        if (strcmp(data->filter_value, DP_REQ_OPT_FILES_INITGR) != 0) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Unexpected initgr filter value: %d\n", data->filter_type);
+            ret = EINVAL;
+            goto immediate;
+        }
+        update_req = &id_ctx->initgroups_req;
+        needs_update = id_ctx->updating_groups || id_ctx->updating_passwd \
+                       ? true \
+                       : false;
+        break;
+    default:
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Unexpected entry type: %d\n", data->entry_type & BE_REQ_TYPE_MASK);
+        ret = EINVAL;
+        goto immediate;
+    }
+
+    if (needs_update == false) {
+        DEBUG(SSSDBG_TRACE_LIBS, "The files domain no longer needs an update\n");
+        ret = EOK;
+        goto immediate;
+    }
+
+    if (*update_req != NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "BUG: Received a concurrent update!\n");
+        ret = EAGAIN;
+        goto immediate;
+    }
+
+    /* id_ctx now must mark the requests as updated when the inotify-induced
+     * update finishes
+     */
+    *update_req = req;
+    return req;
+
+immediate:
+    dp_reply_std_set(&state->reply, DP_ERR_DECIDE, ret, NULL);
+
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else {
+        tevent_req_error(req, ret);
+    }
+
+    tevent_req_post(req, params->ev);
+    return req;
+}
+
+static void finish_update_req(struct tevent_req **update_req,
+                              errno_t ret)
+{
+    if (*update_req == NULL) {
+        return;
+    }
+
+    if (ret != EOK) {
+        tevent_req_error(*update_req, ret);
+    } else {
+        tevent_req_done(*update_req);
+    }
+    *update_req = NULL;
+}
+
+void files_account_info_finished(struct files_id_ctx *id_ctx,
+                                 int req_type,
+                                 errno_t ret)
+{
+    switch (req_type) {
+    case BE_REQ_USER:
+        finish_update_req(&id_ctx->users_req, ret);
+        if (id_ctx->updating_groups == false) {
+            finish_update_req(&id_ctx->initgroups_req, ret);
+        }
+        break;
+    case BE_REQ_GROUP:
+        finish_update_req(&id_ctx->groups_req, ret);
+        if (id_ctx->updating_passwd == false) {
+            finish_update_req(&id_ctx->initgroups_req, ret);
+        }
+        break;
+    default:
+        DEBUG(SSSDBG_CRIT_FAILURE,
+               "Unexpected req_type %d\n", req_type);
+        return;
+    }
+}
+
+errno_t files_account_info_handler_recv(TALLOC_CTX *mem_ctx,
+                                        struct tevent_req *req,
+                                        struct dp_reply_std *data)
+{
+    struct files_account_info_handler_state *state = NULL;
+
+    state = tevent_req_data(req, struct files_account_info_handler_state);
+
+    TEVENT_REQ_RETURN_ON_ERROR(req);
+
+    *data = state->reply;
+    return EOK;
+}

--- a/src/providers/files/files_init.c
+++ b/src/providers/files/files_init.c
@@ -1,0 +1,92 @@
+/*
+    SSSD
+
+    files_init.c - Initialization of the files provider
+
+    Copyright (C) 2016 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "providers/data_provider/dp.h"
+#include "providers/files/files_private.h"
+
+int sssm_files_init(TALLOC_CTX *mem_ctx,
+                    struct be_ctx *be_ctx,
+                    struct data_provider *provider,
+                    const char *module_name,
+                    void **_module_data)
+{
+    struct files_id_ctx *ctx;
+    int ret;
+    const char *passwd_file = NULL;
+    const char *group_file = NULL;
+
+    /* So far this is mostly useful for tests */
+    passwd_file = getenv("SSS_FILES_PASSWD");
+    if (passwd_file == NULL) {
+        passwd_file = "/etc/passwd";
+    }
+
+    group_file = getenv("SSS_FILES_GROUP");
+    if (group_file == NULL) {
+        group_file = "/etc/group";
+    }
+
+    ctx = talloc_zero(mem_ctx, struct files_id_ctx);
+    if (ctx == NULL) {
+        return ENOMEM;
+    }
+    ctx->be = be_ctx;
+    ctx->domain = be_ctx->domain;
+    ctx->passwd_file = passwd_file;
+    ctx->group_file = group_file;
+
+    ctx->fctx = sf_init(ctx, be_ctx->ev,
+                        ctx->passwd_file, ctx->group_file,
+                        ctx);
+    if (ctx->fctx == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    *_module_data = ctx;
+    ret = EOK;
+done:
+    if (ret != EOK) {
+        talloc_free(ctx);
+    }
+    return ret;
+}
+
+int sssm_files_id_init(TALLOC_CTX *mem_ctx,
+                       struct be_ctx *be_ctx,
+                       void *module_data,
+                       struct dp_method *dp_methods)
+{
+    struct files_id_ctx *ctx;
+
+    ctx = talloc_get_type(module_data, struct files_id_ctx);
+    if (ctx == NULL) {
+        return EINVAL;
+    }
+
+    dp_set_method(dp_methods, DPM_ACCOUNT_HANDLER,
+                  files_account_info_handler_send,
+                  files_account_info_handler_recv,
+                  ctx, struct files_id_ctx,
+                  struct dp_id_data, struct dp_reply_std);
+
+    return EOK;
+}

--- a/src/providers/files/files_ops.c
+++ b/src/providers/files/files_ops.c
@@ -1,0 +1,801 @@
+/*
+    SSSD
+
+    Files provider operations
+
+    Copyright (C) 2016 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <dlfcn.h>
+
+#include "config.h"
+
+#include "providers/files/files_private.h"
+#include "db/sysdb.h"
+#include "util/inotify.h"
+#include "util/util.h"
+
+#define FILES_REALLOC_CHUNK 64
+
+#define PWD_MAXSIZE         1024
+#define GRP_MAXSIZE         2048
+
+struct files_ctx {
+    struct snotify_ctx *pwd_watch;
+    struct snotify_ctx *grp_watch;
+
+    struct files_ops_ctx *ops;
+};
+
+static errno_t enum_files_users(TALLOC_CTX *mem_ctx,
+                                struct files_id_ctx *id_ctx,
+                                struct passwd ***_users)
+{
+    errno_t ret, close_ret;
+    struct passwd *pwd_iter = NULL;
+    struct passwd *pwd = NULL;
+    struct passwd **users = NULL;
+    FILE *pwd_handle = NULL;
+    size_t n_users = 0;
+
+    pwd_handle = fopen(id_ctx->passwd_file, "r");
+    if (pwd_handle == NULL) {
+        ret = errno;
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Cannot open passwd file %s [%d]\n",
+              id_ctx->passwd_file, ret);
+        goto done;
+    }
+
+    users = talloc_zero_array(mem_ctx, struct passwd *,
+                              FILES_REALLOC_CHUNK);
+    if (users == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    while ((pwd_iter = fgetpwent(pwd_handle)) != NULL) {
+        /* FIXME - we might want to support paging of sorts to avoid allocating
+         * all users atop a memory context or only return users that differ from
+         * the local storage as a diff to minimize memory spikes
+         */
+        DEBUG(SSSDBG_TRACE_LIBS,
+              "User found (%s, %s, %"SPRIuid", %"SPRIgid", %s, %s, %s)\n",
+              pwd_iter->pw_name, pwd_iter->pw_passwd,
+              pwd_iter->pw_uid, pwd_iter->pw_gid,
+              pwd_iter->pw_gecos, pwd_iter->pw_dir,
+              pwd_iter->pw_shell);
+
+        pwd = talloc_zero(users, struct passwd);
+        if (pwd == NULL) {
+            ret = ENOMEM;
+            goto done;
+        }
+
+        pwd->pw_uid = pwd_iter->pw_uid;
+        pwd->pw_gid = pwd_iter->pw_gid;
+
+        pwd->pw_name = talloc_strdup(pwd, pwd_iter->pw_name);
+        if (pwd->pw_name == NULL) {
+            /* We only check pw_name here on purpose to allow broken
+             * records to be optionally rejected when saving them
+             * or fallback values to be used.
+             */
+            ret = ENOMEM;
+            goto done;
+        }
+
+        pwd->pw_dir = talloc_strdup(pwd, pwd_iter->pw_dir);
+        pwd->pw_gecos = talloc_strdup(pwd, pwd_iter->pw_gecos);
+        pwd->pw_shell = talloc_strdup(pwd, pwd_iter->pw_shell);
+        pwd->pw_passwd = talloc_strdup(pwd, pwd_iter->pw_passwd);
+
+        users[n_users] = pwd;
+        n_users++;
+        if (n_users % FILES_REALLOC_CHUNK == 0) {
+            users = talloc_realloc(mem_ctx,
+                                   users,
+                                   struct passwd *,
+                                   talloc_get_size(users) + FILES_REALLOC_CHUNK);
+            if (users == NULL) {
+                ret = ENOMEM;
+                goto done;
+            }
+        }
+    }
+
+    ret = EOK;
+    *_users = users;
+done:
+    if (ret != EOK) {
+        talloc_free(users);
+    }
+
+    if (pwd_handle) {
+        close_ret = fclose(pwd_handle);
+        if (close_ret != 0) {
+            close_ret = errno;
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Cannot close passwd file %s [%d]\n",
+                  id_ctx->passwd_file, close_ret);
+        }
+    }
+    return ret;
+}
+
+static errno_t enum_files_groups(TALLOC_CTX *mem_ctx,
+                                 struct files_id_ctx *id_ctx,
+                                 struct group ***_groups)
+{
+    errno_t ret, close_ret;
+    struct group *grp_iter = NULL;
+    struct group *grp = NULL;
+    struct group **groups = NULL;
+    size_t n_groups = 0;
+    FILE *grp_handle = NULL;
+
+    grp_handle = fopen(id_ctx->group_file, "r");
+    if (grp_handle == NULL) {
+        ret = errno;
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Cannot open group file %s [%d]\n",
+              id_ctx->group_file, ret);
+        goto done;
+    }
+
+    groups = talloc_zero_array(mem_ctx, struct group *,
+                               FILES_REALLOC_CHUNK);
+    if (groups == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    while ((grp_iter = fgetgrent(grp_handle)) != NULL) {
+        DEBUG(SSSDBG_TRACE_LIBS,
+              "Group found (%s, %"SPRIgid")\n",
+              grp_iter->gr_name, grp_iter->gr_gid);
+
+        grp = talloc_zero(groups, struct group);
+        if (grp == NULL) {
+            ret = ENOMEM;
+            goto done;
+        }
+
+        grp->gr_gid = grp_iter->gr_gid;
+        grp->gr_name = talloc_strdup(grp, grp_iter->gr_name);
+        if (grp->gr_name == NULL) {
+            /* We only check gr_name here on purpose to allow broken
+             * records to be optionally rejected when saving them
+             * or fallback values to be used.
+             */
+            ret = ENOMEM;
+            goto done;
+        }
+        grp->gr_passwd = talloc_strdup(grp, grp_iter->gr_passwd);
+
+        if (grp_iter->gr_mem != NULL && grp_iter->gr_mem[0] != '\0') {
+            size_t nmem;
+
+            for (nmem = 0; grp_iter->gr_mem[nmem] != NULL; nmem++);
+
+            grp->gr_mem = talloc_zero_array(grp, char *, nmem + 1);
+            if (grp->gr_mem == NULL) {
+                ret = ENOMEM;
+                goto done;
+            }
+
+            for (nmem = 0; grp_iter->gr_mem[nmem] != NULL; nmem++) {
+                grp->gr_mem[nmem] = talloc_strdup(grp, grp_iter->gr_mem[nmem]);
+                if (grp->gr_mem[nmem] == NULL) {
+                    ret = ENOMEM;
+                    goto done;
+                }
+            }
+        }
+
+        groups[n_groups] = grp;
+        n_groups++;
+        if (n_groups % FILES_REALLOC_CHUNK == 0) {
+            groups = talloc_realloc(mem_ctx,
+                                    groups,
+                                    struct group *,
+                                    talloc_get_size(groups) + FILES_REALLOC_CHUNK);
+            if (groups == NULL) {
+                ret = ENOMEM;
+                goto done;
+            }
+        }
+    }
+
+    ret = EOK;
+    *_groups = groups;
+done:
+    if (ret != EOK) {
+        talloc_free(groups);
+    }
+
+    if (grp_handle) {
+        close_ret = fclose(grp_handle);
+        if (close_ret != 0) {
+            close_ret = errno;
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Cannot close group file %s [%d]\n",
+                  id_ctx->group_file, close_ret);
+        }
+    }
+    return ret;
+}
+
+static errno_t delete_all_users(struct sss_domain_info *dom)
+{
+    TALLOC_CTX *tmp_ctx;
+    struct ldb_dn *base_dn;
+    errno_t ret;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Out of memory!\n");
+        return ENOMEM;
+    }
+
+    base_dn = sysdb_user_base_dn(tmp_ctx, dom);
+    if (base_dn == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = sysdb_delete_recursive(dom->sysdb, base_dn, true);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "Unable to delete users subtree [%d]: %s\n",
+              ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = EOK;
+
+done:
+    talloc_free(tmp_ctx);
+
+    return ret;
+}
+
+static errno_t save_file_user(struct files_id_ctx *id_ctx,
+                              struct passwd *pw)
+{
+    errno_t ret;
+    char *fqname;
+    TALLOC_CTX *tmp_ctx = NULL;
+    const char *shell;
+    const char *gecos;
+    struct sysdb_attrs *attrs = NULL;
+
+    if (strcmp(pw->pw_name, "root") == 0
+            || pw->pw_uid == 0
+            || pw->pw_gid == 0) {
+        DEBUG(SSSDBG_TRACE_FUNC, "Skipping %s\n", pw->pw_name);
+        return EOK;
+    }
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    fqname = sss_create_internal_fqname(tmp_ctx, pw->pw_name,
+                                        id_ctx->domain->name);
+    if (fqname == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    attrs = sysdb_new_attrs(tmp_ctx);
+    if (attrs == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    if (pw->pw_shell && pw->pw_shell[0] != '\0') {
+        shell = pw->pw_shell;
+    } else {
+        shell = NULL;
+    }
+
+    if (pw->pw_gecos && pw->pw_gecos[0] != '\0') {
+        gecos = pw->pw_gecos;
+    } else {
+        gecos = NULL;
+    }
+
+    /* FIXME - optimize later */
+    ret = sysdb_store_user(id_ctx->domain,
+                           fqname,
+                           pw->pw_passwd,
+                           pw->pw_uid,
+                           pw->pw_gid,
+                           gecos,
+                           pw->pw_dir,
+                           shell,
+                           NULL, attrs,
+                           NULL, 0, 0);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    ret = EOK;
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+static errno_t sf_enum_groups(struct files_id_ctx *id_ctx);
+
+errno_t sf_enum_users(struct files_id_ctx *id_ctx)
+{
+    errno_t ret;
+    errno_t tret;
+    TALLOC_CTX *tmp_ctx = NULL;
+    struct passwd **users = NULL;
+    bool in_transaction = false;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    ret = enum_files_users(tmp_ctx, id_ctx, &users);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    ret = sysdb_transaction_start(id_ctx->domain->sysdb);
+    if (ret != EOK) {
+        goto done;
+    }
+    in_transaction = true;
+
+    /* remove previous cache contents */
+    /* FIXME - this is terribly inefficient */
+    ret = delete_all_users(id_ctx->domain);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    for (size_t i = 0; users[i]; i++) {
+        ret = save_file_user(id_ctx, users[i]);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "Cannot save user %s: [%d]: %s\n",
+                  users[i]->pw_name, ret, sss_strerror(ret));
+            continue;
+        }
+    }
+
+    ret = sysdb_transaction_commit(id_ctx->domain->sysdb);
+    if (ret != EOK) {
+        goto done;
+    }
+    in_transaction = false;
+
+    /* Covers the case when someone edits /etc/group, adds a group member and
+     * only then edits passwd and adds the user. The reverse is not needed,
+     * because member/memberof links are established when groups are saved.
+     */
+    ret = sf_enum_groups(id_ctx);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "Cannot refresh groups\n");
+        goto done;
+    }
+
+    ret = EOK;
+done:
+    if (in_transaction) {
+        tret = sysdb_transaction_cancel(id_ctx->domain->sysdb);
+        if (tret != EOK) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Cannot cancel transaction: %d\n", ret);
+        }
+    }
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+static const char **get_cached_user_names(TALLOC_CTX *mem_ctx,
+                                          struct sss_domain_info *dom)
+{
+    errno_t ret;
+    struct ldb_result *res = NULL;
+    const char **user_names = NULL;
+    unsigned c = 0;
+
+    ret = sysdb_enumpwent(mem_ctx, dom, &res);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    user_names = talloc_zero_array(mem_ctx, const char *, res->count + 1);
+    if (user_names == NULL) {
+        goto done;
+    }
+
+    for (unsigned i = 0; i < res->count; i++) {
+        user_names[c] = ldb_msg_find_attr_as_string(res->msgs[i],
+                                                    SYSDB_NAME,
+                                                    NULL);
+        if (user_names[c] == NULL) {
+            continue;
+        }
+        c++;
+    }
+
+done:
+    /* Don't free res and keep it around to avoid duplicating the names */
+    return user_names;
+}
+
+static errno_t delete_all_groups(struct sss_domain_info *dom)
+{
+    TALLOC_CTX *tmp_ctx;
+    struct ldb_dn *base_dn;
+    errno_t ret;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Out of memory!\n");
+        return ENOMEM;
+    }
+
+    base_dn = sysdb_group_base_dn(tmp_ctx, dom);
+    if (base_dn == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = sysdb_delete_recursive(dom->sysdb, base_dn, true);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "Unable to delete groups subtree [%d]: %s\n",
+              ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = EOK;
+
+done:
+    talloc_free(tmp_ctx);
+
+    return ret;
+}
+
+static errno_t save_file_group(struct files_id_ctx *id_ctx,
+                               struct group *grp,
+                               const char **cached_users)
+{
+    errno_t ret;
+    char *fqname;
+    struct sysdb_attrs *attrs = NULL;
+    TALLOC_CTX *tmp_ctx = NULL;
+    char **fq_gr_files_mem;
+    const char **fq_gr_mem;
+    unsigned mi = 0;
+
+    if (strcmp(grp->gr_name, "root") == 0
+            || grp->gr_gid == 0) {
+        DEBUG(SSSDBG_TRACE_FUNC, "Skipping %s\n", grp->gr_name);
+        return EOK;
+    }
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    fqname = sss_create_internal_fqname(tmp_ctx, grp->gr_name,
+                                        id_ctx->domain->name);
+    if (fqname == NULL) {
+        ret = ENOMEM;
+        goto done;
+
+    }
+
+    attrs = sysdb_new_attrs(tmp_ctx);
+    if (attrs == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    if (grp->gr_mem && grp->gr_mem[0]) {
+        fq_gr_files_mem = sss_create_internal_fqname_list(
+                                            tmp_ctx,
+                                            (const char *const*) grp->gr_mem,
+                                            id_ctx->domain->name);
+        if (fq_gr_files_mem == NULL) {
+            ret = ENOMEM;
+            goto done;
+        }
+
+        fq_gr_mem = talloc_zero_array(tmp_ctx, const char *,
+                                      talloc_array_length(fq_gr_files_mem));
+        if (fq_gr_mem == NULL) {
+            ret = ENOMEM;
+            goto done;
+        }
+
+        for (unsigned i=0; fq_gr_files_mem[i] != NULL; i++) {
+            if (string_in_list(fq_gr_files_mem[i],
+                               discard_const(cached_users),
+                               true)) {
+                fq_gr_mem[mi] = fq_gr_files_mem[i];
+                mi++;
+
+                DEBUG(SSSDBG_TRACE_LIBS,
+                      "User %s is cached, will become a member of %s\n",
+                      fq_gr_files_mem[i], grp->gr_name);
+            } else {
+                ret = sysdb_attrs_add_string(attrs,
+                                             SYSDB_GHOST,
+                                             fq_gr_files_mem[i]);
+                if (ret != EOK) {
+                    DEBUG(SSSDBG_MINOR_FAILURE,
+                          "Cannot add ghost %s for group %s\n",
+                          fq_gr_files_mem[i], fqname);
+                    continue;
+                }
+
+                DEBUG(SSSDBG_TRACE_LIBS,
+                      "User %s is not cached, will become a ghost of %s\n",
+                      fq_gr_files_mem[i], grp->gr_name);
+            }
+        }
+
+        if (fq_gr_mem != NULL && fq_gr_mem[0] != NULL) {
+            ret = sysdb_attrs_users_from_str_list(
+                    attrs, SYSDB_MEMBER, id_ctx->domain->name,
+                    (const char *const *) fq_gr_mem);
+            if (ret) {
+                DEBUG(SSSDBG_OP_FAILURE, "Could not add group members\n");
+                goto done;
+            }
+        }
+
+    }
+
+    ret = sysdb_store_group(id_ctx->domain, fqname, grp->gr_gid,
+                            attrs, 0, 0);
+    if (ret) {
+        DEBUG(SSSDBG_OP_FAILURE, "Could not add group to cache\n");
+        goto done;
+    }
+
+    ret = EOK;
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+static errno_t sf_enum_groups(struct files_id_ctx *id_ctx)
+{
+    errno_t ret;
+    errno_t tret;
+    TALLOC_CTX *tmp_ctx = NULL;
+    struct group **groups = NULL;
+    bool in_transaction = false;
+    const char **cached_users = NULL;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    ret = enum_files_groups(tmp_ctx, id_ctx, &groups);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    cached_users = get_cached_user_names(tmp_ctx, id_ctx->domain);
+    if (cached_users == NULL) {
+        goto done;
+    }
+
+    ret = sysdb_transaction_start(id_ctx->domain->sysdb);
+    if (ret != EOK) {
+        goto done;
+    }
+    in_transaction = true;
+
+    /* remove previous cache contents */
+    ret = delete_all_groups(id_ctx->domain);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    for (size_t i = 0; groups[i]; i++) {
+        ret = save_file_group(id_ctx, groups[i], cached_users);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "Cannot save group %s\n", groups[i]->gr_name);
+            continue;
+        }
+    }
+
+    ret = sysdb_transaction_commit(id_ctx->domain->sysdb);
+    if (ret != EOK) {
+        goto done;
+    }
+    in_transaction = false;
+
+    ret = EOK;
+done:
+    if (in_transaction) {
+        tret = sysdb_transaction_cancel(id_ctx->domain->sysdb);
+        if (tret != EOK) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Cannot cancel transaction: %d\n", ret);
+        }
+    }
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+static void sf_cb_done(struct files_id_ctx *id_ctx)
+{
+    /* Only activate a domain when both callbacks are done */
+    if (id_ctx->updating_passwd == false
+            && id_ctx->updating_groups == false) {
+        dp_sbus_domain_active(id_ctx->be->provider,
+                              id_ctx->domain);
+    }
+}
+
+static int sf_passwd_cb(const char *filename, uint32_t flags, void *pvt)
+{
+    struct files_id_ctx *id_ctx;
+    errno_t ret;
+
+    id_ctx = talloc_get_type(pvt, struct files_id_ctx);
+    if (id_ctx == NULL) {
+        return EINVAL;
+    }
+
+    DEBUG(SSSDBG_TRACE_FUNC, "passwd notification\n");
+
+    if (strcmp(filename, id_ctx->passwd_file) != 0) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Wrong file, expected %s, got %s\n",
+              id_ctx->passwd_file, filename);
+        return EINVAL;
+    }
+
+    id_ctx->updating_passwd = true;
+    dp_sbus_domain_inconsistent(id_ctx->be->provider, id_ctx->domain);
+
+    dp_sbus_reset_users_ncache(id_ctx->be->provider, id_ctx->domain);
+    dp_sbus_reset_users_memcache(id_ctx->be->provider);
+    dp_sbus_reset_initgr_memcache(id_ctx->be->provider);
+
+    ret = sf_enum_users(id_ctx);
+
+    id_ctx->updating_passwd = false;
+    sf_cb_done(id_ctx);
+    files_account_info_finished(id_ctx, BE_REQ_USER, ret);
+    return ret;
+}
+
+static int sf_group_cb(const char *filename, uint32_t flags, void *pvt)
+{
+    struct files_id_ctx *id_ctx;
+    errno_t ret;
+
+    id_ctx = talloc_get_type(pvt, struct files_id_ctx);
+    if (id_ctx == NULL) {
+        return EINVAL;
+    }
+
+    DEBUG(SSSDBG_TRACE_FUNC, "group notification\n");
+
+    if (strcmp(filename, id_ctx->group_file) != 0) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Wrong file, expected %s, got %s\n",
+              id_ctx->group_file, filename);
+        return EINVAL;
+    }
+
+    id_ctx->updating_groups = true;
+    dp_sbus_domain_inconsistent(id_ctx->be->provider, id_ctx->domain);
+
+    dp_sbus_reset_groups_ncache(id_ctx->be->provider, id_ctx->domain);
+    dp_sbus_reset_groups_memcache(id_ctx->be->provider);
+    dp_sbus_reset_initgr_memcache(id_ctx->be->provider);
+
+    ret = sf_enum_groups(id_ctx);
+
+    id_ctx->updating_groups = false;
+    sf_cb_done(id_ctx);
+    files_account_info_finished(id_ctx, BE_REQ_GROUP, ret);
+    return ret;
+}
+
+static void startup_enum_files(struct tevent_context *ev,
+                               struct tevent_immediate *imm,
+                               void *pvt)
+{
+    struct files_id_ctx *id_ctx = talloc_get_type(pvt, struct files_id_ctx);
+    errno_t ret;
+
+    talloc_zfree(imm);
+
+    ret = sf_enum_users(id_ctx);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Enumerating users failed, data might be inconsistent!\n");
+    }
+
+    ret = sf_enum_groups(id_ctx);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Enumerating groups failed, data might be inconsistent!\n");
+    }
+}
+
+static struct snotify_ctx *sf_setup_watch(TALLOC_CTX *mem_ctx,
+                                          struct tevent_context *ev,
+                                          const char *filename,
+                                          snotify_cb_fn fn,
+                                          struct files_id_ctx *id_ctx)
+{
+    return snotify_create(mem_ctx, ev, SNOTIFY_WATCH_DIR,
+                          filename, NULL,
+                          IN_DELETE_SELF | IN_CLOSE_WRITE | IN_MOVE_SELF | \
+                          IN_CREATE | IN_MOVED_TO,
+                          fn, id_ctx);
+}
+
+struct files_ctx *sf_init(TALLOC_CTX *mem_ctx,
+                          struct tevent_context *ev,
+                          const char *passwd_file,
+                          const char *group_file,
+                          struct files_id_ctx *id_ctx)
+{
+    struct files_ctx *fctx;
+    struct tevent_immediate *imm;
+
+    fctx = talloc(mem_ctx, struct files_ctx);
+    if (fctx == NULL) {
+        return NULL;
+    }
+
+    fctx->pwd_watch = sf_setup_watch(fctx, ev, passwd_file,
+                                     sf_passwd_cb, id_ctx);
+    fctx->grp_watch = sf_setup_watch(fctx, ev, group_file,
+                                     sf_group_cb, id_ctx);
+    if (fctx->pwd_watch == NULL || fctx->grp_watch == NULL) {
+        talloc_free(fctx);
+        return NULL;
+    }
+
+    /* Enumerate users and groups on startup to process any changes when
+     * sssd was down. We schedule a request here to minimize the time
+     * we spend in the init function
+     */
+    imm = tevent_create_immediate(id_ctx);
+    if (imm == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "tevent_create_immediate failed.\n");
+        talloc_free(fctx);
+        return NULL;
+    }
+    tevent_schedule_immediate(imm, ev, startup_enum_files, id_ctx);
+
+    return fctx;
+}

--- a/src/providers/files/files_private.h
+++ b/src/providers/files/files_private.h
@@ -1,0 +1,74 @@
+/*
+    SSSD
+
+    Files provider declarations
+
+    Copyright (C) 2016 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __FILES_PRIVATE_H_
+#define __FILES_PRIVATE_H_
+
+#include "config.h"
+
+#include <talloc.h>
+#include <tevent.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <nss.h>
+#include <pwd.h>
+#include <grp.h>
+
+#include "providers/data_provider/dp.h"
+
+struct files_id_ctx {
+    struct be_ctx *be;
+    struct sss_domain_info *domain;
+    struct files_ctx *fctx;
+
+    const char *passwd_file;
+    const char *group_file;
+
+    bool updating_passwd;
+    bool updating_groups;
+
+    struct tevent_req *users_req;
+    struct tevent_req *groups_req;
+    struct tevent_req *initgroups_req;
+};
+
+/* files_ops.c */
+struct files_ctx *sf_init(TALLOC_CTX *mem_ctx,
+                          struct tevent_context *ev,
+                          const char *passwd_file,
+                          const char *group_file,
+                          struct files_id_ctx *id_ctx);
+
+/* files_id.c */
+struct tevent_req *
+files_account_info_handler_send(TALLOC_CTX *mem_ctx,
+                               struct files_id_ctx *id_ctx,
+                               struct dp_id_data *data,
+                               struct dp_req_params *params);
+
+errno_t files_account_info_handler_recv(TALLOC_CTX *mem_ctx,
+                                        struct tevent_req *req,
+                                        struct dp_reply_std *data);
+
+void files_account_info_finished(struct files_id_ctx *id_ctx,
+                                 int req_type,
+                                 errno_t ret);
+#endif /* __FILES_PRIVATE_H_ */

--- a/src/responder/common/iface/responder_domain.c
+++ b/src/responder/common/iface/responder_domain.c
@@ -1,0 +1,73 @@
+/*
+    Copyright (C) 2016 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <string.h>
+#include <errno.h>
+
+#include "util/util.h"
+#include "sbus/sssd_dbus.h"
+#include "responder/common/responder.h"
+#include "responder/common/iface/responder_iface.h"
+
+static void set_domain_state_by_name(struct resp_ctx *rctx,
+                                     const char *domain_name,
+                                     enum sss_domain_state state)
+{
+    struct sss_domain_info *dom;
+
+    if (domain_name == NULL) {
+        DEBUG(SSSDBG_MINOR_FAILURE, "BUG: NULL domain name\n");
+        return;
+    }
+
+    DEBUG(SSSDBG_TRACE_LIBS, "Setting state of domain %s\n", domain_name);
+
+    for (dom = rctx->domains;
+         dom != NULL;
+         dom = get_next_domain(dom, SSS_GND_ALL_DOMAINS)) {
+
+        if (strcasecmp(dom->name, domain_name) == 0) {
+            break;
+        }
+    }
+
+    if (dom != NULL) {
+        sss_domain_set_state(dom, state);
+    }
+}
+
+int sss_resp_domain_active(struct sbus_request *req,
+                           void *data,
+                           const char *domain_name)
+{
+    struct resp_ctx *rctx = talloc_get_type(data, struct resp_ctx);
+
+    DEBUG(SSSDBG_TRACE_LIBS, "Enabling domain %s\n", domain_name);
+    set_domain_state_by_name(rctx, domain_name, DOM_ACTIVE);
+    return iface_responder_domain_SetActive_finish(req);
+}
+
+int sss_resp_domain_inconsistent(struct sbus_request *req,
+                                 void *data,
+                                 const char *domain_name)
+{
+    struct resp_ctx *rctx = talloc_get_type(data, struct resp_ctx);
+
+    DEBUG(SSSDBG_TRACE_LIBS, "Disabling domain %s\n", domain_name);
+    set_domain_state_by_name(rctx, domain_name, DOM_INCONSISTENT);
+    return iface_responder_domain_SetInconsistent_finish(req);
+}

--- a/src/responder/common/iface/responder_iface.c
+++ b/src/responder/common/iface/responder_iface.c
@@ -1,0 +1,36 @@
+/*
+    Copyright (C) 2016 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "sbus/sssd_dbus.h"
+#include "responder/common/iface/responder_iface.h"
+#include "responder/common/responder.h"
+
+struct iface_responder_domain iface_responder_domain = {
+    { &iface_responder_domain_meta, 0 },
+    .SetActive = sss_resp_domain_active,
+    .SetInconsistent = sss_resp_domain_inconsistent,
+};
+
+static struct sbus_iface_map iface_map[] = {
+    { RESPONDER_PATH, &iface_responder_domain.vtable },
+    { NULL, NULL }
+};
+
+struct sbus_iface_map *responder_get_sbus_interface()
+{
+    return iface_map;
+}

--- a/src/responder/common/iface/responder_iface.h
+++ b/src/responder/common/iface/responder_iface.h
@@ -1,0 +1,37 @@
+/*
+    Copyright (C) 2016 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _RESPONDER_IFACE_H_
+#define _RESPONDER_IFACE_H_
+
+#include "responder/common/iface/responder_iface_generated.h"
+
+#define RESPONDER_PATH "/org/freedesktop/sssd/responder"
+
+struct sbus_iface_map *responder_get_sbus_interface(void);
+
+/* org.freedesktop.sssd.Responder.Domain */
+
+int sss_resp_domain_active(struct sbus_request *req,
+                           void *data,
+                           const char *domain_name);
+
+int sss_resp_domain_inconsistent(struct sbus_request *req,
+                                 void *data,
+                                 const char *domain_name);
+
+#endif /* _RESPONDER_IFACE_H_ */

--- a/src/responder/common/iface/responder_iface.h
+++ b/src/responder/common/iface/responder_iface.h
@@ -34,4 +34,9 @@ int sss_resp_domain_inconsistent(struct sbus_request *req,
                                  void *data,
                                  const char *domain_name);
 
+/* org.freedesktop.sssd.Responder.NegativeCache */
+
+int sss_resp_reset_ncache_users(struct sbus_request *req, void *data);
+int sss_resp_reset_ncache_groups(struct sbus_request *req, void *data);
+
 #endif /* _RESPONDER_IFACE_H_ */

--- a/src/responder/common/iface/responder_iface.xml
+++ b/src/responder/common/iface/responder_iface.xml
@@ -10,4 +10,10 @@
             <arg name="name" type="s" direction="in" />
         </method>
     </interface>
+
+    <interface name="org.freedesktop.sssd.Responder.NegativeCache">
+        <annotation value="iface_responder_ncache" name="org.freedesktop.DBus.GLib.CSymbol"/>
+        <method name="ResetUsers" />
+        <method name="ResetGroups" />
+    </interface>
 </node>

--- a/src/responder/common/iface/responder_iface.xml
+++ b/src/responder/common/iface/responder_iface.xml
@@ -1,0 +1,13 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+    <interface name="org.freedesktop.sssd.Responder.Domain">
+        <annotation value="iface_responder_domain" name="org.freedesktop.DBus.GLib.CSymbol"/>
+        <method name="SetActive">
+            <arg name="name" type="s" direction="in" />
+        </method>
+        <method name="SetInconsistent">
+            <arg name="name" type="s" direction="in" />
+        </method>
+    </interface>
+</node>

--- a/src/responder/common/iface/responder_iface_generated.c
+++ b/src/responder/common/iface/responder_iface_generated.c
@@ -1,0 +1,78 @@
+/* The following definitions are auto-generated from responder_iface.xml */
+
+#include "util/util.h"
+#include "sbus/sssd_dbus.h"
+#include "sbus/sssd_dbus_meta.h"
+#include "sbus/sssd_dbus_invokers.h"
+#include "responder_iface_generated.h"
+
+/* invokes a handler with a 's' DBus signature */
+static int invoke_s_method(struct sbus_request *dbus_req, void *function_ptr);
+
+/* arguments for org.freedesktop.sssd.Responder.Domain.SetActive */
+const struct sbus_arg_meta iface_responder_domain_SetActive__in[] = {
+    { "name", "s" },
+    { NULL, }
+};
+
+int iface_responder_domain_SetActive_finish(struct sbus_request *req)
+{
+   return sbus_request_return_and_finish(req,
+                                         DBUS_TYPE_INVALID);
+}
+
+/* arguments for org.freedesktop.sssd.Responder.Domain.SetInconsistent */
+const struct sbus_arg_meta iface_responder_domain_SetInconsistent__in[] = {
+    { "name", "s" },
+    { NULL, }
+};
+
+int iface_responder_domain_SetInconsistent_finish(struct sbus_request *req)
+{
+   return sbus_request_return_and_finish(req,
+                                         DBUS_TYPE_INVALID);
+}
+
+/* methods for org.freedesktop.sssd.Responder.Domain */
+const struct sbus_method_meta iface_responder_domain__methods[] = {
+    {
+        "SetActive", /* name */
+        iface_responder_domain_SetActive__in,
+        NULL, /* no out_args */
+        offsetof(struct iface_responder_domain, SetActive),
+        invoke_s_method,
+    },
+    {
+        "SetInconsistent", /* name */
+        iface_responder_domain_SetInconsistent__in,
+        NULL, /* no out_args */
+        offsetof(struct iface_responder_domain, SetInconsistent),
+        invoke_s_method,
+    },
+    { NULL, }
+};
+
+/* interface info for org.freedesktop.sssd.Responder.Domain */
+const struct sbus_interface_meta iface_responder_domain_meta = {
+    "org.freedesktop.sssd.Responder.Domain", /* name */
+    iface_responder_domain__methods,
+    NULL, /* no signals */
+    NULL, /* no properties */
+    sbus_invoke_get_all, /* GetAll invoker */
+};
+
+/* invokes a handler with a 's' DBus signature */
+static int invoke_s_method(struct sbus_request *dbus_req, void *function_ptr)
+{
+    const char * arg_0;
+    int (*handler)(struct sbus_request *, void *, const char *) = function_ptr;
+
+    if (!sbus_request_parse_or_finish(dbus_req,
+                               DBUS_TYPE_STRING, &arg_0,
+                               DBUS_TYPE_INVALID)) {
+         return EOK; /* request handled */
+    }
+
+    return (handler)(dbus_req, dbus_req->intf->handler_data,
+                     arg_0);
+}

--- a/src/responder/common/iface/responder_iface_generated.c
+++ b/src/responder/common/iface/responder_iface_generated.c
@@ -61,6 +61,46 @@ const struct sbus_interface_meta iface_responder_domain_meta = {
     sbus_invoke_get_all, /* GetAll invoker */
 };
 
+int iface_responder_ncache_ResetUsers_finish(struct sbus_request *req)
+{
+   return sbus_request_return_and_finish(req,
+                                         DBUS_TYPE_INVALID);
+}
+
+int iface_responder_ncache_ResetGroups_finish(struct sbus_request *req)
+{
+   return sbus_request_return_and_finish(req,
+                                         DBUS_TYPE_INVALID);
+}
+
+/* methods for org.freedesktop.sssd.Responder.NegativeCache */
+const struct sbus_method_meta iface_responder_ncache__methods[] = {
+    {
+        "ResetUsers", /* name */
+        NULL, /* no in_args */
+        NULL, /* no out_args */
+        offsetof(struct iface_responder_ncache, ResetUsers),
+        NULL, /* no invoker */
+    },
+    {
+        "ResetGroups", /* name */
+        NULL, /* no in_args */
+        NULL, /* no out_args */
+        offsetof(struct iface_responder_ncache, ResetGroups),
+        NULL, /* no invoker */
+    },
+    { NULL, }
+};
+
+/* interface info for org.freedesktop.sssd.Responder.NegativeCache */
+const struct sbus_interface_meta iface_responder_ncache_meta = {
+    "org.freedesktop.sssd.Responder.NegativeCache", /* name */
+    iface_responder_ncache__methods,
+    NULL, /* no signals */
+    NULL, /* no properties */
+    sbus_invoke_get_all, /* GetAll invoker */
+};
+
 /* invokes a handler with a 's' DBus signature */
 static int invoke_s_method(struct sbus_request *dbus_req, void *function_ptr)
 {

--- a/src/responder/common/iface/responder_iface_generated.h
+++ b/src/responder/common/iface/responder_iface_generated.h
@@ -16,6 +16,11 @@
 #define IFACE_RESPONDER_DOMAIN_SETACTIVE "SetActive"
 #define IFACE_RESPONDER_DOMAIN_SETINCONSISTENT "SetInconsistent"
 
+/* constants for org.freedesktop.sssd.Responder.NegativeCache */
+#define IFACE_RESPONDER_NCACHE "org.freedesktop.sssd.Responder.NegativeCache"
+#define IFACE_RESPONDER_NCACHE_RESETUSERS "ResetUsers"
+#define IFACE_RESPONDER_NCACHE_RESETGROUPS "ResetGroups"
+
 /* ------------------------------------------------------------------------
  * DBus handlers
  *
@@ -47,6 +52,19 @@ int iface_responder_domain_SetActive_finish(struct sbus_request *req);
 /* finish function for SetInconsistent */
 int iface_responder_domain_SetInconsistent_finish(struct sbus_request *req);
 
+/* vtable for org.freedesktop.sssd.Responder.NegativeCache */
+struct iface_responder_ncache {
+    struct sbus_vtable vtable; /* derive from sbus_vtable */
+    int (*ResetUsers)(struct sbus_request *req, void *data);
+    int (*ResetGroups)(struct sbus_request *req, void *data);
+};
+
+/* finish function for ResetUsers */
+int iface_responder_ncache_ResetUsers_finish(struct sbus_request *req);
+
+/* finish function for ResetGroups */
+int iface_responder_ncache_ResetGroups_finish(struct sbus_request *req);
+
 /* ------------------------------------------------------------------------
  * DBus Interface Metadata
  *
@@ -59,5 +77,8 @@ int iface_responder_domain_SetInconsistent_finish(struct sbus_request *req);
 
 /* interface info for org.freedesktop.sssd.Responder.Domain */
 extern const struct sbus_interface_meta iface_responder_domain_meta;
+
+/* interface info for org.freedesktop.sssd.Responder.NegativeCache */
+extern const struct sbus_interface_meta iface_responder_ncache_meta;
 
 #endif /* __RESPONDER_IFACE_XML__ */

--- a/src/responder/common/iface/responder_iface_generated.h
+++ b/src/responder/common/iface/responder_iface_generated.h
@@ -1,0 +1,63 @@
+/* The following declarations are auto-generated from responder_iface.xml */
+
+#ifndef __RESPONDER_IFACE_XML__
+#define __RESPONDER_IFACE_XML__
+
+#include "sbus/sssd_dbus.h"
+
+/* ------------------------------------------------------------------------
+ * DBus Constants
+ *
+ * Various constants of interface and method names mostly for use by clients
+ */
+
+/* constants for org.freedesktop.sssd.Responder.Domain */
+#define IFACE_RESPONDER_DOMAIN "org.freedesktop.sssd.Responder.Domain"
+#define IFACE_RESPONDER_DOMAIN_SETACTIVE "SetActive"
+#define IFACE_RESPONDER_DOMAIN_SETINCONSISTENT "SetInconsistent"
+
+/* ------------------------------------------------------------------------
+ * DBus handlers
+ *
+ * These structures are filled in by implementors of the different
+ * dbus interfaces to handle method calls.
+ *
+ * Handler functions of type sbus_msg_handler_fn accept raw messages,
+ * other handlers are typed appropriately. If a handler that is
+ * set to NULL is invoked it will result in a
+ * org.freedesktop.DBus.Error.NotSupported error for the caller.
+ *
+ * Handlers have a matching xxx_finish() function (unless the method has
+ * accepts raw messages). These finish functions the
+ * sbus_request_return_and_finish() with the appropriate arguments to
+ * construct a valid reply. Once a finish function has been called, the
+ * @dbus_req it was called with is freed and no longer valid.
+ */
+
+/* vtable for org.freedesktop.sssd.Responder.Domain */
+struct iface_responder_domain {
+    struct sbus_vtable vtable; /* derive from sbus_vtable */
+    int (*SetActive)(struct sbus_request *req, void *data, const char *arg_name);
+    int (*SetInconsistent)(struct sbus_request *req, void *data, const char *arg_name);
+};
+
+/* finish function for SetActive */
+int iface_responder_domain_SetActive_finish(struct sbus_request *req);
+
+/* finish function for SetInconsistent */
+int iface_responder_domain_SetInconsistent_finish(struct sbus_request *req);
+
+/* ------------------------------------------------------------------------
+ * DBus Interface Metadata
+ *
+ * These structure definitions are filled in with the information about
+ * the interfaces, methods, properties and so on.
+ *
+ * The actual definitions are found in the accompanying C file next
+ * to this header.
+ */
+
+/* interface info for org.freedesktop.sssd.Responder.Domain */
+extern const struct sbus_interface_meta iface_responder_domain_meta;
+
+#endif /* __RESPONDER_IFACE_XML__ */

--- a/src/responder/common/iface/responder_ncache.c
+++ b/src/responder/common/iface/responder_ncache.c
@@ -1,5 +1,8 @@
 /*
-    Copyright (C) 2016 Red Hat
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2017 Red Hat
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,29 +18,24 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "util/util.h"
 #include "sbus/sssd_dbus.h"
-#include "responder/common/iface/responder_iface.h"
 #include "responder/common/responder.h"
+#include "responder/common/negcache.h"
+#include "responder/common/iface/responder_iface.h"
 
-struct iface_responder_domain iface_responder_domain = {
-    { &iface_responder_domain_meta, 0 },
-    .SetActive = sss_resp_domain_active,
-    .SetInconsistent = sss_resp_domain_inconsistent,
-};
-
-struct iface_responder_ncache iface_responder_ncache = {
-    { &iface_responder_ncache_meta, 0 },
-    .ResetUsers = sss_resp_reset_ncache_users,
-    .ResetGroups = sss_resp_reset_ncache_groups,
-};
-
-static struct sbus_iface_map iface_map[] = {
-    { RESPONDER_PATH, &iface_responder_domain.vtable },
-    { RESPONDER_PATH, &iface_responder_ncache.vtable },
-    { NULL, NULL }
-};
-
-struct sbus_iface_map *responder_get_sbus_interface()
+int sss_resp_reset_ncache_users(struct sbus_request *req, void *data)
 {
-    return iface_map;
+    struct resp_ctx *rctx = talloc_get_type(data, struct resp_ctx);
+
+    sss_ncache_reset_users(rctx->ncache);
+    return iface_responder_ncache_ResetUsers_finish(req);
+}
+
+int sss_resp_reset_ncache_groups(struct sbus_request *req, void *data)
+{
+    struct resp_ctx *rctx = talloc_get_type(data, struct resp_ctx);
+
+    sss_ncache_reset_groups(rctx->ncache);
+    return iface_responder_ncache_ResetGroups_finish(req);
 }

--- a/src/responder/common/negcache.h
+++ b/src/responder/common/negcache.h
@@ -78,6 +78,8 @@ int sss_ncache_set_service_port(struct sss_nc_ctx *ctx, bool permanent,
                                 uint16_t port, const char *proto);
 
 int sss_ncache_reset_permanent(struct sss_nc_ctx *ctx);
+int sss_ncache_reset_users(struct sss_nc_ctx *ctx);
+int sss_ncache_reset_groups(struct sss_nc_ctx *ctx);
 
 struct resp_ctx;
 

--- a/src/responder/common/responder.h
+++ b/src/responder/common/responder.h
@@ -48,9 +48,14 @@ extern hash_table_t *dp_requests;
  * So we set umask to 0111. */
 #define SCKT_RSP_UMASK 0111
 
-/* if there is a provider other than the special local */
+/* Neither the local provider nor the files provider have a back
+ * end in the traditional sense and can always just consult
+ * the responder's cache
+ */
 #define NEED_CHECK_PROVIDER(provider) \
-    (provider != NULL && strcmp(provider, "local") != 0)
+    (provider != NULL && \
+     (strcmp(provider, "local") != 0 && \
+      strcmp(provider, "files") != 0))
 
 /* needed until nsssrv.h is updated */
 struct cli_request {

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -38,6 +38,7 @@
 #include "confdb/confdb.h"
 #include "sbus/sssd_dbus.h"
 #include "responder/common/responder.h"
+#include "responder/common/iface/responder_iface.h"
 #include "responder/common/responder_packet.h"
 #include "providers/data_provider.h"
 #include "monitor/monitor_interfaces.h"
@@ -666,6 +667,7 @@ static int sss_dp_init(struct resp_ctx *rctx,
 {
     struct be_conn *be_conn;
     int ret;
+    struct sbus_iface_map *resp_sbus_iface;
 
     be_conn = talloc_zero(rctx, struct be_conn);
     if (!be_conn) return ENOMEM;
@@ -693,6 +695,19 @@ static int sss_dp_init(struct resp_ctx *rctx,
         ret = sbus_conn_register_iface_map(be_conn->conn, sbus_iface, rctx);
         if (ret != EOK) {
             DEBUG(SSSDBG_FATAL_FAILURE, "Failed to register D-Bus interface.\n");
+            return ret;
+        }
+    }
+
+    resp_sbus_iface = responder_get_sbus_interface();
+    if (resp_sbus_iface != NULL) {
+        ret = sbus_conn_register_iface_map(be_conn->conn,
+                                           resp_sbus_iface,
+                                           rctx);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_FATAL_FAILURE,
+                  "Cannot register generic responder iface at %s: %d\n",
+                  resp_sbus_iface->path, ret);
             return ret;
         }
     }

--- a/src/responder/common/responder_dp.c
+++ b/src/responder/common/responder_dp.c
@@ -495,6 +495,12 @@ sss_dp_get_account_send(TALLOC_CTX *mem_ctx,
         goto error;
     }
 
+    if (NEED_CHECK_PROVIDER(dom->provider) == false) {
+        DEBUG(SSSDBG_TRACE_INTERNAL, "Domain %s does not check DP\n", dom->name);
+        ret = EOK;
+        goto error;
+    }
+
     info = talloc_zero(state, struct sss_dp_account_info);
     info->fast_reply = fast_reply;
     info->type = type;
@@ -539,7 +545,11 @@ sss_dp_get_account_send(TALLOC_CTX *mem_ctx,
     return req;
 
 error:
-    tevent_req_error(req, ret);
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else {
+        tevent_req_error(req, ret);
+    }
     tevent_req_post(req, rctx->ev);
     return req;
 }

--- a/src/responder/nss/nss_iface.c
+++ b/src/responder/nss/nss_iface.c
@@ -175,7 +175,7 @@ int nss_memorycache_invalidate_initgroups(struct sbus_request *req, void *data)
           "Invalidating all initgroup records in memory cache\n");
     sss_mmap_cache_reset(nctx->initgr_mc_ctx);
 
-    return iface_nss_memorycache_InvalidateAllInitgrRecords_finish(req);
+    return iface_nss_memorycache_InvalidateAllInitgroups_finish(req);
 }
 
 
@@ -202,7 +202,7 @@ struct iface_nss_memorycache iface_nss_memorycache = {
     .UpdateInitgroups = nss_memorycache_update_initgroups,
     .InvalidateAllUsers = nss_memorycache_invalidate_users,
     .InvalidateAllGroups = nss_memorycache_invalidate_groups,
-    .InvalidateAllInitgrRecords = nss_memorycache_invalidate_initgroups,
+    .InvalidateAllInitgroups = nss_memorycache_invalidate_initgroups,
 };
 
 static struct sbus_iface_map iface_map[] = {

--- a/src/responder/nss/nss_iface.c
+++ b/src/responder/nss/nss_iface.c
@@ -144,6 +144,41 @@ done:
     talloc_free(tmp_ctx);
 }
 
+int nss_memorycache_invalidate_users(struct sbus_request *req, void *data)
+{
+    struct resp_ctx *rctx = talloc_get_type(data, struct resp_ctx);
+    struct nss_ctx *nctx = talloc_get_type(rctx->pvt_ctx, struct nss_ctx);
+
+    DEBUG(SSSDBG_TRACE_LIBS, "Invalidating all users in memory cache\n");
+    sss_mmap_cache_reset(nctx->pwd_mc_ctx);
+
+    return iface_nss_memorycache_InvalidateAllUsers_finish(req);
+}
+
+int nss_memorycache_invalidate_groups(struct sbus_request *req, void *data)
+{
+    struct resp_ctx *rctx = talloc_get_type(data, struct resp_ctx);
+    struct nss_ctx *nctx = talloc_get_type(rctx->pvt_ctx, struct nss_ctx);
+
+    DEBUG(SSSDBG_TRACE_LIBS, "Invalidating all groups in memory cache\n");
+    sss_mmap_cache_reset(nctx->grp_mc_ctx);
+
+    return iface_nss_memorycache_InvalidateAllGroups_finish(req);
+}
+
+int nss_memorycache_invalidate_initgroups(struct sbus_request *req, void *data)
+{
+    struct resp_ctx *rctx = talloc_get_type(data, struct resp_ctx);
+    struct nss_ctx *nctx = talloc_get_type(rctx->pvt_ctx, struct nss_ctx);
+
+    DEBUG(SSSDBG_TRACE_LIBS,
+          "Invalidating all initgroup records in memory cache\n");
+    sss_mmap_cache_reset(nctx->initgr_mc_ctx);
+
+    return iface_nss_memorycache_InvalidateAllInitgrRecords_finish(req);
+}
+
+
 int nss_memorycache_update_initgroups(struct sbus_request *sbus_req,
                                       void *data,
                                       const char *user,
@@ -164,7 +199,10 @@ int nss_memorycache_update_initgroups(struct sbus_request *sbus_req,
 
 struct iface_nss_memorycache iface_nss_memorycache = {
     { &iface_nss_memorycache_meta, 0 },
-    .UpdateInitgroups = nss_memorycache_update_initgroups
+    .UpdateInitgroups = nss_memorycache_update_initgroups,
+    .InvalidateAllUsers = nss_memorycache_invalidate_users,
+    .InvalidateAllGroups = nss_memorycache_invalidate_groups,
+    .InvalidateAllInitgrRecords = nss_memorycache_invalidate_initgroups,
 };
 
 static struct sbus_iface_map iface_map[] = {

--- a/src/responder/nss/nss_iface.xml
+++ b/src/responder/nss/nss_iface.xml
@@ -12,7 +12,7 @@
         </method>
         <method name="InvalidateAllGroups">
         </method>
-        <method name="InvalidateAllInitgrRecords">
+        <method name="InvalidateAllInitgroups">
         </method>
     </interface>
 </node>

--- a/src/responder/nss/nss_iface.xml
+++ b/src/responder/nss/nss_iface.xml
@@ -8,5 +8,11 @@
             <arg name="domain" type="s" direction="in" />
             <arg name="groups" type="au" direction="in" />
         </method>
+        <method name="InvalidateAllUsers">
+        </method>
+        <method name="InvalidateAllGroups">
+        </method>
+        <method name="InvalidateAllInitgrRecords">
+        </method>
     </interface>
 </node>

--- a/src/responder/nss/nss_iface_generated.c
+++ b/src/responder/nss/nss_iface_generated.c
@@ -35,7 +35,7 @@ int iface_nss_memorycache_InvalidateAllGroups_finish(struct sbus_request *req)
                                          DBUS_TYPE_INVALID);
 }
 
-int iface_nss_memorycache_InvalidateAllInitgrRecords_finish(struct sbus_request *req)
+int iface_nss_memorycache_InvalidateAllInitgroups_finish(struct sbus_request *req)
 {
    return sbus_request_return_and_finish(req,
                                          DBUS_TYPE_INVALID);
@@ -65,10 +65,10 @@ const struct sbus_method_meta iface_nss_memorycache__methods[] = {
         NULL, /* no invoker */
     },
     {
-        "InvalidateAllInitgrRecords", /* name */
+        "InvalidateAllInitgroups", /* name */
         NULL, /* no in_args */
         NULL, /* no out_args */
-        offsetof(struct iface_nss_memorycache, InvalidateAllInitgrRecords),
+        offsetof(struct iface_nss_memorycache, InvalidateAllInitgroups),
         NULL, /* no invoker */
     },
     { NULL, }

--- a/src/responder/nss/nss_iface_generated.c
+++ b/src/responder/nss/nss_iface_generated.c
@@ -23,6 +23,24 @@ int iface_nss_memorycache_UpdateInitgroups_finish(struct sbus_request *req)
                                          DBUS_TYPE_INVALID);
 }
 
+int iface_nss_memorycache_InvalidateAllUsers_finish(struct sbus_request *req)
+{
+   return sbus_request_return_and_finish(req,
+                                         DBUS_TYPE_INVALID);
+}
+
+int iface_nss_memorycache_InvalidateAllGroups_finish(struct sbus_request *req)
+{
+   return sbus_request_return_and_finish(req,
+                                         DBUS_TYPE_INVALID);
+}
+
+int iface_nss_memorycache_InvalidateAllInitgrRecords_finish(struct sbus_request *req)
+{
+   return sbus_request_return_and_finish(req,
+                                         DBUS_TYPE_INVALID);
+}
+
 /* methods for org.freedesktop.sssd.nss.MemoryCache */
 const struct sbus_method_meta iface_nss_memorycache__methods[] = {
     {
@@ -31,6 +49,27 @@ const struct sbus_method_meta iface_nss_memorycache__methods[] = {
         NULL, /* no out_args */
         offsetof(struct iface_nss_memorycache, UpdateInitgroups),
         invoke_ssau_method,
+    },
+    {
+        "InvalidateAllUsers", /* name */
+        NULL, /* no in_args */
+        NULL, /* no out_args */
+        offsetof(struct iface_nss_memorycache, InvalidateAllUsers),
+        NULL, /* no invoker */
+    },
+    {
+        "InvalidateAllGroups", /* name */
+        NULL, /* no in_args */
+        NULL, /* no out_args */
+        offsetof(struct iface_nss_memorycache, InvalidateAllGroups),
+        NULL, /* no invoker */
+    },
+    {
+        "InvalidateAllInitgrRecords", /* name */
+        NULL, /* no in_args */
+        NULL, /* no out_args */
+        offsetof(struct iface_nss_memorycache, InvalidateAllInitgrRecords),
+        NULL, /* no invoker */
     },
     { NULL, }
 };

--- a/src/responder/nss/nss_iface_generated.h
+++ b/src/responder/nss/nss_iface_generated.h
@@ -14,6 +14,9 @@
 /* constants for org.freedesktop.sssd.nss.MemoryCache */
 #define IFACE_NSS_MEMORYCACHE "org.freedesktop.sssd.nss.MemoryCache"
 #define IFACE_NSS_MEMORYCACHE_UPDATEINITGROUPS "UpdateInitgroups"
+#define IFACE_NSS_MEMORYCACHE_INVALIDATEALLUSERS "InvalidateAllUsers"
+#define IFACE_NSS_MEMORYCACHE_INVALIDATEALLGROUPS "InvalidateAllGroups"
+#define IFACE_NSS_MEMORYCACHE_INVALIDATEALLINITGRRECORDS "InvalidateAllInitgrRecords"
 
 /* ------------------------------------------------------------------------
  * DBus handlers
@@ -37,10 +40,22 @@
 struct iface_nss_memorycache {
     struct sbus_vtable vtable; /* derive from sbus_vtable */
     int (*UpdateInitgroups)(struct sbus_request *req, void *data, const char *arg_user, const char *arg_domain, uint32_t arg_groups[], int len_groups);
+    int (*InvalidateAllUsers)(struct sbus_request *req, void *data);
+    int (*InvalidateAllGroups)(struct sbus_request *req, void *data);
+    int (*InvalidateAllInitgrRecords)(struct sbus_request *req, void *data);
 };
 
 /* finish function for UpdateInitgroups */
 int iface_nss_memorycache_UpdateInitgroups_finish(struct sbus_request *req);
+
+/* finish function for InvalidateAllUsers */
+int iface_nss_memorycache_InvalidateAllUsers_finish(struct sbus_request *req);
+
+/* finish function for InvalidateAllGroups */
+int iface_nss_memorycache_InvalidateAllGroups_finish(struct sbus_request *req);
+
+/* finish function for InvalidateAllInitgrRecords */
+int iface_nss_memorycache_InvalidateAllInitgrRecords_finish(struct sbus_request *req);
 
 /* ------------------------------------------------------------------------
  * DBus Interface Metadata

--- a/src/responder/nss/nss_iface_generated.h
+++ b/src/responder/nss/nss_iface_generated.h
@@ -16,7 +16,7 @@
 #define IFACE_NSS_MEMORYCACHE_UPDATEINITGROUPS "UpdateInitgroups"
 #define IFACE_NSS_MEMORYCACHE_INVALIDATEALLUSERS "InvalidateAllUsers"
 #define IFACE_NSS_MEMORYCACHE_INVALIDATEALLGROUPS "InvalidateAllGroups"
-#define IFACE_NSS_MEMORYCACHE_INVALIDATEALLINITGRRECORDS "InvalidateAllInitgrRecords"
+#define IFACE_NSS_MEMORYCACHE_INVALIDATEALLINITGROUPS "InvalidateAllInitgroups"
 
 /* ------------------------------------------------------------------------
  * DBus handlers
@@ -42,7 +42,7 @@ struct iface_nss_memorycache {
     int (*UpdateInitgroups)(struct sbus_request *req, void *data, const char *arg_user, const char *arg_domain, uint32_t arg_groups[], int len_groups);
     int (*InvalidateAllUsers)(struct sbus_request *req, void *data);
     int (*InvalidateAllGroups)(struct sbus_request *req, void *data);
-    int (*InvalidateAllInitgrRecords)(struct sbus_request *req, void *data);
+    int (*InvalidateAllInitgroups)(struct sbus_request *req, void *data);
 };
 
 /* finish function for UpdateInitgroups */
@@ -54,8 +54,8 @@ int iface_nss_memorycache_InvalidateAllUsers_finish(struct sbus_request *req);
 /* finish function for InvalidateAllGroups */
 int iface_nss_memorycache_InvalidateAllGroups_finish(struct sbus_request *req);
 
-/* finish function for InvalidateAllInitgrRecords */
-int iface_nss_memorycache_InvalidateAllInitgrRecords_finish(struct sbus_request *req);
+/* finish function for InvalidateAllInitgroups */
+int iface_nss_memorycache_InvalidateAllInitgroups_finish(struct sbus_request *req);
 
 /* ------------------------------------------------------------------------
  * DBus Interface Metadata

--- a/src/responder/nss/nss_private.h
+++ b/src/responder/nss/nss_private.h
@@ -151,4 +151,8 @@ int sized_member_name(TALLOC_CTX *mem_ctx,
                       const char *member_name,
                       struct sized_string **_name);
 
+const char *
+nss_get_pwfield(struct nss_ctx *nctx,
+                struct sss_domain_info *dom);
+
 #endif /* _NSS_PRIVATE_H_ */

--- a/src/responder/nss/nss_protocol_grent.c
+++ b/src/responder/nss/nss_protocol_grent.c
@@ -219,9 +219,6 @@ nss_protocol_fill_grent(struct nss_ctx *nss_ctx,
         return ENOMEM;
     }
 
-    /* Password field content. */
-    to_sized_string(&pwfield, nss_ctx->pwfield);
-
     /* First two fields (length and reserved), filled up later. */
     ret = sss_packet_grow(packet, 2 * sizeof(uint32_t));
     if (ret != EOK) {
@@ -234,6 +231,9 @@ nss_protocol_fill_grent(struct nss_ctx *nss_ctx,
     for (i = 0; i < result->count; i++) {
         talloc_free_children(tmp_ctx);
         msg = result->msgs[i];
+
+        /* Password field content. */
+        to_sized_string(&pwfield, nss_get_pwfield(nss_ctx, result->domain));
 
         ret = nss_get_grent(tmp_ctx, nss_ctx, result->domain, msg,
                             &gid, &name);

--- a/src/responder/nss/nss_protocol_pwent.c
+++ b/src/responder/nss/nss_protocol_pwent.c
@@ -287,9 +287,6 @@ nss_protocol_fill_pwent(struct nss_ctx *nss_ctx,
         return ENOMEM;
     }
 
-    /* Password field content. */
-    to_sized_string(&pwfield, nss_ctx->pwfield);
-
     /* First two fields (length and reserved), filled up later. */
     ret = sss_packet_grow(packet, 2 * sizeof(uint32_t));
     if (ret != EOK) {
@@ -302,6 +299,9 @@ nss_protocol_fill_pwent(struct nss_ctx *nss_ctx,
     for (i = 0; i < result->count; i++) {
         talloc_free_children(tmp_ctx);
         msg = result->msgs[i];
+
+        /* Password field content. */
+        to_sized_string(&pwfield, nss_get_pwfield(nss_ctx, result->domain));
 
         ret = nss_get_pwent(tmp_ctx, nss_ctx, result->domain, msg, &uid, &gid,
                             &name, &gecos, &homedir, &shell);

--- a/src/responder/nss/nss_utils.c
+++ b/src/responder/nss/nss_utils.c
@@ -24,6 +24,7 @@
 #include "util/util.h"
 #include "confdb/confdb.h"
 #include "responder/common/responder.h"
+#include "responder/nss/nss_private.h"
 
 const char *
 nss_get_name_from_msg(struct sss_domain_info *domain,
@@ -137,4 +138,15 @@ int sized_member_name(TALLOC_CTX *mem_ctx,
 done:
     talloc_free(tmp_ctx);
     return ret;
+}
+
+const char *
+nss_get_pwfield(struct nss_ctx *nctx,
+               struct sss_domain_info *dom)
+{
+    if (dom->pwfield != NULL) {
+        return dom->pwfield;
+    }
+
+    return nctx->pwfield;
 }

--- a/src/sbus/sssd_dbus_utils.h
+++ b/src/sbus/sssd_dbus_utils.h
@@ -25,6 +25,13 @@ errno_t sbus_talloc_bound_message(TALLOC_CTX *mem_ctx, DBusMessage *msg);
 errno_t sbus_error_to_errno(DBusError *error);
 errno_t sbus_check_reply(DBusMessage *reply);
 
+/* Creates a DBusMessage from a vararg list. Please note that even though
+ * this function and sbus_create_message accept a talloc memory context,
+ * it is not valid to free the resulting message with talloc_free() directly.
+ * Instead, either free the parent memory context or directly call
+ * dbus_message_unref on the message if you pass NULL memory context to
+ * these functions
+ */
 DBusMessage *sbus_create_message_valist(TALLOC_CTX *mem_ctx,
                                         const char *bus,
                                         const char *path,

--- a/src/tests/cmocka/test_inotify.c
+++ b/src/tests/cmocka/test_inotify.c
@@ -1,0 +1,582 @@
+/*
+    Copyright (C) 2016 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <errno.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <talloc.h>
+#include <popt.h>
+
+#include "limits.h"
+#include "util/io.h"
+#include "util/inotify.h"
+#include "util/util.h"
+#include "tests/common.h"
+
+struct inotify_test_ctx {
+    char *filename;
+    char *dirname;
+
+    int ncb;
+    int threshold;
+    /* if the cb receives flags not in this set, test fails */
+    uint32_t exp_flags;
+
+    struct sss_test_ctx *tctx;
+    struct tevent_timer *fail_te;
+};
+
+static void test_timeout(struct tevent_context *ev,
+                         struct tevent_timer *te,
+                         struct timeval t,
+                         void *ptr)
+{
+    DEBUG(SSSDBG_FATAL_FAILURE, "The test timed out!\n");
+    talloc_free(te);
+    fail();
+}
+
+static struct inotify_test_ctx *common_setup(TALLOC_CTX *mem_ctx)
+{
+    struct inotify_test_ctx *ctx;
+    struct timeval tv;
+
+    ctx = talloc_zero(mem_ctx, struct inotify_test_ctx);
+    if (ctx == NULL) {
+        return NULL;
+    }
+
+    ctx->tctx = create_ev_test_ctx(ctx);
+    if (ctx->tctx == NULL) {
+        talloc_free(ctx);
+        return NULL;
+    }
+
+    gettimeofday(&tv, NULL);
+    tv.tv_sec += 5;
+    ctx->fail_te = tevent_add_timer(ctx->tctx->ev, ctx,
+                                    tv, test_timeout, ctx);
+    if (ctx->fail_te == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to queue fallback timer!\n");
+        talloc_free(ctx);
+        return NULL;
+    }
+
+    return ctx;
+}
+
+static int inotify_test_setup(void **state)
+{
+    struct inotify_test_ctx *ctx;
+    int fd;
+
+    ctx = common_setup(NULL);
+    if (ctx == NULL) {
+        return 1;
+    }
+
+    ctx->filename = talloc_strdup(ctx, "test_inotify.XXXXXX");
+    if (ctx->filename == NULL) {
+        talloc_free(ctx);
+        return 1;
+    }
+
+    fd = mkstemp(ctx->filename);
+    if (fd == -1) {
+        talloc_free(ctx);
+        return 1;
+    }
+    close(fd);
+
+    *state = ctx;
+    return 0;
+}
+
+static int inotify_test_dir_setup(void **state)
+{
+    struct inotify_test_ctx *ctx;
+
+    ctx = common_setup(NULL);
+    if (ctx == NULL) {
+        return 1;
+    }
+
+    ctx->dirname = talloc_strdup(ctx, "test_inotify_dir.XXXXXX");
+    if (ctx->dirname == NULL) {
+        talloc_free(ctx);
+        return 1;
+    }
+
+    ctx->dirname = mkdtemp(ctx->dirname);
+    if (ctx->dirname == NULL) {
+        talloc_free(ctx);
+        return 1;
+    }
+
+    ctx->filename = talloc_asprintf(ctx, "%s/testfile", ctx->dirname);
+    if (ctx->filename == NULL) {
+        talloc_free(ctx);
+        return 1;
+    }
+
+    *state = ctx;
+    return 0;
+}
+
+static int inotify_test_teardown(void **state)
+{
+    struct inotify_test_ctx *ctx = talloc_get_type_abort(*state,
+                                                     struct inotify_test_ctx);
+    int ret;
+
+    ret = unlink(ctx->filename);
+    if (ret == -1 && errno != ENOENT) {
+        return 1;
+    }
+
+    talloc_free(ctx);
+    return 0;
+}
+
+static int inotify_test_dir_teardown(void **state)
+{
+    struct inotify_test_ctx *ctx = talloc_get_type_abort(*state,
+                                                     struct inotify_test_ctx);
+    int ret;
+
+    ret = unlink(ctx->filename);
+    if (ret == -1 && errno != ENOENT) {
+        return 1;
+    }
+
+    ret = rmdir(ctx->dirname);
+    if (ret == -1 && errno != ENOENT) {
+        return 1;
+    }
+
+    talloc_free(ctx);
+    return 0;
+}
+
+static void file_mod_op(struct tevent_context *ev,
+                        struct tevent_timer *te,
+                        struct timeval t,
+                        void *ptr)
+{
+    struct inotify_test_ctx *test_ctx = talloc_get_type_abort(ptr,
+                                                struct inotify_test_ctx);
+    FILE *f;
+
+    talloc_free(te);
+
+    f = fopen(test_ctx->filename, "w");
+    if (f == NULL) {
+        test_ctx->tctx->error = errno;
+        test_ctx->tctx->done = true;
+        return;
+    }
+
+    fprintf(f, "%s\n", test_ctx->filename);
+    fflush(f);
+    fclose(f);
+}
+
+static void check_and_set_threshold(struct inotify_test_ctx *test_ctx,
+                                    uint32_t flags)
+{
+    if (test_ctx->exp_flags != 0 && !(test_ctx->exp_flags & flags)) {
+        fail();
+    }
+
+    test_ctx->ncb++;
+}
+
+static int inotify_set_threshold_cb(const char *filename,
+                                    uint32_t flags,
+                                    void *pvt)
+{
+    struct inotify_test_ctx *test_ctx = talloc_get_type_abort(pvt,
+                                                struct inotify_test_ctx);
+
+    check_and_set_threshold(test_ctx, flags);
+    return EOK;
+}
+
+static int inotify_threshold_cb(const char *filename,
+                                uint32_t flags,
+                                void *pvt)
+{
+    struct inotify_test_ctx *test_ctx = talloc_get_type_abort(pvt,
+                                                struct inotify_test_ctx);
+
+    check_and_set_threshold(test_ctx, flags);
+    if (test_ctx->ncb == test_ctx->threshold) {
+        test_ctx->tctx->done = true;
+        return EOK;
+    }
+
+    return EOK;
+}
+
+/* Test that running two modifications fires the callback twice */
+static void test_inotify_mod(void **state)
+{
+    struct inotify_test_ctx *test_ctx = talloc_get_type_abort(*state,
+                                                     struct inotify_test_ctx);
+    struct snotify_ctx *ctx;
+    struct timeval tv;
+    struct tevent_timer *te;
+    errno_t ret;
+
+    ctx = snotify_create(test_ctx, test_ctx->tctx->ev, SNOTIFY_WATCH_DIR,
+                         test_ctx->filename, NULL, IN_MODIFY,
+                         inotify_threshold_cb, test_ctx);
+    assert_non_null(ctx);
+
+    test_ctx->threshold = 2;
+    test_ctx->exp_flags = IN_MODIFY;
+
+    gettimeofday(&tv, NULL);
+    tv.tv_usec += 500;
+    te = tevent_add_timer(test_ctx->tctx->ev, test_ctx,
+                          tv, file_mod_op, test_ctx);
+    if (te == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to queue file update!\n");
+        return;
+    }
+
+    gettimeofday(&tv, NULL);
+    tv.tv_sec += 1;
+    te = tevent_add_timer(test_ctx->tctx->ev, test_ctx,
+                          tv, file_mod_op, test_ctx);
+    if (te == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to queue file update!\n");
+        return;
+    }
+
+    ret = test_ev_loop(test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+
+    talloc_free(ctx);
+}
+
+static void file_mv_op(struct tevent_context *ev,
+                       struct tevent_timer *te,
+                       struct timeval t,
+                       void *ptr)
+{
+    struct inotify_test_ctx *test_ctx = talloc_get_type_abort(ptr,
+                                                struct inotify_test_ctx);
+    FILE *f;
+    int fd;
+    char src_tmp_file[] = "test_inotify_src.XXXXXX";
+    int ret;
+
+    talloc_free(te);
+
+    fd = mkstemp(src_tmp_file);
+    if (fd == -1) {
+        test_ctx->tctx->error = errno;
+        test_ctx->tctx->done = true;
+        return;
+    }
+
+    f = fdopen(fd, "w");
+    if (f == NULL) {
+        close(fd);
+        unlink(src_tmp_file);
+        test_ctx->tctx->error = errno;
+        test_ctx->tctx->done = true;
+        return;
+    }
+
+    fprintf(f, "%s\n", test_ctx->filename);
+    fflush(f);
+    fclose(f);
+
+    ret = rename(src_tmp_file, test_ctx->filename);
+    if (ret == -1) {
+        unlink(src_tmp_file);
+        test_ctx->tctx->error = errno;
+        test_ctx->tctx->done = true;
+        return;
+    }
+}
+
+static void test_inotify_mv(void **state)
+{
+    struct inotify_test_ctx *test_ctx = talloc_get_type_abort(*state,
+                                                     struct inotify_test_ctx);
+    struct snotify_ctx *ctx;
+    struct timeval tv;
+    struct tevent_timer *te;
+    errno_t ret;
+
+    ctx = snotify_create(test_ctx, test_ctx->tctx->ev, SNOTIFY_WATCH_DIR,
+                         test_ctx->filename, NULL, IN_MOVED_TO,
+                         inotify_threshold_cb, test_ctx);
+    assert_non_null(ctx);
+
+    test_ctx->threshold = 1;
+    test_ctx->exp_flags = IN_MOVED_TO;
+
+    gettimeofday(&tv, NULL);
+    tv.tv_usec += 200;
+    te = tevent_add_timer(test_ctx->tctx->ev, test_ctx,
+                          tv, file_mv_op, test_ctx);
+    if (te == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to queue file update!\n");
+        return;
+    }
+
+    ret = test_ev_loop(test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+}
+
+static void file_del_add_op(struct tevent_context *ev,
+                            struct tevent_timer *te,
+                            struct timeval t,
+                            void *ptr)
+{
+    struct inotify_test_ctx *test_ctx = talloc_get_type_abort(ptr,
+                                                struct inotify_test_ctx);
+    FILE *f;
+    int ret;
+
+    talloc_free(te);
+
+    ret = unlink(test_ctx->filename);
+    if (ret == -1) {
+        test_ctx->tctx->error = errno;
+        test_ctx->tctx->done = true;
+        return;
+    }
+
+    f = fopen(test_ctx->filename, "w");
+    if (f == NULL) {
+        test_ctx->tctx->error = errno;
+        test_ctx->tctx->done = true;
+        return;
+    }
+
+    fprintf(f, "%s\n", test_ctx->filename);
+    fflush(f);
+    fclose(f);
+}
+
+static void test_inotify_del_add(void **state)
+{
+    struct inotify_test_ctx *test_ctx = talloc_get_type_abort(*state,
+                                                     struct inotify_test_ctx);
+    struct snotify_ctx *ctx;
+    struct timeval tv;
+    struct tevent_timer *te;
+    errno_t ret;
+
+    test_ctx->threshold = 1;
+    test_ctx->exp_flags = IN_CREATE;
+
+    ctx = snotify_create(test_ctx, test_ctx->tctx->ev, SNOTIFY_WATCH_DIR,
+                         test_ctx->filename, NULL,
+                         IN_CREATE,
+                         inotify_threshold_cb, test_ctx);
+    assert_non_null(ctx);
+
+    gettimeofday(&tv, NULL);
+    tv.tv_usec += 200;
+    te = tevent_add_timer(test_ctx->tctx->ev, test_ctx,
+                          tv, file_del_add_op, test_ctx);
+    if (te == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to queue file update!\n");
+        return;
+    }
+
+    ret = test_ev_loop(test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+}
+
+static void test_inotify_file_moved_in(void **state)
+{
+    struct inotify_test_ctx *test_ctx = talloc_get_type_abort(*state,
+                                                     struct inotify_test_ctx);
+    struct snotify_ctx *ctx;
+    struct timeval tv;
+    struct tevent_timer *te;
+    errno_t ret;
+
+    test_ctx->threshold = 1;
+    test_ctx->exp_flags = IN_CREATE;
+
+    ctx = snotify_create(test_ctx, test_ctx->tctx->ev, SNOTIFY_WATCH_DIR,
+                         test_ctx->filename, NULL,
+                         IN_CREATE | IN_CLOSE_WRITE,
+                         inotify_threshold_cb, test_ctx);
+    assert_non_null(ctx);
+
+    gettimeofday(&tv, NULL);
+    tv.tv_usec += 200;
+
+    te = tevent_add_timer(test_ctx->tctx->ev, test_ctx,
+                          tv, file_mod_op, test_ctx);
+    if (te == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to queue file update!\n");
+        return;
+    }
+
+    ret = test_ev_loop(test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+}
+
+static void file_del_op(struct tevent_context *ev,
+                        struct tevent_timer *te,
+                        struct timeval t,
+                        void *ptr)
+{
+    struct inotify_test_ctx *test_ctx = talloc_get_type_abort(ptr,
+                                                struct inotify_test_ctx);
+    int ret;
+
+    talloc_free(te);
+
+    ret = unlink(test_ctx->filename);
+    if (ret == -1) {
+        test_ctx->tctx->error = errno;
+        test_ctx->tctx->done = true;
+        return;
+    }
+}
+
+static void check_threshold_cb(struct tevent_context *ev,
+                               struct tevent_timer *te,
+                               struct timeval t,
+                               void *ptr)
+{
+    struct inotify_test_ctx *test_ctx = talloc_get_type_abort(ptr,
+                                                struct inotify_test_ctx);
+
+    /* tests that no more callbacks were issued and exactly one
+     * was caught for both requests
+     */
+    if (test_ctx->ncb == test_ctx->threshold) {
+        test_ctx->tctx->done = true;
+        return;
+    }
+
+    fail();
+}
+
+static void test_inotify_delay(void **state)
+{
+    struct inotify_test_ctx *test_ctx = talloc_get_type_abort(*state,
+                                                     struct inotify_test_ctx);
+    struct snotify_ctx *ctx;
+    struct timeval tv;
+    struct tevent_timer *te;
+    errno_t ret;
+    struct timeval delay = { .tv_sec = 1, .tv_usec = 0 };
+
+    test_ctx->threshold = 1;
+    test_ctx->exp_flags = IN_CREATE | IN_DELETE;
+
+    ctx = snotify_create(test_ctx, test_ctx->tctx->ev, SNOTIFY_WATCH_DIR,
+                         test_ctx->filename, &delay,
+                         IN_CREATE | IN_DELETE,
+                         inotify_set_threshold_cb, test_ctx);
+    assert_non_null(ctx);
+
+    gettimeofday(&tv, NULL);
+    tv.tv_usec += 100;
+    te = tevent_add_timer(test_ctx->tctx->ev, test_ctx,
+                          tv, file_mod_op, test_ctx);
+    if (te == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to queue file update!\n");
+        return;
+    }
+
+    gettimeofday(&tv, NULL);
+    tv.tv_usec += 200;
+    te = tevent_add_timer(test_ctx->tctx->ev, test_ctx,
+                          tv, file_del_op, test_ctx);
+    if (te == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to queue file update!\n");
+        return;
+    }
+
+    gettimeofday(&tv, NULL);
+    tv.tv_sec += 2;
+    te = tevent_add_timer(test_ctx->tctx->ev, test_ctx,
+                          tv, check_threshold_cb, test_ctx);
+    if (te == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to queue file update!\n");
+        return;
+    }
+
+    ret = test_ev_loop(test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+}
+
+int main(int argc, const char *argv[])
+{
+    poptContext pc;
+    int opt;
+    struct poptOption long_options[] = {
+        POPT_AUTOHELP
+        SSSD_DEBUG_OPTS
+        POPT_TABLEEND
+    };
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_inotify_mv,
+                                        inotify_test_setup,
+                                        inotify_test_teardown),
+        cmocka_unit_test_setup_teardown(test_inotify_mod,
+                                        inotify_test_setup,
+                                        inotify_test_teardown),
+        cmocka_unit_test_setup_teardown(test_inotify_del_add,
+                                        inotify_test_setup,
+                                        inotify_test_teardown),
+        cmocka_unit_test_setup_teardown(test_inotify_file_moved_in,
+                                        inotify_test_dir_setup,
+                                        inotify_test_dir_teardown),
+        cmocka_unit_test_setup_teardown(test_inotify_delay,
+                                        inotify_test_dir_setup,
+                                        inotify_test_dir_teardown),
+    };
+
+    /* Set debug level to invalid value so we can deside if -d 0 was used. */
+    debug_level = SSSDBG_INVALID;
+
+    pc = poptGetContext(argv[0], argc, argv, long_options, 0);
+    while((opt = poptGetNextOpt(pc)) != -1) {
+        switch(opt) {
+            default:
+                fprintf(stderr, "\nInvalid option %s: %s\n\n",
+                        poptBadOption(pc, 0), poptStrerror(opt));
+                poptPrintUsage(pc, stderr, 0);
+                return 1;
+        }
+    }
+    poptFreeContext(pc);
+
+    DEBUG_CLI_INIT(debug_level);
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/tests/cwrap/Makefile.am
+++ b/src/tests/cwrap/Makefile.am
@@ -63,6 +63,12 @@ SSSD_CACHE_REQ_OBJ = \
     ../../../src/responder/common/cache_req/plugins/cache_req_host_by_name.c \
     $(NULL)
 
+SSSD_RESPONDER_IFACE_OBJ = \
+    ../../../src/responder/common/iface/responder_iface.c \
+    ../../../src/responder/common/iface/responder_domain.c \
+    ../../../src/responder/common/iface/responder_iface_generated.c \
+    $(NULL)
+
 SSSD_RESPONDER_OBJ = \
     ../../../src/responder/common/negcache_files.c \
     ../../../src/responder/common/negcache.c \
@@ -77,6 +83,7 @@ SSSD_RESPONDER_OBJ = \
     ../../../src/responder/common/data_provider/rdp_client.c \
     ../../../src/monitor/monitor_iface_generated.c \
     ../../../src/providers/data_provider_req.c \
+    $(SSSD_RESPONDER_IFACE_OBJ) \
     $(SSSD_CACHE_REQ_OBJ) \
     $(NULL)
 
@@ -158,6 +165,9 @@ endif
 
 responder_common_tests_SOURCES =\
     test_responder_common.c \
+    ../../../src/responder/common/iface/responder_iface.c \
+    ../../../src/responder/common/iface/responder_domain.c \
+    ../../../src/responder/common/iface/responder_iface_generated.c \
     ../../../src/responder/common/negcache_files.c \
     ../../../src/responder/common/negcache.c \
     ../../../src/responder/common/data_provider/rdp_message.c \
@@ -165,6 +175,8 @@ responder_common_tests_SOURCES =\
     ../../../src/responder/common/responder_common.c \
     ../../../src/responder/common/responder_packet.c \
     ../../../src/responder/common/responder_cmd.c \
+    ../../../src/tests/cmocka/common_mock_resp_dp.c \
+    $(SSSD_CACHE_REQ_OBJ) \
     $(NULL)
 responder_common_tests_CFLAGS = \
     $(AM_CFLAGS) \

--- a/src/tests/cwrap/Makefile.am
+++ b/src/tests/cwrap/Makefile.am
@@ -66,6 +66,7 @@ SSSD_CACHE_REQ_OBJ = \
 SSSD_RESPONDER_IFACE_OBJ = \
     ../../../src/responder/common/iface/responder_iface.c \
     ../../../src/responder/common/iface/responder_domain.c \
+    ../../../src/responder/common/iface/responder_ncache.c \
     ../../../src/responder/common/iface/responder_iface_generated.c \
     $(NULL)
 
@@ -167,6 +168,7 @@ responder_common_tests_SOURCES =\
     test_responder_common.c \
     ../../../src/responder/common/iface/responder_iface.c \
     ../../../src/responder/common/iface/responder_domain.c \
+    ../../../src/responder/common/iface/responder_ncache.c \
     ../../../src/responder/common/iface/responder_iface_generated.c \
     ../../../src/responder/common/negcache_files.c \
     ../../../src/responder/common/negcache.c \

--- a/src/tests/dlopen-tests.c
+++ b/src/tests/dlopen-tests.c
@@ -80,6 +80,8 @@ struct so {
     { "libsss_util.so", { LIBPFX"libsss_util.so", NULL } },
     { "libsss_simple.so", { LIBPFX"libdlopen_test_providers.so",
                             LIBPFX"libsss_simple.so", NULL } },
+    { "libsss_files.so", { LIBPFX"libdlopen_test_providers.so",
+                           LIBPFX"libsss_files.so", NULL } },
 #ifdef BUILD_SAMBA
     { "libsss_ad.so", { LIBPFX"libdlopen_test_providers.so",
                         LIBPFX"libsss_ad.so", NULL } },

--- a/src/tests/intg/Makefile.am
+++ b/src/tests/intg/Makefile.am
@@ -23,6 +23,9 @@ dist_noinst_DATA = \
     secrets.py \
     test_secrets.py \
     test_sssctl.py \
+    files_ops.py \
+    test_files_ops.py \
+    test_files_provider.py \
     $(NULL)
 
 config.py: config.py.m4

--- a/src/tests/intg/Makefile.am
+++ b/src/tests/intg/Makefile.am
@@ -1,6 +1,7 @@
 dist_noinst_DATA = \
     config.py.m4 \
     util.py \
+    sssd_nss.py \
     sssd_id.py \
     sssd_ldb.py \
     sssd_netgroup.py \

--- a/src/tests/intg/Makefile.am
+++ b/src/tests/intg/Makefile.am
@@ -6,6 +6,7 @@ dist_noinst_DATA = \
     sssd_ldb.py \
     sssd_netgroup.py \
     sssd_passwd.py \
+    sssd_group.py \
     ds.py \
     ds_openldap.py \
     ent.py \

--- a/src/tests/intg/Makefile.am
+++ b/src/tests/intg/Makefile.am
@@ -1,5 +1,6 @@
 dist_noinst_DATA = \
     config.py.m4 \
+    util.py \
     sssd_id.py \
     sssd_ldb.py \
     sssd_netgroup.py \

--- a/src/tests/intg/Makefile.am
+++ b/src/tests/intg/Makefile.am
@@ -5,6 +5,7 @@ dist_noinst_DATA = \
     sssd_id.py \
     sssd_ldb.py \
     sssd_netgroup.py \
+    sssd_passwd.py \
     ds.py \
     ds_openldap.py \
     ent.py \

--- a/src/tests/intg/ent_test.py
+++ b/src/tests/intg/ent_test.py
@@ -19,23 +19,9 @@
 import re
 import os
 import io
-import shutil
 import pytest
 import ent
 from util import *
-
-
-def backup_envvar_file(name):
-    path = os.environ[name]
-    backup_path = path + ".bak"
-    shutil.copyfile(path, backup_path)
-    return path
-
-
-def restore_envvar_file(name):
-    path = os.environ[name]
-    backup_path = path + ".bak"
-    os.rename(backup_path, path)
 
 
 @pytest.fixture(scope="module")

--- a/src/tests/intg/files_ops.py
+++ b/src/tests/intg/files_ops.py
@@ -1,0 +1,158 @@
+#
+# SSSD integration test - operations on UNIX user and group database
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 only
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import os
+import os.path
+import tempfile
+import pytest
+
+import ent
+from util import backup_envvar_file, restore_envvar_file
+
+
+@pytest.fixture
+def passwd_ops_setup(request):
+    pwd_file = os.environ["NSS_WRAPPER_PASSWD"]
+    backup_envvar_file("NSS_WRAPPER_PASSWD")
+    request.addfinalizer(lambda: restore_envvar_file("NSS_WRAPPER_PASSWD"))
+    pwd_ops = PasswdOps(pwd_file)
+    return pwd_ops
+
+
+@pytest.fixture
+def group_ops_setup(request):
+    grp_file = os.environ["NSS_WRAPPER_GROUP"]
+    backup_envvar_file("NSS_WRAPPER_GROUP")
+    request.addfinalizer(lambda: restore_envvar_file("NSS_WRAPPER_GROUP"))
+    grp_ops = GroupOps(grp_file)
+    return grp_ops
+
+
+@pytest.fixture
+def group_db_setup(request):
+    group = request.param
+    grp_ops = group_ops_setup(request)
+    grp_ops.groupadd(**group)
+    ent.assert_group_by_name(group['name'], group)
+    return grp_ops
+
+
+class FilesOps(object):
+    """
+    A naive implementation of operations as a basis for user or group
+    operations. Uses rename to (hopefully) trigger the same fs-level
+    notifications as shadow-utils would.
+    """
+    def __init__(self, file_name):
+        self.file_name = file_name
+        self.tmp_dir = os.path.dirname(self.file_name)
+
+    @staticmethod
+    def _get_named_line(name, contents):
+        for num, line in enumerate(contents, 0):
+            pname = line.split(':')[0]
+            if name == pname:
+                return num
+        raise KeyError("%s not found" % name)
+
+    def _read_contents(self):
+        with open(self.file_name, "r") as pfile:
+            contents = pfile.readlines()
+        return contents
+
+    def _write_contents(self, contents):
+        tmp_file = tempfile.NamedTemporaryFile(dir=self.tmp_dir, delete=False)
+        tmp_file.writelines(contents)
+        tmp_file.flush()
+
+        os.rename(tmp_file.name, self.file_name)
+
+    def _append_line(self, new_line):
+        contents = self._read_contents()
+        contents.extend(new_line)
+        self._write_contents(contents)
+
+    def _subst_line(self, key, line):
+        contents = self._read_contents()
+        kindex = self._get_named_line(key, contents)
+        contents[kindex] = line
+        self._write_contents(contents)
+
+    def _del_line(self, key):
+        contents = self._read_contents()
+        kindex = self._get_named_line(key, contents)
+        contents.pop(kindex)
+        self._write_contents(contents)
+
+        contents = self._read_contents()
+
+
+class PasswdOps(FilesOps):
+    """
+    A naive implementation of user operations
+    """
+    def __init__(self, file_name):
+        super(PasswdOps, self).__init__(file_name)
+
+    def _pwd2line(self, name, uid, gid, passwd, gecos, homedir, shell):
+        pwd_fmt = "{name}:{passwd}:{uid}:{gid}:{gecos}:{homedir}:{shell}\n"
+        return pwd_fmt.format(name=name,
+                              passwd=passwd,
+                              uid=uid,
+                              gid=gid,
+                              gecos=gecos,
+                              homedir=homedir,
+                              shell=shell)
+
+    def useradd(self, name, uid, gid, passwd='', gecos='', dir='', shell=''):
+        pwd_line = self._pwd2line(name, uid, gid, passwd, gecos, dir, shell)
+        self._append_line(pwd_line)
+
+    def usermod(self, name, uid, gid, passwd='', gecos='', dir='', shell=''):
+        pwd_line = self._pwd2line(name, uid, gid, passwd, gecos, dir, shell)
+        self._subst_line(name, pwd_line)
+
+    def userdel(self, name):
+        self._del_line(name)
+
+
+class GroupOps(FilesOps):
+    """
+    A naive implementation of group operations
+    """
+    def __init__(self, file_name):
+        super(GroupOps, self).__init__(file_name)
+
+    def _grp2line(self, name, gid, mem, passwd):
+        member_list = ",".join(m for m in mem)
+        grp_fmt = "{name}:{passwd}:{gid}:{member_list}\n"
+        return grp_fmt.format(name=name,
+                              passwd=passwd,
+                              gid=gid,
+                              member_list=member_list)
+
+    def groupadd(self, name, gid, mem, passwd="*"):
+        grp_line = self._grp2line(name, gid, mem, passwd)
+        self._append_line(grp_line)
+
+    def groupmod(self, old_name, name, gid, mem, passwd="*"):
+        grp_line = self._grp2line(name, gid, mem, passwd)
+        self._subst_line(old_name, grp_line)
+
+    def groupdel(self, name):
+        self._del_line(name)

--- a/src/tests/intg/sssd_group.py
+++ b/src/tests/intg/sssd_group.py
@@ -1,0 +1,88 @@
+#
+# Module for simulation of utility "getent group -s sss" from coreutils
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 only
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from ctypes import (c_int, c_char_p, c_ulong, POINTER, Structure,
+                    create_string_buffer)
+from sssd_nss import NssReturnCode, SssdNssError, nss_sss_ctypes_loader
+
+GROUP_BUFLEN = 1024
+
+
+class Group(Structure):
+    _fields_ = [("gr_name", c_char_p),
+                ("gr_passwd", c_char_p),
+                ("gr_gid", c_int),
+                ("gr_mem", POINTER(c_char_p))]
+
+
+def getgrnam_r(name, result_p, buffer_p, buflen):
+    """
+    ctypes wrapper for:
+        enum nss_status _nss_sss_getgrnam_r(const char *name,
+                                            struct group *result,
+                                            char *buffer,
+                                            size_t buflen,
+                                            int *errnop)
+    """
+    func = nss_sss_ctypes_loader("_nss_sss_getgrnam_r")
+    func.restype = c_int
+    func.argtypes = [c_char_p, POINTER(Group),
+                     c_char_p, c_ulong, POINTER(c_int)]
+
+    errno = POINTER(c_int)(c_int(0))
+
+    res = func(c_char_p(name), result_p, buffer_p, buflen, errno)
+
+    return (int(res), int(errno[0]), result_p)
+
+
+def set_group_dict(res, result_p):
+    if res != NssReturnCode.SUCCESS:
+        return dict()
+
+    group_dict = dict()
+    group_dict['name'] = result_p[0].gr_name
+    group_dict['gid'] = result_p[0].gr_gid
+    group_dict['mem'] = list()
+
+    i = 0
+    while result_p[0].gr_mem[i] != None:
+        group_dict['mem'].append(result_p[0].gr_mem[i])
+        i = i+1
+
+    return group_dict
+
+
+def call_sssd_getgrnam(name):
+    """
+    A Python wrapper to retrieve a group. Returns:
+        (res, group_dict)
+    if res is NssReturnCode.SUCCESS, then group_dict contains the keys
+    corresponding to the C passwd structure fields. Otherwise, the dictionary
+    is empty and errno indicates the error code
+    """
+    result = Group()
+    result_p = POINTER(Group)(result)
+    buff = create_string_buffer(GROUP_BUFLEN)
+
+    res, errno, result_p = getgrnam_r(name, result_p, buff, GROUP_BUFLEN)
+    if errno != 0:
+        raise SssdNssError(errno, "getgrnam_r")
+
+    group_dict = set_group_dict(res, result_p)
+    return res, group_dict

--- a/src/tests/intg/sssd_id.py
+++ b/src/tests/intg/sssd_id.py
@@ -21,15 +21,7 @@ import pwd
 import grp
 from ctypes import (cdll, c_int, c_char, c_uint32, c_long, c_char_p,
                     POINTER, pointer)
-
-
-class NssReturnCode(object):
-    """ 'enum' class for name service switch return code """
-    TRYAGAIN = -2,
-    UNAVAIL = -1
-    NOTFOUND = 0
-    SUCCESS = 1
-    RETURN = 2
+from sssd_nss import NssReturnCode, nss_sss_ctypes_loader
 
 
 def call_sssd_initgroups(user, gid):
@@ -45,10 +37,8 @@ def call_sssd_initgroups(user, gid):
         gids should contain user group IDs if err is NssReturnCode.SUCCESS
         otherwise errno will contain non-zero value.
     """
-    libnss_sss_path = config.NSS_MODULE_DIR + "/libnss_sss.so.2"
-    libnss_sss = cdll.LoadLibrary(libnss_sss_path)
+    func = nss_sss_ctypes_loader('_nss_sss_initgroups_dyn')
 
-    func = libnss_sss._nss_sss_initgroups_dyn
     func.restype = c_int
     func.argtypes = [POINTER(c_char), c_uint32, POINTER(c_long),
                      POINTER(c_long), POINTER(POINTER(c_uint32)), c_long,

--- a/src/tests/intg/sssd_netgroup.py
+++ b/src/tests/intg/sssd_netgroup.py
@@ -19,6 +19,7 @@
 from ctypes import (cdll, c_int, c_char, c_char_p, c_size_t, c_void_p, c_ulong,
                     POINTER, Structure, Union, create_string_buffer, get_errno)
 import config
+from sssd_nss import NssReturnCode, nss_sss_ctypes_loader
 
 
 class NetgroupType(object):
@@ -48,15 +49,6 @@ class NameList(Structure):
 
 NameList._fields_ = [("next", POINTER(NameList)),
                      ("name", POINTER(c_char))]
-
-
-class NssReturnCode(object):
-    """ 'enum' class for name service switch return code """
-    TRYAGAIN = -2,
-    UNAVAIL = -1
-    NOTFOUND = 0
-    SUCCESS = 1
-    RETURN = 2
 
 
 class Netgrent(Structure):
@@ -92,10 +84,7 @@ class NetgroupRetriever(object):
             result_p will contain POINTER(Netgrent) which can be used in
             _getnetgrent_r or _getnetgrent_r.
         """
-        libnss_sss_path = config.NSS_MODULE_DIR + "/libnss_sss.so.2"
-        libnss_sss = cdll.LoadLibrary(libnss_sss_path)
-
-        func = libnss_sss._nss_sss_setnetgrent
+        func = nss_sss_ctypes_loader('_nss_sss_setnetgrent')
         func.restype = c_int
         func.argtypes = [c_char_p, POINTER(Netgrent)]
 
@@ -123,10 +112,7 @@ class NetgroupRetriever(object):
             if err is NssReturnCode.SUCCESS netgroups will contain list of
             touples. Each touple will consist of 3 elemets either string or
         """
-        libnss_sss_path = config.NSS_MODULE_DIR + "/libnss_sss.so.2"
-        libnss_sss = cdll.LoadLibrary(libnss_sss_path)
-
-        func = libnss_sss._nss_sss_getnetgrent_r
+        func = nss_sss_ctypes_loader('_nss_sss_getnetgrent_r')
         func.restype = c_int
         func.argtypes = [POINTER(Netgrent), POINTER(c_char), c_size_t,
                          POINTER(c_int)]
@@ -148,10 +134,7 @@ class NetgroupRetriever(object):
 
         @return int a constant from class NssReturnCode
         """
-        libnss_sss_path = config.NSS_MODULE_DIR + "/libnss_sss.so.2"
-        libnss_sss = cdll.LoadLibrary(libnss_sss_path)
-
-        func = libnss_sss._nss_sss_endnetgrent
+        func = nss_sss_ctypes_loader('_nss_sss_endnetgrent')
         func.restype = c_int
         func.argtypes = [POINTER(Netgrent)]
 

--- a/src/tests/intg/sssd_nss.py
+++ b/src/tests/intg/sssd_nss.py
@@ -1,0 +1,46 @@
+#
+# Shared module for integration tests that need to access the sssd_nss
+# module directly
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 only
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+import config
+import ctypes
+
+
+class NssReturnCode(object):
+    """ 'enum' class for name service switch return code """
+    TRYAGAIN = -2,
+    UNAVAIL = -1
+    NOTFOUND = 0
+    SUCCESS = 1
+    RETURN = 2
+
+
+class SssdNssError(Exception):
+    """ Raised when one of the NSS operations fail """
+    def __init__(self, errno, nssop):
+        self.errno = errno
+        self.nssop = nssop
+
+    def __str__(self):
+        return "NSS operation %s failed %d" % (nssop, errno)
+
+
+def nss_sss_ctypes_loader(func_name):
+    libnss_sss_path = config.NSS_MODULE_DIR + "/libnss_sss.so.2"
+    libnss_sss = ctypes.cdll.LoadLibrary(libnss_sss_path)
+    func = getattr(libnss_sss, func_name)
+    return func

--- a/src/tests/intg/sssd_passwd.py
+++ b/src/tests/intg/sssd_passwd.py
@@ -1,0 +1,167 @@
+#
+# Module for simulation of utility "getent passwd -s sss" from coreutils
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 only
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from ctypes import (c_int, c_char_p, c_ulong, POINTER,
+                    Structure, create_string_buffer, get_errno)
+from sssd_nss import NssReturnCode, SssdNssError, nss_sss_ctypes_loader
+
+PASSWD_BUFLEN = 1024
+
+
+class Passwd(Structure):
+    _fields_ = [("pw_name", c_char_p),
+                ("pw_passwd", c_char_p),
+                ("pw_uid", c_int),
+                ("pw_gid", c_int),
+                ("pw_gecos", c_char_p),
+                ("pw_dir", c_char_p),
+                ("pw_shell", c_char_p)]
+
+
+def set_user_dict(res, result_p):
+    if res != NssReturnCode.SUCCESS:
+        return dict()
+
+    user_dict = dict()
+    user_dict['name'] = result_p[0].pw_name
+    user_dict['passwd'] = result_p[0].pw_passwd
+    user_dict['uid'] = result_p[0].pw_uid
+    user_dict['gid'] = result_p[0].pw_gid
+    user_dict['gecos'] = result_p[0].pw_gecos
+    user_dict['dir'] = result_p[0].pw_dir
+    user_dict['shell'] = result_p[0].pw_shell
+    return user_dict
+
+
+def getpwnam_r(name, result_p, buffer_p, buflen):
+    """
+    ctypes wrapper for:
+        enum nss_status _nss_sss_getpwnam_r(const char *name,
+                                            struct passwd *result,
+                                            char *buffer,
+                                            size_t buflen,
+                                            int *errnop)
+    """
+    func = nss_sss_ctypes_loader("_nss_sss_getpwnam_r")
+    func.restype = c_int
+    func.argtypes = [c_char_p, POINTER(Passwd),
+                     c_char_p, c_ulong, POINTER(c_int)]
+
+    errno = POINTER(c_int)(c_int(0))
+
+    res = func(c_char_p(name), result_p, buffer_p, buflen, errno)
+
+    return (int(res), int(errno[0]), result_p)
+
+
+def setpwent():
+    """
+    ctypes wrapper for:
+        void setpwent(void)
+    """
+    func = nss_sss_ctypes_loader("_nss_sss_setpwent")
+    func.argtypes = []
+
+    res = func()
+    assert res == NssReturnCode.SUCCESS
+
+    errno = get_errno()
+    if errno != 0:
+        raise SssdNssError(errno, "setpwent")
+
+
+def endpwent():
+    """
+    ctypes wrapper for:
+        void endpwent(void)
+    """
+    func = nss_sss_ctypes_loader("_nss_sss_endpwent")
+    func.argtypes = []
+
+    res = func()
+    assert res == NssReturnCode.SUCCESS
+
+    errno = get_errno()
+    if errno != 0:
+        raise SssdNssError(errno, "endpwent")
+
+
+def getpwent_r(result_p, buffer_p, buflen):
+    """
+    ctypes wrapper for:
+        enum nss_status _nss_sss_getpwent_r(struct passwd *result,
+                                            char *buffer, size_t buflen,
+                                            int *errnop)
+    """
+    func = nss_sss_ctypes_loader("_nss_sss_getpwent_r")
+    func.restype = c_int
+    func.argtypes = [POINTER(Passwd), c_char_p, c_ulong, POINTER(c_int)]
+
+    errno = POINTER(c_int)(c_int(0))
+
+    res = func(result_p, buffer_p, buflen, errno)
+    return (int(res), int(errno[0]), result_p)
+
+
+def getpwent():
+    result = Passwd()
+    result_p = POINTER(Passwd)(result)
+    buff = create_string_buffer(PASSWD_BUFLEN)
+
+    res, errno, result_p = getpwent_r(result_p, buff, PASSWD_BUFLEN)
+    if errno != 0:
+        raise SssdNssError(errno, "getpwent_r")
+
+    user_dict = set_user_dict(res, result_p)
+    return res, user_dict
+
+
+def call_sssd_getpwnam(name):
+    """
+    A Python wrapper to retrieve a user. Returns:
+        (res, user_dict)
+    if res is NssReturnCode.SUCCESS, then user_dict contains the keys
+    corresponding to the C passwd structure fields. Otherwise, the dictionary
+    is empty and errno indicates the error code
+    """
+    result = Passwd()
+    result_p = POINTER(Passwd)(result)
+    buff = create_string_buffer(PASSWD_BUFLEN)
+
+    res, errno, result_p = getpwnam_r(name, result_p, buff, PASSWD_BUFLEN)
+    if errno != 0:
+        raise SssdNssError(errno, "getpwnam_r")
+
+    user_dict = set_user_dict(res, result_p)
+    return res, user_dict
+
+
+def call_sssd_enumeration():
+    """
+    enumerate users from sssd module only
+    """
+    setpwent()
+    user_list = []
+
+    res, user = getpwent()
+    while res == NssReturnCode.SUCCESS:
+        user_list.append(user)
+        res, user = getpwent()
+
+    endpwent()
+    return user_list

--- a/src/tests/intg/test_files_ops.py
+++ b/src/tests/intg/test_files_ops.py
@@ -1,0 +1,84 @@
+#
+# SSSD integration test - operations on UNIX user and group database
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 only
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+import pwd
+import grp
+import pytest
+
+import ent
+from files_ops import passwd_ops_setup, group_ops_setup
+
+USER1 = dict(name='user1', passwd='*', uid=10001, gid=20001,
+             gecos='User for tests',
+             dir='/home/user1',
+             shell='/bin/bash')
+
+GROUP1 = dict(name='group1',
+              gid=30001,
+              mem=['user1'])
+
+
+def test_useradd(passwd_ops_setup):
+    with pytest.raises(KeyError):
+        pwd.getpwnam("user1")
+    passwd_ops_setup.useradd(**USER1)
+    ent.assert_passwd_by_name("user1", USER1)
+
+
+def test_usermod(passwd_ops_setup):
+    passwd_ops_setup.useradd(**USER1)
+    ent.assert_passwd_by_name("user1", USER1)
+
+    USER1['shell'] = '/bin/zsh'
+    passwd_ops_setup.usermod(**USER1)
+    ent.assert_passwd_by_name("user1", USER1)
+
+
+def test_userdel(passwd_ops_setup):
+    passwd_ops_setup.useradd(**USER1)
+    ent.assert_passwd_by_name("user1", USER1)
+
+    passwd_ops_setup.userdel("user1")
+    with pytest.raises(KeyError):
+        pwd.getpwnam("user1")
+
+
+def test_groupadd(group_ops_setup):
+    with pytest.raises(KeyError):
+        grp.getgrnam("group1")
+    group_ops_setup.groupadd(**GROUP1)
+    ent.assert_group_by_name("group1", GROUP1)
+
+
+def test_groupmod(group_ops_setup):
+    group_ops_setup.groupadd(**GROUP1)
+    ent.assert_group_by_name("group1", GROUP1)
+
+    modgroup = dict(GROUP1)
+    modgroup['mem'] = []
+
+    group_ops_setup.groupmod(old_name=GROUP1["name"], **modgroup)
+    ent.assert_group_by_name("group1", modgroup)
+
+
+def test_groupdel(group_ops_setup):
+    group_ops_setup.groupadd(**GROUP1)
+    ent.assert_group_by_name("group1", GROUP1)
+
+    group_ops_setup.groupdel("group1")
+    with pytest.raises(KeyError):
+        grp.getgrnam("group1")

--- a/src/tests/intg/test_files_provider.py
+++ b/src/tests/intg/test_files_provider.py
@@ -1,0 +1,692 @@
+#
+# SSSD files domain tests
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 only
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import os
+import stat
+import time
+import config
+import signal
+import subprocess
+import pwd
+import grp
+import pytest
+
+import ent
+import sssd_id
+from sssd_nss import NssReturnCode
+from sssd_passwd import call_sssd_getpwnam, call_sssd_enumeration
+from sssd_group import call_sssd_getgrnam
+from files_ops import passwd_ops_setup, group_ops_setup
+from util import unindent
+
+CANARY = dict(name='canary', passwd='x', uid=100001, gid=200001,
+              gecos='Used to check if passwd is resolvable',
+              dir='/home/canary',
+              shell='/bin/bash')
+
+USER1 = dict(name='user1', passwd='x', uid=10001, gid=20001,
+             gecos='User for tests',
+             dir='/home/user1',
+             shell='/bin/bash')
+
+USER2 = dict(name='user2', passwd='x', uid=10002, gid=20001,
+             gecos='User2 for tests',
+             dir='/home/user2',
+             shell='/bin/bash')
+
+CANARY_GR = dict(name='canary',
+                 gid=300001,
+                 mem=[])
+
+GROUP1 = dict(name='group1',
+              gid=30001,
+              mem=['user1'])
+
+GROUP12 = dict(name='group12',
+               gid=30012,
+               mem=['user1', 'user2'])
+
+GROUP_NOMEM = dict(name='group_nomem',
+                   gid=40000,
+                   mem=[])
+
+
+def stop_sssd():
+    pid_file = open(config.PIDFILE_PATH, "r")
+    pid = int(pid_file.read())
+    os.kill(pid, signal.SIGTERM)
+    while True:
+        try:
+            os.kill(pid, signal.SIGCONT)
+        except:
+            break
+        time.sleep(1)
+
+
+def create_conf_fixture(request, contents):
+    """Generate sssd.conf and add teardown for removing it"""
+    conf = open(config.CONF_PATH, "w")
+    conf.write(contents)
+    conf.close()
+    os.chmod(config.CONF_PATH, stat.S_IRUSR | stat.S_IWUSR)
+    request.addfinalizer(lambda: os.unlink(config.CONF_PATH))
+
+
+def create_sssd_fixture(request):
+    """Start sssd and add teardown for stopping it and removing state"""
+    os.environ["SSS_FILES_PASSWD"] = os.environ["NSS_WRAPPER_PASSWD"]
+    os.environ["SSS_FILES_GROUP"] = os.environ["NSS_WRAPPER_GROUP"]
+    if subprocess.call(["sssd", "-D", "-f"]) != 0:
+        raise Exception("sssd start failed")
+
+    def teardown():
+        try:
+            stop_sssd()
+        except:
+            pass
+        for path in os.listdir(config.DB_PATH):
+            os.unlink(config.DB_PATH + "/" + path)
+        for path in os.listdir(config.MCACHE_PATH):
+            os.unlink(config.MCACHE_PATH + "/" + path)
+    request.addfinalizer(teardown)
+
+
+# Fixtures
+@pytest.fixture
+def files_domain_only(request):
+    conf = unindent("""\
+        [sssd]
+        domains             = files
+        services            = nss
+
+        [domain/files]
+        id_provider = files
+    """).format(**locals())
+    create_conf_fixture(request, conf)
+    create_sssd_fixture(request)
+    return None
+
+
+def setup_pw_with_list(request, user_list):
+    pwd_ops = passwd_ops_setup(request)
+    for user in user_list:
+        pwd_ops.useradd(**user)
+    ent.assert_passwd_by_name(CANARY['name'], CANARY)
+    return pwd_ops
+
+
+@pytest.fixture
+def add_user_with_canary(request):
+    return setup_pw_with_list(request, [CANARY, USER1])
+
+
+@pytest.fixture
+def setup_pw_with_canary(request):
+    return setup_pw_with_list(request, [CANARY])
+
+
+def setup_gr_with_list(request, group_list):
+    grp_ops = group_ops_setup(request)
+    for group in group_list:
+        grp_ops.groupadd(**group)
+    ent.assert_group_by_name(CANARY_GR['name'], CANARY_GR)
+    return grp_ops
+
+
+@pytest.fixture
+def add_group_with_canary(request):
+    return setup_gr_with_list(request, [GROUP1, CANARY_GR])
+
+
+@pytest.fixture
+def setup_gr_with_canary(request):
+    return setup_gr_with_list(request, [CANARY_GR])
+
+
+def poll_canary(fn, name, threshold=20):
+    """
+    If we query SSSD while it's updating its cache, it would return NOTFOUND
+    rather than a result from potentially outdated or incomplete cache. In
+    reality this doesn't hurt because the order of the modules is normally
+    "sss files" so the user lookup would fall back to files. But in tests
+    we use this loop to wait until the canary user who is always there is
+    resolved.
+    """
+    for _ in range(0, threshold):
+        res, _ = fn(name)
+        if res == NssReturnCode.SUCCESS:
+            return True
+        elif res == NssReturnCode.NOTFOUND:
+            time.sleep(0.1)
+            continue
+        else:
+            return False
+    return False
+
+
+def sssd_getpwnam_sync(name):
+    ret = poll_canary(call_sssd_getpwnam, CANARY["name"])
+    if ret is False:
+        return NssReturnCode.NOTFOUND, None
+
+    return call_sssd_getpwnam(name)
+
+
+def sssd_getgrnam_sync(name):
+    ret = poll_canary(call_sssd_getgrnam, CANARY_GR["name"])
+    if ret is False:
+        return NssReturnCode.NOTFOUND, None
+
+    return call_sssd_getgrnam(name)
+
+
+def sssd_id_sync(name):
+    sssd_getpwnam_sync(CANARY["name"])
+    res, _, groups = sssd_id.get_user_groups(name)
+    return res, groups
+
+
+# Helper functions
+def user_generator(seqnum):
+    return dict(name='user%d' % seqnum,
+                passwd='*',
+                uid=10000 + seqnum,
+                gid=20000 + seqnum,
+                gecos='User for tests',
+                dir='/home/user%d' % seqnum,
+                shell='/bin/bash')
+
+
+def check_user(exp_user, delay=1.0):
+    if delay > 0:
+        time.sleep(delay)
+
+    res, found_user = sssd_getpwnam_sync(exp_user["name"])
+    assert res == NssReturnCode.SUCCESS
+    assert found_user == exp_user
+
+
+def check_group(exp_group, delay=1.0):
+    if delay > 0:
+        time.sleep(delay)
+
+    res, found_group = sssd_getgrnam_sync(exp_group["name"])
+    assert res == NssReturnCode.SUCCESS
+    assert found_group == exp_group
+
+
+def check_group_list(exp_groups_list):
+    for exp_group in exp_groups_list:
+        check_group(exp_group)
+
+
+# User tests
+def test_getpwnam_after_start(add_user_with_canary, files_domain_only):
+    """
+    Test that after startup without any additional operations, a user
+    can be resolved through sssd
+    """
+    res, user = sssd_getpwnam_sync(USER1["name"])
+    assert res == NssReturnCode.SUCCESS
+    assert user == USER1
+
+
+def test_getpwnam_neg(files_domain_only):
+    """
+    Test that a nonexistant user cannot be resolved
+    """
+    res, _ = call_sssd_getpwnam("nosuchuser")
+    assert res == NssReturnCode.NOTFOUND
+
+
+def test_root_does_not_resolve(files_domain_only):
+    """
+    SSSD currently does not resolve the root user even though it can
+    be resolved through the NSS interface
+    """
+    nss_root = pwd.getpwnam("root")
+    assert nss_root is not None
+
+    res, _ = call_sssd_getpwnam("root")
+    assert res == NssReturnCode.NOTFOUND
+
+
+def test_add_remove_add_file_user(setup_pw_with_canary, files_domain_only):
+    """
+    Test that removing a user is detected and the user
+    is removed from the sssd database. Similarly, an add
+    should be detected. Do this several times to test retaining
+    the inotify watch for moved and unlinked files.
+    """
+    res, _ = call_sssd_getpwnam(USER1["name"])
+    assert res == NssReturnCode.NOTFOUND
+
+    setup_pw_with_canary.useradd(**USER1)
+    check_user(USER1)
+
+    setup_pw_with_canary.userdel(USER1["name"])
+    time.sleep(1.0)
+    res, _ = sssd_getpwnam_sync(USER1["name"])
+    assert res == NssReturnCode.NOTFOUND
+
+    setup_pw_with_canary.useradd(**USER1)
+    check_user(USER1)
+
+
+def test_mod_user_shell(add_user_with_canary, files_domain_only):
+    """
+    Test that modifying a user shell is detected and the user
+    is modified in the sssd database
+    """
+    res, user = sssd_getpwnam_sync(USER1["name"])
+    assert res == NssReturnCode.SUCCESS
+    assert user == USER1
+
+    moduser = dict(USER1)
+    moduser['shell'] = '/bin/zsh'
+    add_user_with_canary.usermod(**moduser)
+
+    check_user(moduser)
+
+
+def test_enum_users(setup_pw_with_canary, files_domain_only):
+    """
+    Test that enumerating all users works with the default configuration. Also
+    test that removing all entries and then enumerating again returns an empty
+    set
+    """
+    num_users = 10
+    for i in range(1, num_users+1):
+        user = user_generator(i)
+        setup_pw_with_canary.useradd(**user)
+
+    sssd_getpwnam_sync(CANARY["name"])
+    user_list = call_sssd_enumeration()
+    # +1 because the canary is added
+    assert len(user_list) == num_users+1
+
+
+def incomplete_user_setup(pwd_ops, del_field, exp_field):
+    adduser = dict(USER1)
+    del adduser[del_field]
+    exp_user = dict(USER1)
+    exp_user[del_field] = exp_field
+
+    pwd_ops.useradd(**adduser)
+
+    return exp_user
+
+
+def test_user_no_shell(setup_pw_with_canary, files_domain_only):
+    """
+    Test that resolving a user without a shell defined works and returns
+    a fallback value
+    """
+    check_user(incomplete_user_setup(setup_pw_with_canary, 'shell', ''))
+
+
+def test_user_no_dir(setup_pw_with_canary, files_domain_only):
+    """
+    Test that resolving a user without a homedir defined works and returns
+    a fallback value
+    """
+    check_user(incomplete_user_setup(setup_pw_with_canary, 'dir', '/'))
+
+
+def test_user_no_gecos(setup_pw_with_canary, files_domain_only):
+    """
+    Test that resolving a user without a gecos defined works and returns
+    a fallback value
+    """
+    check_user(incomplete_user_setup(setup_pw_with_canary, 'gecos', ''))
+
+
+def test_user_no_passwd(setup_pw_with_canary, files_domain_only):
+    """
+    Test that resolving a user without a password defined works and returns
+    a fallback value
+    """
+    check_user(incomplete_user_setup(setup_pw_with_canary, 'passwd', 'x'))
+
+
+def bad_incomplete_user_setup(pwd_ops, del_field):
+    adduser = dict(USER1)
+    adduser[del_field] = ''
+
+    pwd_ops.useradd(**adduser)
+
+
+def test_incomplete_user_fail(setup_pw_with_canary, files_domain_only):
+    """
+    Test resolving an incomplete user where the missing field is required
+    to be present in the user record and thus the user shouldn't resolve.
+
+    We cannot test uid and gid missing because nss_wrapper doesn't even
+    load the malformed passwd file, then.
+    """
+    bad_incomplete_user_setup(setup_pw_with_canary, 'name')
+    res, user = sssd_getpwnam_sync(USER1["name"])
+    assert res == NssReturnCode.NOTFOUND
+
+
+def test_getgrnam_after_start(add_group_with_canary, files_domain_only):
+    """
+    Test that after startup without any additional operations, a group
+    can be resolved through sssd
+    """
+    check_group(GROUP1)
+
+
+def test_getgrnam_neg(files_domain_only):
+    """
+    Test that a nonexistant group cannot be resolved
+    """
+    res, user = sssd_getgrnam_sync("nosuchgroup")
+    assert res == NssReturnCode.NOTFOUND
+
+
+def test_root_group_does_not_resolve(files_domain_only):
+    """
+    SSSD currently does not resolve the root group even though it can
+    be resolved through the NSS interface
+    """
+    nss_root = grp.getgrnam("root")
+    assert nss_root is not None
+
+    res, user = call_sssd_getgrnam("root")
+    assert res == NssReturnCode.NOTFOUND
+
+
+def test_add_remove_add_file_group(setup_gr_with_canary, files_domain_only):
+    """
+    Test that removing a group is detected and the group
+    is removed from the sssd database. Similarly, an add
+    should be detected. Do this several times to test retaining
+    the inotify watch for moved and unlinked files.
+    """
+    res, group = call_sssd_getgrnam(GROUP1["name"])
+    assert res == NssReturnCode.NOTFOUND
+
+    setup_gr_with_canary.groupadd(**GROUP1)
+    check_group(GROUP1)
+
+    setup_gr_with_canary.groupdel(GROUP1["name"])
+    time.sleep(1)
+    res, group = call_sssd_getgrnam(GROUP1["name"])
+    assert res == NssReturnCode.NOTFOUND
+
+    setup_gr_with_canary.groupadd(**GROUP1)
+    check_group(GROUP1)
+
+
+def test_mod_group_name(add_group_with_canary, files_domain_only):
+    """
+    Test that modifying a group name is detected and the group
+    is modified in the sssd database
+    """
+    check_group(GROUP1)
+
+    modgroup = dict(GROUP1)
+    modgroup['name'] = 'group1_mod'
+    add_group_with_canary.groupmod(old_name=GROUP1["name"], **modgroup)
+
+    check_group(modgroup)
+
+
+def test_mod_group_gid(add_group_with_canary, files_domain_only):
+    """
+    Test that modifying a group name is detected and the group
+    is modified in the sssd database
+    """
+    check_group(GROUP1)
+
+    modgroup = dict(GROUP1)
+    modgroup['gid'] = 30002
+    add_group_with_canary.groupmod(old_name=GROUP1["name"], **modgroup)
+
+    check_group(modgroup)
+
+
+@pytest.fixture
+def add_group_nomem_with_canary(request):
+    return setup_gr_with_list(request, [GROUP_NOMEM, CANARY_GR])
+
+
+def test_getgrnam_no_members(add_group_nomem_with_canary, files_domain_only):
+    """
+    Test that after startup without any additional operations, a group
+    can be resolved through sssd
+    """
+    check_group(GROUP_NOMEM)
+
+
+def groupadd_list(grp_ops, groups):
+    for grp in groups:
+        grp_ops.groupadd(**grp)
+
+
+def useradd_list(pwd_ops, users):
+    for usr in users:
+        pwd_ops.useradd(**usr)
+
+
+def user_and_group_setup(pwd_ops, grp_ops, users, groups, reverse):
+    """
+    The reverse is added so that we test cases where a group is added first,
+    then a user for this group is created -- in that case, we need to properly
+    link the group after the user is added.
+    """
+    if reverse is False:
+        useradd_list(pwd_ops, users)
+        groupadd_list(grp_ops, groups)
+    else:
+        groupadd_list(grp_ops, groups)
+        useradd_list(pwd_ops, users)
+
+
+def members_check(added_groups):
+    # Test that users are members as per getgrnam
+    check_group_list(added_groups)
+
+    # Test that users are members as per initgroups
+    for group in added_groups:
+        for member in group['mem']:
+            res, groups = sssd_id_sync(member)
+            assert res == sssd_id.NssReturnCode.SUCCESS
+            assert group['name'] in groups
+
+
+def test_getgrnam_members_users_first(setup_pw_with_canary,
+                                      setup_gr_with_canary,
+                                      files_domain_only):
+    """
+    A user is linked with a group
+    """
+    user_and_group_setup(setup_pw_with_canary,
+                         setup_gr_with_canary,
+                         [USER1],
+                         [GROUP1],
+                         False)
+    members_check([GROUP1])
+
+
+def test_getgrnam_members_users_multiple(setup_pw_with_canary,
+                                         setup_gr_with_canary,
+                                         files_domain_only):
+    """
+    Multiple users are linked with a group
+    """
+    user_and_group_setup(setup_pw_with_canary,
+                         setup_gr_with_canary,
+                         [USER1, USER2],
+                         [GROUP12],
+                         False)
+    members_check([GROUP12])
+
+
+def test_getgrnam_members_groups_first(setup_pw_with_canary,
+                                       setup_gr_with_canary,
+                                       files_domain_only):
+    """
+    A group is linked with a user
+    """
+    user_and_group_setup(setup_pw_with_canary,
+                         setup_gr_with_canary,
+                         [USER1],
+                         [GROUP1],
+                         True)
+    members_check([GROUP1])
+
+
+def test_getgrnam_ghost(setup_pw_with_canary,
+                        setup_gr_with_canary,
+                        files_domain_only):
+    """
+    Test that a group with members while the members are not present
+    are added as ghosts. This is also what nss_files does, getgrnam would
+    return group members that do not exist as well.
+    """
+    user_and_group_setup(setup_pw_with_canary,
+                         setup_gr_with_canary,
+                         [],
+                         [GROUP12],
+                         False)
+    check_group(GROUP12)
+    for member in GROUP12['mem']:
+        res, _ = call_sssd_getpwnam(member)
+        assert res == NssReturnCode.NOTFOUND
+
+
+def ghost_and_member_test(pw_ops, grp_ops, reverse):
+    user_and_group_setup(pw_ops,
+                         grp_ops,
+                         [USER1],
+                         [GROUP12],
+                         reverse)
+    check_group(GROUP12)
+
+    # We checked that the group added has the same members as group12,
+    # so both user1 and user2. Now check that user1 is a member of
+    # group12 and its own primary GID but user2 doesn't exist, it's
+    # just a ghost entry
+    res, groups = sssd_id_sync('user1')
+    assert res == sssd_id.NssReturnCode.SUCCESS
+    assert len(groups) == 2
+    assert 'group12' in groups
+
+    res, _ = call_sssd_getpwnam('user2')
+    assert res == NssReturnCode.NOTFOUND
+
+
+def test_getgrnam_user_ghost_and_member(setup_pw_with_canary,
+                                        setup_gr_with_canary,
+                                        files_domain_only):
+    """
+    Test that a group with one member and one ghost.
+    """
+    ghost_and_member_test(setup_pw_with_canary,
+                          setup_gr_with_canary,
+                          False)
+
+
+def test_getgrnam_user_member_and_ghost(setup_pw_with_canary,
+                                        setup_gr_with_canary,
+                                        files_domain_only):
+    """
+    Test that a group with one member and one ghost, adding the group
+    first and then linking the member
+    """
+    ghost_and_member_test(setup_pw_with_canary,
+                          setup_gr_with_canary,
+                          True)
+
+
+def test_getgrnam_add_remove_members(setup_pw_with_canary,
+                                     add_group_nomem_with_canary,
+                                     files_domain_only):
+    """
+    Test that a user is linked with a group
+    """
+    pwd_ops = setup_pw_with_canary
+
+    check_group(GROUP_NOMEM)
+
+    for usr in [USER1, USER2]:
+        pwd_ops.useradd(**usr)
+
+    modgroup = dict(GROUP_NOMEM)
+    modgroup['mem'] = ['user1', 'user2']
+    add_group_nomem_with_canary.groupmod(old_name=modgroup['name'], **modgroup)
+    check_group(modgroup)
+
+    res, groups = sssd_id_sync('user1')
+    assert res == sssd_id.NssReturnCode.SUCCESS
+    assert len(groups) == 2
+    assert 'group_nomem' in groups
+
+    res, groups = sssd_id_sync('user2')
+    assert res == sssd_id.NssReturnCode.SUCCESS
+    assert 'group_nomem' in groups
+
+    modgroup['mem'] = ['user2']
+    add_group_nomem_with_canary.groupmod(old_name=modgroup['name'], **modgroup)
+    check_group(modgroup)
+
+    # User1 exists, but is not a member of any supplementary group anymore
+    res, _ = call_sssd_getpwnam('user1')
+    assert res == sssd_id.NssReturnCode.SUCCESS
+    res, groups = sssd_id_sync('user1')
+    assert res == sssd_id.NssReturnCode.NOTFOUND
+
+    # user2 still is
+    res, groups = sssd_id_sync('user2')
+    assert res == sssd_id.NssReturnCode.SUCCESS
+    assert len(groups) == 2
+    assert 'group_nomem' in groups
+
+
+def test_getgrnam_add_remove_ghosts(setup_pw_with_canary,
+                                    add_group_nomem_with_canary,
+                                    files_domain_only):
+    """
+    Test that a user is linked with a group
+    """
+    pwd_ops = setup_pw_with_canary
+
+    check_group(GROUP_NOMEM)
+
+    modgroup = dict(GROUP_NOMEM)
+    modgroup['mem'] = ['user1', 'user2']
+    add_group_nomem_with_canary.groupmod(old_name=modgroup['name'], **modgroup)
+    check_group(modgroup)
+
+    modgroup['mem'] = ['user2']
+    add_group_nomem_with_canary.groupmod(old_name=modgroup['name'], **modgroup)
+    check_group(modgroup)
+
+    res, _ = call_sssd_getpwnam('user1')
+    assert res == NssReturnCode.NOTFOUND
+    res, _ = call_sssd_getpwnam('user2')
+    assert res == NssReturnCode.NOTFOUND
+
+    # Add this user and verify it's been added as a member
+    pwd_ops.useradd(**USER2)
+    res, groups = sssd_id_sync('user2')
+    assert res == sssd_id.NssReturnCode.SUCCESS
+    assert len(groups) == 2
+    assert 'group_nomem' in groups

--- a/src/tests/intg/util.py
+++ b/src/tests/intg/util.py
@@ -21,6 +21,7 @@ import re
 import os
 import subprocess
 import config
+import shutil
 
 UNINDENT_RE = re.compile("^ +", re.MULTILINE)
 
@@ -64,3 +65,16 @@ def first_dir(*args):
     for arg in args:
         if os.path.isdir(arg):
             return arg
+
+
+def backup_envvar_file(name):
+    path = os.environ[name]
+    backup_path = path + ".bak"
+    shutil.copyfile(path, backup_path)
+    return path
+
+
+def restore_envvar_file(name):
+    path = os.environ[name]
+    backup_path = path + ".bak"
+    os.rename(backup_path, path)

--- a/src/util/domain_info_utils.c
+++ b/src/util/domain_info_utils.c
@@ -814,8 +814,25 @@ done:
     return ret;
 }
 
+static const char *domain_state_str(struct sss_domain_info *dom)
+{
+    switch (dom->state) {
+    case DOM_ACTIVE:
+        return "Active";
+    case DOM_DISABLED:
+        return "Disabled";
+    case DOM_INACTIVE:
+        return "Inactive";
+    case DOM_INCONSISTENT:
+        return "Inconsistent";
+    }
+    return "Unknown";
+}
+
 enum sss_domain_state sss_domain_get_state(struct sss_domain_info *dom)
 {
+    DEBUG(SSSDBG_TRACE_LIBS,
+          "Domain %s is %s\n", dom->name, domain_state_str(dom));
     return dom->state;
 }
 
@@ -823,6 +840,8 @@ void sss_domain_set_state(struct sss_domain_info *dom,
                           enum sss_domain_state state)
 {
     dom->state = state;
+    DEBUG(SSSDBG_TRACE_LIBS,
+          "Domain %s is %s\n", dom->name, domain_state_str(dom));
 }
 
 bool is_email_from_domain(const char *email, struct sss_domain_info *dom)

--- a/src/util/inotify.c
+++ b/src/util/inotify.c
@@ -1,0 +1,562 @@
+/*
+    Copyright (C) 2016 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <talloc.h>
+#include <errno.h>
+#include <libgen.h>
+#include <sys/inotify.h>
+#include <sys/time.h>
+
+#include "util/inotify.h"
+#include "util/util.h"
+
+/* For parent directories, we want to know if a file was moved there or
+ * created there
+ */
+#define PARENT_DIR_MASK (IN_CREATE | IN_MOVED_TO)
+
+/* This structure is recreated if we need to rewatch the file and/or
+ * directory
+ */
+struct snotify_watch_ctx {
+    int inotify_fd;             /* The inotify_fd */
+    struct tevent_fd *tfd;      /* Activity on the fd */
+
+    struct snotify_ctx *snctx;  /* Pointer up to the main snotify struct */
+
+    /* In case we're also watching the parent directory, otherwise -1.
+     * We keep the variable here and not in snctx so that we're able
+     * to catch even changes to the parent directory
+     */
+    int dir_wd;
+    /* The file watch */
+    int file_wd;
+};
+
+/* This is what we call when an event we're interested in arrives */
+struct snotify_cb_ctx {
+    snotify_cb_fn fn;
+    const char *fn_name;
+    uint32_t mask;
+    void *pvt;
+};
+
+/* One instance of a callback. We hoard the inotify notifications
+ * until timer fires in caught_flags
+ */
+struct snotify_dispatcher {
+    struct tevent_timer *te;
+    uint32_t caught_flags;
+};
+
+struct snotify_ctx {
+    struct tevent_context *ev;
+
+    /* The full path of the file we're watching,
+     * its file and directory components */
+    const char *filename;
+    const char *dir_name;
+    const char *base_name;
+
+    /* Private pointer passed to the callback */
+    struct snotify_cb_ctx cb;
+    /* A singleton callback dispatcher */
+    struct snotify_dispatcher *disp;
+
+    /* Internal snotify flags */
+    uint16_t snotify_flags;
+    /* The caller might decide to batch the updates and receive
+     * them all together with a delay
+     */
+    struct timeval delay;
+    /* We keep the structure that actually does the work
+     * separately to be able to reinitialize it when the
+     * file is recrated or moved to the directory
+     */
+    struct snotify_watch_ctx *wctx;
+};
+
+struct flg2str {
+    uint32_t flg;
+    const char *str;
+} flg_table[] = {
+    { 0x00000001, "IN_ACCESS" },
+    { 0x00000002, "IN_MODIFY" },
+    { 0x00000004, "IN_ATTRIB" },
+    { 0x00000008, "IN_CLOSE_WRITE" },
+    { 0x00000010, "IN_CLOSE_NOWRITE" },
+    { 0x00000020, "IN_OPEN" },
+    { 0x00000040, "IN_MOVED_FROM" },
+    { 0x00000080, "IN_MOVED_TO" },
+    { 0x00000100, "IN_CREATE" },
+    { 0x00000200, "IN_DELETE" },
+    { 0x00000400, "IN_DELETE_SELF" },
+    { 0x00000800, "IN_MOVE_SELF" },
+    { 0x00002000, "IN_UNMOUNT" },
+    { 0x00004000, "IN_Q_OVERFLOW" },
+    { 0x00008000, "IN_IGNORED" },
+    { 0x01000000, "IN_ONLYDIR" },
+    { 0x02000000, "IN_DONT_FOLLOW" },
+    { 0x04000000, "IN_EXCL_UNLINK" },
+    { 0x20000000, "IN_MASK_ADD" },
+    { 0x40000000, "IN_ISDIR" },
+    { 0x80000000, "IN_ONESHOT" },
+    { 0, NULL },
+};
+
+#if 0
+static void debug_flags(uint32_t flags, const char *file)
+{
+    char msgbuf[1024];
+    size_t total = 0;
+
+    if (!DEBUG_IS_SET(SSSDBG_TRACE_LIBS)) {
+        return;
+    }
+
+    for (int i = 0; flg_table[i].flg != 0; i++) {
+        if (flags & flg_table[i].flg) {
+            total += snprintf(msgbuf+total,
+                              sizeof(msgbuf)-total,
+                              "%s ", flg_table[i].str);
+        }
+    }
+
+    if (total == 0) {
+            snprintf(msgbuf, sizeof(msgbuf), "NONE\n");
+    }
+    DEBUG(SSSDBG_TRACE_LIBS, "Inotify event: %s on %s\n", msgbuf, file);
+}
+#endif
+
+static void snotify_process_callbacks(struct tevent_context *ev,
+                                      struct tevent_timer *te,
+                                      struct timeval t,
+                                      void *ptr)
+{
+    struct snotify_ctx *snctx;
+
+    snctx = talloc_get_type(ptr, struct snotify_ctx);
+    if (snctx == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Bad pointer\n");
+        return;
+    }
+
+    snctx->cb.fn(snctx->filename,
+                 snctx->disp->caught_flags,
+                 snctx->cb.pvt);
+
+    talloc_zfree(snctx->disp);
+}
+
+static struct snotify_dispatcher *create_dispatcher(struct snotify_ctx *snctx)
+{
+    struct snotify_dispatcher *disp;
+    struct timeval tv;
+
+    disp = talloc_zero(snctx, struct snotify_dispatcher);
+    if (disp == NULL) {
+        return NULL;
+    }
+
+    gettimeofday(&tv, NULL);
+    tv.tv_sec += snctx->delay.tv_sec;
+    tv.tv_usec += snctx->delay.tv_usec;
+
+    DEBUG(SSSDBG_TRACE_FUNC,
+          "Running a timer with delay %ld.%ld\n",
+          (unsigned long) snctx->delay.tv_sec,
+          (unsigned long) snctx->delay.tv_usec);
+
+    disp->te = tevent_add_timer(snctx->ev, disp, tv,
+                                snotify_process_callbacks,
+                                snctx);
+    if (disp->te == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to queue file update!\n");
+        talloc_free(disp);
+        return NULL;
+    }
+
+    return disp;
+}
+
+static struct snotify_dispatcher *get_dispatcher(struct snotify_ctx *snctx)
+{
+    if (snctx->disp != NULL) {
+        DEBUG(SSSDBG_TRACE_INTERNAL, "Reusing existing dispatcher\n");
+        return snctx->disp;
+    }
+
+    return create_dispatcher(snctx);
+}
+
+static errno_t dispatch_event(struct snotify_ctx *snctx,
+                              uint32_t ev_flags)
+{
+    struct snotify_dispatcher *disp;
+
+    if ((snctx->cb.mask & ev_flags) == 0) {
+        return EOK;
+    }
+
+    disp = get_dispatcher(snctx);
+    if (disp == NULL) {
+        return ENOMEM;
+    }
+
+    disp->caught_flags |= ev_flags;
+    DEBUG(SSSDBG_TRACE_FUNC,
+          "Dispatched an event with combined flags 0x%X\n",
+          disp->caught_flags);
+
+    snctx->disp = disp;
+    return EOK;
+}
+
+static errno_t process_dir_event(struct snotify_ctx *snctx,
+                                 const struct inotify_event *in_event)
+{
+    errno_t ret;
+
+    DEBUG(SSSDBG_TRACE_ALL, "inotify name: %s\n", in_event->name);
+    if (in_event->len == 0 \
+            || strcmp(in_event->name, snctx->base_name) != 0) {
+        DEBUG(SSSDBG_TRACE_FUNC, "Not interested in %s\n", in_event->name);
+        return EOK;
+    }
+
+    DEBUG(SSSDBG_TRACE_FUNC,
+          "received notification for watched file [%s] under %s\n",
+          in_event->name, snctx->dir_name);
+
+    /* file the event for the file to see if the caller is interested in it */
+    ret = dispatch_event(snctx, in_event->mask);
+    if (ret == EOK) {
+        /* Tells the outer loop to re-initialize flags once the loop is finished.
+         * However, finish reading all the events first to make sure we don't
+         * miss any
+         */
+        return EAGAIN;
+    }
+
+    return ret;
+}
+
+static errno_t process_file_event(struct snotify_ctx *snctx,
+                                  const struct inotify_event *in_event)
+{
+    if (in_event->mask & IN_IGNORED) {
+        DEBUG(SSSDBG_TRACE_FUNC,
+              "Will reopen moved or deleted file %s\n", snctx->filename);
+        /* Notify caller of the event, don't quit */
+        return EAGAIN;
+    }
+
+    DEBUG(SSSDBG_TRACE_FUNC,
+          "received notification for watched file %s\n", snctx->filename);
+
+    return dispatch_event(snctx, in_event->mask);
+}
+
+static errno_t snotify_rewatch(struct snotify_ctx *snctx);
+
+static void snotify_internal_cb(struct tevent_context *ev,
+                                struct tevent_fd *fde,
+                                uint16_t flags,
+                                void *data)
+{
+    char ev_buf[sizeof(struct inotify_event) + PATH_MAX];
+    const char *ptr;
+    const struct inotify_event *in_event;
+    struct snotify_ctx *snctx;
+    ssize_t len;
+    errno_t ret;
+    bool rewatch;
+
+    snctx = talloc_get_type(data, struct snotify_ctx);
+    if (snctx == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Bad pointer\n");
+        return;
+    }
+
+    while (1) {
+        len = read(snctx->wctx->inotify_fd, ev_buf, sizeof(ev_buf));
+        if (len == -1) {
+            ret = errno;
+            if (ret != EAGAIN) {
+                DEBUG(SSSDBG_OP_FAILURE,
+                      "Cannot read inotify_event [%d]: %s\n",
+                      ret, strerror(ret));
+            } else {
+                DEBUG(SSSDBG_TRACE_INTERNAL, "All inotify events processed\n");
+            }
+            return;
+        }
+
+        if ((size_t) len < sizeof(struct inotify_event)) {
+            /* Did not even read the required amount of data, move on.. */
+            continue;
+        }
+
+        for (ptr = ev_buf;
+             ptr < ev_buf + len;
+             ptr += sizeof(struct inotify_event) + in_event->len) {
+
+            in_event = (const struct inotify_event *) ptr;
+
+            //debug_flags(in_event->mask, in_event->name);
+
+            if (snctx->wctx->dir_wd == in_event->wd) {
+                ret = process_dir_event(snctx, in_event);
+                if (ret == EAGAIN) {
+                    rewatch = true;
+                    /* Continue with the loop and read all the events from
+                     * this descriptor first, then rewatch when done
+                     */
+                } else if (ret != EOK) {
+                    DEBUG(SSSDBG_MINOR_FAILURE,
+                        "Failed to process inotify event\n");
+                    continue;
+                }
+            } else if (snctx->wctx->file_wd == in_event->wd) {
+                ret = process_file_event(snctx, in_event);
+                if (ret != EOK) {
+                    DEBUG(SSSDBG_MINOR_FAILURE,
+                        "Failed to process inotify event\n");
+                    continue;
+                }
+            } else {
+                DEBUG(SSSDBG_MINOR_FAILURE,
+                      "Uknown watch %d\n", in_event->wd);
+                ret = EOK;
+            }
+        }
+    }
+
+    if (rewatch) {
+        ret = snotify_rewatch(snctx);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "Failed to re-set watch");
+        }
+    }
+}
+
+static int watch_ctx_destructor(void *memptr)
+{
+    struct snotify_watch_ctx *wctx;
+
+    wctx = talloc_get_type(memptr, struct snotify_watch_ctx);
+    if (wctx == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Bad pointer\n");
+        return 1;
+    }
+
+    /* We don't need to close the watches explicitly. man 7 inotify says:
+     *   When all file descriptors referring to an inotify instance
+     *   have been closed (using close(2)), the underlying object
+     *   and its resources are freed for reuse by the kernel; all
+     *   associated watches are automatically freed.
+     */
+    if (wctx->inotify_fd != -1) {
+        DEBUG(SSSDBG_TRACE_INTERNAL,
+              "Closing inotify fd %d\n", wctx->inotify_fd);
+        close(wctx->inotify_fd);
+    }
+
+    return 0;
+}
+
+static errno_t copy_filenames(struct snotify_ctx *snctx,
+                              const char *filename)
+{
+    char *p;
+    char fcopy[PATH_MAX];
+
+    strncpy(fcopy, filename, sizeof(fcopy));
+    fcopy[PATH_MAX-1] = '\0';
+
+    p = dirname(fcopy);
+    if (p == NULL) {
+        return EIO;
+    }
+
+    snctx->dir_name = talloc_strdup(snctx, p);
+    if (snctx->dir_name == NULL) {
+        return ENOMEM;
+    }
+
+    strncpy(fcopy, filename, sizeof(fcopy));
+    fcopy[PATH_MAX-1] = '\0';
+
+    p = basename(fcopy);
+    if (p == NULL) {
+        return EIO;
+    }
+
+    snctx->base_name = talloc_strdup(snctx, p);
+    if (snctx->base_name == NULL) {
+        return ENOMEM;
+    }
+
+    snctx->filename = talloc_strdup(snctx, filename);
+    if (snctx->filename == NULL) {
+        return ENOMEM;
+    }
+
+    return EOK;
+}
+
+static struct snotify_watch_ctx *snotify_watch(struct snotify_ctx *snctx,
+                                               uint32_t mask)
+{
+    struct snotify_watch_ctx *wctx;
+    errno_t ret;
+
+    wctx = talloc_zero(snctx, struct snotify_watch_ctx);
+    if (wctx == NULL) {
+        return NULL;
+    }
+    wctx->inotify_fd = -1;
+    wctx->dir_wd = -1;
+    wctx->file_wd = -1;
+    wctx->snctx = snctx;
+    talloc_set_destructor((TALLOC_CTX *)wctx, watch_ctx_destructor);
+
+    wctx->inotify_fd = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
+    if (wctx->inotify_fd == -1) {
+        ret = errno;
+        DEBUG(SSSDBG_CRIT_FAILURE,
+               "inotify_init1 failed: %d: %s\n", ret, strerror(ret));
+        goto fail;
+    }
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Opened inotify fd %d\n", wctx->inotify_fd);
+
+    wctx->tfd = tevent_add_fd(snctx->ev, wctx, wctx->inotify_fd,
+                              TEVENT_FD_READ, snotify_internal_cb,
+                              snctx);
+    if (wctx->tfd == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Cannot add tevent fd watch for %s\n",
+              snctx->filename);
+        goto fail;
+    }
+
+    wctx->file_wd = inotify_add_watch(wctx->inotify_fd, snctx->filename, mask);
+    if (wctx->file_wd == -1) {
+        ret = errno;
+        if (ret != ENOENT || (!(snctx->snotify_flags & SNOTIFY_WATCH_DIR))) {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "inotify_add_watch failed [%d]: %s\n",
+                  ret, strerror(ret));
+            goto fail;
+        }
+    }
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Opened file watch %d\n", wctx->file_wd);
+
+    if (snctx->snotify_flags & SNOTIFY_WATCH_DIR) {
+        /* Create a watch for the parent directory. This is useful for cases
+         * where we start watching a file before it's created, but still want
+         * a notification when the file is moved in
+         */
+        wctx->dir_wd = inotify_add_watch(wctx->inotify_fd,
+                                         snctx->dir_name, PARENT_DIR_MASK);
+        if (wctx->dir_wd == -1) {
+            ret = errno;
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                "inotify_add_watch failed [%d]: %s\n",
+                ret, strerror(ret));
+            goto fail;
+        }
+        DEBUG(SSSDBG_TRACE_INTERNAL,
+              "Opened directory watch %d\n", wctx->dir_wd);
+    }
+
+    return wctx;
+
+fail:
+    talloc_free(wctx);
+    return NULL;
+}
+
+static errno_t snotify_rewatch(struct snotify_ctx *snctx)
+{
+    talloc_free(snctx->wctx);
+
+    snctx->wctx = snotify_watch(snctx, snctx->cb.mask);
+    if (snctx->wctx == NULL) {
+        return ENOMEM;
+    }
+
+    DEBUG(SSSDBG_TRACE_FUNC, "Recreated watch\n");
+    return EOK;
+}
+
+struct snotify_ctx *_snotify_create(TALLOC_CTX *mem_ctx,
+                                    struct tevent_context *ev,
+                                    uint16_t snotify_flags,
+                                    const char *filename,
+                                    struct timeval *delay,
+                                    uint32_t mask,
+                                    snotify_cb_fn fn,
+                                    const char *fn_name,
+                                    void *pvt)
+{
+    errno_t ret;
+    struct snotify_ctx *snctx;
+
+    snctx = talloc_zero(mem_ctx, struct snotify_ctx);
+    if (snctx == NULL) {
+        return NULL;
+    }
+
+    snctx->ev = ev;
+    snctx->snotify_flags = snotify_flags;
+    if (delay) {
+        snctx->delay.tv_sec = delay->tv_sec;
+        snctx->delay.tv_usec = delay->tv_usec;
+    }
+
+    snctx->cb.fn = fn;
+    snctx->cb.fn_name = fn_name;
+    snctx->cb.mask = mask;
+    snctx->cb.pvt = pvt;
+
+    ret = copy_filenames(snctx, filename);
+    if (ret != EOK) {
+        talloc_free(snctx);
+        return NULL;
+    }
+
+    snctx->wctx = snotify_watch(snctx, mask);
+    if (snctx->wctx == NULL) {
+        talloc_free(snctx);
+        return NULL;
+    }
+
+    DEBUG(SSSDBG_TRACE_FUNC,
+          "Added a watch for %s with inotify flags 0x%X "
+          "internal flags 0x%X "
+          "using function %s after delay %ld.%ld\n",
+          snctx->filename,
+          mask,
+          snotify_flags,
+          fn_name,
+          (unsigned long) snctx->delay.tv_sec,
+          (unsigned long) snctx->delay.tv_usec);
+
+    return snctx;
+}

--- a/src/util/inotify.h
+++ b/src/util/inotify.h
@@ -1,0 +1,61 @@
+/*
+    Copyright (C) 2016 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __INOTIFY_H_
+#define __INOTIFY_H_
+
+#include <talloc.h>
+#include <tevent.h>
+#include <sys/inotify.h>
+
+
+typedef int (*snotify_cb_fn)(const char *filename,
+                             uint32_t caught_flags,
+                             void *pvt);
+
+#define SNOTIFY_WATCH_DIR   0x0001
+
+/*
+ * Set up an inotify watch for file at filename. When an inotify
+ * event is caught, it must match the "mask" parameter. The watch
+ * would then call snotify_cb_fn() and include the caught flags.
+ *
+ * If snotify_flags includes SNOTIFY_WATCH_DIR, also the parent directory
+ * of this file would be watched to cover cases where the file might not
+ * exist when the watch is created.
+ *
+ * If you wish to batch inotify requests to avoid hammering the caller
+ * with several successive requests, use the delay parameter. The function
+ * would then only send invoke the callback after the delay and the caught
+ * flags would be OR-ed. By default, the callback is invoked immediately.
+ *
+ * Use the pvt parameter to pass a private context to the function
+ */
+struct snotify_ctx *_snotify_create(TALLOC_CTX *mem_ctx,
+                                    struct tevent_context *ev,
+                                    uint16_t snotify_flags,
+                                    const char *filename,
+                                    struct timeval *delay,
+                                    uint32_t mask,
+                                    snotify_cb_fn fn,
+                                    const char *fn_name,
+                                    void *pvt);
+
+#define snotify_create(mem_ctx, ev, snotify_flags, filename, delay, mask, fn, pvt) \
+        _snotify_create(mem_ctx, ev, snotify_flags, filename, delay, mask, fn, #fn, pvt);
+
+#endif /*  __INOTIFY_H_ */


### PR DESCRIPTION
This patch set implements a new provider that mirrors the contents of passwd and groups files. The intent is to make these users and groups available through the SSSD memory cache to improve performance and make it possible to read extended attributes via the sssd D-Bus interface.

As the next step, we will implement a writable D-Bus interface to make it possible to also manage local users with an API and supersede the AccountService API.

At the moment, the domain must be enabled explicitly. When this branch is merged, another commit would also enable the files domain for all installations by default.

In order to make the resolution precise, the files domain is disabled once an inotify notification arrives During testing, I realized there might be a delay between changing the UNIX files by replacing them and *receiving* the inotify notification. Therefore the tests add a sleep as well. That's not nice and I would be glad if the reviewer can spot how to speed up the inotify notification receiving.