### PR TITLE
Partially revert "CONFIG: Use default config when none provided"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -462,7 +462,6 @@ AM_CPPFLAGS = \
     -DSSSDDATADIR=\"$(sssddatadir)\" \
     -DSSSD_LIBEXEC_PATH=\"$(sssdlibexecdir)\" \
     -DSSSD_CONF_DIR=\"$(sssdconfdir)\" \
-    -DSSSD_DEFAULT_CONF_DIR=\"$(sssddefaultconfdir)\" \
     -DSSS_NSS_MCACHE_DIR=\"$(mcpath)\" \
     -DSSS_NSS_SOCKET_NAME=\"$(pipepath)/nss\" \
     -DSSS_PAM_SOCKET_NAME=\"$(pipepath)/pam\" \
@@ -1232,8 +1231,6 @@ sssd_SOURCES = \
     src/confdb/confdb_setup.c \
     src/monitor/monitor_iface_generated.c \
     src/util/nscd.c \
-    src/tools/files.c \
-    src/tools/selinux.c \
     $(NULL)
 sssd_LDADD = \
     $(SSSD_LIBS) \

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -40,7 +40,6 @@
 
 #define CONFDB_DEFAULT_CFG_FILE_VER 2
 #define CONFDB_FILE "config.ldb"
-#define SSSD_DEFAULT_CONFIG_FILE SSSD_DEFAULT_CONF_DIR"/sssd.conf"
 #define SSSD_CONFIG_FILE SSSD_CONF_DIR"/sssd.conf"
 #define CONFDB_DEFAULT_CONFIG_DIR SSSD_CONF_DIR"/conf.d"
 #define SSSD_MIN_ID 1


### PR DESCRIPTION
This reverts part of commit 59744cff6edb106ae799b2321cb8731edadf409a.

Removed is copying of default configuration into /etc/sssd/sssd.conf
Sample configurations is still part of installation.

Copying default configuration from /usr/lib64/sssd/conf/sssd.conf -> /etc/sssd/sssd.conf
is not the best idea. There are better way how to use default configuration
and we will need to change anyway due to files provider.

I can revert sample configuration as well.
