### PR TITLE
Add more DEBUG messages to help admins diagnose Kerberos login failures

### DIFF
--- a/src/providers/krb5/krb5_auth.c
+++ b/src/providers/krb5/krb5_auth.c
@@ -1023,6 +1023,9 @@ static void krb5_auth_done(struct tevent_req *subreq)
         goto done;
 
     default:
+        DEBUG(SSSDBG_IMPORTANT_INFO,
+              "The krb5_child process returned an error. Please inspect the "
+              "krb5_child.log file or the journal for more information\n");
         state->pam_status = PAM_SYSTEM_ERR;
         state->dp_err = DP_ERR_OK;
         ret = EOK;


### PR DESCRIPTION
This PR contains two trivial (code-wise) patches that just add one DEBUG
message each. It's quite common for admins to get stuck diagnosing issues
where the krb5_child process exists with system error. Moreover, many
system errors are caused by issues during Kerberos ticket validation where
the second patch tries to help to give some tips.

I hope the first patch should be OK to merge. With the second one, I was
struggling a bit to find some useful debug message. If anyone can think
about a better one, I'm all ears. Also, if the DEBUG message would be too
misleading in the general case, I'm equally fine with dropping the second
patch. At least the first one would help to avoid admins asking for help if all
we would tell them is to go and look into the krb5_child.log anyway -- so IMO it
makes sense to just put that info to a debug message.