### PR TITLE
sss_ptr_hash_delete_all: use unsigned long int

### DIFF
--- a/src/util/sss_ptr_hash.c
+++ b/src/util/sss_ptr_hash.c
@@ -332,8 +332,8 @@ void sss_ptr_hash_delete_all(hash_table_t *table,
 {
     struct sss_ptr_hash_value *value;
     hash_value_t *values;
-    size_t count;
-    size_t i;
+    unsigned long count;
+    unsigned long i;
     int hret;
     void *ptr;
 


### PR DESCRIPTION
hash_values() expects a pointer to unsigned long int as second
argument. Using size_t instead causes a 'from incompatible pointer type'
compiler error on e.g. 32bit platforms because size_t is 32bits here
while unsigned long int is 64bits.