### PR TITLE
intg: Generate tmp dir with lowercase

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3103,7 +3103,9 @@ intgcheck-prepare:
 	rm -Rf intg; \
 	$(MKDIR_P) intg/bld; \
 	: Use /hopefully/ short prefix to keep D-Bus socket path short; \
-	prefix=`mktemp --tmpdir --directory sssd-intg.XXXXXXXX`; \
+	prefix=`mktemp --dry-run --tmpdir --directory sssd-intg.XXXXXXXX`; \
+	prefix=`echo $$prefix | tr '[:upper:]' '[:lower:]'`; \
+	mkdir -p $$prefix; \
 	$(LN_S) "$$prefix" intg/pfx; \
 	cd intg/bld; \
 	$(abs_top_srcdir)/configure \


### PR DESCRIPTION
This is a workaround for buggy python-requests 2.12.4.
It cannot handle uppercase letters in file path.

The manual page MKTEMP(1) says that the parameter --dry-run is unsafe.
It is not critical for our use-case in CI but we should revert the patch
after fixed version of puython-request will be released

The broken version of python-requests (2.12.4) is in fedora rawhide and debian testing +