### PR TITLE
Fix compilation with python3.6

### DIFF
--- a/src/python/pyhbac.c
+++ b/src/python/pyhbac.c
@@ -18,6 +18,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "config.h"
+
 #include <Python.h>
 #include <structmember.h>
 

--- a/src/python/pysss.c
+++ b/src/python/pysss.c
@@ -18,6 +18,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "config.h"
+
 #include <Python.h>
 #include <structmember.h>
 #include <talloc.h>

--- a/src/python/pysss_murmur.c
+++ b/src/python/pysss_murmur.c
@@ -18,9 +18,11 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <Python.h>
-#include "util/sss_python.h"
+#include "config.h"
 
+#include <Python.h>
+
+#include "util/sss_python.h"
 #include "util/murmurhash3.h"
 
 PyDoc_STRVAR(murmurhash3_doc,

--- a/src/python/pysss_nss_idmap.c
+++ b/src/python/pysss_nss_idmap.c
@@ -19,9 +19,11 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <Python.h>
-#include "util/sss_python.h"
+#include "config.h"
 
+#include <Python.h>
+
+#include "util/sss_python.h"
 #include "sss_client/idmap/sss_nss_idmap.h"
 
 #define SSS_NAME_KEY "name"

--- a/src/util/sss_python.c
+++ b/src/util/sss_python.c
@@ -19,7 +19,6 @@
 */
 
 #include "src/util/sss_python.h"
-#include "config.h"
 
 PyObject *
 sss_exception_with_doc(char *name, char *doc, PyObject *base, PyObject *dict)

--- a/src/util/sss_python.h
+++ b/src/util/sss_python.h
@@ -1,8 +1,11 @@
 #ifndef __SSS_PYTHON_H__
 #define __SSS_PYTHON_H__
 
+#include "config.h"
+
 #include <Python.h>
 #include <stdbool.h>
+
 #include "util/util.h"
 
 #if PY_VERSION_HEX < 0x02050000


### PR DESCRIPTION
Autotools does not generate defines in conditional way (ifndef .. define)
and therefore it might happen that "defines" in config.h migt redefine
some macros in different way and generate a warning.

e.g.
  In file included from /home/build/sssd/src/util/util.h:24:0,
                   from /home/build/sssd/src/python/pyhbac.c:24:
  ./config.h:322:0: error: "HAVE_LONG_LONG" redefined [-Werror]
   #define HAVE_LONG_LONG 1

  In file included from /usr/include/python3.6m/Python.h:50:0,
                   from /home/build/sssd/src/python/pyhbac.c:21:
  /usr/include/python3.6m/pyport.h:42:0: note: this is the location of the previous definition
   #define HAVE_LONG_LONG

We need to include config.h before Python.h to avoid redefinition of
HAVE_LONG_LONG which is definded conditionally in Python.h