### PR TITLE
Port integration tests to python3

### DIFF
--- a/src/tests/intg/ds_openldap.py
+++ b/src/tests/intg/ds_openldap.py
@@ -233,15 +233,15 @@ class DSOpenLDAP(DS):
         #
         modlist = [
             (ldap.MOD_DELETE, "olcObjectClasses",
-             "{7}( 2.5.6.9 NAME 'groupOfNames' "
-             "DESC 'RFC2256: a group of names (DNs)' SUP top "
-             "STRUCTURAL MUST ( member $ cn ) MAY ( businessCategory $ "
-             "seeAlso $ owner $ ou $ o $ description ) )"),
+             b"{7}( 2.5.6.9 NAME 'groupOfNames' "
+             b"DESC 'RFC2256: a group of names (DNs)' SUP top "
+             b"STRUCTURAL MUST ( member $ cn ) MAY ( businessCategory $ "
+             b"seeAlso $ owner $ ou $ o $ description ) )"),
             (ldap.MOD_ADD, "olcObjectClasses",
-             "{7}( 2.5.6.9 NAME 'groupOfNames' "
-             "DESC 'RFC2256: a group of names (DNs)' SUP top "
-             "STRUCTURAL MUST ( cn ) MAY ( member $ businessCategory $ "
-             "seeAlso $ owner $ ou $ o $ description ) )"),
+             b"{7}( 2.5.6.9 NAME 'groupOfNames' "
+             b"DESC 'RFC2256: a group of names (DNs)' SUP top "
+             b"STRUCTURAL MUST ( cn ) MAY ( member $ businessCategory $ "
+             b"seeAlso $ owner $ ou $ o $ description ) )"),
         ]
         ldap_conn = ldap.initialize(ldapi_url)
         ldap_conn.simple_bind_s(self.admin_rdn + ",cn=config", self.admin_pw)
@@ -254,15 +254,15 @@ class DSOpenLDAP(DS):
         ldap_conn = ldap.initialize(self.ldap_url)
         ldap_conn.simple_bind_s(self.admin_dn, self.admin_pw)
         ldap_conn.add_s(self.base_dn, [
-            ("objectClass", ["dcObject", "organization"]),
-            ("o", "Example Company"),
+            ("objectClass", [b"dcObject", b"organization"]),
+            ("o", b"Example Company"),
         ])
         ldap_conn.add_s("cn=Manager," + self.base_dn, [
-            ("objectClass", "organizationalRole"),
+            ("objectClass", b"organizationalRole"),
         ])
         for ou in ("Users", "Groups", "Netgroups", "Services", "Policies"):
             ldap_conn.add_s("ou=" + ou + "," + self.base_dn, [
-                ("objectClass", ["top", "organizationalUnit"]),
+                ("objectClass", [b"top", b"organizationalUnit"]),
             ])
         ldap_conn.unbind_s()
 

--- a/src/tests/intg/ds_openldap.py
+++ b/src/tests/intg/ds_openldap.py
@@ -19,7 +19,6 @@
 
 import hashlib
 import base64
-import urllib
 import time
 import ldap
 import os
@@ -29,6 +28,11 @@ import shutil
 import sys
 from util import *
 from ds import DS
+
+try:
+    from urllib import quote as url_quote
+except ImportError:
+    from urllib.parse import quote as url_quote
 
 
 def hash_password(password):
@@ -183,7 +187,7 @@ class DSOpenLDAP(DS):
     def setup(self):
         """Setup the instance."""
         ldapi_socket = self.run_dir + "/ldapi"
-        ldapi_url = "ldapi://" + urllib.quote(ldapi_socket, "")
+        ldapi_url = "ldapi://" + url_quote(ldapi_socket, "")
         url_list = ldapi_url + " " + self.ldap_url
 
         os.makedirs(self.conf_slapd_d_dir)

--- a/src/tests/intg/ds_openldap.py
+++ b/src/tests/intg/ds_openldap.py
@@ -166,7 +166,7 @@ class DSOpenLDAP(DS):
             ["slapadd", "-F", self.conf_slapd_d_dir, "-b", "cn=config"],
             stdin=subprocess.PIPE, close_fds=True
         )
-        slapadd.communicate(config)
+        slapadd.communicate(config.encode('utf-8'))
         if slapadd.returncode != 0:
             raise Exception("Failed to add configuration with slapadd")
 

--- a/src/tests/intg/ds_openldap.py
+++ b/src/tests/intg/ds_openldap.py
@@ -38,9 +38,10 @@ except ImportError:
 def hash_password(password):
     """Generate userPassword value for a password."""
     salt = os.urandom(4)
-    hash = hashlib.sha1(password)
+    hash = hashlib.sha1(password.encode('utf-8'))
     hash.update(salt)
-    return "{SSHA}" + base64.standard_b64encode(hash.digest() + salt)
+    hash_base64 = base64.standard_b64encode(hash.digest() + salt)
+    return "{SSHA}" + hash_base64.decode('utf-8')
 
 
 class DSOpenLDAP(DS):

--- a/src/tests/intg/ent.py
+++ b/src/tests/intg/ent.py
@@ -106,7 +106,7 @@ def _diff(ent, pattern, desc_map={}):
         if not isinstance(ent, dict):
             return "not a dict, " + str(type(ent))
 
-        for key, value in pattern.iteritems():
+        for key, value in pattern.items():
             item_name, item_map = _get_desc(desc_map, key)
             d = _diff(ent[key], value, item_map)
             if d:

--- a/src/tests/intg/ent.py
+++ b/src/tests/intg/ent.py
@@ -123,7 +123,7 @@ def _diff(ent, pattern, desc_map={}):
                 if not d:
                     pattern_matches[pi] += 1
 
-        unmatched_pattern = [pattern[pi] for pi in xrange(0, len(pattern))
+        unmatched_pattern = [pattern[pi] for pi in range(0, len(pattern))
                              if pattern_matches[pi] == 0]
 
         items = _get_desc(desc_map, None)[0] + "s"
@@ -144,9 +144,9 @@ def _diff(ent, pattern, desc_map={}):
                     pattern_matches[pi] += 1
                     ent_matches[ei] += 1
 
-        unmatched_pattern = [pattern[pi] for pi in xrange(0, len(pattern))
+        unmatched_pattern = [pattern[pi] for pi in range(0, len(pattern))
                              if pattern_matches[pi] == 0]
-        unmatched_ent = [ent[pi] for pi in xrange(0, len(ent))
+        unmatched_ent = [ent[pi] for pi in range(0, len(ent))
                          if ent_matches[pi] == 0]
 
         items = _get_desc(desc_map, None)[0] + "s"

--- a/src/tests/intg/ent.py
+++ b/src/tests/intg/ent.py
@@ -233,7 +233,7 @@ def get_passwd_list():
     for i, v in enumerate(passwd_list):
         if v.pw_name == "root" and v.pw_uid == 0 and v.pw_gid == 0:
             del passwd_list[i]
-            return map(_convert_passwd, passwd_list)
+            return list(map(_convert_passwd, passwd_list))
     raise Exception("no root user found")
 
 
@@ -393,7 +393,7 @@ def get_group_list():
     for i, v in enumerate(group_list):
         if v.gr_name == "root" and v.gr_gid == 0:
             del group_list[i]
-            return map(_convert_group, group_list)
+            return list(map(_convert_group, group_list))
     raise Exception("no root group found")
 
 

--- a/src/tests/intg/ldap_ent.py
+++ b/src/tests/intg/ldap_ent.py
@@ -28,53 +28,54 @@ def user(base_dn, uid, uidNumber, gidNumber,
     """
     Generate an RFC2307(bis) user add-modlist for passing to ldap.add*
     """
-    uidNumber = str(uidNumber)
-    gidNumber = str(gidNumber)
+    uidNumber = str(uidNumber).encode('utf-8')
+    gidNumber = str(gidNumber).encode('utf-8')
     user = (
         "uid=" + uid + ",ou=Users," + base_dn,
         [
-            ('objectClass', ['top', 'inetOrgPerson', 'posixAccount']),
-            ('cn', [uidNumber if cn is None else cn]),
-            ('sn', ['User' if sn is None else sn]),
+            ('objectClass', [b'top', b'inetOrgPerson', b'posixAccount']),
+            ('cn', [uidNumber if cn is None else cn.encode('utf-8')]),
+            ('sn', [b'User' if sn is None else sn.encode('utf-8')]),
             ('uidNumber', [uidNumber]),
             ('gidNumber', [gidNumber]),
-            ('userPassword', ['Password' + uidNumber
+            ('userPassword', [b'Password' + uidNumber
                               if userPassword is None
-                              else userPassword]),
-            ('homeDirectory', ['/home/' + uid
+                              else userPassword.encode('utf-8')]),
+            ('homeDirectory', [b'/home/' + uid.encode('utf-8')
                                if homeDirectory is None
-                               else homeDirectory]),
-            ('loginShell', ['/bin/bash'
+                               else homeDirectory.encode('utf-8')]),
+            ('loginShell', [b'/bin/bash'
                             if loginShell is None
-                            else loginShell]),
+                            else loginShell.encode('utf-8')]),
         ]
     )
     if gecos is not None:
-        user[1].append(('gecos', [gecos]))
+        user[1].append(('gecos', [gecos.encode('utf-8')]))
     return user
 
 
-def group(base_dn, cn, gidNumber, member_uids=[]):
+def group(base_dn, cn, gidNumber, member_uids=()):
     """
     Generate an RFC2307 group add-modlist for passing to ldap.add*.
     """
-    gidNumber = str(gidNumber)
+    gidNumber = str(gidNumber).encode('utf-8')
     attr_list = [
-        ('objectClass', ['top', 'posixGroup']),
+        ('objectClass', [b'top', b'posixGroup']),
         ('gidNumber', [gidNumber])
     ]
     if len(member_uids) > 0:
-        attr_list.append(('memberUid', member_uids))
+        mem_uids = [member.encode('utf-8') for member in member_uids]
+        attr_list.append(('memberUid', mem_uids))
     return ("cn=" + cn + ",ou=Groups," + base_dn, attr_list)
 
 
-def group_bis(base_dn, cn, gidNumber, member_uids=[], member_gids=[]):
+def group_bis(base_dn, cn, gidNumber, member_uids=(), member_gids=()):
     """
     Generate an RFC2307bis group add-modlist for passing to ldap.add*.
     """
-    gidNumber = str(gidNumber)
+    gidNumber = str(gidNumber).encode('utf-8')
     attr_list = [
-        ('objectClass', ['top', 'extensibleObject', 'groupOfNames']),
+        ('objectClass', [b'top', b'extensibleObject', b'groupOfNames']),
         ('gidNumber', [gidNumber])
     ]
     member_list = []
@@ -83,7 +84,8 @@ def group_bis(base_dn, cn, gidNumber, member_uids=[], member_gids=[]):
     for gid in member_gids:
         member_list.append("cn=" + gid + ",ou=Groups," + base_dn)
     if len(member_list) > 0:
-        attr_list.append(('member', member_list))
+        mem_list = [member.encode('utf-8') for member in member_list]
+        attr_list.append(('member', mem_list))
     return ("cn=" + cn + ",ou=Groups," + base_dn, attr_list)
 
 
@@ -92,11 +94,13 @@ def netgroup(base_dn, cn, triples=(), members=()):
     Generate an RFC2307bis netgroup add-modlist for passing to ldap.add*.
     """
     attr_list = [
-        ('objectClass', ['top', 'nisNetgroup'])
+        ('objectClass', [b'top', b'nisNetgroup'])
     ]
     if triples:
+        triples = [triple.encode('utf-8') for triple in triples]
         attr_list.append(('nisNetgroupTriple', triples))
     if members:
+        members = [member.encode('utf-8') for member in members]
         attr_list.append(('memberNisNetgroup', members))
     return ("cn=" + cn + ",ou=Netgroups," + base_dn, attr_list)
 

--- a/src/tests/intg/ldap_local_override_test.py
+++ b/src/tests/intg/ldap_local_override_test.py
@@ -586,11 +586,12 @@ def env_show_user_override(request, ldap_conn,
 
 def test_show_user_override(ldap_conn, env_show_user_override):
 
-    out = check_output(['sss_override', 'user-show', 'user1'])
+    out = check_output(['sss_override', 'user-show', 'user1']).decode('utf-8')
     assert out == "user1@LDAP:ov_user1:10010:20010:Overriden User 1:"\
                   "/home/ov/user1:/bin/ov_user1_shell:\n"
 
-    out = check_output(['sss_override', 'user-show', 'user2@LDAP'])
+    out = check_output(['sss_override', 'user-show',
+                        'user2@LDAP']).decode('utf-8')
     assert out == "user2@LDAP:ov_user2:10020:20020:Overriden User 2:"\
                   "/home/ov/user2:/bin/ov_user2_shell:\n"
 
@@ -612,7 +613,7 @@ def env_find_user_override(request, ldap_conn,
 
 def test_find_user_override(ldap_conn, env_find_user_override):
 
-    out = check_output(['sss_override', 'user-find'])
+    out = check_output(['sss_override', 'user-find']).decode('utf-8')
 
     # Expected override of users
     exp_usr_ovrd = ['user1@LDAP:ov_user1:10010:20010:Overriden User 1:'
@@ -624,7 +625,7 @@ def test_find_user_override(ldap_conn, env_find_user_override):
 
     out = check_output(['sss_override', 'user-find', '--domain=LDAP'])
 
-    assert set(out.splitlines()) == set(exp_usr_ovrd)
+    assert set(out.decode('utf-8').splitlines()) == set(exp_usr_ovrd)
 
     # Unexpected parameter is reported
     ret = subprocess.call(['sss_override', 'user-find', 'PARAM'])

--- a/src/tests/intg/sssd_id.py
+++ b/src/tests/intg/sssd_id.py
@@ -61,8 +61,8 @@ def call_sssd_initgroups(user, gid):
     limit = c_long(-1)
     errno = POINTER(c_int)(c_int(0))
 
-    res = func(c_char_p(user), c_uint32(gid), start, size, p_groups, limit,
-               errno)
+    res = func(c_char_p(user.encode('utf-8)')), c_uint32(gid), start, size,
+               p_groups, limit, errno)
 
     gids = []
     if res == NssReturnCode.SUCCESS:

--- a/src/tests/intg/sssd_ldb.py
+++ b/src/tests/intg/sssd_ldb.py
@@ -77,7 +77,6 @@ class SssdLdb(object):
     def get_entry_attr(self, cache_type, entry_type, name, domain, attr):
         dbconn = self._get_dbconn(cache_type)
         basedn = self._basedn(name, domain, entry_type)
-        print basedn
 
         res = dbconn.search(base=basedn, scope=ldb.SCOPE_BASE, attrs=[attr])
         if res.count != 1:

--- a/src/tests/intg/sssd_netgroup.py
+++ b/src/tests/intg/sssd_netgroup.py
@@ -73,7 +73,7 @@ class Netgrent(Structure):
 
 class NetgroupRetriever(object):
     def __init__(self, name):
-        self.name = name
+        self.name = name.encode('utf-8')
         self.needed_groups = []
         self.known_groups = []
         self.netgroups = []

--- a/src/tests/intg/sssd_netgroup.py
+++ b/src/tests/intg/sssd_netgroup.py
@@ -225,9 +225,10 @@ class NetgroupRetriever(object):
                     self.known_groups.append(nested_netgroup)
 
             if result_p[0].type == NetgroupType.TRIPLE_VAL:
-                result.append((result_p[0].val.triple.host,
-                               result_p[0].val.triple.user,
-                               result_p[0].val.triple.domain))
+                triple = result_p[0].val.triple
+                result.append((triple.host.decode('utf-8'),
+                               triple.user.decode('utf-8'),
+                               triple.domain.decode('utf-8')))
 
             res, errno, result_p = self._getnetgrent_r(result_p, buff,
                                                        buff_len)

--- a/src/tests/intg/test_enumeration.py
+++ b/src/tests/intg/test_enumeration.py
@@ -446,7 +446,7 @@ def test_add_remove_membership_rfc2307(ldap_conn, user_and_group_rfc2307):
     # Add user to group
     ent.assert_group_by_name("group", dict(mem=ent.contains_only()))
     ldap_conn.modify_s("cn=group,ou=Groups," + ldap_conn.ds_inst.base_dn,
-                       [(ldap.MOD_REPLACE, "memberUid", "user")])
+                       [(ldap.MOD_REPLACE, "memberUid", b"user")])
     time.sleep(INTERACTIVE_TIMEOUT)
     ent.assert_group_by_name("group", dict(mem=ent.contains_only("user")))
     # Remove user from group
@@ -462,19 +462,21 @@ def test_add_remove_membership_rfc2307_bis(ldap_conn,
     Test user and group membership addition and removal are reflected by SSSD,
     with RFC2307bis schema
     """
+    base_dn_bytes = ldap_conn.ds_inst.base_dn.encode('utf-8')
+
     time.sleep(INTERACTIVE_TIMEOUT/2)
     # Add user to group1
     ent.assert_group_by_name("group1", dict(mem=ent.contains_only()))
     ldap_conn.modify_s("cn=group1,ou=Groups," + ldap_conn.ds_inst.base_dn,
                        [(ldap.MOD_REPLACE, "member",
-                         "uid=user,ou=Users," + ldap_conn.ds_inst.base_dn)])
+                         b"uid=user,ou=Users," + base_dn_bytes)])
     time.sleep(INTERACTIVE_TIMEOUT)
     ent.assert_group_by_name("group1", dict(mem=ent.contains_only("user")))
 
     # Add group1 to group2
     ldap_conn.modify_s("cn=group2,ou=Groups," + ldap_conn.ds_inst.base_dn,
                        [(ldap.MOD_REPLACE, "member",
-                         "cn=group1,ou=Groups," + ldap_conn.ds_inst.base_dn)])
+                         b"cn=group1,ou=Groups," + base_dn_bytes)])
     time.sleep(INTERACTIVE_TIMEOUT)
     ent.assert_group_by_name("group2", dict(mem=ent.contains_only("user")))
 

--- a/src/tests/intg/test_ldap.py
+++ b/src/tests/intg/test_ldap.py
@@ -770,13 +770,13 @@ def test_extra_attribute_already_exists(ldap_conn, extra_attributes):
 
     user = 'user'
     extra_attribute = 'givenName'
-    given_name = 'unix_user'
+    given_name = b'unix_user'
 
     user_dn = "uid=" + user + ",ou=Users," + ldap_conn.ds_inst.base_dn
 
-    old = {'objectClass': ['top', 'inetOrgPerson', 'posixAccount']}
-    new = {'objectClass': ['top', 'inetOrgPerson', 'posixAccount',
-                           'extensibleObject']}
+    old = {'objectClass': [b'top', b'inetOrgPerson', b'posixAccount']}
+    new = {'objectClass': [b'top', b'inetOrgPerson', b'posixAccount',
+                           b'extensibleObject']}
     ldif = ldap.modlist.modifyModlist(old, new)
 
     ldap_conn.modify_s(user_dn, ldif)
@@ -848,9 +848,9 @@ def test_remove_user_from_group(ldap_conn, remove_user_from_group):
                              dict(mem=ent.contains_only("user1", "user2")))
 
     # removing of user2 from group1
-    old = {'member': ["uid=user1,ou=Users,dc=example,dc=com",
-                      "uid=user2,ou=Users,dc=example,dc=com"]}
-    new = {'member': ["uid=user1,ou=Users,dc=example,dc=com"]}
+    old = {'member': [b"uid=user1,ou=Users,dc=example,dc=com",
+                      b"uid=user2,ou=Users,dc=example,dc=com"]}
+    new = {'member': [b"uid=user1,ou=Users,dc=example,dc=com"]}
 
     ldif = ldap.modlist.modifyModlist(old, new)
     ldap_conn.modify_s(group1_dn, ldif)
@@ -863,7 +863,7 @@ def test_remove_user_from_group(ldap_conn, remove_user_from_group):
     ent.assert_group_by_name("group1", dict(mem=ent.contains_only("user1")))
 
     # removing of user1 from group1
-    old = {'member': ["uid=user1,ou=Users,dc=example,dc=com"]}
+    old = {'member': [b"uid=user1,ou=Users,dc=example,dc=com"]}
     new = {'member': []}
 
     ldif = ldap.modlist.modifyModlist(old, new)
@@ -912,9 +912,9 @@ def test_remove_user_from_nested_group(ldap_conn,
                                                         "user2")))
 
     # removing of group2 from group3
-    old = {'member': ["cn=group1,ou=Groups,dc=example,dc=com",
-                      "cn=group2,ou=Groups,dc=example,dc=com"]}
-    new = {'member': ["cn=group1,ou=Groups,dc=example,dc=com"]}
+    old = {'member': [b"cn=group1,ou=Groups,dc=example,dc=com",
+                      b"cn=group2,ou=Groups,dc=example,dc=com"]}
+    new = {'member': [b"cn=group1,ou=Groups,dc=example,dc=com"]}
 
     ldif = ldap.modlist.modifyModlist(old, new)
     ldap_conn.modify_s(group3_dn, ldif)
@@ -933,7 +933,7 @@ def test_remove_user_from_nested_group(ldap_conn,
                              dict(mem=ent.contains_only("user1")))
 
     # removing of group1 from group3
-    old = {'member': ["cn=group1,ou=Groups,dc=example,dc=com"]}
+    old = {'member': [b"cn=group1,ou=Groups,dc=example,dc=com"]}
     new = {'member': []}
 
     ldif = ldap.modlist.modifyModlist(old, new)

--- a/src/tests/intg/test_netgroup.py
+++ b/src/tests/intg/test_netgroup.py
@@ -426,8 +426,8 @@ def test_removing_nested_netgroups(removing_nested_netgroups, ldap_conn):
                                         ('host2', 'user2', 'domain2')])
 
     # removing of t2841_netgroup1 from t2841_netgroup3
-    old = {'memberNisNetgroup': ["t2841_netgroup1", "t2841_netgroup2"]}
-    new = {'memberNisNetgroup': ["t2841_netgroup2"]}
+    old = {'memberNisNetgroup': [b"t2841_netgroup1", b"t2841_netgroup2"]}
+    new = {'memberNisNetgroup': [b"t2841_netgroup2"]}
 
     ldif = ldap.modlist.modifyModlist(old, new)
     ldap_conn.modify_s(netgrp_dn, ldif)
@@ -448,7 +448,7 @@ def test_removing_nested_netgroups(removing_nested_netgroups, ldap_conn):
     assert netgroups == [('host2', 'user2', 'domain2')]
 
     # removing of t2841_netgroup2 from t2841_netgroup3
-    old = {'memberNisNetgroup': ["t2841_netgroup2"]}
+    old = {'memberNisNetgroup': [b"t2841_netgroup2"]}
     new = {'memberNisNetgroup': []}
 
     ldif = ldap.modlist.modifyModlist(old, new)

--- a/src/tests/intg/test_secrets.py
+++ b/src/tests/intg/test_secrets.py
@@ -145,7 +145,7 @@ def test_crd_ops(setup_for_secrets, secrets_cli):
     MAX_SECRETS = 10
 
     sec_value = "value"
-    for x in xrange(MAX_SECRETS):
+    for x in range(MAX_SECRETS):
         cli.set_secret(str(x), sec_value)
 
     with pytest.raises(HTTPError) as err507:
@@ -153,7 +153,7 @@ def test_crd_ops(setup_for_secrets, secrets_cli):
     assert str(err507.value).startswith("507")
 
     # Delete all stored secrets used for max secrets tests
-    for x in xrange(MAX_SECRETS):
+    for x in range(MAX_SECRETS):
         cli.del_secret(str(x))
 
     # Don't allow storing a secrets which has a payload larger
@@ -198,7 +198,7 @@ def test_containers(setup_for_secrets, secrets_cli):
     # Don't allow creating a container after reaching the max nested level
     DEFAULT_CONTAINERS_NEST_LEVEL = 4
     container = "mycontainer"
-    for x in xrange(DEFAULT_CONTAINERS_NEST_LEVEL):
+    for x in range(DEFAULT_CONTAINERS_NEST_LEVEL):
         container += "%s/" % str(x)
         cli.create_container(container)
 

--- a/src/tests/intg/test_sssctl.py
+++ b/src/tests/intg/test_sssctl.py
@@ -207,7 +207,7 @@ def get_call_output(cmd):
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
     output, ret = process.communicate()
-    return output
+    return output.decode('utf-8')
 
 
 def test_user_show_basic_sanity(ldap_conn, sanity_rfc2307, portable_LC_ALL):

--- a/src/tests/intg/test_ts_cache.py
+++ b/src/tests/intg/test_ts_cache.py
@@ -319,7 +319,7 @@ def test_group_2307bis_update_same_attrs(ldap_conn,
     # modifyTimestamp attribute, but the attributes themselves will be the same
     # from sssd's point of view
     ldap_conn.modify_s("cn=group1,ou=Groups," + ldap_conn.ds_inst.base_dn,
-                       [(ldap.MOD_ADD, "description", "group one")])
+                       [(ldap.MOD_ADD, "description", b"group one")])
     # wait for slapd to change its database
     time.sleep(1)
 
@@ -348,9 +348,10 @@ def test_group_2307bis_update_diff_attrs(ldap_conn,
                                                 ldb_conn, "group1",
                                                 ("user1", "user11", "user21"))
 
+    user_dn = b"uid=user1,ou=Users," + \
+              ldap_conn.ds_inst.base_dn.encode('utf-8')
     ldap_conn.modify_s("cn=group1,ou=Groups," + ldap_conn.ds_inst.base_dn,
-                       [(ldap.MOD_DELETE, "member",
-                         "uid=user1,ou=Users," + ldap_conn.ds_inst.base_dn)])
+                       [(ldap.MOD_DELETE, "member", user_dn)])
     # wait for slapd to change its database
     time.sleep(1)
 
@@ -437,7 +438,7 @@ def test_group_2307_update_same_attrs(ldap_conn,
     # modifyTimestamp attribute, but the attributes themselves will be the same
     # from sssd's point of view
     ldap_conn.modify_s("cn=group1,ou=Groups," + ldap_conn.ds_inst.base_dn,
-                       [(ldap.MOD_ADD, "description", "group one")])
+                       [(ldap.MOD_ADD, "description", b"group one")])
     # wait for slapd to change its database
     time.sleep(1)
 
@@ -467,7 +468,7 @@ def test_group_2307_update_diff_attrs(ldap_conn,
                                                 ("user1", "user11", "user21"))
 
     ldap_conn.modify_s("cn=group1,ou=Groups," + ldap_conn.ds_inst.base_dn,
-                       [(ldap.MOD_DELETE, "memberUid", "user1")])
+                       [(ldap.MOD_DELETE, "memberUid", b"user1")])
     # wait for slapd to change its database
     time.sleep(1)
 
@@ -548,7 +549,7 @@ def test_user_update_same_attrs(ldap_conn,
     # modifyTimestamp attribute, but the attributes themselves will be the same
     # from sssd's point of view
     ldap_conn.modify_s("uid=user1,ou=Users," + ldap_conn.ds_inst.base_dn,
-                       [(ldap.MOD_ADD, "description", "user one")])
+                       [(ldap.MOD_ADD, "description", b"user one")])
     # wait for slapd to change its database
     time.sleep(1)
 
@@ -578,7 +579,7 @@ def test_user_update_diff_attrs(ldap_conn,
     # modifyTimestamp attribute, but the attributes themselves will be the same
     # from sssd's point of view
     ldap_conn.modify_s("uid=user1,ou=Users," + ldap_conn.ds_inst.base_dn,
-                       [(ldap.MOD_REPLACE, "loginShell", "/bin/zsh")])
+                       [(ldap.MOD_REPLACE, "loginShell", b"/bin/zsh")])
     # wait for slapd to change its database
     time.sleep(1)
 


### PR DESCRIPTION
Attached patches fixed python 2/3 compatibility of integration tests.

You will need to install following packages in fedora: python3-ldb, python3-pyldap, python3-requests
And for testing purposes you can use 
```
   make intgcheck-run PYTHON2=/usr/bin/python2
   make intgcheck-run PYTHON2=/usr/bin/python3
```
I will need to figure out how to incorporate it into CI script.