### PR TITLE
Fix a segfault in IFP's GetUserAttr

### DIFF
--- a/src/responder/ifp/ifpsrv_cmd.c
+++ b/src/responder/ifp/ifpsrv_cmd.c
@@ -537,6 +537,7 @@ static void ifp_user_get_attr_done(struct tevent_req *subreq)
     }
 
     state->res = talloc_steal(state, result->ldb_result);
+    state->dom = result->domain;
     talloc_zfree(result);
 
     fqdn = sss_create_internal_fqname(state, state->inp_name,


### PR DESCRIPTION
This PR fixes a crash in GetUserAttr. To reproduce, it's enough to:
dbus-send --print-reply --system --dest=org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe org.freedesktop.sssd.infopipe.GetUserAttr string:admin array:string:name