### PR TITLE
Add "Wants=" to sssd unit

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4880,6 +4880,7 @@ endif
 init_SCRIPTS =
 systemdunit_DATA =
 systemdconf_DATA =
+sssd_dependent_services =
 if HAVE_SYSTEMD_UNIT
     systemdunit_DATA += \
         src/sysv/systemd/sssd.service \
@@ -4889,11 +4890,15 @@ if HAVE_SYSTEMD_UNIT
         src/sysv/systemd/sssd-pam-priv.socket \
         src/sysv/systemd/sssd-pam.service \
         $(NULL)
+
+sssd_dependent_services += sssd-nss.socket sssd-pam.socket
 if BUILD_AUTOFS
     systemdunit_DATA += \
         src/sysv/systemd/sssd-autofs.socket \
         src/sysv/systemd/sssd-autofs.service \
         $(NULL)
+
+sssd_dependent_services += sssd-autofs.socket
 endif
 if BUILD_IFP
     systemdunit_DATA += \
@@ -4905,6 +4910,8 @@ if BUILD_PAC_RESPONDER
         src/sysv/systemd/sssd-pac.socket \
         src/sysv/systemd/sssd-pac.service \
         $(NULL)
+
+sssd_dependent_services += sssd-pac.socket
 endif
 if BUILD_SECRETS
     systemdunit_DATA += \
@@ -4917,12 +4924,16 @@ if BUILD_SSH
         src/sysv/systemd/sssd-ssh.socket \
         src/sysv/systemd/sssd-ssh.service \
         $(NULL)
+
+sssd_dependent_services += sssd-ssh.socket
 endif
 if BUILD_SUDO
     systemdunit_DATA += \
         src/sysv/systemd/sssd-sudo.socket \
         src/sysv/systemd/sssd-sudo.service \
         $(NULL)
+
+sssd_dependent_services += sssd-sudo.socket
 endif
 if BUILD_KCM
     systemdunit_DATA += \
@@ -4969,7 +4980,8 @@ edit_cmd = $(SED) \
         -e 's|@libexecdir[@]|$(libexecdir)|g' \
         -e 's|@pipepath[@]|$(pipepath)|g' \
         -e 's|@prefix[@]|$(prefix)|g' \
-        -e 's|@SSSD_USER[@]|$(SSSD_USER)|g'
+        -e 's|@SSSD_USER[@]|$(SSSD_USER)|g' \
+        -e 's|@sssd_dependent_services[@]|${sssd_dependent_services}|g'
 
 replace_script = \
     @rm -f $@ $@.tmp; \

--- a/src/man/sssd-sudo.5.xml
+++ b/src/man/sssd-sudo.5.xml
@@ -110,8 +110,7 @@ ldap_sudo_search_base = ou=sudoers,dc=example,dc=com
             <phrase condition="have_systemd">
                 It's important to note that on platforms where systemd is supported
                 there's no need to add the "sudo" provider to the list of services,
-                as it became optional. However, sssd-sudo.socket must be enabled
-                instead.
+                as it became optional.
             </phrase>
         </para>
         <para>

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -220,9 +220,15 @@
                             </para>
                             <para>
                                 <phrase condition="have_systemd">
-                                    By default, all services are disabled and the administrator
-                                    must enable the ones allowed to be used by executing:
-                                    "systemctl enable sssd-@service@.socket".
+                                    By default, the following services are enabled: nss, pam
+                                    <phrase condition="with_sudo">, sudo</phrase>
+                                    <phrase condition="with_autofs">, autofs</phrase>
+                                    <phrase condition="with_ssh">, ssh</phrase>
+                                    <phrase condition="with_pac_responder">, pac</phrase>
+                                    <phrase condition="with_ifp">, ifp</phrase>
+                                    In case the Administrator wants to persistently disable
+                                    one of them, it can be done by running:
+                                    "systemctl mask sssd-@service@.socket"
                                 </phrase>
                             </para>
                         </listitem>

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -779,77 +779,6 @@ static int check_local_domain_unique(struct sss_domain_info *domains)
     return EOK;
 }
 
-static errno_t add_implicit_services(struct confdb_ctx *cdb, TALLOC_CTX *mem_ctx,
-                                     char ***_services)
-{
-    int ret;
-    char **domain_names;
-    TALLOC_CTX *tmp_ctx;
-    size_t c;
-    char *conf_path;
-    char *id_provider;
-    bool add_pac = false;
-
-    tmp_ctx = talloc_new(NULL);
-    if (tmp_ctx == NULL) {
-        DEBUG(SSSDBG_OP_FAILURE, "talloc_new failed.\n");
-        return ENOMEM;
-    }
-
-    ret = confdb_get_string_as_list(cdb, tmp_ctx,
-                                    CONFDB_MONITOR_CONF_ENTRY,
-                                    CONFDB_MONITOR_ACTIVE_DOMAINS,
-                                    &domain_names);
-    if (ret == ENOENT) {
-        DEBUG(SSSDBG_OP_FAILURE, "No domains configured!\n");
-        goto done;
-    }
-
-    for (c = 0; domain_names[c] != NULL; c++) {
-        conf_path = talloc_asprintf(tmp_ctx, CONFDB_DOMAIN_PATH_TMPL,
-                                    domain_names[c]);
-        if (conf_path == NULL) {
-            DEBUG(SSSDBG_OP_FAILURE, "talloc_asprintf failed.\n");
-            ret = ENOMEM;
-            goto done;
-        }
-
-        ret = confdb_get_string(cdb, tmp_ctx, conf_path,
-                                CONFDB_DOMAIN_ID_PROVIDER, NULL, &id_provider);
-        if (ret == EOK) {
-            if (id_provider == NULL) {
-                DEBUG(SSSDBG_OP_FAILURE, "id_provider is not set for "
-                      "domain [%s], trying next domain.\n", domain_names[c]);
-                continue;
-            }
-
-            if (strcasecmp(id_provider, "IPA") == 0) {
-                add_pac = true;
-            }
-        } else {
-            DEBUG(SSSDBG_OP_FAILURE, "Failed to get id_provider for " \
-                                      "domain [%s], trying next domain.\n",
-                                      domain_names[c]);
-        }
-    }
-
-    if (BUILD_WITH_PAC_RESPONDER && add_pac &&
-        !string_in_list("pac", *_services, false)) {
-        ret = add_string_to_list(mem_ctx, "pac", _services);
-        if (ret != EOK) {
-            DEBUG(SSSDBG_OP_FAILURE, "add_string_to_list failed.\n");
-            goto done;
-        }
-    }
-
-    ret = EOK;
-
-done:
-    talloc_free(tmp_ctx);
-
-    return ret;
-}
-
 static char *check_service(char *service)
 {
     const char * const *known_services = get_known_services();
@@ -941,13 +870,6 @@ static int get_monitor_config(struct mt_ctx *ctx)
         return EINVAL;
     }
 #endif
-
-    ret = add_implicit_services(ctx->cdb, ctx, &ctx->services);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "Failed to add implicit configured "
-                                 "services. Some functionality might "
-                                 "be missing\n");
-    }
 
     badsrv = check_services(ctx->services);
     if (badsrv != NULL) {

--- a/src/sysv/systemd/sssd.service.in
+++ b/src/sysv/systemd/sssd.service.in
@@ -2,7 +2,7 @@
 Description=System Security Services Daemon
 # SSSD must be running before we permit user sessions
 Before=systemd-user-sessions.service nss-user-lookup.target
-Wants=nss-user-lookup.target
+Wants=nss-user-lookup.target @sssd_dependent_services@
 
 [Service]
 Environment=DEBUG_LOGGER=--logger=files

--- a/src/tools/sssd_check_socket_activated_responders.c
+++ b/src/tools/sssd_check_socket_activated_responders.c
@@ -260,7 +260,7 @@ int main(int argc, const char *argv[])
         err_msg = talloc_asprintf(
                 tmp_ctx,
                 "There's a misconfiguration in the \"services\" line of "
-                "\"%s\"!\n"
+                "\"%s\" or the responder is being implicitly started!\n"
                 "The \"services\" line contains \"%s\", meaning that the "
                 "responder's process will be started and managed by SSSD's "
                 "monitor. "

--- a/src/tools/sssd_check_socket_activated_responders.c
+++ b/src/tools/sssd_check_socket_activated_responders.c
@@ -54,7 +54,10 @@ static errno_t check_socket_activated_responder(const char *responder)
     }
 
     ret = ini_config_file_open(SSSD_CONFIG_FILE, 0, &file_ctx);
-    if (ret != 0) {
+    if (ret == ENOENT) {
+        ret = EOK;
+        goto done;
+    } else if (ret != 0) {
         DEBUG(SSSDBG_CRIT_FAILURE, "ini_config_file_open() failed [%d][%s]\n",
               ret, sss_strerror(ret));
         goto done;


### PR DESCRIPTION
The first patch changes the current logic of having the services' sockets disabled by default as it adds a "Wants=" to the sssd unit file, making all the services' sockets enabled by the moment sssd service is enabled.

The second patch takes advantage of the first patch and avoids running PAC responder in case its socket is active, leaving the service to be socket-activated when needed.