### PR TITLE
sbus: use sss_ptr_hash for hash tables

### DIFF
--- a/src/sbus/sssd_dbus.h
+++ b/src/sbus/sssd_dbus.h
@@ -247,8 +247,6 @@ sbus_opath_get_object_name(TALLOC_CTX *mem_ctx,
                            const char *object_path,
                            const char *base_path);
 
-bool sbus_conn_disconnecting(struct sbus_connection *conn);
-
 /* max_retries < 0: retry forever
  * max_retries = 0: never retry (why are you calling this function?)
  * max_retries > 0: obvious

--- a/src/sbus/sssd_dbus_connection.c
+++ b/src/sbus/sssd_dbus_connection.c
@@ -170,8 +170,8 @@ int sbus_init_connection(TALLOC_CTX *ctx,
         return EIO;
     }
 
-    ret = sbus_nodes_hash_init(conn, conn, &conn->nodes_fns);
-    if (ret != EOK) {
+    conn->nodes_fns = sbus_nodes_hash_init(conn);
+    if (conn->nodes_fns == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Cannot create node functions hash table\n");
         talloc_free(conn);
         return EIO;

--- a/src/sbus/sssd_dbus_connection.c
+++ b/src/sbus/sssd_dbus_connection.c
@@ -27,9 +27,6 @@
 #include "sbus/sssd_dbus_private.h"
 #include "sbus/sssd_dbus_meta.h"
 
-/* Types */
-struct dbus_ctx_list;
-
 static int sbus_auto_reconnect(struct sbus_connection *conn);
 
 static void sbus_dispatch(struct tevent_context *ev,
@@ -499,12 +496,6 @@ void sbus_reconnect_init(struct sbus_connection *conn,
     conn->max_retries = max_retries;
     conn->reconnect_callback = callback;
     conn->reconnect_pvt = pvt;
-}
-
-bool sbus_conn_disconnecting(struct sbus_connection *conn)
-{
-    if (conn->disconnect == 1) return true;
-    return false;
 }
 
 int sss_dbus_conn_send(DBusConnection *dbus_conn,

--- a/src/sbus/sssd_dbus_connection.c
+++ b/src/sbus/sssd_dbus_connection.c
@@ -177,8 +177,8 @@ int sbus_init_connection(TALLOC_CTX *ctx,
         return EIO;
     }
 
-    ret = sbus_incoming_signal_hash_init(conn, &conn->incoming_signals);
-    if (ret != EOK) {
+    conn->incoming_signals = sbus_incoming_signal_hash_init(conn);
+    if (conn->incoming_signals == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Cannot create incoming singals "
               "hash table\n");
         talloc_free(conn);

--- a/src/sbus/sssd_dbus_connection.c
+++ b/src/sbus/sssd_dbus_connection.c
@@ -163,8 +163,8 @@ int sbus_init_connection(TALLOC_CTX *ctx,
     conn->last_request_time = last_request_time;
     conn->client_destructor_data = client_destructor_data;
 
-    ret = sbus_opath_hash_init(conn, conn, &conn->managed_paths);
-    if (ret != EOK) {
+    conn->managed_paths = sbus_opath_hash_init(conn, conn);
+    if (conn->managed_paths == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Cannot create object paths hash table\n");
         talloc_free(conn);
         return EIO;

--- a/src/sbus/sssd_dbus_interface.c
+++ b/src/sbus/sssd_dbus_interface.c
@@ -686,13 +686,10 @@ done:
     return ret;
 }
 
-errno_t
-sbus_nodes_hash_init(TALLOC_CTX *mem_ctx,
-                     struct sbus_connection *conn,
-                     hash_table_t **_table)
+hash_table_t *
+sbus_nodes_hash_init(TALLOC_CTX *mem_ctx)
 {
-    return sss_hash_create_ex(mem_ctx, 10, _table, 0, 0, 0, 0,
-                              NULL, conn);
+    return sss_ptr_hash_create(mem_ctx, NULL, NULL);
 }
 
 struct sbus_nodes_data {
@@ -706,57 +703,24 @@ sbus_nodes_hash_add(hash_table_t *table,
                     sbus_nodes_fn nodes_fn,
                     void *handler_data)
 {
-    TALLOC_CTX *tmp_ctx;
     struct sbus_nodes_data *data;
-    hash_key_t key;
-    hash_value_t value;
     errno_t ret;
-    bool has_key;
-    int hret;
 
-    tmp_ctx = talloc_new(NULL);
-    if (tmp_ctx == NULL) {
-        return ENOMEM;
-    }
-
-    key.type = HASH_KEY_STRING;
-    key.str = talloc_strdup(tmp_ctx, object_path);
-    if (key.str == NULL) {
-        return ENOMEM;
-    }
-
-    has_key = hash_has_key(table, &key);
-    if (has_key) {
-        ret = EEXIST;
-        goto done;
-    }
-
-    data = talloc_zero(tmp_ctx, struct sbus_nodes_data);
+    data = talloc_zero(table, struct sbus_nodes_data);
     if (data == NULL) {
-        ret = ENOMEM;
-        goto done;
+        return ENOMEM;
     }
 
     data->handler_data = handler_data;
     data->nodes_fn = nodes_fn;
 
-    value.type = HASH_VALUE_PTR;
-    value.ptr = data;
-
-    hret = hash_enter(table, &key, &value);
-    if (hret != HASH_SUCCESS) {
-        ret = EIO;
-        goto done;
+    ret = sss_ptr_hash_add(table, object_path, data, struct sbus_nodes_data);
+    if (ret != EOK) {
+        talloc_free(data);
+        return ret;
     }
 
-    talloc_steal(table, key.str);
-    talloc_steal(table, data);
-
-    ret = EOK;
-
-done:
-    talloc_free(tmp_ctx);
-    return ret;
+    return EOK;
 }
 
 const char **
@@ -765,23 +729,11 @@ sbus_nodes_hash_lookup(TALLOC_CTX *mem_ctx,
                        const char *object_path)
 {
     struct sbus_nodes_data *data;
-    hash_key_t key;
-    hash_value_t value;
-    int hret;
 
-    key.type = HASH_KEY_STRING;
-    key.str = discard_const(object_path);
-
-    hret = hash_lookup(table, &key, &value);
-    if (hret == HASH_ERROR_KEY_NOT_FOUND) {
-        return NULL;
-    } else if (hret != HASH_SUCCESS) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "Unable to search hash table: hret=%d\n", hret);
+    data = sss_ptr_hash_lookup(table, object_path, struct sbus_nodes_data);
+    if (data == NULL) {
         return NULL;
     }
-
-    data = talloc_get_type(value.ptr, struct sbus_nodes_data);
 
     return data->nodes_fn(mem_ctx, object_path, data->handler_data);
 }

--- a/src/sbus/sssd_dbus_private.h
+++ b/src/sbus/sssd_dbus_private.h
@@ -136,10 +136,8 @@ sbus_opath_hash_lookup_supported(TALLOC_CTX *mem_ctx,
                                  const char *object_path,
                                  struct sbus_interface_list **_list);
 
-errno_t
-sbus_nodes_hash_init(TALLOC_CTX *mem_ctx,
-                     struct sbus_connection *conn,
-                     hash_table_t **_table);
+hash_table_t *
+sbus_nodes_hash_init(TALLOC_CTX *mem_ctx);
 
 const char **
 sbus_nodes_hash_lookup(TALLOC_CTX *mem_ctx,

--- a/src/sbus/sssd_dbus_private.h
+++ b/src/sbus/sssd_dbus_private.h
@@ -121,10 +121,9 @@ struct sbus_interface_list {
     struct sbus_interface *interface;
 };
 
-errno_t
+hash_table_t *
 sbus_opath_hash_init(TALLOC_CTX *mem_ctx,
-                     struct sbus_connection *conn,
-                     hash_table_t **_table);
+                     struct sbus_connection *conn);
 
 struct sbus_interface *
 sbus_opath_hash_lookup_iface(hash_table_t *table,

--- a/src/sbus/sssd_dbus_private.h
+++ b/src/sbus/sssd_dbus_private.h
@@ -180,9 +180,8 @@ sbus_signal_handler(DBusConnection *conn,
                     DBusMessage *message,
                     void *handler_data);
 
-errno_t
-sbus_incoming_signal_hash_init(TALLOC_CTX *mem_ctx,
-                               hash_table_t **_table);
+hash_table_t *
+sbus_incoming_signal_hash_init(TALLOC_CTX *mem_ctx);
 
 void sbus_register_common_signals(struct sbus_connection *conn, void *pvt);
 


### PR DESCRIPTION
This patch reuses `sss_ptr_hash` module introduced in NSS patches in `sbus` code.