### PR TITLE
BUILD: Fix linking of test_wbc_calls

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2679,6 +2679,7 @@ test_wbc_calls_LDFLAGS = \
     -Wl,-wrap,sss_nss_getnamebysid \
     $(NULL)
 test_wbc_calls_LDADD = \
+    $(CLIENT_LIBS) \
     $(CMOCKA_LIBS) \
     $(POPT_LIBS) \
     $(TALLOC_LIBS) \


### PR DESCRIPTION
Client code does not anymore depend on libpthread in master.
This is a reason why we didn't notice any linking failure
 in master. But the test should be inked with CLIENT_LIBS.

```    
     CCLD     test_wbc_calls
    /usr/bin/ld: src/sss_client/test_wbc_calls-common.o: undefined reference
        to symbol 'pthread_mutexattr_setrobust@@GLIBC_2.12'
    //lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing
        from command line
    collect2: error: ld returned 1 exit status
    Makefile:12460: recipe for target 'test_wbc_calls' failed
```