### PR TITLE
IPA: Skip conflict entries associated with sudo rules

### DIFF
--- a/src/tests/cmocka/test_ipa_dn.c
+++ b/src/tests/cmocka/test_ipa_dn.c
@@ -169,6 +169,11 @@ static void ipa_get_rdn_test(void **state)
     ret = ipa_get_rdn(test_ctx, test_ctx->sysdb, "cn=rdn,attr1=value1", &rdn, "cn", "attr1", "value1");
     assert_int_equal(ret, ENOENT);
     assert_null(rdn);
+
+    ret = ipa_get_rdn(test_ctx, test_ctx->sysdb, "cn=rdn+nsuniqueid=9b1e3301-c32611e6-bdcae37a-ef905e7c,attr1=value1,attr2=value2,dc=example,dc=com",
+                      &rdn, "cn", "attr1", "value1", "attr2", "value2");
+    assert_int_equal(ret, ENOENT);
+    assert_null(rdn);
 }
 
 int main(int argc, const char *argv[])


### PR DESCRIPTION
SSSD retrieves sudo rule information from the IPA LDAP tree, conflict entries will cause problems for SSSD and disallow sudo access when SSSD code is parsing entries associated with sudo rules. This PR sets a skip_entry boolean when it is appropriate and skips over these conflict entries.

Ticket: https://fedorahosted.org/sssd/ticket/3288

Reproducer steps: Create host conflict entry and associate it with a sudo rule that is assigned to certain hosts, attempt to sudo as IDM user. I had some difficulty attempting to force replication issues causing the creation of a conflict entry, the below manual ldapmodify steps will work also:

- Retrieve the DN of the sudoRule

`# ipa sudorule-find --all --raw | grep 'dn: '
  dn: ipaUniqueID=e9025c46-ddab-11e6-9096-525400af7498,cn=sudorules,cn=sudo,dc=jstephen,dc=local`

- Run ldapmodify similar to below

dn: ipaUniqueID=e9025c46-ddab-11e6-9096-525400af7498,cn=sudorules,cn=sudo,dc=jstephen,dc=local
changetype: modify
add: memberHost
memberHost: fqdn=testhost.jstephen.local+nsuniqueid=cb3d7383-ddb511e6-8c9996c1-71a1e36a,cn=computers,cn=accounts,dc=jstephen,dc=local