### PR TITLE
Explicitly add ordering dependency for the responders' sockets

### DIFF
--- a/src/sysv/systemd/sssd-autofs.socket.in
+++ b/src/sysv/systemd/sssd-autofs.socket.in
@@ -3,6 +3,8 @@ Description=SSSD AutoFS Service responder socket
 Documentation=man:sssd.conf(5)
 After=sssd.service
 BindsTo=sssd.service
+DefaultDependencies=no
+Conflicts=shutdown.target
 
 [Socket]
 ListenStream=@pipepath@/autofs

--- a/src/sysv/systemd/sssd-autofs.socket.in
+++ b/src/sysv/systemd/sssd-autofs.socket.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=SSSD AutoFS Service responder socket
 Documentation=man:sssd.conf(5)
+After=sssd.service
 BindsTo=sssd.service
 
 [Socket]

--- a/src/sysv/systemd/sssd-nss.socket.in
+++ b/src/sysv/systemd/sssd-nss.socket.in
@@ -3,6 +3,8 @@ Description=SSSD NSS Service responder socket
 Documentation=man:sssd.conf(5)
 After=sssd.service
 BindsTo=sssd.service
+DefaultDependencies=no
+Conflicts=shutdown.target
 
 [Socket]
 ListenStream=@pipepath@/nss

--- a/src/sysv/systemd/sssd-nss.socket.in
+++ b/src/sysv/systemd/sssd-nss.socket.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=SSSD NSS Service responder socket
 Documentation=man:sssd.conf(5)
+After=sssd.service
 BindsTo=sssd.service
 
 [Socket]

--- a/src/sysv/systemd/sssd-pac.socket.in
+++ b/src/sysv/systemd/sssd-pac.socket.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=SSSD PAC Service responder socket
 Documentation=man:sssd.conf(5)
+After=sssd.service
 BindsTo=sssd.service
 
 [Socket]

--- a/src/sysv/systemd/sssd-pac.socket.in
+++ b/src/sysv/systemd/sssd-pac.socket.in
@@ -3,6 +3,8 @@ Description=SSSD PAC Service responder socket
 Documentation=man:sssd.conf(5)
 After=sssd.service
 BindsTo=sssd.service
+DefaultDependencies=no
+Conflicts=shutdown.target
 
 [Socket]
 ListenStream=@pipepath@/pac

--- a/src/sysv/systemd/sssd-pam-priv.socket.in
+++ b/src/sysv/systemd/sssd-pam-priv.socket.in
@@ -4,6 +4,8 @@ Documentation=man:sssd.conf(5)
 After=sssd.service
 BindsTo=sssd.service
 BindsTo=sssd-pam.socket
+DefaultDependencies=no
+Conflicts=shutdown.target
 
 [Socket]
 Service=sssd-pam.service

--- a/src/sysv/systemd/sssd-pam-priv.socket.in
+++ b/src/sysv/systemd/sssd-pam-priv.socket.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=SSSD PAM Service responder private socket
 Documentation=man:sssd.conf(5)
+After=sssd.service
 BindsTo=sssd.service
 BindsTo=sssd-pam.socket
 

--- a/src/sysv/systemd/sssd-pam.socket.in
+++ b/src/sysv/systemd/sssd-pam.socket.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=SSSD PAM Service responder socket
 Documentation=man:sssd.conf(5)
+After=sssd.service
 BindsTo=sssd.service
 BindsTo=sssd-pam-priv.socket
 

--- a/src/sysv/systemd/sssd-pam.socket.in
+++ b/src/sysv/systemd/sssd-pam.socket.in
@@ -4,6 +4,8 @@ Documentation=man:sssd.conf(5)
 After=sssd.service
 BindsTo=sssd.service
 BindsTo=sssd-pam-priv.socket
+DefaultDependencies=no
+Conflicts=shutdown.target
 
 [Socket]
 ListenStream=@pipepath@/pam

--- a/src/sysv/systemd/sssd-ssh.socket.in
+++ b/src/sysv/systemd/sssd-ssh.socket.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=SSSD SSH Service responder socket
 Documentation=man:sssd.conf(5)
+After=sssd.service
 BindsTo=sssd.service
 
 [Socket]

--- a/src/sysv/systemd/sssd-ssh.socket.in
+++ b/src/sysv/systemd/sssd-ssh.socket.in
@@ -3,6 +3,8 @@ Description=SSSD SSH Service responder socket
 Documentation=man:sssd.conf(5)
 After=sssd.service
 BindsTo=sssd.service
+DefaultDependencies=no
+Conflicts=shutdown.target
 
 [Socket]
 ListenStream=@pipepath@/ssh

--- a/src/sysv/systemd/sssd-sudo.socket.in
+++ b/src/sysv/systemd/sssd-sudo.socket.in
@@ -3,6 +3,8 @@ Description=SSSD Sudo Service responder socket
 Documentation=man:sssd.conf(5)
 After=sssd.service
 BindsTo=sssd.service
+DefaultDependencies=no
+Conflicts=shutdown.target
 
 [Socket]
 ListenStream=@pipepath@/sudo

--- a/src/sysv/systemd/sssd-sudo.socket.in
+++ b/src/sysv/systemd/sssd-sudo.socket.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=SSSD Sudo Service responder socket
 Documentation=man:sssd.conf(5)
+After=sssd.service
 BindsTo=sssd.service
 
 [Socket]


### PR DESCRIPTION
While debugging the whole breakage reported by Stric I've noticed that the NSS socket has been starting up the NSS responder _before_ SSSD being up. Leading us to a chaotic situation.

By adding this ordering explicitly we can avoid the reported situation.

Interesting that I haven't seen the same behaviour when starting/stopping the socket after the system is up.

I also haven't noticed any kind of problem caused by explicitly adding "After=sssd.service" to the unit files.

**EDITED:
- This patch set previously consisted in two patches before but I ended up dropping the second one as I've noticed some issues about breaking the dependency cycle.

*** EDITED:
- Added a second patch following Lukáš Nykrýn's suggestion