### PR TITLE
SSSD does not start if using only the local provider and services line is empty

### DIFF
--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -2403,6 +2403,15 @@ static int monitor_process_init(struct mt_ctx *ctx,
         }
     }
 
+    /* When the only provider set up is the local one (num_providers == 0) and
+     * there's no responder explicitly set up it means that we should notify
+     * systemd that SSSD is ready right now as any other provider/responder
+     * would be able to do so and the SSSD would end up hitting a systemd
+     * timeout! */
+    if (num_providers == 0 && ctx->services == NULL) {
+        ret = notify_startup();
+    }
+
     return EOK;
 }
 


### PR DESCRIPTION
SSSD has to notify systemd whenever its startup is finished. Currently it has been done only when a service (and here I mean either provider or responder) has been started up.

However, when dealing with socket-activation we have the case where no responders have been set up and, consequently, the sd_notify() code won't ever be triggered by the responders.
Combining the above described scenario with the user setting up only the LOCAL provider, which also won't trigger the sd_notify() code, SSSD can end up hitting a systemd timeout during initialization.

This patch set solve the described issue.