### PR TITLE
Fix storing a sudoRule attriubute in a case-insensitive domain when the attriubute values differ only by case

### DIFF
--- a/src/db/sysdb_sudo.c
+++ b/src/db/sysdb_sudo.c
@@ -857,7 +857,6 @@ static errno_t sysdb_sudo_add_lowered_users(struct sss_domain_info *domain,
 {
     TALLOC_CTX *tmp_ctx;
     const char **users = NULL;
-    const char *lowered = NULL;
     errno_t ret;
 
     if (domain->case_sensitive == true || rule == NULL) {
@@ -884,19 +883,9 @@ static errno_t sysdb_sudo_add_lowered_users(struct sss_domain_info *domain,
     }
 
     for (int i = 0; users[i] != NULL; i++) {
-        lowered = sss_tc_utf8_str_tolower(tmp_ctx, users[i]);
-        if (lowered == NULL) {
-            DEBUG(SSSDBG_OP_FAILURE, "Cannot convert name to lowercase.\n");
-            ret = ENOMEM;
-            goto done;
-        }
-
-        if (strcmp(users[i], lowered) == 0) {
-            /* It protects us from adding duplicate. */
-            continue;
-        }
-
-        ret = sysdb_attrs_add_string(rule, SYSDB_SUDO_CACHE_AT_USER, lowered);
+        ret = sysdb_attrs_add_lower_case_string(rule, true,
+                                                SYSDB_SUDO_CACHE_AT_USER,
+                                                users[i]);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE,
                   "Unable to add %s attribute [%d]: %s\n",

--- a/src/tests/cmocka/test_sysdb_sudo.c
+++ b/src/tests/cmocka/test_sysdb_sudo.c
@@ -335,6 +335,11 @@ void test_store_sudo_case_insensitive(void **state)
 
     test_ctx->tctx->dom->case_sensitive = false;
 
+    ret = sysdb_attrs_add_lower_case_string(rule, false,
+                                            SYSDB_SUDO_CACHE_AT_USER,
+                                            users[0].name);
+    assert_int_equal(ret, EOK);
+
     ret = sysdb_sudo_store(test_ctx->tctx->dom, &rule, 1);
     assert_int_equal(ret, EOK);
 


### PR DESCRIPTION
I guess because different versions of sssd placed different constraints
on the case-sensitiveness of sudo rules, some users run a setup where a
sudoRule's sudoUser attribute only differs by case. This kind of a setup
breaks with the current sssd code.

The attached patch uses the previously introduced function
sysdb_attrs_add_lower_case_string() to work around the issue and only
store the resulting attribute once.