### PR TITLE
SYSTEMD: Update journald drop-in file

### DIFF
--- a/src/sysv/systemd/journal.conf.in
+++ b/src/sysv/systemd/journal.conf.in
@@ -4,4 +4,4 @@
 # run 'systemctl daemon-reload' and then restart the SSSD service
 # for this to take effect
 #ExecStart=
-#ExecStart=@sbindir@/sssd -D
+#ExecStart=@sbindir@/sssd -i


### PR DESCRIPTION
We changed type forking into type notify as part of commit
d4063e9a21a4e203bee7e0a0144fa8cabb14cc46.
But we forgot to update template drop-in file for logging into journald.