### PR TITLE
BUILD: Fix linking of test_sdap_initgr

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2879,11 +2879,12 @@ test_sdap_initgr_CFLAGS = \
 test_sdap_initgr_LDADD = \
     $(CMOCKA_LIBS) \
     $(POPT_LIBS) \
+    $(DHASH_LIBS) \
     $(TALLOC_LIBS) \
+    $(TEVENT_LIBS) \
+    $(LDB_LIBS) \
     $(SSSD_INTERNAL_LTLIBS) \
     libsss_ldap_common.la \
-    libsss_ad_tests.la \
-    libsss_idmap.la \
     libsss_test_common.la \
     libdlopen_test_providers.la \
     $(NULL)


### PR DESCRIPTION
There was a linking fialure on debian:
/usr/bin/ld: src/tests/cmocka/test_sdap_initgr-test_sdap_initgr.o:
   undefined reference to symbol 'hash_iterate@@DHASH_0.4.3'
//usr/lib64/libdhash.so.1: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status

This patch adds some missing libraries and remove unnecessary libraries.