### PR TITLE
sss_cache: User/groups invalidation in domain cache

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -874,6 +874,15 @@ int sysdb_set_entry_attr(struct sysdb_ctx *sysdb,
                          struct sysdb_attrs *attrs,
                          int mod_op);
 
+/* User/group invalidation of cache by direct writing to persistent cache
+ * WARNING: This function can cause performance issue!!
+ * is_user = true --> user invalidation
+ * is_user = false --> group invalidation
+ */
+int sysdb_invalidate_cache_entry(struct sss_domain_info *domain,
+                                 const char *name,
+                                 bool is_user);
+
 /* Replace user attrs */
 int sysdb_set_user_attr(struct sss_domain_info *domain,
                         const char *name,

--- a/src/tests/intg/sssd_ldb.py
+++ b/src/tests/intg/sssd_ldb.py
@@ -19,6 +19,7 @@
 import os
 import ldb
 import config
+import subprocess
 
 
 class CacheType(object):
@@ -83,3 +84,13 @@ class SssdLdb(object):
             return None
 
         return res.msgs[0].get(attr).get(0)
+
+    def invalidate_entry(self, name, entry_type, domain):
+        dbconn = self._get_dbconn(CacheType.timestamps)
+
+        m = ldb.Message()
+        m.dn = ldb.Dn(dbconn, self._basedn(name, domain, entry_type))
+        m["dataExpireTimestamp"] = ldb.MessageElement(str(1),
+                                                      ldb.FLAG_MOD_REPLACE,
+                                                      "dataExpireTimestamp")
+        dbconn.modify(m)

--- a/src/tests/intg/test_ts_cache.py
+++ b/src/tests/intg/test_ts_cache.py
@@ -199,13 +199,11 @@ def ldb_examine(request):
     return ldb_conn
 
 
-def invalidate_group(name):
-    subprocess.call(["sss_cache", "-g", name])
+def invalidate_group(ldb_conn, name):
+    ldb_conn.invalidate_entry(name, sssd_ldb.TsCacheEntry.group, SSSD_DOMAIN)
 
-
-def invalidate_user(name):
-    subprocess.call(["sss_cache", "-u", name])
-
+def invalidate_user(ldb_conn, name):
+    ldb_conn.invalidate_entry(name, sssd_ldb.TsCacheEntry.user, SSSD_DOMAIN)
 
 def get_attrs(ldb_conn, type, name, domain, attr_list):
     sysdb_attrs = dict()
@@ -252,7 +250,7 @@ def prime_cache_group(ldb_conn, name, members):
 
     # just to force different stamps and make sure memcache is gone
     time.sleep(1)
-    invalidate_group(name)
+    invalidate_group(ldb_conn, name)
 
     return sysdb_attrs, ts_attrs
 
@@ -271,7 +269,7 @@ def prime_cache_user(ldb_conn, name, primary_gid):
 
     # just to force different stamps and make sure memcache is gone
     time.sleep(1)
-    invalidate_user(name)
+    invalidate_user(ldb_conn, name)
 
     return sysdb_attrs, ts_attrs
 
@@ -615,3 +613,59 @@ def test_user_2307bis_delete_user(ldap_conn,
     assert sysdb_attrs.get("originalModifyTimestamp") is None
     assert ts_attrs.get("dataExpireTimestamp") is None
     assert ts_attrs.get("originalModifyTimestamp") is None
+
+
+def test_sss_cache_invalidate_user(ldap_conn,
+                                   ldb_examine,
+                                   setup_rfc2307bis ):
+    """
+    Test that sss_cache invalidate user in both caches
+    """
+
+    ldb_conn = ldb_examine
+    old_sysdb_attrs, old_ts_attrs = prime_cache_user(ldb_conn, "user1", 2001)
+
+    subprocess.call(["sss_cache", "-u", "user1"])
+
+    sysdb_attrs, ts_attrs = get_user_attrs(ldb_conn, "user1",
+                                           SSSD_DOMAIN, TS_ATTRLIST)
+
+    assert sysdb_attrs.get("dataExpireTimestamp") == '1'
+    assert ts_attrs.get("dataExpireTimestamp") == '1'
+
+    time.sleep(1)
+    pwd.getpwnam("user1")
+    sysdb_attrs, ts_attrs = get_user_attrs(ldb_conn, "user1",
+                                           SSSD_DOMAIN, TS_ATTRLIST)
+
+    assert sysdb_attrs.get("dataExpireTimestamp") == '1'
+    assert_diff_attrval(ts_attrs, sysdb_attrs, "dataExpireTimestamp")
+
+
+def test_sss_cache_invalidate_group(ldap_conn,
+                                    ldb_examine,
+                                    setup_rfc2307bis ):
+    """
+    Test that sss_cache invalidate group in both caches
+    """
+
+    ldb_conn = ldb_examine
+    old_sysdb_attrs, old_ts_attrs = prime_cache_group(
+                                                ldb_conn, "group1",
+                                                ("user1", "user11", "user21"))
+
+    subprocess.call(["sss_cache", "-g", "group1"])
+
+    sysdb_attrs, ts_attrs = get_group_attrs(ldb_conn, "group1",
+                                            SSSD_DOMAIN, TS_ATTRLIST)
+
+    assert sysdb_attrs.get("dataExpireTimestamp") == '1'
+    assert ts_attrs.get("dataExpireTimestamp") == '1'
+
+    time.sleep(1)
+    grp.getgrnam("group1")
+    sysdb_attrs, ts_attrs = get_group_attrs(ldb_conn, "group1",
+                                            SSSD_DOMAIN, TS_ATTRLIST)
+
+    assert sysdb_attrs.get("dataExpireTimestamp") == '1'
+    assert_diff_attrval(ts_attrs, sysdb_attrs, "dataExpireTimestamp")


### PR DESCRIPTION
When a group/users are invalidated from sss cache, the group/user
information in Domain (cache_LDAP.ldb) and  timestamps cache are
inconsistent with regard to dataExpireTimestamp attribute.
This patch fixes it.

Resolves:
https://fedorahosted.org/sssd/ticket/3164