### PR TITLE
MONITOR: Don't return an error in case we fail to register a service

### DIFF
--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -363,11 +363,7 @@ static int client_registration(struct sbus_request *dbus_req, void *data)
         sbus_request_finish(dbus_req, NULL);
         /* FIXME: should we just talloc_zfree(conn) ? */
 
-        if (ret == ENOENT) {
-            goto done;
-        }
-
-        return ret;
+        goto done;
     }
 
     /* Fill in svc structure with connection data */


### PR DESCRIPTION
This behaviour was mistakenly changed by the {dbus,socket}-activation
series and, as it's now, I've noticed the monitor may end up in some
weird state due to this change, where it doesn't stop properly and leave
some defuncts children processes.

Let's change it back to what it was before and avoid possible
regressions (even if no regression where hit yet).

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>