### PR TITLE
FILES: Remove unnecessary check

### DIFF
--- a/src/providers/files/files_ops.c
+++ b/src/providers/files/files_ops.c
@@ -185,7 +185,7 @@ static errno_t enum_files_groups(TALLOC_CTX *mem_ctx,
         }
         grp->gr_passwd = talloc_strdup(grp, grp_iter->gr_passwd);
 
-        if (grp_iter->gr_mem != NULL && grp_iter->gr_mem[0] != '\0') {
+        if (grp_iter->gr_mem != NULL) {
             size_t nmem;
 
             for (nmem = 0; grp_iter->gr_mem[nmem] != NULL; nmem++);


### PR DESCRIPTION
"grp_iter->gr_mem" is an array of strings and not just a string.
We tried to compare first string to NULL (acctually '\0')
But after that we iterated over the array to find count of members
and we check for NULL one more time.