### PR TITLE
pam: use authtok from PAM stack if available

### DIFF
--- a/src/man/pam_sss.8.xml
+++ b/src/man/pam_sss.8.xml
@@ -49,6 +49,9 @@
             <arg choice='opt'>
                 <replaceable>allow_missing_name</replaceable>
             </arg>
+            <arg choice='opt'>
+                <replaceable>prompt_always</replaceable>
+            </arg>
         </cmdsynopsis>
     </refsynopsisdiv>
 
@@ -181,6 +184,21 @@ auth sufficient pam_sss.so allow_missing_name
                         In this case SSSD will try to determine the user name
                         based on the content of the Smartcard, returns it to
                         pam_sss which will finally put it on the PAM stack.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term>
+                    <option>prompt_always</option>
+                </term>
+                <listitem>
+                    <para>
+                        Always prompt  the user for credentials. With this
+                        option credentials requested by other PAM modules,
+                        typically a password, will be ignored and pam_sss will
+                        prompt for credentials again. Based on the pre-auth
+                        reply by SSSD pam_sss might prompt for a password, a
+                        Smartcard PIN or other credentials.
                     </para>
                 </listitem>
             </varlistentry>

--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -54,6 +54,7 @@
 #define FLAGS_IGNORE_AUTHINFO_UNAVAIL (1 << 4)
 #define FLAGS_USE_2FA (1 << 5)
 #define FLAGS_ALLOW_MISSING_NAME (1 << 6)
+#define FLAGS_PROMPT_ALWAYS (1 << 7)
 
 #define PWEXP_FLAG "pam_sss:password_expired_flag"
 #define FD_DESTRUCTOR "pam_sss:fd_destructor"
@@ -1551,6 +1552,8 @@ static void eval_argv(pam_handle_t *pamh, int argc, const char **argv,
             *flags |= FLAGS_USE_2FA;
         } else if (strcmp(*argv, "allow_missing_name") == 0) {
             *flags |= FLAGS_ALLOW_MISSING_NAME;
+        } else if (strcmp(*argv, "prompt_always") == 0) {
+            *flags |= FLAGS_PROMPT_ALWAYS;
         } else {
             logger(pamh, LOG_WARNING, "unknown option: %s", *argv);
         }
@@ -1565,7 +1568,10 @@ static int get_authtok_for_authentication(pam_handle_t *pamh,
 {
     int ret;
 
-    if (flags & FLAGS_USE_FIRST_PASS) {
+    if ((flags & FLAGS_USE_FIRST_PASS)
+            || ( pi->pamstack_authtok != NULL
+                    && *(pi->pamstack_authtok) != '\0'
+                    && !(flags & FLAGS_PROMPT_ALWAYS))) {
         pi->pam_authtok_type = SSS_AUTHTOK_TYPE_PASSWORD;
         pi->pam_authtok = strdup(pi->pamstack_authtok);
         if (pi->pam_authtok == NULL) {
@@ -1798,10 +1804,12 @@ static int pam_sss(enum sss_cli_command task, pam_handle_t *pamh,
                 /*
                  * Only do preauth if
                  * - FLAGS_USE_FIRST_PASS is not set
-                 * - no password is on the stack
+                 * - no password is on the stack or FLAGS_PROMPT_ALWAYS is set
                  * - preauth indicator file exists.
                  */
-                if ( !(flags & FLAGS_USE_FIRST_PASS) && pi.pam_authtok == NULL
+                if ( !(flags & FLAGS_USE_FIRST_PASS)
+                        && (pi.pam_authtok == NULL
+                                || (flags & FLAGS_PROMPT_ALWAYS))
                         && access(PAM_PREAUTH_INDICATOR, F_OK) == 0) {
                     pam_status = send_and_receive(pamh, &pi, SSS_PAM_PREAUTH,
                                                   quiet_mode);


### PR DESCRIPTION
With this patch the behavior of pam_sss is slightly changed to be more
similar to the behavior of other PAM modules. Currently pam_sss expects
that there is a authtok (password) on the PAM stack if the
'use_first_pass' option was used. Without the option pam_sss
unconditionally prompts for credentials.

With this patch pam_sss will use an authtok from the PAM stack even if
'use_first_pass' is not set but it will assume that it is a password. To
return to the previous behavior the new 'prompt_always' can be used.

Resolves https://fedorahosted.org/sssd/ticket/2984


Besides the use-case mentioned in the ticket with this change it should be
possible to change the default PAM configuration in Fedora and RHEL to allow a
fallback to pam_sss if pam_unix fails, so

auth        [success=done ignore=ignore default=die] pam_unix.so nullok try_first_pass

can be changed to

auth        [sufficient] pam_unix.so nullok try_first_pass

'sufficient' is equivalent to '[success=done new_authtok_reqd=done
default=ignore]' so the 'default=die' is remove here and the next PAM modules
is called.