### PR TITLE
cache_req: use own namespace for UPNs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2192,6 +2192,7 @@ nss_srv_tests_CFLAGS = \
     $(AM_CFLAGS)
 nss_srv_tests_LDFLAGS = \
     -Wl,-wrap,sss_ncache_check_user \
+    -Wl,-wrap,sss_ncache_check_upn \
     -Wl,-wrap,sss_ncache_check_uid \
     -Wl,-wrap,sss_ncache_check_sid \
     -Wl,-wrap,sss_ncache_check_cert \

--- a/src/responder/common/cache_req/plugins/cache_req_user_by_upn.c
+++ b/src/responder/common/cache_req/plugins/cache_req_user_by_upn.c
@@ -66,7 +66,7 @@ cache_req_user_by_upn_ncache_check(struct sss_nc_ctx *ncache,
                                    struct sss_domain_info *domain,
                                    struct cache_req_data *data)
 {
-    return sss_ncache_check_user(ncache, domain, data->name.lookup);
+    return sss_ncache_check_upn(ncache, domain, data->name.lookup);
 }
 
 static errno_t
@@ -74,7 +74,7 @@ cache_req_user_by_upn_ncache_add(struct sss_nc_ctx *ncache,
                                  struct sss_domain_info *domain,
                                  struct cache_req_data *data)
 {
-    return sss_ncache_set_user(ncache, false, domain, data->name.lookup);
+    return sss_ncache_set_upn(ncache, false, domain, data->name.lookup);
 }
 
 static errno_t

--- a/src/responder/common/negcache.c
+++ b/src/responder/common/negcache.c
@@ -289,6 +289,24 @@ int sss_ncache_check_user(struct sss_nc_ctx *ctx, struct sss_domain_info *dom,
     return sss_cache_check_ent(ctx, dom, name, sss_ncache_check_user_int);
 }
 
+int sss_ncache_check_upn(struct sss_nc_ctx *ctx, struct sss_domain_info *dom,
+                         const char *name)
+{
+    char *neg_cache_name = NULL;
+    errno_t ret;
+
+    neg_cache_name = talloc_asprintf(ctx, "@%s", name);
+    if (neg_cache_name == NULL) {
+        return ENOMEM;
+    }
+
+    ret = sss_cache_check_ent(ctx, dom, neg_cache_name,
+                              sss_ncache_check_user_int);
+    talloc_free(neg_cache_name);
+
+    return ret;
+}
+
 int sss_ncache_check_group(struct sss_nc_ctx *ctx, struct sss_domain_info *dom,
                            const char *name)
 {
@@ -538,6 +556,24 @@ int sss_ncache_set_user(struct sss_nc_ctx *ctx, bool permanent,
                         struct sss_domain_info *dom, const char *name)
 {
     return sss_ncache_set_ent(ctx, permanent, dom, name, sss_ncache_set_user_int);
+}
+
+int sss_ncache_set_upn(struct sss_nc_ctx *ctx, bool permanent,
+                       struct sss_domain_info *dom, const char *name)
+{
+    char *neg_cache_name = NULL;
+    errno_t ret;
+
+    neg_cache_name = talloc_asprintf(ctx, "@%s", name);
+    if (neg_cache_name == NULL) {
+        return ENOMEM;
+    }
+
+    ret = sss_ncache_set_ent(ctx, permanent, dom, neg_cache_name,
+                             sss_ncache_set_user_int);
+    talloc_free(neg_cache_name);
+
+    return ret;
 }
 
 int sss_ncache_set_group(struct sss_nc_ctx *ctx, bool permanent,

--- a/src/responder/common/negcache.h
+++ b/src/responder/common/negcache.h
@@ -33,6 +33,8 @@ uint32_t sss_ncache_get_timeout(struct sss_nc_ctx *ctx);
 /* check if the user is expired according to the passed in time to live */
 int sss_ncache_check_user(struct sss_nc_ctx *ctx, struct sss_domain_info *dom,
                           const char *name);
+int sss_ncache_check_upn(struct sss_nc_ctx *ctx, struct sss_domain_info *dom,
+                         const char *name);
 int sss_ncache_check_group(struct sss_nc_ctx *ctx, struct sss_domain_info *dom,
                            const char *name);
 int sss_ncache_check_netgr(struct sss_nc_ctx *ctx, struct sss_domain_info *dom,
@@ -59,6 +61,8 @@ int sss_ncache_check_service_port(struct sss_nc_ctx *ctx,
  * users and groups) */
 int sss_ncache_set_user(struct sss_nc_ctx *ctx, bool permanent,
                         struct sss_domain_info *dom, const char *name);
+int sss_ncache_set_upn(struct sss_nc_ctx *ctx, bool permanent,
+                       struct sss_domain_info *dom, const char *name);
 int sss_ncache_set_group(struct sss_nc_ctx *ctx, bool permanent,
                          struct sss_domain_info *dom, const char *name);
 int sss_ncache_set_netgr(struct sss_nc_ctx *ctx, bool permanent,

--- a/src/tests/cmocka/test_responder_cache_req.c
+++ b/src/tests/cmocka/test_responder_cache_req.c
@@ -839,9 +839,9 @@ void test_user_by_upn_ncache(void **state)
 
     test_ctx = talloc_get_type_abort(*state, struct cache_req_test_ctx);
 
-    /* Setup user. */
-    ret = sss_ncache_set_user(test_ctx->ncache, false,
-                              test_ctx->tctx->dom, users[0].upn);
+    /* Setup user's UPN. */
+    ret = sss_ncache_set_upn(test_ctx->ncache, false,
+                             test_ctx->tctx->dom, users[0].upn);
     assert_int_equal(ret, EOK);
 
     /* Mock values. */


### PR DESCRIPTION
If the UPN use the same domain name as the configured domain an
unsuccessful lookup by name will already create an entry in the negative
cache. If the lookup by UPN would use the same namespace the lookup will
immediately be finished because there would already be an entry in the
negative cache.

Resolves https://fedorahosted.org/sssd/ticket/3313