### PR TITLE
NSS: Fix invalidating memory cache for subdomain users

### DIFF
--- a/src/responder/nss/nss_iface.c
+++ b/src/responder/nss/nss_iface.c
@@ -36,7 +36,9 @@ void nss_update_initgr_memcache(struct nss_ctx *nctx,
     int ret;
     int i, j;
 
-    for (dom = nctx->rctx->domains; dom; dom = get_next_domain(dom, 0)) {
+    for (dom = nctx->rctx->domains;
+         dom;
+         dom = get_next_domain(dom, SSS_GND_DESCEND)) {
         if (strcasecmp(dom->name, domain) == 0) {
             break;
         }


### PR DESCRIPTION
To reproduce, log in as a user from a trusted domain. Before the patch,
you should see an error message about the domain not being found such as:
    (Wed Feb 22 20:35:33 2017) [sssd[nss]] [nss_update_initgr_memcache] (0x0040): Unknown domain (win.trust.test) requested by provider
and the memory cache wouldn't be in fact be invalidated.