### PR TITLE
Add missing dyndns_auth option to AD and IPA provider man pages

### DIFF
--- a/src/man/sssd-ad.5.xml
+++ b/src/man/sssd-ad.5.xml
@@ -941,6 +941,21 @@ ad_gpo_map_deny = +my_pam_service
                 </varlistentry>
 
                 <varlistentry>
+                    <term>dyndns_auth (string)</term>
+                    <listitem>
+                        <para>
+                            Whether the nsupdate utility should use GSS-TSIG
+                            authentication for secure updates with the DNS
+                            server, insecure updates can be sent by setting
+                            this option to 'none'.
+                        </para>
+                        <para>
+                            Default: GSS-TSIG
+                        </para>
+                    </listitem>
+                </varlistentry>
+
+                <varlistentry>
                     <term>dyndns_server (string)</term>
                     <listitem>
                         <para>

--- a/src/man/sssd-ipa.5.xml
+++ b/src/man/sssd-ipa.5.xml
@@ -193,6 +193,21 @@
                 </varlistentry>
 
                 <varlistentry>
+                    <term>dyndns_auth (string)</term>
+                    <listitem>
+                        <para>
+                            Whether the nsupdate utility should use GSS-TSIG
+                            authentication for secure updates with the DNS
+                            server, insecure updates can be sent by setting
+                            this option to 'none'.
+                        </para>
+                        <para>
+                            Default: GSS-TSIG
+                        </para>
+                    </listitem>
+                </varlistentry>
+
+                <varlistentry>
                     <term>ipa_enable_dns_sites (boolean)</term>
                     <listitem>
                         <para>


### PR DESCRIPTION
Add the **dyndns_auth** option into the `sssd-ad` and `sssd-ipa` provider man pages for
more configuration information regarding nsupdate behavior.

There was no ticket for this, I wasn't sure if it was required to create one for this already-implemented option.