### PR TITLE
Add module for starting services

### DIFF
--- a/src/tests/intg/services.py
+++ b/src/tests/intg/services.py
@@ -1,0 +1,82 @@
+#
+# LDAP integration test
+#
+# Copyright (c) 2017 Red Hat, Inc.
+# Author: Lukas Slebodnik <lslebodn@redhat.com>
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 only
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+import os
+import os.path
+import signal
+import subprocess
+import time
+
+import config
+
+
+class SSSD(object):
+    def __init__(self):
+        self.pid = 0
+
+    def start(self):
+        """Start the SSSD process"""
+        assert self.pid == 0
+
+        if subprocess.call(["sssd", "-D", "-f"]) != 0:
+            raise Exception("sssd start failed")
+
+        # wait 2 seconds for pidfile
+        wait_time = 2
+        for _ in range(wait_time * 10):
+            if os.path.isfile(config.PIDFILE_PATH):
+                break
+            time.sleep(.1)
+
+        assert os.path.isfile(config.PIDFILE_PATH)
+        with open(config.PIDFILE_PATH, "r") as pid_file:
+            self.pid = int(pid_file.read())
+
+    def stop(self):
+        """Stop the SSSD process and remove its state"""
+
+        # stop process only if running
+        if self.pid != 0:
+            try:
+                os.kill(self.pid, signal.SIGTERM)
+                while True:
+                    try:
+                        os.kill(self.pid, signal.SIGCONT)
+                    except:
+                        break
+                    time.sleep(.1)
+            except:
+                pass
+
+        # clean pid so we can start service one more time
+        self.pid = 0
+
+    def restart(self):
+        self.stop()
+        self.start()
+
+    def go_offline(self):
+        os.kill(self.pid, signal.SIGUSR1)
+
+    @staticmethod
+    def clean_cache():
+        """Remove SSSD cache files"""
+        for path in os.listdir(config.DB_PATH):
+            os.unlink(config.DB_PATH + "/" + path)
+        for path in os.listdir(config.MCACHE_PATH):
+            os.unlink(config.MCACHE_PATH + "/" + path)

--- a/src/tests/intg/test_ldap.py
+++ b/src/tests/intg/test_ldap.py
@@ -20,7 +20,6 @@ import os
 import stat
 import pwd
 import grp
-import signal
 import subprocess
 import time
 import ldap
@@ -31,6 +30,7 @@ import config
 import ds_openldap
 import ent
 import ldap_ent
+import services
 import sssd_id
 import sssd_ldb
 from util import unindent
@@ -188,41 +188,15 @@ def create_conf_fixture(request, contents):
     create_conf_cleanup(request)
 
 
-def create_sssd_process():
-    """Start the SSSD process"""
-    if subprocess.call(["sssd", "-D", "-f"]) != 0:
-        raise Exception("sssd start failed")
-
-
-def cleanup_sssd_process():
-    """Stop the SSSD process and remove its state"""
-    try:
-        pid_file = open(config.PIDFILE_PATH, "r")
-        pid = int(pid_file.read())
-        os.kill(pid, signal.SIGTERM)
-        while True:
-            try:
-                os.kill(pid, signal.SIGCONT)
-            except:
-                break
-            time.sleep(1)
-    except:
-        pass
-    for path in os.listdir(config.DB_PATH):
-        os.unlink(config.DB_PATH + "/" + path)
-    for path in os.listdir(config.MCACHE_PATH):
-        os.unlink(config.MCACHE_PATH + "/" + path)
-
-
-def create_sssd_cleanup(request):
-    """Add teardown for stopping SSSD and removing its state"""
-    request.addfinalizer(cleanup_sssd_process)
-
-
 def create_sssd_fixture(request):
     """Start SSSD and add teardown for stopping it and removing its state"""
-    create_sssd_process()
-    create_sssd_cleanup(request)
+    request.sssd = services.SSSD()
+    request.sssd.start()
+
+    def cleanup_sssd_process():
+        request.sssd.stop()
+        request.sssd.clean_cache()
+    request.addfinalizer(cleanup_sssd_process)
 
 
 @pytest.fixture

--- a/src/tests/intg/test_local_domain.py
+++ b/src/tests/intg/test_local_domain.py
@@ -20,25 +20,13 @@ import os
 import stat
 import pwd
 import grp
-import time
-import config
-import signal
 import subprocess
 import pytest
+
+import config
 import ent
+import services
 from util import unindent
-
-
-def stop_sssd():
-    pid_file = open(config.PIDFILE_PATH, "r")
-    pid = int(pid_file.read())
-    os.kill(pid, signal.SIGTERM)
-    while True:
-        try:
-            os.kill(pid, signal.SIGCONT)
-        except:
-            break
-        time.sleep(1)
 
 
 def create_conf_fixture(request, contents):
@@ -51,20 +39,14 @@ def create_conf_fixture(request, contents):
 
 
 def create_sssd_fixture(request):
-    """Start sssd and add teardown for stopping it and removing state"""
-    if subprocess.call(["sssd", "-D", "-f"]) != 0:
-        raise Exception("sssd start failed")
+    """Start SSSD and add teardown for stopping it and removing its state"""
+    request.sssd = services.SSSD()
+    request.sssd.start()
 
-    def teardown():
-        try:
-            stop_sssd()
-        except:
-            pass
-        for path in os.listdir(config.DB_PATH):
-            os.unlink(config.DB_PATH + "/" + path)
-        for path in os.listdir(config.MCACHE_PATH):
-            os.unlink(config.MCACHE_PATH + "/" + path)
-    request.addfinalizer(teardown)
+    def cleanup_sssd_process():
+        request.sssd.stop()
+        request.sssd.clean_cache()
+    request.addfinalizer(cleanup_sssd_process)
 
 
 @pytest.fixture

--- a/src/tests/intg/test_ts_cache.py
+++ b/src/tests/intg/test_ts_cache.py
@@ -19,17 +19,18 @@
 
 import os
 import stat
-import ent
 import grp
 import pwd
-import config
-import signal
 import subprocess
 import time
 import ldap
 import pytest
+
+import config
 import ds_openldap
+import ent
 import ldap_ent
+import services
 import sssd_ldb
 import sssd_id
 from util import unindent
@@ -92,33 +93,15 @@ def create_conf_fixture(request, contents):
     request.addfinalizer(lambda: os.unlink(config.CONF_PATH))
 
 
-def stop_sssd():
-    pid_file = open(config.PIDFILE_PATH, "r")
-    pid = int(pid_file.read())
-    os.kill(pid, signal.SIGTERM)
-    while True:
-        try:
-            os.kill(pid, signal.SIGCONT)
-        except:
-            break
-        time.sleep(1)
-
-
 def create_sssd_fixture(request):
-    """Start sssd and add teardown for stopping it and removing state"""
-    if subprocess.call(["sssd", "-D", "-f"]) != 0:
-        raise Exception("sssd start failed")
+    """Start SSSD and add teardown for stopping it and removing its state"""
+    request.sssd = services.SSSD()
+    request.sssd.start()
 
-    def teardown():
-        try:
-            stop_sssd()
-        except:
-            pass
-        for path in os.listdir(config.DB_PATH):
-            os.unlink(config.DB_PATH + "/" + path)
-        for path in os.listdir(config.MCACHE_PATH):
-            os.unlink(config.MCACHE_PATH + "/" + path)
-    request.addfinalizer(teardown)
+    def cleanup_sssd_process():
+        request.sssd.stop()
+        request.sssd.clean_cache()
+    request.addfinalizer(cleanup_sssd_process)
 
 
 def load_data_to_ldap(request, ldap_conn, schema):


### PR DESCRIPTION
This is a WIP version of reducing code duplication in our cwrap integration tests.

I am still not sure whether we should also reuse function `create_sssd_fixture`.
And if yes; then probably in different nodule then `services`

And comments are welcome.

BTW I wrote patches few weeks ago; therefore new tests are not converted.
I am just sending patches to get some feedback.

Site effect of this patches is that tests are cca 20% faster (IIRC)