### PR TITLE
Fix detecting UPN suffixes in IPA subdomain code

### DIFF
--- a/src/db/sysdb_private.h
+++ b/src/db/sysdb_private.h
@@ -190,6 +190,7 @@ struct sss_domain_info *new_subdomain(TALLOC_CTX *mem_ctx,
                                       bool mpg,
                                       bool enumerate,
                                       const char *forest,
+                                      const char **upn_suffixes,
                                       uint32_t trust_direction);
 
 /* Helper functions to deal with the timestamp cache should not be used

--- a/src/db/sysdb_subdomains.c
+++ b/src/db/sysdb_subdomains.c
@@ -32,6 +32,7 @@ struct sss_domain_info *new_subdomain(TALLOC_CTX *mem_ctx,
                                       bool mpg,
                                       bool enumerate,
                                       const char *forest,
+                                      const char **upn_suffixes,
                                       uint32_t trust_direction)
 {
     struct sss_domain_info *dom;
@@ -104,6 +105,14 @@ struct sss_domain_info *new_subdomain(TALLOC_CTX *mem_ctx,
         dom->forest = talloc_strdup(dom, forest);
         if (dom->forest == NULL) {
             DEBUG(SSSDBG_OP_FAILURE, "Failed to copy forest.\n");
+            goto fail;
+        }
+    }
+
+    if (upn_suffixes != NULL) {
+        dom->upn_suffixes = dup_string_list(dom, upn_suffixes);
+        if (dom->upn_suffixes == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE, "Failed to copy UPN upn_suffixes.\n");
             goto fail;
         }
     }
@@ -442,7 +451,7 @@ errno_t sysdb_update_subdomains(struct sss_domain_info *domain)
         if (dom == NULL) {
             dom = new_subdomain(domain, domain, name, realm,
                                 flat, id, mpg, enumerate, forest,
-                                trust_direction);
+                                upn_suffixes, trust_direction);
             if (dom == NULL) {
                 ret = ENOMEM;
                 goto done;

--- a/src/tests/cmocka/test_fqnames.c
+++ b/src/tests/cmocka/test_fqnames.c
@@ -309,7 +309,7 @@ static int parse_name_test_setup(void **state)
      * discovered
      */
     test_ctx->subdom = new_subdomain(dom, dom, SUBDOMNAME, NULL, SUBFLATNAME,
-                                     NULL, false, false, NULL, 0);
+                                     NULL, false, false, NULL, NULL, 0);
     assert_non_null(test_ctx->subdom);
 
     check_leaks_push(test_ctx);

--- a/src/tests/cmocka/test_nss_srv.c
+++ b/src/tests/cmocka/test_nss_srv.c
@@ -3159,7 +3159,7 @@ static int nss_subdom_test_setup(void **state)
 
     subdomain = new_subdomain(nss_test_ctx, nss_test_ctx->tctx->dom,
                               testdom[0], testdom[1], testdom[2], testdom[3],
-                              false, false, NULL, 0);
+                              false, false, NULL, NULL, 0);
     assert_non_null(subdomain);
 
     ret = sysdb_subdomain_store(nss_test_ctx->tctx->sysdb,

--- a/src/tests/sysdb-tests.c
+++ b/src/tests/sysdb-tests.c
@@ -1395,7 +1395,7 @@ START_TEST (test_sysdb_get_user_attr_subdomain)
     /* Create subdomain */
     subdomain = new_subdomain(test_ctx, test_ctx->domain,
                               "test.sub", "TEST.SUB", "test", "S-3",
-                              false, false, NULL, 0);
+                              false, false, NULL, NULL, 0);
     fail_if(subdomain == NULL, "Failed to create new subdomain.");
 
     ret = sss_names_init_from_args(test_ctx,
@@ -5702,7 +5702,7 @@ START_TEST(test_sysdb_subdomain_store_user)
 
     subdomain = new_subdomain(test_ctx, test_ctx->domain,
                               testdom[0], testdom[1], testdom[2], testdom[3],
-                              false, false, NULL, 0);
+                              false, false, NULL, NULL, 0);
     fail_unless(subdomain != NULL, "Failed to create new subdomin.");
     ret = sysdb_subdomain_store(test_ctx->sysdb,
                                 testdom[0], testdom[1], testdom[2], testdom[3],
@@ -5781,7 +5781,7 @@ START_TEST(test_sysdb_subdomain_user_ops)
 
     subdomain = new_subdomain(test_ctx, test_ctx->domain,
                               testdom[0], testdom[1], testdom[2], testdom[3],
-                              false, false, NULL, 0);
+                              false, false, NULL, NULL, 0);
     fail_unless(subdomain != NULL, "Failed to create new subdomin.");
     ret = sysdb_subdomain_store(test_ctx->sysdb,
                                 testdom[0], testdom[1], testdom[2], testdom[3],
@@ -5854,7 +5854,7 @@ START_TEST(test_sysdb_subdomain_group_ops)
 
     subdomain = new_subdomain(test_ctx, test_ctx->domain,
                               testdom[0], testdom[1], testdom[2], testdom[3],
-                              false, false, NULL, 0);
+                              false, false, NULL, NULL, 0);
     fail_unless(subdomain != NULL, "Failed to create new subdomin.");
     ret = sysdb_subdomain_store(test_ctx->sysdb,
                                 testdom[0], testdom[1], testdom[2], testdom[3],


### PR DESCRIPTION
To reproduce, start with a fresh domain and attempt to log in as a user with an UPN suffix.