### PR TITLE
first letter of user name template for override_homedir

### DIFF
--- a/src/man/include/override_homedir.xml
+++ b/src/man/include/override_homedir.xml
@@ -24,6 +24,10 @@
                 <listitem><para>fully qualified user name (user@domain)</para></listitem>
             </varlistentry>
             <varlistentry>
+                <term>%l</term>
+                <listitem><para>The first letter of the login name.</para></listitem>
+            </varlistentry>
+            <varlistentry>
                 <term>%P</term>
                 <listitem><para>UPN - User Principal Name (name@REALM)</para></listitem>
             </varlistentry>

--- a/src/util/sss_nss.c
+++ b/src/util/sss_nss.c
@@ -88,6 +88,24 @@ char *expand_homedir_template(TALLOC_CTX *mem_ctx,
                 talloc_free(username);
                 break;
 
+            case 'l':
+                if (homedir_ctx->username == NULL) {
+                    DEBUG(SSSDBG_CRIT_FAILURE,
+                          "Cannot expand first letter of user name template "
+                          "because user name is empty.\n");
+                    goto done;
+                }
+                username = sss_output_name(tmp_ctx, homedir_ctx->username,
+                                           case_sensitive, 0);
+                if (username == NULL) {
+                    goto done;
+                }
+
+                username[1] = '\0';
+                result = talloc_asprintf_append(result, "%s%s", p, username);
+                talloc_free(username);
+                break;
+
             case 'U':
                 if (homedir_ctx->uid == 0) {
                     DEBUG(SSSDBG_CRIT_FAILURE, "Cannot expand uid template "

--- a/src/util/sss_nss.c
+++ b/src/util/sss_nss.c
@@ -101,8 +101,7 @@ char *expand_homedir_template(TALLOC_CTX *mem_ctx,
                     goto done;
                 }
 
-                username[1] = '\0';
-                result = talloc_asprintf_append(result, "%s%s", p, username);
+                result = talloc_asprintf_append(result, "%s%c", p, username[0]);
                 talloc_free(username);
                 break;
 


### PR DESCRIPTION
This is needed in order to remap homedirs onto large filesystems such as AFS or EOS where there is a filesystem level with the first letter of the user name such as /whatever/r/reguero rather than /whatever/reguero.