### PR TITLE
UTIL: Sanitize newline characters.

### DIFF
--- a/src/util/util.c
+++ b/src/util/util.c
@@ -589,6 +589,14 @@ errno_t sss_filter_sanitize_ex(TALLOC_CTX *mem_ctx,
             output[j++] = '5';
             output[j++] = 'c';
             break;
+        case '\n':
+            output[j++] = '\\';
+            output[j++] = '0';
+            output[j++] = 'd';
+            output[j++] = '\\';
+            output[j++] = '0';
+            output[j++] = 'a';
+            break;
         default:
             output[j++] = input[i];
         }

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -589,10 +589,12 @@ errno_t sss_filter_sanitize_ex(TALLOC_CTX *mem_ctx,
             output[j++] = '5';
             output[j++] = 'c';
             break;
-        case '\n':
+        case '\r':
             output[j++] = '\\';
             output[j++] = '0';
             output[j++] = 'd';
+            break;
+        case '\n':
             output[j++] = '\\';
             output[j++] = '0';
             output[j++] = 'a';


### PR DESCRIPTION
Introducing valid usernames with a trailing newline character triggers
the removal of valid LDB cache entries

Resolves:
https://pagure.io/SSSD/sssd/issue/3317