### PR TITLE
Search UPN only in the given domain

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -658,6 +658,7 @@ int sysdb_getpwuid(TALLOC_CTX *mem_ctx,
 
 int sysdb_getpwupn(TALLOC_CTX *mem_ctx,
                    struct sss_domain_info *domain,
+                   bool domain_scope,
                    const char *upn,
                    struct ldb_result **res);
 
@@ -832,12 +833,14 @@ int sysdb_search_user_by_sid_str(TALLOC_CTX *mem_ctx,
 
 int sysdb_search_user_by_upn_res(TALLOC_CTX *mem_ctx,
                                  struct sss_domain_info *domain,
+                                 bool domain_scope,
                                  const char *upn,
                                  const char **attrs,
                                  struct ldb_result **out_res);
 
 int sysdb_search_user_by_upn(TALLOC_CTX *mem_ctx,
                              struct sss_domain_info *domain,
+                             bool domain_scope,
                              const char *sid_str,
                              const char **attrs,
                              struct ldb_message **msg);

--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -538,6 +538,7 @@ int sysdb_search_user_by_sid_str(TALLOC_CTX *mem_ctx,
 
 int sysdb_search_user_by_upn_res(TALLOC_CTX *mem_ctx,
                                  struct sss_domain_info *domain,
+                                 bool domain_scope,
                                  const char *upn,
                                  const char **attrs,
                                  struct ldb_result **out_res)
@@ -555,7 +556,11 @@ int sysdb_search_user_by_upn_res(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    base_dn = sysdb_base_dn(domain->sysdb, tmp_ctx);
+    if (domain_scope == true) {
+        base_dn = sysdb_user_base_dn(tmp_ctx, domain);
+    } else {
+        base_dn = sysdb_base_dn(domain->sysdb, tmp_ctx);
+    }
     if (base_dn == NULL) {
         ret = ENOMEM;
         goto done;
@@ -599,6 +604,7 @@ done:
 
 int sysdb_search_user_by_upn(TALLOC_CTX *mem_ctx,
                              struct sss_domain_info *domain,
+                             bool domain_scope,
                              const char *upn,
                              const char **attrs,
                              struct ldb_message **msg)
@@ -613,7 +619,7 @@ int sysdb_search_user_by_upn(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    ret = sysdb_search_user_by_upn_res(tmp_ctx, domain, upn, attrs, &res);
+    ret = sysdb_search_user_by_upn_res(tmp_ctx, domain, domain_scope, upn, attrs, &res);
     if (ret == ENOENT) {
         DEBUG(SSSDBG_TRACE_FUNC, "No entry with upn [%s] found.\n", upn);
         goto done;

--- a/src/db/sysdb_search.c
+++ b/src/db/sysdb_search.c
@@ -454,6 +454,7 @@ static char *enum_filter(TALLOC_CTX *mem_ctx,
 
 int sysdb_getpwupn(TALLOC_CTX *mem_ctx,
                    struct sss_domain_info *domain,
+                   bool domain_scope,
                    const char *upn,
                    struct ldb_result **_res)
 {
@@ -468,7 +469,7 @@ int sysdb_getpwupn(TALLOC_CTX *mem_ctx,
         return ENOMEM;
     }
 
-    ret = sysdb_search_user_by_upn_res(tmp_ctx, domain, upn, attrs, &res);
+    ret = sysdb_search_user_by_upn_res(tmp_ctx, domain, domain_scope, upn, attrs, &res);
     if (ret != EOK && ret != ENOENT) {
         DEBUG(SSSDBG_OP_FAILURE, "sysdb_search_user_by_upn_res() failed.\n");
         goto done;
@@ -1322,7 +1323,7 @@ int sysdb_initgroups_by_upn(TALLOC_CTX *mem_ctx,
         return ENOMEM;
     }
 
-    ret = sysdb_search_user_by_upn(tmp_ctx, domain, upn, attrs, &msg);
+    ret = sysdb_search_user_by_upn(tmp_ctx, domain, false, upn, attrs, &msg);
     if (ret != EOK && ret != ENOENT) {
         DEBUG(SSSDBG_OP_FAILURE, "sysdb_search_user_by_upn() failed.\n");
         goto done;
@@ -2113,7 +2114,7 @@ errno_t sysdb_get_real_name(TALLOC_CTX *mem_ctx,
     }
 
     if (res->count == 0) {
-        ret = sysdb_search_user_by_upn(tmp_ctx, domain, name_or_upn_or_sid,
+        ret = sysdb_search_user_by_upn(tmp_ctx, domain, false, name_or_upn_or_sid,
                                        NULL, &msg);
         if (ret == ENOENT) {
             ret = sysdb_search_user_by_sid_str(tmp_ctx, domain,

--- a/src/providers/ad/ad_pac.c
+++ b/src/providers/ad/ad_pac.c
@@ -51,7 +51,7 @@ static errno_t find_user_entry(TALLOC_CTX *mem_ctx, struct sss_domain_info *dom,
     }
 
     if (ar->extra_value && strcmp(ar->extra_value, EXTRA_NAME_IS_UPN) == 0) {
-        ret = sysdb_search_user_by_upn(tmp_ctx, dom, ar->filter_value,
+        ret = sysdb_search_user_by_upn(tmp_ctx, dom, false, ar->filter_value,
                                        user_attrs, &msg);
     } else {
         switch (ar->filter_type) {

--- a/src/providers/ipa/ipa_subdomains_id.c
+++ b/src/providers/ipa/ipa_subdomains_id.c
@@ -1051,7 +1051,7 @@ errno_t get_object_from_cache(TALLOC_CTX *mem_ctx,
         case BE_REQ_USER_AND_GROUP:
             if (ar->extra_value
                     && strcmp(ar->extra_value, EXTRA_NAME_IS_UPN) == 0) {
-                ret = sysdb_search_user_by_upn(mem_ctx, dom, ar->filter_value,
+                ret = sysdb_search_user_by_upn(mem_ctx, dom, false, ar->filter_value,
                                                attrs, &msg);
             } else {
                 ret = sysdb_search_user_by_name(mem_ctx, dom, ar->filter_value,

--- a/src/providers/ldap/ldap_id.c
+++ b/src/providers/ldap/ldap_id.c
@@ -526,7 +526,7 @@ static void users_get_done(struct tevent_req *subreq)
             return;
         case BE_FILTER_NAME:
             if (state->name_is_upn == true) {
-                ret = sysdb_search_user_by_upn(state, state->domain,
+                ret = sysdb_search_user_by_upn(state, state->domain, false,
                                                state->filter_value,
                                                NULL, &msg);
                 if (ret != EOK) {

--- a/src/responder/common/cache_req/plugins/cache_req_user_by_upn.c
+++ b/src/responder/common/cache_req/plugins/cache_req_user_by_upn.c
@@ -85,10 +85,10 @@ cache_req_user_by_upn_lookup(TALLOC_CTX *mem_ctx,
                              struct ldb_result **_result)
 {
     if (data->attrs == NULL) {
-        return sysdb_getpwupn(mem_ctx, domain, false, data->name.lookup, _result);
+        return sysdb_getpwupn(mem_ctx, domain, true, data->name.lookup, _result);
     }
 
-    return sysdb_search_user_by_upn_res(mem_ctx, domain, false,
+    return sysdb_search_user_by_upn_res(mem_ctx, domain, true,
                                         data->name.lookup, data->attrs,
                                         _result);
 }

--- a/src/responder/common/cache_req/plugins/cache_req_user_by_upn.c
+++ b/src/responder/common/cache_req/plugins/cache_req_user_by_upn.c
@@ -85,11 +85,12 @@ cache_req_user_by_upn_lookup(TALLOC_CTX *mem_ctx,
                              struct ldb_result **_result)
 {
     if (data->attrs == NULL) {
-        return sysdb_getpwupn(mem_ctx, domain, data->name.lookup, _result);
+        return sysdb_getpwupn(mem_ctx, domain, false, data->name.lookup, _result);
     }
 
-    return sysdb_search_user_by_upn_res(mem_ctx, domain, data->name.lookup,
-                                        data->attrs, _result);
+    return sysdb_search_user_by_upn_res(mem_ctx, domain, false,
+                                        data->name.lookup, data->attrs,
+                                        _result);
 }
 
 static struct tevent_req *

--- a/src/tests/cmocka/test_sysdb_ts_cache.c
+++ b/src/tests/cmocka/test_sysdb_ts_cache.c
@@ -1303,14 +1303,14 @@ static void test_user_byupn(void **state)
                            TEST_NOW_2);
     assert_int_equal(ret, EOK);
 
-    ret = sysdb_getpwupn(test_ctx, test_ctx->tctx->dom, TEST_USER_UPN, &res);
+    ret = sysdb_getpwupn(test_ctx, test_ctx->tctx->dom, false, TEST_USER_UPN, &res);
     assert_int_equal(ret, EOK);
     assert_int_equal(res->count, 1);
     assert_ts_attrs_res(res, TEST_NOW_2 + TEST_CACHE_TIMEOUT, TEST_NOW_2);
     talloc_free(res);
 
     ret = sysdb_search_user_by_upn_res(test_ctx, test_ctx->tctx->dom,
-                                       TEST_USER_UPN, pw_fetch_attrs,
+                                       false, TEST_USER_UPN, pw_fetch_attrs,
                                        &res);
     assert_int_equal(ret, EOK);
     assert_int_equal(res->count, 1);
@@ -1318,7 +1318,7 @@ static void test_user_byupn(void **state)
     talloc_free(res);
 
     ret = sysdb_search_user_by_upn(test_ctx, test_ctx->tctx->dom,
-                                   TEST_USER_UPN, pw_fetch_attrs,
+                                   false, TEST_USER_UPN, pw_fetch_attrs,
                                    &msg);
     assert_int_equal(ret, EOK);
     assert_ts_attrs_msg(msg, TEST_NOW_2 + TEST_CACHE_TIMEOUT, TEST_NOW_2);

--- a/src/tests/sysdb-tests.c
+++ b/src/tests/sysdb-tests.c
@@ -6253,12 +6253,12 @@ START_TEST(test_upn_basic)
                            attrs, NULL, -1, 0);
     fail_unless(ret == EOK, "Could not store user.");
 
-    ret = sysdb_search_user_by_upn(test_ctx, test_ctx->domain,
+    ret = sysdb_search_user_by_upn(test_ctx, test_ctx->domain, false,
                                    "abc@def.ghi", NULL, &msg);
     fail_unless(ret == ENOENT,
                 "sysdb_search_user_by_upn failed with non-existing UPN.");
 
-    ret = sysdb_search_user_by_upn(test_ctx, test_ctx->domain,
+    ret = sysdb_search_user_by_upn(test_ctx, test_ctx->domain, false,
                                    UPN_PRINC, NULL, &msg);
     fail_unless(ret == EOK, "sysdb_search_user_by_upn failed.");
 
@@ -6290,7 +6290,7 @@ START_TEST(test_upn_basic_case)
         return;
     }
 
-    ret = sysdb_search_user_by_upn(test_ctx, test_ctx->domain,
+    ret = sysdb_search_user_by_upn(test_ctx, test_ctx->domain, false,
                                    UPN_PRINC_WRONG_CASE, NULL, &msg);
     fail_unless(ret == EOK, "sysdb_search_user_by_upn failed.");
 
@@ -6322,7 +6322,7 @@ START_TEST(test_upn_canon)
         return;
     }
 
-    ret = sysdb_search_user_by_upn(test_ctx, test_ctx->domain,
+    ret = sysdb_search_user_by_upn(test_ctx, test_ctx->domain, false,
                                    UPN_CANON_PRINC, NULL, &msg);
     fail_unless(ret == EOK, "sysdb_search_user_by_upn failed.");
 
@@ -6359,7 +6359,7 @@ START_TEST(test_upn_canon_case)
         return;
     }
 
-    ret = sysdb_search_user_by_upn(test_ctx, test_ctx->domain,
+    ret = sysdb_search_user_by_upn(test_ctx, test_ctx->domain, false,
                                    UPN_CANON_PRINC_WRONG_CASE, NULL, &msg);
     fail_unless(ret == EOK, "sysdb_search_user_by_upn failed.");
 
@@ -6410,12 +6410,12 @@ START_TEST(test_upn_dup)
                            attrs, NULL, -1, 0);
     fail_unless(ret == EOK, "Could not store user.");
 
-    ret = sysdb_search_user_by_upn(test_ctx, test_ctx->domain,
+    ret = sysdb_search_user_by_upn(test_ctx, test_ctx->domain, false,
                                    UPN_CANON_PRINC, NULL, &msg);
     fail_unless(ret == EINVAL,
                 "sysdb_search_user_by_upn failed for duplicated UPN.");
 
-    ret = sysdb_search_user_by_upn(test_ctx, test_ctx->domain,
+    ret = sysdb_search_user_by_upn(test_ctx, test_ctx->domain, false,
                                    UPN_PRINC, NULL, &msg);
     fail_unless(ret == EOK, "sysdb_search_user_by_upn failed.");
 


### PR DESCRIPTION
We were searching UPNs in the whole sysdb, which made cache_req think the
result came in from the domain it was searching.

The bug manifested when a user from a trusted domain was looked by UPN, then
cache_req searched the main domain, the result from subdomain was considered
as coming from the main domain and as a result, the getpwnam() output was
not qualified. That is a problem, because PAM applications often sanitize
the user with getpwnam, so effectively a login with UPN was shortened to
just a shortname and failed.