### PR TITLE
SECRETS: Shutdown the responder in case it becomes idle

### DIFF
--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -239,6 +239,7 @@ option = description
 option = containers_nest_level
 option = max_secrets
 option = max_payload_size
+option = responder_idle_timeout
 
 [rule/allowed_sec_users_options]
 validator = ini_allowed_options

--- a/src/responder/common/responder.h
+++ b/src/responder/common/responder.h
@@ -344,6 +344,8 @@ void responder_set_fd_limit(rlim_t fd_limit);
 
 errno_t reset_client_idle_timer(struct cli_ctx *cctx);
 
+errno_t responder_setup_idle_timeout_config(struct resp_ctx *rctx);
+
 #define GET_DOMAINS_DEFAULT_TIMEOUT 60
 
 struct tevent_req *sss_dp_get_domains_send(TALLOC_CTX *mem_ctx,

--- a/src/responder/secrets/secsrv.c
+++ b/src/responder/secrets/secsrv.c
@@ -100,6 +100,11 @@ static int sec_get_config(struct sec_ctx *sctx)
         sctx->rctx->client_idle_timeout = 10;
     }
 
+    ret = responder_setup_idle_timeout_config(sctx->rctx);
+    if (ret != EOK) {
+        goto fail;
+    }
+
     ret = EOK;
 
 fail:


### PR DESCRIPTION
Similarly to what has been done for the other responders, let's shutdown the secrets responder in case it becomes idle.

Resolves:
https://pagure.io/SSSD/sssd/issue/3316

