### PR TITLE
README.md: Point to our releases on pagure

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,19 @@ to connect to multiple different account sources.
 More information about SSSD can be found on its project page -
 https://pagure.io/SSSD/sssd/
 
-## Building and installation
+## Downloading SSSD
+SSSD is shipped as a binary package by most Linux distributions. If you
+want to obtain the latest source files, please navigate to the
+[Releases folder on pagure](https://releases.pagure.org/SSSD/sssd/)
+
+## Releases
+SSSD maintains two release streams - stable and LTM. Releases designated as
+LTM are long-term maintenance releases and will see bugfixes and security
+patches for a longer time than other releases.
+
+The list of all releases is maintained together with [SSSD documentation](https://docs.pagure.org/SSSD.sssd/users/releases.html)
+
+## Building and installation from source
 Please see the file BUILD.txt for details
 
 ## Documentation


### PR DESCRIPTION
Since the README.md is more or less what the wiki front page used to be,
it makes sense, especially for Github users, to point to our releases
from README.md