### PR TITLE
cache_req: use rctx as memory context during midpoint refresh

### DIFF
--- a/src/responder/common/cache_req/cache_req_search.c
+++ b/src/responder/common/cache_req/cache_req_search.c
@@ -266,7 +266,7 @@ static errno_t cache_req_search_dp(struct tevent_req *req,
                         "Performing midpoint cache update of [%s]\n",
                         state->cr->debugobj);
 
-        subreq = state->cr->plugin->dp_send_fn(state->cr, state->cr,
+        subreq = state->cr->plugin->dp_send_fn(state->rctx, state->cr,
                                                state->cr->data,
                                                state->cr->domain,
                                                state->result);


### PR DESCRIPTION
Otherwise the tevent request is freed when we return data from cache_req
to caller. It is no big deal since the request is still finished on provider
side but the reply wouldn't be processed.