### PR TITLE
Subdomain config

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2753,6 +2753,28 @@ subdomain_inherit = ldap_purge_cache_timeout
 
     </refsect1>
 
+    <refsect1 id='trusted-domains'>
+        <title>TRUSTED DOMAIN SECTION</title>
+        <para>
+            Some options used in the domain section can also be used in the
+            trusted domain section, that is, in a section called
+            <quote>[domain/<replaceable>DOMAIN_NAME</replaceable>]/<replaceable>TRUSTED_DOMAIN_NAME</replaceable>]</quote>.
+            Currently supported options in the trusted domain section are:
+        </para>
+            <para>ldap_search_base,</para>
+            <para>ldap_user_search_base,</para>
+            <para>ldap_group_search_base,</para>
+            <para>ldap_netgroup_search_base,</para>
+            <para>ldap_service_search_base,</para>
+            <para>ad_server,</para>
+            <para>ad_backup_server,</para>
+            <para>ad_site.</para>
+        <para>
+            For more details about these options see their individual description
+            in the manual page.
+        </para>
+    </refsect1>
+
     <refsect1 id='example'>
         <title>EXAMPLE</title>
         <para>

--- a/src/providers/ad/ad_common.h
+++ b/src/providers/ad/ad_common.h
@@ -99,6 +99,10 @@ struct ad_options {
     struct be_nsupdate_ctx *dyndns_ctx;
 };
 
+char *create_subdom_conf_path(TALLOC_CTX *mem_ctx,
+                              const char *conf_path,
+                              const char *subdom_name);
+
 errno_t
 ad_get_common_options(TALLOC_CTX *mem_ctx,
                       struct confdb_ctx *cdb,
@@ -106,19 +110,31 @@ ad_get_common_options(TALLOC_CTX *mem_ctx,
                       struct sss_domain_info *dom,
                       struct ad_options **_opts);
 
-struct ad_options *ad_create_default_options(TALLOC_CTX *mem_ctx);
+/* FIXME: ad_get_common_options and ad_create_options are
+ * similar. The later is subdomain specific. It may be
+ * good to merge the two into one more generic funtion. */
+struct ad_options *ad_create_options(TALLOC_CTX *mem_ctx,
+                                     struct confdb_ctx *cdb,
+                                     const char *conf_path,
+                                     struct sss_domain_info *subdom);
 
 struct ad_options *ad_create_2way_trust_options(TALLOC_CTX *mem_ctx,
+                                                struct confdb_ctx *cdb,
+                                                const char *conf_path,
                                                 const char *realm,
-                                                const char *ad_domain,
+                                                struct sss_domain_info *subdom,
                                                 const char *hostname,
                                                 const char *keytab);
 
 struct ad_options *ad_create_1way_trust_options(TALLOC_CTX *mem_ctx,
-                                                const char *ad_domain,
+                                                struct confdb_ctx *cdb,
+                                                const char *conf_path,
+                                                struct sss_domain_info *subdom,
                                                 const char *hostname,
                                                 const char *keytab,
                                                 const char *sasl_authid);
+
+errno_t ad_set_search_bases(struct sdap_options *id_opts);
 
 errno_t
 ad_failover_init(TALLOC_CTX *mem_ctx, struct be_ctx *ctx,

--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -158,6 +158,7 @@ ad_subdom_ad_ctx_new(struct be_ctx *be_ctx,
     const char *realm;
     const char *hostname;
     const char *keytab;
+    char *subdom_conf_path;
 
     realm = dp_opt_get_cstring(id_ctx->ad_options->basic, AD_KRB5_REALM);
     hostname = dp_opt_get_cstring(id_ctx->ad_options->basic, AD_HOSTNAME);
@@ -168,8 +169,18 @@ ad_subdom_ad_ctx_new(struct be_ctx *be_ctx,
         return EINVAL;
     }
 
-    ad_options = ad_create_2way_trust_options(id_ctx, realm, ad_domain,
+    subdom_conf_path = create_subdom_conf_path(id_ctx,
+                                               be_ctx->conf_path,
+                                               subdom->name);
+    if (subdom_conf_path == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "subdom_conf_path failed\n");
+        return ENOMEM;
+    }
+
+    ad_options = ad_create_2way_trust_options(id_ctx, be_ctx->cdb,
+                                              subdom_conf_path, realm, subdom,
                                               hostname, keytab);
+    talloc_free(subdom_conf_path);
     if (ad_options == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Cannot initialize AD options\n");
         talloc_free(ad_options);

--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -156,6 +156,8 @@ ad_subdom_ad_ctx_new(struct be_ctx *be_ctx,
     struct sdap_domain *sdom;
     errno_t ret;
     const char *realm;
+    const char *servers;
+    const char *backup_servers;
     const char *hostname;
     const char *keytab;
     char *subdom_conf_path;
@@ -201,7 +203,10 @@ ad_subdom_ad_ctx_new(struct be_ctx *be_ctx,
         return ENOMEM;
     }
 
-    ret = ad_failover_init(ad_options, be_ctx, NULL, NULL, realm,
+    servers = dp_opt_get_string(ad_options->basic, AD_SERVER);
+    backup_servers = dp_opt_get_string(ad_options->basic, AD_BACKUP_SERVER);
+
+    ret = ad_failover_init(ad_options, be_ctx, servers, backup_servers, realm,
                            service_name, gc_service_name,
                            subdom->name, &ad_options->service);
     if (ret != EOK) {

--- a/src/providers/ipa/ipa_subdomains_server.c
+++ b/src/providers/ipa/ipa_subdomains_server.c
@@ -231,7 +231,7 @@ ipa_ad_ctx_new(struct be_ctx *be_ctx,
         ret = dp_opt_set_string(ad_options->id->basic, SDAP_USER_EXTRA_ATTRS,
                                 extra_attrs);
         if (ret != EOK) {
-            DEBUG(SSSDBG_OP_FAILURE, "dp_opt_get_string failed.\n");
+            DEBUG(SSSDBG_OP_FAILURE, "dp_opt_set_string failed.\n");
             talloc_free(ad_options);
             return ret;
         }

--- a/src/providers/ipa/ipa_subdomains_server.c
+++ b/src/providers/ipa/ipa_subdomains_server.c
@@ -223,6 +223,8 @@ ipa_ad_ctx_new(struct be_ctx *be_ctx,
     struct ad_srv_plugin_ctx *srv_ctx;
     const char *ad_domain;
     const char *ad_site_override;
+    const char *ad_servers;
+    const char *ad_backup_servers;
     struct sdap_domain *sdom;
     errno_t ret;
     const char *extra_attrs;
@@ -279,9 +281,12 @@ ipa_ad_ctx_new(struct be_ctx *be_ctx,
         return ENOMEM;
     }
 
+    ad_servers = dp_opt_get_string(ad_options->basic, AD_SERVER);
+    ad_backup_servers = dp_opt_get_string(ad_options->basic, AD_BACKUP_SERVER);
+
     /* Set KRB5 realm to same as the one of IPA when IPA
      * is able to attach PAC. For testing, use hardcoded. */
-    ret = ad_failover_init(ad_options, be_ctx, NULL, NULL,
+    ret = ad_failover_init(ad_options, be_ctx, ad_servers, ad_backup_servers,
                            id_ctx->server_mode->realm,
                            service_name, gc_service_name,
                            subdom->name, &ad_options->service);

--- a/src/tests/cmocka/test_ad_common.c
+++ b/src/tests/cmocka/test_ad_common.c
@@ -389,24 +389,6 @@ struct ad_common_test_ctx {
     struct sss_domain_info *subdom;
 };
 
-static void test_ad_create_default_options(void **state)
-{
-    struct ad_options *ad_options;
-    const char *s;
-
-    ad_options = ad_create_default_options(global_talloc_context);
-
-    assert_non_null(ad_options->basic);
-
-    /* Not too much to test here except some defaults */
-    s = dp_opt_get_string(ad_options->basic, AD_DOMAIN);
-    assert_null(s);
-
-    assert_non_null(ad_options->id);
-
-    talloc_free(ad_options);
-}
-
 static int test_ad_common_setup(void **state)
 {
     struct ad_common_test_ctx *test_ctx;
@@ -462,9 +444,12 @@ static void test_ad_create_1way_trust_options(void **state)
     /* Make sure this is not the keytab that __wrap_krb5_kt_default uses */
     mock_keytab_with_contents(test_ctx, ONEWAY_KEYTAB_PATH, ONEWAY_TEST_PRINC);
 
+    test_ctx->subdom->name = discard_const(ONEWAY_DOMNAME);
     test_ctx->ad_ctx->ad_options = ad_create_1way_trust_options(
                                                             test_ctx->ad_ctx,
-                                                            ONEWAY_DOMNAME,
+                                                            NULL,
+                                                            NULL,
+                                                            test_ctx->subdom,
                                                             ONEWAY_HOST_NAME,
                                                             ONEWAY_KEYTAB_PATH,
                                                             ONEWAY_AUTHID);
@@ -524,13 +509,17 @@ static void test_ad_create_2way_trust_options(void **state)
 
     call_real_sasl_options = true;
     mock_keytab_with_contents(test_ctx, KEYTAB_PATH, KEYTAB_TEST_PRINC);
+    test_ctx->subdom->name = discard_const(DOMNAME);
 
     test_ctx->ad_ctx->ad_options = ad_create_2way_trust_options(
-                                                            test_ctx->ad_ctx,
-                                                            REALMNAME,
-                                                            DOMNAME,
-                                                            HOST_NAME,
-                                                            NULL);
+                                        test_ctx->ad_ctx,
+                                        NULL,
+                                        NULL,
+                                        REALMNAME,
+                                        test_ctx->subdom,
+                                        HOST_NAME,
+                                        NULL);
+
     assert_non_null(test_ctx->ad_ctx->ad_options);
 
     assert_int_equal(test_ctx->ad_ctx->ad_options->id->schema_type,
@@ -592,11 +581,15 @@ test_ldap_conn_setup(void **state)
 
     ad_ctx = test_ctx->ad_ctx;
 
-    ad_ctx->ad_options = ad_create_2way_trust_options(ad_ctx,
-                                                      REALMNAME,
-                                                      DOMNAME,
-                                                      HOST_NAME,
-                                                      NULL);
+    test_ctx->ad_ctx->ad_options = ad_create_2way_trust_options(
+                                        ad_ctx,
+                                        NULL,
+                                        NULL,
+                                        REALMNAME,
+                                        test_ctx->subdom,
+                                        HOST_NAME,
+                                        NULL);
+
     assert_non_null(ad_ctx->ad_options);
 
     ad_ctx->gc_ctx = talloc_zero(ad_ctx, struct sdap_id_conn_ctx);
@@ -889,7 +882,6 @@ int main(int argc, const char *argv[])
     };
 
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test(test_ad_create_default_options),
         cmocka_unit_test_setup_teardown(test_ad_create_1way_trust_options,
                                         test_ad_common_setup,
                                         test_ad_common_teardown),


### PR DESCRIPTION
This is the part of subdomain configuration feature needed to allow specify the search bases for the subdomain (one of the two use cases that were specified in the desin doc).

The second part with the server was more complicated then I expected, so I will send it separately (hopefully today or tomorrow), but I can not delay this first part anymore).

In order to test create a ipa-ad trust and redefine for example the ldap_search_base or ldap_user_search_base on the server side SSSD. BOth client and server side SSSDs will be able to use the alternative search base (no config changes needed on the client side SSSD).