### PR TITLE
Add support to lookup for users/groups in subdomains just by the user shortname

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -736,6 +736,7 @@ dist_noinst_HEADERS = \
     src/db/sysdb_private.h \
     src/db/sysdb_services.h \
     src/db/sysdb_ssh.h \
+    src/db/sysdb_domain_resolution_order.h \
     src/confdb/confdb.h \
     src/confdb/confdb_private.h \
     src/confdb/confdb_setup.h \
@@ -995,6 +996,7 @@ libsss_util_la_SOURCES = \
     src/db/sysdb_idmap.c \
     src/db/sysdb_gpo.c \
     src/db/sysdb_certmap.c \
+    src/db/sysdb_domain_resolution_order.c \
     src/monitor/monitor_sbus.c \
     src/providers/dp_auth_util.c \
     src/providers/dp_pam_data_util.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -263,6 +263,7 @@ if HAVE_CMOCKA
         test_sysdb_certmap \
         test_sysdb_sudo \
         test_sysdb_utils \
+        test_sysdb_domain_resolution_order \
         test_wbc_calls \
         test_be_ptask \
         test_copy_ccache \
@@ -2867,6 +2868,21 @@ test_sysdb_utils_CFLAGS = \
     $(AM_CFLAGS) \
     $(NULL)
 test_sysdb_utils_LDADD = \
+    $(CMOCKA_LIBS) \
+    $(LDB_LIBS) \
+    $(POPT_LIBS) \
+    $(TALLOC_LIBS) \
+    $(SSSD_INTERNAL_LTLIBS) \
+    libsss_test_common.la \
+    $(NULL)
+
+test_sysdb_domain_resolution_order_SOURCES = \
+    src/tests/cmocka/test_sysdb_domain_resolution_order.c \
+    $(NULL)
+test_sysdb_domain_resolution_order_CFLAGS = \
+    $(AM_CFLAGS) \
+    $(NULL)
+test_sysdb_domain_resolution_order_LDADD = \
     $(CMOCKA_LIBS) \
     $(LDB_LIBS) \
     $(POPT_LIBS) \

--- a/Makefile.am
+++ b/Makefile.am
@@ -528,6 +528,7 @@ SSSD_CACHE_REQ_OBJ = \
 	src/responder/common/cache_req/cache_req_result.c \
 	src/responder/common/cache_req/cache_req_search.c \
 	src/responder/common/cache_req/cache_req_data.c \
+	src/responder/common/cache_req/cache_req_domain.c \
 	src/responder/common/cache_req/plugins/cache_req_common.c \
 	src/responder/common/cache_req/plugins/cache_req_enum_users.c \
 	src/responder/common/cache_req/plugins/cache_req_enum_groups.c \
@@ -689,6 +690,7 @@ dist_noinst_HEADERS = \
     src/responder/common/iface/responder_iface.h \
     src/responder/common/iface/responder_iface_generated.h \
     src/responder/common/cache_req/cache_req.h \
+    src/responder/common/cache_req/cache_req_domain.h \
     src/responder/common/cache_req/cache_req_plugin.h \
     src/responder/common/cache_req/cache_req_private.h \
     src/responder/common/data_provider/rdp.h \
@@ -2199,6 +2201,7 @@ responder_socket_access_tests_SOURCES = \
     src/responder/common/responder_common.c \
     src/responder/common/responder_packet.c \
     src/responder/common/responder_cmd.c \
+    src/responder/common/cache_req/cache_req_domain.c \
     src/responder/common/data_provider/rdp_message.c \
     src/responder/common/data_provider/rdp_client.c \
     $(SSSD_RESPONDER_IFACE_OBJ) \

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -74,6 +74,7 @@
 #define CONFDB_MONITOR_CERT_VERIFICATION "certificate_verification"
 #define CONFDB_MONITOR_DISABLE_NETLINK "disable_netlink"
 #define CONFDB_MONITOR_ENABLE_FILES_DOM "enable_files_domain"
+#define CONFDB_MONITOR_DOMAIN_RESOLUTION_ORDER "domain_resolution_order"
 
 /* Both monitor and domains */
 #define CONFDB_NAME_REGEX   "re_expression"

--- a/src/config/SSSDConfig/__init__.py.in
+++ b/src/config/SSSDConfig/__init__.py.in
@@ -66,6 +66,7 @@ option_strings = {
     'override_space': _('All spaces in group or user names will be replaced with this character'),
     'disable_netlink' : _('Tune sssd to honor or ignore netlink state changes'),
     'enable_files_domain' : _('Enable or disable the implicit files domain'),
+    'domain_resolution_order': _('A specific order of the domains to be looked up'),
 
     # [nss]
     'enum_cache_timeout' : _('Enumeration cache timeout length (seconds)'),

--- a/src/config/SSSDConfigTest.py
+++ b/src/config/SSSDConfigTest.py
@@ -94,6 +94,10 @@ class SSSDConfigTestValid(unittest.TestCase):
         self.assertTrue('default_domain_suffix' in new_options)
         self.assertEquals(new_options['default_domain_suffix'][0], str)
 
+        self.assertTrue('domain_resolution_order' in new_options)
+        self.assertEquals(new_options['domain_resolution_order'][0], list)
+        self.assertEquals(new_options['domain_resolution_order'][1], str)
+
         del sssdconfig
 
     def testDomains(self):
@@ -314,7 +318,8 @@ class SSSDConfigTestSSSDService(unittest.TestCase):
             'certificate_verification',
             'override_space',
             'disable_netlink',
-            'enable_files_domain']
+            'enable_files_domain',
+            'domain_resolution_order']
 
         self.assertTrue(type(options) == dict,
                         "Options should be a dictionary")

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -43,6 +43,7 @@ option = override_space
 option = config_file_version
 option = disable_netlink
 option = enable_files_domain
+option = domain_resolution_order
 
 [rule/allowed_nss_options]
 validator = ini_allowed_options

--- a/src/config/etc/sssd.api.conf
+++ b/src/config/etc/sssd.api.conf
@@ -32,6 +32,7 @@ certificate_verification = str, None, false
 override_space = str, None, false
 disable_netlink = bool, None, false
 enable_files_domain = str, None, false
+domain_resolution_order = list, str, false
 
 [nss]
 # Name service

--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -489,6 +489,17 @@ int sysdb_transaction_cancel(struct sysdb_ctx *sysdb);
 /* functions related to subdomains */
 errno_t sysdb_domain_create(struct sysdb_ctx *sysdb, const char *domain_name);
 
+errno_t sysdb_domain_get_domain_resolution_order(
+                                        TALLOC_CTX *mem_ctx,
+                                        struct sysdb_ctx *sysdb,
+                                        const char *domain_name,
+                                        const char **_domain_resolution_order);
+
+errno_t sysdb_domain_update_domain_resolution_order(
+                                        struct sysdb_ctx *sysdb,
+                                        const char *domain_name,
+                                        const char *domain_resolution_order);
+
 errno_t sysdb_subdomain_store(struct sysdb_ctx *sysdb,
                               const char *name, const char *realm,
                               const char *flat_name, const char *domain_id,

--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -494,7 +494,8 @@ errno_t sysdb_subdomain_store(struct sysdb_ctx *sysdb,
                               uint32_t trust_direction,
                               struct ldb_message_element *upn_suffixes);
 
-errno_t sysdb_update_subdomains(struct sss_domain_info *domain);
+errno_t sysdb_update_subdomains(struct sss_domain_info *domain,
+                                struct confdb_ctx *confdb);
 
 errno_t sysdb_master_domain_update(struct sss_domain_info *domain);
 

--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -533,6 +533,15 @@ errno_t sysdb_update_view_name(struct sysdb_ctx *sysdb, const char *view_name);
 errno_t sysdb_get_view_name(TALLOC_CTX *mem_ctx, struct sysdb_ctx *sysdb,
                             char **view_name);
 
+errno_t sysdb_update_view_domain_resolution_order(
+                                        struct sysdb_ctx *sysdb,
+                                        const char *domain_resolution_order);
+
+errno_t sysdb_get_view_domain_resolution_order(
+                                        TALLOC_CTX *mem_ctx,
+                                        struct sysdb_ctx *sysdb,
+                                        const char **_domain_resolution_order);
+
 static inline bool is_default_view(const char *view_name)
 {
     /* NULL is treated as default */

--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -184,6 +184,8 @@
 #define SYSDB_OVERRIDE_GROUP_CLASS "groupOverride"
 #define SYSDB_OVERRIDE_DN "overrideDN"
 #define SYSDB_OVERRIDE_OBJECT_DN "overrideObjectDN"
+#define SYSDB_USE_DOMAIN_RESOLUTION_ORDER "useDomainResolutionOrder"
+#define SYSDB_DOMAIN_RESOLUTION_ORDER "domainResolutionOrder"
 
 #define SYSDB_NEXTID_FILTER "("SYSDB_NEXTID"=*)"
 

--- a/src/db/sysdb_domain_resolution_order.c
+++ b/src/db/sysdb_domain_resolution_order.c
@@ -1,0 +1,169 @@
+/*
+    Authors:
+        Fabiano Fidêncio <fidencio@redhat.com>
+
+    Copyright (C) 2017 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <ldb.h>
+
+#include "db/sysdb.h"
+#include "db/sysdb_private.h"
+
+static errno_t
+sysdb_get_domain_resolution_order_string_attr(TALLOC_CTX *mem_ctx,
+                                              struct sysdb_ctx *sysdb,
+                                              struct ldb_dn *dn,
+                                              const char *const *attrs,
+                                              const char **_attr)
+{
+    TALLOC_CTX *tmp_ctx;
+    struct ldb_result *res;
+    const char *attr;
+    errno_t ret;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    ret = ldb_search(sysdb->ldb, tmp_ctx, &res, dn, LDB_SCOPE_BASE, attrs,
+                     NULL);
+    if (ret != LDB_SUCCESS) {
+        ret = EIO;
+        goto done;
+    }
+
+    if (res->count > 1) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Base search returned [%d] results, expected 1.\n", res->count);
+        ret = EINVAL;
+        goto done;
+    } else if (res->count == 0) {
+        ret = ENOENT;
+        goto done;
+    } else {
+        /* res->count == 1 */
+        attr = ldb_msg_find_attr_as_string(res->msgs[0], attrs[0], NULL);
+        if (attr == NULL) {
+            ret = ENOENT;
+            goto done;
+        }
+    }
+
+    *_attr = talloc_steal(mem_ctx, attr);
+
+    ret = EOK;
+
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+errno_t
+sysdb_get_domain_resolution_order(TALLOC_CTX *mem_ctx,
+                                  struct sysdb_ctx *sysdb,
+                                  struct ldb_dn *dn,
+                                  const char **_domain_resolution_order)
+{
+    TALLOC_CTX *tmp_ctx;
+    const char *domain_resolution_order = NULL;
+    const char *attrs[] = { SYSDB_DOMAIN_RESOLUTION_ORDER, NULL };
+    errno_t ret;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    ret = sysdb_get_domain_resolution_order_string_attr(
+            tmp_ctx, sysdb, dn, attrs, &domain_resolution_order);
+    if (ret != EOK && ret != ENOENT) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "sysdb_get_domain_resolution_order_string_attr() failed "
+              "[%d]: [%s]",
+              ret, sss_strerror(ret));
+        goto done;
+    } else if (ret == ENOENT) {
+        *_domain_resolution_order = NULL;
+        goto done;
+    } else {
+        /* ret == EOK */
+        *_domain_resolution_order = talloc_steal(mem_ctx,
+                                                 domain_resolution_order);
+    }
+
+    ret = EOK;
+
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+errno_t
+sysdb_update_domain_resolution_order(struct sysdb_ctx *sysdb,
+                                     struct ldb_dn *dn,
+                                     const char *domain_resolution_order)
+{
+    TALLOC_CTX *tmp_ctx;
+    struct ldb_message *msg;
+    errno_t ret;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    msg = ldb_msg_new(tmp_ctx);
+    if (msg == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    msg->dn = dn;
+
+    ret = ldb_msg_add_empty(msg, SYSDB_DOMAIN_RESOLUTION_ORDER,
+                            LDB_FLAG_MOD_REPLACE, NULL);
+    if (ret != LDB_SUCCESS) {
+        ret = sysdb_error_to_errno(ret);
+        goto done;
+    }
+
+    if (domain_resolution_order != NULL) {
+        ret = ldb_msg_add_string(msg, SYSDB_DOMAIN_RESOLUTION_ORDER,
+                                 domain_resolution_order);
+        if (ret != LDB_SUCCESS) {
+            ret = sysdb_error_to_errno(ret);
+            goto done;
+        }
+    }
+
+    ret = ldb_modify(sysdb->ldb, msg);
+    if (ret != LDB_SUCCESS) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "ldb_modify()_failed: [%s][%d][%s]\n",
+              ldb_strerror(ret), ret, ldb_errstring(sysdb->ldb));
+        ret = sysdb_error_to_errno(ret);
+        goto done;
+    }
+
+
+    ret = EOK;
+
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}

--- a/src/db/sysdb_domain_resolution_order.h
+++ b/src/db/sysdb_domain_resolution_order.h
@@ -1,0 +1,37 @@
+/*
+    Authors:
+        Fabiano Fidêncio <fidencio@redhat.com>
+
+    Copyright (C) 2017 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _SYSDB_DOMAIN_RESOLUTION_ORDER_H_
+#define _SYSDB_DOMAIN_RESOLUTION_ORDER_H_
+
+#include "db/sysdb.h"
+
+errno_t
+sysdb_get_domain_resolution_order(TALLOC_CTX *mem_ctx,
+                                  struct sysdb_ctx *sysdb,
+                                  struct ldb_dn *dn,
+                                  const char **_domain_resolution_order);
+
+errno_t
+sysdb_update_domain_resolution_order(struct sysdb_ctx *sysdb,
+                                     struct ldb_dn *dn,
+                                     const char *domain_resolution_order);
+
+#endif /* _SYSDB_DOMAIN_RESOLUTION_ORDER_H_ */

--- a/src/db/sysdb_private.h
+++ b/src/db/sysdb_private.h
@@ -191,7 +191,8 @@ struct sss_domain_info *new_subdomain(TALLOC_CTX *mem_ctx,
                                       bool enumerate,
                                       const char *forest,
                                       const char **upn_suffixes,
-                                      uint32_t trust_direction);
+                                      uint32_t trust_direction,
+                                      struct confdb_ctx *confdb);
 
 /* Helper functions to deal with the timestamp cache should not be used
  * outside the sysdb itself. The timestamp cache should be completely

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -542,6 +542,26 @@
                             </para>
                         </listitem>
                     </varlistentry>
+                    <varlistentry>
+                        <term>domain_resolution_order</term>
+                        <listitem>
+                            <para>
+                                Comma separated list of domains and subdomains
+                                representing the lookup order that will be
+                                followed.
+                                The list doesn't have to include all possible
+                                domains as the missing domains will be looked
+                                up based on the order they're presented in the
+                                <quote>domains</quote> configuration option.
+                                The subdomains which are not listed as part of
+                                <quote>lookup_order</quote> will be looked up
+                                in a random order for each parent domain.
+                            </para>
+                            <para>
+                                Default: Not set
+                            </para>
+                        </listitem>
+                    </varlistentry>
                 </variablelist>
             </para>
         </refsect2>

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2780,7 +2780,8 @@ subdomain_inherit = ldap_purge_cache_timeout
             <para>ldap_service_search_base,</para>
             <para>ad_server,</para>
             <para>ad_backup_server,</para>
-            <para>ad_site.</para>
+            <para>ad_site,</para>
+            <para>use_fully_qualified_names</para>
         <para>
             For more details about these options see their individual description
             in the manual page.

--- a/src/providers/ad/ad_common.c
+++ b/src/providers/ad/ad_common.c
@@ -33,13 +33,6 @@ errno_t ad_set_search_bases(struct sdap_options *id_opts);
 static errno_t ad_set_sdap_options(struct ad_options *ad_opts,
                                    struct sdap_options *id_opts);
 
-char *create_subdom_conf_path(TALLOC_CTX *mem_ctx,
-                              const char *conf_path,
-                              const char *subdom_name)
-{
-    return talloc_asprintf(mem_ctx, "%s/%s", conf_path, subdom_name);
-}
-
 static struct sdap_options *
 ad_create_default_sdap_options(TALLOC_CTX *mem_ctx)
 {

--- a/src/providers/ad/ad_common.h
+++ b/src/providers/ad/ad_common.h
@@ -99,10 +99,6 @@ struct ad_options {
     struct be_nsupdate_ctx *dyndns_ctx;
 };
 
-char *create_subdom_conf_path(TALLOC_CTX *mem_ctx,
-                              const char *conf_path,
-                              const char *subdom_name);
-
 errno_t
 ad_get_common_options(TALLOC_CTX *mem_ctx,
                       struct confdb_ctx *cdb,

--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -656,7 +656,8 @@ static errno_t ad_subdom_reinit(struct ad_subdomains_ctx *subdoms_ctx)
         /* Just continue */
     }
 
-    ret = sysdb_update_subdomains(subdoms_ctx->be_ctx->domain);
+    ret = sysdb_update_subdomains(subdoms_ctx->be_ctx->domain,
+                                  subdoms_ctx->be_ctx->cdb);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "sysdb_update_subdomains failed.\n");
         return ret;

--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -171,9 +171,7 @@ ad_subdom_ad_ctx_new(struct be_ctx *be_ctx,
         return EINVAL;
     }
 
-    subdom_conf_path = create_subdom_conf_path(id_ctx,
-                                               be_ctx->conf_path,
-                                               subdom->name);
+    subdom_conf_path = subdomain_create_conf_path(id_ctx, subdom);
     if (subdom_conf_path == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "subdom_conf_path failed\n");
         return ENOMEM;

--- a/src/providers/ipa/ipa_subdomains.c
+++ b/src/providers/ipa/ipa_subdomains.c
@@ -126,7 +126,7 @@ ipa_subdom_reinit(struct ipa_subdomains_ctx *ctx)
         return ret;
     }
 
-    ret = sysdb_update_subdomains(ctx->be_ctx->domain);
+    ret = sysdb_update_subdomains(ctx->be_ctx->domain, ctx->be_ctx->cdb);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "sysdb_update_subdomains failed.\n");
         return ret;
@@ -780,7 +780,8 @@ done:
 static errno_t ipa_apply_view(struct sss_domain_info *domain,
                               struct ipa_id_ctx *ipa_id_ctx,
                               const char *view_name,
-                              bool read_at_init)
+                              bool read_at_init,
+                              struct confdb_ctx *confdb)
 {
     const char *current = ipa_id_ctx->view_name;
     struct sysdb_ctx *sysdb = domain->sysdb;
@@ -876,7 +877,7 @@ static errno_t ipa_apply_view(struct sss_domain_info *domain,
             goto done;
         }
 
-        ret = sysdb_update_subdomains(domain);
+        ret = sysdb_update_subdomains(domain, confdb);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "sysdb_update_subdomains failed "
                   "[%d]: %s\n", ret, sss_strerror(ret));
@@ -1654,7 +1655,8 @@ static void ipa_subdomains_view_name_done(struct tevent_req *subreq)
 
     ret = ipa_apply_view(state->sd_ctx->be_ctx->domain,
                          state->sd_ctx->ipa_id_ctx, view_name,
-                         state->sd_ctx->view_read_at_init);
+                         state->sd_ctx->view_read_at_init,
+                         state->sd_ctx->be_ctx->cdb);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to set view [%d]: %s\n",
               ret, sss_strerror(ret));

--- a/src/providers/ipa/ipa_subdomains.c
+++ b/src/providers/ipa/ipa_subdomains.c
@@ -1684,6 +1684,151 @@ static errno_t ipa_subdomains_view_name_recv(struct tevent_req *req)
     return EOK;
 }
 
+struct ipa_subdomains_view_domain_resolution_order_state {
+    struct sss_domain_info *domain;
+    const char *view_name;
+};
+
+static void
+ipa_subdomains_view_domain_resolution_order_done(struct tevent_req *subreq);
+
+static struct tevent_req *
+ipa_subdomains_view_domain_resolution_order_send(
+                                            TALLOC_CTX *mem_ctx,
+                                            struct tevent_context *ev,
+                                            struct ipa_subdomains_ctx *sd_ctx,
+                                            struct sdap_handle *sh)
+{
+    struct ipa_subdomains_view_domain_resolution_order_state *state;
+    struct tevent_req *subreq;
+    struct tevent_req *req;
+    const char *attrs[] = { IPA_DOMAIN_RESOLUTION_ORDER, NULL };
+    char *ldap_basedn;
+    char *base;
+    errno_t ret;
+
+    req = tevent_req_create(mem_ctx, &state,
+                    struct ipa_subdomains_view_domain_resolution_order_state);
+    if (req == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "tevent_req_create() failed\n");
+        return NULL;
+    }
+
+    state->domain = sd_ctx->be_ctx->domain;
+    state->view_name = sd_ctx->ipa_id_ctx->view_name;
+
+    ret = domain_to_basedn(state, sd_ctx->be_ctx->domain->name, &ldap_basedn);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "domain_to_basedn failed.\n");
+        goto immediately;
+    }
+
+    base = talloc_asprintf(state, "cn=%s,cn=views,cn=accounts,%s",
+                           sd_ctx->ipa_id_ctx->view_name, ldap_basedn);
+    if (base == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "talloc_asprintf failed.\n");
+        ret = ENOMEM;
+        goto immediately;
+    }
+
+    subreq = sdap_get_generic_send(
+                            state, ev, sd_ctx->sdap_id_ctx->opts, sh,
+                            base, LDAP_SCOPE_BASE, NULL, attrs, NULL, 0,
+                            dp_opt_get_int(sd_ctx->sdap_id_ctx->opts->basic,
+                                           SDAP_ENUM_SEARCH_TIMEOUT),
+                            false);
+    if (subreq == NULL) {
+        ret = ENOMEM;
+        goto immediately;
+    }
+
+    tevent_req_set_callback(subreq, ipa_subdomains_view_domain_resolution_order_done,
+                            req);
+
+    return req;
+
+immediately:
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else {
+        tevent_req_error(req, ret);
+    }
+    tevent_req_post(req, ev);
+
+    return req;
+}
+
+static void
+ipa_subdomains_view_domain_resolution_order_done(struct tevent_req *subreq)
+{
+    struct ipa_subdomains_view_domain_resolution_order_state *state;
+    struct tevent_req *req;
+    size_t reply_count;
+    struct sysdb_attrs **reply;
+    const char *domain_resolution_order;
+    errno_t ret;
+
+    req = tevent_req_callback_data(subreq, struct tevent_req);
+    state = tevent_req_data(req,
+                    struct ipa_subdomains_view_domain_resolution_order_state);
+
+    ret = sdap_get_generic_recv(subreq, state, &reply_count, &reply);
+    talloc_zfree(subreq);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "Unable to get view name [%d]: %s\n",
+              ret, sss_strerror(ret));
+        goto done;
+    }
+
+    if (reply_count > 1) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "More than one object returned.\n");
+        ret = EINVAL;
+        goto done;
+    } else if (reply_count == 0) {
+        domain_resolution_order = NULL;
+    } else {
+        /* reply_count == 1 */
+        ret = sysdb_attrs_get_string(reply[0], IPA_DOMAIN_RESOLUTION_ORDER,
+                                     &domain_resolution_order);
+        if (ret != EOK && ret != ENOENT) {
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "Failed to get the view domains' resolution order "
+                  "configuration value for view [%s] [%d]: %s\n",
+                  state->view_name, ret, sss_strerror(ret));
+            goto done;
+        } else if (ret == ENOENT) {
+            domain_resolution_order = NULL;
+        }
+    }
+
+    ret = sysdb_update_view_domain_resolution_order(state->domain->sysdb,
+                                                    domain_resolution_order);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "sysdb_update_view_domain_resolution_order() [%d]: [%s].\n",
+              ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = EOK;
+
+done:
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    tevent_req_done(req);
+}
+
+static errno_t
+ipa_subdomains_view_domain_resolution_order_recv(struct tevent_req *req)
+{
+    TEVENT_REQ_RETURN_ON_ERROR(req);
+
+    return EOK;
+}
+
 struct ipa_domain_resolution_order_state {
     struct sss_domain_info *domain;
 };
@@ -1809,6 +1954,8 @@ static void ipa_subdomains_refresh_certmap_done(struct tevent_req *subreq);
 static void ipa_subdomains_refresh_master_done(struct tevent_req *subreq);
 static void ipa_subdomains_refresh_slave_done(struct tevent_req *subreq);
 static void ipa_subdomains_refresh_view_name_done(struct tevent_req *subreq);
+static void ipa_subdomains_refresh_view_domain_resolution_order_done(
+                                                    struct tevent_req *subreq);
 static void ipa_domain_refresh_resolution_order_done(struct tevent_req *subreq);
 
 static struct tevent_req *
@@ -2042,6 +2189,41 @@ static void ipa_subdomains_refresh_view_name_done(struct tevent_req *subreq)
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Unable to get view name [%d]: %s\n",
+              ret, sss_strerror(ret));
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    subreq = ipa_subdomains_view_domain_resolution_order_send(
+                                            state,
+                                            state->ev,
+                                            state->sd_ctx,
+                                            sdap_id_op_handle(state->sdap_op));
+    if (subreq == NULL) {
+        tevent_req_error(req, ENOMEM);
+        return;
+    }
+
+    tevent_req_set_callback(subreq,
+                    ipa_subdomains_refresh_view_domain_resolution_order_done,
+                    req);
+}
+
+static void
+ipa_subdomains_refresh_view_domain_resolution_order_done(struct tevent_req *subreq)
+{
+    struct ipa_subdomains_refresh_state *state;
+    struct tevent_req *req;
+    errno_t ret;
+
+    req = tevent_req_callback_data(subreq, struct tevent_req);
+    state = tevent_req_data(req, struct ipa_subdomains_refresh_state);
+
+    ret = ipa_subdomains_view_domain_resolution_order_recv(subreq);
+    talloc_zfree(subreq);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Unable to get view domain_resolution order [%d]: %s\n",
               ret, sss_strerror(ret));
         tevent_req_error(req, ret);
         return;

--- a/src/providers/ipa/ipa_subdomains.c
+++ b/src/providers/ipa/ipa_subdomains.c
@@ -29,6 +29,7 @@
 #include "providers/ipa/ipa_common.h"
 #include "providers/ipa/ipa_id.h"
 #include "providers/ipa/ipa_opts.h"
+#include "providers/ipa/ipa_config.h"
 
 #include <ctype.h>
 
@@ -50,6 +51,8 @@
 #define OBJECTCLASS "objectClass"
 
 #define IPA_ASSIGNED_ID_VIEW "ipaAssignedIDView"
+
+#define IPA_DOMAIN_RESOLUTION_ORDER "ipaDomainResolutionOrder"
 
 /* do not refresh more often than every 5 seconds for now */
 #define IPA_SUBDOMAIN_REFRESH_LIMIT 5
@@ -1681,6 +1684,117 @@ static errno_t ipa_subdomains_view_name_recv(struct tevent_req *req)
     return EOK;
 }
 
+struct ipa_domain_resolution_order_state {
+    struct sss_domain_info *domain;
+};
+
+static void ipa_domain_resolution_order_done(struct tevent_req *subreq);
+
+static struct tevent_req *
+ipa_domain_resolution_order_send(TALLOC_CTX *mem_ctx,
+                                 struct tevent_context *ev,
+                                 struct ipa_subdomains_ctx *sd_ctx,
+                                 struct sdap_handle *sh)
+{
+    struct ipa_domain_resolution_order_state *state;
+    struct tevent_req *subreq;
+    struct tevent_req *req;
+    const char *attrs[] = {IPA_DOMAIN_RESOLUTION_ORDER, NULL};
+    errno_t ret;
+
+    req = tevent_req_create(mem_ctx, &state,
+                            struct ipa_domain_resolution_order_state);
+    if (req == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "tevent_req_create() failed\n");
+        return NULL;
+    }
+
+    state->domain = sd_ctx->be_ctx->domain;
+
+    subreq = ipa_get_config_send(state, ev, sh, sd_ctx->sdap_id_ctx->opts,
+                                 state->domain->name, attrs);
+    if (subreq == NULL) {
+        ret = ENOMEM;
+        goto immediately;
+    }
+
+    tevent_req_set_callback(subreq, ipa_domain_resolution_order_done, req);
+
+    return req;
+
+immediately:
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else {
+        tevent_req_error(req, ret);
+    }
+    tevent_req_post(req, ev);
+
+    return req;
+}
+
+static void ipa_domain_resolution_order_done(struct tevent_req *subreq)
+{
+    struct ipa_domain_resolution_order_state *state;
+    struct tevent_req *req;
+    struct sysdb_attrs *config = NULL;
+    const char *domain_resolution_order = NULL;
+    errno_t ret;
+
+    req = tevent_req_callback_data(subreq, struct tevent_req);
+    state = tevent_req_data(req, struct ipa_domain_resolution_order_state);
+
+    ret = ipa_get_config_recv(subreq, state, &config);
+    talloc_zfree(subreq);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Failed to get the domains' resolution order configuration "
+              "from the server [%d]: %s\n",
+              ret, sss_strerror(ret));
+        goto done;
+    }
+
+    if (config != NULL) {
+        ret = sysdb_attrs_get_string(config, IPA_DOMAIN_RESOLUTION_ORDER,
+                                     &domain_resolution_order);
+        if (ret != EOK && ret != ENOENT) {
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "Failed to get the domains' resolution order configuration "
+                  "value [%d]: %s\n",
+                  ret, sss_strerror(ret));
+            goto done;
+        } else if (ret == ENOENT) {
+            domain_resolution_order = NULL;
+        }
+    }
+
+    ret = sysdb_domain_update_domain_resolution_order(
+                        state->domain->sysdb, state->domain->name,
+                        domain_resolution_order);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "sysdb_domain_update_resolution_order() [%d]: [%s].\n",
+              ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = EOK;
+
+done:
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    tevent_req_done(req);
+}
+
+static errno_t ipa_domain_resolution_order_recv(struct tevent_req *req)
+{
+    TEVENT_REQ_RETURN_ON_ERROR(req);
+
+    return EOK;
+}
 
 struct ipa_subdomains_refresh_state {
     struct tevent_context *ev;
@@ -1695,6 +1809,7 @@ static void ipa_subdomains_refresh_certmap_done(struct tevent_req *subreq);
 static void ipa_subdomains_refresh_master_done(struct tevent_req *subreq);
 static void ipa_subdomains_refresh_slave_done(struct tevent_req *subreq);
 static void ipa_subdomains_refresh_view_done(struct tevent_req *subreq);
+static void ipa_domain_refresh_resolution_order_done(struct tevent_req *subreq);
 
 static struct tevent_req *
 ipa_subdomains_refresh_send(TALLOC_CTX *mem_ctx,
@@ -1916,7 +2031,6 @@ static void ipa_subdomains_refresh_view_done(struct tevent_req *subreq)
 {
     struct ipa_subdomains_refresh_state *state;
     struct tevent_req *req;
-    int dp_error;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
@@ -1924,24 +2038,55 @@ static void ipa_subdomains_refresh_view_done(struct tevent_req *subreq)
 
     ret = ipa_subdomains_view_name_recv(subreq);
     talloc_zfree(subreq);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Unable to get view name [%d]: %s\n",
+              ret, sss_strerror(ret));
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    subreq = ipa_domain_resolution_order_send(state, state->ev, state->sd_ctx,
+                                            sdap_id_op_handle(state->sdap_op));
+    if (subreq == NULL) {
+        tevent_req_error(req, ENOMEM);
+        return;
+    }
+
+    tevent_req_set_callback(subreq,
+                            ipa_domain_refresh_resolution_order_done,
+                            req);
+}
+
+static void
+ipa_domain_refresh_resolution_order_done(struct tevent_req *subreq)
+{
+    struct ipa_subdomains_refresh_state *state;
+    struct tevent_req *req;
+    int dp_error;
+    errno_t ret;
+
+    req = tevent_req_callback_data(subreq, struct tevent_req);
+    state = tevent_req_data(req, struct ipa_subdomains_refresh_state);
+
+    ret = ipa_domain_resolution_order_recv(subreq);
+    talloc_zfree(subreq);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_MINOR_FAILURE,
+              "Unable to get the domains order resolution [%d]: %s\n",
+              ret, sss_strerror(ret));
+        tevent_req_error(req, ret);
+        return;
+    }
+
     ret = sdap_id_op_done(state->sdap_op, ret, &dp_error);
     if (dp_error == DP_ERR_OK && ret != EOK) {
         /* retry */
         ret = ipa_subdomains_refresh_retry(req);
-        if (ret != EOK) {
-            goto done;
-        }
-        return;
     } else if (dp_error == DP_ERR_OFFLINE) {
         ret = ERR_OFFLINE;
-        goto done;
-    } else if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to get view name "
-              "[%d]: %s\n", ret, sss_strerror(ret));
-        goto done;
     }
 
-done:
     if (ret != EOK) {
         DEBUG(SSSDBG_TRACE_FUNC, "Unable to refresh subdomains [%d]: %s\n",
               ret, sss_strerror(ret));
@@ -1949,7 +2094,6 @@ done:
         return;
     }
 
-    DEBUG(SSSDBG_TRACE_FUNC, "Subdomains refreshed.\n");
     tevent_req_done(req);
 }
 

--- a/src/providers/ipa/ipa_subdomains.c
+++ b/src/providers/ipa/ipa_subdomains.c
@@ -1808,7 +1808,7 @@ static void ipa_subdomains_refresh_ranges_done(struct tevent_req *subreq);
 static void ipa_subdomains_refresh_certmap_done(struct tevent_req *subreq);
 static void ipa_subdomains_refresh_master_done(struct tevent_req *subreq);
 static void ipa_subdomains_refresh_slave_done(struct tevent_req *subreq);
-static void ipa_subdomains_refresh_view_done(struct tevent_req *subreq);
+static void ipa_subdomains_refresh_view_name_done(struct tevent_req *subreq);
 static void ipa_domain_refresh_resolution_order_done(struct tevent_req *subreq);
 
 static struct tevent_req *
@@ -2023,11 +2023,12 @@ static void ipa_subdomains_refresh_slave_done(struct tevent_req *subreq)
         return;
     }
 
-    tevent_req_set_callback(subreq, ipa_subdomains_refresh_view_done, req);
+    tevent_req_set_callback(subreq, ipa_subdomains_refresh_view_name_done,
+                            req);
     return;
 }
 
-static void ipa_subdomains_refresh_view_done(struct tevent_req *subreq)
+static void ipa_subdomains_refresh_view_name_done(struct tevent_req *subreq)
 {
     struct ipa_subdomains_refresh_state *state;
     struct tevent_req *req;

--- a/src/providers/ipa/ipa_subdomains_server.c
+++ b/src/providers/ipa/ipa_subdomains_server.c
@@ -176,9 +176,7 @@ static struct ad_options *ipa_ad_options_new(struct be_ctx *be_ctx,
     forest_realm = subdom->forest_root->realm;
     forest = subdom->forest_root->forest;
 
-    subdom_conf_path = create_subdom_conf_path(id_ctx,
-                                               be_ctx->conf_path,
-                                               subdom->name);
+    subdom_conf_path = subdomain_create_conf_path(id_ctx, subdom);
     if (subdom_conf_path == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "subdom_conf_path failed\n");
         return NULL;

--- a/src/responder/common/cache_req/cache_req_domain.c
+++ b/src/responder/common/cache_req/cache_req_domain.c
@@ -1,0 +1,166 @@
+/*
+    Authors:
+        Fabiano Fidêncio <fidencio@redhat.com>
+
+    Copyright (C) 2017 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "responder/common/cache_req/cache_req_domain.h"
+
+struct cache_req_domain *
+cache_req_domain_get_domain_by_name(struct cache_req_domain *domains,
+                                    const char *name)
+{
+    struct cache_req_domain *dom;
+    struct cache_req_domain *ret = NULL;
+
+    DLIST_FOR_EACH(dom, domains) {
+        if (sss_domain_get_state(dom->domain) == DOM_DISABLED) {
+            continue;
+        }
+
+        if (strcasecmp(dom->domain->name, name) == 0 ||
+            (dom->domain->flat_name != NULL &&
+             strcasecmp(dom->domain->flat_name, name) == 0)) {
+            ret = dom;
+            break;
+        }
+    }
+
+    if (ret == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Unknown domains [%s].\n", name);
+    }
+
+    return ret;
+}
+
+void cache_req_domain_list_zfree(struct cache_req_domain **cr_domains)
+{
+    struct cache_req_domain *p, *q, *r;
+
+    DLIST_FOR_EACH_SAFE(p, q, *cr_domains) {
+        r = p;
+        DLIST_REMOVE(*cr_domains, p);
+        talloc_zfree(r);
+    }
+
+    *cr_domains = NULL;
+}
+
+static struct cache_req_domain *
+cache_req_domain_new_list_from_string_list(TALLOC_CTX *mem_ctx,
+                                           struct sss_domain_info *domains,
+                                           char **resolution_order)
+{
+    struct cache_req_domain *cr_domains = NULL;
+    struct cache_req_domain *cr_domain;
+    struct sss_domain_info *dom;
+    char *name;
+    int flag = SSS_GND_ALL_DOMAINS;
+    int i;
+    errno_t ret;
+
+    if (resolution_order != NULL) {
+        for (i = 0; resolution_order[i] != NULL; i++) {
+            name = resolution_order[i];
+            for (dom = domains; dom; dom = get_next_domain(dom, flag)) {
+                if (strcasecmp(name, dom->name) != 0) {
+                    continue;
+                }
+
+                cr_domain = talloc_zero(mem_ctx, struct cache_req_domain);
+                if (cr_domain == NULL) {
+                    ret = ENOMEM;
+                    goto done;
+                }
+                cr_domain->domain = dom;
+
+                DLIST_ADD_END(cr_domains, cr_domain,
+                              struct cache_req_domain *);
+                break;
+            }
+        }
+    }
+
+    for (dom = domains; dom; dom = get_next_domain(dom, flag)) {
+        if (string_in_list(dom->name, resolution_order, false)) {
+            continue;
+        }
+
+        cr_domain = talloc_zero(mem_ctx, struct cache_req_domain);
+        if (cr_domain == NULL) {
+            ret = ENOMEM;
+            goto done;
+        }
+        cr_domain->domain = dom;
+
+        DLIST_ADD_END(cr_domains, cr_domain, struct cache_req_domain *);
+    }
+
+    ret = EOK;
+
+done:
+    if (ret != EOK) {
+        cache_req_domain_list_zfree(&cr_domains);
+    }
+
+    return cr_domains;
+}
+
+struct cache_req_domain *
+cache_req_domain_new_list_from_domain_resolution_order(
+                                        TALLOC_CTX *mem_ctx,
+                                        struct sss_domain_info *domains,
+                                        const char *domain_resolution_order)
+{
+    TALLOC_CTX *tmp_ctx;
+    struct cache_req_domain *cr_domains = NULL;
+    char **list = NULL;
+    errno_t ret;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return NULL;
+    }
+
+    if (domain_resolution_order != NULL) {
+        if (strcmp(domain_resolution_order, ":") != 0) {
+            ret = split_on_separator(tmp_ctx, domain_resolution_order, ':',
+                                     true, true, &list, NULL);
+            if (ret != EOK) {
+                DEBUG(SSSDBG_MINOR_FAILURE,
+                        "split_on_separator() failed [%d]: [%s].\n",
+                        ret, sss_strerror(ret));
+                goto done;
+            }
+        }
+    }
+
+    cr_domains = cache_req_domain_new_list_from_string_list(mem_ctx, domains,
+                                                            list);
+    if (cr_domains == NULL) {
+        ret = ENOMEM;
+        DEBUG(SSSDBG_OP_FAILURE,
+              "cache_req_domain_new_list_from_domain_resolution_order() "
+              "failed [%d]: [%s].\n",
+              ret, sss_strerror(ret));
+        goto done;
+    }
+
+done:
+    talloc_free(tmp_ctx);
+    return cr_domains;
+}

--- a/src/responder/common/cache_req/cache_req_domain.h
+++ b/src/responder/common/cache_req/cache_req_domain.h
@@ -1,0 +1,46 @@
+/*
+    Authors:
+        Fabiano Fidêncio <fidencio@redhat.com>
+
+    Copyright (C) 2017 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _CACHE_REQ_DOMAIN_H_
+#define _CACHE_REQ_DOMAIN_H_
+
+#include "responder/common/responder.h"
+
+struct cache_req_domain {
+    struct sss_domain_info *domain;
+
+    struct cache_req_domain *prev;
+    struct cache_req_domain *next;
+};
+
+struct cache_req_domain *
+cache_req_domain_get_domain_by_name(struct cache_req_domain *domains,
+                                    const char *name);
+
+struct cache_req_domain *
+cache_req_domain_new_list_from_domain_resolution_order(
+                                        TALLOC_CTX *mem_ctx,
+                                        struct sss_domain_info *domains,
+                                        const char *domain_resolution_order);
+
+void cache_req_domain_list_zfree(struct cache_req_domain **cr_domains);
+
+
+#endif /* _CACHE_REQ_DOMAIN_H_ */

--- a/src/responder/common/cache_req/plugins/cache_req_enum_svc.c
+++ b/src/responder/common/cache_req/plugins/cache_req_enum_svc.c
@@ -68,7 +68,7 @@ const struct cache_req_plugin cache_req_enum_svc = {
     .allow_missing_fqn = true,
     .allow_switch_to_upn = false,
     .upn_equivalent = CACHE_REQ_SENTINEL,
-    .get_next_domain_flags = 0,
+    .get_next_domain_flags = SSS_GND_DESCEND,
 
     .is_well_known_fn = NULL,
     .prepare_domain_data_fn = NULL,

--- a/src/responder/common/cache_req/plugins/cache_req_group_by_filter.c
+++ b/src/responder/common/cache_req/plugins/cache_req_group_by_filter.c
@@ -123,7 +123,7 @@ const struct cache_req_plugin cache_req_group_by_filter = {
     .allow_missing_fqn = false,
     .allow_switch_to_upn = false,
     .upn_equivalent = CACHE_REQ_SENTINEL,
-    .get_next_domain_flags = 0,
+    .get_next_domain_flags = SSS_GND_DESCEND,
 
     .is_well_known_fn = NULL,
     .prepare_domain_data_fn = cache_req_group_by_filter_prepare_domain_data,

--- a/src/responder/common/cache_req/plugins/cache_req_group_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_group_by_name.c
@@ -186,7 +186,7 @@ const struct cache_req_plugin cache_req_group_by_name = {
     .allow_missing_fqn = false,
     .allow_switch_to_upn = false,
     .upn_equivalent = CACHE_REQ_SENTINEL,
-    .get_next_domain_flags = 0,
+    .get_next_domain_flags = SSS_GND_DESCEND,
 
     .is_well_known_fn = NULL,
     .prepare_domain_data_fn = cache_req_group_by_name_prepare_domain_data,

--- a/src/responder/common/cache_req/plugins/cache_req_initgroups_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_initgroups_by_name.c
@@ -201,7 +201,7 @@ const struct cache_req_plugin cache_req_initgroups_by_name = {
     .allow_missing_fqn = false,
     .allow_switch_to_upn = true,
     .upn_equivalent = CACHE_REQ_INITGROUPS_BY_UPN,
-    .get_next_domain_flags = 0,
+    .get_next_domain_flags = SSS_GND_DESCEND,
 
     .is_well_known_fn = NULL,
     .prepare_domain_data_fn = cache_req_initgroups_by_name_prepare_domain_data,

--- a/src/responder/common/cache_req/plugins/cache_req_netgroup_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_netgroup_by_name.c
@@ -120,7 +120,7 @@ const struct cache_req_plugin cache_req_netgroup_by_name = {
     .allow_missing_fqn = true,
     .allow_switch_to_upn = false,
     .upn_equivalent = CACHE_REQ_SENTINEL,
-    .get_next_domain_flags = 0,
+    .get_next_domain_flags = SSS_GND_DESCEND,
 
     .is_well_known_fn = NULL,
     .prepare_domain_data_fn = cache_req_netgroup_by_name_prepare_domain_data,

--- a/src/responder/common/cache_req/plugins/cache_req_object_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_object_by_name.c
@@ -196,7 +196,7 @@ const struct cache_req_plugin cache_req_object_by_name = {
     .allow_missing_fqn = false,
     .allow_switch_to_upn = true,
     .upn_equivalent = CACHE_REQ_USER_BY_UPN,
-    .get_next_domain_flags = 0,
+    .get_next_domain_flags = SSS_GND_DESCEND,
 
     .is_well_known_fn = cache_req_object_by_name_well_known,
     .prepare_domain_data_fn = cache_req_object_by_name_prepare_domain_data,

--- a/src/responder/common/cache_req/plugins/cache_req_svc_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_svc_by_name.c
@@ -144,7 +144,7 @@ const struct cache_req_plugin cache_req_svc_by_name = {
     .allow_missing_fqn = false,
     .allow_switch_to_upn = false,
     .upn_equivalent = CACHE_REQ_SENTINEL,
-    .get_next_domain_flags = 0,
+    .get_next_domain_flags = SSS_GND_DESCEND,
 
     .is_well_known_fn = NULL,
     .prepare_domain_data_fn = cache_req_svc_by_name_prepare_domain_data,

--- a/src/responder/common/cache_req/plugins/cache_req_svc_by_port.c
+++ b/src/responder/common/cache_req/plugins/cache_req_svc_by_port.c
@@ -117,7 +117,7 @@ const struct cache_req_plugin cache_req_svc_by_port = {
     .allow_missing_fqn = false,
     .allow_switch_to_upn = false,
     .upn_equivalent = CACHE_REQ_SENTINEL,
-    .get_next_domain_flags = 0,
+    .get_next_domain_flags = SSS_GND_DESCEND,
 
     .is_well_known_fn = NULL,
     .prepare_domain_data_fn = cache_req_svc_by_port_prepare_domain_data,

--- a/src/responder/common/cache_req/plugins/cache_req_user_by_filter.c
+++ b/src/responder/common/cache_req/plugins/cache_req_user_by_filter.c
@@ -123,7 +123,7 @@ const struct cache_req_plugin cache_req_user_by_filter = {
     .allow_missing_fqn = false,
     .allow_switch_to_upn = false,
     .upn_equivalent = CACHE_REQ_SENTINEL,
-    .get_next_domain_flags = 0,
+    .get_next_domain_flags = SSS_GND_DESCEND,
 
     .is_well_known_fn = NULL,
     .prepare_domain_data_fn = cache_req_user_by_filter_prepare_domain_data,

--- a/src/responder/common/cache_req/plugins/cache_req_user_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_user_by_name.c
@@ -191,7 +191,7 @@ const struct cache_req_plugin cache_req_user_by_name = {
     .allow_missing_fqn = false,
     .allow_switch_to_upn = true,
     .upn_equivalent = CACHE_REQ_USER_BY_UPN,
-    .get_next_domain_flags = 0,
+    .get_next_domain_flags = SSS_GND_DESCEND,
 
     .is_well_known_fn = NULL,
     .prepare_domain_data_fn = cache_req_user_by_name_prepare_domain_data,

--- a/src/responder/common/responder.h
+++ b/src/responder/common/responder.h
@@ -115,6 +115,7 @@ struct resp_ctx {
     int client_idle_timeout;
 
     struct cache_req_domain *cr_domains;
+    const char *domain_resolution_order;
 
     time_t last_request_time;
     int idle_timeout;

--- a/src/responder/common/responder.h
+++ b/src/responder/common/responder.h
@@ -37,6 +37,7 @@
 #include "sbus/sssd_dbus.h"
 #include "responder/common/negcache.h"
 #include "sss_client/sss_cli.h"
+#include "responder/common/cache_req/cache_req_domain.h"
 
 extern hash_table_t *dp_requests;
 
@@ -112,6 +113,8 @@ struct resp_ctx {
     struct sss_domain_info *domains;
     int domains_timeout;
     int client_idle_timeout;
+
+    struct cache_req_domain *cr_domains;
 
     time_t last_request_time;
     int idle_timeout;
@@ -386,5 +389,7 @@ char *sss_resp_create_fqname(TALLOC_CTX *mem_ctx,
                              struct sss_domain_info *dom,
                              bool name_is_upn,
                              const char *orig_name);
+
+errno_t sss_resp_populate_cr_domains(struct resp_ctx *rctx);
 
 #endif /* __SSS_RESPONDER_H__ */

--- a/src/responder/common/responder_get_domains.c
+++ b/src/responder/common/responder_get_domains.c
@@ -192,6 +192,13 @@ struct tevent_req *sss_dp_get_domains_send(TALLOC_CTX *mem_ctx,
 
     if (state->dom == NULL) {
         /* All domains were local */
+        ret = sss_resp_populate_cr_domains(state->rctx);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "sss_resp_populate_cr_domains() failed [%d]: [%s]\n",
+                  ret, sss_strerror(ret));
+            goto immediately;
+        }
         ret = EOK;
         goto immediately;
     }
@@ -253,6 +260,13 @@ sss_dp_get_domains_process(struct tevent_req *subreq)
     if (state->dom == NULL) {
         /* All domains were local */
         set_time_of_last_request(state->rctx);
+        ret = sss_resp_populate_cr_domains(state->rctx);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "sss_resp_populate_cr_domains() failed [%d]: [%s]\n",
+                  ret, sss_strerror(ret));
+            goto fail;
+        }
         tevent_req_done(req);
         return;
     }

--- a/src/responder/common/responder_get_domains.c
+++ b/src/responder/common/responder_get_domains.c
@@ -126,7 +126,8 @@ get_next_domain_recv(TALLOC_CTX *mem_ctx,
 }
 
 /* ====== Iterate over all domains, searching for their subdomains  ======= */
-static errno_t process_subdomains(struct sss_domain_info *dom);
+static errno_t process_subdomains(struct sss_domain_info *dom,
+                                  struct confdb_ctx *confdb);
 static void set_time_of_last_request(struct resp_ctx *rctx);
 static errno_t check_last_request(struct resp_ctx *rctx, const char *hint);
 
@@ -234,7 +235,7 @@ sss_dp_get_domains_process(struct tevent_req *subreq)
         goto fail;
     }
 
-    ret = process_subdomains(state->dom);
+    ret = process_subdomains(state->dom, state->rctx->cdb);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "process_subdomains failed, "
                                   "trying next domain.\n");
@@ -270,7 +271,7 @@ fail:
 }
 
 static errno_t
-process_subdomains(struct sss_domain_info *domain)
+process_subdomains(struct sss_domain_info *domain, struct confdb_ctx *confdb)
 {
     int ret;
 
@@ -288,7 +289,7 @@ process_subdomains(struct sss_domain_info *domain)
     /* Retrieve all subdomains of this domain from sysdb
      * and create their struct sss_domain_info representations
      */
-    ret = sysdb_update_subdomains(domain);
+    ret = sysdb_update_subdomains(domain, confdb);
     if (ret != EOK) {
         DEBUG(SSSDBG_FUNC_DATA, "sysdb_update_subdomains failed.\n");
         goto done;

--- a/src/tests/cmocka/common_mock_resp.c
+++ b/src/tests/cmocka/common_mock_resp.c
@@ -51,6 +51,12 @@ mock_rctx(TALLOC_CTX *mem_ctx,
     rctx->ev = ev;
     rctx->domains = domains;
     rctx->pvt_ctx = pvt_ctx;
+    if (domains != NULL) {
+        ret = sss_resp_populate_cr_domains(rctx);
+        if (ret != EOK) {
+            return NULL;
+        }
+    }
     return rctx;
 }
 

--- a/src/tests/cmocka/common_mock_resp_dp.c
+++ b/src/tests/cmocka/common_mock_resp_dp.c
@@ -21,6 +21,7 @@
 */
 
 #include "util/util.h"
+#include "responder/common/responder.h"
 #include "tests/cmocka/common_mock_resp.h"
 
 /* Mock DP requests that finish immediatelly and return
@@ -165,6 +166,12 @@ sss_dp_get_domains_send(TALLOC_CTX *mem_ctx,
                         bool force,
                         const char *hint)
 {
+    errno_t ret;
+    ret = sss_resp_populate_cr_domains(rctx);
+    if (ret != EOK) {
+        return NULL;
+    }
+
     return test_req_succeed_send(mem_ctx, rctx->ev);
 }
 

--- a/src/tests/cmocka/test_fqnames.c
+++ b/src/tests/cmocka/test_fqnames.c
@@ -309,7 +309,7 @@ static int parse_name_test_setup(void **state)
      * discovered
      */
     test_ctx->subdom = new_subdomain(dom, dom, SUBDOMNAME, NULL, SUBFLATNAME,
-                                     NULL, false, false, NULL, NULL, 0);
+                                     NULL, false, false, NULL, NULL, 0, NULL);
     assert_non_null(test_ctx->subdom);
 
     check_leaks_push(test_ctx);

--- a/src/tests/cmocka/test_ipa_subdomains_server.c
+++ b/src/tests/cmocka/test_ipa_subdomains_server.c
@@ -263,7 +263,7 @@ static void add_test_subdomains(struct trust_test_ctx *test_ctx,
                                 direction, NULL);
     assert_int_equal(ret, EOK);
 
-    ret = sysdb_update_subdomains(test_ctx->tctx->dom);
+    ret = sysdb_update_subdomains(test_ctx->tctx->dom, test_ctx->tctx->confdb);
     assert_int_equal(ret, EOK);
 
 }

--- a/src/tests/cmocka/test_nss_srv.c
+++ b/src/tests/cmocka/test_nss_srv.c
@@ -3440,6 +3440,10 @@ static int nss_subdom_test_setup(void **state)
                                   nss_test_ctx->tctx->confdb);
     assert_int_equal(ret, EOK);
 
+    ret = sss_resp_populate_cr_domains(nss_test_ctx->rctx);
+    assert_int_equal(ret, EOK);
+    assert_non_null(nss_test_ctx->rctx->cr_domains);
+
     nss_test_ctx->subdom = nss_test_ctx->tctx->dom->subdomains;
 
     ret = store_group(nss_test_ctx, nss_test_ctx->subdom,

--- a/src/tests/cmocka/test_nss_srv.c
+++ b/src/tests/cmocka/test_nss_srv.c
@@ -3219,7 +3219,7 @@ static int nss_subdom_test_setup(void **state)
                                   nss_test_ctx->tctx->confdb);
     assert_int_equal(ret, EOK);
 
-    nss_test_ctx->subdom = subdomain;
+    nss_test_ctx->subdom = nss_test_ctx->tctx->dom->subdomains;
     return 0;
 }
 

--- a/src/tests/cmocka/test_nss_srv.c
+++ b/src/tests/cmocka/test_nss_srv.c
@@ -418,6 +418,26 @@ static errno_t store_user(struct nss_test_ctx *ctx,
     return ret;
 }
 
+static errno_t delete_user(struct nss_test_ctx *ctx,
+                           struct sss_domain_info *dom,
+                           struct passwd *user)
+{
+    errno_t ret;
+    char *fqname;
+
+    fqname = sss_create_internal_fqname(ctx,
+                                        user->pw_name,
+                                        dom->name);
+    if (fqname == NULL) {
+        return ENOMEM;
+    }
+
+    ret = sysdb_delete_user(dom, fqname, user->pw_uid);
+
+    talloc_free(fqname);
+    return ret;
+}
+
 static errno_t set_user_attr(struct nss_test_ctx *ctx,
                              struct sss_domain_info *dom,
                              struct passwd *user,
@@ -491,6 +511,27 @@ static errno_t store_group(struct nss_test_ctx *ctx,
     return ret;
 }
 
+static errno_t delete_group(struct nss_test_ctx *ctx,
+                            struct sss_domain_info *dom,
+                            struct group *group)
+{
+    errno_t ret;
+    char *fqname;
+
+    fqname = sss_create_internal_fqname(ctx,
+                                        group->gr_name,
+                                        dom->name);
+
+    if (fqname == NULL) {
+        return ENOMEM;
+    }
+
+    ret = sysdb_delete_group(dom, fqname, group->gr_gid);
+
+    talloc_free(fqname);
+    return ret;
+}
+
 static void assert_groups_equal(struct group *expected,
                                 struct group *gr, const int nmem)
 {
@@ -540,6 +581,42 @@ static errno_t store_group_member(struct nss_test_ctx *ctx,
     return ret;
 }
 
+static errno_t remove_group_member(struct nss_test_ctx *ctx,
+                                   const char *shortname_group,
+                                   struct sss_domain_info *group_dom,
+                                   const char *shortname_member,
+                                   struct sss_domain_info *member_dom,
+                                   enum sysdb_member_type type)
+{
+    errno_t ret;
+    char *group_fqname = NULL;
+    char *member_fqname = NULL;
+
+    group_fqname = sss_create_internal_fqname(ctx,
+                                        shortname_group,
+                                        group_dom->name);
+    if (group_fqname == NULL) {
+        return ENOMEM;
+    }
+
+    member_fqname = sss_create_internal_fqname(ctx,
+                                        shortname_member,
+                                        member_dom->name);
+    if (member_fqname == NULL) {
+        talloc_free(group_fqname);
+        return ENOMEM;
+    }
+
+    ret = sysdb_remove_group_member(group_dom,
+                                    group_fqname,
+                                    member_fqname,
+                                    type,
+                                    false);
+
+    talloc_free(group_fqname);
+    talloc_free(member_fqname);
+    return ret;
+}
 
 /* ====================== The tests =============================== */
 struct passwd getpwnam_usr = {
@@ -1599,34 +1676,6 @@ void test_nss_getgrnam_members_subdom(void **state)
 {
     errno_t ret;
 
-    ret = store_group(nss_test_ctx, nss_test_ctx->subdom,
-                      &testsubdomgroup, 0);
-    assert_int_equal(ret, EOK);
-
-    ret = store_user(nss_test_ctx, nss_test_ctx->subdom,
-                     &submember1, NULL, 0);
-    assert_int_equal(ret, EOK);
-
-    ret = store_user(nss_test_ctx, nss_test_ctx->subdom,
-                     &submember2, NULL, 0);
-    assert_int_equal(ret, EOK);
-
-    ret = store_group_member(nss_test_ctx,
-                             testsubdomgroup.gr_name,
-                             nss_test_ctx->subdom,
-                             submember1.pw_name,
-                             nss_test_ctx->subdom,
-                             SYSDB_MEMBER_USER);
-    assert_int_equal(ret, EOK);
-
-    ret = store_group_member(nss_test_ctx,
-                             testsubdomgroup.gr_name,
-                             nss_test_ctx->subdom,
-                             submember2.pw_name,
-                             nss_test_ctx->subdom,
-                             SYSDB_MEMBER_USER);
-    assert_int_equal(ret, EOK);
-
     mock_input_user_or_group("testsubdomgroup@"TEST_SUBDOM_NAME);
     will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETGRNAM);
     will_return_always(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
@@ -1756,6 +1805,14 @@ static int test_nss_getgrnam_check_mix_dom_fqdn(uint32_t status,
 void test_nss_getgrnam_mix_dom_fqdn(void **state)
 {
     errno_t ret;
+
+    ret = store_group_member(nss_test_ctx,
+                             testgroup_members.gr_name,
+                             nss_test_ctx->tctx->dom,
+                             submember1.pw_name,
+                             nss_test_ctx->subdom,
+                             SYSDB_MEMBER_USER);
+    assert_int_equal(ret, EOK);
 
     nss_test_ctx->tctx->dom->fqnames = true;
 
@@ -3220,6 +3277,35 @@ static int nss_subdom_test_setup(void **state)
     assert_int_equal(ret, EOK);
 
     nss_test_ctx->subdom = nss_test_ctx->tctx->dom->subdomains;
+
+    ret = store_group(nss_test_ctx, nss_test_ctx->subdom,
+                      &testsubdomgroup, 0);
+    assert_int_equal(ret, EOK);
+
+    ret = store_user(nss_test_ctx, nss_test_ctx->subdom,
+                     &submember1, NULL, 0);
+    assert_int_equal(ret, EOK);
+
+    ret = store_user(nss_test_ctx, nss_test_ctx->subdom,
+                     &submember2, NULL, 0);
+    assert_int_equal(ret, EOK);
+
+    ret = store_group_member(nss_test_ctx,
+                             testsubdomgroup.gr_name,
+                             nss_test_ctx->subdom,
+                             submember1.pw_name,
+                             nss_test_ctx->subdom,
+                             SYSDB_MEMBER_USER);
+    assert_int_equal(ret, EOK);
+
+    ret = store_group_member(nss_test_ctx,
+                             testsubdomgroup.gr_name,
+                             nss_test_ctx->subdom,
+                             submember2.pw_name,
+                             nss_test_ctx->subdom,
+                             SYSDB_MEMBER_USER);
+    assert_int_equal(ret, EOK);
+
     return 0;
 }
 
@@ -3239,6 +3325,38 @@ static int nss_test_teardown(void **state)
 {
     talloc_free(nss_test_ctx);
     return 0;
+}
+
+static int nss_subdom_test_teardown(void **state)
+{
+    errno_t ret;
+
+    ret = remove_group_member(nss_test_ctx,
+                              testsubdomgroup.gr_name,
+                              nss_test_ctx->subdom,
+                              submember2.pw_name,
+                              nss_test_ctx->subdom,
+                              SYSDB_MEMBER_USER);
+    assert_int_equal(ret, EOK);
+
+    ret = remove_group_member(nss_test_ctx,
+                              testsubdomgroup.gr_name,
+                              nss_test_ctx->subdom,
+                              submember1.pw_name,
+                              nss_test_ctx->subdom,
+                              SYSDB_MEMBER_USER);
+    assert_int_equal(ret, EOK);
+
+    ret = delete_user(nss_test_ctx, nss_test_ctx->subdom, &submember2);
+    assert_int_equal(ret, EOK);
+
+    ret = delete_user(nss_test_ctx, nss_test_ctx->subdom, &submember1);
+    assert_int_equal(ret, EOK);
+
+    ret = delete_group(nss_test_ctx, nss_test_ctx->subdom, &testsubdomgroup);
+    assert_int_equal(ret, EOK);
+
+    return nss_test_teardown(state);
 }
 
 struct passwd testbysid = {
@@ -3904,16 +4022,16 @@ int main(int argc, const char *argv[])
                                         nss_fqdn_test_setup, nss_test_teardown),
         cmocka_unit_test_setup_teardown(test_nss_getgrnam_members_subdom,
                                         nss_subdom_test_setup,
-                                        nss_test_teardown),
+                                        nss_subdom_test_teardown),
         cmocka_unit_test_setup_teardown(test_nss_getgrnam_mix_dom,
                                         nss_subdom_test_setup,
-                                        nss_test_teardown),
+                                        nss_subdom_test_teardown),
         cmocka_unit_test_setup_teardown(test_nss_getgrnam_mix_dom_fqdn,
                                         nss_subdom_test_setup,
-                                        nss_test_teardown),
+                                        nss_subdom_test_teardown),
         cmocka_unit_test_setup_teardown(test_nss_getgrnam_mix_subdom,
                                         nss_subdom_test_setup,
-                                        nss_test_teardown),
+                                        nss_subdom_test_teardown),
         cmocka_unit_test_setup_teardown(test_nss_getgrnam_space,
                                         nss_test_setup, nss_test_teardown),
         cmocka_unit_test_setup_teardown(test_nss_getgrnam_space_sub,

--- a/src/tests/cmocka/test_nss_srv.c
+++ b/src/tests/cmocka/test_nss_srv.c
@@ -1648,16 +1648,29 @@ static int test_nss_getgrnam_members_check_subdom(uint32_t status,
     tmp_ctx = talloc_new(nss_test_ctx);
     assert_non_null(tmp_ctx);
 
-    exp_members[0] = sss_tc_fqname(tmp_ctx, nss_test_ctx->subdom->names,
-                                   nss_test_ctx->subdom, submember1.pw_name);
-    assert_non_null(exp_members[0]);
-    exp_members[1] = sss_tc_fqname(tmp_ctx, nss_test_ctx->subdom->names,
-                                   nss_test_ctx->subdom, submember2.pw_name);
-    assert_non_null(exp_members[1]);
+    if (nss_test_ctx->subdom->fqnames) {
+        exp_members[0] = sss_tc_fqname(tmp_ctx,
+                                       nss_test_ctx->subdom->names,
+                                       nss_test_ctx->subdom,
+                                       submember1.pw_name);
+        assert_non_null(exp_members[0]);
 
-    expected.gr_name = sss_tc_fqname(tmp_ctx, nss_test_ctx->subdom->names,
-                                     nss_test_ctx->subdom, testsubdomgroup.gr_name);
-    assert_non_null(expected.gr_name);
+        exp_members[1] = sss_tc_fqname(tmp_ctx,
+                                       nss_test_ctx->subdom->names,
+                                       nss_test_ctx->subdom,
+                                       submember2.pw_name);
+        assert_non_null(exp_members[1]);
+
+        expected.gr_name = sss_tc_fqname(tmp_ctx,
+                                         nss_test_ctx->subdom->names,
+                                         nss_test_ctx->subdom,
+                                         testsubdomgroup.gr_name);
+        assert_non_null(expected.gr_name);
+    } else {
+        exp_members[0] = submember1.pw_name;
+        exp_members[1] = submember2.pw_name;
+        expected.gr_name = testsubdomgroup.gr_name;
+    }
 
     assert_int_equal(status, EOK);
 
@@ -1692,6 +1705,29 @@ void test_nss_getgrnam_members_subdom(void **state)
     assert_int_equal(ret, EOK);
 }
 
+void test_nss_getgrnam_members_subdom_nonfqnames(void **state)
+{
+    errno_t ret;
+
+    nss_test_ctx->subdom->fqnames = false;
+
+    mock_input_user_or_group("testsubdomgroup");
+    mock_account_recv_simple();
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETGRNAM);
+    will_return_always(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+
+    /* Query for that group, call a callback when command finishes */
+    set_cmd_cb(test_nss_getgrnam_members_check_subdom);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETGRNAM,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+
+    assert_int_equal(ret, EOK);
+}
+
 static int test_nss_getgrnam_check_mix_dom(uint32_t status,
                                            uint8_t *body, size_t blen)
 {
@@ -1710,9 +1746,15 @@ static int test_nss_getgrnam_check_mix_dom(uint32_t status,
     tmp_ctx = talloc_new(nss_test_ctx);
     assert_non_null(tmp_ctx);
 
-    exp_members[0] = sss_tc_fqname(tmp_ctx, nss_test_ctx->subdom->names,
-                                   nss_test_ctx->subdom, submember1.pw_name);
-    assert_non_null(exp_members[0]);
+    if (nss_test_ctx->subdom->fqnames) {
+        exp_members[0] = sss_tc_fqname(tmp_ctx,
+                                       nss_test_ctx->subdom->names,
+                                       nss_test_ctx->subdom,
+                                       submember1.pw_name);
+        assert_non_null(exp_members[0]);
+    } else {
+        exp_members[0] = submember1.pw_name;
+    }
     exp_members[1] = testmember1.pw_name;
     exp_members[2] = testmember2.pw_name;
 
@@ -1756,6 +1798,35 @@ void test_nss_getgrnam_mix_dom(void **state)
     assert_int_equal(ret, EOK);
 }
 
+void test_nss_getgrnam_mix_dom_nonfqnames(void **state)
+{
+    errno_t ret;
+
+    nss_test_ctx->subdom->fqnames = false;
+
+    ret = store_group_member(nss_test_ctx,
+                             testgroup_members.gr_name,
+                             nss_test_ctx->tctx->dom,
+                             submember1.pw_name,
+                             nss_test_ctx->subdom,
+                             SYSDB_MEMBER_USER);
+    assert_int_equal(ret, EOK);
+
+    mock_input_user_or_group("testgroup_members");
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETGRNAM);
+    will_return_always(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+
+    /* Query for that group, call a callback when command finishes */
+    set_cmd_cb(test_nss_getgrnam_check_mix_dom);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETGRNAM,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+}
+
 static int test_nss_getgrnam_check_mix_dom_fqdn(uint32_t status,
                                                 uint8_t *body, size_t blen)
 {
@@ -1773,21 +1844,33 @@ static int test_nss_getgrnam_check_mix_dom_fqdn(uint32_t status,
     tmp_ctx = talloc_new(nss_test_ctx);
     assert_non_null(tmp_ctx);
 
-    exp_members[0] = sss_tc_fqname(tmp_ctx, nss_test_ctx->subdom->names,
-                                   nss_test_ctx->subdom, submember1.pw_name);
-    assert_non_null(exp_members[0]);
-    exp_members[1] = sss_tc_fqname(tmp_ctx, nss_test_ctx->tctx->dom->names,
-                                   nss_test_ctx->tctx->dom, testmember1.pw_name);
-    assert_non_null(exp_members[1]);
-    exp_members[2] = sss_tc_fqname(tmp_ctx, nss_test_ctx->tctx->dom->names,
-                                   nss_test_ctx->tctx->dom, testmember2.pw_name);
-    assert_non_null(exp_members[2]);
+    if (nss_test_ctx->subdom->fqnames) {
+        exp_members[0] = sss_tc_fqname(tmp_ctx,
+                                       nss_test_ctx->subdom->names,
+                                       nss_test_ctx->subdom,
+                                       submember1.pw_name);
+        assert_non_null(exp_members[0]);
+    } else {
+        exp_members[0] = submember1.pw_name;
+    }
+    if (nss_test_ctx->tctx->dom->fqnames) {
+        exp_members[1] = sss_tc_fqname(tmp_ctx, nss_test_ctx->tctx->dom->names,
+                                       nss_test_ctx->tctx->dom, testmember1.pw_name);
+        assert_non_null(exp_members[1]);
+        exp_members[2] = sss_tc_fqname(tmp_ctx, nss_test_ctx->tctx->dom->names,
+                                       nss_test_ctx->tctx->dom, testmember2.pw_name);
+        assert_non_null(exp_members[2]);
 
-    expected.gr_name = sss_tc_fqname(tmp_ctx,
-                                     nss_test_ctx->tctx->dom->names,
-                                     nss_test_ctx->tctx->dom,
-                                     testgroup_members.gr_name);
-    assert_non_null(expected.gr_name);
+        expected.gr_name = sss_tc_fqname(tmp_ctx,
+                                         nss_test_ctx->tctx->dom->names,
+                                         nss_test_ctx->tctx->dom,
+                                         testgroup_members.gr_name);
+        assert_non_null(expected.gr_name);
+    } else {
+        exp_members[1] = testmember1.pw_name;
+        exp_members[2] = testmember2.pw_name;
+        expected.gr_name = testgroup_members.gr_name;
+    }
 
     assert_int_equal(status, EOK);
 
@@ -1834,6 +1917,40 @@ void test_nss_getgrnam_mix_dom_fqdn(void **state)
     assert_int_equal(ret, EOK);
 }
 
+void test_nss_getgrnam_mix_dom_fqdn_nonfqnames(void **state)
+{
+    errno_t ret;
+
+    ret = store_group_member(nss_test_ctx,
+                             testgroup_members.gr_name,
+                             nss_test_ctx->tctx->dom,
+                             submember1.pw_name,
+                             nss_test_ctx->subdom,
+                             SYSDB_MEMBER_USER);
+    assert_int_equal(ret, EOK);
+
+    nss_test_ctx->tctx->dom->fqnames = false;
+    nss_test_ctx->subdom->fqnames = false;
+
+
+    mock_input_user_or_group("testgroup_members");
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETGRNAM);
+    will_return_always(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+
+    /* Query for that group, call a callback when command finishes */
+    set_cmd_cb(test_nss_getgrnam_check_mix_dom_fqdn);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETGRNAM,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+
+    /* Restore FQDN settings */
+    nss_test_ctx->tctx->dom->fqnames = false;
+    assert_int_equal(ret, EOK);
+}
+
 static int test_nss_getgrnam_check_mix_subdom(uint32_t status,
                                               uint8_t *body, size_t blen)
 {
@@ -1851,20 +1968,37 @@ static int test_nss_getgrnam_check_mix_subdom(uint32_t status,
     tmp_ctx = talloc_new(nss_test_ctx);
     assert_non_null(tmp_ctx);
 
-    exp_members[0] = sss_tc_fqname(tmp_ctx, nss_test_ctx->subdom->names,
-                                   nss_test_ctx->subdom, submember1.pw_name);
-    assert_non_null(exp_members[0]);
-    exp_members[1] = sss_tc_fqname(tmp_ctx, nss_test_ctx->subdom->names,
-                                   nss_test_ctx->subdom, submember2.pw_name);
-    assert_non_null(exp_members[1]);
+    if (nss_test_ctx->subdom->fqnames) {
+        exp_members[0] = sss_tc_fqname(tmp_ctx,
+                                       nss_test_ctx->subdom->names,
+                                       nss_test_ctx->subdom,
+                                       submember1.pw_name);
+        assert_non_null(exp_members[0]);
+
+        exp_members[1] = sss_tc_fqname(tmp_ctx,
+                                       nss_test_ctx->subdom->names,
+                                       nss_test_ctx->subdom,
+                                       submember2.pw_name);
+        assert_non_null(exp_members[1]);
+    } else {
+        exp_members[0] = submember1.pw_name;
+        exp_members[1] = submember2.pw_name;
+    }
+
     /* Important: this member is from a non-qualified domain, so his name will
      * not be qualified either
      */
     exp_members[2] = testmember1.pw_name;
 
-    expected.gr_name = sss_tc_fqname(tmp_ctx, nss_test_ctx->subdom->names,
-                                     nss_test_ctx->subdom, testsubdomgroup.gr_name);
-    assert_non_null(expected.gr_name);
+    if (nss_test_ctx->subdom->fqnames) {
+        expected.gr_name = sss_tc_fqname(tmp_ctx,
+                                         nss_test_ctx->subdom->names,
+                                         nss_test_ctx->subdom,
+                                         testsubdomgroup.gr_name);
+        assert_non_null(expected.gr_name);
+    } else {
+        expected.gr_name = testsubdomgroup.gr_name;
+    }
 
     assert_int_equal(status, EOK);
 
@@ -1892,6 +2026,36 @@ void test_nss_getgrnam_mix_subdom(void **state)
     assert_int_equal(ret, EOK);
 
     mock_input_user_or_group("testsubdomgroup@"TEST_SUBDOM_NAME);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETGRNAM);
+    will_return_always(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+
+    /* Query for that group, call a callback when command finishes */
+    set_cmd_cb(test_nss_getgrnam_check_mix_subdom);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETGRNAM,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+}
+
+void test_nss_getgrnam_mix_subdom_nonfqnames(void **state)
+{
+    errno_t ret;
+
+    nss_test_ctx->subdom->fqnames = false;
+
+    ret = store_group_member(nss_test_ctx,
+                             testsubdomgroup.gr_name,
+                             nss_test_ctx->subdom,
+                             testmember1.pw_name,
+                             nss_test_ctx->tctx->dom,
+                             SYSDB_MEMBER_USER);
+    assert_int_equal(ret, EOK);
+
+    mock_input_user_or_group("testsubdomgroup");
+    mock_account_recv_simple();
     will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETGRNAM);
     will_return_always(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
 
@@ -4023,13 +4187,25 @@ int main(int argc, const char *argv[])
         cmocka_unit_test_setup_teardown(test_nss_getgrnam_members_subdom,
                                         nss_subdom_test_setup,
                                         nss_subdom_test_teardown),
+        cmocka_unit_test_setup_teardown(test_nss_getgrnam_members_subdom_nonfqnames,
+                                        nss_subdom_test_setup,
+                                        nss_subdom_test_teardown),
         cmocka_unit_test_setup_teardown(test_nss_getgrnam_mix_dom,
+                                        nss_subdom_test_setup,
+                                        nss_subdom_test_teardown),
+        cmocka_unit_test_setup_teardown(test_nss_getgrnam_mix_dom_nonfqnames,
                                         nss_subdom_test_setup,
                                         nss_subdom_test_teardown),
         cmocka_unit_test_setup_teardown(test_nss_getgrnam_mix_dom_fqdn,
                                         nss_subdom_test_setup,
                                         nss_subdom_test_teardown),
+        cmocka_unit_test_setup_teardown(test_nss_getgrnam_mix_dom_fqdn_nonfqnames,
+                                        nss_subdom_test_setup,
+                                        nss_subdom_test_teardown),
         cmocka_unit_test_setup_teardown(test_nss_getgrnam_mix_subdom,
+                                        nss_subdom_test_setup,
+                                        nss_subdom_test_teardown),
+        cmocka_unit_test_setup_teardown(test_nss_getgrnam_mix_subdom_nonfqnames,
                                         nss_subdom_test_setup,
                                         nss_subdom_test_teardown),
         cmocka_unit_test_setup_teardown(test_nss_getgrnam_space,

--- a/src/tests/cmocka/test_nss_srv.c
+++ b/src/tests/cmocka/test_nss_srv.c
@@ -3206,7 +3206,8 @@ static int nss_subdom_test_setup(void **state)
 
     subdomain = new_subdomain(nss_test_ctx, nss_test_ctx->tctx->dom,
                               testdom[0], testdom[1], testdom[2], testdom[3],
-                              false, false, NULL, NULL, 0);
+                              false, false, NULL, NULL, 0,
+                              nss_test_ctx->tctx->confdb);
     assert_non_null(subdomain);
 
     ret = sysdb_subdomain_store(nss_test_ctx->tctx->sysdb,
@@ -3214,7 +3215,8 @@ static int nss_subdom_test_setup(void **state)
                                 false, false, NULL, 0, NULL);
     assert_int_equal(ret, EOK);
 
-    ret = sysdb_update_subdomains(nss_test_ctx->tctx->dom);
+    ret = sysdb_update_subdomains(nss_test_ctx->tctx->dom,
+                                  nss_test_ctx->tctx->confdb);
     assert_int_equal(ret, EOK);
 
     nss_test_ctx->subdom = subdomain;

--- a/src/tests/cmocka/test_sysdb_domain_resolution_order.c
+++ b/src/tests/cmocka/test_sysdb_domain_resolution_order.c
@@ -1,0 +1,190 @@
+/*
+    SSSD
+
+    sysdb_domain_resolution_order - Tests for domain resolution order calls
+
+    Authors:
+        Fabiano Fidêncio <fidencio@redhat.com>
+
+    Copyright (C) 2017 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <popt.h>
+
+#include "tests/cmocka/common_mock.h"
+#include "tests/common.h"
+#include "db/sysdb_domain_resolution_order.h"
+#include "db/sysdb_private.h" /* for sysdb->ldb member */
+
+#define TESTS_PATH "tp_" BASE_FILE_STEM
+#define TEST_CONF_DB "test_sysdb_domain_resolution_order.ldb"
+
+#define TEST_DOM_NAME "test_sysdb_domain_resolution_order"
+
+#define TEST_ID_PROVIDER "ldap"
+
+struct domain_resolution_order_test_ctx {
+    struct sss_test_ctx *tctx;
+};
+
+static int test_sysdb_domain_resolution_order_setup(void **state)
+{
+    struct domain_resolution_order_test_ctx *test_ctx;
+
+    assert_true(leak_check_setup());
+
+    test_ctx = talloc_zero(global_talloc_context,
+                           struct domain_resolution_order_test_ctx);
+    assert_non_null(test_ctx);
+
+    test_dom_suite_setup(TESTS_PATH);
+
+    test_ctx->tctx = create_dom_test_ctx(test_ctx, TESTS_PATH,
+                                         TEST_CONF_DB, TEST_DOM_NAME,
+                                         TEST_ID_PROVIDER, NULL);
+    assert_non_null(test_ctx->tctx);
+
+    *state = test_ctx;
+    return 0;
+}
+
+static int test_sysdb_domain_resolution_order_teardown(void **state)
+{
+    struct domain_resolution_order_test_ctx *test_ctx =
+        talloc_get_type(*state, struct domain_resolution_order_test_ctx);
+
+    test_dom_suite_cleanup(TESTS_PATH, TEST_CONF_DB, TEST_DOM_NAME);
+    talloc_free(test_ctx);
+    assert_true(leak_check_teardown());
+    return 0;
+}
+
+static void test_sysdb_domain_resolution_order_ops(void **state)
+{
+    errno_t ret;
+    struct domain_resolution_order_test_ctx *test_ctx =
+        talloc_get_type(*state, struct domain_resolution_order_test_ctx);
+    const char *domains_in = NULL;
+    const char *domains_out = NULL;
+    struct ldb_dn *dn;
+
+    dn = ldb_dn_new_fmt(test_ctx, test_ctx->tctx->dom->sysdb->ldb,
+                        SYSDB_DOM_BASE, test_ctx->tctx->dom->name);
+
+    /* Adding domainResolutionOrder for the first time */
+    domains_in = "foo:bar:foobar";
+    ret = sysdb_update_domain_resolution_order(test_ctx->tctx->dom->sysdb,
+                                               dn, domains_in);
+    assert_int_equal(ret, EOK);
+
+    ret = sysdb_get_domain_resolution_order(test_ctx,
+                                            test_ctx->tctx->dom->sysdb, dn,
+                                            &domains_out);
+    assert_int_equal(ret, EOK);
+    assert_true(strcmp(domains_in, domains_out) == 0);
+
+    /* Setting the domainResolutionOrder to ":" ...
+     *
+     * It means, the domainResolutionOrder is set, but if there's another
+     * domainResolutionOrder with lower precedence those must be ignored.
+     */
+    domains_in = ":";
+    ret = sysdb_update_domain_resolution_order(test_ctx->tctx->dom->sysdb,
+                                               dn, domains_in);
+    assert_int_equal(ret, EOK);
+
+    ret = sysdb_get_domain_resolution_order(test_ctx,
+                                            test_ctx->tctx->dom->sysdb, dn,
+                                            &domains_out);
+    assert_int_equal(ret, EOK);
+    assert_true(strcmp(domains_in, domains_out) == 0);
+
+    /* Changing the domainResolutionOrder */
+    domains_in = "bar:foobar:foo";
+    ret = sysdb_update_domain_resolution_order(test_ctx->tctx->dom->sysdb,
+                                               dn, domains_in);
+    assert_int_equal(ret, EOK);
+
+    ret = sysdb_get_domain_resolution_order(test_ctx,
+                                            test_ctx->tctx->dom->sysdb, dn,
+                                            &domains_out);
+    assert_int_equal(ret, EOK);
+    assert_true(strcmp(domains_out, domains_out) == 0);
+
+    /* Removing the domainResolutionOrder attribute */
+    domains_in = NULL;
+    ret = sysdb_update_domain_resolution_order(test_ctx->tctx->dom->sysdb,
+                                               dn, domains_in);
+    assert_int_equal(ret, EOK);
+
+    ret = sysdb_get_domain_resolution_order(test_ctx,
+                                            test_ctx->tctx->dom->sysdb, dn,
+                                            &domains_out);
+    assert_int_equal(ret, ENOENT);
+    assert_true(domains_out == NULL);
+}
+
+int main(int argc, const char *argv[])
+{
+    int rv;
+    int no_cleanup = 0;
+    poptContext pc;
+    int opt;
+    struct poptOption long_options[] = {
+        POPT_AUTOHELP
+        SSSD_DEBUG_OPTS
+        {"no-cleanup", 'n', POPT_ARG_NONE, &no_cleanup, 0,
+         _("Do not delete the test database after a test run"), NULL },
+        POPT_TABLEEND
+    };
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_sysdb_domain_resolution_order_ops,
+                                        test_sysdb_domain_resolution_order_setup,
+                                        test_sysdb_domain_resolution_order_teardown),
+    };
+
+    /* Set debug level to invalid value so we can deside if -d 0 was used. */
+    debug_level = SSSDBG_INVALID;
+
+    pc = poptGetContext(argv[0], argc, argv, long_options, 0);
+    while((opt = poptGetNextOpt(pc)) != -1) {
+        switch(opt) {
+        default:
+            fprintf(stderr, "\nInvalid option %s: %s\n\n",
+                    poptBadOption(pc, 0), poptStrerror(opt));
+            poptPrintUsage(pc, stderr, 0);
+            return 1;
+        }
+    }
+    poptFreeContext(pc);
+
+    DEBUG_CLI_INIT(debug_level);
+
+    tests_set_cwd();
+    test_dom_suite_cleanup(TESTS_PATH, TEST_CONF_DB, LOCAL_SYSDB_FILE);
+    test_dom_suite_setup(TESTS_PATH);
+    rv = cmocka_run_group_tests(tests, NULL, NULL);
+
+    if (rv == 0 && no_cleanup == 0) {
+        test_dom_suite_cleanup(TESTS_PATH, TEST_CONF_DB, LOCAL_SYSDB_FILE);
+    }
+    return rv;
+}

--- a/src/tests/cmocka/test_sysdb_subdomains.c
+++ b/src/tests/cmocka/test_sysdb_subdomains.c
@@ -103,7 +103,7 @@ static void test_sysdb_subdomain_create(void **state)
                                 false, false, NULL, 0, NULL);
     assert_int_equal(ret, EOK);
 
-    ret = sysdb_update_subdomains(test_ctx->tctx->dom);
+    ret = sysdb_update_subdomains(test_ctx->tctx->dom, test_ctx->tctx->confdb);
     assert_int_equal(ret, EOK);
 
     assert_non_null(test_ctx->tctx->dom->subdomains);
@@ -115,7 +115,7 @@ static void test_sysdb_subdomain_create(void **state)
                                 false, false, NULL, 1, NULL);
     assert_int_equal(ret, EOK);
 
-    ret = sysdb_update_subdomains(test_ctx->tctx->dom);
+    ret = sysdb_update_subdomains(test_ctx->tctx->dom, test_ctx->tctx->confdb);
     assert_int_equal(ret, EOK);
 
     assert_non_null(test_ctx->tctx->dom->subdomains->next);
@@ -133,7 +133,7 @@ static void test_sysdb_subdomain_create(void **state)
                                 false, false, NULL, 0, NULL);
     assert_int_equal(ret, EOK);
 
-    ret = sysdb_update_subdomains(test_ctx->tctx->dom);
+    ret = sysdb_update_subdomains(test_ctx->tctx->dom, test_ctx->tctx->confdb);
     assert_int_equal(ret, EOK);
 
     assert_int_equal(test_ctx->tctx->dom->subdomains->trust_direction, 1);
@@ -145,7 +145,7 @@ static void test_sysdb_subdomain_create(void **state)
     ret = sysdb_subdomain_delete(test_ctx->tctx->sysdb, dom1[0]);
     assert_int_equal(ret, EOK);
 
-    ret = sysdb_update_subdomains(test_ctx->tctx->dom);
+    ret = sysdb_update_subdomains(test_ctx->tctx->dom, test_ctx->tctx->confdb);
     assert_int_equal(ret, EOK);
 
     assert_int_equal(sss_domain_get_state(test_ctx->tctx->dom->subdomains),
@@ -235,11 +235,11 @@ static void test_sysdb_link_forest_root_ipa(void **state)
                                 0, NULL);
     assert_int_equal(ret, EOK);
 
-    ret = sysdb_update_subdomains(test_ctx->tctx->dom);
+    ret = sysdb_update_subdomains(test_ctx->tctx->dom, test_ctx->tctx->confdb);
     assert_int_equal(ret, EOK);
 
     /* Also update dom2 */
-    ret = sysdb_update_subdomains(test_ctx->tctx->dom->next);
+    ret = sysdb_update_subdomains(test_ctx->tctx->dom->next, test_ctx->tctx->confdb);
     assert_int_equal(ret, EOK);
 
     sub = find_domain_by_name(test_ctx->tctx->dom, dom1[0], true);
@@ -315,11 +315,11 @@ static void test_sysdb_link_forest_root_ad(void **state)
                                 0, NULL);
     assert_int_equal(ret, EOK);
 
-    ret = sysdb_update_subdomains(test_ctx->tctx->dom);
+    ret = sysdb_update_subdomains(test_ctx->tctx->dom, test_ctx->tctx->confdb);
     assert_int_equal(ret, EOK);
 
     /* Also update dom2 */
-    ret = sysdb_update_subdomains(test_ctx->tctx->dom->next);
+    ret = sysdb_update_subdomains(test_ctx->tctx->dom->next, test_ctx->tctx->confdb);
     assert_int_equal(ret, EOK);
 
     assert_non_null(test_ctx->tctx->dom->forest_root);
@@ -395,14 +395,15 @@ static void test_sysdb_link_forest_member_ad(void **state)
     ret = sysdb_master_domain_update(test_ctx->tctx->dom);
     assert_int_equal(ret, EOK);
 
-    ret = sysdb_update_subdomains(test_ctx->tctx->dom);
+    ret = sysdb_update_subdomains(test_ctx->tctx->dom, test_ctx->tctx->confdb);
     assert_int_equal(ret, EOK);
 
     /* Also update dom2 */
     ret = sysdb_master_domain_update(test_ctx->tctx->dom->next);
     assert_int_equal(ret, EOK);
 
-    ret = sysdb_update_subdomains(test_ctx->tctx->dom->next);
+    ret = sysdb_update_subdomains(test_ctx->tctx->dom->next,
+                                  test_ctx->tctx->confdb);
     assert_int_equal(ret, EOK);
 
     /* Checks */
@@ -472,7 +473,7 @@ static void test_sysdb_link_ad_multidom(void **state)
     ret = sysdb_master_domain_update(main_dom1);
     assert_int_equal(ret, EOK);
 
-    ret = sysdb_update_subdomains(main_dom1);
+    ret = sysdb_update_subdomains(main_dom1, NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_master_domain_add_info(main_dom2,
@@ -492,7 +493,7 @@ static void test_sysdb_link_ad_multidom(void **state)
     ret = sysdb_master_domain_update(main_dom2);
     assert_int_equal(ret, EOK);
 
-    ret = sysdb_update_subdomains(main_dom2);
+    ret = sysdb_update_subdomains(main_dom2, NULL);
     assert_int_equal(ret, EOK);
 
     main_dom1 = find_domain_by_name(test_ctx->tctx->dom, TEST_DOM1_NAME, true);

--- a/src/tests/cwrap/Makefile.am
+++ b/src/tests/cwrap/Makefile.am
@@ -41,6 +41,7 @@ SSSD_CACHE_REQ_OBJ = \
     ../../../src/responder/common/cache_req/cache_req_result.c \
     ../../../src/responder/common/cache_req/cache_req_search.c \
     ../../../src/responder/common/cache_req/cache_req_data.c \
+    ../../../src/responder/common/cache_req/cache_req_domain.c \
     ../../../src/responder/common/cache_req/plugins/cache_req_common.c \
     ../../../src/responder/common/cache_req/plugins/cache_req_enum_users.c \
     ../../../src/responder/common/cache_req/plugins/cache_req_enum_groups.c \

--- a/src/tests/sysdb-tests.c
+++ b/src/tests/sysdb-tests.c
@@ -1395,7 +1395,7 @@ START_TEST (test_sysdb_get_user_attr_subdomain)
     /* Create subdomain */
     subdomain = new_subdomain(test_ctx, test_ctx->domain,
                               "test.sub", "TEST.SUB", "test", "S-3",
-                              false, false, NULL, NULL, 0);
+                              false, false, NULL, NULL, 0, NULL);
     fail_if(subdomain == NULL, "Failed to create new subdomain.");
 
     ret = sss_names_init_from_args(test_ctx,
@@ -5821,14 +5821,14 @@ START_TEST(test_sysdb_subdomain_store_user)
 
     subdomain = new_subdomain(test_ctx, test_ctx->domain,
                               testdom[0], testdom[1], testdom[2], testdom[3],
-                              false, false, NULL, NULL, 0);
+                              false, false, NULL, NULL, 0, NULL);
     fail_unless(subdomain != NULL, "Failed to create new subdomin.");
     ret = sysdb_subdomain_store(test_ctx->sysdb,
                                 testdom[0], testdom[1], testdom[2], testdom[3],
                                 false, false, NULL, 0, NULL);
     fail_if(ret != EOK, "Could not set up the test (test subdom)");
 
-    ret = sysdb_update_subdomains(test_ctx->domain);
+    ret = sysdb_update_subdomains(test_ctx->domain, NULL);
     fail_unless(ret == EOK, "sysdb_update_subdomains failed with [%d][%s]",
                             ret, strerror(ret));
 
@@ -5900,14 +5900,14 @@ START_TEST(test_sysdb_subdomain_user_ops)
 
     subdomain = new_subdomain(test_ctx, test_ctx->domain,
                               testdom[0], testdom[1], testdom[2], testdom[3],
-                              false, false, NULL, NULL, 0);
+                              false, false, NULL, NULL, 0, NULL);
     fail_unless(subdomain != NULL, "Failed to create new subdomin.");
     ret = sysdb_subdomain_store(test_ctx->sysdb,
                                 testdom[0], testdom[1], testdom[2], testdom[3],
                                 false, false, NULL, 0, NULL);
     fail_if(ret != EOK, "Could not set up the test (test subdom)");
 
-    ret = sysdb_update_subdomains(test_ctx->domain);
+    ret = sysdb_update_subdomains(test_ctx->domain, NULL);
     fail_unless(ret == EOK, "sysdb_update_subdomains failed with [%d][%s]",
                             ret, strerror(ret));
 
@@ -5973,14 +5973,14 @@ START_TEST(test_sysdb_subdomain_group_ops)
 
     subdomain = new_subdomain(test_ctx, test_ctx->domain,
                               testdom[0], testdom[1], testdom[2], testdom[3],
-                              false, false, NULL, NULL, 0);
+                              false, false, NULL, NULL, 0, NULL);
     fail_unless(subdomain != NULL, "Failed to create new subdomin.");
     ret = sysdb_subdomain_store(test_ctx->sysdb,
                                 testdom[0], testdom[1], testdom[2], testdom[3],
                                 false, false, NULL, 0, NULL);
     fail_if(ret != EOK, "Could not set up the test (test subdom)");
 
-    ret = sysdb_update_subdomains(test_ctx->domain);
+    ret = sysdb_update_subdomains(test_ctx->domain, NULL);
     fail_unless(ret == EOK, "sysdb_update_subdomains failed with [%d][%s]",
                             ret, strerror(ret));
 

--- a/src/tools/common/sss_tools.c
+++ b/src/tools/common/sss_tools.c
@@ -154,7 +154,7 @@ static errno_t sss_tool_domains_init(TALLOC_CTX *mem_ctx,
             }
 
             /* Update list of subdomains for this domain */
-            ret = sysdb_update_subdomains(dom);
+            ret = sysdb_update_subdomains(dom, confdb);
             if (ret != EOK) {
                 DEBUG(SSSDBG_MINOR_FAILURE,
                       "Failed to update subdomains for domain %s.\n",

--- a/src/tools/sss_cache.c
+++ b/src/tools/sss_cache.c
@@ -158,7 +158,7 @@ int main(int argc, const char *argv[])
             dinfo = get_next_domain(dinfo, SSS_GND_DESCEND)) {
         if (!IS_SUBDOMAIN(dinfo)) {
             /* Update list of subdomains for this domain */
-            ret = sysdb_update_subdomains(dinfo);
+            ret = sysdb_update_subdomains(dinfo, tctx->confdb);
             if (ret != EOK) {
                 DEBUG(SSSDBG_MINOR_FAILURE,
                       "Failed to update subdomains for domain %s.\n", dinfo->name);

--- a/src/util/dlinklist.h
+++ b/src/util/dlinklist.h
@@ -147,4 +147,9 @@ do { \
 #define DLIST_FOR_EACH(p, list) \
     for ((p) = (list); (p) != NULL; (p) = (p)->next)
 
+#define DLIST_FOR_EACH_SAFE(p, q, list) \
+    for ((p) = (list), (q) = (p) != NULL ? (p)->next : NULL; \
+         (p) != NULL; \
+         (p) = (q), (q) = (p) != NULL ? (p)->next : NULL)
+
 #endif /* _DLINKLIST_H */

--- a/src/util/domain_info_utils.c
+++ b/src/util/domain_info_utils.c
@@ -870,3 +870,18 @@ bool is_email_from_domain(const char *email, struct sss_domain_info *dom)
 
     return false;
 }
+
+char *subdomain_create_conf_path(TALLOC_CTX *mem_ctx,
+                                 struct sss_domain_info *subdomain)
+{
+    if (!IS_SUBDOMAIN(subdomain)) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "The domain \"%s\" is not a subdomain.\n",
+              subdomain->name);
+        return NULL;
+    }
+
+    return talloc_asprintf(mem_ctx, CONFDB_DOMAIN_PATH_TMPL "/%s",
+                           subdomain->parent->name,
+                           subdomain->name);
+}

--- a/src/util/string_utils.c
+++ b/src/util/string_utils.c
@@ -22,10 +22,10 @@
 
 #include "util/util.h"
 
-static char *replace_char(TALLOC_CTX *mem_ctx,
-                          const char *in,
-                          const char match,
-                          const char sub)
+char *sss_replace_char(TALLOC_CTX *mem_ctx,
+                       const char *in,
+                       const char match,
+                       const char sub)
 {
     char *p;
     char *out;
@@ -63,7 +63,7 @@ char * sss_replace_space(TALLOC_CTX *mem_ctx,
         return talloc_strdup(mem_ctx, orig_name);
     }
 
-    return replace_char(mem_ctx, orig_name, ' ', subst);
+    return sss_replace_char(mem_ctx, orig_name, ' ', subst);
 }
 
 char * sss_reverse_replace_space(TALLOC_CTX *mem_ctx,
@@ -81,7 +81,7 @@ char * sss_reverse_replace_space(TALLOC_CTX *mem_ctx,
         return talloc_strdup(mem_ctx, orig_name);
     }
 
-    return replace_char(mem_ctx, orig_name, subst, ' ');
+    return sss_replace_char(mem_ctx, orig_name, subst, ' ');
 }
 
 errno_t guid_blob_to_string_buf(const uint8_t *blob, char *str_buf,

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -551,6 +551,9 @@ find_domain_by_object_name(struct sss_domain_info *domain,
 bool subdomain_enumerates(struct sss_domain_info *parent,
                           const char *sd_name);
 
+char *subdomain_create_conf_path(TALLOC_CTX *mem_ctx,
+                                 struct sss_domain_info *subdomain);
+
 errno_t sssd_domain_init(TALLOC_CTX *mem_ctx,
                          struct confdb_ctx *cdb,
                          const char *domain_name,

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -600,6 +600,11 @@ errno_t name_to_well_known_sid(const char *dom, const char *name,
                                const char **sid);
 
 /* from string_utils.c */
+char *sss_replace_char(TALLOC_CTX *mem_ctx,
+                       const char *in,
+                       const char match,
+                       const char sub);
+
 char * sss_replace_space(TALLOC_CTX *mem_ctx,
                          const char *orig_name,
                          const char replace_char);


### PR DESCRIPTION
The patches are rebased on top of #154 and provide a solution for https://pagure.io/SSSD/sssd/issue/3001

There are no PAM related tests for those changes. Shall I do it using cmocka tests? Shall I rely on our downstream tests for this?