### PR TITLE
SELINUX: Use getseuserbyname to get IPA seuser

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3794,6 +3794,7 @@ selinux_child_LDADD = \
     $(POPT_LIBS) \
     $(DHASH_LIBS) \
     $(SEMANAGE_LIBS) \
+    $(SELINUX_LIBS) \
     $(NULL)
 endif
 

--- a/src/providers/ipa/selinux_child.c
+++ b/src/providers/ipa/selinux_child.c
@@ -27,6 +27,7 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <popt.h>
+#include <selinux/selinux.h>
 
 #include "util/util.h"
 #include "util/child_common.h"
@@ -172,9 +173,9 @@ static bool seuser_needs_update(struct input_buffer *ibuf)
     char *db_mls_range = NULL;
     errno_t ret;
 
-    ret = get_seuser(ibuf, ibuf->username, &db_seuser, &db_mls_range);
+    ret = getseuserbyname(ibuf->username, &db_seuser, &db_mls_range);
     DEBUG(SSSDBG_TRACE_INTERNAL,
-          "get_seuser: ret: %d seuser: %s mls: %s\n",
+          "getseuserbyname: ret: %d seuser: %s mls: %s\n",
           ret, db_seuser ? db_seuser : "unknown",
           db_mls_range ? db_mls_range : "unknown");
     if (ret == EOK && db_seuser && db_mls_range &&
@@ -183,8 +184,6 @@ static bool seuser_needs_update(struct input_buffer *ibuf)
         needs_update = false;
     }
 
-    talloc_free(db_seuser);
-    talloc_free(db_mls_range);
     return needs_update;
 }
 

--- a/src/util/sss_semanage.c
+++ b/src/util/sss_semanage.c
@@ -367,70 +367,6 @@ done:
     return ret;
 }
 
-int get_seuser(TALLOC_CTX *mem_ctx, const char *login_name,
-               char **_seuser, char **_mls_range)
-{
-    errno_t ret;
-    const char *seuser;
-    const char *mls_range;
-    semanage_handle_t *sm_handle = NULL;
-    semanage_seuser_t *sm_user = NULL;
-    semanage_seuser_key_t *sm_key = NULL;
-
-    sm_handle = sss_semanage_init();
-    if (sm_handle == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Cannot create SELinux handle\n");
-        ret = EIO;
-        goto done;
-    }
-
-    ret = semanage_seuser_key_create(sm_handle, login_name, &sm_key);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Cannot create key for %s\n", login_name);
-        ret = EIO;
-        goto done;
-    }
-
-    ret = semanage_seuser_query(sm_handle, sm_key, &sm_user);
-    if (ret < 0) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Cannot query for %s\n", login_name);
-        ret = EIO;
-        goto done;
-    }
-
-    seuser = semanage_seuser_get_sename(sm_user);
-    if (seuser != NULL) {
-        *_seuser = talloc_strdup(mem_ctx, seuser);
-        if (*_seuser == NULL) {
-            ret = ENOMEM;
-            goto done;
-        }
-        DEBUG(SSSDBG_OP_FAILURE,
-              "SELinux user for %s: %s\n", login_name, *_seuser);
-    } else {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Cannot get sename for %s\n", login_name);
-    }
-
-    mls_range = semanage_seuser_get_mlsrange(sm_user);
-    if (mls_range != NULL) {
-        *_mls_range = talloc_strdup(mem_ctx, mls_range);
-        if (*_mls_range == NULL) {
-            ret = ENOMEM;
-            goto done;
-        }
-        DEBUG(SSSDBG_OP_FAILURE,
-              "SELinux range for %s: %s\n", login_name, *_mls_range);
-    } else {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Cannot get mlsrange for %s\n", login_name);
-    }
-
-    ret = EOK;
-done:
-    semanage_seuser_key_free(sm_key);
-    semanage_seuser_free(sm_user);
-    sss_semanage_close(sm_handle);
-    return ret;
-}
 
 #else /* HAVE_SEMANAGE */
 int set_seuser(const char *login_name, const char *seuser_name,
@@ -444,9 +380,4 @@ int del_seuser(const char *login_name)
     return EOK;
 }
 
-int get_seuser(TALLOC_CTX *mem_ctx, const char *login_name,
-               char **_seuser, char **_mls_range)
-{
-    return EOK;
-}
 #endif  /* HAVE_SEMANAGE */

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -634,8 +634,6 @@ errno_t restore_creds(struct sss_creds *saved_creds);
 int set_seuser(const char *login_name, const char *seuser_name,
                const char *mlsrange);
 int del_seuser(const char *login_name);
-int get_seuser(TALLOC_CTX *mem_ctx, const char *login_name,
-               char **_seuser, char **_mls_range);
 
 /* convert time from generalized form to unix time */
 errno_t sss_utc_to_time_t(const char *str, const char *format, time_t *unix_time);


### PR DESCRIPTION
Retrieve SELinux username utilizing libselinux API as a more reliable method than libsemanage calls and remove get_seuser function which is no longer needed.

Resolves:
https://pagure.io/SSSD/sssd/issue/3308

Tested on IPA client with:
- running `semanage login -d testuser`
- login as **testuser** and check `/var/log/sssd/selinux_child.log`