### PR TITLE
UTIL: Use max 15 characters for AD host UPN

### DIFF
--- a/src/util/sss_krb5.c
+++ b/src/util/sss_krb5.c
@@ -51,7 +51,13 @@ sss_krb5_get_primary(TALLOC_CTX *mem_ctx,
             *c = toupper(*c);
         }
 
-        primary = talloc_asprintf(mem_ctx, "%s$", shortname);
+        /* The samAccountName is recommended to be less than 20 characters.
+         * This is only for users and groups. For machine accounts,
+         * the real limit is caused by NetBIOS protocol.
+         * NetBIOS names are limited to 16 (15 + $)
+         * https://support.microsoft.com/en-us/help/163409/netbios-suffixes-16th-character-of-the-netbios-name
+         */
+        primary = talloc_asprintf(mem_ctx, "%.15s$", shortname);
         talloc_free(shortname);
         return primary;
     }


### PR DESCRIPTION
We do not want to use host principal with AD
"host/name.domain.tld@DOMAIN.TLD" becasue it does not work.
We need to use correct user principal for AD hosts. And we cannot
rely all fallback "*$" becuase of other principals in keytab.

Resolves:
https://pagure.io/SSSD/sssd/issue/3329