### PR TITLE
SSSD-1.15 - config-check: Message when sssd.conf is missing

### DIFF
--- a/src/tools/sssctl/sssctl_config.c
+++ b/src/tools/sssctl/sssctl_config.c
@@ -63,7 +63,10 @@ errno_t sssctl_config_check(struct sss_cmdline *cmdline,
 
     /* Open config file */
     ret = sss_ini_config_file_open(init_data, SSSD_CONFIG_FILE);
-    if (ret != EOK) {
+    if (ret == ENOENT) {
+        ERROR("File %1$s does not exist.\n", SSSD_CONFIG_FILE);
+        goto done;
+    } else if (ret != EOK) {
         DEBUG(SSSDBG_TRACE_FUNC,
               "sss_ini_config_file_open failed: %s [%d]\n",
               sss_strerror(ret),

--- a/src/tools/sssctl/sssctl_config.c
+++ b/src/tools/sssctl/sssctl_config.c
@@ -64,7 +64,13 @@ errno_t sssctl_config_check(struct sss_cmdline *cmdline,
     /* Open config file */
     ret = sss_ini_config_file_open(init_data, SSSD_CONFIG_FILE);
     if (ret == ENOENT) {
+#ifdef ADD_FILES_DOMAIN
+        PRINT("File %1$s does not exist. SSSD will use default "
+              "configuration with files provider.\n", SSSD_CONFIG_FILE);
+        ret = EOK;
+#else
         ERROR("File %1$s does not exist.\n", SSSD_CONFIG_FILE);
+#endif /* ADD_FILES_DOMAIN */
         goto done;
     } else if (ret != EOK) {
         DEBUG(SSSDBG_TRACE_FUNC,


### PR DESCRIPTION
SSSD 1.15 version for patch recently pushed to 1.14.

sssctl config-check should print a message for user
if no sssd.conf was found.

Resolves:
https://pagure.io/SSSD/sssd/issue/3330