### PR TITLE
SPEC: Drop conditional build for krb5_local_auth_plugin

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -97,10 +97,6 @@
     %global with_cifs_utils_plugin_option --disable-cifs-idmap-plugin
 %endif
 
-%if (0%{?fedora} || (0%{?rhel} == 7 &&  0%{?rhel7_minor} >= 1) || (0%{?rhel} == 6 &&  0%{?rhel6_minor} >= 7))
-    %global with_krb5_localauth_plugin 1
-%endif
-
 %if (0%{?fedora})
     %global with_python3 1
 %else
@@ -989,11 +985,9 @@ done
 %dir %{_sysconfdir}/cifs-utils
 %ghost %{_sysconfdir}/cifs-utils/idmap-plugin
 %endif
-%if (0%{?with_krb5_localauth_plugin} == 1)
 %dir %{_libdir}/%{name}
 %dir %{_libdir}/%{name}/modules
 %{_libdir}/%{name}/modules/sssd_krb5_localauth_plugin.so
-%endif
 %{_mandir}/man8/pam_sss.8*
 %{_mandir}/man8/sssd_krb5_locator_plugin.8*
 


### PR DESCRIPTION
It was mainly aimed for time when stable CentOS and
rhel nightly had different versions of krb5.

Anyway, rhel7.0 and rhel <= 6.6 are already out of support