### PR TITLE
Improve PAM test client

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3468,6 +3468,7 @@ pam_test_client_LDADD = \
     $(PAM_LIBS) \
     $(PAM_MISC_LIBS) \
     $(LIBADD_DL) \
+    libsss_simpleifp.la \
     $(NULL)
 
 if BUILD_AUTOFS

--- a/Makefile.am
+++ b/Makefile.am
@@ -146,6 +146,7 @@ sbin_PROGRAMS = \
     sss_override \
     sss_seed \
     sssctl \
+    sss_pam_test_client \
     $(NULL)
 
 sssdlibexec_PROGRAMS = \
@@ -3450,7 +3451,7 @@ endif # BUILD_KCM
 
 endif # HAVE_CMOCKA
 
-noinst_PROGRAMS = pam_test_client
+noinst_PROGRAMS =
 if BUILD_SUDO
 noinst_PROGRAMS += sss_sudo_cli
 endif
@@ -3461,10 +3462,10 @@ if BUILD_WITH_LIBCURL
 noinst_PROGRAMS += tcurl-test-tool
 endif
 
-pam_test_client_SOURCES = \
+sss_pam_test_client_SOURCES = \
     src/sss_client/pam_test_client.c \
     $(NULL)
-pam_test_client_LDADD = \
+sss_pam_test_client_LDADD = \
     $(PAM_LIBS) \
     $(PAM_MISC_LIBS) \
     $(LIBADD_DL) \

--- a/Makefile.am
+++ b/Makefile.am
@@ -3461,8 +3461,14 @@ if BUILD_WITH_LIBCURL
 noinst_PROGRAMS += tcurl-test-tool
 endif
 
-pam_test_client_SOURCES = src/sss_client/pam_test_client.c
-pam_test_client_LDADD = $(PAM_LIBS) $(PAM_MISC_LIBS)
+pam_test_client_SOURCES = \
+    src/sss_client/pam_test_client.c \
+    $(NULL)
+pam_test_client_LDADD = \
+    $(PAM_LIBS) \
+    $(PAM_MISC_LIBS) \
+    $(LIBADD_DL) \
+    $(NULL)
 
 if BUILD_AUTOFS
 autofs_test_client_SOURCES = \

--- a/Makefile.am
+++ b/Makefile.am
@@ -146,7 +146,6 @@ sbin_PROGRAMS = \
     sss_override \
     sss_seed \
     sssctl \
-    sss_pam_test_client \
     $(NULL)
 
 sssdlibexec_PROGRAMS = \
@@ -1725,11 +1724,15 @@ sssctl_SOURCES = \
     src/tools/sssctl/sssctl_domains.c \
     src/tools/sssctl/sssctl_sifp.c \
     src/tools/sssctl/sssctl_config.c \
+    src/tools/sssctl/sssctl_user_checks.c \
     $(SSSD_TOOLS_OBJ) \
     $(NULL)
 sssctl_LDADD = \
     $(TOOLS_LIBS) \
     $(SSSD_INTERNAL_LTLIBS) \
+    $(PAM_LIBS) \
+    $(PAM_MISC_LIBS) \
+    $(LIBADD_DL) \
     libsss_simpleifp.la \
     $(NULL)
 sssctl_CFLAGS = \
@@ -3461,16 +3464,6 @@ endif
 if BUILD_WITH_LIBCURL
 noinst_PROGRAMS += tcurl-test-tool
 endif
-
-sss_pam_test_client_SOURCES = \
-    src/sss_client/pam_test_client.c \
-    $(NULL)
-sss_pam_test_client_LDADD = \
-    $(PAM_LIBS) \
-    $(PAM_MISC_LIBS) \
-    $(LIBADD_DL) \
-    libsss_simpleifp.la \
-    $(NULL)
 
 if BUILD_AUTOFS
 autofs_test_client_SOURCES = \

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -1080,6 +1080,7 @@ done
 %{_sbindir}/sss_debuglevel
 %{_sbindir}/sss_seed
 %{_sbindir}/sssctl
+%{_sbindir}/sss_pam_test_client
 %{_mandir}/man8/sss_groupadd.8*
 %{_mandir}/man8/sss_groupdel.8*
 %{_mandir}/man8/sss_groupmod.8*

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -1080,7 +1080,6 @@ done
 %{_sbindir}/sss_debuglevel
 %{_sbindir}/sss_seed
 %{_sbindir}/sssctl
-%{_sbindir}/sss_pam_test_client
 %{_mandir}/man8/sss_groupadd.8*
 %{_mandir}/man8/sss_groupdel.8*
 %{_mandir}/man8/sss_groupmod.8*

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -9,7 +9,6 @@ src/sss_client/common.c
 src/sss_client/nss_group.c
 src/sss_client/nss_passwd.c
 src/sss_client/pam_sss.c
-src/sss_client/pam_test_client.c
 src/sss_client/ssh/sss_ssh_authorizedkeys.c
 src/sss_client/ssh/sss_ssh_knownhostsproxy.c
 src/tools/sss_useradd.c

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -23,4 +23,12 @@ src/tools/sss_cache.c
 src/tools/sss_debuglevel.c
 src/tools/tools_util.c
 src/tools/tools_util.h
+src/tools/sssctl/sssctl.c
+src/tools/sssctl/sssctl_cache.c
+src/tools/sssctl/sssctl_config.c
+src/tools/sssctl/sssctl_data.c
+src/tools/sssctl/sssctl_domains.c
+src/tools/sssctl/sssctl_logs.c
+src/tools/sssctl/sssctl_sifp.c
+src/tools/sssctl/sssctl_user_checks.c
 src/util/util.h

--- a/src/lib/sifp/sss_sifp_common.c
+++ b/src/lib/sifp/sss_sifp_common.c
@@ -168,7 +168,7 @@ sss_sifp_fetch_user_by_uid(sss_sifp_ctx *ctx,
     uint64_t _uid = uid;
 
     return sss_sifp_fetch_object_by_attr(ctx, IFP_PATH_USERS, IFACE_IFP_USERS,
-                                         IFACE_IFP_USERS_USER, "UserByID",
+                                         IFACE_IFP_USERS_USER, "ByID",
                                          DBUS_TYPE_UINT64, &_uid, _user);
 }
 
@@ -178,6 +178,6 @@ sss_sifp_fetch_user_by_name(sss_sifp_ctx *ctx,
                             sss_sifp_object **_user)
 {
     return sss_sifp_fetch_object_by_name(ctx, IFP_PATH_USERS, IFACE_IFP_USERS,
-                                         IFACE_IFP_USERS_USER, "UserByName",
+                                         IFACE_IFP_USERS_USER, "ByName",
                                          name, _user);
 }

--- a/src/sss_client/pam_test_client.c
+++ b/src/sss_client/pam_test_client.c
@@ -48,34 +48,44 @@ static struct pam_conv conv = {
 # error "Missing text based pam conversation function"
 #endif
 
+#define DEFAULT_ACTION "acct"
+#define DEFAULT_SERVICE "system-auth"
+
 int main(int argc, char *argv[]) {
 
     pam_handle_t *pamh;
     char *user;
     char *action;
+    char *service;
     int ret;
+    size_t c;
+    char **pam_env;
 
     if (argc == 1) {
-        fprintf(stderr, "missing action and user name, using default\n");
-        action = strdup("auth");
-        user = strdup("dummy");
+        fprintf(stderr, "Usage: pam_test_client USERNAME "
+                        "[auth|acct|setc|chau|open|clos] [pam_service]\n");
+        return 0;
     } else if (argc == 2) {
-        fprintf(stdout, "using first argument as action and default user name\n");
-        action = strdup(argv[1]);
-        user = strdup("dummy");
-    } else {
-        action = strdup(argv[1]);
-        user = strdup(argv[2]);
+        fprintf(stderr,"using first argument as user name and default action "
+                       "and service\n");
+    } else if (argc == 3) {
+        fprintf(stderr, "using first argument as user name, second as action "
+                        "and default service\n");
     }
 
-    if (action == NULL || user == NULL) {
+    user = strdup(argv[1]);
+    action =  argc > 2 ? strdup(argv[2]) : strdup(DEFAULT_ACTION);
+    service = argc > 3 ? strdup(argv[3]) : strdup(DEFAULT_SERVICE);
+
+    if (action == NULL || user == NULL || service == NULL) {
         fprintf(stderr, "Out of memory!\n");
         return 1;
     }
 
-    fprintf(stdout, "action: %s\nuser: %s\n", action,user);
+    fprintf(stdout, "user: %s\naction: %s\nservice: %s\n",
+                    user, action, service);
 
-    ret = pam_start("sss_test", user, &conv, &pamh);
+    ret = pam_start(service, user, &conv, &pamh);
     if (ret != PAM_SUCCESS) {
         fprintf(stderr, "pam_start failed: %s\n", pam_strerror(pamh, ret));
         return 1;
@@ -109,7 +119,24 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "unknown action\n");
     }
 
+    fprintf(stderr, "PAM Environment:\n");
+    pam_env = pam_getenvlist(pamh);
+    if (pam_env != NULL && pam_env[0] != NULL) {
+        for (c = 0; pam_env[c] != NULL; c++) {
+            fprintf(stderr," - %s\n", pam_env[c]);
+            free(pam_env[c]);
+        }
+    } else {
+        fprintf(stderr," - no env -\n");
+    }
+    free(pam_env);
+
+
     pam_end(pamh, ret);
+
+    free(user);
+    free(action);
+    free(service);
 
     return 0;
 }

--- a/src/sss_client/pam_test_client.c
+++ b/src/sss_client/pam_test_client.c
@@ -30,8 +30,11 @@
 #include <pwd.h>
 #include <nss.h>
 #include <errno.h>
+#include <inttypes.h>
 
 #include <security/pam_appl.h>
+
+#include "lib/sifp/sss_sifp.h"
 
 #ifdef HAVE_SECURITY_PAM_MISC_H
 # include <security/pam_misc.h>
@@ -57,6 +60,69 @@ static struct pam_conv conv = {
 #define DEFAULT_SERVICE "system-auth"
 
 #define DEFAULT_BUFSIZE 4096
+
+static int get_ifp_user(const char *user)
+{
+    sss_sifp_ctx *sifp;
+    sss_sifp_error error;
+    sss_sifp_object *user_obj;
+    const char *tmp_str;
+    uint32_t tmp_uint32;
+    size_t c;
+
+    struct ifp_user_attr {
+        const char *name;
+        bool is_string;
+    } ifp_user_attr[] = {
+        {"name", true},
+        {"uidNumber", false},
+        {"gidNumber", false},
+        {"gecos", true},
+        {"homeDirectory", true},
+        {"loginShell", true},
+        {NULL, false}
+    };
+
+    error = sss_sifp_init(&sifp);
+    if (error != SSS_SIFP_OK) {
+        fprintf(stderr, "Unable to connect to the InfoPipe");
+        return EFAULT;
+    }
+
+    error = sss_sifp_fetch_user_by_name(sifp, user, &user_obj);
+    if (error != SSS_SIFP_OK) {
+        fprintf(stderr, "Unable to get user object");
+        return EIO;
+    }
+
+    fprintf(stdout, "SSSD InfoPipe user lookup result:\n");
+    for (c = 0; ifp_user_attr[c].name != NULL; c++) {
+        if (ifp_user_attr[c].is_string) {
+            error = sss_sifp_find_attr_as_string(user_obj->attrs,
+                                                 ifp_user_attr[c].name,
+                                                 &tmp_str);
+        } else {
+            error = sss_sifp_find_attr_as_uint32(user_obj->attrs,
+                                                 ifp_user_attr[c].name,
+                                                 &tmp_uint32);
+        }
+        if (error != SSS_SIFP_OK) {
+            fprintf(stderr, "Unable to get user name attr");
+            return EIO;
+        }
+
+        if (ifp_user_attr[c].is_string) {
+            fprintf(stdout, " - %s: %s\n", ifp_user_attr[c].name, tmp_str);
+        } else {
+            fprintf(stdout, " - %s: %"PRIu32"\n", ifp_user_attr[c].name,
+                                                  tmp_uint32);
+        }
+    }
+
+    sss_sifp_free_object(sifp, &user_obj);
+    sss_sifp_free(&sifp);
+    return 0;
+}
 
 static int sss_getpwnam_check(const char *user)
 {
@@ -157,6 +223,11 @@ int main(int argc, char *argv[]) {
         ret = sss_getpwnam_check(user);
         if (ret != 0) {
             fprintf(stderr,"User name lookup with [%s] failed.\n", user);
+        }
+
+        ret = get_ifp_user(user);
+        if (ret != 0) {
+            fprintf(stderr,"InforPipe User lookup with [%s] failed.\n", user);
         }
     }
 

--- a/src/sss_client/pam_test_client.c
+++ b/src/sss_client/pam_test_client.c
@@ -25,6 +25,11 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <string.h>
+#include <dlfcn.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include <nss.h>
+#include <errno.h>
 
 #include <security/pam_appl.h>
 
@@ -50,6 +55,69 @@ static struct pam_conv conv = {
 
 #define DEFAULT_ACTION "acct"
 #define DEFAULT_SERVICE "system-auth"
+
+#define DEFAULT_BUFSIZE 4096
+
+static int sss_getpwnam_check(const char *user)
+{
+    void *dl_handle = NULL;
+    enum nss_status (*getpwnam_r)(const char *name, struct passwd *result,
+                      char *buffer, size_t buflen, int *errnop);
+    struct passwd pwd = {0};
+    enum nss_status status;
+    char *buffer = NULL;
+    size_t buflen;
+    int nss_errno;
+    int ret;
+
+    dl_handle = dlopen("libnss_sss.so.2", RTLD_NOW);
+    if (dl_handle == NULL) {
+        fprintf(stderr, "dlopen failed with [%s].\n", dlerror());
+        ret = EIO;
+        goto done;
+    }
+
+    getpwnam_r = dlsym(dl_handle, "_nss_sss_getpwnam_r");
+    if (getpwnam_r == NULL) {
+        fprintf(stderr, "dlsym failed with [%s].\n", dlerror());
+        ret = EIO;
+        goto done;
+    }
+
+    buflen = DEFAULT_BUFSIZE;
+    buffer = malloc(buflen);
+    if (buffer == NULL) {
+        fprintf(stderr, "malloc failed.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    status = getpwnam_r(user, &pwd, buffer, buflen, &nss_errno);
+    if (status != NSS_STATUS_SUCCESS) {
+        fprintf(stderr, "sss_getpwnam_r failed with [%d].\n", status);
+        ret = EIO;
+        goto done;
+    }
+
+    fprintf(stdout, "SSSD nss user lookup result:\n");
+    fprintf(stdout, " - user name: %s\n", pwd.pw_name);
+    fprintf(stdout, " - user id: %d\n", pwd.pw_uid);
+    fprintf(stdout, " - group id: %d\n", pwd.pw_gid);
+    fprintf(stdout, " - gecos: %s\n", pwd.pw_gecos);
+    fprintf(stdout, " - home directory: %s\n", pwd.pw_dir);
+    fprintf(stdout, " - shell: %s\n", pwd.pw_shell);
+
+    ret = 0;
+
+done:
+    if (dl_handle != NULL) {
+        dlclose(dl_handle);
+    }
+
+    free(buffer);
+
+    return ret;
+}
 
 int main(int argc, char *argv[]) {
 
@@ -84,6 +152,13 @@ int main(int argc, char *argv[]) {
 
     fprintf(stdout, "user: %s\naction: %s\nservice: %s\n",
                     user, action, service);
+
+    if (*user != '\0') {
+        ret = sss_getpwnam_check(user);
+        if (ret != 0) {
+            fprintf(stderr,"User name lookup with [%s] failed.\n", user);
+        }
+    }
 
     ret = pam_start(service, user, &conv, &pamh);
     if (ret != PAM_SUCCESS) {

--- a/src/tools/sssctl/sssctl.c
+++ b/src/tools/sssctl/sssctl.c
@@ -263,6 +263,7 @@ int main(int argc, const char **argv)
         SSS_TOOL_DELIMITER("SSSD Status:"),
         SSS_TOOL_COMMAND("domain-list", "List available domains", 0, sssctl_domain_list),
         SSS_TOOL_COMMAND("domain-status", "Print information about domain", 0, sssctl_domain_status),
+        SSS_TOOL_COMMAND("user-checks", "Print information about a user and check authentication", 0, sssctl_user_checks),
         SSS_TOOL_DELIMITER("Information about cached content:"),
         SSS_TOOL_COMMAND("user-show", "Information about cached user", 0, sssctl_user_show),
         SSS_TOOL_COMMAND("group-show", "Information about cached group", 0, sssctl_group_show),

--- a/src/tools/sssctl/sssctl.h
+++ b/src/tools/sssctl/sssctl.h
@@ -121,4 +121,8 @@ errno_t sssctl_netgroup_show(struct sss_cmdline *cmdline,
 errno_t sssctl_config_check(struct sss_cmdline *cmdline,
                             struct sss_tool_ctx *tool_ctx,
                             void *pvt);
+
+errno_t sssctl_user_checks(struct sss_cmdline *cmdline,
+                           struct sss_tool_ctx *tool_ctx,
+                           void *pvt);
 #endif /* _SSSCTL_H_ */

--- a/src/tools/sssctl/sssctl_user_checks.c
+++ b/src/tools/sssctl/sssctl_user_checks.c
@@ -35,6 +35,9 @@
 #include <security/pam_appl.h>
 
 #include "lib/sifp/sss_sifp.h"
+#include "util/util.h"
+#include "tools/common/sss_tools.h"
+#include "tools/sssctl/sssctl.h"
 
 #ifdef HAVE_SECURITY_PAM_MISC_H
 # include <security/pam_misc.h>
@@ -85,17 +88,17 @@ static int get_ifp_user(const char *user)
 
     error = sss_sifp_init(&sifp);
     if (error != SSS_SIFP_OK) {
-        fprintf(stderr, "Unable to connect to the InfoPipe");
+        fprintf(stderr, _("Unable to connect to the InfoPipe"));
         return EFAULT;
     }
 
     error = sss_sifp_fetch_user_by_name(sifp, user, &user_obj);
     if (error != SSS_SIFP_OK) {
-        fprintf(stderr, "Unable to get user object");
+        fprintf(stderr, _("Unable to get user object"));
         return EIO;
     }
 
-    fprintf(stdout, "SSSD InfoPipe user lookup result:\n");
+    fprintf(stdout, _("SSSD InfoPipe user lookup result:\n"));
     for (c = 0; ifp_user_attr[c].name != NULL; c++) {
         if (ifp_user_attr[c].is_string) {
             error = sss_sifp_find_attr_as_string(user_obj->attrs,
@@ -107,7 +110,7 @@ static int get_ifp_user(const char *user)
                                                  &tmp_uint32);
         }
         if (error != SSS_SIFP_OK) {
-            fprintf(stderr, "Unable to get user name attr");
+            fprintf(stderr, _("Unable to get user name attr"));
             return EIO;
         }
 
@@ -118,6 +121,7 @@ static int get_ifp_user(const char *user)
                                                   tmp_uint32);
         }
     }
+    fprintf(stdout, "\n");
 
     sss_sifp_free_object(sifp, &user_obj);
     sss_sifp_free(&sifp);
@@ -138,14 +142,14 @@ static int sss_getpwnam_check(const char *user)
 
     dl_handle = dlopen("libnss_sss.so.2", RTLD_NOW);
     if (dl_handle == NULL) {
-        fprintf(stderr, "dlopen failed with [%s].\n", dlerror());
+        fprintf(stderr, _("dlopen failed with [%s].\n"), dlerror());
         ret = EIO;
         goto done;
     }
 
     getpwnam_r = dlsym(dl_handle, "_nss_sss_getpwnam_r");
     if (getpwnam_r == NULL) {
-        fprintf(stderr, "dlsym failed with [%s].\n", dlerror());
+        fprintf(stderr, _("dlsym failed with [%s].\n"), dlerror());
         ret = EIO;
         goto done;
     }
@@ -153,25 +157,25 @@ static int sss_getpwnam_check(const char *user)
     buflen = DEFAULT_BUFSIZE;
     buffer = malloc(buflen);
     if (buffer == NULL) {
-        fprintf(stderr, "malloc failed.\n");
+        fprintf(stderr, _("malloc failed.\n"));
         ret = ENOMEM;
         goto done;
     }
 
     status = getpwnam_r(user, &pwd, buffer, buflen, &nss_errno);
     if (status != NSS_STATUS_SUCCESS) {
-        fprintf(stderr, "sss_getpwnam_r failed with [%d].\n", status);
+        fprintf(stderr, _("sss_getpwnam_r failed with [%d].\n"), status);
         ret = EIO;
         goto done;
     }
 
-    fprintf(stdout, "SSSD nss user lookup result:\n");
-    fprintf(stdout, " - user name: %s\n", pwd.pw_name);
-    fprintf(stdout, " - user id: %d\n", pwd.pw_uid);
-    fprintf(stdout, " - group id: %d\n", pwd.pw_gid);
-    fprintf(stdout, " - gecos: %s\n", pwd.pw_gecos);
-    fprintf(stdout, " - home directory: %s\n", pwd.pw_dir);
-    fprintf(stdout, " - shell: %s\n", pwd.pw_shell);
+    fprintf(stdout, _("SSSD nss user lookup result:\n"));
+    fprintf(stdout, _(" - user name: %s\n"), pwd.pw_name);
+    fprintf(stdout, _(" - user id: %d\n"), pwd.pw_uid);
+    fprintf(stdout, _(" - group id: %d\n"), pwd.pw_gid);
+    fprintf(stdout, _(" - gecos: %s\n"), pwd.pw_gecos);
+    fprintf(stdout, _(" - home directory: %s\n"), pwd.pw_dir);
+    fprintf(stdout, _(" - shell: %s\n\n"), pwd.pw_shell);
 
     ret = 0;
 
@@ -185,87 +189,90 @@ done:
     return ret;
 }
 
-int main(int argc, char *argv[]) {
+errno_t sssctl_user_checks(struct sss_cmdline *cmdline,
+                           struct sss_tool_ctx *tool_ctx,
+                           void *pvt)
+{
 
     pam_handle_t *pamh;
-    char *user;
-    char *action;
-    char *service;
+    const char *user = NULL;
+    const char *action = DEFAULT_ACTION;
+    const char *service = DEFAULT_SERVICE;
     int ret;
     size_t c;
     char **pam_env;
 
-    if (argc == 1) {
-        fprintf(stderr, "Usage: pam_test_client USERNAME "
-                        "[auth|acct|setc|chau|open|clos] [pam_service]\n");
-        return 0;
-    } else if (argc == 2) {
-        fprintf(stderr,"using first argument as user name and default action "
-                       "and service\n");
-    } else if (argc == 3) {
-        fprintf(stderr, "using first argument as user name, second as action "
-                        "and default service\n");
+    /* Parse command line. */
+    struct poptOption options[] = {
+        {"action", 'a', POPT_ARG_STRING , &action, 0,
+            _("PAM action [auth|acct|setc|chau|open|clos], default: "
+                DEFAULT_ACTION),
+            NULL },
+        {"service", 's', POPT_ARG_STRING , &service, 0,
+            _("PAM service, default: " DEFAULT_SERVICE), NULL },
+        POPT_TABLEEND
+    };
+
+    ret = sss_tool_popt_ex(cmdline, options, SSS_TOOL_OPT_OPTIONAL,
+                           NULL, NULL, "USERNAME", _("Specify user name."),
+                           &user, NULL);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse command arguments\n");
+        return ret;
     }
 
-    user = strdup(argv[1]);
-    action =  argc > 2 ? strdup(argv[2]) : strdup(DEFAULT_ACTION);
-    service = argc > 3 ? strdup(argv[3]) : strdup(DEFAULT_SERVICE);
-
-    if (action == NULL || user == NULL || service == NULL) {
-        fprintf(stderr, "Out of memory!\n");
-        return 1;
-    }
-
-    fprintf(stdout, "user: %s\naction: %s\nservice: %s\n",
+    fprintf(stdout, _("user: %s\naction: %s\nservice: %s\n\n"),
                     user, action, service);
 
     if (*user != '\0') {
         ret = sss_getpwnam_check(user);
         if (ret != 0) {
-            fprintf(stderr,"User name lookup with [%s] failed.\n", user);
+            fprintf(stderr, _("User name lookup with [%s] failed.\n"), user);
         }
 
         ret = get_ifp_user(user);
         if (ret != 0) {
-            fprintf(stderr,"InforPipe User lookup with [%s] failed.\n", user);
+            fprintf(stderr, _("InforPipe User lookup with [%s] failed.\n"),
+                            user);
         }
     }
 
     ret = pam_start(service, user, &conv, &pamh);
     if (ret != PAM_SUCCESS) {
-        fprintf(stderr, "pam_start failed: %s\n", pam_strerror(pamh, ret));
+        fprintf(stderr, _("pam_start failed: %s\n"), pam_strerror(pamh, ret));
         return 1;
     }
 
     if ( strncmp(action, "auth", 4)== 0 ) {
-        fprintf(stdout, "testing pam_authenticate\n");
+        fprintf(stdout, _("testing pam_authenticate\n\n"));
         ret = pam_authenticate(pamh, 0);
-        fprintf(stderr, "pam_authenticate: %s\n", pam_strerror(pamh, ret));
+        fprintf(stderr, _("pam_authenticate: %s\n\n"), pam_strerror(pamh, ret));
     } else if ( strncmp(action, "chau", 4)== 0 ) {
-        fprintf(stdout, "testing pam_chauthtok\n");
+        fprintf(stdout, _("testing pam_chauthtok\n\n"));
         ret = pam_chauthtok(pamh, 0);
-        fprintf(stderr, "pam_chauthtok: %s\n", pam_strerror(pamh, ret));
+        fprintf(stderr, _("pam_chauthtok: %s\n\n"), pam_strerror(pamh, ret));
     } else if ( strncmp(action, "acct", 4)== 0 ) {
-        fprintf(stdout, "testing pam_acct_mgmt\n");
+        fprintf(stdout, _("testing pam_acct_mgmt\n\n"));
         ret = pam_acct_mgmt(pamh, 0);
-        fprintf(stderr, "pam_acct_mgmt: %s\n", pam_strerror(pamh, ret));
+        fprintf(stderr, _("pam_acct_mgmt: %s\n\n"), pam_strerror(pamh, ret));
     } else if ( strncmp(action, "setc", 4)== 0 ) {
-        fprintf(stdout, "testing pam_setcred\n");
+        fprintf(stdout, _("testing pam_setcred\n\n"));
         ret = pam_setcred(pamh, 0);
-        fprintf(stderr, "pam_setcred: %d[%s]\n", ret, pam_strerror(pamh, ret));
+        fprintf(stderr, _("pam_setcred: [%s]\n\n"), pam_strerror(pamh, ret));
     } else if ( strncmp(action, "open", 4)== 0 ) {
-        fprintf(stdout, "testing pam_open_session\n");
+        fprintf(stdout, _("testing pam_open_session\n\n"));
         ret = pam_open_session(pamh, 0);
-        fprintf(stderr, "pam_open_session: %s\n", pam_strerror(pamh, ret));
+        fprintf(stderr, _("pam_open_session: %s\n\n"), pam_strerror(pamh, ret));
     } else if ( strncmp(action, "clos", 4)== 0 ) {
-        fprintf(stdout, "testing pam_close_session\n");
+        fprintf(stdout, _("testing pam_close_session\n\n"));
         ret = pam_close_session(pamh, 0);
-        fprintf(stderr, "pam_close_session: %s\n", pam_strerror(pamh, ret));
+        fprintf(stderr, _("pam_close_session: %s\n\n"),
+                        pam_strerror(pamh, ret));
     } else {
-        fprintf(stderr, "unknown action\n");
+        fprintf(stderr, _("unknown action\n"));
     }
 
-    fprintf(stderr, "PAM Environment:\n");
+    fprintf(stderr, _("PAM Environment:\n"));
     pam_env = pam_getenvlist(pamh);
     if (pam_env != NULL && pam_env[0] != NULL) {
         for (c = 0; pam_env[c] != NULL; c++) {
@@ -273,16 +280,12 @@ int main(int argc, char *argv[]) {
             free(pam_env[c]);
         }
     } else {
-        fprintf(stderr," - no env -\n");
+        fprintf(stderr, _(" - no env -\n"));
     }
     free(pam_env);
 
 
     pam_end(pamh, ret);
-
-    free(user);
-    free(action);
-    free(service);
 
     return 0;
 }


### PR DESCRIPTION
This patch set makes the PAM test client more flexible and adds additional
lookups of the user via NSS and InfoPipe.

For simplicity this version uses libsss_simpleifp to access InfoPipe. A later
version might use libdbus directly to reduce the number of dependencies.

Related to https://pagure.io/SSSD/sssd/issue/3292