### PR TITLE
T3315 infopipe group users master

### DIFF
--- a/src/responder/ifp/ifp_groups.c
+++ b/src/responder/ifp/ifp_groups.c
@@ -607,12 +607,7 @@ static void resolv_ghosts_group_done(struct tevent_req *subreq)
     }
 
     el = ldb_msg_find_element(group, SYSDB_GHOST);
-    if (el == NULL) {
-        ret = ENOMEM;
-        goto done;
-    }
-
-    if (el->num_values == 0) {
+    if (el == NULL || el->num_values == 0) {
         ret = EOK;
         goto done;
     }


### PR DESCRIPTION
Reproducer is:
```
# PREPARING
ipa user-add --first=Test --last=User --email=u1@test-domain.sssd test_user
ipa group-add test_group

# REPRODUCER
systemctl daemon-reload
sudo su -c "truncate -s0 /var/log/sssd/*.log"
sudo su -c "rm -f /var/lib/sss/db/*" 
sudo su -c "rm -f /var/lib/sss/mc/*"
sudo systemctl restart sssd.service

ipa group-add-member --users=test_user test_group
sss_cache -UG
getent group test_group

# getent show user test_user in test_group, but dbus call doesn't:

dbus-send --print-reply --system --dest=org.freedesktop.sssd.infopipe \
    /org/freedesktop/sssd/infopipe/Groups \
    org.freedesktop.sssd.infopipe.Groups.FindByName \
    string:test_group

# command above returns <RESULT_OBJECT>

# We need to update group in cache because method "org.freedesktop.DBus.Properties.GetAll"
# doesn't update records (<-- this should be better commented)

dbus-send --print-reply --system --dest=org.freedesktop.sssd.infopipe \
   <RESULT_OBJECT>  \
    org.freedesktop.sssd.infopipe.Groups.Group.UpdateMemberList

# --> this call doesn't work without patch "IFP: Parse ghost name in Group.UpdateMemberList"
# after this call group is updated in cache and we can call: 

dbus-send --system --print-reply --dest=org.freedesktop.sssd.infopipe \
    <RESULT_OBJECT> \
    org.freedesktop.DBus.Properties.GetAll \
    string:"org.freedesktop.sssd.infopipe.Groups.Group"

# We expect test_user in result users array.

# CLEANING
ipa group-del test_group
ipa user-del test_user
```