### PR TITLE
IPA: Enhance debug logging for ipa s2n operations

### DIFF
--- a/src/providers/ipa/ipa_s2n_exop.c
+++ b/src/providers/ipa/ipa_s2n_exop.c
@@ -979,6 +979,22 @@ done:
     return ret;
 }
 
+static const char *ipa_s2n_reqtype2str(enum request_types request_type)
+{
+    switch (request_type) {
+    case REQ_SIMPLE:
+        return "REQ_SIMPLE";
+    case REQ_FULL:
+        return "REQ_FULL";
+    case REQ_FULL_WITH_MEMBERS:
+        return "REQ_FULL_WITH_MEMBERS";
+    default:
+        break;
+    }
+
+    return "Unknown request type";
+}
+
 struct ipa_s2n_get_list_state {
     struct tevent_context *ev;
     struct ipa_id_ctx *ipa_ctx;


### PR DESCRIPTION
Troubleshooting IPA client issues during AD Trust user and group resolution can be a difficult task requiring review of IPA client and IPA server SSSD logs during the full timeframe of a lookup request. If groups go missing on the client or client operations timeout with no obvious error then it is difficult to understand which requests to the IPA server are failing. Often times, client-side ipa_s2n functions will fail with a generic `s2n exop request failed` and the SSSD server-side logs are very busy for large AD environments.

This PR is intended to help assist in log analysis and troubleshooting efforts by adding more useful information in the IPA client logs to help narrow down the focus for searching SSSD failures on the server.

- Before patch:

```
[root@ipa-client-f25 ~]# id sssduser@ad.jstephen

[root@ipa-client-f25 ~]# grep 'ipa_s2n' /var/log/sssd/sssd_idm.jstephen.log 
(Thu Mar 16 15:49:43 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_send] (0x0400): Executing extended operation
(Thu Mar 16 15:49:43 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_send] (0x2000): ldap_extended_operation sent, msgid = 17
(Thu Mar 16 15:49:44 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_done] (0x0400): ldap_extended_operation result: Success(0), (null).
(Thu Mar 16 15:49:44 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_send] (0x0400): Executing extended operation
(Thu Mar 16 15:49:44 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_send] (0x2000): ldap_extended_operation sent, msgid = 18
(Thu Mar 16 15:49:44 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_done] (0x0400): ldap_extended_operation result: Success(0), (null).
(Thu Mar 16 15:49:44 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_save_objects] (0x4000): Found original AD upn [sssduser@AD.JSTEPHEN].
(Thu Mar 16 15:49:44 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_save_objects] (0x2000): Updating memberships for sssduser@ad.jstephen
(Thu Mar 16 15:49:44 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_send] (0x0400): Executing extended operation
(Thu Mar 16 15:49:44 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_send] (0x2000): ldap_extended_operation sent, msgid = 19
(Thu Mar 16 15:49:44 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_done] (0x0400): ldap_extended_operation result: Success(0), (null).
(Thu Mar 16 15:49:44 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_save_objects] (0x0400): Processing group secondarygroup@ad.jstephen
(Thu Mar 16 15:49:44 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_send] (0x0400): Executing extended operation
(Thu Mar 16 15:49:44 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_send] (0x2000): ldap_extended_operation sent, msgid = 20
(Thu Mar 16 15:49:44 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_done] (0x0400): ldap_extended_operation result: Success(0), (null).
(Thu Mar 16 15:49:44 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_save_objects] (0x0400): Processing group domain users@ad.jstephen
(Thu Mar 16 15:49:44 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_send] (0x0400): Executing extended operation
(Thu Mar 16 15:49:44 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_send] (0x2000): ldap_extended_operation sent, msgid = 21
(Thu Mar 16 15:49:44 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_done] (0x0400): ldap_extended_operation result: Success(0), (null).
(Thu Mar 16 15:49:44 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_save_objects] (0x0400): Processing group parentofprimarygroup@ad.jstephen
(Thu Mar 16 15:49:45 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_save_objects] (0x4000): Found original AD upn [sssduser@AD.JSTEPHEN].
(Thu Mar 16 15:49:45 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_save_objects] (0x2000): Updating memberships for sssduser@ad.jstephen

```

- After patch
```
[root@ipa-client-f25 ~]# id sssduser@ad.jstephen

[root@ipa-client-f25 ~]# grep 'ipa_s2n' /var/log/sssd/sssd_idm.jstephen.log                                              
(Thu Mar 16 15:59:39 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_get_acct_info_send] (0x0400): Sending request_type: [3] for trust user [sssduser] to IPA server
(Thu Mar 16 15:59:39 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_send] (0x0400): Executing extended operation
(Thu Mar 16 15:59:39 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_send] (0x2000): ldap_extended_operation sent, msgid = 17
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_done] (0x0400): ldap_extended_operation result: Success(0), (null).
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_get_user_done] (0x0400): Received [4] groups in group list from IPA Server
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_get_user_done] (0x0400): [sssduser@ad.jstephen].
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_get_user_done] (0x0400): [secondarygroup@ad.jstephen].
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_get_user_done] (0x0400): [domain users@ad.jstephen].
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_get_user_done] (0x0400): [parentofprimarygroup@ad.jstephen].
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_get_list_step] (0x0400): Sending request_type: [3] for group [sssduser@ad.jstephen].
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_send] (0x0400): Executing extended operation
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_send] (0x2000): ldap_extended_operation sent, msgid = 18
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_done] (0x0400): ldap_extended_operation result: Success(0), (null).
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_get_list_next] (0x0400): Received [sssduser@ad.jstephen] attributes from IPA server.
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_save_objects] (0x4000): Found original AD upn [sssduser@AD.JSTEPHEN].
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_save_objects] (0x2000): Updating memberships for sssduser@ad.jstephen
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_get_list_step] (0x0400): Sending request_type: [3] for group [secondarygroup@ad.jstephen].
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_send] (0x0400): Executing extended operation
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_send] (0x2000): ldap_extended_operation sent, msgid = 19
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_done] (0x0400): ldap_extended_operation result: Success(0), (null).
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_get_list_next] (0x0400): Received [secondarygroup@ad.jstephen] attributes from IPA server.
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_save_objects] (0x0400): Processing group secondarygroup@ad.jstephen
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_get_list_step] (0x0400): Sending request_type: [3] for group [domain users@ad.jstephen].
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_send] (0x0400): Executing extended operation
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_send] (0x2000): ldap_extended_operation sent, msgid = 20
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_done] (0x0400): ldap_extended_operation result: Success(0), (null).
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_get_list_next] (0x0400): Received [domain users@ad.jstephen] attributes from IPA server.
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_save_objects] (0x0400): Processing group domain users@ad.jstephen
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_get_list_step] (0x0400): Sending request_type: [3] for group [parentofprimarygroup@ad.jstephen].
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_send] (0x0400): Executing extended operation
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_send] (0x2000): ldap_extended_operation sent, msgid = 21
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_exop_done] (0x0400): ldap_extended_operation result: Success(0), (null).
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_get_list_next] (0x0400): Received [parentofprimarygroup@ad.jstephen] attributes from IPA server.
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_save_objects] (0x0400): Processing group parentofprimarygroup@ad.jstephen
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_save_objects] (0x4000): Found original AD upn [sssduser@AD.JSTEPHEN].
(Thu Mar 16 15:59:40 2017) [sssd[be[idm.jstephen]]] [ipa_s2n_save_objects] (0x2000): Updating memberships for sssduser@ad.jstephen
```

