### PR TITLE
nss-idmap: add sss_nss_getlistbycert()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1119,7 +1119,7 @@ libsss_nss_idmap_la_LIBADD = \
     $(CLIENT_LIBS)
 libsss_nss_idmap_la_LDFLAGS = \
     -Wl,--version-script,$(srcdir)/src/sss_client/idmap/sss_nss_idmap.exports \
-    -version-info 2:0:2
+    -version-info 3:0:3
 
 dist_noinst_DATA += src/sss_client/idmap/sss_nss_idmap.exports
 

--- a/src/responder/common/responder_packet.h
+++ b/src/responder/common/responder_packet.h
@@ -25,6 +25,7 @@
 #include "sss_client/sss_cli.h"
 
 #define SSS_PACKET_MAX_RECV_SIZE 1024
+#define SSS_CERT_PACKET_MAX_RECV_SIZE ( 10 * SSS_PACKET_MAX_RECV_SIZE )
 
 struct sss_packet;
 

--- a/src/responder/nss/nss_cmd.c
+++ b/src/responder/nss/nss_cmd.c
@@ -932,6 +932,12 @@ static errno_t nss_cmd_getnamebycert(struct cli_ctx *cli_ctx)
                           nss_protocol_fill_single_name);
 }
 
+static errno_t nss_cmd_getlistbycert(struct cli_ctx *cli_ctx)
+{
+    return nss_getby_cert(cli_ctx, CACHE_REQ_USER_BY_CERT,
+                          nss_protocol_fill_name_list);
+}
+
 struct sss_cmd_table *get_nss_cmds(void)
 {
     static struct sss_cmd_table nss_cmds[] = {
@@ -961,6 +967,7 @@ struct sss_cmd_table *get_nss_cmds(void)
         { SSS_NSS_GETIDBYSID, nss_cmd_getidbysid },
         { SSS_NSS_GETORIGBYNAME, nss_cmd_getorigbyname },
         { SSS_NSS_GETNAMEBYCERT, nss_cmd_getnamebycert },
+        { SSS_NSS_GETLISTBYCERT, nss_cmd_getlistbycert },
         { SSS_CLI_NULL, NULL }
     };
 

--- a/src/responder/nss/nss_protocol.h
+++ b/src/responder/nss/nss_protocol.h
@@ -175,6 +175,12 @@ nss_protocol_fill_single_name(struct nss_ctx *nss_ctx,
                               struct cache_req_result *result);
 
 errno_t
+nss_protocol_fill_name_list(struct nss_ctx *nss_ctx,
+                            struct nss_cmd_ctx *cmd_ctx,
+                            struct sss_packet *packet,
+                            struct cache_req_result *result);
+
+errno_t
 nss_protocol_fill_id(struct nss_ctx *nss_ctx,
                      struct nss_cmd_ctx *cmd_ctx,
                      struct sss_packet *packet,

--- a/src/responder/nss/nss_protocol_sid.c
+++ b/src/responder/nss/nss_protocol_sid.c
@@ -498,3 +498,66 @@ nss_protocol_fill_id(struct nss_ctx *nss_ctx,
 
     return EOK;
 }
+
+errno_t
+nss_protocol_fill_name_list(struct nss_ctx *nss_ctx,
+                            struct nss_cmd_ctx *cmd_ctx,
+                            struct sss_packet *packet,
+                            struct cache_req_result *result)
+{
+    enum sss_id_type *id_types;
+    size_t rp = 0;
+    size_t body_len;
+    uint8_t *body;
+    errno_t ret;
+    struct sized_string *sz_names;
+    size_t len;
+    size_t c;
+    const char *tmp_str;
+
+    sz_names = talloc_array(cmd_ctx, struct sized_string, result->count);
+    if (sz_names == NULL) {
+        return ENOMEM;
+    }
+
+    id_types = talloc_array(cmd_ctx, enum sss_id_type, result->count);
+    if (id_types == NULL) {
+        return ENOMEM;
+    }
+
+    len = 0;
+    for (c = 0; c < result->count; c++) {
+        ret = nss_get_id_type(cmd_ctx, result, &(id_types[c]));
+        if (ret != EOK) {
+            return ret;
+        }
+
+        tmp_str = nss_get_name_from_msg(result->domain, result->msgs[c]);
+        if (tmp_str == NULL) {
+            return EINVAL;
+        }
+        to_sized_string(&(sz_names[c]), tmp_str);
+
+        len += sz_names[c].len;
+    }
+
+    len += (2 + result->count) * sizeof(uint32_t);
+
+    ret = sss_packet_grow(packet, len);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sss_packet_grow failed.\n");
+        return ret;
+    }
+
+    sss_packet_get_body(packet, &body, &body_len);
+
+    SAFEALIGN_SET_UINT32(&body[rp], result->count, &rp); /* Num results. */
+    SAFEALIGN_SET_UINT32(&body[rp], 0, &rp); /* Reserved. */
+    for (c = 0; c < result->count; c++) {
+        SAFEALIGN_SET_UINT32(&body[rp], id_types[c], &rp);
+        SAFEALIGN_SET_STRING(&body[rp], sz_names[c].str, sz_names[c].len,
+                             &rp);
+    }
+
+    return EOK;
+}

--- a/src/sss_client/idmap/sss_nss_idmap.exports
+++ b/src/sss_client/idmap/sss_nss_idmap.exports
@@ -25,3 +25,9 @@ SSS_NSS_IDMAP_0.2.0 {
     global:
         sss_nss_getnamebycert;
 } SSS_NSS_IDMAP_0.1.0;
+
+SSS_NSS_IDMAP_0.3.0 {
+    # public functions
+    global:
+        sss_nss_getlistbycert;
+} SSS_NSS_IDMAP_0.2.0;

--- a/src/sss_client/idmap/sss_nss_idmap.h
+++ b/src/sss_client/idmap/sss_nss_idmap.h
@@ -130,13 +130,28 @@ int sss_nss_getorigbyname(const char *fq_name, struct sss_nss_kv **kv_list,
  * @param[in] cert     base64 encoded certificate
  * @param[out] fq_name Fully qualified name of a user or a group,
  *                     must be freed by the caller
- * @param[out] type    Type of the object related to the SID
+ * @param[out] type    Type of the object related to the cert
  *
  * @return
  *  - see #sss_nss_getsidbyname
  */
 int sss_nss_getnamebycert(const char *cert, char **fq_name,
                           enum sss_id_type *type);
+
+/**
+ * @brief Return a list of fully qualified names for the given base64 encoded
+ * X.509 certificate in DER format
+ *
+ * @param[in] cert     base64 encoded certificate
+ * @param[out] fq_name List of fully qualified name of users or groups,
+ *                     must be freed by the caller
+ * @param[out] type    List of types of the objects related to the cert
+ *
+ * @return
+ *  - see #sss_nss_getsidbyname
+ */
+int sss_nss_getlistbycert(const char *cert, char ***fq_name,
+                          enum sss_id_type **type);
 
 /**
  * @brief Free key-value list returned by sss_nss_getorigbyname()

--- a/src/sss_client/sss_cli.h
+++ b/src/sss_client/sss_cli.h
@@ -260,6 +260,11 @@ SSS_NSS_GETNAMEBYCERT = 0x0116, /**< Takes the zero terminated string
                                      of a X509 certificate and returns the zero
                                      terminated fully qualified name of the
                                      related object. */
+SSS_NSS_GETLISTBYCERT = 0x0117, /**< Takes the zero terminated string
+                                     of the base64 encoded DER representation
+                                     of a X509 certificate and returns a list
+                                     of zero terminated fully qualified names
+                                     of the related objects. */
 };
 
 /**


### PR DESCRIPTION
This patch adds a getlistbycert() call to libsss_nss_idmap to make it on
par with InfoPipe.

Related to https://pagure.io/SSSD/sssd/issue/3050

The easiest way to test is via the python bindings with

    python -c "import pysss_nss_idmap; print pysss_nss_idmap.getlistbycert('MIIFvz....')"

where the argument is the base64 encoded certificate.