### PR TITLE
IFP: Filter with * in Users.ListByName method

### DIFF
--- a/src/responder/ifp/ifp_groups.c
+++ b/src/responder/ifp/ifp_groups.c
@@ -307,12 +307,14 @@ static void ifp_groups_list_by_name_done(struct tevent_req *req)
         return;
     }
 
-    ret = ifp_groups_list_copy(list_ctx, result->ldb_result);
-    if (ret != EOK) {
-        error = sbus_error_new(sbus_req, SBUS_ERROR_INTERNAL,
-                               "Failed to copy domain result");
-        sbus_request_fail_and_finish(sbus_req, error);
-        return;
+    if (ret == EOK) {
+        ret = ifp_groups_list_copy(list_ctx, result->ldb_result);
+        if (ret != EOK) {
+            error = sbus_error_new(sbus_req, SBUS_ERROR_INTERNAL,
+                                   "Failed to copy domain result");
+            sbus_request_fail_and_finish(sbus_req, error);
+            return;
+        }
     }
 
     list_ctx->dom = get_next_domain(list_ctx->dom, SSS_GND_DESCEND);
@@ -394,11 +396,13 @@ static void ifp_groups_list_by_domain_and_name_done(struct tevent_req *req)
         goto done;
     }
 
-    ret = ifp_groups_list_copy(list_ctx, result->ldb_result);
-    if (ret != EOK) {
-        error = sbus_error_new(sbus_req, SBUS_ERROR_INTERNAL,
-                               "Failed to copy domain result");
-        goto done;
+    if (ret == EOK) {
+        ret = ifp_groups_list_copy(list_ctx, result->ldb_result);
+        if (ret != EOK) {
+            error = sbus_error_new(sbus_req, SBUS_ERROR_INTERNAL,
+                                   "Failed to copy domain result");
+            goto done;
+        }
     }
 
 done:


### PR DESCRIPTION
This patch fixed asterisk in filter of Users.ListByName method.

Resolves:
https://pagure.io/SSSD/sssd/issue/3305

How to test
```
# We have sssd configured and there are some users
# Wee need also ifp service enabled in sssd.conf

# Restart sssd
systemctl daemon-reload
sudo su -c "truncate -s0 /var/log/sssd/*.log"
sudo su -c "rm -f /var/lib/sss/db/*" 
sudo su -c "rm -f /var/lib/sss/mc/*"
sudo systemctl restart sssd.service
sudo su -c "truncate -s0 /var/log/sssd/*.log"

# It will return users (without patch, it will crash). 
dbus-send --system --print-reply  --dest=org.freedesktop.sssd.infopipe \
    /org/freedesktop/sssd/infopipe/Users \
    org.freedesktop.sssd.infopipe.Users.ListByName \
    string:"*" uint32:"100"
```