### PR TITLE
IFP: Fix of limit = 0 (unlimited result)

### DIFF
--- a/src/responder/ifp/ifp_groups.c
+++ b/src/responder/ifp/ifp_groups.c
@@ -87,8 +87,12 @@ static int ifp_groups_list_copy(struct ifp_list_ctx *list_ctx,
                                 struct ldb_result *result)
 {
     size_t copy_count, i;
+    errno_t ret;
 
-    copy_count = ifp_list_ctx_remaining_capacity(list_ctx, result->count);
+    ret = ifp_list_ctx_remaining_capacity(list_ctx, result->count, &copy_count);
+    if (ret != EOK) {
+        goto done;
+    }
 
     for (i = 0; i < copy_count; i++) {
         list_ctx->paths[list_ctx->path_count + i] = \
@@ -96,12 +100,16 @@ static int ifp_groups_list_copy(struct ifp_list_ctx *list_ctx,
                                            list_ctx->dom,
                                            result->msgs[i]);
         if (list_ctx->paths[list_ctx->path_count + i] == NULL) {
-            return ENOMEM;
+            ret = ENOMEM;
+            goto done;
         }
     }
 
     list_ctx->path_count += copy_count;
-    return EOK;
+    ret = EOK;
+
+done:
+    return ret;
 }
 
 static void ifp_groups_find_by_name_done(struct tevent_req *req);

--- a/src/responder/ifp/ifp_groups.c
+++ b/src/responder/ifp/ifp_groups.c
@@ -307,12 +307,14 @@ static void ifp_groups_list_by_name_done(struct tevent_req *req)
         return;
     }
 
-    ret = ifp_groups_list_copy(list_ctx, result->ldb_result);
-    if (ret != EOK) {
-        error = sbus_error_new(sbus_req, SBUS_ERROR_INTERNAL,
-                               "Failed to copy domain result");
-        sbus_request_fail_and_finish(sbus_req, error);
-        return;
+    if (ret == EOK) {
+        ret = ifp_groups_list_copy(list_ctx, result->ldb_result);
+        if (ret != EOK) {
+            error = sbus_error_new(sbus_req, SBUS_ERROR_INTERNAL,
+                                   "Failed to copy domain result");
+            sbus_request_fail_and_finish(sbus_req, error);
+            return;
+        }
     }
 
     list_ctx->dom = get_next_domain(list_ctx->dom, SSS_GND_DESCEND);
@@ -394,11 +396,13 @@ static void ifp_groups_list_by_domain_and_name_done(struct tevent_req *req)
         goto done;
     }
 
-    ret = ifp_groups_list_copy(list_ctx, result->ldb_result);
-    if (ret != EOK) {
-        error = sbus_error_new(sbus_req, SBUS_ERROR_INTERNAL,
-                               "Failed to copy domain result");
-        goto done;
+    if (ret == EOK) {
+        ret = ifp_groups_list_copy(list_ctx, result->ldb_result);
+        if (ret != EOK) {
+            error = sbus_error_new(sbus_req, SBUS_ERROR_INTERNAL,
+                                   "Failed to copy domain result");
+            goto done;
+        }
     }
 
 done:

--- a/src/responder/ifp/ifp_private.h
+++ b/src/responder/ifp/ifp_private.h
@@ -103,8 +103,9 @@ struct ifp_list_ctx *ifp_list_ctx_new(struct sbus_request *sbus_req,
                                       const char *filter,
                                       uint32_t limit);
 
-size_t ifp_list_ctx_remaining_capacity(struct ifp_list_ctx *list_ctx,
-                                       size_t entries);
+errno_t ifp_list_ctx_remaining_capacity(struct ifp_list_ctx *list_ctx,
+                                        size_t entries,
+                                        size_t *_capacity);
 
 errno_t ifp_ldb_el_output_name(struct resp_ctx *rctx,
                                struct ldb_message *msg,

--- a/src/responder/ifp/ifpsrv_util.c
+++ b/src/responder/ifp/ifpsrv_util.c
@@ -386,6 +386,15 @@ size_t ifp_list_ctx_remaining_capacity(struct ifp_list_ctx *list_ctx,
 {
     size_t capacity = list_ctx->limit - list_ctx->path_count;
 
+    if (list_ctx->limit == 0) {
+        list_ctx->paths = talloc_zero_array(list_ctx, const char *, entries);
+        if (list_ctx->paths == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "talloc_zero_array() failed\n");
+            return 0;
+        }
+        return entries;
+    }
+
     if (capacity < entries) {
         DEBUG(SSSDBG_MINOR_FAILURE,
               "IFP list request has limit of %"PRIu32" entries but back end "

--- a/src/responder/ifp/ifpsrv_util.c
+++ b/src/responder/ifp/ifpsrv_util.c
@@ -381,28 +381,38 @@ struct ifp_list_ctx *ifp_list_ctx_new(struct sbus_request *sbus_req,
     return list_ctx;
 }
 
-size_t ifp_list_ctx_remaining_capacity(struct ifp_list_ctx *list_ctx,
-                                       size_t entries)
+errno_t ifp_list_ctx_remaining_capacity(struct ifp_list_ctx *list_ctx,
+                                        size_t entries,
+                                        size_t *_capacity)
 {
     size_t capacity = list_ctx->limit - list_ctx->path_count;
+    errno_t ret;
 
     if (list_ctx->limit == 0) {
         list_ctx->paths = talloc_zero_array(list_ctx, const char *, entries);
         if (list_ctx->paths == NULL) {
             DEBUG(SSSDBG_CRIT_FAILURE, "talloc_zero_array() failed\n");
-            return 0;
+            ret = ENOMEM;
+            goto done;
         }
-        return entries;
+        capacity = entries;
+        goto immediately;
     }
 
     if (capacity < entries) {
         DEBUG(SSSDBG_MINOR_FAILURE,
               "IFP list request has limit of %"PRIu32" entries but back end "
               "returned %zu entries\n", list_ctx->limit, entries);
-        return capacity;
     } else {
-        return entries;
+        capacity = entries;
     }
+
+immediately:
+    *_capacity = capacity;
+    ret = EOK;
+
+done:
+    return ret;
 }
 
 errno_t ifp_ldb_el_output_name(struct resp_ctx *rctx,

--- a/src/responder/ifp/ifpsrv_util.c
+++ b/src/responder/ifp/ifpsrv_util.c
@@ -372,7 +372,7 @@ struct ifp_list_ctx *ifp_list_ctx_new(struct sbus_request *sbus_req,
     list_ctx->ctx = ctx;
     list_ctx->dom = ctx->rctx->domains;
     list_ctx->filter = filter;
-    list_ctx->paths = talloc_zero_array(list_ctx, const char *, limit);
+    list_ctx->paths = talloc_zero_array(list_ctx, const char *, 1);
     if (list_ctx->paths == NULL) {
         talloc_free(list_ctx);
         return NULL;
@@ -389,12 +389,6 @@ errno_t ifp_list_ctx_remaining_capacity(struct ifp_list_ctx *list_ctx,
     errno_t ret;
 
     if (list_ctx->limit == 0) {
-        list_ctx->paths = talloc_zero_array(list_ctx, const char *, entries);
-        if (list_ctx->paths == NULL) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "talloc_zero_array() failed\n");
-            ret = ENOMEM;
-            goto done;
-        }
         capacity = entries;
         goto immediately;
     }
@@ -408,6 +402,14 @@ errno_t ifp_list_ctx_remaining_capacity(struct ifp_list_ctx *list_ctx,
     }
 
 immediately:
+    talloc_zfree(list_ctx->paths);
+    list_ctx->paths = talloc_zero_array(list_ctx, const char *, capacity);
+    if (list_ctx->paths == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "talloc_zero_array() failed\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
     *_capacity = capacity;
     ret = EOK;
 


### PR DESCRIPTION
If we set limit to 0 it means that result is unlimited. Internally we
restrict number of result by allocation of result array.
In unlimited case there was a bug and zero array was allocated.
This fix allocates neccessary array when we know real result size.

Resolves:
https://pagure.io/SSSD/sssd/issue/3306

How to test (this reproducer needs #208 "IFP: Filter with * in Users.ListByName method" applied)
```
systemctl daemon-reload
sudo su -c "truncate -s0 /var/log/sssd/*.log"
sudo su -c "rm -f /var/lib/sss/db/*" 
sudo su -c "rm -f /var/lib/sss/mc/*"
sudo systemctl restart sssd.service

sudo su -c "truncate -s0 /var/log/sssd/*.log"

dbus-send --system --print-reply  --dest=org.freedesktop.sssd.infopipe \
    /org/freedesktop/sssd/infopipe/Users \
    org.freedesktop.sssd.infopipe.Users.ListByName \
    string:"*" uint32:"0"

dbus-send --system --print-reply  --dest=org.freedesktop.sssd.infopipe \
    /org/freedesktop/sssd/infopipe/Groups \
    org.freedesktop.sssd.infopipe.Groups.ListByName \
    string:"*" uint32:"100"

dbus-send --system --print-reply  --dest=org.freedesktop.sssd.infopipe \
    /org/freedesktop/sssd/infopipe/Users \
    org.freedesktop.sssd.infopipe.Users.ListByDomainAndName \
    string:"domain.cygnus" string:"*" uint32:"100"
```