### PR TITLE
intg: fix configure failure with strict cflags

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3486,7 +3486,7 @@ intgcheck-prepare:
 	    --without-semanage \
 	    --enable-files-domain \
 	    $(INTGCHECK_CONFIGURE_FLAGS) \
-	    CFLAGS="$$CFLAGS $(AM_CFLAGS) -DKCM_PEER_UID=$$(id -u)"; \
+	    CFLAGS="$$CFLAGS -DKCM_PEER_UID=$$(id -u)"; \
 	$(MAKE) $(AM_MAKEFLAGS) ; \
 	: Force single-thread install to workaround concurrency issues; \
 	$(MAKE) $(AM_MAKEFLAGS) -j1 install; \


### PR DESCRIPTION
The warning -Wstrict-prototypes is a part of AM_CFLAGS which was appended
for CFLAGS in make target intgcheck-prepare. And combination with
strict CFLAGS in environment variable (e.g. -Werror) caused failures.

sh$ CFLAGS="-Werror" make intgcheck-prepare

checking for gcc... gcc
checking whether the C compiler works... no
configure: error: in `/home/build/sssd/ci-build-debug/intg/bld':
configure: error: C compiler cannot create executables

configure:3719: checking whether the C compiler works
configure:3741: gcc -g3 -O2 -Werror -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE  -Wall -Wshadow -Wstrict-prototypes -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-s
trings -Wundef -Werror-implicit-function-declaration -Winit-self -Wmissing-include-dirs -fno-strict-aliasing -std=gnu99 -DKCM_PEER_UID=1000   conftest.c  >&5
conftest.c:11:1: error: function declaration isn't a prototype [-Werror=strict-prototypes]
 main ()
 ^~~~
cc1: all warnings being treated as errors