### PR TITLE
sss_cert_pem_to_der: Accept certificate with data before header

### DIFF
--- a/src/tests/cmocka/test_cert_utils.c
+++ b/src/tests/cmocka/test_cert_utils.c
@@ -128,6 +128,13 @@ const uint8_t test_cert_der[] = {
 "lBPDhfTVcWXQwN385uycW/ARtSzzSME2jKKWSIQ=\n" \
 "-----END CERTIFICATE-----\n"
 
+#define TEST_CERT_PEM_WITH_METADATA "Bag Attributes\n" \
+"    friendlyName: ipa-devel\n" \
+"    localKeyID: 8E 0D 04 1F BC 13 73 54 00 8F 65 57 D7 A8 AF 34 0C 18 B3 99\n" \
+"subject= /O=IPA.DEVEL/CN=ipa-devel.ipa.devel\n" \
+"issuer= /O=IPA.DEVEL/CN=Certificate Authority\n" \
+TEST_CERT_PEM
+
 #define TEST_CERT_DERB64 \
 "MIIECTCCAvGgAwIBAgIBCTANBgkqhkiG9w0BAQsFADA0MRIwEAYDVQQKDAlJUEEu" \
 "REVWRUwxHjAcBgNVBAMMFUNlcnRpZmljYXRlIEF1dGhvcml0eTAeFw0xNTA0Mjgx" \
@@ -214,6 +221,15 @@ void test_sss_cert_pem_to_der(void **state)
     assert_int_equal(ret, EINVAL);
 
     ret = sss_cert_pem_to_der(ts, TEST_CERT_PEM, &der, &der_size);
+    assert_int_equal(ret, EOK);
+    assert_int_equal(sizeof(test_cert_der), der_size);
+    assert_memory_equal(der, test_cert_der, der_size);
+
+    talloc_free(der);
+
+    /* https://pagure.io/SSSD/sssd/issue/3354
+       https://tools.ietf.org/html/rfc7468#section-2 */
+    ret = sss_cert_pem_to_der(ts, TEST_CERT_PEM_WITH_METADATA, &der, &der_size);
     assert_int_equal(ret, EOK);
     assert_int_equal(sizeof(test_cert_der), der_size);
     assert_memory_equal(der, test_cert_der, der_size);

--- a/src/util/cert/nss/cert.c
+++ b/src/util/cert/nss/cert.c
@@ -147,16 +147,17 @@ errno_t sss_cert_pem_to_der(TALLOC_CTX *mem_ctx, const char *pem,
         return EINVAL;
     }
 
+    if ((pem = strstr(pem, NS_CERT_HEADER)) == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Missing PEM header.");
+        return EINVAL;
+    }
+
     pem_len = strlen(pem);
     if (pem_len <= NS_CERT_HEADER_LEN + NS_CERT_TRAILER_LEN) {
         DEBUG(SSSDBG_CRIT_FAILURE, "PEM data too short.\n");
         return EINVAL;
     }
 
-    if (strncmp(pem, NS_CERT_HEADER, NS_CERT_HEADER_LEN) != 0) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Wrong PEM header.\n");
-        return EINVAL;
-    }
     if (pem[NS_CERT_HEADER_LEN] != '\n') {
         DEBUG(SSSDBG_CRIT_FAILURE, "Missing newline in PEM data.\n");
         return EINVAL;


### PR DESCRIPTION
According to RFC 7468 parser must not fail when some data are present before
the encapsulation boundary. sss_cert_pem_to_der didn't respect this and refused
valid input. Changing it's code to first locate the certificate header fixes
the issue.

https://pagure.io/SSSD/sssd/issue/3354