### PR TITLE
KRB5_LOCATOR: add env variable to disable plugin

### DIFF
--- a/src/man/sssd_krb5_locator_plugin.8.xml
+++ b/src/man/sssd_krb5_locator_plugin.8.xml
@@ -69,6 +69,11 @@
             If the environment variable SSSD_KRB5_LOCATOR_DEBUG is set to any
             value debug messages will be sent to stderr.
         </para>
+        <para>
+            If the environment variable SSSD_KRB5_LOCATOR_DISABLE is set to any
+            value the plugin is disabled and will just return
+            KRB5_PLUGIN_NO_HANDLE to the caller.
+        </para>
     </refsect1>
 
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="include/seealso.xml" />

--- a/src/tests/cmocka/test_cert_utils.c
+++ b/src/tests/cmocka/test_cert_utils.c
@@ -128,6 +128,13 @@ const uint8_t test_cert_der[] = {
 "lBPDhfTVcWXQwN385uycW/ARtSzzSME2jKKWSIQ=\n" \
 "-----END CERTIFICATE-----\n"
 
+#define TEST_CERT_PEM_WITH_METADATA "Bag Attributes\n" \
+"    friendlyName: ipa-devel\n" \
+"    localKeyID: 8E 0D 04 1F BC 13 73 54 00 8F 65 57 D7 A8 AF 34 0C 18 B3 99\n" \
+"subject= /O=IPA.DEVEL/CN=ipa-devel.ipa.devel\n" \
+"issuer= /O=IPA.DEVEL/CN=Certificate Authority\n" \
+TEST_CERT_PEM
+
 #define TEST_CERT_DERB64 \
 "MIIECTCCAvGgAwIBAgIBCTANBgkqhkiG9w0BAQsFADA0MRIwEAYDVQQKDAlJUEEu" \
 "REVWRUwxHjAcBgNVBAMMFUNlcnRpZmljYXRlIEF1dGhvcml0eTAeFw0xNTA0Mjgx" \
@@ -214,6 +221,15 @@ void test_sss_cert_pem_to_der(void **state)
     assert_int_equal(ret, EINVAL);
 
     ret = sss_cert_pem_to_der(ts, TEST_CERT_PEM, &der, &der_size);
+    assert_int_equal(ret, EOK);
+    assert_int_equal(sizeof(test_cert_der), der_size);
+    assert_memory_equal(der, test_cert_der, der_size);
+
+    talloc_free(der);
+
+    /* https://pagure.io/SSSD/sssd/issue/3354
+       https://tools.ietf.org/html/rfc7468#section-2 */
+    ret = sss_cert_pem_to_der(ts, TEST_CERT_PEM_WITH_METADATA, &der, &der_size);
     assert_int_equal(ret, EOK);
     assert_int_equal(sizeof(test_cert_der), der_size);
     assert_memory_equal(der, test_cert_der, der_size);

--- a/src/util/cert/nss/cert.c
+++ b/src/util/cert/nss/cert.c
@@ -147,16 +147,17 @@ errno_t sss_cert_pem_to_der(TALLOC_CTX *mem_ctx, const char *pem,
         return EINVAL;
     }
 
+    if ((pem = strstr(pem, NS_CERT_HEADER)) == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Missing PEM header.");
+        return EINVAL;
+    }
+
     pem_len = strlen(pem);
     if (pem_len <= NS_CERT_HEADER_LEN + NS_CERT_TRAILER_LEN) {
         DEBUG(SSSDBG_CRIT_FAILURE, "PEM data too short.\n");
         return EINVAL;
     }
 
-    if (strncmp(pem, NS_CERT_HEADER, NS_CERT_HEADER_LEN) != 0) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Wrong PEM header.\n");
-        return EINVAL;
-    }
     if (pem[NS_CERT_HEADER_LEN] != '\n') {
         DEBUG(SSSDBG_CRIT_FAILURE, "Missing newline in PEM data.\n");
         return EINVAL;


### PR DESCRIPTION
If the new environment variable SSSD_KRB5_LOCATOR_DISABLE is set to any
value SSSD's krb5 locator plugin is disabled. The variable is needed
because there is currently no other way than removing the plugin
completely to disable it. For a use-case see e.g.
https://bugzilla.redhat.com/show_bug.cgi?id=1072939.

Related to https://pagure.io/SSSD/sssd/issue/3359