### PR TITLE
SECRETS: Apply separate quotas for cn=secrets and cn=kcm

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1494,7 +1494,6 @@ sssd_secrets_SOURCES = \
     src/util/sss_iobuf.c \
     src/util/tev_curl.c \
     $(SSSD_RESPONDER_OBJ) \
-    $(SSSD_RESOLV_OBJ) \
     $(NULL)
 sssd_secrets_LDADD = \
     $(HTTP_PARSER_LIBS) \

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -242,6 +242,7 @@
 #define CONFDB_SEC_CONF_ENTRY "config/secrets"
 #define CONFDB_SEC_CONTAINERS_NEST_LEVEL "containers_nest_level"
 #define CONFDB_SEC_MAX_SECRETS "max_secrets"
+#define CONFDB_SEC_MAX_UID_SECRETS "max_uid_secrets"
 #define CONFDB_SEC_MAX_PAYLOAD_SIZE "max_payload_size"
 
 /* KCM Service */

--- a/src/config/SSSDConfig/__init__.py.in
+++ b/src/config/SSSDConfig/__init__.py.in
@@ -128,6 +128,7 @@ option_strings = {
     'provider': _('The provider where the secrets will be stored in'),
     'containers_nest_level': _('The maximum allowed number of nested containers'),
     'max_secrets': _('The maximum number of secrets that can be stored'),
+    'max_uid_secrets': _('The maximum number of secrets that can be stored per UID'),
     'max_payload_size': _('The maximum payload size of a secret in kilobytes'),
     # secrets - proxy
     'proxy_url': _('The URL Custodia server is listening on'),

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -13,6 +13,7 @@ section = kcm
 section = session_recording
 section_re = ^secrets/users/[0-9]\+$
 section_re = ^secrets/secrets$
+section_re = ^secrets/kcm$
 section_re = ^domain/[^/\@]\+$
 section_re = ^domain/[^/\@]\+/[^/\@]\+$
 section_re = ^application/[^/\@]\+$
@@ -258,7 +259,7 @@ option = responder_idle_timeout
 
 [rule/allowed_sec_hive_options]
 validator = ini_allowed_options
-section_re = ^secrets/secrets$
+section_re = ^secrets/\(secrets\|kcm\)$
 
 # Secrets service - per-hive configuration
 option = containers_nest_level

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -264,6 +264,7 @@ section_re = ^secrets/\(secrets\|kcm\)$
 # Secrets service - per-hive configuration
 option = containers_nest_level
 option = max_secrets
+option = max_uid_secrets
 option = max_payload_size
 
 [rule/allowed_sec_users_options]

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -12,6 +12,7 @@ section = secrets
 section = kcm
 section = session_recording
 section_re = ^secrets/users/[0-9]\+$
+section_re = ^secrets/secrets$
 section_re = ^domain/[^/\@]\+$
 section_re = ^domain/[^/\@]\+/[^/\@]\+$
 section_re = ^application/[^/\@]\+$
@@ -254,6 +255,15 @@ option = containers_nest_level
 option = max_secrets
 option = max_payload_size
 option = responder_idle_timeout
+
+[rule/allowed_sec_hive_options]
+validator = ini_allowed_options
+section_re = ^secrets/secrets$
+
+# Secrets service - per-hive configuration
+option = containers_nest_level
+option = max_secrets
+option = max_payload_size
 
 [rule/allowed_sec_users_options]
 validator = ini_allowed_options

--- a/src/config/etc/sssd.api.conf
+++ b/src/config/etc/sssd.api.conf
@@ -105,6 +105,7 @@ user_attributes = str, None, false
 provider = str, None, false
 containers_nest_level = int, None, false
 max_secrets = int, None, false
+max_uid_secrets = int, None, false
 max_payload_size = int, None, false
 # Secrets service - proxy
 proxy_url = str, None, false

--- a/src/man/sssd-secrets.5.xml
+++ b/src/man/sssd-secrets.5.xml
@@ -196,7 +196,7 @@ systemctl enable sssd-secrets.service
                     can be stored in the hive.
                 </para>
                 <para>
-                    Default: 1024
+                    Default: 1024 (secrets hive), 256 (kcm hive)
                 </para>
                 </listitem>
             </varlistentry>
@@ -208,7 +208,7 @@ systemctl enable sssd-secrets.service
                     a secret payload in kilobytes.
                 </para>
                 <para>
-                    Default: 16
+                    Default: 16 (secrets hive), 65536 (64 MiB) (kcm hive)
                 </para>
                 </listitem>
             </varlistentry>

--- a/src/man/sssd-secrets.5.xml
+++ b/src/man/sssd-secrets.5.xml
@@ -201,6 +201,18 @@ systemctl enable sssd-secrets.service
                 </listitem>
             </varlistentry>
             <varlistentry>
+                <term>max_uid_secrets (integer)</term>
+                <listitem>
+                <para>
+                    This option specifies the maximum number of secrets that
+                    can be stored per-UID in the hive.
+                </para>
+                <para>
+                    Default: 256 (secrets hive), 64 (kcm hive)
+                </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
                 <term>max_payload_size (integer)</term>
                 <listitem>
                 <para>

--- a/src/man/sssd-secrets.5.xml
+++ b/src/man/sssd-secrets.5.xml
@@ -57,6 +57,32 @@
              collide between users. Secrets can be stored inside
              <quote>containers</quote> which can be nested.
          </para>
+         <para>
+             Since the secrets responder can be used both externally to store
+             general secrets, as described in the rest of this man page, but
+             also internally by other SSSD components to store their secret
+             material, some configuration options, like quotas can be configured
+             per <quote>hive</quote> in a configuration subsection named after
+             the hive. The currently supported hives are:
+             <variablelist>
+                 <varlistentry>
+                     <term>secrets</term>
+                     <listitem><para>secrets for general usage</para></listitem>
+                 </varlistentry>
+                 <varlistentry>
+                     <term>kcm</term>
+                     <listitem>
+                             <para>used by the
+                             <citerefentry>
+                                 <refentrytitle>sssd-kcm</refentrytitle>
+                                 <manvolnum>8</manvolnum>
+                            </citerefentry>
+                            service.
+                            </para>
+                    </listitem>
+                 </varlistentry>
+             </variablelist>
+         </para>
     </refsect1>
 
     <refsect1 id='usage'>
@@ -144,6 +170,12 @@ systemctl enable sssd-secrets.service
                 </para>
                 </listitem>
             </varlistentry>
+        </variablelist>
+        <para>
+            The following options affect only the secrets <quote>hive</quote>
+            and therefore should be set in a per-hive subsection.
+        </para>
+        <variablelist>
             <varlistentry>
                 <term>containers_nest_level (integer)</term>
                 <listitem>
@@ -161,7 +193,7 @@ systemctl enable sssd-secrets.service
                 <listitem>
                 <para>
                     This option specifies the maximum number of secrets that
-                    can be stored.
+                    can be stored in the hive.
                 </para>
                 <para>
                     Default: 1024
@@ -181,6 +213,17 @@ systemctl enable sssd-secrets.service
                 </listitem>
             </varlistentry>
         </variablelist>
+        <para>
+            For example, to adjust quotas differently for both the <quote>secrets</quote>
+            and the <quote>kcm</quote> hives, configure the following:
+            <programlisting>
+[secrets/secrets]
+max_payload_size = 128
+
+[secrets/kcm]
+max_payload_size = 256
+            </programlisting>
+        </para>
         <para>
             The following options are only applicable for configurations that
             use the <quote>proxy</quote> provider.

--- a/src/man/sssd-secrets.5.xml
+++ b/src/man/sssd-secrets.5.xml
@@ -173,7 +173,8 @@ systemctl enable sssd-secrets.service
         </variablelist>
         <para>
             The following options affect only the secrets <quote>hive</quote>
-            and therefore should be set in a per-hive subsection.
+            and therefore should be set in a per-hive subsection. Setting the
+            option to 0 means "unlimited".
         </para>
         <variablelist>
             <varlistentry>

--- a/src/responder/secrets/local.c
+++ b/src/responder/secrets/local.c
@@ -397,6 +397,10 @@ static int local_db_check_containers_nest_level(struct local_db_req *lc_req,
 {
     int nest_level;
 
+    if (lc_req->quota->containers_nest_level == 0) {
+        return EOK;
+    }
+
     /* We need do not care for the synthetic containers that constitute the
      * base path (cn=<uidnumber>,cn=user,cn=secrets). */
     nest_level = ldb_dn_get_comp_num(leaf_dn) - 3;
@@ -456,6 +460,10 @@ static int local_db_check_peruid_number_of_secrets(TALLOC_CTX *mem_ctx,
     struct ldb_dn *cli_basedn = NULL;
     int ret;
 
+    if (lc_req->quota->max_uid_secrets == 0) {
+        return EOK;
+    }
+
     tmp_ctx = talloc_new(mem_ctx);
     if (tmp_ctx == NULL) {
         return ENOMEM;
@@ -501,6 +509,10 @@ static int local_db_check_number_of_secrets(TALLOC_CTX *mem_ctx,
     struct ldb_dn *dn;
     int ret;
 
+    if (lc_req->quota->max_secrets == 0) {
+        return EOK;
+    }
+
     tmp_ctx = talloc_new(mem_ctx);
     if (!tmp_ctx) return ENOMEM;
 
@@ -537,6 +549,10 @@ static int local_check_max_payload_size(struct local_db_req *lc_req,
                                         int payload_size)
 {
     int max_payload_size;
+
+    if (lc_req->quota->max_payload_size == 0) {
+        return EOK;
+    }
 
     max_payload_size = lc_req->quota->max_payload_size * 1024; /* kb */
     if (payload_size > max_payload_size) {

--- a/src/responder/secrets/proxy.c
+++ b/src/responder/secrets/proxy.c
@@ -29,7 +29,6 @@
 #define SEC_PROXY_TIMEOUT 5
 
 struct proxy_context {
-    struct resolv_ctx *resctx;
     struct confdb_ctx *cdb;
     struct tcurl_ctx *tcurl;
 };
@@ -585,7 +584,6 @@ int proxy_secrets_provider_handle(struct sec_ctx *sctx,
     pctx = talloc(handle, struct proxy_context);
     if (!pctx) return ENOMEM;
 
-    pctx->resctx = sctx->resctx;
     pctx->cdb = sctx->rctx->cdb;
     pctx->tcurl = tcurl_init(pctx, sctx->rctx->ev);
     if (pctx->tcurl == NULL) {

--- a/src/responder/secrets/secsrv.c
+++ b/src/responder/secrets/secsrv.c
@@ -162,12 +162,6 @@ static int sec_process_init(TALLOC_CTX *mem_ctx,
         goto fail;
     }
 
-    ret = resolv_init(sctx, ev, SEC_NET_TIMEOUT, &sctx->resctx);
-    if (ret != EOK) {
-        /* not fatal for now */
-        DEBUG(SSSDBG_CRIT_FAILURE, "Failed to initialize resolver library\n");
-    }
-
     /* Set up file descriptor limits */
     responder_set_fd_limit(sctx->fd_limit);
 

--- a/src/responder/secrets/secsrv.c
+++ b/src/responder/secrets/secsrv.c
@@ -52,7 +52,7 @@ static int sec_get_config(struct sec_ctx *sctx)
                          sctx->rctx->confdb_service_path,
                          CONFDB_SEC_CONTAINERS_NEST_LEVEL,
                          DEFAULT_SEC_CONTAINERS_NEST_LEVEL,
-                         &sctx->containers_nest_level);
+                         &sctx->sec_config.quota.containers_nest_level);
 
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
@@ -64,7 +64,7 @@ static int sec_get_config(struct sec_ctx *sctx)
                          sctx->rctx->confdb_service_path,
                          CONFDB_SEC_MAX_SECRETS,
                          DEFAULT_SEC_MAX_SECRETS,
-                         &sctx->max_secrets);
+                         &sctx->sec_config.quota.max_secrets);
 
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
@@ -76,7 +76,7 @@ static int sec_get_config(struct sec_ctx *sctx)
                          sctx->rctx->confdb_service_path,
                          CONFDB_SEC_MAX_PAYLOAD_SIZE,
                          DEFAULT_SEC_MAX_PAYLOAD_SIZE,
-                         &sctx->max_payload_size);
+                         &sctx->sec_config.quota.max_payload_size);
 
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,

--- a/src/responder/secrets/secsrv.c
+++ b/src/responder/secrets/secsrv.c
@@ -33,6 +33,100 @@
 #define DEFAULT_SEC_MAX_SECRETS 1024
 #define DEFAULT_SEC_MAX_PAYLOAD_SIZE 16
 
+static int sec_get_quota(struct sec_ctx *sctx,
+                         const char *section_config_path,
+                         int default_max_containers_nest_level,
+                         int default_max_num_secrets,
+                         int default_max_payload,
+                         struct sec_quota *quota)
+{
+    int ret;
+
+    ret = confdb_get_int(sctx->rctx->cdb,
+                         section_config_path,
+                         CONFDB_SEC_CONTAINERS_NEST_LEVEL,
+                         default_max_containers_nest_level,
+                         &quota->containers_nest_level);
+
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE,
+              "Failed to get container nesting level for %s\n",
+              section_config_path);
+        return ret;
+    }
+
+    ret = confdb_get_int(sctx->rctx->cdb,
+                         section_config_path,
+                         CONFDB_SEC_MAX_SECRETS,
+                         default_max_num_secrets,
+                         &quota->max_secrets);
+
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE,
+              "Failed to get maximum number of entries for %s\n",
+              section_config_path);
+        return ret;
+    }
+
+    ret = confdb_get_int(sctx->rctx->cdb,
+                         section_config_path,
+                         CONFDB_SEC_MAX_PAYLOAD_SIZE,
+                         default_max_payload,
+                         &quota->max_payload_size);
+
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE,
+              "Failed to get payload's maximum size for an entry in %s\n",
+              section_config_path);
+        return ret;
+    }
+
+    return EOK;
+}
+
+static int sec_get_hive_config(struct sec_ctx *sctx,
+                               const char *hive_name,
+                               struct sec_hive_config *hive_config,
+                               int default_max_containers_nest_level,
+                               int default_max_num_secrets,
+                               int default_max_payload)
+{
+    int ret;
+    TALLOC_CTX *tmp_ctx;
+
+    tmp_ctx = talloc_new(sctx);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    hive_config->confdb_section = talloc_asprintf(sctx,
+                                                  "config/secrets/%s",
+                                                  hive_name);
+    if (hive_config->confdb_section == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = sec_get_quota(sctx,
+                        hive_config->confdb_section,
+                        default_max_containers_nest_level,
+                        default_max_num_secrets,
+                        default_max_payload,
+                        &hive_config->quota);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Cannot read quota settings for %s [%d]: %s\n",
+              hive_name, ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = EOK;
+
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
 static int sec_get_config(struct sec_ctx *sctx)
 {
     int ret;
@@ -48,39 +142,32 @@ static int sec_get_config(struct sec_ctx *sctx)
         goto fail;
     }
 
-    ret = confdb_get_int(sctx->rctx->cdb,
-                         sctx->rctx->confdb_service_path,
-                         CONFDB_SEC_CONTAINERS_NEST_LEVEL,
-                         DEFAULT_SEC_CONTAINERS_NEST_LEVEL,
-                         &sctx->sec_config.quota.containers_nest_level);
-
+    /* Read the global quota first -- this should be removed in a future release */
+    /* Note that this sets the defaults for the sec_config quota to be used
+     * in sec_get_hive_config()
+     */
+    ret = sec_get_quota(sctx,
+                        sctx->rctx->confdb_service_path,
+                        DEFAULT_SEC_CONTAINERS_NEST_LEVEL,
+                        DEFAULT_SEC_MAX_SECRETS,
+                        DEFAULT_SEC_MAX_PAYLOAD_SIZE,
+                        &sctx->sec_config.quota);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
-              "Failed to get containers' maximum depth\n");
+              "Failed to get legacy global quotas\n");
         goto fail;
     }
 
-    ret = confdb_get_int(sctx->rctx->cdb,
-                         sctx->rctx->confdb_service_path,
-                         CONFDB_SEC_MAX_SECRETS,
-                         DEFAULT_SEC_MAX_SECRETS,
-                         &sctx->sec_config.quota.max_secrets);
-
+    /* Read the per-hive configuration */
+    ret = sec_get_hive_config(sctx,
+                              "secrets",
+                              &sctx->sec_config,
+                              sctx->sec_config.quota.containers_nest_level,
+                              sctx->sec_config.quota.max_secrets,
+                              sctx->sec_config.quota.max_payload_size);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
-              "Failed to get maximum number of entries\n");
-        goto fail;
-    }
-
-    ret = confdb_get_int(sctx->rctx->cdb,
-                         sctx->rctx->confdb_service_path,
-                         CONFDB_SEC_MAX_PAYLOAD_SIZE,
-                         DEFAULT_SEC_MAX_PAYLOAD_SIZE,
-                         &sctx->sec_config.quota.max_payload_size);
-
-    if (ret != EOK) {
-        DEBUG(SSSDBG_FATAL_FAILURE,
-              "Failed to get payload's maximum size for an entry\n");
+              "Failed to get configuration of the secrets hive\n");
         goto fail;
     }
 

--- a/src/responder/secrets/secsrv.c
+++ b/src/responder/secrets/secsrv.c
@@ -146,6 +146,16 @@ static int sec_get_hive_config(struct sec_ctx *sctx,
         goto done;
     }
 
+    if (hive_config->quota.max_payload_size == 0
+             || (sctx->max_payload_size != 0
+                 && hive_config->quota.max_payload_size > sctx->max_payload_size)) {
+        /* If the quota is unlimited or it's larger than what
+         * we already have, save the total limit so we know how much to
+         * accept from clients
+         */
+        sctx->max_payload_size = hive_config->quota.max_payload_size;
+    }
+
     ret = EOK;
 
 done:
@@ -167,6 +177,11 @@ static int sec_get_config(struct sec_ctx *sctx)
               "Failed to get file descriptors limit\n");
         goto fail;
     }
+
+    /* Set the global max_payload to ridiculously small value so that either 0 (unlimited)
+     * or any sensible value overwrite it
+     */
+    sctx->max_payload_size = 1;
 
     /* Read the global quota first -- this should be removed in a future release */
     /* Note that this sets the defaults for the sec_config quota to be used

--- a/src/responder/secrets/secsrv.c
+++ b/src/responder/secrets/secsrv.c
@@ -30,8 +30,16 @@
 
 #define DEFAULT_SEC_FD_LIMIT 2048
 #define DEFAULT_SEC_CONTAINERS_NEST_LEVEL 4
+
 #define DEFAULT_SEC_MAX_SECRETS 1024
 #define DEFAULT_SEC_MAX_PAYLOAD_SIZE 16
+
+/* The number of secrets in the /kcm hive should be quite small,
+ * but the secret size must be large because one secret in the /kcm
+ * hive holds the whole ccache which consists of several credentials
+ */
+#define DEFAULT_SEC_KCM_MAX_SECRETS      256
+#define DEFAULT_SEC_KCM_MAX_PAYLOAD_SIZE 65536
 
 static int sec_get_quota(struct sec_ctx *sctx,
                          const char *section_config_path,
@@ -165,6 +173,18 @@ static int sec_get_config(struct sec_ctx *sctx)
                               sctx->sec_config.quota.containers_nest_level,
                               sctx->sec_config.quota.max_secrets,
                               sctx->sec_config.quota.max_payload_size);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE,
+              "Failed to get configuration of the secrets hive\n");
+        goto fail;
+    }
+
+    ret = sec_get_hive_config(sctx,
+                              "kcm",
+                              &sctx->kcm_config,
+                              DEFAULT_SEC_CONTAINERS_NEST_LEVEL,
+                              DEFAULT_SEC_KCM_MAX_SECRETS,
+                              DEFAULT_SEC_KCM_MAX_PAYLOAD_SIZE);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
               "Failed to get configuration of the secrets hive\n");

--- a/src/responder/secrets/secsrv.h
+++ b/src/responder/secrets/secsrv.h
@@ -49,6 +49,7 @@ struct sec_ctx {
 
     struct sec_hive_config sec_config;
     struct sec_hive_config kcm_config;
+    int max_payload_size;
 
     struct provider_handle **providers;
 };

--- a/src/responder/secrets/secsrv.h
+++ b/src/responder/secrets/secsrv.h
@@ -30,10 +30,7 @@
 #include <tevent.h>
 #include <ldb.h>
 
-#define SEC_NET_TIMEOUT 5
-
 struct sec_ctx {
-    struct resolv_ctx *resctx;
     struct resp_ctx *rctx;
     int fd_limit;
     int containers_nest_level;

--- a/src/responder/secrets/secsrv.h
+++ b/src/responder/secrets/secsrv.h
@@ -32,8 +32,6 @@
 
 #define SEC_NET_TIMEOUT 5
 
-struct resctx;
-
 struct sec_ctx {
     struct resolv_ctx *resctx;
     struct resp_ctx *rctx;

--- a/src/responder/secrets/secsrv.h
+++ b/src/responder/secrets/secsrv.h
@@ -47,6 +47,7 @@ struct sec_ctx {
     int fd_limit;
 
     struct sec_hive_config sec_config;
+    struct sec_hive_config kcm_config;
 
     struct provider_handle **providers;
 };

--- a/src/responder/secrets/secsrv.h
+++ b/src/responder/secrets/secsrv.h
@@ -30,12 +30,23 @@
 #include <tevent.h>
 #include <ldb.h>
 
+struct sec_quota {
+    int max_secrets;
+    int max_payload_size;
+    int containers_nest_level;
+};
+
+struct sec_hive_config {
+    const char *confdb_section;
+
+    struct sec_quota quota;
+};
+
 struct sec_ctx {
     struct resp_ctx *rctx;
     int fd_limit;
-    int containers_nest_level;
-    int max_secrets;
-    int max_payload_size;
+
+    struct sec_hive_config sec_config;
 
     struct provider_handle **providers;
 };

--- a/src/responder/secrets/secsrv.h
+++ b/src/responder/secrets/secsrv.h
@@ -32,6 +32,7 @@
 
 struct sec_quota {
     int max_secrets;
+    int max_uid_secrets;
     int max_payload_size;
     int containers_nest_level;
 };

--- a/src/responder/secrets/secsrv_private.h
+++ b/src/responder/secrets/secsrv_private.h
@@ -75,6 +75,7 @@ struct sec_req_ctx {
     bool complete;
 
     size_t total_size;
+    size_t max_payload_size;
 
     char *request_url;
     char *mapped_path;
@@ -151,7 +152,6 @@ bool sec_req_has_header(struct sec_req_ctx *req,
                         const char *name, const char *value);
 
 /* secsrv_cmd.c */
-#define SEC_REQUEST_MAX_SIZE 65536
 #define SEC_PACKET_MAX_RECV_SIZE 8192
 
 int sec_send_data(int fd, struct sec_data *data);

--- a/src/tests/intg/test_secrets.py
+++ b/src/tests/intg/test_secrets.py
@@ -169,36 +169,6 @@ def test_crd_ops(setup_for_secrets, secrets_cli):
         cli.del_secret("foo")
     assert str(err404.value).startswith("404")
 
-    # Don't allow storing more secrets after reaching the max
-    # number of entries.
-    MAX_SECRETS = 10
-
-    sec_value = "value"
-    for x in range(MAX_SECRETS):
-        cli.set_secret(str(x), sec_value)
-
-    with pytest.raises(HTTPError) as err507:
-        cli.set_secret(str(MAX_SECRETS), sec_value)
-    assert str(err507.value).startswith("507")
-
-    # Delete all stored secrets used for max secrets tests
-    for x in range(MAX_SECRETS):
-        cli.del_secret(str(x))
-
-    # Don't allow storing a secrets which has a payload larger
-    # than max_payload_size
-    KILOBYTE = 1024
-    MAX_PAYLOAD_SIZE = 2 * KILOBYTE
-
-    sec_value = "x" * MAX_PAYLOAD_SIZE
-
-    cli.set_secret("foo", sec_value)
-
-    sec_value += "x"
-    with pytest.raises(HTTPError) as err413:
-        cli.set_secret("bar", sec_value)
-    assert str(err413.value).startswith("413")
-
 
 def run_curlwrap_tool(args, exp_http_code):
     cmd = subprocess.Popen(args,
@@ -434,3 +404,97 @@ def test_idle_timeout(setup_for_cli_timeout_test):
 
     nfds_post = get_num_fds(secpid)
     assert nfds_pre == nfds_post
+
+def run_quota_test(cli, max_secrets, max_payload_size):
+    sec_value = "value"
+    for x in range(max_secrets):
+        cli.set_secret(str(x), sec_value)
+
+    with pytest.raises(HTTPError) as err507:
+        cli.set_secret(str(max_secrets), sec_value)
+    assert str(err507.value).startswith("507")
+
+    # Delete all stored secrets used for max secrets tests
+    for x in range(max_secrets):
+        cli.del_secret(str(x))
+
+    # Don't allow storing a secrets which has a payload larger
+    # than max_payload_size
+    KILOBYTE = 1024
+    kb_payload_size = max_payload_size * KILOBYTE
+
+    sec_value = "x" * kb_payload_size
+
+    cli.set_secret("foo", sec_value)
+
+    sec_value += "x"
+    with pytest.raises(HTTPError) as err413:
+        cli.set_secret("bar", sec_value)
+    assert str(err413.value).startswith("413")
+
+
+@pytest.fixture
+def setup_for_global_quota(request):
+    conf = unindent("""\
+        [sssd]
+        domains = local
+        services = nss
+
+        [domain/local]
+        id_provider = local
+
+        [secrets]
+        max_secrets = 10
+        max_payload_size = 2
+    """).format(**locals())
+
+    create_conf_fixture(request, conf)
+    create_sssd_secrets_fixture(request)
+    return None
+
+
+def test_global_quota(setup_for_global_quota, secrets_cli):
+    """
+    Test that the deprecated configuration of quotas in the global
+    secrets section is still supported
+    """
+    cli = secrets_cli
+
+    # Don't allow storing more secrets after reaching the max
+    # number of entries.
+    run_quota_test(cli, 10, 2)
+
+
+@pytest.fixture
+def setup_for_secrets_quota(request):
+    conf = unindent("""\
+        [sssd]
+        domains = local
+        services = nss
+
+        [domain/local]
+        id_provider = local
+
+        [secrets]
+        max_secrets = 5
+        max_payload_size = 1
+
+        [secrets/secrets]
+        max_secrets = 10
+        max_payload_size = 2
+    """).format(**locals())
+
+    create_conf_fixture(request, conf)
+    create_sssd_secrets_fixture(request)
+    return None
+
+
+def test_sec_quota(setup_for_secrets_quota, secrets_cli):
+    """
+    Test that the new secrets/secrets section takes precedence.
+    """
+    cli = secrets_cli
+
+    # Don't allow storing more secrets after reaching the max
+    # number of entries.
+    run_quota_test(cli, 10, 2)

--- a/src/tests/intg/test_secrets.py
+++ b/src/tests/intg/test_secrets.py
@@ -543,3 +543,58 @@ def test_per_uid_limit(setup_for_uid_limit, secrets_cli):
 
     # FIXME - at this point, it would be nice to test that another UID can still
     # store secrets, but sadly socket_wrapper doesn't allow us to fake UIDs yet
+
+
+@pytest.fixture
+def setup_for_unlimited_quotas(request):
+    conf = unindent("""\
+        [sssd]
+        domains = local
+        services = nss
+
+        [domain/local]
+        id_provider = local
+
+        [secrets]
+        debug_level = 10
+
+        [secrets/secrets]
+        max_secrets = 0
+        max_uid_secrets = 0
+        max_payload_size = 0
+        containers_nest_level = 0
+    """).format(**locals())
+
+    create_conf_fixture(request, conf)
+    create_sssd_secrets_fixture(request)
+    return None
+
+
+def test_unlimited_quotas(setup_for_unlimited_quotas, secrets_cli):
+    """
+    Test that setting quotas to zero disabled any checks and lets
+    store whatever.
+    """
+    cli = secrets_cli
+
+    # test much larger amount of secrets that we allow by default
+    sec_value = "value"
+    for x in range(2048):
+        cli.set_secret(str(x), sec_value)
+
+    # test a much larger secret size than the default one
+    KILOBYTE = 1024
+    payload_size = 32 * KILOBYTE
+
+    sec_value = "x" * payload_size
+    cli.set_secret("foo", sec_value)
+
+    fooval = cli.get_secret("foo")
+    assert fooval == sec_value
+
+    # test a deep secret nesting structure
+    DEFAULT_CONTAINERS_NEST_LEVEL = 128
+    container = "mycontainer"
+    for x in range(DEFAULT_CONTAINERS_NEST_LEVEL):
+        container += "%s/" % str(x)
+        cli.create_container(container)

--- a/src/tests/intg/test_secrets.py
+++ b/src/tests/intg/test_secrets.py
@@ -498,3 +498,48 @@ def test_sec_quota(setup_for_secrets_quota, secrets_cli):
     # Don't allow storing more secrets after reaching the max
     # number of entries.
     run_quota_test(cli, 10, 2)
+
+
+@pytest.fixture
+def setup_for_uid_limit(request):
+    conf = unindent("""\
+        [sssd]
+        domains = local
+        services = nss
+
+        [domain/local]
+        id_provider = local
+
+        [secrets]
+
+        [secrets/secrets]
+        max_secrets = 10
+        max_uid_secrets = 5
+    """).format(**locals())
+
+    create_conf_fixture(request, conf)
+    create_sssd_secrets_fixture(request)
+    return None
+
+
+def test_per_uid_limit(setup_for_uid_limit, secrets_cli):
+    """
+    Test that per-UID limits are enforced even if the global limit would still
+    allow to store more secrets
+    """
+    cli = secrets_cli
+
+    # Don't allow storing more secrets after reaching the max
+    # number of entries.
+    MAX_UID_SECRETS = 5
+
+    sec_value = "value"
+    for x in range(MAX_UID_SECRETS):
+        cli.set_secret(str(x), sec_value)
+
+    with pytest.raises(HTTPError) as err507:
+        cli.set_secret(str(MAX_UID_SECRETS), sec_value)
+    assert str(err507.value).startswith("507")
+
+    # FIXME - at this point, it would be nice to test that another UID can still
+    # store secrets, but sadly socket_wrapper doesn't allow us to fake UIDs yet


### PR DESCRIPTION
While testing the KCM responder some more, I realized that we always checked
the (hardcoded, no less) base DN of cn=secrets when checking for
quotas. These patches make the quota check separate for each of the
cn=secrets/cn=kcm hives, add a test and mention in documentation that the
quota from sssd-secrets applies for how many ccaches can be stored.