### PR TITLE
Config check regex

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -252,6 +252,7 @@ if HAVE_CMOCKA
         dp_opt_tests \
         responder-get-domains-tests \
         sbus-internal-tests \
+        config_check_tests \
         sss_sifp-tests \
         test_search_bases \
         test_ldap_auth \
@@ -2430,6 +2431,19 @@ sbus_internal_tests_LDADD = \
     libsss_crypt.la \
     libsss_debug.la \
     libsss_test_common.la
+
+config_check_tests_SOURCES = \
+    src/tests/cmocka/test_config_check.c \
+    $(NULL)
+config_check_tests_CFLAGS = \
+    $(AM_CFLAGS) \
+    $(NULL)
+config_check_tests_LDADD = \
+    $(CMOCKA_LIBS) \
+    libsss_util.la \
+    libsss_debug.la \
+    libsss_test_common.la \
+    $(NULL)
 
 test_find_uid_SOURCES = \
     src/tests/cmocka/test_find_uid.c \

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -712,3 +712,6 @@ option = ad_server
 option = ad_backup_server
 option = ad_site
 option = use_fully_qualified_names
+
+[rule/sssd_checks]
+validator = sssd_checks

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -13,7 +13,8 @@ section = kcm
 section_re = ^secrets/users/[0-9]\+$
 section_re = ^domain/[^/\@]\+$
 section_re = ^domain/[^/\@]\+/[^/\@]\+$
-section_re = ^application/.*$
+section_re = ^application/[^/\@]\+$
+
 
 [rule/allowed_sssd_options]
 validator = ini_allowed_options

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -695,10 +695,7 @@ option = ldap_user_uid_number
 option = ldap_user_uuid
 option = ldap_use_tokengroups
 
-[rule/allowed_application_options]
-validator = ini_allowed_options
-section_re = ^application/.*$
-
+# For application domains
 option = inherit_from
 
 [rule/allowed_subdomain_options]

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -295,7 +295,7 @@ option = responder_idle_timeout
 
 [rule/allowed_domain_options]
 validator = ini_allowed_options
-section_re = ^(domain|application)/.*$
+section_re = ^\(domain\|application\)/.*$
 
 option = debug
 option = debug_level

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -11,7 +11,8 @@ section = ifp
 section = secrets
 section = kcm
 section_re = ^secrets/users/[0-9]\+$
-section_re = ^domain/.*$
+section_re = ^domain/[^/\@]\+$
+section_re = ^domain/[^/\@]\+/[^/\@]\+$
 section_re = ^application/.*$
 
 [rule/allowed_sssd_options]
@@ -699,3 +700,17 @@ validator = ini_allowed_options
 section_re = ^application/.*$
 
 option = inherit_from
+
+[rule/allowed_subdomain_options]
+validator = ini_allowed_options
+section_re = ^domain/[^/\@]\+/[^/\@]\+$
+
+option = ldap_search_base
+option = ldap_user_search_base
+option = ldap_group_search_base
+option = ldap_netgroup_search_base
+option = ldap_service_search_base
+option = ad_server
+option = ad_backup_server
+option = ad_site
+option = use_fully_qualified_names

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2912,7 +2912,7 @@ ldap_user_extra_attrs = phone:telephoneNumber
         <para>
             Some options used in the domain section can also be used in the
             trusted domain section, that is, in a section called
-            <quote>[domain/<replaceable>DOMAIN_NAME</replaceable>]/<replaceable>TRUSTED_DOMAIN_NAME</replaceable>]</quote>.
+            <quote>[domain/<replaceable>DOMAIN_NAME</replaceable>/<replaceable>TRUSTED_DOMAIN_NAME</replaceable>]</quote>.
             Currently supported options in the trusted domain section are:
         </para>
             <para>ldap_search_base,</para>

--- a/src/tests/cmocka/test_config_check.c
+++ b/src/tests/cmocka/test_config_check.c
@@ -204,6 +204,26 @@ void config_check_test_good_sections(void **state)
     config_check_test_common(cfg_str, 0, expected_errors);
 }
 
+void config_check_test_inherit_from_in_normal_dom(void **state)
+{
+    char cfg_str[] = "[domain/A.test]\n"
+                     "inherit_from = domain\n";
+    const char *expected_errors[] = {
+        "[rule/sssd_checks]: Attribute 'inherit_from' is not allowed in section 'domain/A.test'. Check for typos.",
+    };
+
+    config_check_test_common(cfg_str, 1, expected_errors);
+}
+
+void config_check_test_inherit_from_in_app_dom(void **state)
+{
+    char cfg_str[] = "[application/A.test]\n"
+                     "inherit_from = domain\n";
+    const char *expected_errors[] = {NULL};
+
+    config_check_test_common(cfg_str, 0, expected_errors);
+}
+
 int main(int argc, const char *argv[])
 {
     poptContext pc;
@@ -222,6 +242,7 @@ int main(int argc, const char *argv[])
         cmocka_unit_test(config_check_test_bad_pac_option_name),
         cmocka_unit_test(config_check_test_bad_ifp_option_name),
         cmocka_unit_test(config_check_test_good_sections),
+        cmocka_unit_test(config_check_test_inherit_from_in_normal_dom),
     };
 
     /* Set debug level to invalid value so we can deside if -d 0 was used. */

--- a/src/tests/cmocka/test_config_check.c
+++ b/src/tests/cmocka/test_config_check.c
@@ -1,0 +1,255 @@
+/*
+    Authors:
+        Michal Zidek <mzidek@redhat.com>
+
+    Copyright (C) 2014 Red Hat
+
+    Config file validators test
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <popt.h>
+#include <ini_configobj.h>
+
+#include "util/util.h"
+#include "util/sss_ini.h"
+#include "tests/cmocka/common_mock.h"
+
+#ifdef HAVE_LIBINI_CONFIG_V1_3
+
+#define RULES_PATH ABS_SRC_DIR"/src/config/cfg_rules.ini"
+
+struct sss_ini_initdata {
+    char **error_list;
+    struct ref_array *ra_success_list;
+    struct ref_array *ra_error_list;
+    struct ini_cfgobj *sssd_config;
+    struct value_obj *obj;
+    const struct stat *cstat;
+    struct ini_cfgfile *file;
+};
+
+void config_check_test_common(const char *cfg_string,
+                              size_t num_errors_expected,
+                              const char **errors_expected)
+{
+    struct sss_ini_initdata *init_data;
+    size_t num_errors;
+    char **strs;
+    int ret;
+    TALLOC_CTX *tmp_ctx;
+
+    tmp_ctx = talloc_new(NULL);
+    assert_non_null(tmp_ctx);
+
+    init_data = sss_ini_initdata_init(tmp_ctx);
+
+    ret = ini_config_file_from_mem(discard_const(cfg_string),
+                                   strlen(cfg_string),
+                                   &init_data->file);
+    assert_int_equal(ret, EOK);
+
+    ret = ini_config_create(&(init_data->sssd_config));
+    assert_int_equal(ret, EOK);
+
+    ret = ini_config_parse(init_data->file,
+                           INI_STOP_ON_ANY,
+                           INI_MV1S_OVERWRITE,
+                           INI_PARSE_NOWRAP,
+                           init_data->sssd_config);
+    assert_int_equal(ret, EOK);
+
+    ret = sss_ini_call_validators_strs(tmp_ctx, init_data,
+                                       RULES_PATH,
+                                       &strs, &num_errors);
+    assert_int_equal(ret, EOK);
+
+    /* Output from validators */
+    for (int i = 0; i < num_errors; i++) {
+        /* Keep this printf loop for faster debugging */
+        printf("%s\n", strs[i]);
+    }
+
+    for (int i = 0; i < num_errors && i <= num_errors_expected; i++) {
+        assert_string_equal(strs[i], errors_expected[i]);
+    }
+
+    /* Check if the number of errors is the same */
+    assert_int_equal(num_errors_expected, num_errors);
+}
+
+void config_check_test_bad_section_name(void **state)
+{
+    char cfg_str[] = "[sssssssssssssd]";
+    const char *expected_errors[] = {
+        "[rule/allowed_sections]: Section [sssssssssssssd] is not allowed. Check for typos.",
+    };
+
+    config_check_test_common(cfg_str, 1, expected_errors);
+}
+
+void config_check_test_bad_sssd_option_name(void **state)
+{
+    char cfg_str[] = "[sssd]\n"
+                     "debug_leTYPOvel = 10\n";
+    const char *expected_errors[] = {
+        "[rule/allowed_sssd_options]: Attribute 'debug_leTYPOvel' is not allowed in section 'sssd'. Check for typos.",
+    };
+
+    config_check_test_common(cfg_str, 1, expected_errors);
+}
+
+void config_check_test_bad_pam_option_name(void **state)
+{
+    char cfg_str[] = "[pam]\n"
+                     "debug_leTYPOvel = 10\n";
+    const char *expected_errors[] = {
+        "[rule/allowed_pam_options]: Attribute 'debug_leTYPOvel' is not allowed in section 'pam'. Check for typos.",
+    };
+
+    config_check_test_common(cfg_str, 1, expected_errors);
+}
+
+void config_check_test_bad_nss_option_name(void **state)
+{
+    char cfg_str[] = "[nss]\n"
+                     "debug_leTYPOvel = 10\n";
+    const char *expected_errors[] = {
+        "[rule/allowed_nss_options]: Attribute 'debug_leTYPOvel' is not allowed in section 'nss'. Check for typos.",
+    };
+
+    config_check_test_common(cfg_str, 1, expected_errors);
+}
+
+void config_check_test_bad_pac_option_name(void **state)
+{
+    char cfg_str[] = "[pac]\n"
+                     "debug_leTYPOvel = 10\n";
+    const char *expected_errors[] = {
+        "[rule/allowed_pac_options]: Attribute 'debug_leTYPOvel' is not allowed in section 'pac'. Check for typos.",
+    };
+
+    config_check_test_common(cfg_str, 1, expected_errors);
+}
+
+void config_check_test_bad_ifp_option_name(void **state)
+{
+    char cfg_str[] = "[ifp]\n"
+                     "debug_leTYPOvel = 10\n";
+    const char *expected_errors[] = {
+        "[rule/allowed_ifp_options]: Attribute 'debug_leTYPOvel' is not allowed in section 'ifp'. Check for typos.",
+    };
+
+    config_check_test_common(cfg_str, 1, expected_errors);
+}
+
+void config_check_test_bad_domain_option_name(void **state)
+{
+    char cfg_str[] = "[domain/A.test\n"
+                     "debug_leTYPOvel = 10\n";
+    const char *expected_errors[] = {
+        "[rule/allowed_subdomain_options]: Attribute 'debug_leTYPOvel' is not allowed in section 'domain/A.test'. Check for typos.",
+    };
+
+    config_check_test_common(cfg_str, 1, expected_errors);
+}
+
+void config_check_test_bad_appdomain_option_name(void **state)
+{
+    char cfg_str[] = "[application/myapp\n"
+                     "debug_leTYPOvel = 10\n";
+    const char *expected_errors[] = {
+        "[rule/allowed_subdomain_options]: Attribute 'debug_leTYPOvel' is not allowed in section 'application/myapp'. Check for typos.",
+    };
+
+    config_check_test_common(cfg_str, 1, expected_errors);
+}
+
+void config_check_test_bad_subdom_option_name(void **state)
+{
+    char cfg_str[] = "[domain/A.test/B.A.test]\n"
+                     "debug_leTYPOvel = 10\n";
+    const char *expected_errors[] = {
+        "[rule/allowed_sssd_options]: Attribute 'debug_leTYPOvel' is not allowed in section 'domain/A.test/B.A.test'. Check for typos.",
+    };
+
+    config_check_test_common(cfg_str, 1, expected_errors);
+}
+
+void config_check_test_good_sections(void **state)
+{
+    char cfg_str[] = "[sssd]\n"
+                     "[pam]\n"
+                     "[nss]\n"
+                     "[domain/testdom.test]\n"
+                     "[domain/testdom.test/testsubdom.testdom.test]\n"
+                     "[application/myapp]\n"
+                     "[secrets]\n"
+                     "[ifp]\n"
+                     "[pac]\n";
+    const char *expected_errors[] = {NULL};
+
+    config_check_test_common(cfg_str, 0, expected_errors);
+}
+
+int main(int argc, const char *argv[])
+{
+    poptContext pc;
+    int opt;
+    struct poptOption long_options[] = {
+        POPT_AUTOHELP
+        SSSD_DEBUG_OPTS
+        POPT_TABLEEND
+    };
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(config_check_test_bad_section_name),
+        cmocka_unit_test(config_check_test_bad_sssd_option_name),
+        cmocka_unit_test(config_check_test_bad_pam_option_name),
+        cmocka_unit_test(config_check_test_bad_nss_option_name),
+        cmocka_unit_test(config_check_test_bad_pac_option_name),
+        cmocka_unit_test(config_check_test_bad_ifp_option_name),
+        cmocka_unit_test(config_check_test_good_sections),
+    };
+
+    /* Set debug level to invalid value so we can deside if -d 0 was used. */
+    debug_level = SSSDBG_INVALID;
+
+    pc = poptGetContext(argv[0], argc, argv, long_options, 0);
+    while((opt = poptGetNextOpt(pc)) != -1) {
+        switch(opt) {
+        default:
+            fprintf(stderr, "\nInvalid option %s: %s\n\n",
+                    poptBadOption(pc, 0), poptStrerror(opt));
+            poptPrintUsage(pc, stderr, 0);
+            return 1;
+        }
+    }
+    poptFreeContext(pc);
+
+    DEBUG_CLI_INIT(debug_level);
+    tests_set_cwd();
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}
+
+#else /* !HAVE_LIBINI_CONFIG_V1_3 */
+
+int main(int argc, const char *argv[])
+{
+    fprintf(stderr, "%s requires newer version of libini\n", argv[0]);
+    return 0;
+}
+
+#endif /* HAVE_LIBINI_CONFIG_V1_3 */

--- a/src/util/sss_ini.c
+++ b/src/util/sss_ini.c
@@ -561,12 +561,62 @@ error:
 }
 
 #ifdef HAVE_LIBINI_CONFIG_V1_3
+/* Here we can put custom SSSD specific checks that can not be implemented
+ * using libini validators */
+static int custom_sssd_checks(const char *rule_name,
+                              struct ini_cfgobj *rules_obj,
+                              struct ini_cfgobj *config_obj,
+                              struct ini_errobj *errobj,
+                              void **data)
+{
+    char **cfg_sections = NULL;
+    int num_cfg_sections;
+    struct value_obj *vo = NULL;
+    char dom_prefix[] = "domain/";
+    int ret;
+
+    /* Get all sections in configuration */
+    cfg_sections = ini_get_section_list(config_obj, &num_cfg_sections, &ret);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    /* Check if a normal domain section (not application domains) has option
+     * inherit_from and report error if it does */
+    for (int i = 0; i < num_cfg_sections; i++) {
+        if (strncmp(dom_prefix, cfg_sections[i], strlen(dom_prefix)) == 0) {
+            ret = ini_get_config_valueobj(cfg_sections[i],
+                                          "inherit_from",
+                                          config_obj,
+                                          INI_GET_NEXT_VALUE,
+                                          &vo);
+            if (vo != NULL) {
+                ret = ini_errobj_add_msg(errobj, "Attribute 'inherit_from' is "
+                                         "not allowed in section '%s'. Check "
+                                         "for typos.", cfg_sections[i]);
+                if (ret != EOK) {
+                    goto done;
+                }
+            }
+        }
+    }
+
+    ret = EOK;
+done:
+    ini_free_section_list(cfg_sections);
+    return EOK;
+}
+
+
 static int sss_ini_call_validators_errobj(struct sss_ini_initdata *data,
                                           const char *rules_path,
                                           struct ini_errobj *errobj)
 {
     int ret;
     struct ini_cfgobj *rules_cfgobj = NULL;
+    struct ini_validator custom_sssd = {"sssd_checks", custom_sssd_checks, NULL};
+    struct ini_validator *sss_validators[] = {&custom_sssd, NULL};
+
 
     ret = ini_rules_read_from_file(rules_path, &rules_cfgobj);
     if (ret != EOK) {
@@ -575,7 +625,7 @@ static int sss_ini_call_validators_errobj(struct sss_ini_initdata *data,
         goto done;
     }
 
-    ret = ini_rules_check(rules_cfgobj, data->sssd_config, NULL, errobj);
+    ret = ini_rules_check(rules_cfgobj, data->sssd_config, sss_validators, errobj);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
               "ini_rules_check failed %d [%s]\n", ret, strerror(ret));


### PR DESCRIPTION
Some updates for src/config/cfg_rules.ini

The most controversial is the third patch. It removes the special rule for application domains and only uses the rule for normal domains in both application and normal domains. The reason is that the validator ini_allowed_options checks all sections that match the regex in section_re and allows only listed options. This is done for all rules that use that validator *separately and there is not 'include' directive or anything like that. So we can either duplicate all the options from domain section or allow the one mistake where the inherit_from used in normal domain section will be undetected. I am more in favor of the second option, because adding inherit_from by mistake is unlikely and the rules look better this way.

However it would be good to enhance the libini to add solution for this by introducing the ability to somehow merger the rules.