### PR TITLE
Failure to filter out AD subdomain with flatname is used

### DIFF
--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -562,7 +562,8 @@ static errno_t ad_subdomains_process(TALLOC_CTX *mem_ctx,
             DEBUG(SSSDBG_TRACE_FUNC, "Enabling subdomain %s\n", sd_name);
         }
 
-        if (strcasecmp(sd_name, domain->name) == 0) {
+        if ((strcasecmp(sd_name, domain->name) == 0) ||
+                (strcasecmp(sd_name, domain->realm) == 0)) {
             DEBUG(SSSDBG_TRACE_INTERNAL,
                   "Not including primary domain %s in the subdomain list\n",
                   domain->name);


### PR DESCRIPTION
Ticket: https://pagure.io/SSSD/sssd/issue/3365

SSSD fails to filter out the child domain it is connected to when domain flatname is used instead of fully qualified domain name in `sssd.conf`, this leads to creation of an empty subdomain.

After the patch, no duplicate subdomain is created. Tested by performing `id` against user in connected-to child domain(used 2 AD domains:root and child for this). 

```
  [sssm_ad_subdomains_init] (0x2000): Initializing AD subdomains handler
  [new_subdomain] (0x0400): Creating [AD.JSTEPHEN] as subdomain of [winchld]!
  [ad_subdomains_process] (0x0400): Enabling subdomain WINCHLD.AD.JSTEPHEN
  [ad_subdomains_process] (0x2000): Not including primary domain winchld in the subdomain list
  [ad_subdomains_refresh_done] (0x0400): Subdomains refreshed.
```

I wrote a test for this but I may have gotten some talloc heirarchy incorrect so please let me know if there is a problem to fix here.