### PR TITLE
SDAP: Fix handling of search bases

### DIFF
--- a/src/providers/ad/ad_common.h
+++ b/src/providers/ad/ad_common.h
@@ -130,7 +130,8 @@ struct ad_options *ad_create_1way_trust_options(TALLOC_CTX *mem_ctx,
                                                 const char *keytab,
                                                 const char *sasl_authid);
 
-errno_t ad_set_search_bases(struct sdap_options *id_opts);
+errno_t ad_set_search_bases(struct sdap_options *id_opts,
+                            struct sdap_domain *sdap);
 
 errno_t
 ad_failover_init(TALLOC_CTX *mem_ctx, struct be_ctx *ctx,

--- a/src/providers/ipa/ipa_subdomains_server.c
+++ b/src/providers/ipa/ipa_subdomains_server.c
@@ -332,7 +332,7 @@ ipa_ad_ctx_new(struct be_ctx *be_ctx,
         return EFAULT;
     }
 
-    ret = ad_set_search_bases(ad_options->id);
+    ret = ad_set_search_bases(ad_options->id, sdom);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "Cannot initialize AD search bases\n");
         talloc_free(ad_options);

--- a/src/providers/ldap/ldap_options.c
+++ b/src/providers/ldap/ldap_options.c
@@ -581,8 +581,6 @@ errno_t sdap_parse_search_base(TALLOC_CTX *mem_ctx,
     char *unparsed_base;
     const char *old_filter = NULL;
 
-    *_search_bases = NULL;
-
     switch (class) {
     case SDAP_SEARCH_BASE:
         class_name = "DEFAULT";


### PR DESCRIPTION
We were rewriting the sdap_domain's search bases for only the first
sdap_domain in the list, which does not work for subdomains.

Also when search bases were already initialized in sdap_domain_subdom_add,
we should only rewrite them when they were explicitly set in sssd.conf.

Resolves:
https://pagure.io/SSSD/sssd/issue/3351