### PR TITLE
Allow using the "shortnames" feature without requiring any configuration from the client side

### DIFF
--- a/src/responder/common/cache_req/cache_req.c
+++ b/src/responder/common/cache_req/cache_req.c
@@ -480,7 +480,7 @@ static errno_t cache_req_search_domains_next(struct tevent_req *req)
          * qualified names on domain less search. We do not descend into
          * subdomains here since those are implicitly qualified.
          */
-        if (state->check_next && !allow_no_fqn && domain->fqnames) {
+        if (state->check_next && !allow_no_fqn && state->cr_domain->fqnames) {
             state->cr_domain = state->cr_domain->next;
             continue;
         }

--- a/src/responder/common/cache_req/cache_req_domain.c
+++ b/src/responder/common/cache_req/cache_req_domain.c
@@ -116,6 +116,8 @@ cache_req_domain_new_list_from_string_list(TALLOC_CTX *mem_ctx,
     bool enforce_non_fqnames = false;
     errno_t ret;
 
+    /* Firstly, in case a domains' resolution order is passed ... iterate over
+     * the list adding its domains to the flatten cache req domains' list */
     if (resolution_order != NULL) {
         enforce_non_fqnames = true;
         for (i = 0; resolution_order[i] != NULL; i++) {
@@ -141,6 +143,8 @@ cache_req_domain_new_list_from_string_list(TALLOC_CTX *mem_ctx,
         }
     }
 
+    /* Then iterate through all the other domains (and subdomains) and add them
+     * to the flatten cache req domains' list */
     for (dom = domains; dom; dom = get_next_domain(dom, flag)) {
         if (string_in_list(dom->name, resolution_order, false)) {
             continue;

--- a/src/responder/common/cache_req/cache_req_domain.c
+++ b/src/responder/common/cache_req/cache_req_domain.c
@@ -120,20 +120,21 @@ done:
     return cr_domains;
 }
 
-struct cache_req_domain *
+errno_t
 cache_req_domain_new_list_from_domain_resolution_order(
                                         TALLOC_CTX *mem_ctx,
                                         struct sss_domain_info *domains,
-                                        const char *domain_resolution_order)
+                                        const char *domain_resolution_order,
+                                        struct cache_req_domain **_cr_domains)
 {
     TALLOC_CTX *tmp_ctx;
-    struct cache_req_domain *cr_domains = NULL;
+    struct cache_req_domain *cr_domains;
     char **list = NULL;
     errno_t ret;
 
     tmp_ctx = talloc_new(NULL);
     if (tmp_ctx == NULL) {
-        return NULL;
+        return ENOMEM;
     }
 
     if (domain_resolution_order != NULL) {
@@ -160,7 +161,10 @@ cache_req_domain_new_list_from_domain_resolution_order(
         goto done;
     }
 
+    *_cr_domains = cr_domains;
+    ret = EOK;
+
 done:
     talloc_free(tmp_ctx);
-    return cr_domains;
+    return ret;
 }

--- a/src/responder/common/cache_req/cache_req_domain.c
+++ b/src/responder/common/cache_req/cache_req_domain.c
@@ -191,6 +191,10 @@ cache_req_domain_new_list_from_domain_resolution_order(
 
     if (domain_resolution_order != NULL) {
         if (strcmp(domain_resolution_order, ":") != 0) {
+            DEBUG(SSSDBG_TRACE_FUNC,
+                  "Domain resolution order list (split by ':'): \"%s\"\n",
+                  domain_resolution_order);
+
             ret = split_on_separator(tmp_ctx, domain_resolution_order, ':',
                                      true, true, &list, NULL);
             if (ret != EOK) {
@@ -199,7 +203,14 @@ cache_req_domain_new_list_from_domain_resolution_order(
                         ret, sss_strerror(ret));
                 goto done;
             }
+        } else {
+            DEBUG(SSSDBG_TRACE_FUNC,
+                  "Domain resolution order list: ':' "
+                  "(do not use any specific order)\n");
         }
+    } else {
+        DEBUG(SSSDBG_TRACE_FUNC,
+              "Domain resolution order list: not set\n");
     }
 
     cr_domains = cache_req_domain_new_list_from_string_list(mem_ctx, domains,

--- a/src/responder/common/cache_req/cache_req_domain.h
+++ b/src/responder/common/cache_req/cache_req_domain.h
@@ -34,11 +34,12 @@ struct cache_req_domain *
 cache_req_domain_get_domain_by_name(struct cache_req_domain *domains,
                                     const char *name);
 
-struct cache_req_domain *
+errno_t
 cache_req_domain_new_list_from_domain_resolution_order(
                                         TALLOC_CTX *mem_ctx,
                                         struct sss_domain_info *domains,
-                                        const char *domain_resolution_order);
+                                        const char *domain_resolution_order,
+                                        struct cache_req_domain **_cr_domains);
 
 void cache_req_domain_list_zfree(struct cache_req_domain **cr_domains);
 

--- a/src/responder/common/cache_req/cache_req_domain.h
+++ b/src/responder/common/cache_req/cache_req_domain.h
@@ -25,6 +25,7 @@
 
 struct cache_req_domain {
     struct sss_domain_info *domain;
+    bool fqnames;
 
     struct cache_req_domain *prev;
     struct cache_req_domain *next;

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -1594,6 +1594,8 @@ errno_t sss_resp_populate_cr_domains(struct resp_ctx *rctx)
                 rctx, rctx->domains,
                 rctx->domain_resolution_order, &cr_domains);
         if (ret == EOK) {
+            DEBUG(SSSDBG_TRACE_FUNC,
+                  "Using domain_resolution_order from sssd.conf\n");
             goto done;
         } else {
             DEBUG(SSSDBG_MINOR_FAILURE,
@@ -1624,6 +1626,8 @@ errno_t sss_resp_populate_cr_domains(struct resp_ctx *rctx)
                                                        dom->sysdb,
                                                        &cr_domains);
         if (ret == EOK) {
+            DEBUG(SSSDBG_TRACE_FUNC,
+                  "Using domain_resolution_order from IPA ID View\n");
             goto done;
         }
 
@@ -1641,6 +1645,8 @@ errno_t sss_resp_populate_cr_domains(struct resp_ctx *rctx)
                                                   dom->sysdb, dom->name,
                                                   &cr_domains);
     if (ret == EOK) {
+        DEBUG(SSSDBG_TRACE_FUNC,
+              "Using domain_resolution_order from IPA Config\n");
         goto done;
     }
 

--- a/src/tests/cmocka/test_nss_srv.c
+++ b/src/tests/cmocka/test_nss_srv.c
@@ -1709,8 +1709,6 @@ void test_nss_getgrnam_members_subdom_nonfqnames(void **state)
 {
     errno_t ret;
 
-    nss_test_ctx->subdom->fqnames = false;
-
     mock_input_user_or_group("testsubdomgroup");
     mock_account_recv_simple();
     will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETGRNAM);
@@ -1801,8 +1799,6 @@ void test_nss_getgrnam_mix_dom(void **state)
 void test_nss_getgrnam_mix_dom_nonfqnames(void **state)
 {
     errno_t ret;
-
-    nss_test_ctx->subdom->fqnames = false;
 
     ret = store_group_member(nss_test_ctx,
                              testgroup_members.gr_name,
@@ -1917,6 +1913,7 @@ void test_nss_getgrnam_mix_dom_fqdn(void **state)
     assert_int_equal(ret, EOK);
 }
 
+
 void test_nss_getgrnam_mix_dom_fqdn_nonfqnames(void **state)
 {
     errno_t ret;
@@ -1928,10 +1925,6 @@ void test_nss_getgrnam_mix_dom_fqdn_nonfqnames(void **state)
                              nss_test_ctx->subdom,
                              SYSDB_MEMBER_USER);
     assert_int_equal(ret, EOK);
-
-    nss_test_ctx->tctx->dom->fqnames = false;
-    nss_test_ctx->subdom->fqnames = false;
-
 
     mock_input_user_or_group("testgroup_members");
     will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETGRNAM);
@@ -2043,8 +2036,6 @@ void test_nss_getgrnam_mix_subdom(void **state)
 void test_nss_getgrnam_mix_subdom_nonfqnames(void **state)
 {
     errno_t ret;
-
-    nss_test_ctx->subdom->fqnames = false;
 
     ret = store_group_member(nss_test_ctx,
                              testsubdomgroup.gr_name,
@@ -3417,9 +3408,11 @@ static int nss_test_setup_extra_attr(void **state)
     return 0;
 }
 
-static int nss_subdom_test_setup(void **state)
+static int nss_subdom_test_setup_common(void **state, bool nonfqnames)
 {
     const char *const testdom[4] = { TEST_SUBDOM_NAME, "TEST.SUB", "test", "S-3" };
+    struct sss_domain_info *dom;
+
     struct sss_domain_info *subdomain;
     errno_t ret;
 
@@ -3439,6 +3432,17 @@ static int nss_subdom_test_setup(void **state)
     ret = sysdb_update_subdomains(nss_test_ctx->tctx->dom,
                                   nss_test_ctx->tctx->confdb);
     assert_int_equal(ret, EOK);
+
+    if (nonfqnames) {
+        for (dom = nss_test_ctx->rctx->domains;
+             dom != NULL;
+             dom = get_next_domain(dom, SSS_GND_ALL_DOMAINS)) {
+            if (strcmp(dom->name, subdomain->name) == 0) {
+                dom->fqnames = false;
+                break;
+            }
+        }
+    }
 
     ret = sss_resp_populate_cr_domains(nss_test_ctx->rctx);
     assert_int_equal(ret, EOK);
@@ -3475,6 +3479,17 @@ static int nss_subdom_test_setup(void **state)
     assert_int_equal(ret, EOK);
 
     return 0;
+
+}
+
+static int nss_subdom_test_setup(void **state)
+{
+    return nss_subdom_test_setup_common(state, false);
+}
+
+static int nss_subdom_test_setup_nonfqnames(void **state)
+{
+    return nss_subdom_test_setup_common(state, true);
 }
 
 static int nss_fqdn_fancy_test_setup(void **state)
@@ -4192,25 +4207,25 @@ int main(int argc, const char *argv[])
                                         nss_subdom_test_setup,
                                         nss_subdom_test_teardown),
         cmocka_unit_test_setup_teardown(test_nss_getgrnam_members_subdom_nonfqnames,
-                                        nss_subdom_test_setup,
+                                        nss_subdom_test_setup_nonfqnames,
                                         nss_subdom_test_teardown),
         cmocka_unit_test_setup_teardown(test_nss_getgrnam_mix_dom,
                                         nss_subdom_test_setup,
                                         nss_subdom_test_teardown),
         cmocka_unit_test_setup_teardown(test_nss_getgrnam_mix_dom_nonfqnames,
-                                        nss_subdom_test_setup,
+                                        nss_subdom_test_setup_nonfqnames,
                                         nss_subdom_test_teardown),
         cmocka_unit_test_setup_teardown(test_nss_getgrnam_mix_dom_fqdn,
                                         nss_subdom_test_setup,
                                         nss_subdom_test_teardown),
         cmocka_unit_test_setup_teardown(test_nss_getgrnam_mix_dom_fqdn_nonfqnames,
-                                        nss_subdom_test_setup,
+                                        nss_subdom_test_setup_nonfqnames,
                                         nss_subdom_test_teardown),
         cmocka_unit_test_setup_teardown(test_nss_getgrnam_mix_subdom,
                                         nss_subdom_test_setup,
                                         nss_subdom_test_teardown),
         cmocka_unit_test_setup_teardown(test_nss_getgrnam_mix_subdom_nonfqnames,
-                                        nss_subdom_test_setup,
+                                        nss_subdom_test_setup_nonfqnames,
                                         nss_subdom_test_teardown),
         cmocka_unit_test_setup_teardown(test_nss_getgrnam_space,
                                         nss_test_setup, nss_test_teardown),


### PR DESCRIPTION
This patch set contains:
- One patch fixing a fallback issue related to domain resolution order;
- One patch adding the ability to use the "shortnames" feature without requiring any configuration from the client side;

Please, see the commit messages for detailed information.

