### PR TITLE
IPA: Use search bases from sdap_domain instead of inferring search base from IPA domain structure

### DIFF
--- a/src/providers/ldap/sdap_ops.c
+++ b/src/providers/ldap/sdap_ops.c
@@ -101,7 +101,7 @@ sdap_search_bases_ex_send(TALLOC_CTX *mem_ctx,
         state->map_num_attrs = 0;
     }
 
-    if (state->attrs == NULL) {
+    if (state->attrs == NULL && state->map != NULL) {
         ret = build_attrs_from_map(state, state->map, state->map_num_attrs,
                                    NULL, &state->attrs, NULL);
         if (ret != EOK) {


### PR DESCRIPTION
This PR fixes https://pagure.io/SSSD/sssd/issue/3378

To test the patch, add some external groups (ipa group-add --external)
that contain members from a trusted AD domain on an IPA server. Then,
resolve the AD domain object.

Before the patch, the search for the ipaExternalGroup class objects would
have been based on the root search base of the IPA server, after the patch
it should be based on the cn=accounts subtree.