### PR TITLE
KCM: Modify krb5 snippet file kcm_default_ccache

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -87,7 +87,7 @@ sudolibdir = @sudolibpath@
 polkitdir = @polkitdir@
 pamconfdir = $(sysconfdir)/pam.d
 systemtap_tapdir = @tapset_dir@
-krb5sysincludedir = $(sysconfdir)/krb5.conf.d
+sssdkcmdatadir = $(datadir)/sssd-kcm
 
 if HAVE_SYSTEMD_UNIT
 ifp_exec_cmd = $(sssdlibexecdir)/sssd_ifp --uid 0 --gid 0 --debug-to-files --dbus-activated
@@ -189,7 +189,7 @@ sssdlibexec_PROGRAMS += sssd_secrets
 endif
 if BUILD_KCM
 sssdlibexec_PROGRAMS += sssd_kcm
-dist_krb5sysinclude_DATA = contrib/kcm_default_ccache
+dist_sssdkcmdata_DATA = contrib/kcm_default_ccache
 endif
 
 
@@ -4760,7 +4760,7 @@ if BUILD_SAMBA
 	mv $(DESTDIR)/$(winbindplugindir)/winbind_idmap_sss.so $(DESTDIR)/$(winbindplugindir)/sss.so
 endif
 if BUILD_KCM
-	$(MKDIR_P) $(DESTDIR)/$(krb5sysincludedir)
+	$(MKDIR_P) $(DESTDIR)/$(sssdkcmdatadir)
 endif
 
 uninstall-hook:

--- a/contrib/kcm_default_ccache
+++ b/contrib/kcm_default_ccache
@@ -2,11 +2,11 @@
 # directory that is included from the Kerberos configuration file (/etc/krb5.conf)
 # On Fedora/RHEL/CentOS, this is /etc/krb5.conf.d/
 #
-# To enable the KCM credential cache, uncomment the following lines and
-# enable the KCM socket and the service:
-#   systemctl enable sssd-kcm.socket
+# To enable the KCM credential cache enable the KCM socket and the service:
+#   systemctl enable sssd-secrets.socket sssd-kcm.socket
 #   systemctl start sssd-kcm.socket
-#   systemctl enable sssd-kcm.service
+#
+# To disable the KCM credential cache, comment out the following lines.
 
-#[libdefaults]
-#    default_ccache_name = KCM:
+[libdefaults]
+    default_ccache_name = KCM:

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -1264,8 +1264,8 @@ done
 %if (0%{?with_kcm} == 1)
 %files kcm
 %{_libexecdir}/%{servicename}/sssd_kcm
-%dir %{_sysconfdir}/krb5.conf.d
-%config(noreplace) %{_sysconfdir}/krb5.conf.d/kcm_default_ccache
+%dir %{_datadir}/sssd-kcm
+%{_datadir}/sssd-kcm/kcm_default_ccache
 %{_unitdir}/sssd-kcm.socket
 %{_unitdir}/sssd-kcm.service
 %{_mandir}/man8/sssd-kcm.8*


### PR DESCRIPTION
The file kcm_default_ccache must enable KCM ccache by default
without any modification of the file.

The patch also fixes few issues.
* /etc/krb5.conf.d is fedora/el7 specific and therefore should not
  be created by make. File will be installed to $datadir/sssd-kcm by
  default
* /etc/krb5.conf.d/ should not be owned by sssd-kcm because it is owned
  by dependency of sssd-kcm (krb5-libs)

  sh$ rpm -qf /etc/krb5.conf.d/
  sssd-kcm-1.15.3-0.20170411.0929.gitdbeae4834.fc26.x86_64
  krb5-libs-1.15.1-7.fc26.x86_64