### PR TITLE
filter_users and filter_groups stop working properly in v 1.15

### DIFF
--- a/src/responder/common/cache_req/cache_req_plugin.h
+++ b/src/responder/common/cache_req/cache_req_plugin.h
@@ -93,6 +93,18 @@ typedef errno_t
                            struct cache_req_data *data);
 
 /**
+ * Filter the result through the negative cache.
+ *
+ * This is useful for plugins which don't use name as an input
+ * token but can be affected by filter_users and filter_groups
+ * options.
+ */
+typedef errno_t
+(*cache_req_ncache_filter_fn)(struct sss_nc_ctx *ncache,
+                              struct sss_domain_info *domain,
+                              const char *name);
+
+/**
  * Add an object into global negative cache.
  *
  * @return EOK If everything went fine.
@@ -207,6 +219,7 @@ struct cache_req_plugin {
     cache_req_global_ncache_add_fn global_ncache_add_fn;
     cache_req_ncache_check_fn ncache_check_fn;
     cache_req_ncache_add_fn ncache_add_fn;
+    cache_req_ncache_filter_fn ncache_filter_fn;
     cache_req_lookup_fn lookup_fn;
     cache_req_dp_send_fn dp_send_fn;
     cache_req_dp_recv_fn dp_recv_fn;

--- a/src/responder/common/cache_req/cache_req_private.h
+++ b/src/responder/common/cache_req/cache_req_private.h
@@ -137,6 +137,11 @@ cache_req_create_and_add_result(TALLOC_CTX *mem_ctx,
                                 size_t *_num_results);
 
 struct ldb_result *
+cache_req_create_ldb_result_from_msg_list(TALLOC_CTX *mem_ctx,
+                                          struct ldb_message **ldb_msgs,
+                                          size_t ldb_msg_count);
+
+struct ldb_result *
 cache_req_create_ldb_result_from_msg(TALLOC_CTX *mem_ctx,
                                      struct ldb_message *ldb_msg);
 

--- a/src/responder/common/cache_req/cache_req_result.c
+++ b/src/responder/common/cache_req/cache_req_result.c
@@ -122,6 +122,41 @@ cache_req_create_and_add_result(TALLOC_CTX *mem_ctx,
 }
 
 struct ldb_result *
+cache_req_create_ldb_result_from_msg_list(TALLOC_CTX *mem_ctx,
+                                          struct ldb_message **ldb_msgs,
+                                          size_t ldb_msg_count)
+{
+    struct ldb_result *ldb_result;
+
+    if (ldb_msgs == NULL || ldb_msgs[0] == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "No message set!\n");
+        return NULL;
+    }
+
+    ldb_result = talloc_zero(NULL, struct ldb_result);
+    if (ldb_result == NULL) {
+        return NULL;
+    }
+
+    ldb_result->extended = NULL;
+    ldb_result->controls = NULL;
+    ldb_result->refs = NULL;
+    ldb_result->count = ldb_msg_count;
+    ldb_result->msgs = talloc_zero_array(ldb_result, struct ldb_message *,
+                                         ldb_msg_count + 1);
+    if (ldb_result->msgs == NULL) {
+        talloc_free(ldb_result);
+        return NULL;
+    }
+
+    for (size_t i = 0; i < ldb_msg_count; i++) {
+        ldb_result->msgs[i] = talloc_steal(ldb_result->msgs, ldb_msgs[i]);
+    }
+
+    return ldb_result;
+}
+
+struct ldb_result *
 cache_req_create_ldb_result_from_msg(TALLOC_CTX *mem_ctx,
                                      struct ldb_message *ldb_msg)
 {

--- a/src/responder/common/cache_req/cache_req_search.c
+++ b/src/responder/common/cache_req/cache_req_search.c
@@ -84,6 +84,87 @@ static void cache_req_search_ncache_add(struct cache_req *cr)
     return;
 }
 
+static errno_t cache_req_search_ncache_filter(TALLOC_CTX *mem_ctx,
+                                              struct cache_req *cr,
+                                              struct ldb_result *result,
+                                              struct ldb_result **_result)
+{
+    TALLOC_CTX *tmp_ctx;
+    struct ldb_result *filtered_result;
+    struct ldb_message **msgs;
+    size_t msg_count;
+    const char *name;
+    errno_t ret;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    if (cr->plugin->ncache_filter_fn == NULL) {
+        CACHE_REQ_DEBUG(SSSDBG_TRACE_FUNC, cr,
+                        "This request type does not support filtering "
+                        "result by negative cache\n");
+
+        *_result = talloc_steal(mem_ctx, result);
+
+        ret = EOK;
+        goto done;
+    }
+
+    CACHE_REQ_DEBUG(SSSDBG_TRACE_FUNC, cr,
+                    "Filtering out results by negative cache\n");
+
+    msgs = talloc_zero_array(tmp_ctx, struct ldb_message *, result->count);
+    msg_count = 0;
+
+    for (size_t i = 0; i < result->count; i++) {
+        name = sss_get_name_from_msg(cr->domain, result->msgs[i]);
+        if (name == NULL) {
+            CACHE_REQ_DEBUG(SSSDBG_CRIT_FAILURE, cr,
+                  "sss_get_name_from_msg() returned NULL, which should never "
+                  "happen in this scenario!\n");
+            ret = ERR_INTERNAL;
+            goto done;
+        }
+
+        ret = cr->plugin->ncache_filter_fn(cr->ncache, cr->domain, name);
+        if (ret == EEXIST) {
+            CACHE_REQ_DEBUG(SSSDBG_TRACE_FUNC, cr,
+                            "[%s] filtered out! (negative cache)\n",
+                            name);
+            continue;
+        } else if (ret != EOK && ret != ENOENT) {
+            CACHE_REQ_DEBUG(SSSDBG_CRIT_FAILURE, cr,
+                            "Unable to check negative cache [%d]: %s\n",
+                            ret, sss_strerror(ret));
+            goto done;
+        }
+
+        msgs[msg_count] = talloc_steal(msgs, result->msgs[i]);
+        msg_count++;
+    }
+
+    if (msg_count == 0) {
+        ret = ENOENT;
+        goto done;
+    }
+
+    filtered_result = cache_req_create_ldb_result_from_msg_list(tmp_ctx, msgs,
+                                                                msg_count);
+    if (filtered_result == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    *_result = talloc_steal(mem_ctx, filtered_result);
+    ret = EOK;
+
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
 static errno_t cache_req_search_cache(TALLOC_CTX *mem_ctx,
                                       struct cache_req *cr,
                                       struct ldb_result **_result)
@@ -338,9 +419,17 @@ static void cache_req_search_oob_done(struct tevent_req *subreq)
 
 static void cache_req_search_done(struct tevent_req *subreq)
 {
+    TALLOC_CTX *tmp_ctx;
     struct cache_req_search_state *state;
     struct tevent_req *req;
+    struct ldb_result *result = NULL;
     errno_t ret;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct cache_req_search_state);
@@ -349,22 +438,35 @@ static void cache_req_search_done(struct tevent_req *subreq)
     talloc_zfree(subreq);
 
     /* Get result from cache again. */
-    ret = cache_req_search_cache(state, state->cr, &state->result);
-    if (ret == ENOENT) {
-        /* Only store entry in negative cache if DP request succeeded
-         * because only then we know that the entry does not exist. */
-        if (state->dp_success) {
-            cache_req_search_ncache_add(state->cr);
+    ret = cache_req_search_cache(tmp_ctx, state->cr, &result);
+    if (ret != EOK) {
+        if (ret == ENOENT) {
+            /* Only store entry in negative cache if DP request succeeded
+             * because only then we know that the entry does not exist. */
+            if (state->dp_success) {
+                cache_req_search_ncache_add(state->cr);
+            }
         }
-        tevent_req_error(req, ENOENT);
-        return;
-    } else if (ret != EOK) {
-        tevent_req_error(req, ret);
-        return;
+        goto done;
+    }
+
+    /* ret == EOK */
+    ret = cache_req_search_ncache_filter(state, state->cr, result,
+                                         &state->result);
+    if (ret != EOK) {
+        goto done;
     }
 
     CACHE_REQ_DEBUG(SSSDBG_TRACE_FUNC, state->cr,
                     "Returning updated object [%s]\n", state->cr->debugobj);
+
+done:
+    talloc_free(tmp_ctx);
+
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
 
     tevent_req_done(req);
     return;

--- a/src/responder/common/cache_req/plugins/cache_req_enum_groups.c
+++ b/src/responder/common/cache_req/plugins/cache_req_enum_groups.c
@@ -75,6 +75,7 @@ const struct cache_req_plugin cache_req_enum_groups = {
     .global_ncache_add_fn = NULL,
     .ncache_check_fn = NULL,
     .ncache_add_fn = NULL,
+    .ncache_filter_fn = NULL,
     .lookup_fn = cache_req_enum_groups_lookup,
     .dp_send_fn = cache_req_enum_groups_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_enum_groups.c
+++ b/src/responder/common/cache_req/plugins/cache_req_enum_groups.c
@@ -55,6 +55,14 @@ cache_req_enum_groups_dp_send(TALLOC_CTX *mem_ctx,
                                    SSS_DP_GROUP, NULL, 0, NULL);
 }
 
+static errno_t
+cache_req_enum_groups_ncache_filter(struct sss_nc_ctx *ncache,
+                                    struct sss_domain_info *domain,
+                                    const char *name)
+{
+    return sss_ncache_check_group(ncache, domain, name);
+}
+
 const struct cache_req_plugin cache_req_enum_groups = {
     .name = "Enumerate groups",
     .attr_expiration = SYSDB_CACHE_EXPIRE,
@@ -75,7 +83,7 @@ const struct cache_req_plugin cache_req_enum_groups = {
     .global_ncache_add_fn = NULL,
     .ncache_check_fn = NULL,
     .ncache_add_fn = NULL,
-    .ncache_filter_fn = NULL,
+    .ncache_filter_fn = cache_req_enum_groups_ncache_filter,
     .lookup_fn = cache_req_enum_groups_lookup,
     .dp_send_fn = cache_req_enum_groups_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_enum_svc.c
+++ b/src/responder/common/cache_req/plugins/cache_req_enum_svc.c
@@ -76,6 +76,7 @@ const struct cache_req_plugin cache_req_enum_svc = {
     .global_ncache_add_fn = NULL,
     .ncache_check_fn = NULL,
     .ncache_add_fn = NULL,
+    .ncache_filter_fn = NULL,
     .lookup_fn = cache_req_enum_svc_lookup,
     .dp_send_fn = cache_req_enum_svc_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_enum_users.c
+++ b/src/responder/common/cache_req/plugins/cache_req_enum_users.c
@@ -75,6 +75,7 @@ const struct cache_req_plugin cache_req_enum_users = {
     .global_ncache_add_fn = NULL,
     .ncache_check_fn = NULL,
     .ncache_add_fn = NULL,
+    .ncache_filter_fn = NULL,
     .lookup_fn = cache_req_enum_users_lookup,
     .dp_send_fn = cache_req_enum_users_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_enum_users.c
+++ b/src/responder/common/cache_req/plugins/cache_req_enum_users.c
@@ -55,6 +55,14 @@ cache_req_enum_users_dp_send(TALLOC_CTX *mem_ctx,
                                    SSS_DP_USER, NULL, 0, NULL);
 }
 
+static errno_t
+cache_req_enum_users_ncache_filter(struct sss_nc_ctx *ncache,
+                                   struct sss_domain_info *domain,
+                                   const char *name)
+{
+    return sss_ncache_check_user(ncache, domain, name);
+}
+
 const struct cache_req_plugin cache_req_enum_users = {
     .name = "Enumerate users",
     .attr_expiration = SYSDB_CACHE_EXPIRE,
@@ -75,7 +83,7 @@ const struct cache_req_plugin cache_req_enum_users = {
     .global_ncache_add_fn = NULL,
     .ncache_check_fn = NULL,
     .ncache_add_fn = NULL,
-    .ncache_filter_fn = NULL,
+    .ncache_filter_fn = cache_req_enum_users_ncache_filter,
     .lookup_fn = cache_req_enum_users_lookup,
     .dp_send_fn = cache_req_enum_users_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_group_by_filter.c
+++ b/src/responder/common/cache_req/plugins/cache_req_group_by_filter.c
@@ -131,6 +131,7 @@ const struct cache_req_plugin cache_req_group_by_filter = {
     .global_ncache_add_fn = NULL,
     .ncache_check_fn = NULL,
     .ncache_add_fn = NULL,
+    .ncache_filter_fn = NULL,
     .lookup_fn = cache_req_group_by_filter_lookup,
     .dp_send_fn = cache_req_group_by_filter_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_group_by_id.c
+++ b/src/responder/common/cache_req/plugins/cache_req_group_by_id.c
@@ -43,6 +43,14 @@ cache_req_group_by_id_ncache_check(struct sss_nc_ctx *ncache,
 }
 
 static errno_t
+cache_req_group_by_id_ncache_filter(struct sss_nc_ctx *ncache,
+                                    struct sss_domain_info *domain,
+                                    const char *name)
+{
+    return sss_ncache_check_group(ncache, domain, name);
+}
+
+static errno_t
 cache_req_group_by_id_global_ncache_add(struct sss_nc_ctx *ncache,
                                         struct cache_req_data *data)
 {
@@ -144,7 +152,7 @@ const struct cache_req_plugin cache_req_group_by_id = {
     .global_ncache_add_fn = cache_req_group_by_id_global_ncache_add,
     .ncache_check_fn = cache_req_group_by_id_ncache_check,
     .ncache_add_fn = NULL,
-    .ncache_filter_fn = NULL,
+    .ncache_filter_fn = cache_req_group_by_id_ncache_filter,
     .lookup_fn = cache_req_group_by_id_lookup,
     .dp_send_fn = cache_req_group_by_id_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_group_by_id.c
+++ b/src/responder/common/cache_req/plugins/cache_req_group_by_id.c
@@ -144,6 +144,7 @@ const struct cache_req_plugin cache_req_group_by_id = {
     .global_ncache_add_fn = cache_req_group_by_id_global_ncache_add,
     .ncache_check_fn = cache_req_group_by_id_ncache_check,
     .ncache_add_fn = NULL,
+    .ncache_filter_fn = NULL,
     .lookup_fn = cache_req_group_by_id_lookup,
     .dp_send_fn = cache_req_group_by_id_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_group_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_group_by_name.c
@@ -194,6 +194,7 @@ const struct cache_req_plugin cache_req_group_by_name = {
     .global_ncache_add_fn = NULL,
     .ncache_check_fn = cache_req_group_by_name_ncache_check,
     .ncache_add_fn = cache_req_group_by_name_ncache_add,
+    .ncache_filter_fn = NULL,
     .lookup_fn = cache_req_group_by_name_lookup,
     .dp_send_fn = cache_req_group_by_name_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_host_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_host_by_name.c
@@ -92,6 +92,7 @@ const struct cache_req_plugin cache_req_host_by_name = {
     .global_ncache_add_fn = NULL,
     .ncache_check_fn = NULL,
     .ncache_add_fn = NULL,
+    .ncache_filter_fn = NULL,
     .lookup_fn = cache_req_host_by_name_lookup,
     .dp_send_fn = cache_req_host_by_name_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_initgroups_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_initgroups_by_name.c
@@ -209,6 +209,7 @@ const struct cache_req_plugin cache_req_initgroups_by_name = {
     .global_ncache_add_fn = NULL,
     .ncache_check_fn = cache_req_initgroups_by_name_ncache_check,
     .ncache_add_fn = cache_req_initgroups_by_name_ncache_add,
+    .ncache_filter_fn = NULL,
     .lookup_fn = cache_req_initgroups_by_name_lookup,
     .dp_send_fn = cache_req_initgroups_by_name_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_initgroups_by_upn.c
+++ b/src/responder/common/cache_req/plugins/cache_req_initgroups_by_upn.c
@@ -120,6 +120,7 @@ const struct cache_req_plugin cache_req_initgroups_by_upn = {
     .global_ncache_add_fn = NULL,
     .ncache_check_fn = cache_req_initgroups_by_upn_ncache_check,
     .ncache_add_fn = cache_req_initgroups_by_upn_ncache_add,
+    .ncache_filter_fn = NULL,
     .lookup_fn = cache_req_initgroups_by_upn_lookup,
     .dp_send_fn = cache_req_initgroups_by_upn_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_netgroup_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_netgroup_by_name.c
@@ -128,6 +128,7 @@ const struct cache_req_plugin cache_req_netgroup_by_name = {
     .global_ncache_add_fn = NULL,
     .ncache_check_fn = cache_req_netgroup_by_name_ncache_check,
     .ncache_add_fn = cache_req_netgroup_by_name_ncache_add,
+    .ncache_filter_fn = NULL,
     .lookup_fn = cache_req_netgroup_by_name_lookup,
     .dp_send_fn = cache_req_netgroup_by_name_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_object_by_id.c
+++ b/src/responder/common/cache_req/plugins/cache_req_object_by_id.c
@@ -50,6 +50,21 @@ cache_req_object_by_id_ncache_check(struct sss_nc_ctx *ncache,
 }
 
 static errno_t
+cache_req_object_by_id_ncache_filter(struct sss_nc_ctx *ncache,
+                                     struct sss_domain_info *domain,
+                                     const char *name)
+{
+    errno_t ret;
+
+    ret = sss_ncache_check_user(ncache, domain, name);
+    if (ret == EEXIST) {
+        ret = sss_ncache_check_group(ncache, domain, name);
+    }
+
+    return ret;
+}
+
+static errno_t
 cache_req_object_by_id_global_ncache_add(struct sss_nc_ctx *ncache,
                                          struct cache_req_data *data)
 {
@@ -111,7 +126,7 @@ const struct cache_req_plugin cache_req_object_by_id = {
     .global_ncache_add_fn = cache_req_object_by_id_global_ncache_add,
     .ncache_check_fn = cache_req_object_by_id_ncache_check,
     .ncache_add_fn = NULL,
-    .ncache_filter_fn = NULL,
+    .ncache_filter_fn = cache_req_object_by_id_ncache_filter,
     .lookup_fn = cache_req_object_by_id_lookup,
     .dp_send_fn = cache_req_object_by_id_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_object_by_id.c
+++ b/src/responder/common/cache_req/plugins/cache_req_object_by_id.c
@@ -111,6 +111,7 @@ const struct cache_req_plugin cache_req_object_by_id = {
     .global_ncache_add_fn = cache_req_object_by_id_global_ncache_add,
     .ncache_check_fn = cache_req_object_by_id_ncache_check,
     .ncache_add_fn = NULL,
+    .ncache_filter_fn = NULL,
     .lookup_fn = cache_req_object_by_id_lookup,
     .dp_send_fn = cache_req_object_by_id_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_object_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_object_by_name.c
@@ -204,6 +204,7 @@ const struct cache_req_plugin cache_req_object_by_name = {
     .global_ncache_add_fn = NULL,
     .ncache_check_fn = cache_req_object_by_name_ncache_check,
     .ncache_add_fn = cache_req_object_by_name_ncache_add,
+    .ncache_filter_fn = NULL,
     .lookup_fn = cache_req_object_by_name_lookup,
     .dp_send_fn = cache_req_object_by_name_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_object_by_sid.c
+++ b/src/responder/common/cache_req/plugins/cache_req_object_by_sid.c
@@ -120,6 +120,7 @@ const struct cache_req_plugin cache_req_object_by_sid = {
     .global_ncache_add_fn = cache_req_object_by_sid_global_ncache_add,
     .ncache_check_fn = cache_req_object_by_sid_ncache_check,
     .ncache_add_fn = NULL,
+    .ncache_filter_fn = NULL,
     .lookup_fn = cache_req_object_by_sid_lookup,
     .dp_send_fn = cache_req_object_by_sid_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_svc_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_svc_by_name.c
@@ -152,6 +152,7 @@ const struct cache_req_plugin cache_req_svc_by_name = {
     .global_ncache_add_fn = NULL,
     .ncache_check_fn = cache_req_svc_by_name_ncache_check,
     .ncache_add_fn = cache_req_svc_by_name_ncache_add,
+    .ncache_filter_fn = NULL,
     .lookup_fn = cache_req_svc_by_name_lookup,
     .dp_send_fn = cache_req_svc_by_name_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_svc_by_port.c
+++ b/src/responder/common/cache_req/plugins/cache_req_svc_by_port.c
@@ -125,6 +125,7 @@ const struct cache_req_plugin cache_req_svc_by_port = {
     .global_ncache_add_fn = NULL,
     .ncache_check_fn = cache_req_svc_by_port_ncache_check,
     .ncache_add_fn = cache_req_svc_by_port_ncache_add,
+    .ncache_filter_fn = NULL,
     .lookup_fn = cache_req_svc_by_port_lookup,
     .dp_send_fn = cache_req_svc_by_port_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_user_by_cert.c
+++ b/src/responder/common/cache_req/plugins/cache_req_user_by_cert.c
@@ -94,6 +94,7 @@ const struct cache_req_plugin cache_req_user_by_cert = {
     .global_ncache_add_fn = cache_req_user_by_cert_global_ncache_add,
     .ncache_check_fn = cache_req_user_by_cert_ncache_check,
     .ncache_add_fn = NULL,
+    .ncache_filter_fn = NULL,
     .lookup_fn = cache_req_user_by_cert_lookup,
     .dp_send_fn = cache_req_user_by_cert_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_user_by_filter.c
+++ b/src/responder/common/cache_req/plugins/cache_req_user_by_filter.c
@@ -131,6 +131,7 @@ const struct cache_req_plugin cache_req_user_by_filter = {
     .global_ncache_add_fn = NULL,
     .ncache_check_fn = NULL,
     .ncache_add_fn = NULL,
+    .ncache_filter_fn = NULL,
     .lookup_fn = cache_req_user_by_filter_lookup,
     .dp_send_fn = cache_req_user_by_filter_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_user_by_id.c
+++ b/src/responder/common/cache_req/plugins/cache_req_user_by_id.c
@@ -144,6 +144,7 @@ const struct cache_req_plugin cache_req_user_by_id = {
     .global_ncache_add_fn = cache_req_user_by_id_global_ncache_add,
     .ncache_check_fn = cache_req_user_by_id_ncache_check,
     .ncache_add_fn = NULL,
+    .ncache_filter_fn = NULL,
     .lookup_fn = cache_req_user_by_id_lookup,
     .dp_send_fn = cache_req_user_by_id_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_user_by_id.c
+++ b/src/responder/common/cache_req/plugins/cache_req_user_by_id.c
@@ -43,6 +43,14 @@ cache_req_user_by_id_ncache_check(struct sss_nc_ctx *ncache,
 }
 
 static errno_t
+cache_req_user_by_id_ncache_filter(struct sss_nc_ctx *ncache,
+                                   struct sss_domain_info *domain,
+                                   const char *name)
+{
+    return sss_ncache_check_user(ncache, domain, name);
+}
+
+static errno_t
 cache_req_user_by_id_global_ncache_add(struct sss_nc_ctx *ncache,
                                        struct cache_req_data *data)
 {
@@ -144,7 +152,7 @@ const struct cache_req_plugin cache_req_user_by_id = {
     .global_ncache_add_fn = cache_req_user_by_id_global_ncache_add,
     .ncache_check_fn = cache_req_user_by_id_ncache_check,
     .ncache_add_fn = NULL,
-    .ncache_filter_fn = NULL,
+    .ncache_filter_fn = cache_req_user_by_id_ncache_filter,
     .lookup_fn = cache_req_user_by_id_lookup,
     .dp_send_fn = cache_req_user_by_id_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_user_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_user_by_name.c
@@ -199,6 +199,7 @@ const struct cache_req_plugin cache_req_user_by_name = {
     .global_ncache_add_fn = NULL,
     .ncache_check_fn = cache_req_user_by_name_ncache_check,
     .ncache_add_fn = cache_req_user_by_name_ncache_add,
+    .ncache_filter_fn = NULL,
     .lookup_fn = cache_req_user_by_name_lookup,
     .dp_send_fn = cache_req_user_by_name_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/common/cache_req/plugins/cache_req_user_by_upn.c
+++ b/src/responder/common/cache_req/plugins/cache_req_user_by_upn.c
@@ -125,6 +125,7 @@ const struct cache_req_plugin cache_req_user_by_upn = {
     .global_ncache_add_fn = NULL,
     .ncache_check_fn = cache_req_user_by_upn_ncache_check,
     .ncache_add_fn = cache_req_user_by_upn_ncache_add,
+    .ncache_filter_fn = NULL,
     .lookup_fn = cache_req_user_by_upn_lookup,
     .dp_send_fn = cache_req_user_by_upn_dp_send,
     .dp_recv_fn = cache_req_common_dp_recv

--- a/src/responder/nss/nss_protocol_grent.c
+++ b/src/responder/nss/nss_protocol_grent.c
@@ -41,7 +41,7 @@ nss_get_grent(TALLOC_CTX *mem_ctx,
     }
 
     /* Get fields. */
-    name = nss_get_name_from_msg(domain, msg);
+    name = sss_get_name_from_msg(domain, msg);
     gid = sss_view_ldb_msg_find_attr_as_uint64(domain, msg, SYSDB_GIDNUM, 0);
 
     if (name == NULL || gid == 0) {

--- a/src/responder/nss/nss_protocol_grent.c
+++ b/src/responder/nss/nss_protocol_grent.c
@@ -241,18 +241,6 @@ nss_protocol_fill_grent(struct nss_ctx *nss_ctx,
             continue;
         }
 
-        /* Check negative cache during enumeration. */
-        if (cmd_ctx->enumeration) {
-            ret = sss_ncache_check_group(nss_ctx->rctx->ncache,
-                                         result->domain, name->str);
-            if (ret == EEXIST) {
-                DEBUG(SSSDBG_TRACE_FUNC,
-                      "User [%s] filtered out! (negative cache)\n",
-                      name->str);
-                continue;
-            }
-        }
-
         /* Adjust packet size: gid, num_members + string fields. */
 
         ret = sss_packet_grow(packet, 2 * sizeof(uint32_t)

--- a/src/responder/nss/nss_protocol_pwent.c
+++ b/src/responder/nss/nss_protocol_pwent.c
@@ -309,17 +309,6 @@ nss_protocol_fill_pwent(struct nss_ctx *nss_ctx,
             continue;
         }
 
-        /* Check negative cache during enumeration. */
-        if (cmd_ctx->enumeration) {
-            ret = sss_ncache_check_user(nss_ctx->rctx->ncache,
-                                        result->domain, name->str);
-            if (ret == EEXIST) {
-                DEBUG(SSSDBG_TRACE_FUNC,
-                      "User [%s] filtered out! (negative cache)\n", name->str);
-                continue;
-            }
-        }
-
         /* Adjust packet size: uid, gid + string fields. */
 
         ret = sss_packet_grow(packet, 2 * sizeof(uint32_t)

--- a/src/responder/nss/nss_protocol_pwent.c
+++ b/src/responder/nss/nss_protocol_pwent.c
@@ -225,7 +225,7 @@ nss_get_pwent(TALLOC_CTX *mem_ctx,
 
     /* Get fields. */
     upn = ldb_msg_find_attr_as_string(msg, SYSDB_UPN, NULL);
-    name = nss_get_name_from_msg(domain, msg);
+    name = sss_get_name_from_msg(domain, msg);
     gid = nss_get_gid(domain, msg);
     uid = sss_view_ldb_msg_find_attr_as_uint64(domain, msg, SYSDB_UIDNUM, 0);
 

--- a/src/responder/nss/nss_protocol_sid.c
+++ b/src/responder/nss/nss_protocol_sid.c
@@ -532,7 +532,7 @@ nss_protocol_fill_name_list(struct nss_ctx *nss_ctx,
             return ret;
         }
 
-        tmp_str = nss_get_name_from_msg(result->domain, result->msgs[c]);
+        tmp_str = sss_get_name_from_msg(result->domain, result->msgs[c]);
         if (tmp_str == NULL) {
             return EINVAL;
         }

--- a/src/responder/nss/nss_utils.c
+++ b/src/responder/nss/nss_utils.c
@@ -27,33 +27,6 @@
 #include "responder/nss/nss_private.h"
 
 const char *
-nss_get_name_from_msg(struct sss_domain_info *domain,
-                      struct ldb_message *msg)
-{
-    const char *name;
-
-    /* If domain has a view associated we return overridden name
-     * if possible. */
-    if (DOM_HAS_VIEWS(domain)) {
-        name = ldb_msg_find_attr_as_string(msg, OVERRIDE_PREFIX SYSDB_NAME,
-                                           NULL);
-        if (name != NULL) {
-            return name;
-        }
-    }
-
-    /* Otherwise we try to return name override from
-     * Default Truest View for trusted users. */
-    name = ldb_msg_find_attr_as_string(msg, SYSDB_DEFAULT_OVERRIDE_NAME, NULL);
-    if (name != NULL) {
-        return name;
-    }
-
-    /* If no override is found we return the original name. */
-    return ldb_msg_find_attr_as_string(msg, SYSDB_NAME, NULL);
-}
-
-const char *
 nss_get_pwfield(struct nss_ctx *nctx,
                struct sss_domain_info *dom)
 {

--- a/src/tests/intg/test_ldap.py
+++ b/src/tests/intg/test_ldap.py
@@ -980,3 +980,99 @@ def rfc2307bis_no_nesting(request, ldap_conn):
 def test_zero_nesting_level(ldap_conn, rfc2307bis_no_nesting):
     ent.assert_group_by_name("group1",
                              dict(mem=ent.contains_only("user1")))
+
+
+@pytest.fixture
+def sanity_nss_filter(request, ldap_conn):
+    ent_list = ldap_ent.List(ldap_conn.ds_inst.base_dn)
+    ent_list.add_user("user1", 1001, 2001)
+    ent_list.add_user("user2", 1002, 2002)
+    ent_list.add_user("user3", 1003, 2003)
+
+    ent_list.add_group_bis("group1", 2001)
+    ent_list.add_group_bis("group2", 2002)
+    ent_list.add_group_bis("group3", 2003)
+
+    ent_list.add_group_bis("empty_group1", 2010)
+    ent_list.add_group_bis("empty_group2", 2011)
+
+    ent_list.add_group_bis("two_user_group", 2012, ["user1", "user2"])
+    ent_list.add_group_bis("group_empty_group", 2013, [], ["empty_group1"])
+    ent_list.add_group_bis("group_two_empty_groups", 2014,
+                           [], ["empty_group1", "empty_group2"])
+    ent_list.add_group_bis("one_user_group1", 2015, ["user1"])
+    ent_list.add_group_bis("one_user_group2", 2016, ["user2"])
+    ent_list.add_group_bis("group_one_user_group", 2017,
+                           [], ["one_user_group1"])
+    ent_list.add_group_bis("group_two_user_group", 2018,
+                           [], ["two_user_group"])
+    ent_list.add_group_bis("group_two_one_user_groups", 2019,
+                           [], ["one_user_group1", "one_user_group2"])
+
+    create_ldap_fixture(request, ldap_conn, ent_list)
+    conf = format_basic_conf(ldap_conn, SCHEMA_RFC2307_BIS) + \
+        unindent("""
+            [nss]
+            filter_users = user2
+            filter_groups = group_two_one_user_groups
+        """).format(**locals())
+    create_conf_fixture(request, conf)
+    create_sssd_fixture(request)
+    return None
+
+
+def test_nss_filters(ldap_conn, sanity_nss_filter):
+    passwd_pattern = expected_list_to_name_dict([
+        dict(name='user1', passwd='*', uid=1001, gid=2001, gecos='1001',
+             dir='/home/user1', shell='/bin/bash'),
+        dict(name='user3', passwd='*', uid=1003, gid=2003, gecos='1003',
+             dir='/home/user3', shell='/bin/bash')
+    ])
+
+    # test filtered user
+    ent.assert_each_passwd_by_name(passwd_pattern)
+    with pytest.raises(KeyError):
+        pwd.getpwnam("user2")
+    with pytest.raises(KeyError):
+        pwd.getpwuid(1002)
+
+    group_pattern = expected_list_to_name_dict([
+        dict(name='group1', passwd='*', gid=2001, mem=ent.contains_only()),
+        dict(name='group2', passwd='*', gid=2002, mem=ent.contains_only()),
+        dict(name='group3', passwd='*', gid=2003, mem=ent.contains_only()),
+        dict(name='empty_group1', passwd='*', gid=2010,
+             mem=ent.contains_only()),
+        dict(name='empty_group2', passwd='*', gid=2011,
+             mem=ent.contains_only()),
+        dict(name='two_user_group', passwd='*', gid=2012,
+             mem=ent.contains_only("user1")),
+        dict(name='group_empty_group', passwd='*', gid=2013,
+             mem=ent.contains_only()),
+        dict(name='group_two_empty_groups', passwd='*', gid=2014,
+             mem=ent.contains_only()),
+        dict(name='one_user_group1', passwd='*', gid=2015,
+             mem=ent.contains_only("user1")),
+        dict(name='one_user_group2', passwd='*', gid=2016,
+             mem=ent.contains_only()),
+        dict(name='group_one_user_group', passwd='*', gid=2017,
+             mem=ent.contains_only("user1")),
+        dict(name='group_two_user_group', passwd='*', gid=2018,
+             mem=ent.contains_only("user1")),
+    ])
+
+    # test filtered group
+    ent.assert_each_group_by_name(group_pattern)
+    with pytest.raises(KeyError):
+        grp.getgrnam("group_two_one_user_groups")
+    with pytest.raises(KeyError):
+        grp.getgrgid(2019)
+
+    # test non-existing user/group
+    with pytest.raises(KeyError):
+        pwd.getpwnam("non_existent_user")
+    with pytest.raises(KeyError):
+        pwd.getpwuid(9)
+    with pytest.raises(KeyError):
+        grp.getgrnam("non_existent_group")
+    with pytest.raises(KeyError):
+        grp.getgrgid(14)

--- a/src/util/usertools.c
+++ b/src/util/usertools.c
@@ -816,3 +816,70 @@ done:
     talloc_free(tmp_ctx);
     return outname;
 }
+
+const char *
+sss_get_name_from_msg(struct sss_domain_info *domain,
+                      struct ldb_message *msg)
+{
+    const char *name;
+
+    /* If domain has a view associated we return overridden name
+     * if possible. */
+    if (DOM_HAS_VIEWS(domain)) {
+        name = ldb_msg_find_attr_as_string(msg, OVERRIDE_PREFIX SYSDB_NAME,
+                                           NULL);
+        if (name != NULL) {
+            return name;
+        }
+    }
+
+    /* Otherwise we try to return name override from
+     * Default Truest View for trusted users. */
+    name = ldb_msg_find_attr_as_string(msg, SYSDB_DEFAULT_OVERRIDE_NAME, NULL);
+    if (name != NULL) {
+        return name;
+    }
+
+    /* If no override is found we return the original name. */
+    return ldb_msg_find_attr_as_string(msg, SYSDB_NAME, NULL);
+}
+
+int sss_output_fqname(TALLOC_CTX *mem_ctx,
+                      struct sss_domain_info *domain,
+                      const char *name,
+                      char override_space,
+                      char **_output_name)
+{
+    TALLOC_CTX *tmp_ctx = NULL;
+    errno_t ret;
+    char *output_name;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    output_name = sss_output_name(tmp_ctx, name, domain->case_preserve,
+                                  override_space);
+    if (output_name == NULL) {
+        ret = EIO;
+        goto done;
+    }
+
+    if (domain->fqnames) {
+        output_name = sss_tc_fqname(tmp_ctx, domain->names,
+                                    domain, output_name);
+        if (output_name == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "sss_tc_fqname failed\n");
+            ret = EIO;
+            goto done;
+        }
+    }
+
+    *_output_name = talloc_steal(mem_ctx, output_name);
+    ret = EOK;
+done:
+    talloc_zfree(tmp_ctx);
+    return ret;
+}

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -304,6 +304,15 @@ char *sss_output_name(TALLOC_CTX *mem_ctx,
                       bool case_sensitive,
                       const char replace_space);
 
+int sss_output_fqname(TALLOC_CTX *mem_ctx,
+                      struct sss_domain_info *domain,
+                      const char *name,
+                      char override_space,
+                      char **_output_name);
+
+const char *sss_get_name_from_msg(struct sss_domain_info *domain,
+                                  struct ldb_message *msg);
+
 /* from backup-file.c */
 int backup_file(const char *src, int dbglvl);
 


### PR DESCRIPTION
This patchset fix the issue reported on https://pagure.io/SSSD/sssd/issue/3362.

@pbrezina suggested to do the changes in a new cache_req module, but I'm really not sure whether we want to have NSS specific code (like nss_get_pwent() and nss_get_grent() calls) there.

For now I'm leaving this as it was before the nss/cache_req refactoring.