### PR TITLE
Subdomain inherit

### DIFF
--- a/src/db/sysdb_subdomains.c
+++ b/src/db/sysdb_subdomains.c
@@ -218,6 +218,22 @@ check_subdom_config_file(struct confdb_ctx *confdb,
           sd_conf_path, CONFDB_DOMAIN_FQ,
           subdomain->fqnames ? "TRUE" : "FALSE");
 
+
+    /* ignore_group_members */
+    ret = confdb_get_bool(confdb, sd_conf_path,
+                          CONFDB_DOMAIN_IGNORE_GROUP_MEMBERS,
+                          false, &subdomain->ignore_group_members);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Failed to get %s option for the subdomain: %s\n",
+              CONFDB_DOMAIN_FQ, subdomain->name);
+        goto done;
+    }
+
+    DEBUG(SSSDBG_CONF_SETTINGS, "%s/%s has value %s\n",
+          sd_conf_path, CONFDB_DOMAIN_IGNORE_GROUP_MEMBERS,
+          subdomain->ignore_group_members ? "TRUE" : "FALSE");
+
     ret = EOK;
 done:
     talloc_free(tmp_ctx);

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2923,7 +2923,12 @@ ldap_user_extra_attrs = phone:telephoneNumber
             <para>ad_server,</para>
             <para>ad_backup_server,</para>
             <para>ad_site,</para>
-            <para>use_fully_qualified_names</para>
+            <para>use_fully_qualified_names,</para>
+            <para>ignore_group_members,</para>
+            <para>ldap_purge_cache_timeout,</para>
+            <para>ldap_use_tokengroups,</para>
+            <para>ldap_user_principal.</para>
+
         <para>
             For more details about these options see their individual description
             in the manual page.


### PR DESCRIPTION
I tested if the options that work in subdomain inherit also work in trusted domain section in sssd.conf. Most seem to work without any changes in the code except for two. With these two patches only one that does not work remains (I wanted to send patchset that adds all the options, but I got stuck on the option that sets the ldap principal, so I am sending this in the meantime).