### PR TITLE
IPA: Improve s2n debug message for missing ipaNTSecurityIdentifier

### DIFF
--- a/src/providers/ipa/ipa_s2n_exop.c
+++ b/src/providers/ipa/ipa_s2n_exop.c
@@ -2580,7 +2580,13 @@ static errno_t ipa_s2n_save_objects(struct sss_domain_info *dom,
     ret = sysdb_attrs_get_string(attrs->sysdb_attrs, SYSDB_SID_STR, &sid_str);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "Cannot find SID of object with override.\n");
+              "Cannot find SID of object.\n");
+        if (name != NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Object [%s] has no SID, please check the "
+                  "ipaNTSecurityIdentifier attribute on the server-side.\n",
+                  name);
+        }
         goto done;
     }
 


### PR DESCRIPTION
This patch is piggybacking off of `https://github.com/SSSD/sssd/pull/242` for a similar issue 
that occurred downstream.

This patch improves the log message to be more information for
the SSSD user troubleshooting issues.

If the IDM POSIX group used for AD trust HBAC/SUDO operation is missing
the ipaNTSecurityIdentifier it can cause client s2n operations failures
resolving the group which resulted in the inability to login for the AD
user.