### PR TITLE
DP: Reduce Data Provider log level noise

### DIFF
--- a/src/providers/data_provider/dp_methods.c
+++ b/src/providers/data_provider/dp_methods.c
@@ -109,7 +109,7 @@ errno_t dp_find_method(struct data_provider *provider,
     }
 
     if (!dp_target_initialized(provider->targets, target)) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Target [%s] is not initialized\n",
+        DEBUG(SSSDBG_CONF_SETTINGS, "Target [%s] is not initialized\n",
               dp_target_to_string(target));
         return ERR_MISSING_DP_TARGET;
     }

--- a/src/providers/data_provider/dp_targets.c
+++ b/src/providers/data_provider/dp_targets.c
@@ -284,7 +284,7 @@ static errno_t dp_target_init(struct be_ctx *be_ctx,
     if (!target->explicitly_configured && (ret == ELIBBAD || ret == ENOTSUP)) {
         /* Target not found but it wasn't explicitly
          * configured so we shall just continue. */
-        DEBUG(SSSDBG_CRIT_FAILURE, "Target [%s] is not supported by "
+        DEBUG(SSSDBG_CONF_SETTINGS, "Target [%s] is not supported by "
               "module [%s].\n", target->name, target->module_name);
         ret = EOK;
         goto done;

--- a/src/responder/common/responder_dp.c
+++ b/src/responder/common/responder_dp.c
@@ -218,8 +218,17 @@ static int sss_dp_get_reply(DBusPendingCall *pending,
             err = ETIME;
             goto done;
         }
-        DEBUG(SSSDBG_FATAL_FAILURE,"The Data Provider returned an error [%s]\n",
-                 dbus_message_get_error_name(reply));
+
+        if (strcmp(dbus_message_get_error_name(reply),
+                   SBUS_ERROR_DP_NOTSUP) == 0) {
+            DEBUG(SSSDBG_CONF_SETTINGS,
+                  "Data Provider does not support this operation.\n");
+        } else {
+            DEBUG(SSSDBG_FATAL_FAILURE,
+                  "The Data Provider returned an error [%s]\n",
+                  dbus_message_get_error_name(reply));
+        }
+
         /* Falling through to default intentionally*/
         SSS_ATTRIBUTE_FALLTHROUGH;
     default:


### PR DESCRIPTION

Certain operations are not supported with certain providers
causing informational Data Provider log messages to be logged as
errors or failures. This patch lowers the log level to reduce overall
log noise and ensure only critical log messages are logged when
a low debug_level value is used.

Resolves:
https://pagure.io/SSSD/sssd/issue/3287
https://pagure.io/SSSD/sssd/issue/3278

Tested with the LDAP provider changing ``debug_level``
between 7 and 1 then checking for log messages:

* Before patch with **debug_level=1**
```
# egrep 'dp_find_method|dp_target_init|Data Provider returned' /var/log/sssd/*
[dp_target_init] (0x0020): Target [selinux] is not supported by module [ldap].
[dp_target_init] (0x0020): Target [hostid] is not supported by module [ldap].
[dp_target_init] (0x0020): Target [subdomains] is not supported by module [ldap].
[dp_find_method] (0x0020): Target [subdomains] is not initialized
[dp_find_method] (0x0020): Target [subdomains] is not initialized
[dp_find_method] (0x0020): Target [subdomains] is not initialized
[dp_find_method] (0x0020): Target [subdomains] is not initialized
[sss_dp_get_reply] (0x0010): The Data Provider returned an error [org.freedesktop.sssd.Error.DataProvider.NotSupported]
[sss_dp_get_reply] (0x0010): The Data Provider returned an error [org.freedesktop.sssd.Error.DataProvider.NotSupported]
[sss_dp_get_reply] (0x0010): The Data Provider returned an error [org.freedesktop.sssd.Error.DataProvider.NotSupported]
[sss_dp_get_reply] (0x0010): The Data Provider returned an error [org.freedesktop.sssd.Error.DataProvider.NotSupported]
```

* After patch with **debug_level=1**
```
# egrep 'dp_find_method|dp_target_init|Data Provider returned' /var/log/sssd/*
#

```