### PR TITLE
Just a few small fixes

### DIFF
--- a/contrib/fedora/bashrc_sssd
+++ b/contrib/fedora/bashrc_sssd
@@ -104,7 +104,8 @@ warn()
 # and making sure that the NSS and PAM modules have the right SELinux context.
 sssinstall()
 {
-    sudo make -j$PROCESSORS install \
+    # Force single-thread install to workaround concurrency issues
+    sudo make -j1 install \
         && sudo rm -f $SSS_LIBDIR/ldb/modules/ldb/memberof.la \
         && sudo restorecon -v /$SSS_LIB/libnss_sss.so.2 \
                               /$SSS_LIB/security/pam_sss.so

--- a/src/providers/ldap/sdap_async_initgroups.c
+++ b/src/providers/ldap/sdap_async_initgroups.c
@@ -3429,7 +3429,6 @@ static void sdap_get_initgr_pgid(struct tevent_req *subreq)
         DEBUG(SSSDBG_TRACE_ALL,
               "No need to check for domain local group memberships.\n");
     } else {
-        DEBUG(SSSDBG_OP_FAILURE, "sdap_ad_check_domain_local_groups failed.\n");
         DEBUG(SSSDBG_OP_FAILURE,
               "sdap_ad_check_domain_local_groups failed, "
               "meberships to domain local groups might be missing.\n");

--- a/src/responder/nss/nss_iface.c
+++ b/src/responder/nss/nss_iface.c
@@ -191,7 +191,7 @@ int nss_memorycache_update_initgroups(struct sbus_request *sbus_req,
     struct resp_ctx *rctx = talloc_get_type(data, struct resp_ctx);
     struct nss_ctx *nctx = talloc_get_type(rctx->pvt_ctx, struct nss_ctx);
 
-    DEBUG(SSSDBG_TRACE_LIBS, "Updating inigroups memory cache of [%s@%s]\n",
+    DEBUG(SSSDBG_TRACE_LIBS, "Updating initgroups memory cache of [%s@%s]\n",
           user, domain);
 
     nss_update_initgr_memcache(nctx, user, domain, num_groups, groups);

--- a/src/responder/nss/nsssrv.c
+++ b/src/responder/nss/nsssrv.c
@@ -469,7 +469,7 @@ int nss_process_init(TALLOC_CTX *mem_ctx,
                               SSS_MC_CACHE_ELEMENTS, (time_t)memcache_timeout,
                               &nctx->initgr_mc_ctx);
     if (ret) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "inigroups mmap cache is DISABLED\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "initgroups mmap cache is DISABLED\n");
     }
 
     /* Set up file descriptor limits */


### PR DESCRIPTION
This patch set consists in a few small fixes:

- "NSS: Fix typo inigroups -> initgroups" just fixes a typo;
- "LDAP: Remove duplicated debug message" just removes a duplicated debug message;
- "CONTRIB: Force single-thread install to workaround concurrency issues" takes the same approach already taken for the intgcheck tests and force single thread installation to workaround concurrency issues.