### PR TITLE
LDAP/AD: Do not fail in case rfc2307bis_nested_groups_recv() returns ENOENT

### DIFF
--- a/src/providers/ldap/sdap_async_initgroups_ad.c
+++ b/src/providers/ldap/sdap_async_initgroups_ad.c
@@ -1746,7 +1746,13 @@ static void sdap_ad_get_domain_local_groups_done(struct tevent_req *subreq)
 
     ret = rfc2307bis_nested_groups_recv(subreq);
     talloc_zfree(subreq);
-    if (ret != EOK) {
+    if (ret == ENOENT) {
+        /* In case of ENOENT we can just proceed without making
+         * sdap_get_initgr_user() fail because there's no nested
+         * groups for this user/group. */
+        ret = EOK;
+        goto done;
+    } else if (ret != EOK) {
         tevent_req_error(req, ret);
         return;
     }


### PR DESCRIPTION
Commit 25699846 introduced a regression seen when an initgroup lookup is
done and there's no nested groups involved.

In this scenario the whole lookup fails due to an ENOENT returned by
rfc2307bis_nested_groups_recv(), which leads to the user removal from
sysdb causing some authentication issues.

The problem was caught by the "Allow only single user from domain1"
test, part of ad_access_filter tests (present in
"client-ad_provider-ad_forest" package) ran and reported by Lukáš
Slebodnik.

Resolves:
https://pagure.io/SSSD/sssd/issue/3331

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>