### PR TITLE
IFP: Fix name qualification for user groups  (1.14 backport)

### DIFF
--- a/src/responder/common/responder.h
+++ b/src/responder/common/responder.h
@@ -358,4 +358,25 @@ char *sss_resp_create_fqname(TALLOC_CTX *mem_ctx,
                              bool name_is_upn,
                              const char *orig_name);
 
+/**
+ * Helper functions to format output names
+ */
+
+/* Format orig_name into a sized_string in output format as prescribed
+ * by the name_dom domain
+ */
+int sized_output_name(TALLOC_CTX *mem_ctx,
+                      struct resp_ctx *rctx,
+                      const char *orig_name,
+                      struct sss_domain_info *name_dom,
+                      struct sized_string **_name);
+
+/* Format orig_name into a sized_string in output format as prescribed
+ * by the domain read from the fully qualified name.
+ */
+int sized_domain_name(TALLOC_CTX *mem_ctx,
+                      struct resp_ctx *rctx,
+                      const char *member_name,
+                      struct sized_string **_name);
+
 #endif /* __SSS_RESPONDER_H__ */

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -1269,3 +1269,93 @@ void responder_set_fd_limit(rlim_t fd_limit)
                "Proceeding with system values\n");
     }
 }
+
+/**
+ * Helper functions to format output names
+ */
+int sized_output_name(TALLOC_CTX *mem_ctx,
+                      struct resp_ctx *rctx,
+                      const char *orig_name,
+                      struct sss_domain_info *name_dom,
+                      struct sized_string **_name)
+{
+    TALLOC_CTX *tmp_ctx = NULL;
+    errno_t ret;
+    char *username;
+    struct sized_string *name;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    username = sss_output_name(tmp_ctx, orig_name, name_dom->case_preserve,
+                               rctx->override_space);
+    if (username == NULL) {
+        ret = EIO;
+        goto done;
+    }
+
+    if (name_dom->fqnames) {
+        username = sss_tc_fqname(tmp_ctx, name_dom->names, name_dom, username);
+        if (username == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "sss_replace_space failed\n");
+            ret = EIO;
+            goto done;
+        }
+    }
+
+    name = talloc_zero(tmp_ctx, struct sized_string);
+    if (name == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    to_sized_string(name, username);
+    name->str = talloc_steal(name, username);
+    *_name = talloc_steal(mem_ctx, name);
+    ret = EOK;
+done:
+    talloc_zfree(tmp_ctx);
+    return ret;
+}
+
+int sized_domain_name(TALLOC_CTX *mem_ctx,
+                      struct resp_ctx *rctx,
+                      const char *member_name,
+                      struct sized_string **_name)
+{
+    TALLOC_CTX *tmp_ctx = NULL;
+    errno_t ret;
+    char *domname;
+    struct sss_domain_info *member_dom;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    ret = sss_parse_internal_fqname(tmp_ctx, member_name, NULL, &domname);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "sss_parse_internal_fqname failed\n");
+        goto done;
+    }
+
+    if (domname == NULL) {
+        ret = ERR_WRONG_NAME_FORMAT;
+        goto done;
+    }
+
+    member_dom = find_domain_by_name(get_domains_head(rctx->domains),
+                                     domname, true);
+    if (member_dom == NULL) {
+        ret = ERR_DOMAIN_NOT_FOUND;
+        goto done;
+    }
+
+    ret = sized_output_name(mem_ctx, rctx, member_name,
+                            member_dom, _name);
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}

--- a/src/responder/nss/nsssrv_cmd.c
+++ b/src/responder/nss/nsssrv_cmd.c
@@ -253,93 +253,6 @@ static const char *get_shell_override(TALLOC_CTX *mem_ctx,
     return talloc_strdup(mem_ctx, NOLOGIN_SHELL);
 }
 
-static int sized_output_name(TALLOC_CTX *mem_ctx,
-                             struct resp_ctx *rctx,
-                             const char *orig_name,
-                             struct sss_domain_info *name_dom,
-                             struct sized_string **_name)
-{
-    TALLOC_CTX *tmp_ctx = NULL;
-    errno_t ret;
-    char *username;
-    struct sized_string *name;
-
-    tmp_ctx = talloc_new(NULL);
-    if (tmp_ctx == NULL) {
-        return ENOMEM;
-    }
-
-    username = sss_output_name(tmp_ctx, orig_name, name_dom->case_preserve,
-                               rctx->override_space);
-    if (username == NULL) {
-        ret = EIO;
-        goto done;
-    }
-
-    if (name_dom->fqnames) {
-        username = sss_tc_fqname(tmp_ctx, name_dom->names, name_dom, username);
-        if (username == NULL) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "sss_replace_space failed\n");
-            ret = EIO;
-            goto done;
-        }
-    }
-
-    name = talloc_zero(tmp_ctx, struct sized_string);
-    if (name == NULL) {
-        ret = ENOMEM;
-        goto done;
-    }
-
-    to_sized_string(name, username);
-    name->str = talloc_steal(name, username);
-    *_name = talloc_steal(mem_ctx, name);
-    ret = EOK;
-done:
-    talloc_zfree(tmp_ctx);
-    return ret;
-}
-
-static int sized_member_name(TALLOC_CTX *mem_ctx,
-                             struct resp_ctx *rctx,
-                             const char *member_name,
-                             struct sized_string **_name)
-{
-    TALLOC_CTX *tmp_ctx = NULL;
-    errno_t ret;
-    char *domname;
-    struct sss_domain_info *member_dom;
-
-    tmp_ctx = talloc_new(NULL);
-    if (tmp_ctx == NULL) {
-        return ENOMEM;
-    }
-
-    ret = sss_parse_internal_fqname(tmp_ctx, member_name, NULL, &domname);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "sss_parse_internal_fqname failed\n");
-        goto done;
-    }
-
-    if (domname == NULL) {
-        ret = ERR_WRONG_NAME_FORMAT;
-        goto done;
-    }
-
-    member_dom = find_domain_by_name(get_domains_head(rctx->domains),
-                                     domname, true);
-    if (member_dom == NULL) {
-        ret = ERR_DOMAIN_NOT_FOUND;
-        goto done;
-    }
-
-    ret = sized_output_name(mem_ctx, rctx, member_name,
-                            member_dom, _name);
-done:
-    talloc_free(tmp_ctx);
-    return ret;
-}
-
 static int fill_pwent(struct sss_packet *packet,
                       struct sss_domain_info *dom,
                       struct nss_ctx *nctx,
@@ -2736,7 +2649,7 @@ static int fill_members(struct sss_packet *packet,
             }
         }
 
-        ret = sized_member_name(tmp_ctx, rctx, fqname, &name);
+        ret = sized_domain_name(tmp_ctx, rctx, fqname, &name);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "sized_member_name failed: %d\n", ret);
             goto done;


### PR DESCRIPTION
This PR back-ports patches that fix qualification of user groups coming through the org.freedesktop.sssd.infopipe.GetUserGroups interface in the 1.14 branch.