### PR TITLE
Add systemtap probes into the top-level data provider requests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1587,6 +1587,9 @@ sssd_be_LDADD = \
 sssd_be_LDFLAGS = \
     -Wl,--version-script,$(srcdir)/src/providers/sssd_be.exports \
     -export-dynamic
+if BUILD_SYSTEMTAP
+sssd_be_LDADD += stap_generated_probes.lo
+endif
 
 if BUILD_PYTHON_BINDINGS
 sss_obfuscate_pythondir = $(sbindir)
@@ -1893,6 +1896,9 @@ libdlopen_test_providers_la_LIBADD = \
     $(SSSD_LIBS) \
     $(CARES_LIBS) \
     $(SSSD_INTERNAL_LTLIBS)
+if BUILD_SYSTEMTAP
+libdlopen_test_providers_la_LIBADD += stap_generated_probes.lo
+endif
 libdlopen_test_providers_la_LDFLAGS = \
     -shared \
     -avoid-version \
@@ -3317,6 +3323,9 @@ test_dp_request_LDADD = \
     $(LIBADD_DL) \
     libsss_test_common.la \
     $(NULL)
+if BUILD_SYSTEMTAP
+test_dp_request_LDADD += stap_generated_probes.lo
+endif
 
 test_dp_builtin_SOURCES = \
     src/providers/data_provider/dp_modules.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -1257,6 +1257,7 @@ dist_systemtap_tap_DATA = \
 dist_sssdtapscript_DATA = \
     contrib/systemtap/id_perf.stp \
     contrib/systemtap/nested_group_perf.stp \
+    contrib/systemtap/dp_request.stp \
     $(NULL)
 
 stap_generated_probes.h: $(srcdir)/src/systemtap/sssd_probes.d

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -1003,6 +1003,7 @@ done
 %dir %{_datadir}/sssd/systemtap
 %{_datadir}/sssd/systemtap/id_perf.stp
 %{_datadir}/sssd/systemtap/nested_group_perf.stp
+%{_datadir}/sssd/systemtap/dp_request.stp
 %dir %{_datadir}/systemtap
 %dir %{_datadir}/systemtap/tapset
 %{_datadir}/systemtap/tapset/sssd.stp

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -1008,6 +1008,7 @@ done
 %dir %{_datadir}/systemtap/tapset
 %{_datadir}/systemtap/tapset/sssd.stp
 %{_datadir}/systemtap/tapset/sssd_functions.stp
+%{_mandir}/man5/sssd-systemtap.5*
 %endif
 
 %if (0%{?install_pcscd_polkit_rule} == 1)

--- a/contrib/systemtap/dp_request.stp
+++ b/contrib/systemtap/dp_request.stp
@@ -1,0 +1,85 @@
+/* Start Run with:
+ *   stap -v dp_request.stp
+ *
+ * Then reproduce slow login or id/getent in another terminal.
+ * Ctrl-C running stap once login completes.
+ *
+ * Probe tapsets are in /usr/share/systemtap/tapset/sssd.stp
+ */
+
+
+global num_dp_requests
+
+global time_in_dp_req
+global elapsed_time
+global dp_req_send_start
+global dp_req_send_end
+
+/* Used for tracking slowest request as tz_ctime() only converts seconds, not ms */
+global dp_req_send_sec_start
+global dp_req_send_sec_end
+
+global slowest_req_name
+global slowest_req_target
+global slowest_req_method
+global slowest_req_time = 0
+global slowest_req_start_time
+global slowest_req_end_time
+
+function print_report()
+{
+	printf("\nEnding Systemtap Run - Providing Summary\n")
+	printf("Total Number of DP requests: [%d]\n", num_dp_requests)
+	printf("Total time in DP requests: [%s]\n", msecs_to_string(time_in_dp_req))
+	printf("Slowest request data:\n")
+	printf("\tRequest: [%s]\n", slowest_req_name)
+	printf("\tTarget:  [%s]\n", dp_target_str(slowest_req_target))
+	printf("\tMethod:  [%s]\n", dp_method_str(slowest_req_method))
+	printf("\tStart Time: [%s]\n", tz_ctime(slowest_req_start_time))
+	printf("\tEnd Time: [%s]\n", tz_ctime(slowest_req_end_time))
+	printf("\tDuration: [%s]\n\n", msecs_to_string(slowest_req_time))
+}
+
+probe dp_req_send
+{
+	dp_req_send_start = gettimeofday_ms()
+	dp_req_send_sec_start = gettimeofday_s()
+
+	printf("\t--> DP Request [%s] sent for domain [%s]\n", dp_req_name, dp_req_domain)
+	printf("\t--> Target: [%s] - Method: [%s]\n", dp_target_str(dp_req_target), dp_method_str(dp_req_method))
+
+	num_dp_requests++
+}
+
+probe dp_req_done
+{
+	dp_req_send_end = gettimeofday_ms()
+	dp_req_send_sec_end = gettimeofday_s()
+	elapsed_time = (dp_req_send_end - dp_req_send_start)
+
+	printf("\t\t DP Request [%s] finished with return code [%d]: [%s]\n",
+	        dp_req_name, dp_ret, dp_errorstr)
+	printf("\t\t Elapsed time [%s]\n\n", msecs_to_string(elapsed_time))
+
+	/* Track slowest request information */
+	if (elapsed_time > slowest_req_time) {
+		slowest_req_time = elapsed_time
+		slowest_req_name = dp_req_name
+		slowest_req_method = dp_req_method
+		slowest_req_target = slowest_req_target
+		slowest_req_start_time = dp_req_send_sec_start
+		slowest_req_end_time = dp_req_send_sec_end
+	}
+
+	time_in_dp_req += (dp_req_send_end - dp_req_send_start)
+}
+
+probe begin
+{
+	printf("\t*** Beginning run! ***\n")
+}
+
+probe end
+{
+    print_report()
+}

--- a/src/man/Makefile.am
+++ b/src/man/Makefile.am
@@ -30,6 +30,9 @@ endif
 if BUILD_SECRETS
 KCM_CONDS = ;with_kcm
 endif
+if BUILD_SYSTEMTAP
+STAP_CONDS = ;with_stap
+endif
 if GPO_DEFAULT_ENFORCING
 GPO_CONDS = ;gpo_default_enforcing
 else
@@ -43,7 +46,7 @@ FILES_CONDS = ;enable_files_domain
 else
 FILES_CONDS = ;no_enable_files_domain
 endif
-CONDS = with_false$(SUDO_CONDS)$(AUTOFS_CONDS)$(SSH_CONDS)$(PAC_RESPONDER_CONDS)$(IFP_CONDS)$(GPO_CONDS)$(SEC_CONDS)$(SYSTEMD_CONDS)$(FILES_CONDS)$(KCM_CONDS)
+CONDS = with_false$(SUDO_CONDS)$(AUTOFS_CONDS)$(SSH_CONDS)$(PAC_RESPONDER_CONDS)$(IFP_CONDS)$(GPO_CONDS)$(SEC_CONDS)$(SYSTEMD_CONDS)$(FILES_CONDS)$(KCM_CONDS)$(STAP_CONDS)
 
 
 #Special Rules:
@@ -90,6 +93,10 @@ endif
 
 if BUILD_KCM
 man_MANS += sssd-kcm.8
+endif
+
+if BUILD_SYSTEMTAP
+man_MANS += sssd-systemtap.5
 endif
 
 if BUILD_NFS_IDMAP

--- a/src/man/include/seealso.xml
+++ b/src/man/include/seealso.xml
@@ -97,5 +97,11 @@
                 <refentrytitle>sss_rpcidmapd</refentrytitle>
                 <manvolnum>5</manvolnum>
             </citerefentry>
+            <phrase condition="with_stap">
+                <citerefentry>
+                    <refentrytitle>sssd-systemtap</refentrytitle>
+                    <manvolnum>5</manvolnum>
+                </citerefentry>,
+            </phrase>
         </para>
     </refsect1>

--- a/src/man/po/po4a.cfg
+++ b/src/man/po/po4a.cfg
@@ -33,6 +33,7 @@
 [type:docbook] sssd-secrets.5.xml $lang:$(builddir)/$lang/sssd-secrets.5.xml
 [type:docbook] sssd-session-recording.5.xml $lang:$(builddir)/$lang/sssd-session-recording.5.xml
 [type:docbook] sssd-kcm.8.xml $lang:$(builddir)/$lang/sssd-kcm.8.xml
+[type:docbook] sssd-systemtap.5.xml $lang:$(builddir)/$lang/sssd-systemtap.5.xml
 [type:docbook] include/service_discovery.xml $lang:$(builddir)/$lang/include/service_discovery.xml opt:"-k 0"
 [type:docbook] include/upstream.xml $lang:$(builddir)/$lang/include/upstream.xml opt:"-k 0"
 [type:docbook] include/failover.xml $lang:$(builddir)/$lang/include/failover.xml opt:"-k 0"

--- a/src/man/sssd-systemtap.5.xml
+++ b/src/man/sssd-systemtap.5.xml
@@ -1,0 +1,386 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DocBook V4.4//EN"
+"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
+<reference>
+<title>SSSD Manual pages</title>
+<refentry>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="include/upstream.xml" />
+
+    <refmeta>
+        <refentrytitle>sssd-systemtap</refentrytitle>
+        <manvolnum>5</manvolnum>
+        <refmiscinfo class="manual">File Formats and Conventions</refmiscinfo>
+    </refmeta>
+
+    <refnamediv id='name'>
+        <refname>sssd-systemtap</refname>
+        <refpurpose>SSSD systemtap information</refpurpose>
+    </refnamediv>
+
+    <refsect1 id='description'>
+        <title>DESCRIPTION</title>
+        <para>
+            This manual page provides information about
+            the systemtap functionality
+            in
+            <citerefentry>
+                <refentrytitle>sssd</refentrytitle>
+                <manvolnum>8</manvolnum>
+            </citerefentry>.
+       </para>
+        <para>
+            SystemTap Probe points have been added into various
+            locations in SSSD code to assist in troubleshooting
+            and analyzing performance related issues.
+       </para>
+        <para>
+            <itemizedlist>
+                <listitem>
+                    <para>
+                        Sample SystemTap scripts are
+                        provided in /usr/share/sssd/systemtap/
+                    </para>
+                </listitem>
+                <listitem>
+                    <para>
+                        Probes and miscellaneous functions are
+                        defined in /usr/share/systemtap/tapset/sssd.stp
+                        and /usr/share/systemtap/tapset/sssd_functions.stp
+                        respectively.
+                    </para>
+                </listitem>
+            </itemizedlist>
+        </para>
+    </refsect1>
+
+    <refsect1 id='probe-points'>
+        <title>PROBE POINTS</title>
+        <para>
+            The information below lists the probe points and arguments available
+            in the following format:
+        </para>
+            <variablelist>
+                <varlistentry>
+                    <term>probe $name</term>
+                    <listitem>
+                        <para>
+                            Description of probe point
+                        </para>
+                        <programlisting>
+variable1:datatype
+variable2:datatype
+variable3:datatype
+...
+                        </programlisting>
+                    </listitem>
+                </varlistentry>
+            </variablelist>
+
+        <refsect2 id='database-transaction-probes'>
+            <title>Database Transaction Probes</title>
+            <para>
+              <variablelist>
+                <varlistentry>
+                    <term>probe sssd_transaction_start</term>
+                    <listitem>
+                        <para>
+                            Start of a sysdb transaction, probes the
+                            sysdb_transaction_start() function.
+                        </para>
+                        <programlisting>
+nesting:integer
+probestr:string
+                        </programlisting>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>probe sssd_transaction_cancel</term>
+                    <listitem>
+                        <para>
+                            Cancellation of a sysdb transaction,
+                            probes the sysdb_transaction_cancel()
+                            function.
+                        </para>
+                        <programlisting>
+nesting:integer
+probestr:string
+                        </programlisting>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>probe sssd_transaction_commit_before</term>
+                    <listitem>
+                        <para>
+                            Probes the sysdb_transaction_commit_before()
+                            function.
+                        </para>
+                        <programlisting>
+nesting:integer
+probestr:string
+                        </programlisting>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>probe sssd_transaction_commit_after</term>
+                    <listitem>
+                        <para>
+                            Probes the sysdb_transaction_commit_after()
+                            function.
+                        </para>
+                        <programlisting>
+nesting:integer
+probestr:string
+                        </programlisting>
+                    </listitem>
+                </varlistentry>
+              </variablelist>
+            </para>
+        </refsect2>
+
+        <refsect2 id='ldap-search-probes'>
+            <title>LDAP Search Probes</title>
+            <para>
+              <variablelist>
+                <varlistentry>
+                    <term>probe sdap_search_send</term>
+                    <listitem>
+                        <para>
+                            Probes the sdap_get_generic_ext_send()
+                            function.
+                        </para>
+                        <programlisting>
+base:string
+scope:integer
+filter:string
+probestr:string
+                        </programlisting>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>probe sdap_search_recv</term>
+                    <listitem>
+                        <para>
+                            Probes the sdap_get_generic_ext_recv()
+                            function.
+                        </para>
+                        <programlisting>
+base:string
+scope:integer
+filter:string
+probestr:string
+                        </programlisting>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>probe sdap_deref_send</term>
+                    <listitem>
+                        <para>
+                            Probes the sdap_deref_search_send()
+                            function.
+                        </para>
+                        <programlisting>
+base_dn:string
+deref_attr:string
+probestr:string
+                        </programlisting>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>probe sdap_deref_recv</term>
+                    <listitem>
+                        <para>
+                            Probes the sdap_deref_search_recv()
+                            function.
+                        </para>
+                        <programlisting>
+base:string
+scope:integer
+filter:string
+probestr:string
+                        </programlisting>
+                    </listitem>
+                </varlistentry>
+              </variablelist>
+            </para>
+        </refsect2>
+
+       <refsect2 id='ldap-account-req-probes'>
+           <title>LDAP Account Request Probes</title>
+           <para>
+             <variablelist>
+               <varlistentry>
+                   <term>probe sdap_acct_req_send</term>
+                   <listitem>
+                       <para>
+                           Probes the sdap_acct_req_send()
+                           function.
+                       </para>
+                       <programlisting>
+entry_type:int
+filter_type:int
+filter_value:string
+extra_value:string
+                       </programlisting>
+                   </listitem>
+               </varlistentry>
+               <varlistentry>
+                   <term>probe sdap_acct_req_recv</term>
+                   <listitem>
+                       <para>
+                           Probes the sdap_acct_req_recv()
+                           function.
+                       </para>
+                       <programlisting>
+entry_type:int
+filter_type:int
+filter_value:string
+extra_value:string
+                       </programlisting>
+                   </listitem>
+               </varlistentry>
+            </variablelist>
+        </para>
+        </refsect2>
+
+       <refsect2 id='ldap-user-search-probes'>
+           <title>LDAP User Search Probes</title>
+           <para>
+             <variablelist>
+               <varlistentry>
+                   <term>probe sdap_search_user_send</term>
+                   <listitem>
+                       <para>
+                           Probes the sdap_search_user_send()
+                           function.
+                       </para>
+                       <programlisting>
+filter:string
+                       </programlisting>
+                   </listitem>
+               </varlistentry>
+               <varlistentry>
+                   <term>probe sdap_search_user_recv</term>
+                   <listitem>
+                       <para>
+                           Probes the sdap_search_user_recv()
+                           function.
+                       </para>
+                       <programlisting>
+filter:string
+                       </programlisting>
+                   </listitem>
+               </varlistentry>
+               <varlistentry>
+                   <term>probe sdap_search_user_save_begin</term>
+                   <listitem>
+                       <para>
+                           Probes the sdap_search_user_save_begin()
+                           function.
+                       </para>
+                       <programlisting>
+filter:string
+                       </programlisting>
+                   </listitem>
+               </varlistentry>
+               <varlistentry>
+                   <term>probe sdap_search_user_save_end</term>
+                   <listitem>
+                       <para>
+                           Probes the sdap_search_user_save_end()
+                           function.
+                       </para>
+                       <programlisting>
+filter:string
+                       </programlisting>
+                   </listitem>
+               </varlistentry>
+            </variablelist>
+        </para>
+        </refsect2>
+
+       <refsect2 id='data-provider-request-probes'>
+           <title>Data Provider Request Probes</title>
+           <para>
+             <variablelist>
+               <varlistentry>
+                   <term>probe dp_req_send</term>
+                   <listitem>
+                       <para>
+                           A Data Provider request is submitted.
+                       </para>
+                       <programlisting>
+dp_req_domain:string
+dp_req_name:string
+dp_req_target:int
+dp_req_method:int
+                       </programlisting>
+                   </listitem>
+               </varlistentry>
+               <varlistentry>
+                   <term>probe dp_req_done</term>
+                   <listitem>
+                       <para>
+                           A Data Provider request is completed.
+                       </para>
+                       <programlisting>
+dp_req_name:string
+dp_req_target:int
+dp_req_method:int
+dp_ret:int
+dp_errorstr:string
+                       </programlisting>
+                   </listitem>
+               </varlistentry>
+            </variablelist>
+        </para>
+        </refsect2>
+
+    <refsect2 id='miscellaneous-functions'>
+        <title>MISCELLANEOUS FUNCTIONS</title>
+        <para>
+            The information below lists the probe points and arguments available
+            in the following format:
+        </para>
+            <variablelist>
+                <varlistentry>
+                    <term>function acct_req_desc(entry_type)</term>
+                    <listitem>
+                        <para>
+                            Convert entry_type to string and return string
+                        </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>function sssd_acct_req_probestr(fc_name, entry_type,
+                          filter_type, filter_value, extra_value)</term>
+                    <listitem>
+                        <para>
+                            Create probe string based on filter type
+                        </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>function dp_target_str(target)</term>
+                    <listitem>
+                        <para>
+                            Convert target to string and return string
+                        </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>function dp_method_str(target)</term>
+                    <listitem>
+                        <para>
+                            Convert method to string and return string
+                        </para>
+                    </listitem>
+                </varlistentry>
+            </variablelist>
+    </refsect2>
+
+    </refsect1>
+
+	<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="include/seealso.xml" />
+
+</refentry>
+</reference>

--- a/src/systemtap/sssd.stp.in
+++ b/src/systemtap/sssd.stp.in
@@ -254,3 +254,21 @@ probe sdap_nested_group_process_recv = process("@libdir@/sssd/libsss_ldap_common
     probestr = sprintf("-> %s(orig_dn=[%s])",
                        $$name, orig_dn);
 }
+
+## Data Provider Request Probes
+probe dp_req_send = process("@libexecdir@/sssd/sssd_be").mark("dp_req_send")
+{
+    dp_req_domain = user_string($arg1, "NULL");
+    dp_req_name = user_string($arg2, "NULL");
+    dp_req_target = $arg3;
+    dp_req_method = $arg4;
+}
+
+probe dp_req_done = process("@libexecdir@/sssd/sssd_be").mark("dp_req_done")
+{
+    dp_req_name = user_string($arg1, "NULL");
+    dp_req_target = $arg2;
+    dp_req_method = $arg3;
+    dp_ret = $arg4;
+    dp_errorstr = user_string($arg5, "NULL");
+}

--- a/src/systemtap/sssd_functions.stp
+++ b/src/systemtap/sssd_functions.stp
@@ -1,3 +1,13 @@
+// constants
+global TARGET_ID=0, TARGET_AUTH=1, TARGET_ACCESS=2, TARGET_CHPASS=3,
+       TARGET_SUDO=4, TARGET_AUTOFS=5, TARGET_SELINUX=6, TARGET_HOSTID=7,
+       TARGET_SUBDOMAINS=8, TARGET_SENTINEL=9
+
+global METHOD_CHECK_ONLINE=0, METHOD_ACCOUNT_HANDLER=1, METHOD_AUTH_HANDLER=2,
+       METHOD_ACCESS_HANDLER=3, METHOD_SELINUX_HANDLER=4, METHOD_SUDO_HANDLER=5,
+       METHOD_AUTOFS_HANDLER=6, METHOD_HOSTID_HANDLER=7, METHOD_DOMAINS_HANDLER=8,
+       METHOD_SENTINEL=9
+
 function acct_req_desc(entry_type)
 {
     if (entry_type == 0x0001) {
@@ -63,4 +73,62 @@ function sssd_acct_req_probestr(fc_name, entry_type, filter_type,
                        fc_name, str_entry_type, str_filter_type,
                        filter_value, extra_value)
     return probestr
+}
+
+function dp_target_str(target)
+{
+    if (target == TARGET_ID) {
+        str_target = "ID"
+    } else if (target == TARGET_AUTH) {
+        str_target = "AUTH"
+    } else if (target == TARGET_ACCESS) {
+        str_target = "ACCESS"
+    } else if (target == TARGET_CHPASS) {
+        str_target = "CHPASS"
+    } else if (target == TARGET_SUDO) {
+        str_target = "SUDO"
+    } else if (target == TARGET_AUTOFS) {
+        str_target = "AUTOFS"
+    } else if (target == TARGET_SELINUX) {
+        str_target = "SELINUX"
+    } else if (target == TARGET_HOSTID) {
+        str_target = "HOSTID"
+    } else if (target == TARGET_SUBDOMAINS) {
+        str_target = "SUBDOMAINS"
+    } else if (target == TARGET_SENTINEL) {
+        str_target = "TARGET_SENTINEL"
+    } else {
+        str_target = "UNKNOWN"
+    }
+
+    return str_target
+}
+
+function dp_method_str(method)
+{
+    if (method == METHOD_CHECK_ONLINE) {
+        str_method = "Check Online"
+    } else if (method == METHOD_ACCOUNT_HANDLER) {
+        str_method = "Account Handler"
+    } else if (method == METHOD_AUTH_HANDLER) {
+        str_method = "Auth Handler"
+    } else if (method == METHOD_ACCESS_HANDLER) {
+        str_method = "Access Handler"
+    } else if (method == METHOD_SELINUX_HANDLER) {
+        str_method = "SELinux Handler"
+    } else if (method == METHOD_SUDO_HANDLER) {
+        str_method = "Sudo Handler"
+    } else if (method == METHOD_AUTOFS_HANDLER) {
+        str_method = "Autofs Handler"
+    } else if (method == METHOD_HOSTID_HANDLER) {
+        str_method = "HostID Handler"
+    } else if (method == METHOD_DOMAINS_HANDLER) {
+        str_method = "Domains Handler"
+    } else if (method == METHOD_SENTINEL) {
+        str_method = "Method Sentinel"
+    } else {
+        str_method = "UNKNOWN"
+    }
+
+    return str_method
 }

--- a/src/systemtap/sssd_probes.d
+++ b/src/systemtap/sssd_probes.d
@@ -65,4 +65,9 @@ provider sssd {
     probe sdap_nested_group_sysdb_search_groups_post();
     probe sdap_nested_group_populate_search_users_pre();
     probe sdap_nested_group_populate_search_users_post();
+
+    probe dp_req_send(const char *domain, const char *dp_req_name,
+                      int target, int method);
+    probe dp_req_done(const char *dp_req_name, int target, int method,
+                      int ret, const char *errorstr);
 }


### PR DESCRIPTION
Adding Data Provider probes and SystemTap script **dp_request.stp** to probe 
DP requests for performance analysis primarily based on elapsed time to complete a request.
The intention is to identify delays during logins and user lookups.

I'm not sure if the comments in **src/systemtap/sssd.stp.in** are worthwhile but the intention for someone writing their own stap script they could avoid having to look at the actual source code to see which target variables are retrieved(though the variable names are self-explanatory).

Resolves: https://pagure.io/SSSD/sssd/issue/3061