### PR TITLE
KCM: include missing header file

### DIFF
--- a/src/responder/kcm/kcmsrv_cmd.c
+++ b/src/responder/kcm/kcmsrv_cmd.c
@@ -19,6 +19,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <sys/uio.h>
 #include <krb5/krb5.h>
 
 #include "config.h"


### PR DESCRIPTION
man 2 readv says that the header file "sys/uio.h" must be included
for the functions readv/writev

Previously, "sys/uio.h" was included in "sys/socket.h" in glibc.
It worked just by a change. But it will be changed in glibc-2.26.
https://sourceware.org/bugzilla/show_bug.cgi?id=21426

src/responder/kcm/kcmsrv_cmd.c: In function 'kcm_iovec_op':
src/responder/kcm/kcmsrv_cmd.c:75:15: error: implicit declaration of function
    'readv'; did you mean 'read'? [-Werror=implicit-function-declaration]

src/responder/kcm/kcmsrv_cmd.c:77:15: error: implicit declaration of function
    'writev'; did you mean 'write'? [-Werror=implicit-function-declaration]