### PR TITLE
sss_nss_getlistbycert: return results from multiple domains

### DIFF
--- a/src/responder/nss/nss_protocol.h
+++ b/src/responder/nss/nss_protocol.h
@@ -181,6 +181,12 @@ nss_protocol_fill_name_list(struct nss_ctx *nss_ctx,
                             struct cache_req_result *result);
 
 errno_t
+nss_protocol_fill_name_list_all_domains(struct nss_ctx *nss_ctx,
+                                        struct nss_cmd_ctx *cmd_ctx,
+                                        struct sss_packet *packet,
+                                        struct cache_req_result **results);
+
+errno_t
 nss_protocol_fill_id(struct nss_ctx *nss_ctx,
                      struct nss_cmd_ctx *cmd_ctx,
                      struct sss_packet *packet,

--- a/src/responder/nss/nss_protocol_sid.c
+++ b/src/responder/nss/nss_protocol_sid.c
@@ -561,3 +561,81 @@ nss_protocol_fill_name_list(struct nss_ctx *nss_ctx,
 
     return EOK;
 }
+
+errno_t
+nss_protocol_fill_name_list_all_domains(struct nss_ctx *nss_ctx,
+                                        struct nss_cmd_ctx *cmd_ctx,
+                                        struct sss_packet *packet,
+                                        struct cache_req_result **results)
+{
+    enum sss_id_type *id_types;
+    size_t rp = 0;
+    size_t body_len;
+    uint8_t *body;
+    errno_t ret;
+    struct sized_string *sz_names;
+    size_t len;
+    size_t c;
+    const char *tmp_str;
+    size_t d;
+    size_t total = 0;
+    size_t iter = 0;
+
+    if (results == NULL) {
+        return EINVAL;
+    }
+
+    for (d = 0; results[d] != NULL; d++) {
+        total += results[d]->count;
+    }
+
+    sz_names = talloc_array(cmd_ctx, struct sized_string, total);
+    if (sz_names == NULL) {
+        return ENOMEM;
+    }
+
+    id_types = talloc_array(cmd_ctx, enum sss_id_type, total);
+    if (id_types == NULL) {
+        return ENOMEM;
+    }
+
+    len = 0;
+    for (d = 0; results[d] != NULL; d++) {
+        for (c = 0; c < results[d]->count; c++) {
+            ret = nss_get_id_type(cmd_ctx, results[d], &(id_types[iter]));
+            if (ret != EOK) {
+                return ret;
+            }
+
+            tmp_str = sss_get_name_from_msg(results[d]->domain,
+                                            results[d]->msgs[c]);
+            if (tmp_str == NULL) {
+                return EINVAL;
+            }
+            to_sized_string(&(sz_names[iter]), tmp_str);
+
+            len += sz_names[iter].len;
+            iter++;
+        }
+    }
+
+    len += (2 + total) * sizeof(uint32_t);
+
+    ret = sss_packet_grow(packet, len);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sss_packet_grow failed.\n");
+        return ret;
+    }
+
+    sss_packet_get_body(packet, &body, &body_len);
+
+    SAFEALIGN_SET_UINT32(&body[rp], total, &rp); /* Num results. */
+    SAFEALIGN_SET_UINT32(&body[rp], 0, &rp); /* Reserved. */
+    for (c = 0; c < total; c++) {
+        SAFEALIGN_SET_UINT32(&body[rp], id_types[c], &rp);
+        SAFEALIGN_SET_STRING(&body[rp], sz_names[c].str, sz_names[c].len,
+                             &rp);
+    }
+
+    return EOK;
+}


### PR DESCRIPTION
Currently only the results from one domain were returned although all
domains were searched and the results were available. Unit tests are
updated to cover this case as well.

Resolves https://pagure.io/SSSD/sssd/issue/3393