### PR TITLE
IPA: Fix the PAM error code that auth code expects to start migration

### DIFF
--- a/src/providers/ipa/ipa_auth.c
+++ b/src/providers/ipa/ipa_auth.c
@@ -249,7 +249,7 @@ static void ipa_pam_auth_handler_krb5_done(struct tevent_req *subreq)
     }
 
     if (state->pd->cmd == SSS_PAM_AUTHENTICATE
-            && state->pd->pam_status == PAM_CRED_ERR) {
+            && state->pd->pam_status == PAM_NO_MODULE_DATA) {
         realm = dp_opt_get_string(state->auth_ctx->ipa_options, IPA_KRB5_REALM);
         subreq = get_password_migration_flag_send(state, state->ev,
                                                   state->auth_ctx->sdap_id_ctx,


### PR DESCRIPTION
Resolves:
   https://pagure.io/SSSD/sssd/issue/3394

To support PKINIT, we now return PAM_NO_MODULE_DATA when the krb5_child
process returns ERR_NO_AUTH_METHOD_AVAILABLE. Previously, we used to return
PAM_CRED_ERR which the IPA auth code expects in order to start password
migration.

This patch syncs the two again.

To reproduce, add an ipa user without password:
   ipa user-add migration_user Then try to log in as that user:
   ssh migration_user@myclient

The IPA auth code should be then executed.