### PR TITLE
pam_sss: add support for SSS_PAM_CERT_INFO_WITH_HINT

### DIFF
--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -351,6 +351,9 @@ struct sss_domain_info {
     char *forest;
     struct sss_domain_info *forest_root;
     const char **upn_suffixes;
+
+    struct certmap_info **certmaps;
+    bool user_name_hint;
 };
 
 /**

--- a/src/db/sysdb_certmap.c
+++ b/src/db/sysdb_certmap.c
@@ -269,7 +269,7 @@ errno_t sysdb_get_certmap(TALLOC_CTX *mem_ctx, struct sysdb_ctx *sysdb,
     size_t d;
     struct ldb_dn *container_dn = NULL;
     int ret;
-    struct certmap_info **maps;
+    struct certmap_info **maps = NULL;
     TALLOC_CTX *tmp_ctx = NULL;
     struct ldb_result *res;
     const char *tmp_str;
@@ -320,7 +320,7 @@ errno_t sysdb_get_certmap(TALLOC_CTX *mem_ctx, struct sysdb_ctx *sysdb,
 
     if (res->count == 0) {
         DEBUG(SSSDBG_TRACE_FUNC, "No certificate maps found.\n");
-        ret = ENOENT;
+        ret = EOK;
         goto done;
     }
 
@@ -377,7 +377,7 @@ errno_t sysdb_get_certmap(TALLOC_CTX *mem_ctx, struct sysdb_ctx *sysdb,
                                                SYSDB_CERTMAP_PRIORITY,
                                                (uint64_t) -1);
         if (tmp_uint != (uint64_t) -1) {
-            if (tmp_uint >= UINT32_MAX) {
+            if (tmp_uint > UINT32_MAX) {
                 DEBUG(SSSDBG_OP_FAILURE, "Priority value [%lu] too large.\n",
                                          (unsigned long) tmp_uint);
                 ret = EINVAL;
@@ -414,11 +414,14 @@ errno_t sysdb_get_certmap(TALLOC_CTX *mem_ctx, struct sysdb_ctx *sysdb,
         }
     }
 
-    *certmaps = talloc_steal(mem_ctx, maps);
-    *user_name_hint = hint;
     ret = EOK;
 
 done:
+    if (ret == EOK) {
+        *certmaps = talloc_steal(mem_ctx, maps);
+        *user_name_hint = hint;
+    }
+
     talloc_free(tmp_ctx);
 
     return ret;

--- a/src/responder/pam/pamsrv.h
+++ b/src/responder/pam/pamsrv.h
@@ -101,7 +101,7 @@ errno_t pam_check_cert_recv(struct tevent_req *req, TALLOC_CTX *mem_ctx,
 
 errno_t add_pam_cert_response(struct pam_data *pd, const char *user,
                               const char *token_name, const char *module_name,
-                              const char *key_id);
+                              const char *key_id, enum response_type type);
 
 bool may_do_cert_auth(struct pam_ctx *pctx, struct pam_data *pd);
 

--- a/src/sss_client/pam_message.h
+++ b/src/sss_client/pam_message.h
@@ -63,6 +63,7 @@ struct pam_items {
     char *token_name;
     char *module_name;
     char *key_id;
+    bool user_name_hint;
 };
 
 int pack_message_v3(struct pam_items *pi, size_t *size, uint8_t **buffer);

--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -982,6 +982,7 @@ static int eval_response(pam_handle_t *pamh, size_t buflen, uint8_t *buf,
 
                 break;
             case SSS_PAM_CERT_INFO:
+            case SSS_PAM_CERT_INFO_WITH_HINT:
                 if (buf[p + (len - 1)] != '\0') {
                     D(("cert info does not end with \\0."));
                     break;
@@ -994,7 +995,19 @@ static int eval_response(pam_handle_t *pamh, size_t buflen, uint8_t *buf,
                     break;
                 }
 
-                if (pi->pam_user == NULL || *(pi->pam_user) == '\0') {
+                if (type == SSS_PAM_CERT_INFO && pi->cert_user == '\0') {
+                    D(("Invalid CERT message"));
+                    break;
+                }
+
+                if (type == SSS_PAM_CERT_INFO_WITH_HINT) {
+                    pi->user_name_hint = true;
+                } else {
+                    pi->user_name_hint = false;
+                }
+
+                if ((pi->pam_user == NULL || *(pi->pam_user) == '\0')
+                        && pi->cert_user != '\0') {
                     ret = pam_set_item(pamh, PAM_USER, pi->cert_user);
                     if (ret != PAM_SUCCESS) {
                         D(("Failed to set PAM_USER during "
@@ -1469,7 +1482,7 @@ done:
     return ret;
 }
 
-#define SC_PROMPT_FMT "PIN for %s for user %s"
+#define SC_PROMPT_FMT "PIN for %s"
 
 static int prompt_sc_pin(pam_handle_t *pamh, struct pam_items *pi)
 {
@@ -1478,32 +1491,108 @@ static int prompt_sc_pin(pam_handle_t *pamh, struct pam_items *pi)
     char *prompt;
     size_t size;
     size_t needed_size;
+    const struct pam_conv *conv;
+    const struct pam_message *mesg[2] = { NULL, NULL };
+    struct pam_message m[2] = { {0}, {0} };
+    struct pam_response *resp = NULL;
 
-    if (pi->token_name == NULL || *pi->token_name == '\0'
-            || pi->cert_user == NULL || *pi->cert_user == '\0') {
+    if (pi->token_name == NULL || *pi->token_name == '\0') {
         return EINVAL;
     }
 
-    size = sizeof(SC_PROMPT_FMT) + strlen(pi->token_name) +
-           strlen(pi->cert_user);
+    size = sizeof(SC_PROMPT_FMT) + strlen(pi->token_name);
     prompt = malloc(size);
     if (prompt == NULL) {
         D(("malloc failed."));
         return ENOMEM;
     }
 
-    ret = snprintf(prompt, size, SC_PROMPT_FMT, pi->token_name, pi->cert_user);
+    ret = snprintf(prompt, size, SC_PROMPT_FMT, pi->token_name);
     if (ret < 0 || ret >= size) {
         D(("snprintf failed."));
         free(prompt);
         return EFAULT;
     }
 
-    ret = do_pam_conversation(pamh, PAM_PROMPT_ECHO_OFF, prompt, NULL, &answer);
-    free(prompt);
-    if (ret != PAM_SUCCESS) {
-        D(("do_pam_conversation failed."));
-        return ret;
+    if (pi->user_name_hint) {
+        ret = pam_get_item(pamh, PAM_CONV, (const void **) &conv);
+        if (ret != PAM_SUCCESS) {
+            return ret;
+        }
+        if (conv == NULL || conv->conv == NULL) {
+            logger(pamh, LOG_ERR, "No conversation function");
+            return PAM_SYSTEM_ERR;
+        }
+
+        m[0].msg_style = PAM_PROMPT_ECHO_OFF;
+        m[0].msg = prompt;
+        m[1].msg_style = PAM_PROMPT_ECHO_ON;
+        m[1].msg = "User name hint: ";
+
+        mesg[0] = (const struct pam_message *) m;
+        /* The following assignment might look a bit odd but is recommended in the
+         * pam_conv man page to make sure that the second argument of the PAM
+         * conversation function can be interpreted in two different ways.
+         * Basically it is important that both the actual struct pam_message and
+         * the pointers to the struct pam_message are arrays. Since the assignment
+         * makes clear that mesg[] and (*mesg)[] are arrays it should be kept this
+         * way and not be replaced by other equivalent assignments. */
+        mesg[1] = & (( *mesg )[1]);
+
+        ret = conv->conv(2, mesg, &resp, conv->appdata_ptr);
+        if (ret != PAM_SUCCESS) {
+            D(("Conversation failure: %s.", pam_strerror(pamh, ret)));
+            return ret;
+        }
+
+        if (resp == NULL) {
+            D(("response expected, but resp==NULL"));
+            return PAM_SYSTEM_ERR;
+        }
+
+        if (resp[0].resp == NULL || *(resp[0].resp) == '\0') {
+            D(("Missing PIN."));
+            ret = PAM_CRED_INSUFFICIENT;
+            goto done;
+        }
+
+        answer = strndup(resp[0].resp, MAX_AUTHTOK_SIZE);
+        _pam_overwrite((void *)resp[0].resp);
+        free(resp[0].resp);
+        resp[0].resp = NULL;
+        if(answer == NULL) {
+            D(("strndup failed"));
+            ret = PAM_BUF_ERR;
+            goto done;
+        }
+
+        if (resp[1].resp != NULL && *(resp[1].resp) != '\0') {
+            ret = pam_set_item(pamh, PAM_USER, resp[1].resp);
+            free(resp[1].resp);
+            resp[1].resp = NULL;
+            if (ret != PAM_SUCCESS) {
+                D(("Failed to set PAM_USER with user name hint [%s]",
+                   pam_strerror(pamh, ret)));
+                goto done;
+            }
+
+            ret = pam_get_item(pamh, PAM_USER, (const void **)&(pi->pam_user));
+            if (ret != PAM_SUCCESS) {
+                D(("Failed to get PAM_USER with user name hint [%s]",
+                   pam_strerror(pamh, ret)));
+                goto done;
+            }
+
+            pi->pam_user_size = strlen(pi->pam_user) + 1;
+        }
+    } else {
+        ret = do_pam_conversation(pamh, PAM_PROMPT_ECHO_OFF, prompt, NULL,
+                                  &answer);
+        free(prompt);
+        if (ret != PAM_SUCCESS) {
+            D(("do_pam_conversation failed."));
+            return ret;
+        }
     }
 
     if (answer == NULL) {
@@ -1551,6 +1640,20 @@ done:
     _pam_overwrite((void *)answer);
     free(answer);
     answer=NULL;
+
+    if (resp != NULL) {
+        if (resp[0].resp != NULL) {
+            _pam_overwrite((void *)resp[0].resp);
+            free(resp[0].resp);
+        }
+        if (resp[1].resp != NULL) {
+            _pam_overwrite((void *)resp[1].resp);
+            free(resp[1].resp);
+        }
+
+        free(resp);
+        resp = NULL;
+    }
 
     return ret;
 }
@@ -1680,7 +1783,7 @@ static int get_authtok_for_authentication(pam_handle_t *pamh,
                 ret = prompt_2fa(pamh, pi, _("First Factor: "),
                                  _("Second Factor: "));
             }
-        } else if (pi->cert_user != NULL) {
+        } else if (pi->token_name != NULL && *(pi->token_name) != '\0') {
             ret = prompt_sc_pin(pamh, pi);
         } else {
             ret = prompt_password(pamh, pi, _("Password: "));

--- a/src/sss_client/sss_cli.h
+++ b/src/sss_client/sss_cli.h
@@ -427,7 +427,13 @@ enum response_type {
                           * @param Three zero terminated strings, if one of the
                           * strings is missing the message will contain only
                           * an empty string (\0) for that component. */
-    SSS_PAM_CERT_INFO,
+    SSS_PAM_CERT_INFO,   /**< A message indicating that Smartcard/certificate
+                          * based authentication is available and contains
+                          * details about the found Smartcard.
+                          * @param user name, zero terminated
+                          * @param token name, zero terminated
+                          * @param PKCS#11 module name, zero terminated
+                          * @param key id, zero terminated */
     SSS_OTP,             /**< Indicates that the autotok was a OTP, so don't
                           * cache it. There is no message.
                           * @param None. */
@@ -442,6 +448,9 @@ enum response_type {
                               * be used together with other prompting options
                               * to determine the type of prompting.
                               * @param None. */
+    SSS_PAM_CERT_INFO_WITH_HINT, /**< Same as SSS_PAM_CERT_INFO but user name
+                                  * might be missing and should be prompted
+                                  * for. */
 };
 
 /**

--- a/src/tests/cmocka/test_pam_srv.c
+++ b/src/tests/cmocka/test_pam_srv.c
@@ -1873,10 +1873,14 @@ void test_pam_preauth_cert_no_logon_name(void **state)
      * Since there is a matching user the upcoming lookup by name will find
      * the user entry. But since we force the lookup by name to go to the
      * backend to make sure the group-membership data is up to date the
-     * backend response has to be mocked twice and the second argument of
-     * mock_input_pam_cert cannot be NULL but must match the user name. */
-    mock_input_pam_cert(pam_test_ctx, "pamuser", NULL, NULL,
+     * backend response has to be mocked twice.
+     * Additionally sss_parse_inp_recv() must be mocked because the cache
+     * request will be done with the username found by the certificate
+     * lookup. */
+    mock_input_pam_cert(pam_test_ctx, NULL, NULL, NULL,
                         test_lookup_by_cert_cb, TEST_TOKEN_CERT, false);
+    mock_account_recv_simple();
+    mock_parse_inp("pamuser", NULL, EOK);
 
     will_return(__wrap_sss_packet_get_cmd, SSS_PAM_PREAUTH);
     will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);

--- a/src/tests/cmocka/test_pam_srv.c
+++ b/src/tests/cmocka/test_pam_srv.c
@@ -747,7 +747,8 @@ static int test_pam_cert_check_gdm_smartcard(uint32_t status, uint8_t *body,
     return EOK;
 }
 
-static int test_pam_cert_check(uint32_t status, uint8_t *body, size_t blen)
+static int test_pam_cert_check_ex(uint32_t status, uint8_t *body, size_t blen,
+                                  enum response_type type, const char *name)
 {
     size_t rp = 0;
     uint32_t val;
@@ -758,30 +759,34 @@ static int test_pam_cert_check(uint32_t status, uint8_t *body, size_t blen)
     assert_int_equal(val, pam_test_ctx->exp_pam_status);
 
     SAFEALIGN_COPY_UINT32(&val, body + rp, &rp);
-    assert_int_equal(val, 2);
+    if (name == NULL || *name == '\0') {
+        assert_int_equal(val, 1);
+    } else {
+        assert_int_equal(val, 2);
+
+        SAFEALIGN_COPY_UINT32(&val, body + rp, &rp);
+        assert_int_equal(val, SSS_PAM_DOMAIN_NAME);
+
+        SAFEALIGN_COPY_UINT32(&val, body + rp, &rp);
+        assert_int_equal(val, 9);
+
+        assert_int_equal(*(body + rp + val - 1), 0);
+        assert_string_equal(body + rp, TEST_DOM_NAME);
+        rp += val;
+    }
 
     SAFEALIGN_COPY_UINT32(&val, body + rp, &rp);
-    assert_int_equal(val, SSS_PAM_DOMAIN_NAME);
+    assert_int_equal(val, type);
 
     SAFEALIGN_COPY_UINT32(&val, body + rp, &rp);
-    assert_int_equal(val, 9);
-
-    assert_int_equal(*(body + rp + val - 1), 0);
-    assert_string_equal(body + rp, TEST_DOM_NAME);
-    rp += val;
-
-    SAFEALIGN_COPY_UINT32(&val, body + rp, &rp);
-    assert_int_equal(val, SSS_PAM_CERT_INFO);
-
-    SAFEALIGN_COPY_UINT32(&val, body + rp, &rp);
-    assert_int_equal(val, (sizeof("pamuser@"TEST_DOM_NAME)
+    assert_int_equal(val, (strlen(name) + 1
                                 + sizeof(TEST_TOKEN_NAME)
                                 + sizeof(TEST_MODULE_NAME)
                                 + sizeof(TEST_KEY_ID)));
 
-    assert_int_equal(*(body + rp + sizeof("pamuser@"TEST_DOM_NAME) - 1), 0);
-    assert_string_equal(body + rp, "pamuser@"TEST_DOM_NAME);
-    rp += sizeof("pamuser@"TEST_DOM_NAME);
+    assert_int_equal(*(body + rp + strlen(name)), 0);
+    assert_string_equal(body + rp, name);
+    rp += strlen(name) + 1;
 
     assert_int_equal(*(body + rp + sizeof(TEST_TOKEN_NAME) - 1), 0);
     assert_string_equal(body + rp, TEST_TOKEN_NAME);
@@ -798,6 +803,27 @@ static int test_pam_cert_check(uint32_t status, uint8_t *body, size_t blen)
     assert_int_equal(rp, blen);
 
     return EOK;
+}
+
+static int test_pam_cert_check(uint32_t status, uint8_t *body, size_t blen)
+{
+    return test_pam_cert_check_ex(status, body, blen,
+                                  SSS_PAM_CERT_INFO, "pamuser@"TEST_DOM_NAME);
+}
+
+static int test_pam_cert_check_with_hint(uint32_t status, uint8_t *body,
+                                         size_t blen)
+{
+    return test_pam_cert_check_ex(status, body, blen,
+                                  SSS_PAM_CERT_INFO_WITH_HINT,
+                                  "pamuser@"TEST_DOM_NAME);
+}
+
+static int test_pam_cert_check_with_hint_no_user(uint32_t status, uint8_t *body,
+                                                 size_t blen)
+{
+    return test_pam_cert_check_ex(status, body, blen,
+                                  SSS_PAM_CERT_INFO_WITH_HINT, "");
 }
 
 static int test_pam_offline_chauthtok_check(uint32_t status,
@@ -1895,6 +1921,33 @@ void test_pam_preauth_cert_no_logon_name(void **state)
     assert_int_equal(ret, EOK);
 }
 
+void test_pam_preauth_cert_no_logon_name_with_hint(void **state)
+{
+    int ret;
+
+    set_cert_auth_param(pam_test_ctx->pctx, NSS_DB);
+    pam_test_ctx->rctx->domains->user_name_hint = true;
+
+    /* If no logon name is given the user is looked by certificate first.
+     * Since user name hint is enabled we do not have to search the user
+     * during pre-auth and there is no need for an extra mocked response as in
+     * test_pam_preauth_cert_no_logon_name. */
+    mock_input_pam_cert(pam_test_ctx, NULL, NULL, NULL,
+                        test_lookup_by_cert_cb, TEST_TOKEN_CERT, false);
+
+    will_return(__wrap_sss_packet_get_cmd, SSS_PAM_PREAUTH);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+
+    set_cmd_cb(test_pam_cert_check_with_hint);
+    ret = sss_cmd_execute(pam_test_ctx->cctx, SSS_PAM_PREAUTH,
+                          pam_test_ctx->pam_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(pam_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+}
+
 void test_pam_preauth_cert_no_logon_name_double_cert(void **state)
 {
     int ret;
@@ -1908,6 +1961,29 @@ void test_pam_preauth_cert_no_logon_name_double_cert(void **state)
     will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
 
     set_cmd_cb(test_pam_creds_insufficient_check);
+    ret = sss_cmd_execute(pam_test_ctx->cctx, SSS_PAM_PREAUTH,
+                          pam_test_ctx->pam_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(pam_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+}
+
+void test_pam_preauth_cert_no_logon_name_double_cert_with_hint(void **state)
+{
+    int ret;
+
+    set_cert_auth_param(pam_test_ctx->pctx, NSS_DB);
+    pam_test_ctx->rctx->domains->user_name_hint = true;
+
+    mock_input_pam_cert(pam_test_ctx, NULL, NULL, NULL,
+                        test_lookup_by_cert_double_cb, TEST_TOKEN_CERT, false);
+
+    will_return(__wrap_sss_packet_get_cmd, SSS_PAM_PREAUTH);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+
+    set_cmd_cb(test_pam_cert_check_with_hint_no_user);
     ret = sss_cmd_execute(pam_test_ctx->cctx, SSS_PAM_PREAUTH,
                           pam_test_ctx->pam_cmds);
     assert_int_equal(ret, EOK);
@@ -2426,8 +2502,14 @@ int main(int argc, const char *argv[])
         cmocka_unit_test_setup_teardown(test_pam_preauth_cert_no_logon_name,
                                         pam_test_setup, pam_test_teardown),
         cmocka_unit_test_setup_teardown(
+                                  test_pam_preauth_cert_no_logon_name_with_hint,
+                                  pam_test_setup, pam_test_teardown),
+        cmocka_unit_test_setup_teardown(
                                 test_pam_preauth_cert_no_logon_name_double_cert,
                                 pam_test_setup, pam_test_teardown),
+        cmocka_unit_test_setup_teardown(
+                      test_pam_preauth_cert_no_logon_name_double_cert_with_hint,
+                      pam_test_setup, pam_test_teardown),
         cmocka_unit_test_setup_teardown(test_pam_preauth_no_cert_no_logon_name,
                                         pam_test_setup, pam_test_teardown),
         cmocka_unit_test_setup_teardown(

--- a/src/tests/cmocka/test_sysdb_certmap.c
+++ b/src/tests/cmocka/test_sysdb_certmap.c
@@ -88,7 +88,8 @@ static void test_sysdb_get_certmap_not_exists(void **state)
 
     ret = sysdb_get_certmap(ctctx, ctctx->tctx->sysdb, &certmap,
                             &user_name_hint);
-    assert_int_equal(ret, ENOENT);
+    assert_int_equal(ret, EOK);
+    assert_null(certmap);
 
 }
 
@@ -134,7 +135,7 @@ static void test_sysdb_update_certmap(void **state)
     int ret;
     const char *domains[] = { "dom1.test", "dom2.test", "dom3.test", NULL };
     struct certmap_info map_a = { discard_const("map_a"), 11, discard_const("abc"), discard_const("def"), NULL };
-    struct certmap_info map_b = { discard_const("map_b"), 22, discard_const("abc"), NULL, domains };
+    struct certmap_info map_b = { discard_const("map_b"), UINT_MAX, discard_const("abc"), NULL, domains };
     struct certmap_info *certmap_empty[] = { NULL };
     struct certmap_info *certmap_a[] = { &map_a, NULL };
     struct certmap_info *certmap_b[] = { &map_b, NULL };
@@ -152,7 +153,8 @@ static void test_sysdb_update_certmap(void **state)
 
     ret = sysdb_get_certmap(ctctx, ctctx->tctx->sysdb, &certmap,
                             &user_name_hint);
-    assert_int_equal(ret, ENOENT);
+    assert_int_equal(ret, EOK);
+    assert_null(certmap);
 
     ret = sysdb_update_certmap(ctctx->tctx->sysdb, certmap_a, false);
     assert_int_equal(ret, EOK);

--- a/src/tools/sssctl/sssctl_user_checks.c
+++ b/src/tools/sssctl/sssctl_user_checks.c
@@ -200,6 +200,8 @@ errno_t sssctl_user_checks(struct sss_cmdline *cmdline,
     const char *action = DEFAULT_ACTION;
     const char *service = DEFAULT_SERVICE;
     int ret;
+    int pret;
+    const char *pam_user = NULL;
     size_t c;
     char **pam_env;
 
@@ -246,7 +248,14 @@ errno_t sssctl_user_checks(struct sss_cmdline *cmdline,
     if ( strncmp(action, "auth", 4)== 0 ) {
         fprintf(stdout, _("testing pam_authenticate\n\n"));
         ret = pam_authenticate(pamh, 0);
-        fprintf(stderr, _("pam_authenticate: %s\n\n"), pam_strerror(pamh, ret));
+        pret = pam_get_item(pamh, PAM_USER, (const void **) &pam_user);
+        if (pret != PAM_SUCCESS) {
+            fprintf(stderr, _("pam_get_item failed: %s\n"), pam_strerror(pamh,
+                                                                         pret));
+            pam_user = "- not available -";
+        }
+        fprintf(stderr, _("pam_authenticate for user [%s]: %s\n\n"), pam_user,
+                                                       pam_strerror(pamh, ret));
     } else if ( strncmp(action, "chau", 4)== 0 ) {
         fprintf(stdout, _("testing pam_chauthtok\n\n"));
         ret = pam_chauthtok(pamh, 0);


### PR DESCRIPTION
This patchset got lost when I prepared the certificate mapping patch set.

Applications like gdm with enabled Smartcard support will try to determine the
user based on data from the certificate or expected that it is done for them
and hence do not prompt for a user name. If a certificate is mapped to multiple
accounts this cannot work because it is not clear which account should be used.
In this case a 'user name hint' must be given by the user to help the
application to find the right user.

To get a consistent user experience while still only prompt for a PIN in
environments where a certificate is uniquely mapped to only a single user IPA
offers the 'ipa certmapconfig-mod --promptusername=BOOL' command to switch
'user name hinting' on or off.

To test the behavior 'sssctl user-checks' can be used.
/etc/pam.d/smartcart-auth should be configured for SSSD and like:
...
auth        required      pam_env.so
auth        sufficient    pam_sss.so allow_missing_name
auth        required      pam_deny.so
...

If now a Smartcard in inserted where the certificate is mapped to multiple
users you will see:

user: 
action: auth
service: gdm-smartcard

testing pam_authenticate

PIN for AD.DEVEL Admin (OpenSC Card)
User name hint: 
pam_authenticate for user []: Authentication failure

PAM Environment:
 - PKCS11_LOGIN_TOKEN_NAME=AD.DEVEL Admin (OpenSC Card)




if no user name hint is given and

user: 
action: auth
service: gdm-smartcard

testing pam_authenticate

PIN for AD.DEVEL Admin (OpenSC Card)
User name hint: scuser
pam_authenticate for user [scuser]: Success

PAM Environment:
 - PKCS11_LOGIN_TOKEN_NAME=AD.DEVEL Admin (OpenSC Card)




if a suitable user name hint was given.