### PR TITLE
pam: properly support UPN logon names

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2357,6 +2357,9 @@ nss_srv_tests_LDADD = \
 EXTRA_pam_srv_tests_DEPENDENCIES = \
     $(ldblib_LTLIBRARIES) \
     $(NULL)
+if HAVE_NSS
+EXTRA_pam_srv_tests_DEPENDENCIES += p11_child
+endif
 pam_srv_tests_SOURCES = \
     $(TEST_MOCK_RESP_OBJ) \
     src/tests/cmocka/test_pam_srv.c \

--- a/src/responder/common/cache_req/plugins/cache_req_initgroups_by_upn.c
+++ b/src/responder/common/cache_req/plugins/cache_req_initgroups_by_upn.c
@@ -66,7 +66,7 @@ cache_req_initgroups_by_upn_ncache_check(struct sss_nc_ctx *ncache,
                                          struct sss_domain_info *domain,
                                          struct cache_req_data *data)
 {
-    return sss_ncache_check_user(ncache, domain, data->name.lookup);
+    return sss_ncache_check_upn(ncache, domain, data->name.lookup);
 }
 
 static errno_t
@@ -74,7 +74,7 @@ cache_req_initgroups_by_upn_ncache_add(struct sss_nc_ctx *ncache,
                                        struct sss_domain_info *domain,
                                        struct cache_req_data *data)
 {
-    return sss_ncache_set_user(ncache, false, domain, data->name.lookup);
+    return sss_ncache_set_upn(ncache, false, domain, data->name.lookup);
 }
 
 static errno_t

--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -1560,7 +1560,7 @@ static int pam_check_user_search(struct pam_auth_req *preq)
 
     data = cache_req_data_name(preq,
                                CACHE_REQ_INITGROUPS,
-                               preq->pd->user);
+                               preq->pd->logon_name);
     if (data == NULL) {
         return ENOMEM;
     }
@@ -1589,7 +1589,7 @@ static int pam_check_user_search(struct pam_auth_req *preq)
                            preq->cctx->rctx->ncache,
                            0,
                            preq->req_dom_type,
-                           preq->pd->domain,
+                           NULL,
                            data);
     if (!dpreq) {
         DEBUG(SSSDBG_CRIT_FAILURE,


### PR DESCRIPTION
Many logon applications like /bin/login or sshd canonicalize the user
name before they call pam_start() and hence the UPN is not seen by
SSSD's pam responder. But some like e.g. gdm don't and authentication
might fail if a UPN is used.

The reason is that currently the already parsed short name of the user
was used in the cache_req and hence the cache_req was not able to fall
back to the UPN lookup code. This patch uses the name originally
provided by the user as input to allow the fallback to the UPN lookup.

Resolves https://pagure.io/SSSD/sssd/issue/3240