### PR TITLE
cache_req: Fix warning maybe-uninitialized

### DIFF
--- a/src/responder/common/cache_req/cache_req_search.c
+++ b/src/responder/common/cache_req/cache_req_search.c
@@ -421,7 +421,7 @@ static void cache_req_search_done(struct tevent_req *subreq)
 {
     TALLOC_CTX *tmp_ctx;
     struct cache_req_search_state *state;
-    struct tevent_req *req;
+    struct tevent_req *req = NULL;
     struct ldb_result *result = NULL;
     errno_t ret;
 


### PR DESCRIPTION
the variable `req` could be used uninitialized in done section if talloc_new returns `NULL` 

src/responder/common/cache_req/cache_req_search.c:
     In function 'cache_req_search_done':
src/responder/common/cache_req/cache_req_search.c:467:9:
     error: 'req' may be used uninitialized in this function
     [-Werror=maybe-uninitialized]
         tevent_req_error(req, ret);
         ^
src/responder/common/cache_req/cache_req_search.c:424:24:
     note: 'req' was declared here
     struct tevent_req *req;
                        ^
cc1: all warnings being treated as errors