### PR TITLE
KRB5: Advise the user to inspect the krb5_child.log if the child doesn't return a valid response

### DIFF
--- a/src/providers/krb5/krb5_auth.c
+++ b/src/providers/krb5/krb5_auth.c
@@ -890,6 +890,9 @@ static void krb5_auth_done(struct tevent_req *subreq)
                         state->be_ctx->domain->pwd_expiration_warning,
                         &res);
     if (ret) {
+        DEBUG(SSSDBG_IMPORTANT_INFO,
+              "The krb5_child process returned an error. Please inspect the "
+              "krb5_child.log file or the journal for more information\n");
         DEBUG(SSSDBG_OP_FAILURE, "Could not parse child response [%d]: %s\n",
               ret, strerror(ret));
         goto done;


### PR DESCRIPTION
If the child returns a runtime error, it is often not clear from the domain
debug logs what to do next. This patch adds a DEBUG message that tells the
admin to look into the krb5_child.log

Resolves: https://pagure.io/SSSD/sssd/issue/2955