### PR TITLE
CONFIG: Add subdomain_homedir to config locations

### DIFF
--- a/src/config/SSSDConfig/__init__.py.in
+++ b/src/config/SSSDConfig/__init__.py.in
@@ -188,6 +188,7 @@ option_strings = {
     'subdomain_enumerate' : _('Control enumeration of trusted domains'),
     'subdomain_refresh_interval' : _('How often should subdomains list be refreshed'),
     'subdomain_inherit' : _('List of options that should be inherited into a subdomain'),
+    'subdomain_homedir' : _('Default subdomain homedir value'),
     'cached_auth_timeout' : _('How long can cached credentials be used for cached authentication'),
     'full_name_format' : _('Printf-compatible format for displaying fully-qualified names'),
     're_expression' : _('Regex to parse username and domain'),

--- a/src/config/SSSDConfigTest.py
+++ b/src/config/SSSDConfigTest.py
@@ -567,6 +567,7 @@ class SSSDConfigTestSSSDDomain(unittest.TestCase):
             'realmd_tags',
             'subdomain_refresh_interval',
             'subdomain_inherit',
+            'subdomain_homedir',
             'full_name_format',
             're_expression',
             'cached_auth_timeout']
@@ -936,6 +937,7 @@ class SSSDConfigTestSSSDDomain(unittest.TestCase):
             'realmd_tags',
             'subdomain_refresh_interval',
             'subdomain_inherit',
+            'subdomain_homedir',
             'full_name_format',
             're_expression',
             'cached_auth_timeout']

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -351,6 +351,7 @@ option = description
 option = realmd_tags
 option = subdomain_refresh_interval
 option = subdomain_inherit
+option = subdomain_homedir
 option = cached_auth_timeout
 option = wildcard_limit
 option = full_name_format

--- a/src/config/etc/sssd.api.conf
+++ b/src/config/etc/sssd.api.conf
@@ -172,6 +172,7 @@ description = str, None, false
 realmd_tags = str, None, false
 subdomain_refresh_interval = int, None, false
 subdomain_inherit = str, None, false
+subdomain_homedir = str, None, false
 cached_auth_timeout = int, None, false
 full_name_format = str, None, false
 re_expression = str, None, false


### PR DESCRIPTION
Option **subdomain_homedir** was missing from Python config API an
`cfg_rules.ini` leading to config file validation failures. Add this option
into the necessary locations similar to other provider-generic domain
options.

Resolves:
https://pagure.io/SSSD/sssd/issue/3389