### PR TITLE
BUILD: Fix build without ssh

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2587,9 +2587,11 @@ test_ipa_idmap_LDADD = \
 
 test_utils_SOURCES = \
     src/tests/cmocka/test_utils.c \
-    src/tests/cmocka/test_sss_ssh.c \
     src/tests/cmocka/test_string_utils.c \
     $(NULL)
+if BUILD_SSH
+test_utils_SOURCES += src/tests/cmocka/test_sss_ssh.c
+endif
 test_utils_CFLAGS = \
     $(AM_CFLAGS)
 test_utils_LDADD = \

--- a/src/responder/common/cache_req/plugins/cache_req_host_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_host_by_name.c
@@ -41,6 +41,7 @@ cache_req_host_by_name_lookup(TALLOC_CTX *mem_ctx,
                               struct sss_domain_info *domain,
                               struct ldb_result **_result)
 {
+#ifdef BUILD_SSH
     struct ldb_result *result;
     struct ldb_message *msg;
     errno_t ret;
@@ -59,6 +60,9 @@ cache_req_host_by_name_lookup(TALLOC_CTX *mem_ctx,
     *_result = result;
 
     return EOK;
+#else
+    return ERR_INTERNAL;
+#endif /* BUILD_SSH */
 }
 
 struct tevent_req *

--- a/src/tests/cmocka/test_utils.c
+++ b/src/tests/cmocka/test_utils.c
@@ -1923,7 +1923,9 @@ int main(int argc, const char *argv[])
         cmocka_unit_test_setup_teardown(test_expand_homedir_template,
                                         setup_homedir_ctx,
                                         teardown_homedir_ctx),
+#ifdef BUILD_SSH
         cmocka_unit_test(test_textual_public_key),
+#endif
         cmocka_unit_test(test_replace_whitespaces),
         cmocka_unit_test(test_reverse_replace_whitespaces),
         cmocka_unit_test(test_guid_blob_to_string_buf),


### PR DESCRIPTION
Reported by gentoo user on IRC because SSH responder is optionally build there.

cache_req_host_by_name_lookup should be used only by ssh responder.
But we cannot rely on this fact and therefore we should return
ERR_INTERNAL instead of EOK to catch mis-usage of the cache_req
plugin

autoreconf -if
./configure --without-ssh
make check

  CCLD     sssd_nss
src/responder/common/cache_req/plugins/cache_req_host_by_name.o:
    In function `cache_req_host_by_name_lookup':
src/responder/common/cache_req/plugins/cache_req_host_by_name.c:48:
     undefined reference to `sysdb_get_ssh_host'
collect2: error: ld returned 1 exit status
make: *** [Makefile:14285: sssd_nss] Error 1

src/tests/cmocka/test_utils-test_sss_ssh.o: In function `test_textual_public_key':
src/tests/cmocka/test_sss_ssh.c:78: undefined reference to `sss_ssh_format_pubkey'
src/tests/cmocka/test_sss_ssh.c:82: undefined reference to `sss_ssh_format_pubkey'
src/tests/cmocka/test_sss_ssh.c:86: undefined reference to `sss_ssh_format_pubkey'
src/tests/cmocka/test_sss_ssh.c:89: undefined reference to `sss_ssh_format_pubkey'
src/tests/cmocka/test_sss_ssh.c:92: undefined reference to `sss_ssh_format_pubkey'
src/tests/cmocka/test_utils-test_sss_ssh.o:src/tests/cmocka/test_sss_ssh.c:95:
    more undefined references to `sss_ssh_format_pubkey' follow
collect2: error: ld returned 1 exit status