### PR TITLE
BUILD: Link libwbclient with libdl

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1187,6 +1187,7 @@ libwbclient_la_SOURCES = \
     src/sss_client/libwbclient/wbc_ctx_sssd.c \
     $(NULL)
 libwbclient_la_LIBADD = \
+    $(LIBADD_DL) \
     libsss_nss_idmap.la \
     $(CLIENT_LIBS) \
     $(NULL)


### PR DESCRIPTION
https://lists.fedorahosted.org/archives/list/sssd-users@lists.fedorahosted.org/message/HD5UETSOGEBAYEOVO35QUXKSZP5LAEA6/

dlopen-tests cannot catch it because it has to be linked with libdl

sh$ grep dlopen src/sss_client/libwbclient/
src/sss_client/libwbclient/wbc_pwd_sssd.c:    ctx->dl_handle = dlopen("libnss_sss.so.2", RTLD_NOW);

sh$ nm --dynamic --undefined-only .libs/libwbclient.so | grep dlopen
                 U dlopen