### PR TITLE
krb5: accept changed principal if krb5_canonicalize=True

### DIFF
--- a/src/providers/krb5/krb5_auth.c
+++ b/src/providers/krb5/krb5_auth.c
@@ -829,6 +829,7 @@ static void krb5_auth_done(struct tevent_req *subreq)
     char *renew_interval_str;
     time_t renew_interval_time = 0;
     bool use_enterprise_principal;
+    bool canonicalize;
 
     ret = handle_child_recv(subreq, pd, &buf, &len);
     talloc_zfree(subreq);
@@ -908,6 +909,7 @@ static void krb5_auth_done(struct tevent_req *subreq)
 
     use_enterprise_principal = dp_opt_get_bool(kr->krb5_ctx->opts,
                                                KRB5_USE_ENTERPRISE_PRINCIPAL);
+    canonicalize = dp_opt_get_bool(kr->krb5_ctx->opts, KRB5_CANONICALIZE);
 
     /* Check if the cases of our upn are correct and update it if needed.
      * Fail if the upn differs by more than just the case for non-enterprise
@@ -915,6 +917,7 @@ static void krb5_auth_done(struct tevent_req *subreq)
     if (res->correct_upn != NULL &&
         strcmp(kr->upn, res->correct_upn) != 0) {
         if (strcasecmp(kr->upn, res->correct_upn) == 0 ||
+            canonicalize == true ||
             use_enterprise_principal == true) {
             talloc_free(kr->upn);
             kr->upn = talloc_strdup(kr, res->correct_upn);


### PR DESCRIPTION
Currently SSSD accepts significant changes in the principal only if
krb5_use_enterprise_principal=True. But canonicalization can lead to
similar changes so they should be accepted in this case as well.

Resolves https://pagure.io/SSSD/sssd/issue/3408