### PR TITLE
I found two Coverity warnings in the current master while looking for another issue.

### DIFF
--- a/src/providers/ipa/ipa_s2n_exop.c
+++ b/src/providers/ipa/ipa_s2n_exop.c
@@ -991,6 +991,7 @@ static errno_t s2n_response_to_attrs(TALLOC_CTX *mem_ctx,
                 } else {
                     DEBUG(SSSDBG_TRACE_ALL,
                           "[%s] from root domain, skipping.\n", fq_name);
+                    ret = EOK; /* Free resources and continue in the loop */
                 }
                 ber_memfree(domain_name);
                 ber_memfree(name);

--- a/src/providers/ipa/ipa_s2n_exop.c
+++ b/src/providers/ipa/ipa_s2n_exop.c
@@ -2664,6 +2664,7 @@ static void ipa_s2n_get_list_done(struct tevent_req  *subreq)
         } else {
             tevent_req_error(req, EINVAL);
         }
+        return;
     }
 
     ret = sysdb_attrs_get_string(state->attrs->sysdb_attrs, SYSDB_SID_STR,


### PR DESCRIPTION
IPA: Return from function after marking a request as finished

Fixes:
```
    Error: UNINIT (CWE-457):
    sssd-1.15.3/src/providers/ipa/ipa_s2n_exop.c:782: var_decl: Declaring variable "ret" without initializer.
    sssd-1.15.3/src/providers/ipa/ipa_s2n_exop.c:1001: uninit_use: Using uninitialized value "ret".
    #  999|                   name = NULL;
    # 1000|                   fq_name = NULL;
    # 1001|->                 if (ret != EOK) {
    # 1002|                       DEBUG(SSSDBG_OP_FAILURE, "add_to_name_list failed.\n");
    # 1003|                       goto done;
```

IPA: Avoid using uninitialized ret value when skipping entries from the joined domain

Fixes:
```
   Error: FORWARD_NULL (CWE-476):
   sssd-1.15.3/src/providers/ipa/ipa_s2n_exop.c:2659: var_compare_op: Comparing "state->attrs" to null implies that "state->attrs" might be null.
   sssd-1.15.3/src/providers/ipa/ipa_s2n_exop.c:2668: var_deref_op: Dereferencing null pointer "state->attrs".
   # 2666|       }
   # 2667|   
   # 2668|->     ret = sysdb_attrs_get_string(state->attrs->sysdb_attrs, SYSDB_SID_STR,
   # 2669|                                    &sid_str);
   # 2670|       if (ret == ENOENT) {
```
