### PR TITLE
SSSDConfig: Handle integer parsing more leniently

### DIFF
--- a/src/config/SSSDConfig/__init__.py.in
+++ b/src/config/SSSDConfig/__init__.py.in
@@ -1793,6 +1793,8 @@ class SSSDConfig(SSSDChangeConf):
         for option,value in service.get_all_options().items():
             if (type(value) == list):
                 value = ', '.join(value)
+            if option == "debug_level":
+                value = self._get_debug_level_val(value)
             addkw.append( { 'type'  : 'option',
                             'name'  : option,
                             'value' : str(value) } )
@@ -2137,6 +2139,8 @@ class SSSDConfig(SSSDChangeConf):
         for option,value in domain.get_all_options().items():
             if (type(value) == list):
                 value = ', '.join(value)
+            if option == "debug_level":
+                value = self._get_debug_level_val(value)
             self.set(sectionname, option, str(value))
 
         if domain.active:

--- a/src/config/SSSDConfig/__init__.py.in
+++ b/src/config/SSSDConfig/__init__.py.in
@@ -917,9 +917,11 @@ class SSSDService(SSSDConfigObject):
         if type(value) != option_schema[0]:
             # If it's possible to convert it, do so
             try:
-                if option_schema[0] == bool and \
-                type(value) == str:
+                if option_schema[0] == bool and type(value) == str:
                     value = self.schema.bool_lookup[value.lower()]
+                elif option_schema[0] == int and type(value) == str:
+                    # Make sure we handle any reasonable base
+                    value = int(value, 0)
                 else:
                     value = option_schema[0](value)
             except ValueError:

--- a/src/config/SSSDConfig/ipachangeconf.py
+++ b/src/config/SSSDConfig/ipachangeconf.py
@@ -151,6 +151,13 @@ class IPAChangeConf:
             return section
         return self.sectnamdel[0]+section+self.sectnamdel[1]+self.deol
 
+    @staticmethod
+    def _get_debug_level_val(value):
+        if value > 16:
+            value = hex(value)
+
+        return value
+
     def dump(self, options, level=0):
         output = ""
         if level >= len(self.indent):

--- a/src/config/SSSDConfigTest.py
+++ b/src/config/SSSDConfigTest.py
@@ -118,6 +118,17 @@ class SSSDConfigTestValid(unittest.TestCase):
         self.assertTrue('debug_level' in domain_opts.keys())
         self.assertTrue('id_provider' in domain_opts.keys())
         self.assertTrue('auth_provider' in domain_opts.keys())
+        self.assertEqual(ipa_domain.get_option('debug_level'), 0xff0)
+
+        proxy_domain = sssdconfig.get_domain('PROXY')
+        self.assertEqual(proxy_domain.get_option('debug_level'), 1)
+
+        # Verify attributes in responders
+        pam_responder = sssdconfig.get_service('pam')
+        self.assertEqual(pam_responder.get_option('debug_level'), 2)
+
+        sudo_responder = sssdconfig.get_service('sudo')
+        self.assertEqual(sudo_responder.get_option('debug_level'), 0xfc10)
 
         del sssdconfig
 

--- a/src/config/SSSDConfigTest.py
+++ b/src/config/SSSDConfigTest.py
@@ -232,6 +232,18 @@ class SSSDConfigTestValid(unittest.TestCase):
         ldap_domain.set_active(True)
         sssdconfig.save_domain(ldap_domain)
 
+        proxy_domain = sssdconfig.get_domain('PROXY')
+        proxy_domain.set_option('debug_level', 0x1f10)
+        sssdconfig.save_domain(proxy_domain)
+
+        sudo_responder = sssdconfig.get_service('sudo')
+        sudo_responder.set_option('debug_level', 0x2210)
+        sssdconfig.save_service(sudo_responder)
+
+        pam_responder = sssdconfig.get_service('pam')
+        pam_responder.set_option('debug_level', 9)
+        sssdconfig.save_service(pam_responder)
+
         of = self.tmp_dir + '/testModifyExistingConfig.conf'
 
         #Ensure the output file doesn't exist
@@ -249,6 +261,35 @@ class SSSDConfigTestValid(unittest.TestCase):
         #Output files should not be readable or writable by
         #non-owners, and should not be executable by anyone
         self.assertFalse(S_IMODE(mode) & 0o177)
+
+        # try to import saved configuration file
+        config = SSSDConfig.SSSDConfig(srcdir + "/etc/sssd.api.conf",
+                                       srcdir + "/etc/sssd.api.d")
+        config.import_config(configfile=of)
+
+        # test set_option 'debug_level' value
+
+        # check internal state before parsing strings which is done in
+        # get_domain or get_service
+        debug_option = [ x for x in config.options('domain/LDAP')
+                           if x['name'] == 'debug_level']
+        self.assertEqual(len(debug_option), 1)
+        self.assertEqual(debug_option[0]['value'], '3')
+
+        debug_option = [ x for x in config.options('domain/PROXY')
+                           if x['name'] == 'debug_level']
+        self.assertEqual(len(debug_option), 1)
+        self.assertEqual(debug_option[0]['value'], '0x1f10')
+
+        debug_option = [ x for x in config.options('sudo')
+                           if x['name'] == 'debug_level']
+        self.assertEqual(len(debug_option), 1)
+        self.assertEqual(debug_option[0]['value'], '0x2210')
+
+        debug_option = [ x for x in config.options('pam')
+                           if x['name'] == 'debug_level']
+        self.assertEqual(len(debug_option), 1)
+        self.assertEqual(debug_option[0]['value'], '9')
 
         #Remove the output file
         os.unlink(of)

--- a/src/config/testconfigs/sssd-valid.conf
+++ b/src/config/testconfigs/sssd-valid.conf
@@ -18,7 +18,7 @@ debug_timestamps = False
 [domain/PROXY]
 id_provider = proxy
 auth_provider = proxy
-debug_level = 0
+debug_level = 1
 
 [domain/IPA]
 id_provider = ldap
@@ -53,8 +53,8 @@ debug_level = 0
 nosuchoption = True
 
 [pam]
-debug_level = 0
+debug_level = 2
 nosuchoption = True
 
 [sudo]
-debug_level = 0
+debug_level = 0xfC10


### PR DESCRIPTION
    debug_level is usually defined as decimal value <= 10
    or as a hexadecimal value which is used as a bitmask
    
    Parsing of hexadecimal value was partially fixed by commit
    7fac271ccebb84743c39f553eb5ec013cf1d10aa but only for
    sssd domains. It was not fixed for sssd services.
    
      File "/usr/share/authconfig/authinfo.py", line 3142, in writeSSSDPAM
        pam = self.sssdConfig.get_service('pam')
      File "/usr/lib/python3.6/site-packages/SSSDConfig/__init__.py", line 1620, in get_service
        service.set_option(opt['name'], opt['value'])
      File "/usr/lib/python3.6/site-packages/SSSDConfig/__init__.py", line 932, in set_option
        (option_schema[0], optionname, type(value)))
    TypeError: Expected <class 'int'> for debug_level, received <class 'str'>
    
    Resolves:
    https://pagure.io/SSSD/sssd/issue/341