### PR TITLE
Check the timestamp cache during the users/groups cleanup

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -1142,6 +1142,13 @@ int sysdb_search_users(TALLOC_CTX *mem_ctx,
                        size_t *msgs_count,
                        struct ldb_message ***msgs);
 
+int sysdb_search_users_by_timestamp(TALLOC_CTX *mem_ctx,
+                                    struct sss_domain_info *domain,
+                                    const char *sub_filter,
+                                    const char **attrs,
+                                    size_t *_msgs_count,
+                                    struct ldb_message ***_msgs);
+
 int sysdb_delete_user(struct sss_domain_info *domain,
                       const char *name, uid_t uid);
 
@@ -1151,6 +1158,13 @@ int sysdb_search_groups(TALLOC_CTX *mem_ctx,
                         const char **attrs,
                         size_t *msgs_count,
                         struct ldb_message ***msgs);
+
+int sysdb_search_groups_by_timestamp(TALLOC_CTX *mem_ctx,
+                                     struct sss_domain_info *domain,
+                                     const char *sub_filter,
+                                     const char **attrs,
+                                     size_t *_msgs_count,
+                                     struct ldb_message ***_msgs);
 
 int sysdb_delete_group(struct sss_domain_info *domain,
                        const char *name, gid_t gid);

--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -3520,7 +3520,7 @@ int sysdb_search_ts_users(TALLOC_CTX *mem_ctx,
     ZERO_STRUCT(*res);
 
     if (domain->sysdb->ldb_ts == NULL) {
-        return ENOENT;
+        return ERR_NO_TS;
     }
 
     ret = sysdb_cache_search_users(mem_ctx, domain, domain->sysdb->ldb_ts,
@@ -3737,7 +3737,7 @@ int sysdb_search_ts_groups(TALLOC_CTX *mem_ctx,
     ZERO_STRUCT(*res);
 
     if (domain->sysdb->ldb_ts == NULL) {
-        return ENOENT;
+        return ERR_NO_TS;
     }
 
     ret = sysdb_cache_search_groups(mem_ctx, domain, domain->sysdb->ldb_ts,

--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -5065,6 +5065,15 @@ errno_t sysdb_mark_entry_as_expired_ldb_dn(struct sss_domain_info *dom,
         goto done;
     }
 
+    if (dom->sysdb->ldb_ts != NULL) {
+        ret = ldb_modify(dom->sysdb->ldb_ts, msg);
+        if (ret != LDB_SUCCESS) {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "Could not mark an entry as expired in the timestamp cache\n");
+            /* non-fatal */
+        }
+    }
+
     ret = EOK;
 
 done:

--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -5160,6 +5160,17 @@ int sysdb_invalidate_cache_entry(struct sss_domain_info *domain,
         goto done;
     }
 
+    if (sysdb->ldb_ts != NULL) {
+        ret = sysdb_set_cache_entry_attr(sysdb->ldb_ts, entry_dn,
+                                         attrs, SYSDB_MOD_REP);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "Cannot set attrs in the timestamp cache for %s, %d [%s]\n",
+                  ldb_dn_get_linearized(entry_dn), ret, sss_strerror(ret));
+            /* non-fatal */
+        }
+    }
+
     DEBUG(SSSDBG_FUNC_DATA,
           "Cache entry [%s] has been invalidated.\n",
           ldb_dn_get_linearized(entry_dn));

--- a/src/db/sysdb_private.h
+++ b/src/db/sysdb_private.h
@@ -260,6 +260,13 @@ int sysdb_search_ts_groups(TALLOC_CTX *mem_ctx,
                            const char **attrs,
                            struct ldb_result *res);
 
+errno_t sysdb_search_ts_matches(TALLOC_CTX *mem_ctx,
+                                struct sysdb_ctx *sysdb,
+                                const char *attrs[],
+                                struct ldb_result *ts_res,
+                                const char *filter,
+                                struct ldb_result **_res);
+
 /* Compares the modifyTimestamp attribute between old_entry and
  * new_entry. Returns true if they differ (or either entry is missing
  * the attribute) and false if the attribute is the same

--- a/src/db/sysdb_search.c
+++ b/src/db/sysdb_search.c
@@ -489,7 +489,6 @@ errno_t sysdb_search_ts_matches(TALLOC_CTX *mem_ctx,
                                 const char *filter,
                                 struct ldb_result **_res)
 {
-    char *dn_filter;
     TALLOC_CTX *tmp_ctx = NULL;
     struct ldb_result *res;
     errno_t ret;
@@ -501,7 +500,7 @@ errno_t sysdb_search_ts_matches(TALLOC_CTX *mem_ctx,
     }
 
     tmp_ctx = talloc_new(NULL);
-    if (!tmp_ctx) {
+    if (tmp_ctx == NULL) {
         return ENOMEM;
     }
 
@@ -511,7 +510,43 @@ errno_t sysdb_search_ts_matches(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    dn_filter = talloc_asprintf(tmp_ctx, "(&(%s=%s)(|", SYSDB_NAME, filter);
+    ret = ldb_search(sysdb->ldb, tmp_ctx, &res, NULL,
+                     LDB_SCOPE_SUBTREE, attrs, "%s", filter);
+    if (ret) {
+        ret = sysdb_error_to_errno(ret);
+        goto done;
+    }
+
+    *_res = talloc_steal(mem_ctx, res);
+    ret = EOK;
+
+done:
+    talloc_zfree(tmp_ctx);
+    return ret;
+}
+
+static errno_t sysdb_enum_dn_filter(TALLOC_CTX *mem_ctx,
+                                    struct ldb_result *ts_res,
+                                    const char *name_filter,
+                                    char **_dn_filter)
+{
+    TALLOC_CTX *tmp_ctx = NULL;
+    char *dn_filter;
+    errno_t ret;
+
+    if (ts_res->count == 0) {
+        *_dn_filter = NULL;
+        ret = EOK;
+        goto done;
+    }
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    dn_filter = talloc_asprintf(tmp_ctx, "(&(%s=%s)(|", SYSDB_NAME,
+                                name_filter);
     if (dn_filter == NULL) {
         ret = ENOMEM;
         goto done;
@@ -535,15 +570,9 @@ errno_t sysdb_search_ts_matches(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    ret = ldb_search(sysdb->ldb, tmp_ctx, &res, NULL,
-                     LDB_SCOPE_SUBTREE, attrs, "%s", dn_filter);
-    if (ret) {
-        ret = sysdb_error_to_errno(ret);
-        goto done;
-    }
-
+    *_dn_filter = talloc_steal(mem_ctx, dn_filter);
     ret = EOK;
-    *_res = talloc_steal(mem_ctx, res);
+
 done:
     talloc_zfree(tmp_ctx);
     return ret;
@@ -558,6 +587,7 @@ int sysdb_enumpwent_filter(TALLOC_CTX *mem_ctx,
     TALLOC_CTX *tmp_ctx;
     static const char *attrs[] = SYSDB_PW_ATTRS;
     char *filter = NULL;
+    char *dn_filter = NULL;
     const char *ts_filter = NULL;
     struct ldb_dn *base_dn;
     struct ldb_result *res;
@@ -595,8 +625,13 @@ int sysdb_enumpwent_filter(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
+    ret = sysdb_enum_dn_filter(tmp_ctx, &ts_res, name_filter, &dn_filter);
+    if (ret != EOK) {
+        goto done;
+    }
+
     ret = sysdb_search_ts_matches(tmp_ctx, domain->sysdb, attrs, &ts_res,
-                                  name_filter, &ts_cache_res);
+                                  dn_filter, &ts_cache_res);
     if (ret != EOK && ret != ENOENT) {
         goto done;
     }
@@ -1052,6 +1087,7 @@ int sysdb_enumgrent_filter(TALLOC_CTX *mem_ctx,
     const char *filter = NULL;
     const char *ts_filter = NULL;
     const char *base_filter;
+    char *dn_filter = NULL;
     struct ldb_dn *base_dn;
     struct ldb_result *res;
     struct ldb_result ts_res;
@@ -1100,8 +1136,13 @@ int sysdb_enumgrent_filter(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
+    ret = sysdb_enum_dn_filter(tmp_ctx, &ts_res, name_filter, &dn_filter);
+    if (ret != EOK) {
+        goto done;
+    }
+
     ret = sysdb_search_ts_matches(tmp_ctx, domain->sysdb, attrs, &ts_res,
-                                  name_filter, &ts_cache_res);
+                                  dn_filter, &ts_cache_res);
     if (ret != EOK && ret != ENOENT) {
         goto done;
     }

--- a/src/db/sysdb_search.c
+++ b/src/db/sysdb_search.c
@@ -587,6 +587,10 @@ int sysdb_enumpwent_filter(TALLOC_CTX *mem_ctx,
     ret = sysdb_search_ts_users(tmp_ctx, domain, ts_filter,
                                 sysdb_ts_cache_attrs,
                                 &ts_res);
+    if (ret == ERR_NO_TS) {
+        ret = ENOENT;
+    }
+
     if (ret != EOK && ret != ENOENT) {
         goto done;
     }
@@ -1088,6 +1092,10 @@ int sysdb_enumgrent_filter(TALLOC_CTX *mem_ctx,
     ret = sysdb_search_ts_groups(tmp_ctx, domain, ts_filter,
                                  sysdb_ts_cache_attrs,
                                  &ts_res);
+    if (ret == ERR_NO_TS) {
+        ret = ENOENT;
+    }
+
     if (ret != EOK && ret != ENOENT) {
         goto done;
     }

--- a/src/db/sysdb_search.c
+++ b/src/db/sysdb_search.c
@@ -482,12 +482,12 @@ done:
     return ret;
 }
 
-static errno_t search_ts_matches(TALLOC_CTX *mem_ctx,
-                                 struct sysdb_ctx *sysdb,
-                                 const char *attrs[],
-                                 struct ldb_result *ts_res,
-                                 const char *filter,
-                                 struct ldb_result **_res)
+errno_t sysdb_search_ts_matches(TALLOC_CTX *mem_ctx,
+                                struct sysdb_ctx *sysdb,
+                                const char *attrs[],
+                                struct ldb_result *ts_res,
+                                const char *filter,
+                                struct ldb_result **_res)
 {
     char *dn_filter;
     TALLOC_CTX *tmp_ctx = NULL;
@@ -595,8 +595,8 @@ int sysdb_enumpwent_filter(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    ret = search_ts_matches(tmp_ctx, domain->sysdb, attrs, &ts_res,
-                            name_filter, &ts_cache_res);
+    ret = sysdb_search_ts_matches(tmp_ctx, domain->sysdb, attrs, &ts_res,
+                                  name_filter, &ts_cache_res);
     if (ret != EOK && ret != ENOENT) {
         goto done;
     }
@@ -1100,8 +1100,8 @@ int sysdb_enumgrent_filter(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    ret = search_ts_matches(tmp_ctx, domain->sysdb, attrs, &ts_res,
-                            name_filter, &ts_cache_res);
+    ret = sysdb_search_ts_matches(tmp_ctx, domain->sysdb, attrs, &ts_res,
+                                  name_filter, &ts_cache_res);
     if (ret != EOK && ret != ENOENT) {
         goto done;
     }

--- a/src/providers/ldap/ldap_id_cleanup.c
+++ b/src/providers/ldap/ldap_id_cleanup.c
@@ -219,7 +219,8 @@ static int cleanup_users(struct sdap_options *opts,
         goto done;
     }
 
-    ret = sysdb_search_users(tmpctx, dom, subfilter, attrs, &count, &msgs);
+    ret = sysdb_search_users_by_timestamp(tmpctx, dom, subfilter, attrs,
+                                          &count, &msgs);
     if (ret == ENOENT) {
         count = 0;
     } else if (ret != EOK) {
@@ -394,7 +395,8 @@ static int cleanup_groups(TALLOC_CTX *memctx,
         goto done;
     }
 
-    ret = sysdb_search_groups(tmpctx, domain, subfilter, attrs, &count, &msgs);
+    ret = sysdb_search_groups_by_timestamp(tmpctx, domain, subfilter, attrs,
+                                           &count, &msgs);
     if (ret == ENOENT) {
         count = 0;
     } else if (ret != EOK) {


### PR DESCRIPTION
This patch set basically changes the behaviour of the cleanup_user() and cleanup_groups() functions used by ldap_id_cleanup().

With the current behaviour the searches for the users/groups to be cleaned up are always done in the cache, while the up to date information about their expiration is kept in the timestamp cache.

So, in order to fix [3389](https://pagure.io/SSSD/sssd/issue/3369), let's perform the search in the timestamp cache whenever it's possible.

I'm really not sure whether the dn_filter I'm building is totally correct, so I'd like to ask whoever review this patchset to take a careful look that the last patch, specially in the cleanup_dn_filter() function.

The way I'm testing this issue is:
- I have a LDAP server with a few users and have the following options configured on sssd.conf (client side):
```
enumerate = true
ldap_enumeration_refresh_timeout = 35
ldap_purge_cache_timeout = 60
entry_cache_timeout = 20
```