### PR TITLE
SECRETS: Fix warning Wpointer-bool-conversion

### DIFF
--- a/src/responder/secrets/proxy.c
+++ b/src/responder/secrets/proxy.c
@@ -140,13 +140,13 @@ static int proxy_sec_get_cfg(struct proxy_context *pctx,
                           true, &cfg->verify_peer);
     if (ret) goto done;
     DEBUG(SSSDBG_CONF_SETTINGS, "verify_peer: %s\n",
-          (&cfg->verify_peer ? "true" : "false"));
+          cfg->verify_peer ? "true" : "false");
 
     ret = confdb_get_bool(pctx->cdb, secreq->cfg_section, "verify_host",
                           true, &cfg->verify_host);
     if (ret) goto done;
     DEBUG(SSSDBG_CONF_SETTINGS, "verify_host: %s\n",
-          (&cfg->verify_host ? "true" : "false"));
+          cfg->verify_host ? "true" : "false");
 
     ret = proxy_get_config_string(pctx, cfg, false, secreq,
                                   "capath", &cfg->capath);


### PR DESCRIPTION
I was playing with clang after a longer period and found this issue

Debug messages would always say that verify_peer and verify_host
are enabled. Even though they would be explicitly disabled.

src/responder/secrets/proxy.c:143:18: error:
    address of 'cfg->verify_peer' will always evaluate to
      'true' [-Werror,-Wpointer-bool-conversion]
          (&cfg->verify_peer ? "true" : "false"));
            ~~~~~^~~~~~~~~~~ ~
src/util/debug.h:108:32: note: expanded from macro 'DEBUG'
                     format, ##__VA_ARGS__); \
                               ^~~~~~~~~~~
src/responder/secrets/proxy.c:149:18: error:
    address of 'cfg->verify_host' will always evaluate to
      'true' [-Werror,-Wpointer-bool-conversion]
          (&cfg->verify_host ? "true" : "false"));
            ~~~~~^~~~~~~~~~~ ~
src/util/debug.h:108:32: note: expanded from macro 'DEBUG'
                     format, ##__VA_ARGS__); \
                               ^~~~~~~~~~~