### PR TITLE
BUILD: Improve error messages for optional dependencies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -197,7 +197,6 @@ m4_include([src/external/service.m4])
 
 if test x$with_secrets = xyes; then
     m4_include([src/external/libhttp_parser.m4])
-    m4_include([src/external/libjansson.m4])
 fi
 
 if test x$with_kcm = xyes; then
@@ -206,6 +205,7 @@ fi
 
 if test x$with_kcm = xyes -o x$with_secrets = xyes; then
     m4_include([src/external/libcurl.m4])
+    m4_include([src/external/libjansson.m4])
 fi
 
 # This variable is defined by external/libcurl.m4, but conditionals

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -224,10 +224,14 @@ BuildRequires: systemtap-sdt-devel
 %endif
 %if (0%{?with_secrets} == 1)
 BuildRequires: http-parser-devel
-BuildRequires: jansson-devel
 %endif
+%if (0%{?with_kcm} == 1)
 BuildRequires: libuuid-devel
+%endif
+%if (0%{?with_secrets} == 1 || 0%{?with_kcm} == 1)
+BuildRequires: jansson-devel
 BuildRequires: libcurl-devel
+%endif
 
 %description
 Provides a set of daemons to manage access to remote directories and

--- a/src/external/libcurl.m4
+++ b/src/external/libcurl.m4
@@ -1,5 +1,9 @@
 PKG_CHECK_MODULES([CURL], [libcurl], [found_libcurl=yes],
-              [AC_MSG_ERROR([The libcurl development library was not found.])])
+              [AC_MSG_ERROR([The libcurl development library was not found.
+You must have the header file curl/curl.h installed to build sssd
+with secrets and KCM responder. If you want to build sssd without these
+responders then specify --without-secrets --without-kcm when running configure.
+])])
 
 AS_IF([test x"$found_libcurl" = xyes],
     CFLAGS="$CFLAGS $CURL_CFLAGS"

--- a/src/external/libjansson.m4
+++ b/src/external/libjansson.m4
@@ -13,5 +13,6 @@ AS_IF([test x"$found_jansson" != xyes],
                       [-L$sss_extra_libdir -ljanson])],
         [AC_MSG_ERROR([
 You must have the header file jansson.h installed to build sssd
-with secrets responder. If you want to build sssd without secret responder
-then specify --without-secrets when running configure.])])])
+with secrets and KCM responder. If you want to build sssd without these
+responders then specify --without-secrets --without-kcm when running configure.
+])])])


### PR DESCRIPTION
sssd-kcm is enabled by default and build failed in case of `configure --without-secrets` due to missing dependency on libjansson. It should fail at configure time.

Patch also improve hints for missing optional dependencies