### PR TITLE
certmap: Remove unnecessary included files

### DIFF
--- a/src/lib/certmap/sss_certmap.c
+++ b/src/lib/certmap/sss_certmap.c
@@ -22,6 +22,10 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "config.h"
+
+#include <ctype.h>
+
 #include "util/util.h"
 #include "util/cert.h"
 #include "util/crypto/sss_crypto.h"

--- a/src/lib/certmap/sss_certmap.h
+++ b/src/lib/certmap/sss_certmap.h
@@ -27,9 +27,6 @@
 
 #include <stdlib.h>
 #include <stdint.h>
-#include <stdbool.h>
-#include <sys/types.h>
-
 #include <talloc.h>
 
 /**

--- a/src/lib/certmap/sss_certmap_krb5_match.c
+++ b/src/lib/certmap/sss_certmap_krb5_match.c
@@ -25,7 +25,6 @@
 #include <ctype.h>
 
 #include "util/util.h"
-#include "util/cert.h"
 #include "util/crypto/sss_crypto.h"
 #include "lib/certmap/sss_certmap.h"
 #include "lib/certmap/sss_certmap_int.h"

--- a/src/lib/certmap/sss_certmap_krb5_match.c
+++ b/src/lib/certmap/sss_certmap_krb5_match.c
@@ -22,6 +22,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <ctype.h>
+
 #include "util/util.h"
 #include "util/cert.h"
 #include "util/crypto/sss_crypto.h"

--- a/src/lib/certmap/sss_certmap_ldap_mapping.c
+++ b/src/lib/certmap/sss_certmap_ldap_mapping.c
@@ -22,11 +22,15 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "util/util.h"
-#include "util/cert.h"
-#include "util/crypto/sss_crypto.h"
+#include <errno.h>
+#include <stdbool.h>
+#include <string.h>
+#include <talloc.h>
+
+#include "util/dlinklist.h"
 #include "lib/certmap/sss_certmap.h"
 #include "lib/certmap/sss_certmap_int.h"
+
 struct template_table {
     const char *name;
     const char **attr_name;

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -27,6 +27,7 @@
 #include <sys/param.h>
 #include <time.h>
 #include <string.h>
+#include <signal.h>
 #ifdef HAVE_SYS_INOTIFY_H
 #include <sys/inotify.h>
 #endif

--- a/src/monitor/monitor_iface_generated.c
+++ b/src/monitor/monitor_iface_generated.c
@@ -1,6 +1,9 @@
 /* The following definitions are auto-generated from monitor_iface.xml */
 
-#include "util/util.h"
+#include <stddef.h>
+
+#include "dbus/dbus-protocol.h"
+#include "util/util_errors.h"
 #include "sbus/sssd_dbus.h"
 #include "sbus/sssd_dbus_meta.h"
 #include "sbus/sssd_dbus_invokers.h"

--- a/src/monitor/monitor_iface_generated.h
+++ b/src/monitor/monitor_iface_generated.h
@@ -4,6 +4,7 @@
 #define __MONITOR_IFACE_XML__
 
 #include "sbus/sssd_dbus.h"
+#include "sbus/sssd_dbus_meta.h"
 
 /* ------------------------------------------------------------------------
  * DBus Constants

--- a/src/providers/data_provider/dp_iface_generated.c
+++ b/src/providers/data_provider/dp_iface_generated.c
@@ -1,6 +1,9 @@
 /* The following definitions are auto-generated from dp_iface.xml */
 
-#include "util/util.h"
+#include <stddef.h>
+
+#include "dbus/dbus-protocol.h"
+#include "util/util_errors.h"
 #include "sbus/sssd_dbus.h"
 #include "sbus/sssd_dbus_meta.h"
 #include "sbus/sssd_dbus_invokers.h"

--- a/src/providers/data_provider/dp_iface_generated.h
+++ b/src/providers/data_provider/dp_iface_generated.h
@@ -4,6 +4,7 @@
 #define __DP_IFACE_XML__
 
 #include "sbus/sssd_dbus.h"
+#include "sbus/sssd_dbus_meta.h"
 
 /* ------------------------------------------------------------------------
  * DBus Constants

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -31,6 +31,7 @@
 #include <errno.h>
 #include <dlfcn.h>
 #include <popt.h>
+#include <signal.h>
 #include <dbus/dbus.h>
 
 #include <security/pam_appl.h>

--- a/src/providers/ipa/ipa_access.c
+++ b/src/providers/ipa/ipa_access.c
@@ -22,7 +22,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <sys/param.h>
 #include <security/pam_modules.h>
 
 #include "util/util.h"

--- a/src/providers/ipa/ipa_auth.c
+++ b/src/providers/ipa/ipa_auth.c
@@ -22,7 +22,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <sys/param.h>
 #include <security/pam_modules.h>
 
 #include "util/util.h"

--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -25,6 +25,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include <fcntl.h>
 #include <popt.h>
 
 #include <security/pam_modules.h>

--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -26,6 +26,7 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <ctype.h>
 #include <popt.h>
 
 #include <security/pam_modules.h>

--- a/src/providers/krb5/krb5_child_handler.c
+++ b/src/providers/krb5/krb5_child_handler.c
@@ -22,6 +22,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <signal.h>
+
 #include "util/util.h"
 #include "util/child_common.h"
 #include "providers/krb5/krb5_common.h"

--- a/src/providers/krb5/krb5_common.c
+++ b/src/providers/krb5/krb5_common.c
@@ -25,6 +25,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <netdb.h>
+#include <signal.h>
 #include <arpa/inet.h>
 #include <ctype.h>
 

--- a/src/providers/ldap/ldap_child.c
+++ b/src/providers/ldap/ldap_child.c
@@ -25,6 +25,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include <signal.h>
 #include <popt.h>
 
 #include "util/util.h"

--- a/src/providers/ldap/ldap_common.c
+++ b/src/providers/ldap/ldap_common.c
@@ -22,6 +22,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <signal.h>
+
 #include "providers/ldap/ldap_common.h"
 #include "providers/fail_over.h"
 #include "providers/ldap/sdap_async_private.h"

--- a/src/providers/ldap/sdap_access.c
+++ b/src/providers/ldap/sdap_access.c
@@ -25,7 +25,6 @@
 #include "config.h"
 
 #include <time.h>
-#include <sys/param.h>
 #include <security/pam_modules.h>
 #include <talloc.h>
 #include <tevent.h>

--- a/src/providers/ldap/sdap_async_users.c
+++ b/src/providers/ldap/sdap_async_users.c
@@ -21,6 +21,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <ctype.h>
+
 #include "util/util.h"
 #include "util/probes.h"
 #include "db/sysdb.h"

--- a/src/providers/ldap/sdap_child_helpers.c
+++ b/src/providers/ldap/sdap_child_helpers.c
@@ -27,6 +27,7 @@
 #include <pwd.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <signal.h>
 
 #include "util/util.h"
 #include "util/sss_krb5.h"

--- a/src/providers/proxy/proxy_auth.c
+++ b/src/providers/proxy/proxy_auth.c
@@ -22,6 +22,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <signal.h>
+
 #include "providers/proxy/proxy.h"
 #include "providers/proxy/proxy_iface_generated.h"
 

--- a/src/providers/proxy/proxy_iface_generated.c
+++ b/src/providers/proxy/proxy_iface_generated.c
@@ -1,6 +1,9 @@
 /* The following definitions are auto-generated from proxy_iface.xml */
 
-#include "util/util.h"
+#include <stddef.h>
+
+#include "dbus/dbus-protocol.h"
+#include "util/util_errors.h"
 #include "sbus/sssd_dbus.h"
 #include "sbus/sssd_dbus_meta.h"
 #include "sbus/sssd_dbus_invokers.h"

--- a/src/providers/proxy/proxy_iface_generated.h
+++ b/src/providers/proxy/proxy_iface_generated.h
@@ -4,6 +4,7 @@
 #define __PROXY_IFACE_XML__
 
 #include "sbus/sssd_dbus.h"
+#include "sbus/sssd_dbus_meta.h"
 
 /* ------------------------------------------------------------------------
  * DBus Constants

--- a/src/resolv/async_resolv.c
+++ b/src/resolv/async_resolv.c
@@ -36,6 +36,7 @@
 #include <stddef.h>
 #include <string.h>
 #include <unistd.h>
+#include <limits.h>
 
 #include "config.h"
 #include "resolv/async_resolv.h"

--- a/src/resolv/async_resolv_utils.c
+++ b/src/resolv/async_resolv_utils.c
@@ -22,6 +22,7 @@
 #include <talloc.h>
 #include <tevent.h>
 #include <unistd.h>
+#include <limits.h>
 
 #include "util/util.h"
 #include "resolv/async_resolv.h"

--- a/src/responder/common/iface/responder_iface_generated.c
+++ b/src/responder/common/iface/responder_iface_generated.c
@@ -1,6 +1,9 @@
 /* The following definitions are auto-generated from responder_iface.xml */
 
-#include "util/util.h"
+#include <stddef.h>
+
+#include "dbus/dbus-protocol.h"
+#include "util/util_errors.h"
 #include "sbus/sssd_dbus.h"
 #include "sbus/sssd_dbus_meta.h"
 #include "sbus/sssd_dbus_invokers.h"

--- a/src/responder/common/iface/responder_iface_generated.h
+++ b/src/responder/common/iface/responder_iface_generated.h
@@ -4,6 +4,7 @@
 #define __RESPONDER_IFACE_XML__
 
 #include "sbus/sssd_dbus.h"
+#include "sbus/sssd_dbus_meta.h"
 
 /* ------------------------------------------------------------------------
  * DBus Constants

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <sys/time.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <popt.h>
 #include <dbus/dbus.h>
 

--- a/src/responder/ifp/ifp_iface_generated.c
+++ b/src/responder/ifp/ifp_iface_generated.c
@@ -1,6 +1,9 @@
 /* The following definitions are auto-generated from ifp_iface.xml */
 
-#include "util/util.h"
+#include <stddef.h>
+
+#include "dbus/dbus-protocol.h"
+#include "util/util_errors.h"
 #include "sbus/sssd_dbus.h"
 #include "sbus/sssd_dbus_meta.h"
 #include "sbus/sssd_dbus_invokers.h"

--- a/src/responder/ifp/ifp_iface_generated.h
+++ b/src/responder/ifp/ifp_iface_generated.h
@@ -4,6 +4,7 @@
 #define __IFP_IFACE_XML__
 
 #include "sbus/sssd_dbus.h"
+#include "sbus/sssd_dbus_meta.h"
 
 /* ------------------------------------------------------------------------
  * DBus Constants

--- a/src/responder/nss/nss_iface_generated.c
+++ b/src/responder/nss/nss_iface_generated.c
@@ -1,6 +1,9 @@
 /* The following definitions are auto-generated from nss_iface.xml */
 
-#include "util/util.h"
+#include <stddef.h>
+
+#include "dbus/dbus-protocol.h"
+#include "util/util_errors.h"
 #include "sbus/sssd_dbus.h"
 #include "sbus/sssd_dbus_meta.h"
 #include "sbus/sssd_dbus_invokers.h"

--- a/src/responder/nss/nss_iface_generated.h
+++ b/src/responder/nss/nss_iface_generated.h
@@ -4,6 +4,7 @@
 #define __NSS_IFACE_XML__
 
 #include "sbus/sssd_dbus.h"
+#include "sbus/sssd_dbus_meta.h"
 
 /* ------------------------------------------------------------------------
  * DBus Constants

--- a/src/responder/secrets/local.c
+++ b/src/responder/secrets/local.c
@@ -22,6 +22,8 @@
 #include "responder/secrets/secsrv_private.h"
 #include "util/crypto/sss_crypto.h"
 #include <time.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 #include <ldb.h>
 
 #define MKEY_SIZE (256 / 8)

--- a/src/sbus/sbus_codegen
+++ b/src/sbus/sbus_codegen
@@ -497,7 +497,10 @@ def generate_source(ifaces, filename, include_header=None):
     out("/* The following definitions are auto-generated from %s */", basename)
     out("")
 
-    out("#include \"util/util.h\"")
+    out("#include <stddef.h>")
+    out("")
+    out("#include \"dbus/dbus-protocol.h\"")
+    out("#include \"util/util_errors.h\"")
     out("#include \"sbus/sssd_dbus.h\"")
     out("#include \"sbus/sssd_dbus_meta.h\"")
     out("#include \"sbus/sssd_dbus_invokers.h\"")
@@ -568,6 +571,7 @@ def generate_header(ifaces, filename):
     out("#define %s", guard)
     out("")
     out("#include \"sbus/sssd_dbus.h\"")
+    out("#include \"sbus/sssd_dbus_meta.h\"")
 
     out("")
     out("/* ------------------------------------------------------------------------")

--- a/src/sbus/sssd_dbus_server.c
+++ b/src/sbus/sssd_dbus_server.c
@@ -23,6 +23,7 @@
 #include <sys/stat.h>
 #include <tevent.h>
 #include <dbus/dbus.h>
+#include <limits.h>
 
 #include "util/util.h"
 #include "sbus/sssd_dbus.h"

--- a/src/tests/cmocka/test_ipa_subdomains_server.c
+++ b/src/tests/cmocka/test_ipa_subdomains_server.c
@@ -25,7 +25,8 @@
 #include <errno.h>
 #include <popt.h>
 #include <stdlib.h>
-
+#include <sys/stat.h>
+#include <fcntl.h>
 #include <sys/types.h>
 #include <ifaddrs.h>
 #include <arpa/inet.h>

--- a/src/tests/sbus_codegen_tests_generated.c
+++ b/src/tests/sbus_codegen_tests_generated.c
@@ -1,6 +1,9 @@
 /* The following definitions are auto-generated from sbus_codegen_tests.xml */
 
-#include "util/util.h"
+#include <stddef.h>
+
+#include "dbus/dbus-protocol.h"
+#include "util/util_errors.h"
 #include "sbus/sssd_dbus.h"
 #include "sbus/sssd_dbus_meta.h"
 #include "sbus/sssd_dbus_invokers.h"

--- a/src/tests/sbus_codegen_tests_generated.h
+++ b/src/tests/sbus_codegen_tests_generated.h
@@ -4,6 +4,7 @@
 #define __SBUS_CODEGEN_TESTS_XML__
 
 #include "sbus/sssd_dbus.h"
+#include "sbus/sssd_dbus_meta.h"
 
 /* ------------------------------------------------------------------------
  * DBus Constants

--- a/src/tests/sysdb-tests.c
+++ b/src/tests/sysdb-tests.c
@@ -23,6 +23,7 @@
 #include <check.h>
 #include <talloc.h>
 #include <tevent.h>
+#include <ctype.h>
 #include <popt.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/src/tests/util-tests.c
+++ b/src/tests/util-tests.c
@@ -30,6 +30,7 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <arpa/inet.h>
 
 #include "util/util.h"
 #include "util/sss_utf8.h"

--- a/src/tools/common/sss_process.c
+++ b/src/tools/common/sss_process.c
@@ -20,6 +20,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <signal.h>
 
 #include "util/util.h"
 #include "tools/common/sss_process.h"

--- a/src/tools/sss_signal.c
+++ b/src/tools/sss_signal.c
@@ -19,6 +19,7 @@
 */
 
 #include <stdlib.h>
+#include <signal.h>
 
 #include "config.h"
 #include "tools/common/sss_process.h"

--- a/src/tools/sssctl/sssctl_logs.c
+++ b/src/tools/sssctl/sssctl_logs.c
@@ -20,6 +20,7 @@
 
 #include <popt.h>
 #include <stdio.h>
+#include <signal.h>
 
 #include "util/util.h"
 #include "tools/common/sss_tools.h"

--- a/src/tools/tools_mc_util.c
+++ b/src/tools/tools_mc_util.c
@@ -22,6 +22,7 @@
 #include <talloc.h>
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <signal.h>
 
 #include "db/sysdb.h"
 #include "util/util.h"

--- a/src/util/child_common.c
+++ b/src/util/child_common.c
@@ -24,6 +24,7 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
+#include <signal.h>
 #include <tevent.h>
 #include <sys/wait.h>
 #include <errno.h>

--- a/src/util/crypto/sss_crypto.c
+++ b/src/util/crypto/sss_crypto.c
@@ -19,6 +19,10 @@
 */
 
 #include "config.h"
+
+#include <sys/stat.h>
+#include <fcntl.h>
+
 #include "util/util.h"
 #include "util/crypto/sss_crypto.h"
 

--- a/src/util/domain_info_utils.c
+++ b/src/util/domain_info_utils.c
@@ -18,6 +18,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <ctype.h>
 #include <utime.h>
 
 #include "confdb/confdb.h"

--- a/src/util/inotify.c
+++ b/src/util/inotify.c
@@ -18,6 +18,7 @@
 #include <talloc.h>
 #include <errno.h>
 #include <libgen.h>
+#include <limits.h>
 #include <sys/inotify.h>
 #include <sys/time.h>
 

--- a/src/util/nscd.c
+++ b/src/util/nscd.c
@@ -21,6 +21,7 @@
 
 #include "config.h"
 
+#include <ctype.h>
 #include <stdio.h>
 #include <talloc.h>
 #include <stdlib.h>

--- a/src/util/server.c
+++ b/src/util/server.c
@@ -28,6 +28,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <signal.h>
 #include <ldb.h>
 #include "util/util.h"
 #include "confdb/confdb.h"

--- a/src/util/signal.c
+++ b/src/util/signal.c
@@ -21,7 +21,7 @@
 #include "util/util.h"
 #include <sys/types.h>
 #include <sys/wait.h>
-
+#include <signal.h>
 
 /**
  * @file

--- a/src/util/sss_krb5.c
+++ b/src/util/sss_krb5.c
@@ -17,6 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include <ctype.h>
 #include <stdio.h>
 #include <errno.h>
 #include <talloc.h>

--- a/src/util/sss_ldap.c
+++ b/src/util/sss_ldap.c
@@ -19,6 +19,9 @@
 */
 
 #include "config.h"
+
+#include <fcntl.h>
+
 #include "util/util.h"
 #include "util/sss_sockets.h"
 #include "util/sss_ldap.h"

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -25,6 +25,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
+#include <fcntl.h>
 #include <talloc.h>
 #include <dhash.h>
 #include <time.h>

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -25,7 +25,6 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <fcntl.h>
 #include <string.h>
 #include <strings.h>
 #include <ctype.h>

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -25,12 +25,10 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <unistd.h>
 #include <fcntl.h>
 #include <string.h>
 #include <strings.h>
 #include <ctype.h>
-#include <errno.h>
 #include <libintl.h>
 #include <limits.h>
 #include <locale.h>

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -25,7 +25,6 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <ctype.h>
 #include <libintl.h>
 #include <limits.h>
 #include <locale.h>

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -190,7 +190,6 @@ void server_loop(struct main_context *main_ctx);
 void orderly_shutdown(int status);
 
 /* from signal.c */
-#include <signal.h>
 void BlockSignals(bool block, int signum);
 void (*CatchSignal(int signum,void (*handler)(int )))(int);
 

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -36,7 +36,6 @@
 #include <pcre.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <arpa/inet.h>
 #include <netinet/in.h>
 
 #include <talloc.h>

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -26,7 +26,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <libintl.h>
-#include <limits.h>
 #include <locale.h>
 #include <time.h>
 #include <pcre.h>

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -25,8 +25,6 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <string.h>
-#include <strings.h>
 #include <ctype.h>
 #include <libintl.h>
 #include <limits.h>

--- a/src/util/util_watchdog.c
+++ b/src/util/util_watchdog.c
@@ -19,6 +19,8 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <signal.h>
+
 #include "util/util.h"
 
 #define WATCHDOG_DEF_INTERVAL 10


### PR DESCRIPTION
Patch also replace util.h on place where it was not needed directly
and directly include required header files.

+ some patches to reduce util/util.h