### PR TITLE
KRB5: Fix access_provider=krb5

### DIFF
--- a/src/providers/krb5/krb5_child_handler.c
+++ b/src/providers/krb5/krb5_child_handler.c
@@ -156,14 +156,14 @@ static errno_t create_send_buffer(struct krb5child_req *kr,
         return ENOMEM;
     }
 
-    buf->size = 8*sizeof(uint32_t) + strlen(kr->upn);
+    buf->size = 9*sizeof(uint32_t) + strlen(kr->upn);
 
     if (kr->pd->cmd == SSS_PAM_AUTHENTICATE ||
         kr->pd->cmd == SSS_PAM_PREAUTH ||
         kr->pd->cmd == SSS_CMD_RENEW ||
         kr->pd->cmd == SSS_PAM_CHAUTHTOK_PRELIM ||
         kr->pd->cmd == SSS_PAM_CHAUTHTOK) {
-        buf->size += 5*sizeof(uint32_t) + strlen(kr->ccname) + strlen(keytab) +
+        buf->size += 4*sizeof(uint32_t) + strlen(kr->ccname) + strlen(keytab) +
                      sss_authtok_get_size(kr->pd->authtok);
 
         buf->size += sizeof(uint32_t);


### PR DESCRIPTION
Resolves:
   https://pagure.io/SSSD/sssd/issue/3418

The domain type (posix or not) was being sent to the krb5_child always, but
the buffer only had enough space in case of authentication, not
authorization.

This patch makes the buffer one uint32_t unit larger.

To reproduce, just set up sssd.conf with:
```
   access_provider = krb5
```

Without the patch, you would see messages like:
```
   ==14111== Invalid write of size 2
   ==14111==    at 0x4C3041B: memcpy@@GLIBC_2.14 (vg_replace_strmem.c:1018)
   ==14111==    by 0xE0EE275: safealign_memcpy (util_safealign.h:51)
   ==14111==    by 0xE0EECB3: create_send_buffer (krb5_child_handler.c:239)
   ==14111==    by 0xE0EFDDE: handle_child_send (krb5_child_handler.c:529)
   ==14111==    by 0xE0EDEDD: krb5_access_send (krb5_access.c:149)
   ==14111==    by 0xE0ED32F: krb5_pam_handler_send (krb5_auth.c:1250)
   ==14111==    by 0x418868: file_dp_request (dp_request.c:254)
   ==14111==    by 0x418976: dp_req_send (dp_request.c:300)
   ==14111==    by 0x41C25F: dp_pam_handler (dp_target_auth.c:219)
   ==14111==    by 0x52B3456: sbus_request_invoke_or_finish
(sssd_dbus_request.c:71)
   ==14111==    by 0x52B0F37: sbus_message_handler_got_caller_id
(sssd_dbus_interface.c:1048)
   ==14111==    by 0x923C923: tevent_common_loop_immediate
(tevent_immediate.c:135)
   ==14111==  Address 0x126ab506 is 150 bytes inside a block of size 151
alloc'd
   ==14111==    at 0x4C2BBAD: malloc (vg_replace_malloc.c:299)
   ==14111==    by 0x944D7F4: __talloc_with_prefix (talloc.c:698)
   ==14111==    by 0x944D7F4: __talloc (talloc.c:739)
   ==14111==    by 0x944D7F4: _talloc_named_const (talloc.c:896)
   ==14111==    by 0x944D7F4: talloc_named_const (talloc.c:1675)
   ==14111==    by 0xE0EE7B6: create_send_buffer (krb5_child_handler.c:185)
   ==14111==    by 0xE0EFDDE: handle_child_send (krb5_child_handler.c:529)
   ==14111==    by 0xE0EDEDD: krb5_access_send (krb5_access.c:149)
   ==14111==    by 0xE0ED32F: krb5_pam_handler_send (krb5_auth.c:1250)
   ==14111==    by 0x418868: file_dp_request (dp_request.c:254)
   ==14111==    by 0x418976: dp_req_send (dp_request.c:300)
   ==14111==    by 0x41C25F: dp_pam_handler (dp_target_auth.c:219)
   ==14111==    by 0x52B3456: sbus_request_invoke_or_finish
(sssd_dbus_request.c:71)
   ==14111==    by 0x52B0F37: sbus_message_handler_got_caller_id
(sssd_dbus_interface.c:1048)
   ==14111==    by 0x923C923: tevent_common_loop_immediate
(tevent_immediate.c:135)
```