### PR TITLE
MAN: Document that the secrets provider can only be specified in a per-client section

### DIFF
--- a/src/man/sssd-secrets.5.xml
+++ b/src/man/sssd-secrets.5.xml
@@ -128,19 +128,29 @@ systemctl enable sssd-secrets.service
             </citerefentry> manual page for a complete list. In addition,
             there are some secrets-specific options as well.
         </para>
+        <para>
+            The secrets responder is configured with a global
+            <quote>[secrets]</quote> section and an optional per-user
+            <quote>[secrets/users/$uid]</quote> section in sssd.conf. Please
+            note that some options, notably as the provider type, can only
+            be specified in the per-user subsections.
+        </para>
         <variablelist>
             <varlistentry>
                 <term>provider (string)</term>
                 <listitem>
                 <para>
-                    This option specifies where should the secrets
-                    be stored. The secrets responder can configure a
-                    per-user subsections that define which provider store
-                    the secrets for this particular user. The per-user
-                    subsections should contain all options for that user's
-                    provider. If a per-user section does not exist, the
-                    global settings from the secret responder's section
-                    are used.  The following providers are supported:
+                    This option specifies where should the secrets be
+                    stored. The secrets responder can configure a per-user
+                    subsections (e.g. <quote>[secrets/users/123]</quote>
+                    - see bottom of this manual page for a full example
+                    using Custodia for a particular user) that define
+                    which provider store the secrets for this particular
+                    user. The per-user subsections should contain all
+                    options for that user's provider. Please note that
+                    currently the global provider is always local, the
+                    proxy provider can only be specified in a per-user
+                    section. The following providers are supported:
                     <variablelist>
                         <varlistentry>
                             <term>local</term>


### PR DESCRIPTION
Resolves:
    https://pagure.io/SSSD/sssd/issue/3417