### PR TITLE
TESTS: Add one config-check test case

### DIFF
--- a/src/tests/cmocka/test_config_check.c
+++ b/src/tests/cmocka/test_config_check.c
@@ -106,6 +106,17 @@ void config_check_test_bad_section_name(void **state)
     config_check_test_common(cfg_str, 1, expected_errors);
 }
 
+void config_check_test_too_many_subdomains(void **state)
+{
+    char cfg_str[] = "[domain/ad.test/b.test/c.test]";
+    const char *expected_errors[] = {
+        "[rule/allowed_sections]: Section [domain/ad.test/b.test/c.test] is not allowed. "
+        "Check for typos.",
+    };
+
+    config_check_test_common(cfg_str, 1, expected_errors);
+}
+
 void config_check_test_bad_sssd_option_name(void **state)
 {
     char cfg_str[] = "[sssd]\n"
@@ -253,6 +264,7 @@ int main(int argc, const char *argv[])
 
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(config_check_test_bad_section_name),
+        cmocka_unit_test(config_check_test_too_many_subdomains),
         cmocka_unit_test(config_check_test_bad_sssd_option_name),
         cmocka_unit_test(config_check_test_bad_pam_option_name),
         cmocka_unit_test(config_check_test_bad_nss_option_name),


### PR DESCRIPTION
Add test case with wrong subdomain section format, where the too many
domains are used to identify the trusted domain instead of just the
connected domain and the one trusted domain that is being configured.

This test case came out of discussion I had a while ago with Fabiano when we came to conclusion that some people may try to falsely set the subdomain configuration by putting all domains in the forest between the connected domain and the trusted domain. Fabiano suggested it would be good to have explicit tests for this in the config-check tests and I agreed :)