### PR TITLE
pam_sss: Fix checking of empty string cert_user

### DIFF
--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -995,7 +995,7 @@ static int eval_response(pam_handle_t *pamh, size_t buflen, uint8_t *buf,
                     break;
                 }
 
-                if (type == SSS_PAM_CERT_INFO && pi->cert_user == '\0') {
+                if (type == SSS_PAM_CERT_INFO && *pi->cert_user == '\0') {
                     D(("Invalid CERT message"));
                     break;
                 }
@@ -1007,7 +1007,7 @@ static int eval_response(pam_handle_t *pamh, size_t buflen, uint8_t *buf,
                 }
 
                 if ((pi->pam_user == NULL || *(pi->pam_user) == '\0')
-                        && pi->cert_user != '\0') {
+                        && *pi->cert_user != '\0') {
                     ret = pam_set_item(pamh, PAM_USER, pi->cert_user);
                     if (ret != PAM_SUCCESS) {
                         D(("Failed to set PAM_USER during "


### PR DESCRIPTION
src/sss_client/pam_sss.c: In function ‘eval_response’:
src/sss_client/pam_sss.c:998:64: error: comparison between pointer and zero character constant [-Werror=pointer-compare]
                 if (type == SSS_PAM_CERT_INFO && pi->cert_user == '\0') {
                                                                ^~
src/sss_client/pam_sss.c:998:50: note: did you mean to dereference the pointer?
                 if (type == SSS_PAM_CERT_INFO && pi->cert_user == '\0') {
                                                  ^
src/sss_client/pam_sss.c:1010:42: error: comparison between pointer and zero character constant [-Werror=pointer-compare]
                         && pi->cert_user != '\0') {
                                          ^~
src/sss_client/pam_sss.c:1010:28: note: did you mean to dereference the pointer?
                         && pi->cert_user != '\0') {