### PR TITLE
LDAP: Fix nesting level comparison

### DIFF
--- a/src/providers/ldap/sdap_async_initgroups.c
+++ b/src/providers/ldap/sdap_async_initgroups.c
@@ -2253,7 +2253,7 @@ struct tevent_req *rfc2307bis_nested_groups_send(
     if (!req) return NULL;
 
     if ((num_groups == 0) ||
-        (nesting > dp_opt_get_int(opts->basic, SDAP_NESTING_LEVEL))) {
+        (nesting >= dp_opt_get_int(opts->basic, SDAP_NESTING_LEVEL))) {
         /* No parent groups to process or too deep*/
         ret = EOK;
         goto done;


### PR DESCRIPTION
Very(very) basic fix to correct an issue with nesting level comparison of option
`ldap_group_nesting_level` to ensure that setting nesting level 0 will avoid parent group of group searches.

This was tested and confirmed as fixed downstream, but if needed can be tested with the LDAP provider and `ldap_schema = rfc2307bis` with nesting level set to 0.

Resolves:
https://pagure.io/SSSD/sssd/issue/3425