### PR TITLE
Introduce sysdb_search_by_orig_dn()

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -342,6 +342,12 @@ struct certmap_info {
     const char **domains;
 };
 
+enum sysdb_member_type {
+    SYSDB_MEMBER_USER,
+    SYSDB_MEMBER_GROUP,
+    SYSDB_MEMBER_NETGROUP,
+    SYSDB_MEMBER_SERVICE,
+};
 
 /* These attributes are stored in the timestamp cache */
 extern const char *sysdb_ts_cache_attrs[];
@@ -573,6 +579,20 @@ errno_t sysdb_invalidate_overrides(struct sysdb_ctx *sysdb);
 errno_t sysdb_apply_default_override(struct sss_domain_info *domain,
                                      struct sysdb_attrs *override_attrs,
                                      struct ldb_dn *obj_dn);
+
+errno_t sysdb_search_by_orig_dn(TALLOC_CTX *mem_ctx,
+                                struct sss_domain_info *domain,
+                                enum sysdb_member_type type,
+                                const char *member_dn,
+                                const char **attrs,
+                                size_t *msgs_counts,
+                                struct ldb_message ***msgs);
+
+#define sysdb_search_users_by_orig_dn(mem_ctx, domain, member_dn, attrs, msgs_counts, msgs) \
+    sysdb_search_by_orig_dn(mem_ctx, domain, SYSDB_MEMBER_USER, member_dn, attrs, msgs_counts, msgs);
+
+#define sysdb_search_groups_by_orig_dn(mem_ctx, domain, member_dn, attrs, msgs_counts, msgs) \
+    sysdb_search_by_orig_dn(mem_ctx, domain, SYSDB_MEMBER_GROUP, member_dn, attrs, msgs_counts, msgs);
 
 errno_t sysdb_search_user_override_attrs_by_name(TALLOC_CTX *mem_ctx,
                                             struct sss_domain_info *domain,
@@ -1039,13 +1059,6 @@ int sysdb_store_group(struct sss_domain_info *domain,
                       struct sysdb_attrs *attrs,
                       uint64_t cache_timeout,
                       time_t now);
-
-enum sysdb_member_type {
-    SYSDB_MEMBER_USER,
-    SYSDB_MEMBER_GROUP,
-    SYSDB_MEMBER_NETGROUP,
-    SYSDB_MEMBER_SERVICE,
-};
 
 int sysdb_add_group_member(struct sss_domain_info *domain,
                            const char *group,

--- a/src/providers/ipa/ipa_subdomains_ext_groups.c
+++ b/src/providers/ipa/ipa_subdomains_ext_groups.c
@@ -315,7 +315,6 @@ static errno_t add_ad_user_to_cached_groups(struct ldb_dn *user_dn,
     struct sysdb_attrs *user_attrs;
     size_t msgs_count;
     struct ldb_message **msgs;
-    char *subfilter;
     TALLOC_CTX *tmp_ctx;
     int ret;
 
@@ -332,15 +331,8 @@ static errno_t add_ad_user_to_cached_groups(struct ldb_dn *user_dn,
             continue;
         }
 
-        subfilter = talloc_asprintf(tmp_ctx, "(%s=%s)", SYSDB_ORIG_DN, groups[c]);
-        if (subfilter == NULL) {
-            DEBUG(SSSDBG_OP_FAILURE, "talloc_asprintf failed.\n");
-            ret = ENOMEM;
-            goto done;
-        }
-
-        ret = sysdb_search_groups(tmp_ctx, group_dom, subfilter, NULL,
-                                  &msgs_count, &msgs);
+        ret = sysdb_search_groups_by_orig_dn(tmp_ctx, group_dom, groups[c],
+                                             NULL, &msgs_count, &msgs);
         if (ret != EOK) {
             if (ret == ENOENT) {
                 DEBUG(SSSDBG_TRACE_ALL, "Group [%s] not in the cache.\n",


### PR DESCRIPTION
This patchset came as a suggestion from @jhrozek as the most part of users/groups searches done are by orig dn, would make sense to have these methods exposed and used wherever it's possible.