### PR TITLE
krb5: disable enterprise principals during password changes

### DIFF
--- a/src/providers/krb5/krb5_child_handler.c
+++ b/src/providers/krb5/krb5_child_handler.c
@@ -143,7 +143,8 @@ static errno_t create_send_buffer(struct krb5child_req *kr,
         return EINVAL;
     }
 
-    if (kr->pd->cmd == SSS_CMD_RENEW || kr->is_offline) {
+    if (kr->pd->cmd == SSS_CMD_RENEW || kr->pd->cmd == SSS_PAM_CHAUTHTOK_PRELIM
+            || kr->pd->cmd == SSS_PAM_CHAUTHTOK || kr->is_offline) {
         use_enterprise_principal = false;
     } else {
         use_enterprise_principal = dp_opt_get_bool(kr->krb5_ctx->opts,


### PR DESCRIPTION
Currently using enterprise principals during password changes does not
work reliable.

First there is a special behavior if canonicalization, which in general
should be used together with enterprise principals, is enabled with AD,
see https://pagure.io/SSSD/sssd/issue/1405 and
https://pagure.io/SSSD/sssd/issue/1615 for details. As a result of this
SSSD currently disables canonicalization during password changes.

Additionally it looks like MIT Kerberos does not handle canonicalized
principals well, even if canonicalization is enabled, if not the default
krbtgt/REALM@REALM but kadmin/changepw@REALM is requested. Since it is
currently not clear what is the expected behavior here it make sense to
completely disable enterprise principals during password changes for the
time being.

Resolves https://pagure.io/SSSD/sssd/issue/3426