### PR TITLE
IFP: Fix error handling in ifp_user_get_attr_handle_reply()

### DIFF
--- a/src/responder/ifp/ifpsrv_cmd.c
+++ b/src/responder/ifp/ifpsrv_cmd.c
@@ -236,9 +236,11 @@ ifp_user_get_attr_handle_reply(struct sss_domain_info *domain,
             if (strcmp(attrs[ai], "domainname") == 0) {
                 ret = ifp_add_value_to_dict(&iter_dict, "domainname",
                                             domain->name);
-                DEBUG(SSSDBG_MINOR_FAILURE,
-                      "Cannot add attribute %s to message\n", attrs[ai]);
-                continue;
+                if (ret != EOK) {
+                    DEBUG(SSSDBG_MINOR_FAILURE,
+                          "Cannot add attribute domainname to message\n");
+                    continue;
+                }
             }
 
             el = sss_view_ldb_msg_find_element(domain, res->msgs[0], attrs[ai]);


### PR DESCRIPTION
This is a simple patch found by Coverity.