### PR TITLE
RESPONDER: Use fqnames as output when needed

### DIFF
--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -291,7 +291,6 @@ struct sss_domain_info {
     bool enumerate;
     char **sd_enumerate;
     bool fqnames;
-    bool output_fqnames;
     bool mpg;
     bool ignore_group_members;
     uint32_t id_min;
@@ -355,6 +354,10 @@ struct sss_domain_info {
 
     struct certmap_info **certmaps;
     bool user_name_hint;
+
+    /* Do not use the _output_fqnames property directly in new code, but rather
+     * use sss_domain_info_{get,set}_output_fqnames(). */
+    bool output_fqnames;
 };
 
 /**

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -291,6 +291,7 @@ struct sss_domain_info {
     bool enumerate;
     char **sd_enumerate;
     bool fqnames;
+    bool output_fqnames;
     bool mpg;
     bool ignore_group_members;
     uint32_t id_min;

--- a/src/db/sysdb_subdomains.c
+++ b/src/db/sysdb_subdomains.c
@@ -129,6 +129,13 @@ struct sss_domain_info *new_subdomain(TALLOC_CTX *mem_ctx,
     dom->mpg = mpg;
     dom->state = DOM_ACTIVE;
 
+    /* use fully qualified names as output in order to avoid causing
+     * conflicts with users who have the same name and either the
+     * shortname user resolution is enabled or the trusted domain has
+     * been explicitly set to use non-fully qualified names as input.
+     */
+    dom->output_fqnames = true;
+
     /* If the parent domain filters out group members, the subdomain should
      * as well if configured */
     inherit_option = string_in_list(CONFDB_DOMAIN_IGNORE_GROUP_MEMBERS,

--- a/src/responder/common/cache_req/cache_req_domain.c
+++ b/src/responder/common/cache_req/cache_req_domain.c
@@ -136,7 +136,7 @@ cache_req_domain_new_list_from_string_list(TALLOC_CTX *mem_ctx,
                  * input is allowed by default. However, we really want to use
                  * the fully qualified name as output in order to avoid
                  * conflicts whith users who have the very same name. */
-                cr_domain->domain->output_fqnames = true;
+                sss_domain_info_set_output_fqnames(cr_domain->domain, true);
 
                 DLIST_ADD_END(cr_domains, cr_domain,
                               struct cache_req_domain *);
@@ -166,7 +166,7 @@ cache_req_domain_new_list_from_string_list(TALLOC_CTX *mem_ctx,
          * qualified name as output in order to avoid conflicts whith users
          * who have the very same name. */
         if (resolution_order != NULL) {
-            cr_domain->domain->output_fqnames = true;
+            sss_domain_info_set_output_fqnames(cr_domain->domain, true);
         }
 
         DLIST_ADD_END(cr_domains, cr_domain, struct cache_req_domain *);

--- a/src/responder/common/cache_req/cache_req_domain.c
+++ b/src/responder/common/cache_req/cache_req_domain.c
@@ -132,6 +132,12 @@ cache_req_domain_new_list_from_string_list(TALLOC_CTX *mem_ctx,
                 cr_domain->fqnames =
                     cache_req_domain_use_fqnames(dom, enforce_non_fqnames);
 
+                /* when using the domain resolution order, using shortnames as
+                 * input is allowed by default. However, we really want to use
+                 * the fully qualified name as output in order to avoid
+                 * conflicts whith users who have the very same name. */
+                cr_domain->domain->output_fqnames = true;
+
                 DLIST_ADD_END(cr_domains, cr_domain,
                               struct cache_req_domain *);
                 break;
@@ -154,6 +160,14 @@ cache_req_domain_new_list_from_string_list(TALLOC_CTX *mem_ctx,
         cr_domain->domain = dom;
         cr_domain->fqnames =
             cache_req_domain_use_fqnames(dom, enforce_non_fqnames);
+
+        /* when using the domain resolution order, using shortnames as input
+         * is allowed by default. However, we really want to use the fully
+         * qualified name as output in order to avoid conflicts whith users
+         * who have the very same name. */
+        if (resolution_order != NULL) {
+            cr_domain->domain->output_fqnames = true;
+        }
 
         DLIST_ADD_END(cr_domains, cr_domain, struct cache_req_domain *);
     }

--- a/src/responder/common/cache_req/cache_req_domain.h
+++ b/src/responder/common/cache_req/cache_req_domain.h
@@ -35,6 +35,14 @@ struct cache_req_domain *
 cache_req_domain_get_domain_by_name(struct cache_req_domain *domains,
                                     const char *name);
 
+/*
+ * This function may have a side effect of setting the output_fqnames' domain
+ * property when it's called.
+ *
+ * It happens as the output_fqnames' domain property must only be set depending
+ * on whether a domain resolution order is set or not, and the saner place to
+ * set it to all domains is when flattening those (thus, in this function).
+ */
 errno_t
 cache_req_domain_new_list_from_domain_resolution_order(
                                         TALLOC_CTX *mem_ctx,

--- a/src/tests/cmocka/test_nss_srv.c
+++ b/src/tests/cmocka/test_nss_srv.c
@@ -1648,29 +1648,23 @@ static int test_nss_getgrnam_members_check_subdom(uint32_t status,
     tmp_ctx = talloc_new(nss_test_ctx);
     assert_non_null(tmp_ctx);
 
-    if (nss_test_ctx->subdom->fqnames) {
-        exp_members[0] = sss_tc_fqname(tmp_ctx,
-                                       nss_test_ctx->subdom->names,
-                                       nss_test_ctx->subdom,
-                                       submember1.pw_name);
-        assert_non_null(exp_members[0]);
+    exp_members[0] = sss_tc_fqname(tmp_ctx,
+                                   nss_test_ctx->subdom->names,
+                                   nss_test_ctx->subdom,
+                                   submember1.pw_name);
+    assert_non_null(exp_members[0]);
 
-        exp_members[1] = sss_tc_fqname(tmp_ctx,
-                                       nss_test_ctx->subdom->names,
-                                       nss_test_ctx->subdom,
-                                       submember2.pw_name);
-        assert_non_null(exp_members[1]);
+    exp_members[1] = sss_tc_fqname(tmp_ctx,
+                                   nss_test_ctx->subdom->names,
+                                   nss_test_ctx->subdom,
+                                   submember2.pw_name);
+    assert_non_null(exp_members[1]);
 
-        expected.gr_name = sss_tc_fqname(tmp_ctx,
-                                         nss_test_ctx->subdom->names,
-                                         nss_test_ctx->subdom,
-                                         testsubdomgroup.gr_name);
-        assert_non_null(expected.gr_name);
-    } else {
-        exp_members[0] = submember1.pw_name;
-        exp_members[1] = submember2.pw_name;
-        expected.gr_name = testsubdomgroup.gr_name;
-    }
+    expected.gr_name = sss_tc_fqname(tmp_ctx,
+                                     nss_test_ctx->subdom->names,
+                                     nss_test_ctx->subdom,
+                                     testsubdomgroup.gr_name);
+    assert_non_null(expected.gr_name);
 
     assert_int_equal(status, EOK);
 
@@ -1744,15 +1738,11 @@ static int test_nss_getgrnam_check_mix_dom(uint32_t status,
     tmp_ctx = talloc_new(nss_test_ctx);
     assert_non_null(tmp_ctx);
 
-    if (nss_test_ctx->subdom->fqnames) {
-        exp_members[0] = sss_tc_fqname(tmp_ctx,
-                                       nss_test_ctx->subdom->names,
-                                       nss_test_ctx->subdom,
-                                       submember1.pw_name);
-        assert_non_null(exp_members[0]);
-    } else {
-        exp_members[0] = submember1.pw_name;
-    }
+    exp_members[0] = sss_tc_fqname(tmp_ctx,
+                                   nss_test_ctx->subdom->names,
+                                   nss_test_ctx->subdom,
+                                   submember1.pw_name);
+    assert_non_null(exp_members[0]);
     exp_members[1] = testmember1.pw_name;
     exp_members[2] = testmember2.pw_name;
 
@@ -1840,15 +1830,12 @@ static int test_nss_getgrnam_check_mix_dom_fqdn(uint32_t status,
     tmp_ctx = talloc_new(nss_test_ctx);
     assert_non_null(tmp_ctx);
 
-    if (nss_test_ctx->subdom->fqnames) {
-        exp_members[0] = sss_tc_fqname(tmp_ctx,
-                                       nss_test_ctx->subdom->names,
-                                       nss_test_ctx->subdom,
-                                       submember1.pw_name);
-        assert_non_null(exp_members[0]);
-    } else {
-        exp_members[0] = submember1.pw_name;
-    }
+    exp_members[0] = sss_tc_fqname(tmp_ctx,
+                                   nss_test_ctx->subdom->names,
+                                   nss_test_ctx->subdom,
+                                   submember1.pw_name);
+    assert_non_null(exp_members[0]);
+
     if (nss_test_ctx->tctx->dom->fqnames) {
         exp_members[1] = sss_tc_fqname(tmp_ctx, nss_test_ctx->tctx->dom->names,
                                        nss_test_ctx->tctx->dom, testmember1.pw_name);
@@ -1961,37 +1948,28 @@ static int test_nss_getgrnam_check_mix_subdom(uint32_t status,
     tmp_ctx = talloc_new(nss_test_ctx);
     assert_non_null(tmp_ctx);
 
-    if (nss_test_ctx->subdom->fqnames) {
-        exp_members[0] = sss_tc_fqname(tmp_ctx,
-                                       nss_test_ctx->subdom->names,
-                                       nss_test_ctx->subdom,
-                                       submember1.pw_name);
-        assert_non_null(exp_members[0]);
+    exp_members[0] = sss_tc_fqname(tmp_ctx,
+                                   nss_test_ctx->subdom->names,
+                                   nss_test_ctx->subdom,
+                                   submember1.pw_name);
+    assert_non_null(exp_members[0]);
 
-        exp_members[1] = sss_tc_fqname(tmp_ctx,
-                                       nss_test_ctx->subdom->names,
-                                       nss_test_ctx->subdom,
-                                       submember2.pw_name);
-        assert_non_null(exp_members[1]);
-    } else {
-        exp_members[0] = submember1.pw_name;
-        exp_members[1] = submember2.pw_name;
-    }
+    exp_members[1] = sss_tc_fqname(tmp_ctx,
+                                   nss_test_ctx->subdom->names,
+                                   nss_test_ctx->subdom,
+                                   submember2.pw_name);
+    assert_non_null(exp_members[1]);
 
     /* Important: this member is from a non-qualified domain, so his name will
      * not be qualified either
      */
     exp_members[2] = testmember1.pw_name;
 
-    if (nss_test_ctx->subdom->fqnames) {
-        expected.gr_name = sss_tc_fqname(tmp_ctx,
-                                         nss_test_ctx->subdom->names,
-                                         nss_test_ctx->subdom,
-                                         testsubdomgroup.gr_name);
-        assert_non_null(expected.gr_name);
-    } else {
-        expected.gr_name = testsubdomgroup.gr_name;
-    }
+    expected.gr_name = sss_tc_fqname(tmp_ctx,
+                                     nss_test_ctx->subdom->names,
+                                     nss_test_ctx->subdom,
+                                     testsubdomgroup.gr_name);
+    assert_non_null(expected.gr_name);
 
     assert_int_equal(status, EOK);
 

--- a/src/util/domain_info_utils.c
+++ b/src/util/domain_info_utils.c
@@ -905,3 +905,14 @@ const char *sss_domain_type_str(struct sss_domain_info *dom)
     }
     return "Unknown";
 }
+
+void sss_domain_info_set_output_fqnames(struct sss_domain_info *domain,
+                                        bool output_fqnames)
+{
+    domain->output_fqnames = output_fqnames;
+}
+
+bool sss_domain_info_get_output_fqnames(struct sss_domain_info *domain)
+{
+    return domain->output_fqnames;
+}

--- a/src/util/usertools.c
+++ b/src/util/usertools.c
@@ -867,7 +867,7 @@ int sss_output_fqname(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    if (domain->output_fqnames || domain->fqnames) {
+    if (sss_domain_info_get_output_fqnames(domain) || domain->fqnames) {
         output_name = sss_tc_fqname(tmp_ctx, domain->names,
                                     domain, output_name);
         if (output_name == NULL) {

--- a/src/util/usertools.c
+++ b/src/util/usertools.c
@@ -867,7 +867,7 @@ int sss_output_fqname(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    if (domain->fqnames) {
+    if (domain->output_fqnames || domain->fqnames) {
         output_name = sss_tc_fqname(tmp_ctx, domain->names,
                                     domain, output_name);
         if (output_name == NULL) {

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -562,6 +562,11 @@ errno_t sssd_domain_init(TALLOC_CTX *mem_ctx,
                          const char *db_path,
                          struct sss_domain_info **_domain);
 
+void sss_domain_info_set_output_fqnames(struct sss_domain_info *domain,
+                                        bool output_fqname);
+
+bool sss_domain_info_get_output_fqnames(struct sss_domain_info *domain);
+
 #define IS_SUBDOMAIN(dom) ((dom)->parent != NULL)
 
 #define DOM_HAS_VIEWS(dom) ((dom)->has_views)


### PR DESCRIPTION
As some regressions have been caused by not handling properly naming
conflicts when using shortnames, last explicitly use fully qualified
names as output in the following situations:
- domain resolution order is set;
- a trusted domain has been using `use_fully_qualified_name = false`

In both cases we want to ensure that even handling shortnames as input,
the output will always be fully qualified.

Resolves:
https://pagure.io/SSSD/sssd/issue/3403

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>