### PR TITLE
Master valgrind

### DIFF
--- a/contrib/ci/run
+++ b/contrib/ci/run
@@ -214,7 +214,7 @@ function build_debug()
                                 valgrind-condense 99 \
                                 \"$valgrind_test_pattern\" -- \
                                 --trace-children=yes \
-                                --trace-children-skip='*/bin/*,*/sbin/*' \
+                                --trace-children-skip='*/bin/*,*/sbin/*,./dummy-child' \
                                 --leak-check=full \
                                 --gen-suppressions=all \
                                 --suppressions=\"$CI_DIR/sssd.supp\" \

--- a/contrib/ci/run
+++ b/contrib/ci/run
@@ -199,8 +199,7 @@ function build_debug()
     test_dir=`mktemp --directory /dev/shm/ci-test-dir.XXXXXXXX`
     stage configure         "$BASE_DIR/configure" \
                                 "${CONFIGURE_ARG_LIST[@]}" \
-                                --with-test-dir="$test_dir" \
-                                SHELL=/bin/sh
+                                --with-test-dir="$test_dir"
 
     # Not building "tests" due to https://fedorahosted.org/sssd/ticket/2350
     stage make-tests        make -j $CPU_NUM check LOG_COMPILER=true


### PR DESCRIPTION
There was a bug in valgrind < 3.13 which override some log files
and therefore there was missing errors for shell wrappers generated
by libtool for dummy-child.
    
https://bugs.kde.org/show_bug.cgi?id=162848
    
We could add more suppressions for errors/leaks in bash to our suppression
file but dummy child is built just for test purposes. Another possible solution
would to avoid linking dummy-child with internal libraries; So libtool
would not generate shell wrapper for dummy-child.
But the simplest think is to ignore all errors for dummy-child.

current master:
http://sssd-ci.duckdns.org/logs/job/71/50/summary.html

This patchset:
http://sssd-ci.duckdns.org/logs/job/71/51/summary.html