### PR TITLE
SDAP: Add sdap_domain_copy_search_bases

### DIFF
--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -158,13 +158,7 @@ update_parent_sdap_list(struct sdap_domain *parent_list,
     }
 
     /* Update the search bases */
-    sditer->search_bases = child_sdap->search_bases;
-    sditer->user_search_bases = child_sdap->user_search_bases;
-    sditer->group_search_bases = child_sdap->group_search_bases;
-    sditer->netgroup_search_bases = child_sdap->netgroup_search_bases;
-    sditer->sudo_search_bases = child_sdap->sudo_search_bases;
-    sditer->service_search_bases = child_sdap->service_search_bases;
-    sditer->autofs_search_bases = child_sdap->autofs_search_bases;
+    sdap_domain_copy_search_bases(sditer, child_sdap);
 
     return EOK;
 }

--- a/src/providers/ipa/ipa_subdomains_server.c
+++ b/src/providers/ipa/ipa_subdomains_server.c
@@ -926,13 +926,7 @@ static errno_t ipa_server_create_trusts_step(struct tevent_req *req)
 
             /* Replace basedn and search bases from sdom_b with values
              * from sdom_a */
-            sdom_b->search_bases = sdom_a->search_bases;
-            sdom_b->user_search_bases = sdom_a->user_search_bases;
-            sdom_b->group_search_bases = sdom_a->group_search_bases;
-            sdom_b->netgroup_search_bases = sdom_a->netgroup_search_bases;
-            sdom_b->sudo_search_bases = sdom_a->sudo_search_bases;
-            sdom_b->service_search_bases = sdom_a->service_search_bases;
-            sdom_b->autofs_search_bases = sdom_a->autofs_search_bases;
+            sdap_domain_copy_search_bases(sdom_b, sdom_a);
         }
     }
 

--- a/src/providers/ldap/sdap.c
+++ b/src/providers/ldap/sdap.c
@@ -1732,3 +1732,15 @@ size_t sdap_steal_objects_in_dom(struct sdap_options *opts,
 
     return copied;
 }
+
+void sdap_domain_copy_search_bases(struct sdap_domain *to,
+                                   struct sdap_domain *from)
+{
+    to->search_bases = from->search_bases;
+    to->user_search_bases = from->user_search_bases;
+    to->group_search_bases = from->group_search_bases;
+    to->netgroup_search_bases = from->netgroup_search_bases;
+    to->sudo_search_bases = from->sudo_search_bases;
+    to->service_search_bases = from->service_search_bases;
+    to->autofs_search_bases = from->autofs_search_bases;
+}

--- a/src/providers/ldap/sdap.h
+++ b/src/providers/ldap/sdap.h
@@ -645,4 +645,7 @@ bool sdap_object_in_domain(struct sdap_options *opts,
                            struct sysdb_attrs *obj,
                            struct sss_domain_info *dom);
 
+void sdap_domain_copy_search_bases(struct sdap_domain *to,
+                                   struct sdap_domain *from);
+
 #endif /* _SDAP_H_ */


### PR DESCRIPTION
Add function to copy search bases from one sdap_domain to
another.

Resolves:
https://pagure.io/SSSD/sssd/issue/3435