### PR TITLE
Make sure overrides work with files provider

### DIFF
--- a/src/responder/common/responder.h
+++ b/src/responder/common/responder.h
@@ -58,6 +58,10 @@ extern hash_table_t *dp_requests;
      (strcmp(provider, "local") != 0 && \
       strcmp(provider, "files") != 0))
 
+#define NEED_CHECK_AUTH_PROVIDER(provider) \
+    (provider != NULL && \
+      strcmp(provider, "local") != 0)
+
 /* needed until nsssrv.h is updated */
 struct cli_request {
 

--- a/src/responder/common/responder_get_domains.c
+++ b/src/responder/common/responder_get_domains.c
@@ -428,6 +428,14 @@ static void get_domains_at_startup_done(struct tevent_req *req)
         }
     }
 
+    if (!NEED_CHECK_PROVIDER(state->rctx->domains->provider)) {
+        ret = sysdb_master_domain_update(state->rctx->domains);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_OP_FAILURE, "sysdb_master_domain_update failed, "
+                                     "ignored.\n");
+        }
+    }
+
     talloc_free(state);
     return;
 }

--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -1898,7 +1898,7 @@ static void pam_dom_forwarder(struct pam_auth_req *preq)
         }
     }
 
-    if (!NEED_CHECK_PROVIDER(preq->domain->provider) ) {
+    if (!NEED_CHECK_AUTH_PROVIDER(preq->domain->provider) ) {
         preq->callback = pam_reply;
         ret = LOCAL_pam_handler(preq);
     } else {


### PR DESCRIPTION
There are two issues with overrides and the files provider. First since there
is not backend to call the domain object is not refreshed during the initial
get_domains request. As a result the current view is not read from the cache
and not added to the domain object. As a result the nss responders not aware
that there are overrides at all.

The second is that the overide related attributes are removed from the user and
group object while they are refreshed form the files.

Tests for overrides and the files provider can be found in
https://github.com/SSSD/sssd/pull/265.

The third patch is not strictly related to overrides but to the files provider
in general. Currently the configured auth provider wouldn't be called because
the files provider is handled like the local provider. Please let me know if
this patch should get a ticket and a PR on its own or if it can stay here.

Resolves https://pagure.io/SSSD/sssd/issue/3391