### PR TITLE
sudo: add a threshold option to reduce size of rules refresh filter

### DIFF
--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -139,6 +139,8 @@
 #define CONFDB_DEFAULT_SUDO_TIMED false
 #define CONFDB_SUDO_INVERSE_ORDER "sudo_inverse_order"
 #define CONFDB_DEFAULT_SUDO_INVERSE_ORDER false
+#define CONFDB_SUDO_THRESHOLD "sudo_threshold"
+#define CONFDB_DEFAULT_SUDO_THRESHOLD 50
 
 /* autofs */
 #define CONFDB_AUTOFS_CONF_ENTRY "config/autofs"

--- a/src/config/SSSDConfig/__init__.py.in
+++ b/src/config/SSSDConfig/__init__.py.in
@@ -107,6 +107,7 @@ option_strings = {
     # [sudo]
     'sudo_timed' : _('Whether to evaluate the time-based attributes in sudo rules'),
     'sudo_inverse_order' : _('If true, SSSD will switch back to lower-wins ordering logic'),
+    'sudo_threshold' : _('Maximum number of rules that can be refreshed at once. If this is exceeded, full refresh is performed.'),
 
     # [autofs]
     'autofs_negative_timeout' : _('Negative cache timeout length (seconds)'),

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -144,6 +144,7 @@ option = cache_first
 # sudo service
 option = sudo_timed
 option = sudo_inverse_order
+option = sudo_threshold
 
 [rule/allowed_autofs_options]
 validator = ini_allowed_options

--- a/src/config/etc/sssd.api.conf
+++ b/src/config/etc/sssd.api.conf
@@ -79,6 +79,7 @@ pam_app_services = str, None, false
 # sudo service
 sudo_timed = bool, None, false
 sudo_inverse_order = bool, None, false
+sudo_threshold = int, None, false
 
 [autofs]
 # autofs service

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -1374,6 +1374,25 @@ pam_account_locked_message = Account locked, please contact help desk.
                     </listitem>
                 </varlistentry>
             </variablelist>
+            <variablelist>
+                <varlistentry>
+                    <term>sudo_threshold (integer)</term>
+                    <listitem>
+                        <para>
+                            Maximum number of expired rules that can be
+                            refreshed at once. If number of expired rules
+                            is below threshold, those rules are refreshed
+                            with <quote>rules refresh</quote> mechanism. If
+                            the threshold is exceeded a
+                            <quote>full refresh</quote> of sudo rules is
+                            triggered instead.
+                        </para>
+                        <para>
+                            Default: 50
+                        </para>
+                    </listitem>
+                </varlistentry>
+            </variablelist>
         </refsect2>
 
         <refsect2 id='AUTOFS' condition="with_autofs">

--- a/src/responder/sudo/sudosrv.c
+++ b/src/responder/sudo/sudosrv.c
@@ -148,6 +148,17 @@ int sudo_process_init(TALLOC_CTX *mem_ctx,
         goto fail;
     }
 
+    /* Get sudo_inverse_order option */
+    ret = confdb_get_int(sudo_ctx->rctx->cdb,
+                         CONFDB_SUDO_CONF_ENTRY, CONFDB_SUDO_THRESHOLD,
+                         CONFDB_DEFAULT_SUDO_THRESHOLD,
+                         &sudo_ctx->threshold);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Error reading from confdb (%d) [%s]\n",
+              ret, strerror(ret));
+        goto fail;
+    }
+
     ret = schedule_get_domains_task(rctx, rctx->ev, rctx, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "schedule_get_domains_tasks failed.\n");

--- a/src/responder/sudo/sudosrv_get_sudorules.c
+++ b/src/responder/sudo/sudosrv_get_sudorules.c
@@ -479,6 +479,7 @@ sudosrv_refresh_rules_send(TALLOC_CTX *mem_ctx,
                            struct tevent_context *ev,
                            struct resp_ctx *rctx,
                            struct sss_domain_info *domain,
+                           int threshold,
                            uid_t uid,
                            const char *username,
                            char **groups)
@@ -520,9 +521,19 @@ sudosrv_refresh_rules_send(TALLOC_CTX *mem_ctx,
     DEBUG(SSSDBG_TRACE_INTERNAL, "Refreshing %d expired rules of [%s@%s]\n",
           num_rules, username, domain->name);
 
-    subreq = sss_dp_get_sudoers_send(state, rctx, domain, false,
-                                     SSS_DP_SUDO_REFRESH_RULES,
-                                     username, num_rules, rules);
+    if (num_rules > threshold) {
+        DEBUG(SSSDBG_TRACE_INTERNAL, "Rules threshold [%d] is reached, "
+              "performing full refresh instead.\n", threshold);
+
+        subreq = sss_dp_get_sudoers_send(state, rctx, domain, false,
+                                         SSS_DP_SUDO_FULL_REFRESH,
+                                         username, 0, NULL);
+    } else {
+        subreq = sss_dp_get_sudoers_send(state, rctx, domain, false,
+                                         SSS_DP_SUDO_REFRESH_RULES,
+                                         username, num_rules, rules);
+    }
+
     if (subreq == NULL) {
         ret = ENOMEM;
         goto immediately;
@@ -609,6 +620,7 @@ struct sudosrv_get_rules_state {
     struct sss_domain_info *domain;
     char **groups;
     bool inverse_order;
+    int threshold;
 
     struct sysdb_attrs **rules;
     uint32_t num_rules;
@@ -640,6 +652,7 @@ struct tevent_req *sudosrv_get_rules_send(TALLOC_CTX *mem_ctx,
     state->type = type;
     state->uid = uid;
     state->inverse_order = sudo_ctx->inverse_order;
+    state->threshold = sudo_ctx->threshold;
 
     DEBUG(SSSDBG_TRACE_FUNC, "Running initgroups for [%s]\n", username);
 
@@ -696,8 +709,9 @@ static void sudosrv_get_rules_initgr_done(struct tevent_req *subreq)
     }
 
     subreq = sudosrv_refresh_rules_send(state, state->ev, state->rctx,
-                                        state->domain, state->uid,
-                                        state->username, state->groups);
+                                        state->domain, state->threshold,
+                                        state->uid,state->username,
+                                        state->groups);
     if (subreq == NULL) {
         ret = ENOMEM;
         goto done;

--- a/src/responder/sudo/sudosrv_private.h
+++ b/src/responder/sudo/sudosrv_private.h
@@ -48,6 +48,7 @@ struct sudo_ctx {
      */
     bool timed;
     bool inverse_order;
+    int threshold;
 };
 
 struct sudo_cmd_ctx {


### PR DESCRIPTION
If a large number of rules is expired at one time the ldap filter may
become too large to be processed by server. This commits adds a new
option "sudo_threshold" to sudo responder. If the threshold is
exceeded a full refreshed is done instead of rules refresh.