### PR TITLE
MAN: Updating option ipa_server_mode in man sssd-ipa

### DIFF
--- a/src/man/sssd-ipa.5.xml
+++ b/src/man/sssd-ipa.5.xml
@@ -482,14 +482,15 @@
                 <varlistentry>
                     <term>ipa_server_mode (boolean)</term>
                     <listitem>
-                        <para>
-                            This option should only be set by the IPA
-                            installer.
+			<para>
+                            This option will be set by the IPA installer
+                            (ipa-server-install) automatically and denotes
+                            if SSSD is running on an IPA server or not.
                         </para>
-                        <para>
-                            The option denotes that the SSSD is running on
-                            IPA server and should perform lookups of users
-                            and groups from trusted domains differently.
+			<para>
+                            On an IPA server SSSD will lookup users and groups
+                            from trusted domains directly while on a client
+                            it will ask an IPA server.
                         </para>
                         <para>
                             Default: false


### PR DESCRIPTION
Changes done for section ipa_server_mode since description of section was bit vague. Text is re-phrased vor better understanding.

Resolves: https://pagure.io/SSSD/sssd/issue/3404