### PR TITLE
MAN: The timeout option doesn't say after how many heartbeats will the process be killed

### DIFF
--- a/src/man/sssd-ipa.5.xml
+++ b/src/man/sssd-ipa.5.xml
@@ -482,14 +482,15 @@
                 <varlistentry>
                     <term>ipa_server_mode (boolean)</term>
                     <listitem>
-                        <para>
-                            This option should only be set by the IPA
-                            installer.
+			<para>
+                            This option will be set by the IPA installer
+                            (ipa-server-install) automatically and denotes
+                            if SSSD is running on an IPA server or not.
                         </para>
-                        <para>
-                            The option denotes that the SSSD is running on
-                            IPA server and should perform lookups of users
-                            and groups from trusted domains differently.
+			<para>
+                            On an IPA server SSSD will lookup users and group
+                            from trusted domains directly while on a client
+                            it will ask an IPA server.
                         </para>
                         <para>
                             Default: false

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -161,7 +161,9 @@
                         <para>
                             Timeout in seconds between heartbeats for this
                             service. This is used to ensure that the process
-                            is alive and capable of answering requests.
+                            is alive and capable of answering requests. Note
+                            after three missed heartbeats process will self
+                            terminate.
                         </para>
                         <para>
                             Default: 10


### PR DESCRIPTION
Text added in timeout section of sssd.conf man page describing number of heartbeat missed before process self kills itself.

Resolves: https://pagure.io/SSSD/sssd/issue/3398