### PR TITLE
MAN: The timeout option doesn't say after how many heartbeats will the process be killed

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -161,7 +161,9 @@
                         <para>
                             Timeout in seconds between heartbeats for this
                             service. This is used to ensure that the process
-                            is alive and capable of answering requests.
+                            is alive and capable of answering requests. Note
+                            that after three missed heartbeats the process
+                            will terminate itself.
                         </para>
                         <para>
                             Default: 10


### PR DESCRIPTION
Text added in timeout section of sssd.conf man page describing number of heartbeat missed before process self kills itself.

Resolves: https://pagure.io/SSSD/sssd/issue/3398