### PR TITLE
MAN: Improve description of 'trusted domain section' in sssd.conf's man page

### DIFF
--- a/src/man/sssd-ipa.5.xml
+++ b/src/man/sssd-ipa.5.xml
@@ -482,14 +482,15 @@
                 <varlistentry>
                     <term>ipa_server_mode (boolean)</term>
                     <listitem>
-                        <para>
-                            This option should only be set by the IPA
-                            installer.
+			<para>
+                            This option will be set by the IPA installer
+                            (ipa-server-install) automatically and denotes
+                            if SSSD is running on an IPA server or not.
                         </para>
-                        <para>
-                            The option denotes that the SSSD is running on
-                            IPA server and should perform lookups of users
-                            and groups from trusted domains differently.
+			<para>
+                            On an IPA server SSSD will lookup users and groups
+                            from trusted domains directly while on a client
+                            it will ask an IPA server.
                         </para>
                         <para>
                             Default: false

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -161,7 +161,9 @@
                         <para>
                             Timeout in seconds between heartbeats for this
                             service. This is used to ensure that the process
-                            is alive and capable of answering requests.
+                            is alive and capable of answering requests. Note
+                            that after three missed heartbeats the process
+                            will terminate itself.
                         </para>
                         <para>
                             Default: 10

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2914,8 +2914,8 @@ ldap_user_extra_attrs = phone:telephoneNumber
         <para>
             Some options used in the domain section can also be used in the
             trusted domain section, that is, in a section called
-	    <quote>[domain/<replaceable>DOMAIN_NAME</replaceable>/<replaceable>TRUSTED_DOMAIN_NAME</replaceable>]</quote>.
-            Where DOMAIN_NAME is actual joined-to base domain. Please refer 
+            <quote>[domain/<replaceable>DOMAIN_NAME</replaceable>/<replaceable>TRUSTED_DOMAIN_NAME</replaceable>]</quote>.
+            Where DOMAIN_NAME is actual joined-to base domain. Please refer
             examples below for explanation.
             Currently supported options in the trusted domain section are:
         </para>
@@ -2967,10 +2967,9 @@ max_id = 20000
 enumerate = False
 </programlisting>
 	</para>
-
         <para>
-	    2. The following example shows configuration in IPA AD trust. AD having
-	    having child domain. Suppose IPA domain(ipa.com) has trust with AD 
+            2. The following example shows configuration in IPA AD trust. AD having
+            having child domain. Suppose IPA domain(ipa.com) has trust with AD 
             domain(ad.com). ad.com has child domain(child.ad.com). To enable 
             shortnames in child domain following configuration should be used.
 <programlisting>


### PR DESCRIPTION
PR generated to include explaination for ipa ad trust sssd configuration where ad has a child domain. Explanation is added to 'TRUSTED DOMAIN SECTION'. Also an example is included to better understanding.

Resolves: https://pagure.io/SSSD/sssd/issue/3399