### PR TITLE
IPA: check if IPA hostname is a FQDN

### DIFF
--- a/src/man/sssd-ipa.5.xml
+++ b/src/man/sssd-ipa.5.xml
@@ -113,6 +113,7 @@
                             Optional. May be set on machines where the
                             hostname(5) does not reflect the fully qualified
                             name used in the IPA domain to identify this host.
+                            The hostname must be fully qualified.
                         </para>
                     </listitem>
                 </varlistentry>

--- a/src/providers/ipa/ipa_init.c
+++ b/src/providers/ipa/ipa_init.c
@@ -577,12 +577,23 @@ done:
     return ret;
 }
 
+static bool ipa_check_fqdn(const char *str)
+{
+    return strchr(str, '.');
+}
+
 static errno_t ipa_init_misc(struct be_ctx *be_ctx,
                              struct ipa_options *ipa_options,
                              struct ipa_id_ctx *ipa_id_ctx,
                              struct sdap_id_ctx *sdap_id_ctx)
 {
     errno_t ret;
+
+    if (!ipa_check_fqdn(dp_opt_get_string(ipa_options->basic,
+                        IPA_HOSTNAME))) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+            "ipa_hostname is not Fully Qualified Domain Name.\n");
+    }
 
     ret = ipa_init_dyndns(be_ctx, ipa_options);
     if (ret != EOK) {


### PR DESCRIPTION
Some users change the IPA hostname post-install which results in strange bugs. Code change make sure that the ipa_hostname contains at least one domain component.

Resolves: https://pagure.io/SSSD/sssd/issue/1946