### PR TITLE
RESPONDERS: Fix terminating idle connections

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -623,7 +623,9 @@
                             a client of an SSSD process can hold onto a file
                             descriptor without communicating on it. This value
                             is limited in order to avoid resource exhaustion
-                            on the system.
+                            on the system. The timeout can't be shorter than
+                            10 seconds. If a lower value is configured, it
+                            will be adjusted to 10 seconds.
                         </para>
                         <para>
                             Default: 60

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -608,7 +608,15 @@ static void accept_fd_handler(struct tevent_context *ev,
     cctx->ev = ev;
     cctx->rctx = rctx;
 
-    /* Set up the idle timer */
+    /* Record the new time and set up the idle timer */
+    ret = reset_client_idle_timer(cctx);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_MINOR_FAILURE,
+              "Could not create idle timer for client. "
+              "This connection may not auto-terminate\n");
+        /* Non-fatal, continue */
+    }
+
     ret = setup_client_idle_timer(cctx);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
@@ -635,7 +643,7 @@ static void client_idle_handler(struct tevent_context *ev,
     if (cctx->last_request_time > now) {
         DEBUG(SSSDBG_IMPORTANT_INFO,
               "Time shift detected, re-scheduling the client timeout\n");
-        goto end;
+        goto done;
     }
 
     if ((now - cctx->last_request_time) > cctx->rctx->client_idle_timeout) {
@@ -649,7 +657,7 @@ static void client_idle_handler(struct tevent_context *ev,
         return;
     }
 
-end:
+done:
     setup_client_idle_timer(cctx);
 }
 
@@ -662,11 +670,9 @@ errno_t reset_client_idle_timer(struct cli_ctx *cctx)
 
 static errno_t setup_client_idle_timer(struct cli_ctx *cctx)
 {
-    time_t now = time(NULL);
     struct timeval tv =
             tevent_timeval_current_ofs(cctx->rctx->client_idle_timeout/2, 0);
 
-    cctx->last_request_time = now;
     talloc_zfree(cctx->idle);
 
     cctx->idle = tevent_add_timer(cctx->ev, cctx, tv, client_idle_handler, cctx);

--- a/src/tests/intg/test_secrets.py
+++ b/src/tests/intg/test_secrets.py
@@ -55,9 +55,9 @@ def create_sssd_secrets_fixture(request):
     assert secpid >= 0
 
     if secpid == 0:
-        if subprocess.call([resp_path, "--uid=0", "--gid=0"]) != 0:
-            print("sssd_secrets failed to start")
-            sys.exit(99)
+        os.execv(resp_path, ("--uid=0", "--gid=0"))
+        print("sssd_secrets failed to start")
+        sys.exit(99)
     else:
         sock_path = os.path.join(config.RUNSTATEDIR, "secrets.socket")
         sck = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -83,13 +83,8 @@ def create_sssd_secrets_fixture(request):
     return secpid
 
 
-@pytest.fixture
-def setup_for_secrets(request):
-    """
-    Just set up the local provider for tests and enable the secrets
-    responder
-    """
-    conf = unindent("""\
+def generate_sec_config():
+    return unindent("""\
         [sssd]
         domains = local
         services = nss
@@ -100,11 +95,19 @@ def setup_for_secrets(request):
         [secrets]
         max_secrets = 10
         max_payload_size = 2
-    """).format(**locals())
+    """)
+
+
+@pytest.fixture
+def setup_for_secrets(request):
+    """
+    Just set up the local provider for tests and enable the secrets
+    responder
+    """
+    conf = generate_sec_config()
 
     create_conf_fixture(request, conf)
-    create_sssd_secrets_fixture(request)
-    return None
+    return create_sssd_secrets_fixture(request)
 
 
 def get_secrets_socket():
@@ -385,3 +388,49 @@ def test_containers(setup_for_secrets, secrets_cli):
     with pytest.raises(HTTPError) as err406:
         cli.create_container(container)
     assert str(err406.value).startswith("406")
+
+
+def get_num_fds(pid):
+    procpath = os.path.join("/proc/", str(pid), "fd")
+    return len([fdname for fdname in os.listdir(procpath)])
+
+
+@pytest.fixture
+def setup_for_cli_timeout_test(request):
+    """
+    Same as the generic setup, except a short client_idle_timeout so that
+    the test_idle_timeout() test closes the fd towards the client.
+    """
+    conf = generate_sec_config() + \
+        unindent("""
+        client_idle_timeout = 10
+        """).format()
+
+    create_conf_fixture(request, conf)
+    return create_sssd_secrets_fixture(request)
+
+
+def test_idle_timeout(setup_for_cli_timeout_test):
+    """
+    Test that idle file descriptors are reaped after the idle timeout
+    passes
+    """
+    secpid = setup_for_cli_timeout_test
+    sock_path = get_secrets_socket()
+
+    nfds_pre = get_num_fds(secpid)
+
+    sock = socket.socket(family=socket.AF_UNIX)
+    sock.connect(sock_path)
+    time.sleep(1)
+    nfds_conn = get_num_fds(secpid)
+    assert nfds_pre + 1 == nfds_conn
+    # With the idle timeout set to 10 seconds, we need to sleep at least 15,
+    # because the internal timer ticks every timeout/2 seconds, so it would
+    # tick at 5, 10 and 15 seconds and the client timeout check uses a
+    # greater-than comparison, so the 10-seconds tick wouldn't yet trigger
+    # disconnect
+    time.sleep(15)
+
+    nfds_post = get_num_fds(secpid)
+    assert nfds_pre == nfds_post


### PR DESCRIPTION
The client_idle_handler() function tried to schedule another tevent timer
to check for idle client connections in case the current connection was
still valid, but in doing so, it also stored the current time into the
last_request_time field of the client context.

This kept the connection always alive, because the last_request_time could
then never be older than the timeout.

This patch changes the setup_client_idle_timer() function to only do what
the synopsis says and set the idle timer. The caller (usually the function
that accepts the connection) is supposed to store the request time itself.

To test, revert the patch with the code fix and run the integration test
in the other patch.