### PR TITLE
KRB5: Return invalid credentials internally when attempting to renew an expired TGT

### DIFF
--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -2108,6 +2108,14 @@ done:
         krb5_cc_close(kr->ctx, ccache);
     }
 
+    if (kerr == KRB5KRB_AP_ERR_TKT_EXPIRED) {
+        DEBUG(SSSDBG_TRACE_LIBS,
+              "Attempted to renew an expired TGT, changing the error code "
+              "to expired creds internally\n");
+        /* map_krb5_error() won't touch the sssd-internal code */
+        kerr = ERR_CREDS_EXPIRED;
+    }
+
     return map_krb5_error(kerr);
 }
 


### PR DESCRIPTION
Since 1.14.2 and in particular commit
d3348f49260998880bb7cd3b2fb72d562b1b7a64 we return ERR_NETWORK_IO for any
krb5_child operations that receive KRB5KRB_AP_ERR_TKT_EXPIRED from libkrb5.

However, when the action that krb5_child performs is ticket renewal and the
ticket is totally expired, this can send the SSSD into offline mode.

Instead, this patch converts the KRB5KRB_AP_ERR_TKT_EXPIRED code into
sssd-internal ERR_CREDS_EXPIRED which map_krb5_error() won't map anymore.

The effect on the deamon is that just the single renewal fails, but the
failover code is not called and therefore sssd doesn't switch into offline
mode.

Resolves: https://pagure.io/SSSD/sssd/issue/3406