### PR TITLE
ad_account_can_shortcut: shortcut if ID is unknown

### DIFF
--- a/src/providers/ad/ad_id.c
+++ b/src/providers/ad/ad_id.c
@@ -86,6 +86,8 @@ static bool ad_account_can_shortcut(struct sdap_idmap_ctx *idmap_ctx,
         if (err != IDMAP_SUCCESS) {
             DEBUG(SSSDBG_MINOR_FAILURE, "Mapping ID [%s] to SID failed: "
                   "[%s]\n", filter_value, idmap_error_string(err));
+            /* assume id is from a different domain */
+            shortcut = true;
             goto done;
         }
         /* fall through */


### PR DESCRIPTION
If sss_idmap_unix_to_sid() returns an error we can assume that the given
POSIX ID is not from the current domain and can be skipped. This is e.g.
the case in the IPA provider if a POSIX ID used in the IPA domain is
checked in a trusted id-mapped AD domain before the IPA domain is checked.

Resolves https://pagure.io/SSSD/sssd/issue/3452

Additionally this PR adds some missing descriptions for idmap error codes.