### PR TITLE
KCM: temporary increase hardcoded buffers

### DIFF
--- a/src/responder/kcm/kcmsrv_ops.c
+++ b/src/responder/kcm/kcmsrv_ops.c
@@ -31,7 +31,7 @@
 #include "responder/kcm/kcmsrv_ops.h"
 #include "responder/kcm/kcmsrv_ccache.h"
 
-#define KCM_REPLY_MAX   2048
+#define KCM_REPLY_MAX 16384
 
 struct kcm_op_ctx {
     struct kcm_resp_ctx *kcm_data;

--- a/src/util/tev_curl.c
+++ b/src/util/tev_curl.c
@@ -35,7 +35,7 @@
 #include "util/tev_curl.h"
 
 #define TCURL_IOBUF_CHUNK   1024
-#define TCURL_IOBUF_MAX     4096
+#define TCURL_IOBUF_MAX    16384
 
 static bool global_is_curl_initialized;
 


### PR DESCRIPTION
Temporary workaround:
https://pagure.io/SSSD/sssd/issue/3386

I would prefer to have at least partially usable kcm in official release
due to downstream distributions.