### PR TITLE
sydb: index improvements

### DIFF
--- a/src/db/sysdb_init.c
+++ b/src/db/sysdb_init.c
@@ -503,6 +503,13 @@ static errno_t sysdb_domain_cache_upgrade(TALLOC_CTX *mem_ctx,
         }
     }
 
+    if (strcmp(version, SYSDB_VERSION_0_18) == 0) {
+        ret = sysdb_upgrade_18(sysdb, &version);
+        if (ret != EOK) {
+            goto done;
+        }
+    }
+
     ret = EOK;
 done:
     sysdb->ldb = save_ldb;

--- a/src/db/sysdb_private.h
+++ b/src/db/sysdb_private.h
@@ -23,6 +23,7 @@
 #ifndef __INT_SYS_DB_H__
 #define __INT_SYS_DB_H__
 
+#define SYSDB_VERSION_0_19 "0.19"
 #define SYSDB_VERSION_0_18 "0.18"
 #define SYSDB_VERSION_0_17 "0.17"
 #define SYSDB_VERSION_0_16 "0.16"
@@ -42,7 +43,7 @@
 #define SYSDB_VERSION_0_2 "0.2"
 #define SYSDB_VERSION_0_1 "0.1"
 
-#define SYSDB_VERSION SYSDB_VERSION_0_18
+#define SYSDB_VERSION SYSDB_VERSION_0_19
 
 #define SYSDB_BASE_LDIF \
      "dn: @ATTRIBUTES\n" \
@@ -72,6 +73,11 @@
      "@IDXATTR: sshKnownHostsExpire\n" \
      "@IDXATTR: objectSIDString\n" \
      "@IDXONE: 1\n" \
+     "@IDXATTR: ghost\n" \
+     "@IDXATTR: userPrincipalName\n" \
+     "@IDXATTR: canonicalUserPrincipalName\n" \
+     "@IDXATTR: uniqueID\n" \
+     "@IDXATTR: mail\n" \
      "\n" \
      "dn: @MODULES\n" \
      "@LIST: asq,memberof\n" \
@@ -162,6 +168,7 @@ int sysdb_upgrade_16(struct sysdb_ctx *sysdb, const char **ver);
 int sysdb_upgrade_17(struct sysdb_ctx *sysdb,
                      struct sysdb_dom_upgrade_ctx *upgrade_ctx,
                      const char **ver);
+int sysdb_upgrade_18(struct sysdb_ctx *sysdb, const char **ver);
 
 int sysdb_add_string(struct ldb_message *msg,
                      const char *attr, const char *value);


### PR DESCRIPTION
This patch first adds some missing attributes to the index. The most
important one here is 'ghost' which is used in the backed during group
lookups.

Additionally the index for one-level searches @IDXONE is removed. One
level searches were only used in a few places and are replace by this
patch with sub-tree searches. The main reason for the removal is that
maintaining the index is quite costly because it is basically a single
huge blob in the underlying tdb database.

Finally this patch removes the index on the objectClass attribute and
adds a new index on an new attribute called objectCategory which is used
instead of objectClass for all objects expect user and group. Typically
user and group searches are done by name or ID attributes which are more
specific then objectClass. And since most of the objects in the cache
will be users and groups a search for all users or groups will be near
to a full database search so that the index won't help much in this case
either. The reason for removing it are the costs to manage it when there
are many users or groups.

Due to the index changes some search results are returned in different
order. I updated the related tests so that the checks do not depend on a
specific order anymore.

If 'LDB_WARN_UNINDEXED=1' is set in /etc/sysconfig/sssd full database
searches are indicated with a 'ldb FULL SEARCH: ...' debug message.
Since there are no extra costs we might want to enable this by default
with a certain debug level.

Currently there are two types of un-indexed searches. Searches with
'(distinguishedName=*)' in the filter are related to sub-tree deletes
and '(dataExpireTimestamp<=...)' are related to refresh and cleanup
tasks. Please note that '<=' and sub-string searches cannot be indexed.