### PR TITLE
Move header files consumed by both server and client to special folder

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -652,7 +652,6 @@ dist_noinst_HEADERS = \
     src/util/dlinklist.h \
     src/util/debug.h \
     src/util/util.h \
-    src/util/io.h \
     src/util/util_errors.h \
     src/util/safe-format-string.h \
     src/util/session_recording.h \
@@ -673,13 +672,11 @@ dist_noinst_HEADERS = \
     src/util/refcount.h \
     src/util/find_uid.h \
     src/util/user_info_msg.h \
-    src/util/murmurhash3.h \
     src/util/mmap_cache.h \
     src/util/atomic_io.h \
     src/util/auth_utils.h \
     src/util/authtok.h \
     src/util/authtok-utils.h \
-    src/util/util_safealign.h \
     src/util/util_sss_idmap.h \
     src/util/util_creds.h \
     src/util/inotify.h \
@@ -849,6 +846,9 @@ dist_noinst_HEADERS = \
     src/tools/common/sss_colondb.h \
     src/tools/sssctl/sssctl.h \
     src/util/probes.h \
+    src/shared/io.h \
+    src/shared/murmurhash3.h \
+    src/shared/safealign.h \
     $(NULL)
 
 

--- a/src/lib/idmap/sss_idmap.c
+++ b/src/lib/idmap/sss_idmap.c
@@ -29,7 +29,7 @@
 
 #include "lib/idmap/sss_idmap.h"
 #include "lib/idmap/sss_idmap_private.h"
-#include "util/murmurhash3.h"
+#include "shared/murmurhash3.h"
 
 #define SID_FMT "%s-%d"
 #define SID_STR_MAX_LEN 1024

--- a/src/providers/ldap/sdap_idmap.c
+++ b/src/providers/ldap/sdap_idmap.c
@@ -20,9 +20,9 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "shared/murmurhash3.h"
 #include "util/util.h"
 #include "util/dlinklist.h"
-#include "util/murmurhash3.h"
 #include "providers/ldap/sdap_idmap.h"
 #include "util/util_sss_idmap.h"
 

--- a/src/python/pysss_murmur.c
+++ b/src/python/pysss_murmur.c
@@ -23,7 +23,7 @@
 #include <Python.h>
 
 #include "util/sss_python.h"
-#include "util/murmurhash3.h"
+#include "shared/murmurhash3.h"
 
 PyDoc_STRVAR(murmurhash3_doc,
 "murmurhash3(key, key_len, seed) -> 32bit integer hash\n\

--- a/src/shared/io.h
+++ b/src/shared/io.h
@@ -22,11 +22,6 @@
 #ifndef _UTIL_IO_H_
 #define _UTIL_IO_H_
 
-/* CAUTION:
- * This file is also used in sss_client (pam, nss). Therefore it have to be
- * minimalist and cannot include DEBUG macros or header file util.h.
- */
-
 int sss_open_cloexec(const char *pathname, int flags, int *ret);
 int sss_openat_cloexec(int dir_fd, const char *pathname, int flags, int *ret);
 

--- a/src/shared/murmurhash3.h
+++ b/src/shared/murmurhash3.h
@@ -11,10 +11,6 @@
 
 #include <stdint.h>
 
-/* CAUTION:
- * This file is also used in sss_client (pam, nss). Therefore it have to be
- * minimalist and cannot include DEBUG macros or header file util.h.
- */
 uint32_t murmurhash3(const char *key, int len, uint32_t seed);
 
 #endif /* _UTIL_MURMURHASH3_H_ */

--- a/src/shared/safealign.h
+++ b/src/shared/safealign.h
@@ -20,14 +20,8 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/* CAUTION:
- * This file is also used in sss_client (pam, nss). Therefore it has to be
- * minimalist and cannot include DEBUG macros or header file util.h.
- */
-
-
-#ifndef _UTIL_SAFEALIGN_H
-#define _UTIL_SAFEALIGN_H
+#ifndef _SAFEALIGN_H
+#define _SAFEALIGN_H
 
 #include <string.h>
 #include <stdint.h>
@@ -144,4 +138,4 @@ safealign_memcpy(void *dest, const void *src, size_t n, size_t *counter)
 #define SAFEALIGN_SET_UINT16 SAFEALIGN_SETMEM_UINT16
 #define SAFEALIGN_SET_STRING SAFEALIGN_SETMEM_STRING
 
-#endif /* _UTIL_SAFEALIGN_H */
+#endif /* _SAFEALIGN_H */

--- a/src/sss_client/nss_mc_common.c
+++ b/src/sss_client/nss_mc_common.c
@@ -32,7 +32,7 @@
 #include <stdlib.h>
 #include "nss_mc.h"
 #include "sss_cli.h"
-#include "util/io.h"
+#include "shared/io.h"
 
 /* FIXME: hook up to library destructor to avoid leaks */
 /* FIXME: temporarily open passwd file on our own, later we will probably

--- a/src/sss_client/nss_mc_group.c
+++ b/src/sss_client/nss_mc_group.c
@@ -27,7 +27,7 @@
 #include <sys/mman.h>
 #include <time.h>
 #include "nss_mc.h"
-#include "util/util_safealign.h"
+#include "shared/safealign.h"
 
 struct sss_cli_mc_ctx gr_mc_ctx = { UNINITIALIZED, -1, 0, NULL, 0, NULL, 0,
                                     NULL, 0, 0 };

--- a/src/sss_client/nss_mc_initgr.c
+++ b/src/sss_client/nss_mc_initgr.c
@@ -30,7 +30,7 @@
 #include <sys/mman.h>
 #include <time.h>
 #include "nss_mc.h"
-#include "util/util_safealign.h"
+#include "shared/safealign.h"
 
 struct sss_cli_mc_ctx initgr_mc_ctx = { UNINITIALIZED, -1, 0, NULL, 0, NULL, 0,
                                         NULL, 0, 0 };

--- a/src/sss_client/sss_cli.h
+++ b/src/sss_client/sss_cli.h
@@ -32,7 +32,7 @@
 #include <stdint.h>
 #include <limits.h>
 
-#include "util/util_safealign.h"
+#include "shared/safealign.h"
 
 #ifndef HAVE_ERRNO_T
 #define HAVE_ERRNO_T

--- a/src/tests/cmocka/test_inotify.c
+++ b/src/tests/cmocka/test_inotify.c
@@ -26,7 +26,7 @@
 #include <popt.h>
 
 #include "limits.h"
-#include "util/io.h"
+#include "shared/io.h"
 #include "util/inotify.h"
 #include "util/util.h"
 #include "tests/common.h"

--- a/src/tests/cmocka/test_io.c
+++ b/src/tests/cmocka/test_io.c
@@ -36,7 +36,7 @@
 #include <libgen.h>
 
 #include "limits.h"
-#include "util/io.h"
+#include "shared/io.h"
 #include "util/util.h"
 #include "tests/common.h"
 

--- a/src/tests/util-tests.c
+++ b/src/tests/util-tests.c
@@ -34,7 +34,7 @@
 
 #include "util/util.h"
 #include "util/sss_utf8.h"
-#include "util/murmurhash3.h"
+#include "shared/murmurhash3.h"
 #include "tests/common_check.h"
 
 #define FILENAME_TEMPLATE "tests-atomicio-XXXXXX"

--- a/src/util/io.c
+++ b/src/util/io.c
@@ -28,7 +28,7 @@
 #include <fcntl.h>
 #include <errno.h>
 
-#include "util/io.h"
+#include "shared/io.h"
 
 /* CAUTION:
  * This file have to be minimalist and cannot include DEBUG macros

--- a/src/util/mmap_cache.h
+++ b/src/util/mmap_cache.h
@@ -22,7 +22,7 @@
 #ifndef _MMAP_CACHE_H_
 #define _MMAP_CACHE_H_
 
-#include "util/murmurhash3.h"
+#include "shared/murmurhash3.h"
 
 
 /* NOTE: all the code here assumes that writing a uint32_t nto mmapped

--- a/src/util/murmurhash3.c
+++ b/src/util/murmurhash3.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 #include "config.h"
-#include "util/murmurhash3.h"
+#include "shared/murmurhash3.h"
 #include "util/sss_endian.h"
 
 static uint32_t rotl(uint32_t x, int8_t r)

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -39,9 +39,10 @@
 #include <dhash.h>
 
 #include "confdb/confdb.h"
+#include "shared/io.h"
+#include "shared/safealign.h"
 #include "util/atomic_io.h"
 #include "util/util_errors.h"
-#include "util/util_safealign.h"
 #include "util/sss_format.h"
 #include "util/debug.h"
 
@@ -591,7 +592,6 @@ errno_t get_dom_names(TALLOC_CTX *mem_ctx,
 /* from util_lock.c */
 errno_t sss_br_lock_file(int fd, size_t start, size_t len,
                          int num_tries, useconds_t wait);
-#include "io.h"
 
 #ifdef HAVE_PAC_RESPONDER
 #define BUILD_WITH_PAC_RESPONDER true


### PR DESCRIPTION
There are few header files consumed by both client and server. Movement of these headers to some special forlder (src/shared) is desirable.

Resolves: https://pagure.io/SSSD/sssd/issue/1898