### PR TITLE
Print a warning when enumeration is requested but disabled

### DIFF
--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -1010,6 +1010,10 @@ static int confdb_get_domain_internal(struct confdb_ctx *cdb,
 
     if (!domain->enumerate) {
         DEBUG(SSSDBG_TRACE_FUNC, "No enumeration for [%s]!\n", domain->name);
+        DEBUG(SSSDBG_CONF_SETTINGS,
+             "Please note that when enumeration is disabled `getent "
+             "passwd` does not return all users by design. See "
+             "sssd.conf man page for more detailed information\n");
     }
 
     ret = confdb_get_string(cdb, tmp_ctx, CONFDB_MONITOR_CONF_ENTRY,

--- a/src/responder/common/cache_req/cache_req.c
+++ b/src/responder/common/cache_req/cache_req.c
@@ -176,6 +176,12 @@ cache_req_validate_domain_enumeration(struct cache_req *cr,
     if (domain->enumerate == false) {
         CACHE_REQ_DEBUG(SSSDBG_TRACE_FUNC, cr, "Domain %s does not support "
                         "enumeration, skipping...\n", domain->name);
+	if(cr->rctx->enumeration_warn_logged == false) {
+            sss_log(SSS_LOG_NOTICE, "Enumeration requested but not enabled\n");
+            CACHE_REQ_DEBUG(SSSDBG_TRACE_FUNC, cr,
+                            "Enumeration requested but not enabled\n");
+            cr->rctx->enumeration_warn_logged = true;
+	}
         return false;
     }
 

--- a/src/responder/common/responder.h
+++ b/src/responder/common/responder.h
@@ -157,6 +157,7 @@ struct resp_ctx {
     bool socket_activated;
     bool dbus_activated;
     bool cache_first;
+    bool enumeration_warn_logged;
 };
 
 struct cli_creds;


### PR DESCRIPTION
Purpose of this PR is to add an explanatory message to be logged once at the start-up explaning that if enumeration is off 'getent passwd' will not return all users information. This is by design.
Again Log level for this message it kept low [SSSDBG_OP_FAILURE     0x0040   /* level 2 */]. We want this message to be printed in almost all cases because it tells this functionality is be design and prevents anyone from opening a bug.

Resolves: https://pagure.io/SSSD/sssd/issue/2301