### PR TITLE
Revert "LDAP: Fix nesting level comparison"

### DIFF
--- a/src/providers/ldap/sdap_async_initgroups.c
+++ b/src/providers/ldap/sdap_async_initgroups.c
@@ -2253,7 +2253,7 @@ struct tevent_req *rfc2307bis_nested_groups_send(
     if (!req) return NULL;
 
     if ((num_groups == 0) ||
-        (nesting >= dp_opt_get_int(opts->basic, SDAP_NESTING_LEVEL))) {
+        (nesting > dp_opt_get_int(opts->basic, SDAP_NESTING_LEVEL))) {
         /* No parent groups to process or too deep*/
         ret = EOK;
         goto done;


### PR DESCRIPTION
This reverts commit 925a14d50edf0e3b800ce659b10b771ae1cde293.

It broke a test for enumerate nested groups if they are part
of non POSIX groups https://pagure.io/SSSD/sssd/issue/2406