### PR TITLE
idmap_error_string: add missing descriptions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1139,7 +1139,7 @@ libsss_idmap_la_SOURCES = \
     src/util/murmurhash3.c
 libsss_idmap_la_LDFLAGS = \
     -Wl,--version-script,$(srcdir)/src/lib/idmap/sss_idmap.exports \
-    -version-info 5:0:5
+    -version-info 5:1:5
 
 dist_noinst_DATA += src/lib/idmap/sss_idmap.exports
 

--- a/src/lib/idmap/sss_idmap.c
+++ b/src/lib/idmap/sss_idmap.c
@@ -180,6 +180,22 @@ const char *idmap_error_string(enum idmap_error_code err)
             break;
         case IDMAP_NO_RANGE:
             return "IDMAP range not found";
+            break;
+        case IDMAP_BUILTIN_SID:
+            return "IDMAP SID from BUILTIN domain";
+            break;
+        case IDMAP_OUT_OF_SLICES:
+            return "IDMAP not more free slices";
+            break;
+        case IDMAP_COLLISION:
+            return "IDMAP new range collides with existing one";
+            break;
+        case IDMAP_EXTERNAL:
+            return "IDMAP ID managed externally";
+            break;
+        case IDMAP_NAME_UNKNOWN:
+            return "IDMAP domain with the given name not found";
+            break;
         default:
             return "IDMAP unknown error code";
     }

--- a/src/lib/idmap/sss_idmap.h
+++ b/src/lib/idmap/sss_idmap.h
@@ -84,7 +84,11 @@ enum idmap_error_code {
     IDMAP_EXTERNAL,
 
     /** The provided  name was not found */
-    IDMAP_NAME_UNKNOWN
+    IDMAP_NAME_UNKNOWN,
+
+    /** Sentinel to indicate the end of the error code list, not returned by
+     * any call */
+    IDMAP_ERR_LAST
 };
 
 /**

--- a/src/tests/cmocka/test_sss_idmap.c
+++ b/src/tests/cmocka/test_sss_idmap.c
@@ -674,6 +674,16 @@ void test_sss_idmap_check_collision_ex(void **state)
     assert_int_equal(err, IDMAP_SUCCESS);
 }
 
+void test_sss_idmap_error_string(void **state)
+{
+    size_t c;
+
+    for (c = IDMAP_SUCCESS; c < IDMAP_ERR_LAST; c++) {
+        assert_string_not_equal(idmap_error_string(c),
+                                idmap_error_string(IDMAP_ERR_LAST));
+    }
+}
+
 int main(int argc, const char *argv[])
 {
     poptContext pc;
@@ -713,6 +723,7 @@ int main(int argc, const char *argv[])
                                         test_sss_idmap_setup_with_both,
                                         test_sss_idmap_teardown),
         cmocka_unit_test(test_sss_idmap_check_collision_ex),
+        cmocka_unit_test(test_sss_idmap_error_string),
     };
 
     /* Set debug level to invalid value so we can deside if -d 0 was used. */


### PR DESCRIPTION
Related to https://fedorahosted.org/sssd/ticket/1960
Related to https://fedorahosted.org/sssd/ticket/1938
Related to https://fedorahosted.org/sssd/ticket/1844
Related to https://fedorahosted.org/sssd/ticket/1593