### PR TITLE
MAN: Don't tell the user to autostart sssd-kcm.service; it's socket-enabled

### DIFF
--- a/src/man/sssd-kcm.8.xml
+++ b/src/man/sssd-kcm.8.xml
@@ -112,7 +112,6 @@
             <programlisting>
 systemctl start sssd-kcm.socket
 systemctl enable sssd-kcm.socket
-systemctl enable sssd-kcm.service
             </programlisting>
             Please note your distribution may already configure the units
             for you.
@@ -131,7 +130,6 @@ systemctl enable sssd-kcm.service
             <programlisting>
 systemctl start sssd-secrets.socket
 systemctl enable sssd-secrets.socket
-systemctl enable sssd-secrets.service
             </programlisting>
             Your distribution should already set the dependencies between the services.
         </para>


### PR DESCRIPTION
This matches what we tell the user to do in PR#244.