### PR TITLE
UTIL: Create custom abort function for talloc_get_type_abort()

### DIFF
--- a/src/util/util.c
+++ b/src/util/util.c
@@ -36,6 +36,11 @@
 int socket_activated = 0;
 int dbus_activated = 0;
 
+void sss_talloc_abort(const char *reason)
+{
+    DEBUG(SSSDBG_FATAL_FAILURE, "Talloc abort: %s\n", reason);
+}
+
 static void free_args(char **args)
 {
     int i;

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -351,6 +351,9 @@ errno_t check_and_open_readonly(const char *filename, int *fd,
 #define SSS_NO_SPECIAL \
         (SSS_NO_LINKLOCAL|SSS_NO_LOOPBACK|SSS_NO_MULTICAST|SSS_NO_BROADCAST)
 
+/*This sets custom abort function using talloc_set_abort_fn*/
+void sss_talloc_abort(const char* reason);
+
 /* These two functions accept addr in network order */
 bool check_ipv4_addr(struct in_addr *addr, uint8_t check);
 bool check_ipv6_addr(struct in6_addr *addr, uint8_t check);


### PR DESCRIPTION
Bug is about replacing talloc_get_type() with talloc_get_type_abort(const void *ptr,#type). talloc_get_type_abort() is type safe equivalent of talloc_get_type(). talloc_get_type_abort() calls abort() function is case of type mismatch.

How it will work:
a. Defining a custom abort function sss_talloc_abort(const char *reason) in src/util/util.c.
b. Setting this custom abort function using void talloc_set_abort_fn(void (abort_fn)(const char reason)) => talloc_set_abort_fn(sss_talloc_abort);
c. Replacing all occurances of talloc_get_type() with talloc_get_type_abort();

About the Change:
Change will comprise of 3 patches
Patch-1(This Patch): Introduces the new sss_talloc_abort() function, which will be setted as custom abort function by passing to talloc_set_abort_fn().
Patch-2: When changes are finalized, custom abort function's contents are finalized. This patch will enable custom abort function wherever required.
Patch-3: When above two patches goes well. This will change all occurences of talloc_get_type() to talloc_get_type_abort().

Resolves: https://pagure.io/SSSD/sssd/issue/1149