### PR TITLE
CACHE_REQ_SR_OVERLAY: Fix coverity warning

### DIFF
--- a/src/responder/common/cache_req/cache_req_sr_overlay.c
+++ b/src/responder/common/cache_req/cache_req_sr_overlay.c
@@ -204,6 +204,8 @@ static errno_t cache_req_sr_overlay_match_users(
         }
     }
 
+    ret = EOK;
+
 done:
     talloc_zfree(tmp_ctx);
     return ret;


### PR DESCRIPTION
Setting ret as EOK in case everything goes well.