### PR TITLE
INTG: Add --with-session-recording=false to intgcheck's configure

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3538,6 +3538,7 @@ intgcheck-prepare:
 	    --with-ldb-lib-dir="$$prefix"/lib/ldb \
 	    --enable-intgcheck-reqs \
 	    --without-semanage \
+	    --with-session-recording-shell=/bin/false \
 	    $(INTGCHECK_CONFIGURE_FLAGS) \
 	    CFLAGS="$$CFLAGS -DKCM_PEER_UID=$$(id -u)"; \
 	$(MAKE) $(AM_MAKEFLAGS) ; \

--- a/contrib/ci/configure.sh
+++ b/contrib/ci/configure.sh
@@ -29,7 +29,6 @@ declare -a CONFIGURE_ARG_LIST=(
     "--enable-ldb-version-check"
     "--with-syslog=journald"
     "--enable-systemtap"
-    "--with-session-recording-shell=/bin/false"
 )
 
 


### PR DESCRIPTION
Let's ensure that running `make intgcheck-*` doesn't fail when done
locally.