### PR TITLE
Fixes related to negative cache and "root" user/group

### DIFF
--- a/src/responder/common/cache_req/cache_req_data.c
+++ b/src/responder/common/cache_req/cache_req_data.c
@@ -119,12 +119,6 @@ cache_req_data_create(TALLOC_CTX *mem_ctx,
     case CACHE_REQ_USER_BY_ID:
     case CACHE_REQ_GROUP_BY_ID:
     case CACHE_REQ_OBJECT_BY_ID:
-        if (input->id == 0) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "Bug: id cannot be 0!\n");
-            ret = ERR_INTERNAL;
-            goto done;
-        }
-
         data->id = input->id;
         break;
     case CACHE_REQ_OBJECT_BY_SID:

--- a/src/responder/common/negcache.c
+++ b/src/responder/common/negcache.c
@@ -887,7 +887,9 @@ errno_t sss_ncache_prepopulate(struct sss_nc_ctx *ncache,
                 continue;
             }
         } else {
-            for (dom = domain_list; dom; dom = get_next_domain(dom, 0)) {
+            for (dom = domain_list;
+                 dom != NULL;
+                 dom = get_next_domain(dom, SSS_GND_ALL_DOMAINS)) {
                 fqname = sss_create_internal_fqname(tmpctx, name, dom->name);
                 if (fqname == NULL) {
                     continue;
@@ -1000,7 +1002,9 @@ errno_t sss_ncache_prepopulate(struct sss_nc_ctx *ncache,
                 continue;
             }
         } else {
-            for (dom = domain_list; dom; dom = get_next_domain(dom, 0)) {
+            for (dom = domain_list;
+                 dom != NULL;
+                 dom = get_next_domain(dom, SSS_GND_ALL_DOMAINS)) {
                 fqname = sss_create_internal_fqname(tmpctx, name, dom->name);
                 if (fqname == NULL) {
                     continue;

--- a/src/responder/common/negcache.c
+++ b/src/responder/common/negcache.c
@@ -1073,6 +1073,23 @@ errno_t sss_ncache_prepopulate(struct sss_nc_ctx *ncache,
         }
     }
 
+    /* Also add "root" uid and gid to the negative cache */
+    ret = sss_ncache_set_uid(ncache, true, NULL, 0);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_MINOR_FAILURE,
+              "Failed to store permanent uid filter for root (0) "
+              "(%d [%s])\n",
+              ret, strerror(ret));
+    }
+
+    ret = sss_ncache_set_gid(ncache, true, NULL, 0);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_MINOR_FAILURE,
+              "Failed to store permanent gid filter for root (0) "
+              "(%d [%s])\n",
+              ret, strerror(ret));
+    }
+
     ret = EOK;
 
 done:

--- a/src/responder/common/negcache.c
+++ b/src/responder/common/negcache.c
@@ -786,7 +786,7 @@ errno_t sss_ncache_prepopulate(struct sss_nc_ctx *ncache,
         return ENOMEM;
     }
 
-    /* Populate domain-specific negative cache entries */
+    /* Populate domain-specific negative cache user entries */
     for (dom = domain_list; dom; dom = get_next_domain(dom, 0)) {
         conf_path = talloc_asprintf(tmpctx, CONFDB_DOMAIN_PATH_TMPL,
                                     dom->name);
@@ -844,6 +844,7 @@ errno_t sss_ncache_prepopulate(struct sss_nc_ctx *ncache,
         }
     }
 
+    /* Populate non domain-specific negative cache user entries */
     ret = confdb_get_string_as_list(cdb, tmpctx, CONFDB_NSS_CONF_ENTRY,
                                     CONFDB_NSS_FILTER_USERS, &filter_list);
     if (ret == ENOENT) {
@@ -920,6 +921,7 @@ errno_t sss_ncache_prepopulate(struct sss_nc_ctx *ncache,
         }
     }
 
+    /* Populate domain-specific negative cache group entries */
     filter_set = false;
     for (dom = domain_list; dom; dom = get_next_domain(dom, 0)) {
         conf_path = talloc_asprintf(tmpctx, CONFDB_DOMAIN_PATH_TMPL, dom->name);
@@ -970,6 +972,7 @@ errno_t sss_ncache_prepopulate(struct sss_nc_ctx *ncache,
         }
     }
 
+    /* Populate non domain-specific negative cache group entries */
     ret = confdb_get_string_as_list(cdb, tmpctx, CONFDB_NSS_CONF_ENTRY,
                                     CONFDB_NSS_FILTER_GROUPS, &filter_list);
     if (ret == ENOENT) {

--- a/src/responder/nss/nss_get_object.c
+++ b/src/responder/nss/nss_get_object.c
@@ -125,6 +125,12 @@ memcache_delete_entry(struct nss_ctx *nss_ctx,
                       name, dom->name);
                 continue;
             }
+        } else if (id == 0) {
+            /*
+             * As "root" is not handled by SSSD, let's just return EOK here
+             * instead of erroring out.
+             */
+            return EOK;
         } else if (id != 0) {
             ret = memcache_delete_entry_by_id(nss_ctx, id, type);
             if (ret != EOK) {

--- a/src/tests/cmocka/test_negcache.c
+++ b/src/tests/cmocka/test_negcache.c
@@ -630,6 +630,12 @@ static void test_sss_ncache_prepopulate(void **state)
 
     ret = check_group_in_ncache(ncache, dom, "testgroup3@somedomain");
     assert_int_equal(ret, ENOENT);
+
+    ret = check_user_in_ncache(ncache, dom, "root");
+    assert_int_equal(ret, EEXIST);
+
+    ret = check_group_in_ncache(ncache, dom, "root");
+    assert_int_equal(ret, EEXIST);
 }
 
 static void test_sss_ncache_default_domain_suffix(void **state)

--- a/src/tests/cmocka/test_negcache.c
+++ b/src/tests/cmocka/test_negcache.c
@@ -564,6 +564,24 @@ static int check_group_in_ncache(struct sss_nc_ctx *ctx,
     return ret;
 }
 
+static int check_uid_in_ncache(struct sss_nc_ctx *ctx,
+                               uid_t uid)
+{
+    int ret;
+
+    ret = sss_ncache_check_uid(ctx, NULL, uid);
+    return ret;
+}
+
+static int check_gid_in_ncache(struct sss_nc_ctx *ctx,
+                               gid_t gid)
+{
+    int ret;
+
+    ret = sss_ncache_check_gid(ctx, NULL, gid);
+    return ret;
+}
+
 static void test_sss_ncache_prepopulate(void **state)
 {
     int ret;
@@ -635,6 +653,12 @@ static void test_sss_ncache_prepopulate(void **state)
     assert_int_equal(ret, EEXIST);
 
     ret = check_group_in_ncache(ncache, dom, "root");
+    assert_int_equal(ret, EEXIST);
+
+    ret = check_uid_in_ncache(ncache, 0);
+    assert_int_equal(ret, EEXIST);
+
+    ret = check_gid_in_ncache(ncache, 0);
     assert_int_equal(ret, EEXIST);
 }
 

--- a/src/tests/intg/test_files_provider.py
+++ b/src/tests/intg/test_files_provider.py
@@ -29,8 +29,10 @@ import pytest
 import ent
 import sssd_id
 from sssd_nss import NssReturnCode
-from sssd_passwd import call_sssd_getpwnam, call_sssd_enumeration
-from sssd_group import call_sssd_getgrnam
+from sssd_passwd import (call_sssd_getpwnam,
+                         call_sssd_enumeration,
+                         call_sssd_getpwuid)
+from sssd_group import call_sssd_getgrnam, call_sssd_getgrgid
 from files_ops import passwd_ops_setup, group_ops_setup
 from util import unindent
 
@@ -258,12 +260,28 @@ def sssd_getpwnam_sync(name):
     return call_sssd_getpwnam(name)
 
 
+def sssd_getpwuid_sync(uid):
+    ret = poll_canary(call_sssd_getpwnam, CANARY["name"])
+    if ret is False:
+        return NssReturnCode.NOTFOUND, None
+
+    return call_sssd_getpwuid(uid)
+
+
 def sssd_getgrnam_sync(name):
     ret = poll_canary(call_sssd_getgrnam, CANARY_GR["name"])
     if ret is False:
         return NssReturnCode.NOTFOUND, None
 
     return call_sssd_getgrnam(name)
+
+
+def sssd_getgrgid_sync(name):
+    ret = poll_canary(call_sssd_getgrnam, CANARY_GR["name"])
+    if ret is False:
+        return NssReturnCode.NOTFOUND, None
+
+    return call_sssd_getgrgid(name)
 
 
 def sssd_id_sync(name):
@@ -303,6 +321,15 @@ def check_group(exp_group, delay=1.0):
         time.sleep(delay)
 
     res, found_group = sssd_getgrnam_sync(exp_group["name"])
+    assert res == NssReturnCode.SUCCESS
+    assert found_group == exp_group
+
+
+def check_group_by_gid(exp_group, delay=1.0):
+    if delay > 0:
+        time.sleep(delay)
+
+    res, found_group = sssd_getgrgid_sync(exp_group["gid"])
     assert res == NssReturnCode.SUCCESS
     assert found_group == exp_group
 
@@ -349,6 +376,16 @@ def test_getpwnam_after_start(add_user_with_canary, files_domain_only):
     assert user == USER1
 
 
+def test_getpwuid_after_start(add_user_with_canary, files_domain_only):
+    """
+    Test that after startup without any additional operations, a user
+    can be resolved through sssd
+    """
+    res, user = sssd_getpwuid_sync(USER1["uid"])
+    assert res == NssReturnCode.SUCCESS
+    assert user == USER1
+
+
 def test_user_overriden(add_user_with_canary, files_domain_only):
     """
     Test that user override works with files domain only
@@ -373,8 +410,8 @@ def test_group_overriden(add_group_with_canary, files_domain_only):
     """
     # Override
     subprocess.check_call(["sss_override", "group-add", GROUP1["name"],
-                          "-n", OV_GROUP1["name"],
-                          "-g", str(OV_GROUP1["gid"])])
+                           "-n", OV_GROUP1["name"],
+                           "-g", str(OV_GROUP1["gid"])])
 
     restart_sssd()
 
@@ -383,9 +420,17 @@ def test_group_overriden(add_group_with_canary, files_domain_only):
 
 def test_getpwnam_neg(files_domain_only):
     """
-    Test that a nonexistant user cannot be resolved
+    Test that a nonexistant user cannot be resolved by name
     """
     res, _ = call_sssd_getpwnam("nosuchuser")
+    assert res == NssReturnCode.NOTFOUND
+
+
+def test_getpwuid_neg(files_domain_only):
+    """
+    Test that a nonexistant user cannot be resolved by UID
+    """
+    res, _ = call_sssd_getpwuid(12345)
     assert res == NssReturnCode.NOTFOUND
 
 
@@ -398,6 +443,18 @@ def test_root_does_not_resolve(files_domain_only):
     assert nss_root is not None
 
     res, _ = call_sssd_getpwnam("root")
+    assert res == NssReturnCode.NOTFOUND
+
+
+def test_uid_zero_does_not_resolve(files_domain_only):
+    """
+    SSSD currently does not resolve the UID 0 even though it can
+    be resolved through the NSS interface
+    """
+    nss_root = pwd.getpwuid(0)
+    assert nss_root is not None
+
+    res, _ = call_sssd_getpwuid(0)
     assert res == NssReturnCode.NOTFOUND
 
 
@@ -522,9 +579,17 @@ def test_incomplete_user_fail(setup_pw_with_canary, files_domain_only):
 def test_getgrnam_after_start(add_group_with_canary, files_domain_only):
     """
     Test that after startup without any additional operations, a group
-    can be resolved through sssd
+    can be resolved through sssd by name
     """
     check_group(GROUP1)
+
+
+def test_getgrgid_after_start(add_group_with_canary, files_domain_only):
+    """
+    Test that after startup without any additional operations, a group
+    can be resolved through sssd by GID
+    """
+    check_group_by_gid(GROUP1)
 
 
 def test_getgrnam_neg(files_domain_only):
@@ -532,6 +597,14 @@ def test_getgrnam_neg(files_domain_only):
     Test that a nonexistant group cannot be resolved
     """
     res, user = sssd_getgrnam_sync("nosuchgroup")
+    assert res == NssReturnCode.NOTFOUND
+
+
+def test_getgrgid_neg(files_domain_only):
+    """
+    Test that a nonexistant group cannot be resolved
+    """
+    res, user = sssd_getgrgid_sync(123456)
     assert res == NssReturnCode.NOTFOUND
 
 
@@ -544,6 +617,18 @@ def test_root_group_does_not_resolve(files_domain_only):
     assert nss_root is not None
 
     res, user = call_sssd_getgrnam("root")
+    assert res == NssReturnCode.NOTFOUND
+
+
+def test_gid_zero_does_not_resolve(files_domain_only):
+    """
+    SSSD currently does not resolve the group with GID 0 even though it
+    can be resolved through the NSS interface
+    """
+    nss_root = grp.getgrgid(0)
+    assert nss_root is not None
+
+    res, user = call_sssd_getgrgid(0)
     assert res == NssReturnCode.NOTFOUND
 
 


### PR DESCRIPTION
This patch set contains a bunch of fixes in the negative cache code.

The patches were tested in an AD-trust environment and more specific instructions/details can be found below:
- **NEGCACHE: Add some comments about each step of sss_ncache_prepopulate()**
  Just verified the comments make sense.

- **NEGCACHE: Always add "root" to the negative cache**:
  - Add `filter_users = foo` and `filter_groups = foo` under `[nss]` section;
  - Restart SSSD (`systemctl restart sssd`) and run `id root`;
  - Inspect sssd_nss.log, checking for the second time the users and groups are added to the negative cache;

    - Without this patch:
      ```
      (Mon Aug 14 17:09:50 2017) [sssd[nss]] [sss_parse_name_for_domains] (0x0200): name 'foo' matched without domain, user is foo
      (Mon Aug 14 17:09:50 2017) [sssd[nss]] [sss_ncache_set_str] (0x0400): Adding [NCE/USER/indirect.ipa.ff/foo@indirect.ipa.ff] to negative cache permanently
      (Mon Aug 14 17:09:50 2017) [sssd[nss]] [sss_parse_name_for_domains] (0x0200): name 'bar' matched without domain, user is bar
      (Mon Aug 14 17:09:50 2017) [sssd[nss]] [sss_ncache_set_str] (0x0400): Adding [NCE/GROUP/indirect.ipa.ff/bar@indirect.ipa.ff] to negative cache permanently
      ```
    - With this patch:
      ```
      (Mon Aug 14 17:13:31 2017) [sssd[nss]] [sss_parse_name_for_domains] (0x0200): name 'foo' matched without domain, user is foo
      (Mon Aug 14 17:13:31 2017) [sssd[nss]] [sss_ncache_set_str] (0x0400): Adding [NCE/USER/indirect.ipa.ff/foo@indirect.ipa.ff] to negative cache permanently
      (Mon Aug 14 17:13:31 2017) [sssd[nss]] [sss_parse_name_for_domains] (0x0200): name 'bar' matched without domain, user is bar
      (Mon Aug 14 17:13:31 2017) [sssd[nss]] [sss_ncache_set_str] (0x0400): Adding [NCE/GROUP/indirect.ipa.ff/bar@indirect.ipa.ff] to negative cache permanently
      (Mon Aug 14 17:13:31 2017) [sssd[nss]] [sss_ncache_set_str] (0x0400): Adding [NCE/USER/indirect.ipa.ff/root@indirect.ipa.ff] to negative cache permanently
      (Mon Aug 14 17:13:31 2017) [sssd[nss]] [sss_ncache_set_str] (0x0400): Adding [NCE/GROUP/indirect.ipa.ff/root@indirect.ipa.ff] to negative cache permanently
      (Mon Aug 14 17:13:31 2017) [sssd[nss]] [sss_domain_get_state] (0x1000): Domain indirect.ad.ff is Active
      (Mon Aug 14 17:13:31 2017) [sssd[nss]] [sss_ncache_set_str] (0x0400): Adding [NCE/USER/indirect.ad.ff/root@indirect.ad.ff] to negative cache permanently
      (Mon Aug 14 17:13:31 2017) [sssd[nss]] [sss_ncache_set_str] (0x0400): Adding [NCE/GROUP/indirect.ad.ff/root@indirect.ad.ff] to negative cache permanently
      ```

- **NEGCACHE: Add "0" to the negative cache**:
  - Considering the very same environment where the previous patch was applied, do:
    - `id 0`;
    - Inspect sssd_nss.log, checking for the cache req call triggered by the command above;
      - Without this patch:
      ```
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [nss_getby_name] (0x0400): Input name: 0
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [cache_req_set_plugin] (0x2000): CR #0: Setting "User by name" plugin
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [cache_req_send] (0x0400): CR #0: New request 'User by name'
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [cache_req_process_input] (0x0400): CR #0: Parsing input name [0]
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [sss_parse_name_for_domains] (0x0200): name '0' matched without domain, user is 0
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [cache_req_set_name] (0x0400): CR #0: Setting name [0]
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [cache_req_select_domains] (0x0400): CR #0: Performing a multi-domain search
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [cache_req_search_domains] (0x0400): CR #0: Search will check the cache and check the data provider
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [cache_req_validate_domain_type] (0x2000): Request type POSIX-only for domain indirect.ipa.ff type POSIX is valid
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [cache_req_set_domain] (0x0400): CR #0: Using domain [indirect.ipa.ff]
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [cache_req_prepare_domain_data] (0x0400): CR #0: Preparing input data for domain [indirect.ipa.ff] rules
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [cache_req_search_send] (0x0400): CR #0: Looking up 0@indirect.ipa.ff
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [cache_req_search_ncache] (0x0400): CR #0: Checking negative cache for [0@indirect.ipa.ff]
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [sss_ncache_check_str] (0x2000): Checking negative cache for [NCE/USER/indirect.ipa.ff/0@indirect.ipa.ff]
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [cache_req_search_ncache] (0x0400): CR #0: [0@indirect.ipa.ff] is not present in negative cache
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [cache_req_search_cache] (0x0400): CR #0: Looking up [0@indirect.ipa.ff] in cache
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [ldb] (0x4000): Added timed event "ltdb_callback": 0x669120
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [ldb] (0x4000): Added timed event "ltdb_timeout": 0x6691e0
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [ldb] (0x4000): Running timer event 0x669120 "ltdb_callback"
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [ldb] (0x4000): Destroying timer event 0x6691e0 "ltdb_timeout"
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [ldb] (0x4000): Ending timer event 0x669120 "ltdb_callback"
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [cache_req_search_cache] (0x0400): CR #0: Object [0@indirect.ipa.ff] was not found in cache
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [cache_req_search_dp] (0x0400): CR #0: Looking up [0@indirect.ipa.ff] in data provider
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [sss_dp_issue_request] (0x0400): Issuing request for [0x416010:1:0@indirect.ipa.ff@indirect.ipa.ff]
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [sss_dp_get_account_msg] (0x0400): Creating request for [indirect.ipa.ff][0x1][BE_REQ_USER][name=0@indirect.ipa.ff:-]
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [sbus_add_timeout] (0x2000): 0x65db60
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [sss_dp_internal_get_send] (0x0400): Entering request [0x416010:1:0@indirect.ipa.ff@indirect.ipa.ff]
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [sbus_remove_timeout] (0x2000): 0x65db60
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [sbus_dispatch] (0x4000): dbus conn: 0x65c8c0
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [sbus_dispatch] (0x4000): Dispatching.
      (Mon Aug 14 17:19:52 2017) [sssd[nss]] [sss_dp_get_reply] (0x1000): Got reply from Data Provider - DP error code: 0 errno: 0 error message: Success
      ```
      - With this patch:
      ```
      (Mon Aug 14 17:26:17 2017) [sssd[nss]] [nss_getby_name] (0x0400): Input name: 0
      (Mon Aug 14 17:26:17 2017) [sssd[nss]] [cache_req_set_plugin] (0x2000): CR #0: Setting "User by name" plugin
      (Mon Aug 14 17:26:17 2017) [sssd[nss]] [cache_req_send] (0x0400): CR #0: New request 'User by name'
      (Mon Aug 14 17:26:17 2017) [sssd[nss]] [cache_req_process_input] (0x0400): CR #0: Parsing input name [0]
      (Mon Aug 14 17:26:17 2017) [sssd[nss]] [sss_parse_name_for_domains] (0x0200): name '0' matched without domain, user is 0
      (Mon Aug 14 17:26:17 2017) [sssd[nss]] [cache_req_set_name] (0x0400): CR #0: Setting name [0]
      (Mon Aug 14 17:26:17 2017) [sssd[nss]] [cache_req_select_domains] (0x0400): CR #0: Performing a multi-domain search
      (Mon Aug 14 17:26:17 2017) [sssd[nss]] [cache_req_search_domains] (0x0400): CR #0: Search will check the cache and check the data provider
      (Mon Aug 14 17:26:17 2017) [sssd[nss]] [cache_req_validate_domain_type] (0x2000): Request type POSIX-only for domain indirect.ipa.ff type POSIX is valid
      (Mon Aug 14 17:26:17 2017) [sssd[nss]] [cache_req_set_domain] (0x0400): CR #0: Using domain [indirect.ipa.ff]
      (Mon Aug 14 17:26:17 2017) [sssd[nss]] [cache_req_prepare_domain_data] (0x0400): CR #0: Preparing input data for domain [indirect.ipa.ff] rules
      (Mon Aug 14 17:26:17 2017) [sssd[nss]] [cache_req_search_send] (0x0400): CR #0: Looking up 0@indirect.ipa.ff
      (Mon Aug 14 17:26:17 2017) [sssd[nss]] [cache_req_search_ncache] (0x0400): CR #0: Checking negative cache for [0@indirect.ipa.ff]
      (Mon Aug 14 17:26:17 2017) [sssd[nss]] [sss_ncache_check_str] (0x2000): Checking negative cache for [NCE/USER/indirect.ipa.ff/0@indirect.ipa.ff]
      (Mon Aug 14 17:26:17 2017) [sssd[nss]] [cache_req_search_ncache] (0x0400): CR #0: [0@indirect.ipa.ff] does not exist (negative cache)
      (Mon Aug 14 17:26:17 2017) [sssd[nss]] [cache_req_validate_domain_type] (0x2000): Request type POSIX-only for domain indirect.ad.ff type POSIX is valid
      (Mon Aug 14 17:26:17 2017) [sssd[nss]] [cache_req_process_result] (0x0400): CR #0: Finished: Not found

      ```

- **NEGCACHE: Descend to subdomains when adding user/groups**:
  - Considering the very same environment where the previous patch was applied, do:
    - `id root`;
    - Inspect sssd_nss.log, looking for when the user `foo` and group `bar` are added to the negative cache;
      - Without this patch:
      ```
      (Mon Aug 14 17:26:17 2017) [sssd[nss]] [sss_parse_name_for_domains] (0x0200): name 'foo' matched without domain, user is foo
      (Mon Aug 14 17:26:17 2017) [sssd[nss]] [sss_ncache_set_str] (0x0400): Adding [NCE/USER/indirect.ipa.ff/foo@indirect.ipa.ff] to negative cache permanently
      (Mon Aug 14 17:26:17 2017) [sssd[nss]] [sss_parse_name_for_domains] (0x0200): name 'bar' matched without domain, user is bar
      ```
      - With this patch:
      ```
      (Mon Aug 14 17:31:54 2017) [sssd[nss]] [sss_parse_name_for_domains] (0x0200): name 'foo' matched without domain, user is foo
      (Mon Aug 14 17:31:54 2017) [sssd[nss]] [sss_ncache_set_str] (0x0400): Adding [NCE/USER/indirect.ipa.ff/foo@indirect.ipa.ff] to negative cache permanently
      (Mon Aug 14 17:31:54 2017) [sssd[nss]] [sss_domain_get_state] (0x1000): Domain indirect.ad.ff is Active
      (Mon Aug 14 17:31:54 2017) [sssd[nss]] [sss_ncache_set_str] (0x0400): Adding [NCE/USER/indirect.ad.ff/foo@indirect.ad.ff] to negative cache permanently
      (Mon Aug 14 17:31:54 2017) [sssd[nss]] [sss_parse_name_for_domains] (0x0200): name 'bar' matched without domain, user is bar
      (Mon Aug 14 17:31:54 2017) [sssd[nss]] [sss_ncache_set_str] (0x0400): Adding [NCE/GROUP/indirect.ipa.ff/bar@indirect.ipa.ff] to negative cache permanently
      (Mon Aug 14 17:31:54 2017) [sssd[nss]] [sss_domain_get_state] (0x1000): Domain indirect.ad.ff is Active
      (Mon Aug 14 17:31:54 2017) [sssd[nss]] [sss_ncache_set_str] (0x0400): Adding [NCE/GROUP/indirect.ad.ff/bar@indirect.ad.ff] to negative cache permanently
      ```
- **CACHE_REQ: Don't error out when searching by id = 0**:
  - With the very same environment, just do:
    - `id root`;
    - Inspect the sssd_nss.log, taking a look after the first cache req request;
      - Without this patch:
        ```
        (Mon Aug 14 19:21:59 2017) [sssd[nss]] [sss_domain_get_state] (0x1000): Domain indirect.ad.ff is Active
        (Mon Aug 14 19:21:59 2017) [sssd[nss]] [nss_protocol_done] (0x4000): Sending reply: not found
        (Mon Aug 14 19:21:59 2017) [sssd[nss]] [nss_getby_id] (0x0400): Input ID: 0
        (Mon Aug 14 19:21:59 2017) [sssd[nss]] [cache_req_data_create] (0x0020): Bug: id cannot be 0!
        (Mon Aug 14 19:21:59 2017) [sssd[nss]] [cache_req_data_create] (0x0020): Unable to create cache_req data [1432158209]: Internal Error
        (Mon Aug 14 19:21:59 2017) [sssd[nss]] [nss_getby_id] (0x0020): Unable to set cache request data!
        (Mon Aug 14 19:21:59 2017) [sssd[nss]] [nss_protocol_done] (0x4000): Sending reply: error [12]: Cannot allocate memory
        ```
      - With this patch:
        ```
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [nss_getby_id] (0x0400): Input ID: 0
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [cache_req_set_plugin] (0x2000): CR #1: Setting "User by ID" plugin
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [cache_req_send] (0x0400): CR #1: New request 'User by ID'
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [cache_req_select_domains] (0x0400): CR #1: Performing a multi-domain search
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [cache_req_search_domains] (0x0400): CR #1: Search will check the cache and check the data provider
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [cache_req_validate_domain_type] (0x2000): Request type POSIX-only for domain indirect.ipa.ff type POSIX is valid
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [cache_req_set_domain] (0x0400): CR #1: Using domain [indirect.ipa.ff]
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [cache_req_search_send] (0x0400): CR #1: Looking up UID:0@indirect.ipa.ff
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [cache_req_search_ncache] (0x0400): CR #1: Checking negative cache for [UID:0@indirect.ipa.ff]
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [sss_ncache_check_str] (0x2000): Checking negative cache for [NCE/UID/0]
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [cache_req_search_ncache] (0x0400): CR #1: [UID:0@indirect.ipa.ff] is not present in negative cache
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [cache_req_search_cache] (0x0400): CR #1: Looking up [UID:0@indirect.ipa.ff] in cache
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [ldb] (0x4000): Added timed event "ltdb_callback": 0x252fa20
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [ldb] (0x4000): Added timed event "ltdb_timeout": 0x2532bc0
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [ldb] (0x4000): Running timer event 0x252fa20 "ltdb_callback"
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [ldb] (0x4000): Destroying timer event 0x2532bc0 "ltdb_timeout"
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [ldb] (0x4000): Ending timer event 0x252fa20 "ltdb_callback"
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [cache_req_search_cache] (0x0400): CR #1: Object [UID:0@indirect.ipa.ff] was not found in cache
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [cache_req_search_dp] (0x0400): CR #1: Looking up [UID:0@indirect.ipa.ff] in data provider
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [sss_dp_issue_request] (0x0400): Issuing request for [0x416030:1:*@indirect.ipa.ff]
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [sss_dp_get_account_msg] (0x0400): Creating request for [indirect.ipa.ff][0x1][BE_REQ_USER][*:-]
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [sbus_add_timeout] (0x2000): 0x252a330
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [sss_dp_internal_get_send] (0x0400): Entering request [0x416030:1:*@indirect.ipa.ff]
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [sbus_remove_timeout] (0x2000): 0x252a330
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [sbus_dispatch] (0x4000): dbus conn: 0x25238c0
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [sbus_dispatch] (0x4000): Dispatching.
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [sss_dp_get_reply] (0x1000): Got reply from Data Provider - DP error code: 0 errno: 0 error message: Success
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [cache_req_search_cache] (0x0400): CR #1: Looking up [UID:0@indirect.ad.ff] in cache
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [ldb] (0x4000): Added timed event "ltdb_callback": 0x252f960
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [ldb] (0x4000): Added timed event "ltdb_timeout": 0x2534150
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [ldb] (0x4000): Running timer event 0x252f960 "ltdb_callback"
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [ldb] (0x4000): Destroying timer event 0x2534150 "ltdb_timeout"
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [ldb] (0x4000): Ending timer event 0x252f960 "ltdb_callback"
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [cache_req_search_cache] (0x0400): CR #1: Object [UID:0@indirect.ad.ff] was not found in cache
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [cache_req_search_ncache_add] (0x2000): CR #1: This request type does not support negative cache
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [cache_req_global_ncache_add] (0x0400): CR #1: Adding [UID:0@indirect.ad.ff] to global negative cache
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [sss_ncache_set_str] (0x0400): Adding [NCE/UID/0] to negative cache
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [cache_req_process_result] (0x0400): CR #1: Finished: Not found
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [memcache_delete_entry] (0x0040): Bug: invalid input!
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [nss_protocol_done] (0x4000): Sending reply: not found
        ```

- **NSS: Don't error out when deleting an entry which has id = 0 from the memcache**:
  - Considering the very same environment, just do:
    - `id root`;
    - Inspect sssd_nss.log, looking for "Bug: invalid input!" from memcache_delete_entry;
      - Without this patch:
        ```
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [cache_req_search_cache] (0x0400): CR #1: Object [UID:0@indirect.ad.ff] was not found in cache
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [cache_req_search_ncache_add] (0x2000): CR #1: This request type does not support negative cache
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [cache_req_global_ncache_add] (0x0400): CR #1: Adding [UID:0@indirect.ad.ff] to global negative cache
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [sss_ncache_set_str] (0x0400): Adding [NCE/UID/0] to negative cache
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [cache_req_process_result] (0x0400): CR #1: Finished: Not found
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [memcache_delete_entry] (0x0040): Bug: invalid input!
        (Mon Aug 14 19:26:11 2017) [sssd[nss]] [nss_protocol_done] (0x4000): Sending reply: not found
        ```
      - With this patch:
        ```
        (Mon Aug 14 19:34:08 2017) [sssd[nss]] [cache_req_search_cache] (0x0400): CR #1: Object [UID:0@indirect.ad.ff] was not found in cache
        (Mon Aug 14 19:34:08 2017) [sssd[nss]] [cache_req_search_ncache_add] (0x2000): CR #1: This request type does not support negative cache
        (Mon Aug 14 19:34:08 2017) [sssd[nss]] [cache_req_global_ncache_add] (0x0400): CR #1: Adding [UID:0@indirect.ad.ff] to global negative cache
        (Mon Aug 14 19:34:08 2017) [sssd[nss]] [sss_ncache_set_str] (0x0400): Adding [NCE/UID/0] to negative cache
        (Mon Aug 14 19:34:08 2017) [sssd[nss]] [cache_req_process_result] (0x0400): CR #1: Finished: Not found
        (Mon Aug 14 19:34:08 2017) [sssd[nss]] [nss_protocol_done] (0x4000): Sending reply: not found
        ```

- **NEGCACHE: Add root's uid/gid to ncache**:
  - Considering the very same environment, just do:
    - `id root`;
    - Inspect sssd_nss.log, looking for a lookup in the data provider;
      - Without this patch:
        ```
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [nss_getby_id] (0x0400): Input ID: 0
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [cache_req_set_plugin] (0x2000): CR #1: Setting "User by ID" plugin
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [cache_req_send] (0x0400): CR #1: New request 'User by ID'
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [cache_req_select_domains] (0x0400): CR #1: Performing a multi-domain search
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [cache_req_search_domains] (0x0400): CR #1: Search will check the cache and check the data provider
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [cache_req_validate_domain_type] (0x2000): Request type POSIX-only for domain indirect.ipa.ff type POSIX is valid
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [cache_req_set_domain] (0x0400): CR #1: Using domain [indirect.ipa.ff]
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [cache_req_search_send] (0x0400): CR #1: Looking up UID:0@indirect.ipa.ff
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [cache_req_search_ncache] (0x0400): CR #1: Checking negative cache for [UID:0@indirect.ipa.ff]
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [sss_ncache_check_str] (0x2000): Checking negative cache for [NCE/UID/0]
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [cache_req_search_ncache] (0x0400): CR #1: [UID:0@indirect.ipa.ff] is not present in negative cache
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [cache_req_search_cache] (0x0400): CR #1: Looking up [UID:0@indirect.ipa.ff] in cache
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [ldb] (0x4000): Added timed event "ltdb_callback": 0x82b230
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [ldb] (0x4000): Added timed event "ltdb_timeout": 0x825100
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [ldb] (0x4000): Running timer event 0x82b230 "ltdb_callback"
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [ldb] (0x4000): Destroying timer event 0x825100 "ltdb_timeout"
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [ldb] (0x4000): Ending timer event 0x82b230 "ltdb_callback"
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [cache_req_search_cache] (0x0400): CR #1: Object [UID:0@indirect.ipa.ff] was not found in cache
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [cache_req_search_dp] (0x0400): CR #1: Looking up [UID:0@indirect.ipa.ff] in data provider
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [sss_dp_issue_request] (0x0400): Issuing request for [0x415ff0:1:*@indirect.ipa.ff]
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [sss_dp_get_account_msg] (0x0400): Creating request for [indirect.ipa.ff][0x1][BE_REQ_USER][*:-]
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [sbus_add_timeout] (0x2000): 0x825330
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [sss_dp_internal_get_send] (0x0400): Entering request [0x415ff0:1:*@indirect.ipa.ff]
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [sbus_remove_timeout] (0x2000): 0x825330
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [sbus_dispatch] (0x4000): dbus conn: 0x81e8c0
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [sbus_dispatch] (0x4000): Dispatching.
        (Mon Aug 14 19:39:17 2017) [sssd[nss]] [sss_dp_get_reply] (0x1000): Got reply from Data Provider - DP error code: 0 errno: 0 error message: Success
        ```
      - With this patch:
        ```
        (Mon Aug 14 19:41:29 2017) [sssd[nss]] [nss_getby_id] (0x0400): Input ID: 0
        (Mon Aug 14 19:41:29 2017) [sssd[nss]] [cache_req_set_plugin] (0x2000): CR #1: Setting "User by ID" plugin
        (Mon Aug 14 19:41:29 2017) [sssd[nss]] [cache_req_send] (0x0400): CR #1: New request 'User by ID'
        (Mon Aug 14 19:41:29 2017) [sssd[nss]] [cache_req_select_domains] (0x0400): CR #1: Performing a multi-domain search
        (Mon Aug 14 19:41:29 2017) [sssd[nss]] [cache_req_search_domains] (0x0400): CR #1: Search will check the cache and check the data provider
        (Mon Aug 14 19:41:29 2017) [sssd[nss]] [cache_req_validate_domain_type] (0x2000): Request type POSIX-only for domain indirect.ipa.ff type POSIX is valid
        (Mon Aug 14 19:41:29 2017) [sssd[nss]] [cache_req_set_domain] (0x0400): CR #1: Using domain [indirect.ipa.ff]
        (Mon Aug 14 19:41:29 2017) [sssd[nss]] [cache_req_search_send] (0x0400): CR #1: Looking up UID:0@indirect.ipa.ff
        (Mon Aug 14 19:41:29 2017) [sssd[nss]] [cache_req_search_ncache] (0x0400): CR #1: Checking negative cache for [UID:0@indirect.ipa.ff]
        (Mon Aug 14 19:41:29 2017) [sssd[nss]] [sss_ncache_check_str] (0x2000): Checking negative cache for [NCE/UID/0]
        (Mon Aug 14 19:41:29 2017) [sssd[nss]] [cache_req_search_ncache] (0x0400): CR #1: [UID:0@indirect.ipa.ff] does not exist (negative cache)
        (Mon Aug 14 19:41:29 2017) [sssd[nss]] [cache_req_validate_domain_type] (0x2000): Request type POSIX-only for domain indirect.ad.ff type POSIX is valid
        (Mon Aug 14 19:41:29 2017) [sssd[nss]] [cache_req_set_domain] (0x0400): CR #1: Using domain [indirect.ad.ff]
        (Mon Aug 14 19:41:29 2017) [sssd[nss]] [cache_req_search_send] (0x0400): CR #1: Looking up UID:0@indirect.ad.ff
        (Mon Aug 14 19:41:29 2017) [sssd[nss]] [cache_req_search_ncache] (0x0400): CR #1: Checking negative cache for [UID:0@indirect.ad.ff]
        (Mon Aug 14 19:41:29 2017) [sssd[nss]] [sss_ncache_check_str] (0x2000): Checking negative cache for [NCE/UID/0]
        (Mon Aug 14 19:41:29 2017) [sssd[nss]] [cache_req_search_ncache] (0x0400): CR #1: [UID:0@indirect.ad.ff] does not exist (negative cache)
        (Mon Aug 14 19:41:29 2017) [sssd[nss]] [cache_req_process_result] (0x0400): CR #1: Finished: Not found
        (Mon Aug 14 19:41:29 2017) [sssd[nss]] [nss_protocol_done] (0x4000): Sending reply: not found
        ```



