### PR TITLE
IPA: Only generate kdcinfo files on clients

### DIFF
--- a/src/providers/ipa/ipa_common.c
+++ b/src/providers/ipa/ipa_common.c
@@ -710,15 +710,6 @@ int ipa_get_auth_options(struct ipa_options *ipa_opts,
               ipa_opts->auth[KRB5_FAST_PRINCIPAL].opt_name, value);
     }
 
-    /* Set flag that controls whether we want to write the
-     * kdcinfo files at all
-     */
-    ipa_opts->service->krb5_service->write_kdcinfo = \
-        dp_opt_get_bool(ipa_opts->auth, KRB5_USE_KDCINFO);
-    DEBUG(SSSDBG_CONF_SETTINGS, "Option %s set to %s\n",
-          ipa_opts->auth[KRB5_USE_KDCINFO].opt_name,
-          ipa_opts->service->krb5_service->write_kdcinfo ? "true" : "false");
-
     *_opts = ipa_opts->auth;
     ret = EOK;
 

--- a/src/providers/ipa/ipa_init.c
+++ b/src/providers/ipa/ipa_init.c
@@ -404,6 +404,24 @@ static errno_t ipa_init_krb5_auth_ctx(TALLOC_CTX *mem_ctx,
         return ret;
     }
 
+    /* On clients, set flag that controls whether we want to write the
+     * kdcinfo files at all. Never write kdcinfo files on servers as
+     * we always want to talk to 'self' anyway and we've had broken
+     * sssd configurations with _srv_ on the server which wwould point
+     * to other KDCs with PKINIT certs not trusted on this IDM server.
+     */
+    if (server_mode) {
+        DEBUG(SSSDBG_TRACE_FUNC,
+              "Disabling kdcinfo files on IDM server\n");
+        dp_opt_set_bool(ipa_options->auth, KRB5_USE_KDCINFO, false);
+    }
+
+    ipa_options->service->krb5_service->write_kdcinfo = \
+        dp_opt_get_bool(ipa_options->auth, KRB5_USE_KDCINFO);
+    DEBUG(SSSDBG_CONF_SETTINGS, "Option %s set to %s\n",
+          ipa_options->auth[KRB5_USE_KDCINFO].opt_name,
+          ipa_options->service->krb5_service->write_kdcinfo ? "true" : "false");
+
     *_krb5_auth_ctx = krb5_auth_ctx;
     return EOK;
 }

--- a/src/providers/ipa/ipa_init.c
+++ b/src/providers/ipa/ipa_init.c
@@ -259,9 +259,10 @@ static errno_t ipa_init_server_mode(struct be_ctx *be_ctx,
     dnsdomain = dp_opt_get_string(be_ctx->be_res->opts, DP_RES_OPT_DNS_DOMAIN);
 
     if (srv_in_server_list(ipa_servers) || sites_enabled) {
-        DEBUG(SSSDBG_MINOR_FAILURE, "SRV resolution or IPA sites enabled "
-              "on the IPA server. Site discovery of trusted AD servers "
-              "might not work.\n");
+        DEBUG(SSSDBG_IMPORTANT_INFO, "SSSD configuration uses either DNS "
+              "SRV resolution or IPA site discovery to locate IPA servers. "
+              "On IPA server itself, it is recommended that SSSD is "
+              "configured to only connect to the IPA server it's running at. ");
 
         /* If SRV discovery is enabled on the server and
          * dns_discovery_domain is set explicitly, then


### PR DESCRIPTION
In some cases, IPA masters end up having a broken SSSD configuration that
also includes the SRV records. This can cause the kdcinfo files to point to
a different master which uses a different PKINIT certificate which is only
valid for that IPA master. This can result e.g. in webui not working.

This patch prevents the kdcinfo files from being generated on the IPA
masters, but keep generating them on the clients.

Not generating kdcinfo files on masters has no negative performance impact,
because libkrb5 is configured via krb5.conf to point to self anyway.