### PR TITLE
intg: Increase startup timeouts for kcm and secrets

### DIFF
--- a/src/tests/intg/test_kcm.py
+++ b/src/tests/intg/test_kcm.py
@@ -90,7 +90,7 @@ def create_sssd_kcm_fixture(sock_path, request):
     else:
         abs_sock_path = os.path.join(config.RUNSTATEDIR, sock_path)
         sck = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        for _ in range(1, 10):
+        for _ in range(1, 100):
             try:
                 sck.connect(abs_sock_path)
             except:

--- a/src/tests/intg/test_secrets.py
+++ b/src/tests/intg/test_secrets.py
@@ -61,7 +61,7 @@ def create_sssd_secrets_fixture(request):
     else:
         sock_path = os.path.join(config.RUNSTATEDIR, "secrets.socket")
         sck = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        for _ in range(1, 10):
+        for _ in range(1, 100):
             try:
                 sck.connect(sock_path)
             except:


### PR DESCRIPTION
    In cwrap environment, we start sssd_kcm and sssd_secrets ourself
    and not by systemd socket activation. Our approach is to wait a second in
    a loop till socket is available. However sometimes 1 second is not enough.
    Patch increases wait timeout from 1 second to 10 and it seems to be enough even
    when processes were executed with valgrind.
    
    Traceback (most recent call last):
      File "src/tests/intg/test_secrets.py", line 419, in setup_for_cli_timeout_test
        return create_sssd_secrets_fixture(request)
      File "src/tests/intg/test_secrets.py", line 82, in create_sssd_secrets_fixture
        assert os.path.exists(sock_path)
    AssertionError: assert False
     +  where False = <function exists at 0x7f6c1cf520c8>('/tmp/sssd-intg.cdv0namx/var/run/secrets.socket')
     +    where <function exists at 0x7f6c1cf520c8> = <module 'posixpath' from '/usr/lib64/python2.7/posixpath.pyc'>.exists
     +      where <module 'posixpath' from '/usr/lib64/python2.7/posixpath.pyc'> = os.path
    
    Resolves:
    https://pagure.io/SSSD/sssd/issue/3481