### PR TITLE
libwbclient: Change return code for wbcAuthenticateUserEx

### DIFF
--- a/src/sss_client/libwbclient/wbc_pam_sssd.c
+++ b/src/sss_client/libwbclient/wbc_pam_sssd.c
@@ -49,7 +49,7 @@ wbcErr wbcAuthenticateUserEx(const struct wbcAuthUserParams *params,
         *error = NULL;
     }
 
-    WBC_SSSD_NOT_IMPLEMENTED;
+    WBC_ERR_WINBIND_NOT_AVAILABLE;
 }
 
 /* Trigger a verification of the trust credentials of a specific domain */


### PR DESCRIPTION
Samba-4.6 change behaviour of few functions
New version of code make sure session info for user is stored in cache.
It is a performance optimisation to prevent contacting KDC for each
session. More details in samba bug
https://bugzilla.samba.org/show_bug.cgi?id=11259

Old return code WBC_SSSD_NOT_IMPLEMENTED was translated
to NT_STATUS_LOGON_FAILURE which caused many failures.

    [2017/08/21 11:34:15.044321,  5, pid=27742, effective(0, 0), real(0, 0)]
    ../libcli/security/security_token.c:53(security_token_debug)
      Security token: (NULL)
    [2017/08/21 11:34:15.044330,  5, pid=27742, effective(0, 0), real(0, 0)]
    ../source3/auth/token_util.c:640(debug_unix_user_token)
      UNIX token of user 0
      Primary group is 0 and contains 0 supplementary groups
    [2017/08/21 11:34:15.044349,  4, pid=27742, effective(0, 0), real(0, 0)]
    ../source3/smbd/sec_ctx.c:439(pop_sec_ctx)
      pop_sec_ctx (0, 0) - sec_ctx_stack_ndx = 0
    [2017/08/21 11:34:15.044360,  1, pid=27742, effective(0, 0), real(0, 0)]
    ../source3/smbd/sesssetup.c:290(reply_sesssetup_and_X_spnego)
      Failed to generate session_info (user and group token) for session
    setup: NT_STATUS_LOGON_FAILURE

Resolves:
https://pagure.io/SSSD/sssd/issue/3461