### PR TITLE
libwbclient: Fix warning statement with no effect

### DIFF
--- a/src/sss_client/libwbclient/wbc_pam_sssd.c
+++ b/src/sss_client/libwbclient/wbc_pam_sssd.c
@@ -49,7 +49,7 @@ wbcErr wbcAuthenticateUserEx(const struct wbcAuthUserParams *params,
         *error = NULL;
     }
 
-    WBC_ERR_WINBIND_NOT_AVAILABLE;
+    return WBC_ERR_WINBIND_NOT_AVAILABLE;
 }
 
 /* Trigger a verification of the trust credentials of a specific domain */


### PR DESCRIPTION
src/sss_client/libwbclient/wbc_pam_sssd.c: In function ‘wbcAuthenticateUserEx’:
src/sss_client/libwbclient/wbc_pam_sssd.c:52:5: error: statement with no effect [-Werror=unused-value]
     WBC_ERR_WINBIND_NOT_AVAILABLE;
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/sss_client/libwbclient/wbc_pam_sssd.c:53:1: error: control reaches end of non-void function [-Werror=return-type]
 }
 ^

`WBC_SSSD_NOT_IMPLEMENTED` is not an error code but also macro which can log to syslog
and then return `WBC_ERR_NOT_IMPLEMENTED`