### PR TITLE
CONFDB: Do not crash with an invalid domain_type value

### DIFF
--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -1345,6 +1345,7 @@ static int confdb_get_domain_internal(struct confdb_ctx *cdb,
         } else {
             DEBUG(SSSDBG_FATAL_FAILURE,
                   "Invalid value for %s\n", CONFDB_DOMAIN_CASE_SENSITIVE);
+            ret = EINVAL;
             goto done;
         }
     } else {
@@ -1414,6 +1415,7 @@ static int confdb_get_domain_internal(struct confdb_ctx *cdb,
         } else {
             DEBUG(SSSDBG_FATAL_FAILURE,
                   "Invalid value %s for [%s]\n", tmp, CONFDB_DOMAIN_TYPE);
+            ret = EINVAL;
             goto done;
         }
     }


### PR DESCRIPTION
If the domain_type parameter contained an invalid value, the error branch
wouldn't have set the 'ret' parameter to an error condition, which might
crash sssd.