### PR TITLE
CONFDB: Set a default value for subdomain_refresh_interval in case an invalid value is set

### DIFF
--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -1419,11 +1419,20 @@ static int confdb_get_domain_internal(struct confdb_ctx *cdb,
     }
 
     ret = get_entry_as_uint32(res->msgs[0], &domain->subdomain_refresh_interval,
-                              CONFDB_DOMAIN_SUBDOMAIN_REFRESH, 14400);
-    if (ret != EOK || domain->subdomain_refresh_interval == 0) {
+                              CONFDB_DOMAIN_SUBDOMAIN_REFRESH,
+                              CONFDB_DOMAIN_SUBDOMAIN_REFRESH_DEFAULT_VALUE);
+    if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
               "Invalid value for [%s]\n", CONFDB_DOMAIN_SUBDOMAIN_REFRESH);
         goto done;
+    } else if (domain->subdomain_refresh_interval == 0) {
+        DEBUG(SSSDBG_MINOR_FAILURE,
+              "Invalid value for [%s]. Setting up the default value: %d\n",
+              CONFDB_DOMAIN_SUBDOMAIN_REFRESH,
+              CONFDB_DOMAIN_SUBDOMAIN_REFRESH_DEFAULT_VALUE);
+
+        domain->subdomain_refresh_interval =
+            CONFDB_DOMAIN_SUBDOMAIN_REFRESH_DEFAULT_VALUE;
     }
 
     ret = init_cached_auth_timeout(cdb, res->msgs[0],

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -207,6 +207,7 @@
 #define CONFDB_DOMAIN_DEFAULT_SUBDOMAIN_HOMEDIR "/home/%d/%u"
 #define CONFDB_DOMAIN_IGNORE_GROUP_MEMBERS "ignore_group_members"
 #define CONFDB_DOMAIN_SUBDOMAIN_REFRESH "subdomain_refresh_interval"
+#define CONFDB_DOMAIN_SUBDOMAIN_REFRESH_DEFAULT_VALUE 14400
 
 #define CONFDB_DOMAIN_USER_CACHE_TIMEOUT "entry_cache_user_timeout"
 #define CONFDB_DOMAIN_GROUP_CACHE_TIMEOUT "entry_cache_group_timeout"


### PR DESCRIPTION
The code as it was seemed wrong as when an invalid value as set we
neither error out nor set a default valid value there.

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>