### PR TITLE
PYTHON: Define constants as bytes instead of strings

### DIFF
--- a/src/python/pysss_nss_idmap.c
+++ b/src/python/pysss_nss_idmap.c
@@ -533,10 +533,17 @@ initpysss_nss_idmap(void)
     PyModule_AddIntConstant(module, "ID_GROUP", SSS_ID_TYPE_GID);
     PyModule_AddIntConstant(module, "ID_BOTH", SSS_ID_TYPE_BOTH);
 
+#ifdef IS_PY3K
+    PyModule_AddObject(module, "SID_KEY", PyBytes_FromString(SSS_SID_KEY));
+    PyModule_AddObject(module, "NAME_KEY", PyBytes_FromString(SSS_NAME_KEY));
+    PyModule_AddObject(module, "ID_KEY", PyBytes_FromString(SSS_ID_KEY));
+    PyModule_AddObject(module, "TYPE_KEY", PyBytes_FromString(SSS_TYPE_KEY));
+#else
     PyModule_AddStringConstant(module, "SID_KEY", SSS_SID_KEY);
     PyModule_AddStringConstant(module, "NAME_KEY", SSS_NAME_KEY);
     PyModule_AddStringConstant(module, "ID_KEY", SSS_ID_KEY);
     PyModule_AddStringConstant(module, "TYPE_KEY", SSS_TYPE_KEY);
+#endif
 
 #ifdef IS_PY3K
     return module;


### PR DESCRIPTION
When using python3 getsidbyname() and getnamebysid() expect the key as
bytes instead of strings, and currently those are defined as strings.
So, in order to avoid people working around this by doing
`pysss_nss_idmap.SID_KEY.encode('utf-8')` let's make their life easier
and properly have those constants defined as bytes.

Resolves: https://pagure.io/SSSD/sssd/issue/3491

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>