### PR TITLE
pysss_nss_idmap: remove unnecessary python2/3 ifdef

### DIFF
--- a/src/python/pysss_nss_idmap.c
+++ b/src/python/pysss_nss_idmap.c
@@ -533,17 +533,10 @@ initpysss_nss_idmap(void)
     PyModule_AddIntConstant(module, "ID_GROUP", SSS_ID_TYPE_GID);
     PyModule_AddIntConstant(module, "ID_BOTH", SSS_ID_TYPE_BOTH);
 
-#ifdef IS_PY3K
-    PyModule_AddObject(module, "SID_KEY", PyBytes_FromString(SSS_SID_KEY));
-    PyModule_AddObject(module, "NAME_KEY", PyBytes_FromString(SSS_NAME_KEY));
-    PyModule_AddObject(module, "ID_KEY", PyBytes_FromString(SSS_ID_KEY));
-    PyModule_AddObject(module, "TYPE_KEY", PyBytes_FromString(SSS_TYPE_KEY));
-#else
     PyModule_AddStringConstant(module, "SID_KEY", SSS_SID_KEY);
     PyModule_AddStringConstant(module, "NAME_KEY", SSS_NAME_KEY);
     PyModule_AddStringConstant(module, "ID_KEY", SSS_ID_KEY);
     PyModule_AddStringConstant(module, "TYPE_KEY", SSS_TYPE_KEY);
-#endif
 
 #ifdef IS_PY3K
     return module;

--- a/src/python/pysss_nss_idmap.c
+++ b/src/python/pysss_nss_idmap.c
@@ -57,7 +57,7 @@ static int add_dict_to_list(PyObject *py_list, PyObject *res_type,
         return ret;
     }
 
-    ret = PyDict_SetItem(py_dict, PyBytes_FromString(SSS_TYPE_KEY), id_type);
+    ret = PyDict_SetItem(py_dict, PyUnicode_FromString(SSS_TYPE_KEY), id_type);
     if (ret != 0) {
         Py_XDECREF(py_dict);
         return ret;
@@ -84,7 +84,7 @@ static int add_dict(PyObject *py_result, PyObject *key, PyObject *res_type,
         return ret;
     }
 
-    ret = PyDict_SetItem(py_dict, PyBytes_FromString(SSS_TYPE_KEY), id_type);
+    ret = PyDict_SetItem(py_dict, PyUnicode_FromString(SSS_TYPE_KEY), id_type);
     if (ret != 0) {
         Py_XDECREF(py_dict);
         return ret;
@@ -125,7 +125,7 @@ static int do_getsidbyname(PyObject *py_result, PyObject *py_name)
 
     ret = sss_nss_getsidbyname(name, &sid, &id_type);
     if (ret == 0) {
-        ret = add_dict(py_result, py_name, PyBytes_FromString(SSS_SID_KEY),
+        ret = add_dict(py_result, py_name, PyUnicode_FromString(SSS_SID_KEY),
                        PyUnicode_FromString(sid), PYNUMBER_FROMLONG(id_type));
     }
     free(sid);
@@ -147,7 +147,7 @@ static int do_getnamebysid(PyObject *py_result, PyObject *py_sid)
 
     ret = sss_nss_getnamebysid(sid, &name, &id_type);
     if (ret == 0) {
-        ret = add_dict(py_result, py_sid, PyBytes_FromString(SSS_NAME_KEY),
+        ret = add_dict(py_result, py_sid, PyUnicode_FromString(SSS_NAME_KEY),
                        PyUnicode_FromString(name), PYNUMBER_FROMLONG(id_type));
     }
     free(name);
@@ -189,7 +189,7 @@ static int do_getsidbyid(PyObject *py_result, PyObject *py_id)
 
     ret = sss_nss_getsidbyid((uint32_t) id, &sid, &id_type);
     if (ret == 0) {
-        ret = add_dict(py_result, py_id, PyBytes_FromString(SSS_SID_KEY),
+        ret = add_dict(py_result, py_id, PyUnicode_FromString(SSS_SID_KEY),
                        PyUnicode_FromString(sid), PYNUMBER_FROMLONG(id_type));
     }
     free(sid);
@@ -211,7 +211,7 @@ static int do_getnamebycert(PyObject *py_result, PyObject *py_cert)
 
     ret = sss_nss_getnamebycert(cert, &name, &id_type);
     if (ret == 0) {
-        ret = add_dict(py_result, py_cert, PyBytes_FromString(SSS_NAME_KEY),
+        ret = add_dict(py_result, py_cert, PyUnicode_FromString(SSS_NAME_KEY),
                        PyUnicode_FromString(name), PYNUMBER_FROMLONG(id_type));
     }
     free(name);
@@ -244,7 +244,7 @@ static int do_getlistbycert(PyObject *py_result, PyObject *py_cert)
 
         for (c = 0; names[c] != NULL; c++) {
             ret = add_dict_to_list(py_list,
-                                   PyBytes_FromString(SSS_NAME_KEY),
+                                   PyUnicode_FromString(SSS_NAME_KEY),
                                    PyUnicode_FromString(names[c]),
                                    PYNUMBER_FROMLONG(id_types[c]));
             if (ret != 0) {
@@ -284,7 +284,7 @@ static int do_getidbysid(PyObject *py_result, PyObject *py_sid)
 
     ret = sss_nss_getidbysid(sid, &id, &id_type);
     if (ret == 0) {
-        ret = add_dict(py_result, py_sid, PyBytes_FromString(SSS_ID_KEY),
+        ret = add_dict(py_result, py_sid, PyUnicode_FromString(SSS_ID_KEY),
                        PYNUMBER_FROMLONG(id), PYNUMBER_FROMLONG(id_type));
     }
 

--- a/src/python/pysss_nss_idmap.c
+++ b/src/python/pysss_nss_idmap.c
@@ -389,8 +389,8 @@ static PyObject *check_args(enum lookup_type type, PyObject *args)
 PyDoc_STRVAR(getsidbyname_doc,
 "getsidbyname(name or list/tuple of names) -> dict(name => dict(results))\n\
 \n\
-Returns a dictionary with a dictonary of results for each given name.\n\
-The result dictonary contain the SID and the type of the object which can be\n\
+Returns a dictionary with a dictionary of results for each given name.\n\
+The result dictionary contain the SID and the type of the object which can be\n\
 accessed with the key constants SID_KEY and TYPE_KEY, respectively.\n\
 \n\
 The return type can be one of the following constants:\n\
@@ -408,8 +408,8 @@ static PyObject * py_getsidbyname(PyObject *module, PyObject *args)
 PyDoc_STRVAR(getsidbyid_doc,
 "getsidbyid(id or list/tuple of id) -> dict(id => dict(results))\n\
 \n\
-Returns a dictionary with a dictonary of results for each given POSIX ID.\n\
-The result dictonary contain the SID and the type of the object which can be\n\
+Returns a dictionary with a dictionary of results for each given POSIX ID.\n\
+The result dictionary contain the SID and the type of the object which can be\n\
 accessed with the key constants SID_KEY and TYPE_KEY, respectively."
 );
 
@@ -421,8 +421,8 @@ static PyObject * py_getsidbyid(PyObject *module, PyObject *args)
 PyDoc_STRVAR(getnamebysid_doc,
 "getnamebysid(sid or list/tuple of sid) -> dict(sid => dict(results))\n\
 \n\
-Returns a dictionary with a dictonary of results for each given SID.\n\
-The result dictonary contain the name and the type of the object which can be\n\
+Returns a dictionary with a dictionary of results for each given SID.\n\
+The result dictionary contain the name and the type of the object which can be\n\
 accessed with the key constants NAME_KEY and TYPE_KEY, respectively.\n\
 \n\
 NOTE: getnamebysid currently works only with id_provider set as \"ad\" or \"ipa\""
@@ -439,8 +439,8 @@ PyDoc_STRVAR(getidbysid_doc,
 Returns the POSIX ID of the object with the given SID."
 "getidbysid(sid or list/tuple of sid) -> dict(sid => dict(results))\n\
 \n\
-Returns a dictionary with a dictonary of results for each given SID.\n\
-The result dictonary contain the POSIX ID and the type of the object which\n\
+Returns a dictionary with a dictionary of results for each given SID.\n\
+The result dictionary contain the POSIX ID and the type of the object which\n\
 can be accessed with the key constants ID_KEY and TYPE_KEY, respectively."
 );
 
@@ -452,8 +452,8 @@ static PyObject * py_getidbysid(PyObject *module, PyObject *args)
 PyDoc_STRVAR(getnamebycert_doc,
 "getnamebycert(certificate or list/tuple of certificates) -> dict(certificate => dict(results))\n\
 \n\
-Returns a dictionary with a dictonary of results for each given certificates.\n\
-The result dictonary contain the name and the type of the object which can be\n\
+Returns a dictionary with a dictionary of results for each given certificates.\n\
+The result dictionary contain the name and the type of the object which can be\n\
 accessed with the key constants NAME_KEY and TYPE_KEY, respectively.\n\
 \n\
 NOTE: getnamebycert currently works only with id_provider set as \"ad\" or \"ipa\""
@@ -467,8 +467,8 @@ static PyObject * py_getnamebycert(PyObject *module, PyObject *args)
 PyDoc_STRVAR(getlistbycert_doc,
 "getnamebycert(certificate or list/tuple of certificates) -> dict(certificate => dict(results))\n\
 \n\
-Returns a dictionary with a dictonary of results for each given certificates.\n\
-The result dictonary contain the name and the type of the object which can be\n\
+Returns a dictionary with a dictionary of results for each given certificates.\n\
+The result dictionary contain the name and the type of the object which can be\n\
 accessed with the key constants NAME_KEY and TYPE_KEY, respectively.\n\
 \n\
 NOTE: getlistbycert currently works only with id_provider set as \"ad\" or \"ipa\""


### PR DESCRIPTION
python2.6 already contains function/macro PyModule_AddObject
and PyBytes_FromString.

Related to:
https://pagure.io/SSSD/sssd/issue/3491