### PR TITLE
certmap: Suppress warning Wmissing-braces

### DIFF
--- a/src/lib/certmap/sss_cert_content_nss.c
+++ b/src/lib/certmap/sss_cert_content_nss.c
@@ -472,9 +472,15 @@ static int add_pkinit_princ_to_san_list(TALLOC_CTX *mem_ctx,
 {
     struct san_list *i = NULL;
     SECStatus rv;
-    struct kerberos_principal_name kname = { 0 };
+    /* To avoid 'Wmissing-braces' warnings with older versions of
+     * gcc kerberos_principal_name cannot be initialized with { 0 }
+     * but must be initialized with memset().
+     */
+    struct kerberos_principal_name kname;
     int ret;
     size_t c;
+
+    memset(&kname, 0, sizeof(kname));
 
     rv = SEC_ASN1DecodeItem(pool, &kname,
                             kerberos_principal_name_template,


### PR DESCRIPTION
Older version of gcc(e.g. gcc-4.8.5-11.el7) had a false positive warning
with c99 struct initialisation "{ 0 }".
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53119
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64709

  CC       src/lib/certmap/libsss_certmap_la-sss_cert_content_nss.lo

src/lib/certmap/sss_cert_content_nss.c:
    In function 'add_pkinit_princ_to_san_list':
src/lib/certmap/sss_cert_content_nss.c:475:12:
    error: missing braces around initializer [-Werror=missing-braces]
     struct kerberos_principal_name kname = { 0 };
            ^
src/lib/certmap/sss_cert_content_nss.c:475:12:
    error: (near initialization for 'kname.realm') [-Werror=missing-braces]