### PR TITLE
ldap: Change ldap_user_certificate to userCertificate;binary

### DIFF
--- a/src/man/include/ipa_modified_defaults.xml
+++ b/src/man/include/ipa_modified_defaults.xml
@@ -83,11 +83,6 @@
                     ldap_user_auth_type = ipaUserAuthType
                 </para>
             </listitem>
-            <listitem>
-                <para>
-                    ldap_user_certificate = userCertificate;binary
-                </para>
-            </listitem>
         </itemizedlist>
     </refsect2>
     <refsect2 id='ldap_group_modifications'>

--- a/src/man/sssd-ldap.5.xml
+++ b/src/man/sssd-ldap.5.xml
@@ -837,8 +837,7 @@
                             certificate of the user.
                         </para>
                         <para>
-                            Default: no set in the general case, userCertificate;binary
-                            for IPA
+                            Default: userCertificate;binary
                         </para>
                     </listitem>
                 </varlistentry>

--- a/src/providers/ldap/ldap_opts.c
+++ b/src/providers/ldap/ldap_opts.c
@@ -179,7 +179,7 @@ struct sdap_attr_map rfc2307_user_map[] = {
     { "ldap_user_nds_login_allowed_time_map", "loginAllowedTimeMap", SYSDB_NDS_LOGIN_ALLOWED_TIME_MAP, NULL },
     { "ldap_user_ssh_public_key", "sshPublicKey", SYSDB_SSH_PUBKEY, NULL },
     { "ldap_user_auth_type", NULL, SYSDB_AUTH_TYPE, NULL },
-    { "ldap_user_certificate", NULL, SYSDB_USER_CERT, NULL },
+    { "ldap_user_certificate", "userCertificate;binary", SYSDB_USER_CERT, NULL },
     { "ldap_user_email", "mail", SYSDB_USER_EMAIL, NULL },
     SDAP_ATTR_MAP_TERMINATOR
 };
@@ -237,7 +237,7 @@ struct sdap_attr_map rfc2307bis_user_map[] = {
     { "ldap_user_nds_login_allowed_time_map", "loginAllowedTimeMap", SYSDB_NDS_LOGIN_ALLOWED_TIME_MAP, NULL },
     { "ldap_user_ssh_public_key", "sshPublicKey", SYSDB_SSH_PUBKEY, NULL },
     { "ldap_user_auth_type", NULL, SYSDB_AUTH_TYPE, NULL },
-    { "ldap_user_certificate", NULL, SYSDB_USER_CERT, NULL },
+    { "ldap_user_certificate", "userCertificate;binary", SYSDB_USER_CERT, NULL },
     { "ldap_user_email", "mail", SYSDB_USER_EMAIL, NULL },
     SDAP_ATTR_MAP_TERMINATOR
 };
@@ -295,7 +295,7 @@ struct sdap_attr_map gen_ad2008r2_user_map[] = {
     { "ldap_user_nds_login_allowed_time_map", NULL, SYSDB_NDS_LOGIN_ALLOWED_TIME_MAP, NULL },
     { "ldap_user_ssh_public_key", NULL, SYSDB_SSH_PUBKEY, NULL },
     { "ldap_user_auth_type", NULL, SYSDB_AUTH_TYPE, NULL },
-    { "ldap_user_certificate", NULL, SYSDB_USER_CERT, NULL },
+    { "ldap_user_certificate", "userCertificate;binary", SYSDB_USER_CERT, NULL },
     { "ldap_user_email", "mail", SYSDB_USER_EMAIL, NULL },
     SDAP_ATTR_MAP_TERMINATOR
 };


### PR DESCRIPTION
IPA and AD providers default to userCertificate;binary for the
ldap_user_certificate option. It will be good to default that value
also for the generic LDAP provider.

Resolves: https://pagure.io/SSSD/sssd/issue/3499