### PR TITLE
Fix two issues related to certificate mapping

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -258,6 +258,7 @@ if HAVE_CMOCKA
         test_search_bases \
         test_ldap_auth \
         test_sdap_access \
+        test_sdap_certmap \
         sdap-tests \
         test_sysdb_ts_cache \
         test_sysdb_views \
@@ -2683,6 +2684,24 @@ test_sdap_access_LDADD = \
     libdlopen_test_providers.la \
     $(NULL)
 
+test_sdap_certmap_SOURCES = \
+    src/tests/cmocka/test_sdap_certmap.c \
+    src/providers/ldap/sdap_certmap.c \
+    $(NULL)
+test_sdap_certmap_CFLAGS = \
+    $(AM_CFLAGS) \
+    $(TALLOC_CFLAGS) \
+    $(POPT_CFLAGS) \
+    $(NULL)
+test_sdap_certmap_LDADD = \
+    $(CMOCKA_LIBS) \
+    $(TALLOC_LIBS) \
+    $(POPT_LIBS) \
+    $(SSSD_INTERNAL_LTLIBS) \
+    libsss_test_common.la \
+    libsss_certmap.la \
+    $(NULL)
+
 ad_access_filter_tests_SOURCES = \
     src/tests/cmocka/test_ad_access_filter.c
 ad_access_filter_tests_LDADD = \
@@ -3742,6 +3761,7 @@ libsss_ldap_common_la_SOURCES = \
     src/providers/ldap/sdap_child_helpers.c \
     src/providers/ldap/sdap_fd_events.c \
     src/providers/ldap/sdap_id_op.c \
+    src/providers/ldap/sdap_certmap.c \
     src/providers/ldap/sdap_idmap.c \
     src/providers/ldap/sdap_idmap.h \
     src/providers/ldap/sdap_range.c \

--- a/src/lib/certmap/sss_certmap_krb5_match.c
+++ b/src/lib/certmap/sss_certmap_krb5_match.c
@@ -180,19 +180,17 @@ static int parse_krb5_get_eku_value(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
+    comp->eku_oid_list = talloc_zero_array(comp, const char *,
+                                           eku_list_size + 1);
+    if (comp->eku_oid_list == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
     for (c = 0; eku_list[c] != NULL; c++) {
         for (k = 0; ext_key_usage[k].name != NULL; k++) {
 CM_DEBUG(ctx, "[%s][%s].", eku_list[c], ext_key_usage[k].name);
             if (strcasecmp(eku_list[c], ext_key_usage[k].name) == 0) {
-                if (comp->eku_oid_list == NULL) {
-                    comp->eku_oid_list = talloc_zero_array(comp, const char *,
-                                                           eku_list_size + 1);
-                    if (comp->eku_oid_list == NULL) {
-                        ret = ENOMEM;
-                        goto done;
-                    }
-                }
-
                 comp->eku_oid_list[e] = talloc_strdup(comp->eku_oid_list,
                                                       ext_key_usage[k].oid);
                 if (comp->eku_oid_list[e] == NULL) {
@@ -224,6 +222,11 @@ CM_DEBUG(ctx, "[%s][%s].", eku_list[c], ext_key_usage[k].name);
             ret = EINVAL;
             goto done;
         }
+    }
+
+    if (e == 0) {
+        talloc_free(comp->eku_oid_list);
+        comp->eku_oid_list = NULL;
     }
 
     ret = 0;

--- a/src/providers/ipa/ipa_init.c
+++ b/src/providers/ipa/ipa_init.c
@@ -680,6 +680,13 @@ static errno_t ipa_init_misc(struct be_ctx *be_ctx,
         return ENOMEM;
     }
 
+    ret = sdap_init_certmap(sdap_id_ctx, sdap_id_ctx);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Failed to initialized certificate mapping.\n");
+        return ret;
+    }
+
     return EOK;
 }
 

--- a/src/providers/ipa/ipa_subdomains_server.c
+++ b/src/providers/ipa/ipa_subdomains_server.c
@@ -361,8 +361,8 @@ ipa_ad_ctx_new(struct be_ctx *be_ctx,
         id_ctx->sdap_id_ctx->opts->idmap_ctx;
 
     /* Set up the certificate mapping context */
-    ad_id_ctx->sdap_id_ctx->opts->certmap_ctx =
-        id_ctx->sdap_id_ctx->opts->certmap_ctx;
+    ad_id_ctx->sdap_id_ctx->opts->sdap_certmap_ctx =
+        id_ctx->sdap_id_ctx->opts->sdap_certmap_ctx;
 
     *_ad_id_ctx = ad_id_ctx;
     return EOK;

--- a/src/providers/ldap/ldap_common.h
+++ b/src/providers/ldap/ldap_common.h
@@ -362,4 +362,9 @@ sdap_id_ctx_new(TALLOC_CTX *mem_ctx, struct be_ctx *bectx,
 errno_t sdap_refresh_init(struct be_refresh_ctx *refresh_ctx,
                           struct sdap_id_ctx *id_ctx);
 
+errno_t sdap_init_certmap(TALLOC_CTX *mem_ctx, struct sdap_id_ctx *id_ctx);
+
+errno_t sdap_setup_certmap(struct sdap_certmap_ctx *sdap_certmap_ctx,
+                           struct certmap_info **certmap_list);
+struct sss_certmap_ctx *sdap_get_sss_certmap(struct sdap_certmap_ctx *ctx);
 #endif /* _LDAP_COMMON_H_ */

--- a/src/providers/ldap/ldap_id.c
+++ b/src/providers/ldap/ldap_id.c
@@ -252,9 +252,8 @@ struct tevent_req *users_get_send(TALLOC_CTX *memctx,
         }
 
         ret = sss_cert_derb64_to_ldap_filter(state, filter_value, attr_name,
-                                             ctx->opts->certmap_ctx,
-                                             state->domain,
-                                             &user_filter);
+                              sdap_get_sss_certmap(ctx->opts->sdap_certmap_ctx),
+                              state->domain, &user_filter);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE,
                   "sss_cert_derb64_to_ldap_filter failed.\n");

--- a/src/providers/ldap/sdap.h
+++ b/src/providers/ldap/sdap.h
@@ -446,6 +446,8 @@ struct sdap_ext_member_ctx {
     ext_member_recv_fn_t ext_member_resolve_recv;
 };
 
+struct sdap_certmap_ctx;
+
 struct sdap_options {
     struct dp_option *basic;
     struct sdap_attr_map *gen_map;
@@ -481,7 +483,7 @@ struct sdap_options {
     enum dc_functional_level dc_functional_level;
 
     /* Certificate mapping support */
-    struct sss_certmap_ctx *certmap_ctx;
+    struct sdap_certmap_ctx *sdap_certmap_ctx;
 };
 
 struct sdap_server_opts {

--- a/src/providers/ldap/sdap_certmap.c
+++ b/src/providers/ldap/sdap_certmap.c
@@ -1,0 +1,152 @@
+
+/*
+    SSSD
+
+    Authors:
+        Sumit Bose <sbose@redhat.com>
+
+    Copyright (C) 2017 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "util/util.h"
+#include "lib/certmap/sss_certmap.h"
+#include "providers/ldap/ldap_common.h"
+
+struct sdap_certmap_ctx {
+    struct sss_certmap_ctx *certmap_ctx;
+};
+
+struct priv_sss_debug {
+    int level;
+};
+
+static void ext_debug(void *private, const char *file, long line,
+                      const char *function, const char *format, ...)
+{
+    va_list ap;
+    struct priv_sss_debug *data = private;
+    int level = SSSDBG_OP_FAILURE;
+
+    if (data != NULL) {
+        level = data->level;
+    }
+
+    if (DEBUG_IS_SET(level)) {
+        va_start(ap, format);
+        sss_vdebug_fn(file, line, function, level, APPEND_LINE_FEED,
+                      format, ap);
+        va_end(ap);
+    }
+}
+
+struct sss_certmap_ctx *sdap_get_sss_certmap(struct sdap_certmap_ctx *ctx)
+{
+    return ctx == NULL ? NULL : ctx->certmap_ctx;
+}
+
+errno_t sdap_setup_certmap(struct sdap_certmap_ctx *sdap_certmap_ctx,
+                           struct certmap_info **certmap_list)
+{
+    int ret;
+    struct sss_certmap_ctx *sss_certmap_ctx = NULL;
+    size_t c;
+
+    if (sdap_certmap_ctx == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Missing sdap_certmap_ctx.\n");
+        return EINVAL;
+    }
+
+    if (certmap_list == NULL || *certmap_list == NULL) {
+        DEBUG(SSSDBG_TRACE_ALL, "No certmap data, nothing to do.\n");
+        ret = EOK;
+        goto done;
+    }
+
+    ret = sss_certmap_init(sdap_certmap_ctx, ext_debug, NULL, &sss_certmap_ctx);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sss_certmap_init failed.\n");
+        goto done;
+    }
+
+    for (c = 0; certmap_list[c] != NULL; c++) {
+        DEBUG(SSSDBG_TRACE_ALL, "Trying to add rule [%s][%d][%s][%s].\n",
+                                certmap_list[c]->name,
+                                certmap_list[c]->priority,
+                                certmap_list[c]->match_rule,
+                                certmap_list[c]->map_rule);
+
+        ret = sss_certmap_add_rule(sss_certmap_ctx, certmap_list[c]->priority,
+                                   certmap_list[c]->match_rule,
+                                   certmap_list[c]->map_rule,
+                                   certmap_list[c]->domains);
+        if (ret != 0) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "sss_certmap_add_rule failed for rule [%s] "
+                  "with error [%d][%s], skipping. "
+                  "Please check for typos and if rule syntax is supported.\n",
+                  certmap_list[c]->name, ret, sss_strerror(ret));
+            continue;
+        }
+    }
+
+    ret = EOK;
+
+done:
+    if (ret == EOK) {
+        sss_certmap_free_ctx(sdap_certmap_ctx->certmap_ctx);
+        sdap_certmap_ctx->certmap_ctx = sss_certmap_ctx;
+    } else {
+        sss_certmap_free_ctx(sss_certmap_ctx);
+    }
+
+    return ret;
+}
+
+errno_t sdap_init_certmap(TALLOC_CTX *mem_ctx, struct sdap_id_ctx *id_ctx)
+{
+    int ret;
+    bool hint;
+    struct certmap_info **certmap_list = NULL;
+
+    if (id_ctx->opts->sdap_certmap_ctx == NULL) {
+        id_ctx->opts->sdap_certmap_ctx = talloc_zero(mem_ctx,
+                                                     struct sdap_certmap_ctx);
+        if (id_ctx->opts->sdap_certmap_ctx == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE, "talloc_zero failed.\n");
+            return ENOMEM;
+        }
+    }
+
+    ret = sysdb_get_certmap(mem_ctx, id_ctx->be->domain->sysdb,
+                            &certmap_list, &hint);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sysdb_get_certmap failed.\n");
+        goto done;
+    }
+
+    ret = sdap_setup_certmap(id_ctx->opts->sdap_certmap_ctx, certmap_list);
+    if (ret != EOK) {
+            DEBUG(SSSDBG_OP_FAILURE, "sdap_setup_certmap failed.\n");
+            goto done;
+    }
+
+    ret = EOK;
+
+done:
+    talloc_free(certmap_list);
+
+    return ret;
+}

--- a/src/tests/cmocka/test_certmap.c
+++ b/src/tests/cmocka/test_certmap.c
@@ -449,6 +449,23 @@ static void test_sss_certmap_add_matching_rule(void **state)
     assert_null(
             ctx->prio_list->rule_list->parsed_match_rule->eku->eku_oid_list[3]);
 
+    ret = sss_certmap_add_rule(ctx, 96,
+                               "KRB5:<EKU>1.2.3",
+                               NULL, NULL);
+    assert_int_equal(ret, 0);
+    assert_non_null(ctx->prio_list);
+    assert_non_null(ctx->prio_list->rule_list);
+    assert_non_null(ctx->prio_list->rule_list->parsed_match_rule);
+    assert_int_equal(ctx->prio_list->rule_list->parsed_match_rule->r,
+                     relation_and);
+    assert_non_null(ctx->prio_list->rule_list->parsed_match_rule->eku);
+    assert_true(string_in_list("1.2.3",
+              discard_const(
+               ctx->prio_list->rule_list->parsed_match_rule->eku->eku_oid_list),
+              true));
+    assert_null(
+            ctx->prio_list->rule_list->parsed_match_rule->eku->eku_oid_list[1]);
+
     /* SAN tests */
     ret = sss_certmap_add_rule(ctx, 89, "KRB5:<SAN>abc", NULL, NULL);
     assert_int_equal(ret, 0);

--- a/src/tests/cmocka/test_sdap_certmap.c
+++ b/src/tests/cmocka/test_sdap_certmap.c
@@ -1,0 +1,244 @@
+/*
+    Authors:
+        Sumit Bose <sbose@redhat.com>
+
+    Copyright (C) 2017 Red Hat
+
+    SSSD tests - sdap certmap
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <setjmp.h>
+#include <unistd.h>
+#include <cmocka.h>
+#include <popt.h>
+
+#include "providers/ldap/ldap_common.h"
+#include "tests/common.h"
+#include "db/sysdb.h"
+
+#define TESTS_PATH "certmap_" BASE_FILE_STEM
+#define TEST_CONF_DB "test_sysdb_certmap.ldb"
+#define TEST_ID_PROVIDER "ldap"
+#define TEST_DOM_NAME "certmap_test"
+
+struct certmap_info map_a = { discard_const("map_a"), 11,
+                              NULL, discard_const("(abc=def)"),
+                              NULL };
+struct certmap_info map_b = { discard_const("map_b"), UINT_MAX,
+                              NULL, NULL, NULL };
+struct certmap_info *certmap[] = { &map_a, &map_b, NULL };
+
+struct certmap_test_ctx {
+    struct sss_test_ctx *tctx;
+    struct sdap_id_ctx *id_ctx;
+};
+
+static int test_sysdb_setup(void **state)
+{
+    int ret;
+    struct certmap_test_ctx *test_ctx;
+    struct sss_test_conf_param params[] = {
+        { NULL, NULL },             /* Sentinel */
+    };
+
+    assert_true(leak_check_setup());
+
+    test_ctx = talloc_zero(global_talloc_context,
+                           struct certmap_test_ctx);
+    assert_non_null(test_ctx);
+    check_leaks_push(test_ctx);
+
+    test_dom_suite_setup(TESTS_PATH);
+
+    test_ctx->tctx = create_dom_test_ctx(test_ctx, TESTS_PATH,
+                                         TEST_CONF_DB, TEST_DOM_NAME,
+                                         TEST_ID_PROVIDER, params);
+    assert_non_null(test_ctx->tctx);
+
+    ret = sysdb_update_certmap(test_ctx->tctx->sysdb, certmap, false);
+    assert_int_equal(ret, EOK);
+
+    test_ctx->id_ctx = talloc_zero(test_ctx->tctx, struct sdap_id_ctx);
+    assert_non_null(test_ctx->id_ctx);
+
+    test_ctx->id_ctx->opts = talloc_zero(test_ctx->tctx, struct sdap_options);
+    assert_non_null(test_ctx->id_ctx->opts);
+
+    test_ctx->id_ctx->be = talloc_zero(test_ctx->tctx, struct be_ctx);
+    assert_non_null(test_ctx->id_ctx->be);
+    test_ctx->id_ctx->be->domain = test_ctx->tctx->dom;
+
+    *state = test_ctx;
+    return 0;
+}
+
+static int test_sysdb_teardown(void **state)
+{
+    struct certmap_test_ctx *test_ctx =
+        talloc_get_type(*state, struct certmap_test_ctx);
+
+    test_dom_suite_cleanup(TESTS_PATH, TEST_CONF_DB, TEST_DOM_NAME);
+    talloc_free(test_ctx->tctx);
+    assert_true(check_leaks_pop(test_ctx));
+    talloc_free(test_ctx);
+    assert_true(leak_check_teardown());
+    return 0;
+}
+
+static void test_sdap_certmap_init(void **state)
+{
+    int ret;
+    struct certmap_test_ctx *test_ctx = talloc_get_type(*state,
+                                                       struct certmap_test_ctx);
+
+    ret = sdap_init_certmap(test_ctx, test_ctx->id_ctx);
+    assert_int_equal(ret, EOK);
+
+    talloc_free(test_ctx->id_ctx->opts->sdap_certmap_ctx);
+}
+
+static void test_sdap_get_sss_certmap(void **state)
+{
+    int ret;
+    struct certmap_test_ctx *test_ctx = talloc_get_type(*state,
+                                                       struct certmap_test_ctx);
+    struct sss_certmap_ctx *sss_certmap_ctx;
+
+    sss_certmap_ctx = sdap_get_sss_certmap(NULL);
+    assert_null(sss_certmap_ctx);
+
+    ret = sdap_init_certmap(test_ctx, test_ctx->id_ctx);
+    assert_int_equal(ret, EOK);
+
+    sss_certmap_ctx = sdap_get_sss_certmap(
+                                      test_ctx->id_ctx->opts->sdap_certmap_ctx);
+    assert_non_null(sss_certmap_ctx);
+
+    talloc_free(test_ctx->id_ctx->opts->sdap_certmap_ctx);
+}
+
+static void test_sdap_certmap_init_twice(void **state)
+{
+    int ret;
+    struct certmap_test_ctx *test_ctx = talloc_get_type(*state,
+                                                       struct certmap_test_ctx);
+    struct sdap_certmap_ctx *sdap_certmap_ref;
+    struct sss_certmap_ctx *sss_certmap_ref;
+
+    ret = sdap_init_certmap(test_ctx, test_ctx->id_ctx);
+    assert_int_equal(ret, EOK);
+
+    sdap_certmap_ref = test_ctx->id_ctx->opts->sdap_certmap_ctx;
+    sss_certmap_ref = sdap_get_sss_certmap(sdap_certmap_ref);
+
+    ret = sdap_init_certmap(test_ctx, test_ctx->id_ctx);
+    assert_int_equal(ret, EOK);
+
+    assert_ptr_equal(sdap_certmap_ref,
+                     test_ctx->id_ctx->opts->sdap_certmap_ctx);
+    assert_ptr_not_equal(sss_certmap_ref,
+                         sdap_get_sss_certmap(sdap_certmap_ref));
+
+    talloc_free(test_ctx->id_ctx->opts->sdap_certmap_ctx);
+}
+
+
+static void test_sdap_setup_certmap(void **state)
+{
+    int ret;
+    struct certmap_test_ctx *test_ctx = talloc_get_type(*state,
+                                                       struct certmap_test_ctx);
+    struct sdap_certmap_ctx *sdap_certmap_ref;
+    struct sss_certmap_ctx *sss_certmap_ref;
+
+    ret = sdap_init_certmap(test_ctx, test_ctx->id_ctx);
+    assert_int_equal(ret, EOK);
+
+    sdap_certmap_ref = test_ctx->id_ctx->opts->sdap_certmap_ctx;
+    sss_certmap_ref = sdap_get_sss_certmap(sdap_certmap_ref);
+
+    ret = sdap_setup_certmap(NULL, NULL);
+    assert_int_equal(ret, EINVAL);
+    assert_ptr_equal(sdap_certmap_ref,
+                     test_ctx->id_ctx->opts->sdap_certmap_ctx);
+    assert_ptr_equal(sss_certmap_ref, sdap_get_sss_certmap(sdap_certmap_ref));
+
+    ret = sdap_setup_certmap(NULL, certmap);
+    assert_int_equal(ret, EINVAL);
+    assert_ptr_equal(sdap_certmap_ref,
+                     test_ctx->id_ctx->opts->sdap_certmap_ctx);
+    assert_ptr_equal(sss_certmap_ref, sdap_get_sss_certmap(sdap_certmap_ref));
+
+    ret = sdap_setup_certmap(sdap_certmap_ref, certmap);
+    assert_int_equal(ret, EOK);
+    assert_ptr_equal(sdap_certmap_ref,
+                     test_ctx->id_ctx->opts->sdap_certmap_ctx);
+    assert_ptr_not_equal(sss_certmap_ref,
+                         sdap_get_sss_certmap(sdap_certmap_ref));
+
+    talloc_free(test_ctx->id_ctx->opts->sdap_certmap_ctx);
+}
+
+int main(int argc, const char *argv[])
+{
+    int rv;
+    poptContext pc;
+    int opt;
+    struct poptOption long_options[] = {
+        POPT_AUTOHELP
+        SSSD_DEBUG_OPTS
+        POPT_TABLEEND
+    };
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_sdap_certmap_init,
+                                        test_sysdb_setup,
+                                        test_sysdb_teardown),
+        cmocka_unit_test_setup_teardown(test_sdap_get_sss_certmap,
+                                        test_sysdb_setup,
+                                        test_sysdb_teardown),
+        cmocka_unit_test_setup_teardown(test_sdap_certmap_init_twice,
+                                        test_sysdb_setup,
+                                        test_sysdb_teardown),
+        cmocka_unit_test_setup_teardown(test_sdap_setup_certmap,
+                                        test_sysdb_setup,
+                                        test_sysdb_teardown),
+    };
+
+    /* Set debug level to invalid value so we can deside if -d 0 was used. */
+    debug_level = SSSDBG_INVALID;
+
+    pc = poptGetContext(argv[0], argc, argv, long_options, 0);
+    while((opt = poptGetNextOpt(pc)) != -1) {
+        switch(opt) {
+        default:
+            fprintf(stderr, "\nInvalid option %s: %s\n\n",
+                    poptBadOption(pc, 0), poptStrerror(opt));
+            poptPrintUsage(pc, stderr, 0);
+            return 1;
+        }
+    }
+    poptFreeContext(pc);
+
+    DEBUG_CLI_INIT(debug_level);
+
+    tests_set_cwd();
+    rv = cmocka_run_group_tests(tests, NULL, NULL);
+
+    return rv;
+}


### PR DESCRIPTION
IPA: fix handling of certmap_ctx

This patch fixes a use-after-free in the AD provider part and initializes
the certmap_ctx with data from the cache at startup.


certmap: make sure eku_oid_list is always allocated

If there are only OIDs in a <EKU> part of a matching rule a NULL pointer
dereference might occur.


Related to https://pagure.io/SSSD/sssd/issue/3508