### PR TITLE
[RFC] Use GNULIB's compiler warning code

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -115,12 +115,7 @@ if WANT_AUX_INFO
     AM_CFLAGS += -aux-info $@.X
 endif
 if HAVE_GCC
-    AM_CFLAGS += -Wall -Wshadow -Wstrict-prototypes -Wpointer-arith \
-                 -Wcast-qual -Wcast-align -Wwrite-strings -Wundef \
-                 -Werror-implicit-function-declaration -Winit-self \
-                 -Wmissing-include-dirs \
-                 -fno-strict-aliasing \
-                 -std=gnu99
+    AM_CFLAGS += $(WARN_CFLAGS)
 endif
 
 pkgconfig_DATA =

--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,11 @@ m4_ifdef([AC_USE_SYSTEM_EXTENSIONS],
     [AC_USE_SYSTEM_EXTENSIONS],
     [AC_GNU_SOURCE])
 
+m4_include([src/warnings.m4])
+m4_include([src/manywarnings.m4])
+m4_include([src/sssd-compile-warnings.m4])
+SSSD_COMPILE_WARNINGS
+
 CFLAGS="$CFLAGS -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE"
 
 

--- a/contrib/ci/configure.sh
+++ b/contrib/ci/configure.sh
@@ -40,6 +40,7 @@ if [[ "$DISTRO_BRANCH" == -redhat-redhatenterprise*-6.*- ||
         "--without-python3-bindings"
         "--without-secrets"
         "--without-kcm"
+        "--enable-werror=no"
     )
 fi
 

--- a/contrib/ci/run
+++ b/contrib/ci/run
@@ -28,7 +28,7 @@ export LC_ALL=C
 . misc.sh
 
 declare -r DEBUG_CFLAGS="-g3 -O2"
-declare -r COVERAGE_CFLAGS="-g3 -O0 --coverage"
+declare -r COVERAGE_CFLAGS="-g3 --coverage -O0 -Wp,-U_FORTIFY_SOURCE"
 declare -r ARCH=`uname -m`
 declare -r CPU_NUM=`getconf _NPROCESSORS_ONLN`
 declare -r TITLE_WIDTH=24

--- a/src/manywarnings.m4
+++ b/src/manywarnings.m4
@@ -1,0 +1,324 @@
+# manywarnings.m4 serial 12
+dnl Copyright (C) 2008-2017 Free Software Foundation, Inc.
+dnl This file is free software; the Free Software Foundation
+dnl gives unlimited permission to copy and/or distribute it,
+dnl with or without modifications, as long as this notice is preserved.
+
+dnl From Simon Josefsson
+
+# gl_MANYWARN_COMPLEMENT(OUTVAR, LISTVAR, REMOVEVAR)
+# --------------------------------------------------
+# Copy LISTVAR to OUTVAR except for the entries in REMOVEVAR.
+# Elements separated by whitespace.  In set logic terms, the function
+# does OUTVAR = LISTVAR \ REMOVEVAR.
+AC_DEFUN([gl_MANYWARN_COMPLEMENT],
+[
+  gl_warn_set=
+  set x $2; shift
+  for gl_warn_item
+  do
+    case " $3 " in
+      *" $gl_warn_item "*)
+        ;;
+      *)
+        gl_warn_set="$gl_warn_set $gl_warn_item"
+        ;;
+    esac
+  done
+  $1=$gl_warn_set
+])
+
+# gl_MANYWARN_ALL_GCC(VARIABLE)
+# -----------------------------
+# Add all documented GCC warning parameters to variable VARIABLE.
+# Note that you need to test them using gl_WARN_ADD if you want to
+# make sure your gcc understands it.
+#
+# The effects of this macro depend on the current language (_AC_LANG).
+AC_DEFUN([gl_MANYWARN_ALL_GCC],
+[_AC_LANG_DISPATCH([$0], _AC_LANG, $@)])
+
+# Specialization for _AC_LANG = C.
+# Use of m4_defun rather than AC_DEFUN works around a bug in autoconf < 2.63b.
+m4_defun([gl_MANYWARN_ALL_GCC(C)],
+[
+  AC_LANG_PUSH([C])
+
+  dnl First, check for some issues that only occur when combining multiple
+  dnl gcc warning categories.
+  AC_REQUIRE([AC_PROG_CC])
+  if test -n "$GCC"; then
+
+    dnl Check if -W -Werror -Wno-missing-field-initializers is supported
+    dnl with the current $CC $CFLAGS $CPPFLAGS.
+    AC_MSG_CHECKING([whether -Wno-missing-field-initializers is supported])
+    AC_CACHE_VAL([gl_cv_cc_nomfi_supported], [
+      gl_save_CFLAGS="$CFLAGS"
+      CFLAGS="$CFLAGS -W -Werror -Wno-missing-field-initializers"
+      AC_COMPILE_IFELSE(
+        [AC_LANG_PROGRAM([[]], [[]])],
+        [gl_cv_cc_nomfi_supported=yes],
+        [gl_cv_cc_nomfi_supported=no])
+      CFLAGS="$gl_save_CFLAGS"])
+    AC_MSG_RESULT([$gl_cv_cc_nomfi_supported])
+
+    if test "$gl_cv_cc_nomfi_supported" = yes; then
+      dnl Now check whether -Wno-missing-field-initializers is needed
+      dnl for the { 0, } construct.
+      AC_MSG_CHECKING([whether -Wno-missing-field-initializers is needed])
+      AC_CACHE_VAL([gl_cv_cc_nomfi_needed], [
+        gl_save_CFLAGS="$CFLAGS"
+        CFLAGS="$CFLAGS -W -Werror"
+        AC_COMPILE_IFELSE(
+          [AC_LANG_PROGRAM(
+             [[int f (void)
+               {
+                 typedef struct { int a; int b; } s_t;
+                 s_t s1 = { 0, };
+                 return s1.b;
+               }
+             ]],
+             [[]])],
+          [gl_cv_cc_nomfi_needed=no],
+          [gl_cv_cc_nomfi_needed=yes])
+        CFLAGS="$gl_save_CFLAGS"
+      ])
+      AC_MSG_RESULT([$gl_cv_cc_nomfi_needed])
+    fi
+
+    dnl Next, check if -Werror -Wuninitialized is useful with the
+    dnl user's choice of $CFLAGS; some versions of gcc warn that it
+    dnl has no effect if -O is not also used
+    AC_MSG_CHECKING([whether -Wuninitialized is supported])
+    AC_CACHE_VAL([gl_cv_cc_uninitialized_supported], [
+      gl_save_CFLAGS="$CFLAGS"
+      CFLAGS="$CFLAGS -Werror -Wuninitialized"
+      AC_COMPILE_IFELSE(
+        [AC_LANG_PROGRAM([[]], [[]])],
+        [gl_cv_cc_uninitialized_supported=yes],
+        [gl_cv_cc_uninitialized_supported=no])
+      CFLAGS="$gl_save_CFLAGS"])
+    AC_MSG_RESULT([$gl_cv_cc_uninitialized_supported])
+
+  fi
+
+  # List all gcc warning categories.
+  # To compare this list to your installed GCC's, run this Bash command:
+  #
+  # comm -3 \
+  #  <(sed -n 's/^  *\(-[^ ]*\) .*/\1/p' manywarnings.m4 | sort) \
+  #  <(gcc --help=warnings | sed -n 's/^  \(-[^ ]*\) .*/\1/p' | sort |
+  #      grep -v -x -F -f <(
+  #         awk '/^[^#]/ {print $1}' ../build-aux/gcc-warning.spec))
+
+  gl_manywarn_set=
+  for gl_manywarn_item in -fno-common \
+    -W \
+    -Wabi \
+    -Waddress \
+    -Waggressive-loop-optimizations \
+    -Wall \
+    -Wattributes \
+    -Wbad-function-cast \
+    -Wbool-compare \
+    -Wbool-operation \
+    -Wbuiltin-declaration-mismatch \
+    -Wbuiltin-macro-redefined \
+    -Wcast-align \
+    -Wchar-subscripts \
+    -Wchkp \
+    -Wclobbered \
+    -Wcomment \
+    -Wcomments \
+    -Wcoverage-mismatch \
+    -Wcpp \
+    -Wdangling-else \
+    -Wdate-time \
+    -Wdeprecated \
+    -Wdeprecated-declarations \
+    -Wdesignated-init \
+    -Wdisabled-optimization \
+    -Wdiscarded-array-qualifiers \
+    -Wdiscarded-qualifiers \
+    -Wdiv-by-zero \
+    -Wdouble-promotion \
+    -Wduplicated-branches \
+    -Wduplicated-cond \
+    -Wduplicate-decl-specifier \
+    -Wempty-body \
+    -Wendif-labels \
+    -Wenum-compare \
+    -Wexpansion-to-defined \
+    -Wextra \
+    -Wformat-contains-nul \
+    -Wformat-extra-args \
+    -Wformat-nonliteral \
+    -Wformat-security \
+    -Wformat-signedness \
+    -Wformat-y2k \
+    -Wformat-zero-length \
+    -Wframe-address \
+    -Wfree-nonheap-object \
+    -Whsa \
+    -Wignored-attributes \
+    -Wignored-qualifiers \
+    -Wimplicit \
+    -Wimplicit-function-declaration \
+    -Wimplicit-int \
+    -Wincompatible-pointer-types \
+    -Winit-self \
+    -Winline \
+    -Wint-conversion \
+    -Wint-in-bool-context \
+    -Wint-to-pointer-cast \
+    -Winvalid-memory-model \
+    -Winvalid-pch \
+    -Wjump-misses-init \
+    -Wlogical-not-parentheses \
+    -Wlogical-op \
+    -Wmain \
+    -Wmaybe-uninitialized \
+    -Wmemset-elt-size \
+    -Wmemset-transposed-args \
+    -Wmisleading-indentation \
+    -Wmissing-braces \
+    -Wmissing-declarations \
+    -Wmissing-field-initializers \
+    -Wmissing-include-dirs \
+    -Wmissing-parameter-type \
+    -Wmissing-prototypes \
+    -Wmultichar \
+    -Wnarrowing \
+    -Wnested-externs \
+    -Wnonnull \
+    -Wnonnull-compare \
+    -Wnull-dereference \
+    -Wodr \
+    -Wold-style-declaration \
+    -Wold-style-definition \
+    -Wopenmp-simd \
+    -Woverflow \
+    -Woverlength-strings \
+    -Woverride-init \
+    -Wpacked \
+    -Wpacked-bitfield-compat \
+    -Wparentheses \
+    -Wpointer-arith \
+    -Wpointer-compare \
+    -Wpointer-sign \
+    -Wpointer-to-int-cast \
+    -Wpragmas \
+    -Wpsabi \
+    -Wrestrict \
+    -Wreturn-local-addr \
+    -Wreturn-type \
+    -Wscalar-storage-order \
+    -Wsequence-point \
+    -Wshadow \
+    -Wshift-count-negative \
+    -Wshift-count-overflow \
+    -Wshift-negative-value \
+    -Wsizeof-array-argument \
+    -Wsizeof-pointer-memaccess \
+    -Wstack-protector \
+    -Wstrict-aliasing \
+    -Wstrict-overflow \
+    -Wstrict-prototypes \
+    -Wsuggest-attribute=const \
+    -Wsuggest-attribute=format \
+    -Wsuggest-attribute=noreturn \
+    -Wsuggest-attribute=pure \
+    -Wsuggest-final-methods \
+    -Wsuggest-final-types \
+    -Wswitch \
+    -Wswitch-bool \
+    -Wswitch-default \
+    -Wswitch-unreachable \
+    -Wsync-nand \
+    -Wsystem-headers \
+    -Wtautological-compare \
+    -Wtrampolines \
+    -Wtrigraphs \
+    -Wtype-limits \
+    -Wuninitialized \
+    -Wunknown-pragmas \
+    -Wunsafe-loop-optimizations \
+    -Wunused \
+    -Wunused-but-set-parameter \
+    -Wunused-but-set-variable \
+    -Wunused-function \
+    -Wunused-label \
+    -Wunused-local-typedefs \
+    -Wunused-macros \
+    -Wunused-parameter \
+    -Wunused-result \
+    -Wunused-value \
+    -Wunused-variable \
+    -Wvarargs \
+    -Wvariadic-macros \
+    -Wvector-operation-performance \
+    -Wvla \
+    -Wvolatile-register-var \
+    -Wwrite-strings \
+    \
+    ; do
+    gl_manywarn_set="$gl_manywarn_set $gl_manywarn_item"
+  done
+
+  # gcc --help=warnings outputs an unusual form for these options; list
+  # them here so that the above 'comm' command doesn't report a false match.
+  # Would prefer "min (PTRDIFF_MAX, SIZE_MAX)", but it must be a literal
+  # and AC_COMPUTE_INT requires it to fit in a long:
+  AC_MSG_CHECKING([max safe object size])
+  AC_COMPUTE_INT([gl_alloc_max],
+    [(LONG_MAX < PTRDIFF_MAX ? LONG_MAX : PTRDIFF_MAX) < (size_t) -1
+     ? (LONG_MAX < PTRDIFF_MAX ? LONG_MAX : PTRDIFF_MAX)
+     : (size_t) -1],
+    [[#include <limits.h>
+      #include <stddef.h>
+      #include <stdint.h>
+    ]],
+    [gl_alloc_max=2147483647])
+  AC_MSG_RESULT([$gl_alloc_max])
+  gl_manywarn_set="$gl_manywarn_set -Walloc-size-larger-than=$gl_alloc_max"
+  gl_manywarn_set="$gl_manywarn_set -Warray-bounds=2"
+  gl_manywarn_set="$gl_manywarn_set -Wformat-overflow=2"
+  gl_manywarn_set="$gl_manywarn_set -Wformat-truncation=2"
+  gl_manywarn_set="$gl_manywarn_set -Wimplicit-fallthrough=5"
+  gl_manywarn_set="$gl_manywarn_set -Wnormalized=nfc"
+  gl_manywarn_set="$gl_manywarn_set -Wshift-overflow=2"
+  gl_manywarn_set="$gl_manywarn_set -Wstringop-overflow=2"
+  gl_manywarn_set="$gl_manywarn_set -Wunused-const-variable=2"
+  gl_manywarn_set="$gl_manywarn_set -Wvla-larger-than=4031"
+
+  # These are needed for older GCC versions.
+  if test -n "$GCC"; then
+    case `($CC --version) 2>/dev/null` in
+      'gcc (GCC) '[[0-3]].* | \
+      'gcc (GCC) '4.[[0-7]].*)
+        gl_manywarn_set="$gl_manywarn_set -fdiagnostics-show-option"
+        gl_manywarn_set="$gl_manywarn_set -funit-at-a-time"
+          ;;
+    esac
+  fi
+
+  # Disable specific options as needed.
+  if test "$gl_cv_cc_nomfi_needed" = yes; then
+    gl_manywarn_set="$gl_manywarn_set -Wno-missing-field-initializers"
+  fi
+
+  if test "$gl_cv_cc_uninitialized_supported" = no; then
+    gl_manywarn_set="$gl_manywarn_set -Wno-uninitialized"
+  fi
+
+  $1=$gl_manywarn_set
+
+  AC_LANG_POP([C])
+])
+
+# Specialization for _AC_LANG = C++.
+# Use of m4_defun rather than AC_DEFUN works around a bug in autoconf < 2.63b.
+m4_defun([gl_MANYWARN_ALL_GCC(C++)],
+[
+  gl_MANYWARN_ALL_GCC_CXX_IMPL([$1])
+])

--- a/src/sssd-compile-warnings.m4
+++ b/src/sssd-compile-warnings.m4
@@ -1,0 +1,100 @@
+dnl
+dnl Enable all known GCC compiler warnings, except for those
+dnl we can't yet cope with
+dnl
+AC_DEFUN([SSSD_COMPILE_WARNINGS],[
+    dnl ******************************
+    dnl More compiler warnings
+    dnl ******************************
+
+    AC_ARG_ENABLE([werror],
+                  AS_HELP_STRING([--enable-werror], [Use -Werror (if supported)]),
+                  [set_werror="$enableval"],
+                  [if test -d $srcdir/.git; then
+                     is_git_version=true
+                     set_werror=yes
+                   else
+                     set_werror=no
+                   fi])
+
+
+    # These are the warnings that, currently, we cannot cope with
+    dontwarn="$dontwarn -Wbad-function-cast"
+    dontwarn="$dontwarn -Wformat-nonliteral"
+    dontwarn="$dontwarn -Wformat-signedness"
+    dontwarn="$dontwarn -Wformat-overflow=2"
+    dontwarn="$dontwarn -Wformat-truncation=2"
+    dontwarn="$dontwarn -Wformat-y2k"
+    dontwarn="$dontwarn -Wlogical-op"
+    dontwarn="$dontwarn -Wmissing-prototypes"
+    dontwarn="$dontwarn -Wmissing-declarations"
+    dontwarn="$dontwarn -Wpacked"
+    dontwarn="$dontwarn -Wstack-protector"
+    dontwarn="$dontwarn -Wstrict-overflow"
+    dontwarn="$dontwarn -Wsuggest-attribute=pure"
+    dontwarn="$dontwarn -Wsuggest-attribute=const"
+    dontwarn="$dontwarn -Wsuggest-attribute=format"
+    dontwarn="$dontwarn -Wsuggest-attribute=noreturn"
+    dontwarn="$dontwarn -Wswitch-default"
+    dontwarn="$dontwarn -Wunused-macros"
+    dontwarn="$dontwarn -Wvla"
+    dontwarn="$dontwarn -Wvla-larger-than=4031"
+
+    # Get all possible GCC warnings
+    gl_MANYWARN_ALL_GCC([maybewarn])
+
+    # Remove the ones we don't want, blacklisted earlier
+    gl_MANYWARN_COMPLEMENT([wantwarn], [$maybewarn], [$dontwarn])
+
+    # Check for $CC support of each warning
+    for w in $wantwarn; do
+      gl_WARN_ADD([$w])
+    done
+
+    # Use improved glibc headers
+    AH_VERBATIM([FORTIFY_SOURCE],
+    [/* Enable compile-time and run-time bounds-checking, and some warnings,
+        without upsetting newer glibc. */
+     #if !defined _FORTIFY_SOURCE && defined __OPTIMIZE__ && __OPTIMIZE__
+     # define _FORTIFY_SOURCE 2
+     #endif
+    ])
+
+    # Extra special flags
+    gl_WARN_ADD([-fno-strict-aliasing])
+    gl_WARN_ADD([-std=gnu99])
+    gl_WARN_ADD([-Werror-implicit-declaration])
+
+    # If we enable this warning, compilation will break on every single
+    # system used by our CI.
+    gl_WARN_ADD([-Wno-system-headers])
+    gl_WARN_ADD([-Wno-cpp])
+    gl_WARN_ADD([-Wno-inline])
+
+    # If we enable this warning, complitaion will break on RHEL6
+    gl_WARN_ADD([-Wno-overlength-strings])
+
+    # Enable this again as soon as GCC is updated on RHEL6
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=34114
+    gl_WARN_ADD([-Wno-unsafe-loop-optimizations])
+
+    # -Wmissing-field-initializers seems to be to strict on RHEL7, thus
+    # let's disable it for now.
+    # Reference: https://pagure.io/SSSD/sssd/issue/3606
+    gl_WARN_ADD([-Wno-missing-field-initializers])
+
+    # GNULIB uses '-W' (aka -Wextra) which includes a bunch of stuff.
+    # Unfortunately, this means you can't simply use, for instance,
+    # '-Wsign-compare' with gl_MANYWARN_COMPLEMENT
+    # So we have -W enabled, and then we have to explicitly turn off ...
+    gl_WARN_ADD([-Wno-array-bounds])
+    gl_WARN_ADD([-Wno-sign-compare])
+    gl_WARN_ADD([-Wno-unused-parameter])
+
+    if test "$set_werror" = "yes"
+    then
+      gl_WARN_ADD([-Werror])
+    fi
+
+    AC_SUBST([WARN_CFLAGS])
+])

--- a/src/tests/cmocka/test_sdap_initgr.c
+++ b/src/tests/cmocka/test_sdap_initgr.c
@@ -195,7 +195,15 @@ struct sdap_get_initgr_state *prepare_state(struct test_sdap_initgr_ctx *ctx,
     }
     assert_non_null(state->dom);
     assert_non_null(recent_dom_info);
-    recent_dom_info->next = NULL;
+    /* GCC complains about a potential dereference of null pointer here.
+     *
+     * It's a false-positive as the explicit check is done in the line before
+     * this comment section, but in order to have GNULIB manywarnings enabled,
+     * let's just add the check here.
+     */
+    if (recent_dom_info != NULL) {
+        recent_dom_info->next = NULL;
+    }
 
     state->opts = mock_sdap_options_ldap(state, state->dom,
                                          ctx->tctx->confdb,

--- a/src/warnings.m4
+++ b/src/warnings.m4
@@ -1,0 +1,79 @@
+# warnings.m4 serial 11
+dnl Copyright (C) 2008-2016 Free Software Foundation, Inc.
+dnl This file is free software; the Free Software Foundation
+dnl gives unlimited permission to copy and/or distribute it,
+dnl with or without modifications, as long as this notice is preserved.
+
+dnl From Simon Josefsson
+
+# gl_AS_VAR_APPEND(VAR, VALUE)
+# ----------------------------
+# Provide the functionality of AS_VAR_APPEND if Autoconf does not have it.
+m4_ifdef([AS_VAR_APPEND],
+[m4_copy([AS_VAR_APPEND], [gl_AS_VAR_APPEND])],
+[m4_define([gl_AS_VAR_APPEND],
+[AS_VAR_SET([$1], [AS_VAR_GET([$1])$2])])])
+
+
+# gl_COMPILER_OPTION_IF(OPTION, [IF-SUPPORTED], [IF-NOT-SUPPORTED],
+#                       [PROGRAM = AC_LANG_PROGRAM()])
+# -----------------------------------------------------------------
+# Check if the compiler supports OPTION when compiling PROGRAM.
+#
+# FIXME: gl_Warn must be used unquoted until we can assume Autoconf
+# 2.64 or newer.
+AC_DEFUN([gl_COMPILER_OPTION_IF],
+[AS_VAR_PUSHDEF([gl_Warn], [gl_cv_warn_[]_AC_LANG_ABBREV[]_$1])dnl
+AS_VAR_PUSHDEF([gl_Flags], [_AC_LANG_PREFIX[]FLAGS])dnl
+AS_LITERAL_IF([$1],
+  [m4_pushdef([gl_Positive], m4_bpatsubst([$1], [^-Wno-], [-W]))],
+  [gl_positive="$1"
+case $gl_positive in
+  -Wno-*) gl_positive=-W`expr "X$gl_positive" : 'X-Wno-\(.*\)'` ;;
+esac
+m4_pushdef([gl_Positive], [$gl_positive])])dnl
+AC_CACHE_CHECK([whether _AC_LANG compiler handles $1], m4_defn([gl_Warn]), [
+  gl_save_compiler_FLAGS="$gl_Flags"
+  gl_AS_VAR_APPEND(m4_defn([gl_Flags]),
+    [" $gl_unknown_warnings_are_errors ]m4_defn([gl_Positive])["])
+  AC_LINK_IFELSE([m4_default([$4], [AC_LANG_PROGRAM([])])],
+                 [AS_VAR_SET(gl_Warn, [yes])],
+                 [AS_VAR_SET(gl_Warn, [no])])
+  gl_Flags="$gl_save_compiler_FLAGS"
+])
+AS_VAR_IF(gl_Warn, [yes], [$2], [$3])
+m4_popdef([gl_Positive])dnl
+AS_VAR_POPDEF([gl_Flags])dnl
+AS_VAR_POPDEF([gl_Warn])dnl
+])
+
+# gl_UNKNOWN_WARNINGS_ARE_ERRORS
+# ------------------------------
+# Clang doesn't complain about unknown warning options unless one also
+# specifies -Wunknown-warning-option -Werror.  Detect this.
+AC_DEFUN([gl_UNKNOWN_WARNINGS_ARE_ERRORS],
+[gl_COMPILER_OPTION_IF([-Werror -Wunknown-warning-option],
+   [gl_unknown_warnings_are_errors='-Wunknown-warning-option -Werror'],
+   [gl_unknown_warnings_are_errors=])])
+
+# gl_WARN_ADD(OPTION, [VARIABLE = WARN_CFLAGS],
+#             [PROGRAM = AC_LANG_PROGRAM()])
+# ---------------------------------------------
+# Adds parameter to WARN_CFLAGS if the compiler supports it when
+# compiling PROGRAM.  For example, gl_WARN_ADD([-Wparentheses]).
+#
+# If VARIABLE is a variable name, AC_SUBST it.
+AC_DEFUN([gl_WARN_ADD],
+[AC_REQUIRE([gl_UNKNOWN_WARNINGS_ARE_ERRORS])
+gl_COMPILER_OPTION_IF([$1],
+  [gl_AS_VAR_APPEND(m4_if([$2], [], [[WARN_CFLAGS]], [[$2]]), [" $1"])],
+  [],
+  [$3])
+m4_ifval([$2],
+         [AS_LITERAL_IF([$2], [AC_SUBST([$2])])],
+         [AC_SUBST([WARN_CFLAGS])])dnl
+])
+
+# Local Variables:
+# mode: autoconf
+# End:


### PR DESCRIPTION
This is the 3rd tentative to have this patch reviewed. For more references, please, see: PR #50.

So, I've re-worked those patches a little bit and here is the time difference when running reconfing with the patches:
```
real	0m26.047s
user	0m21.318s
sys	0m4.635s
```

And now without:
```
real	0m25.565s
user	0m20.696s
sys	0m4.433s
```

This patch set is rebased on top of PR #377.

I really would appreciate if someone could review and give their opinion.

The reason this PR was blocked is because this time difference has been considered a "performance issue".

@jhrozek , could you take a look on this?