### PR TITLE
CI: Use dnf 2.0 for installation of packages in fedora

### DIFF
--- a/contrib/ci/README.md
+++ b/contrib/ci/README.md
@@ -43,6 +43,8 @@ distros:
 
 on Fedora distros:
 
+    # With dnf >= 2.0
+    <USER> ALL=(ALL:ALL) NOPASSWD: /usr/bin/dnf --assumeyes --best --setopt=install_weak_deps=False install -- *
     # We need to use yum-deprecated on Fedora because of BZ1215208.
     <USER> ALL=(ALL:ALL) NOPASSWD: /usr/bin/yum-deprecated --assumeyes install -- *
 

--- a/contrib/ci/distro.sh
+++ b/contrib/ci/distro.sh
@@ -50,7 +50,7 @@ function distro_pkg_install()
 {
     declare prompt=$'Need root permissions to install packages.\n'
     prompt+="Enter sudo password for $USER: "
-    if [[ "$DISTRO_BRANCH" == -redhat-fedora-2[2-9]* ]]; then
+    if [[ "$DISTRO_BRANCH" == -redhat-fedora-2[2-5]* ]]; then
         # TODO switch fedora to DNF once
         # https://bugzilla.redhat.com/show_bug.cgi?id=1215208 is fixed
         [ $# != 0 ] && sudo -p "$prompt" \
@@ -60,6 +60,11 @@ function distro_pkg_install()
                  /^No package .* available.$/ {s=1}
                  {print}
                  END {exit s}'
+    elif [[ "$DISTRO_BRANCH" == -redhat-fedora-* ]]; then
+        [ $# != 0 ] && sudo -p "$prompt" \
+                            /usr/bin/dnf --assumeyes --best \
+                                         --setopt=install_weak_deps=False \
+                                         install -- "$@"
     elif [[ "$DISTRO_BRANCH" == -redhat-* ]]; then
         [ $# != 0 ] && sudo -p "$prompt" yum --assumeyes install -- "$@" |&
             # Pass input to output, fail if a missing package is reported


### PR DESCRIPTION
Weak dependencies are intentionally disabled. If we need them
then they should be explicitly specified because they are not weak.

Resolves:
https://pagure.io/SSSD/sssd/issue/2809