### PR TITLE
SPEC: Update owner and mode for /var/lib/sss/deskprofile

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -959,7 +959,7 @@ done
 %if (0%{?with_secrets} == 1)
 %attr(700,root,root) %dir %{secdbpath}
 %endif
-%attr(700,root,root) %dir %{deskprofilepath}
+%attr(755,sssd,sssd) %dir %{deskprofilepath}
 %ghost %attr(0644,sssd,sssd) %verify(not md5 size mtime) %{mcpath}/passwd
 %ghost %attr(0644,sssd,sssd) %verify(not md5 size mtime) %{mcpath}/group
 %ghost %attr(0644,sssd,sssd) %verify(not md5 size mtime) %{mcpath}/initgroups


### PR DESCRIPTION
Directory is part of make list SSSD_USER_DIRS and therefore
should have such owner&mode also in spec file