### PR TITLE
CONFIG: Fix schema for try_inotify

### DIFF
--- a/src/config/SSSDConfigTest.py
+++ b/src/config/SSSDConfigTest.py
@@ -371,7 +371,9 @@ class SSSDConfigTestSSSDService(unittest.TestCase):
             'override_space',
             'disable_netlink',
             'enable_files_domain',
-            'domain_resolution_order']
+            'domain_resolution_order',
+            'try_inotify',
+        ]
 
         self.assertTrue(type(options) == dict,
                         "Options should be a dictionary")
@@ -567,7 +569,6 @@ class SSSDConfigTestSSSDDomain(unittest.TestCase):
             'max_id',
             'timeout',
             'offline_timeout',
-            'try_inotify',
             'command',
             'enumerate',
             'cache_credentials',
@@ -938,7 +939,6 @@ class SSSDConfigTestSSSDDomain(unittest.TestCase):
             'max_id',
             'timeout',
             'offline_timeout',
-            'try_inotify',
             'command',
             'enumerate',
             'cache_credentials',

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -50,6 +50,7 @@ option = config_file_version
 option = disable_netlink
 option = enable_files_domain
 option = domain_resolution_order
+option = try_inotify
 
 [rule/allowed_nss_options]
 validator = ini_allowed_options
@@ -349,7 +350,6 @@ option = domain_type
 option = min_id
 option = max_id
 option = timeout
-option = try_inotify
 option = enumerate
 option = subdomain_enumerate
 option = offline_timeout

--- a/src/config/etc/sssd.api.conf
+++ b/src/config/etc/sssd.api.conf
@@ -33,6 +33,7 @@ override_space = str, None, false
 disable_netlink = bool, None, false
 enable_files_domain = str, None, false
 domain_resolution_order = list, str, false
+try_inotify = bool, None, false
 
 [nss]
 # Name service
@@ -153,7 +154,6 @@ command = str, None, false
 min_id = int, None, false
 max_id = int, None, false
 timeout = int, None, false
-try_inotify = bool, None, false
 enumerate = bool, None, false
 subdomain_enumerate = str, None, false
 offline_timeout = int, None, false


### PR DESCRIPTION
It is read only from "[sssd]" section.

Resolves:
https://pagure.io/SSSD/sssd/issue/3511