### PR TITLE
Prevent colision for explicitly defined slice. Currently it happens f…

### DIFF
--- a/src/lib/idmap/sss_idmap.c
+++ b/src/lib/idmap/sss_idmap.c
@@ -426,6 +426,16 @@ enum idmap_error_code sss_idmap_calculate_range(struct sss_idmap_ctx *ctx,
          * explicitly.
          */
         new_slice = *slice_num;
+        min = (rangesize * new_slice) + idmap_lower;
+        max = min + rangesize - 1;
+        for (dom = ctx->idmap_domain_info; dom != NULL; dom = dom->next) {
+                if (check_dom_overlap(&dom->range_params,min, max)) {
+                    /* This range overlaps one already registered
+                     * Fail, because the slice was manually configured
+                     */
+                    return IDMAP_COLLISION;
+                  }
+        }
     } else {
         /* If slice is -1, we're being asked to pick a new slice */
 


### PR DESCRIPTION
…or default domain, if someone configures different ldap_idmap_default_domain_sid for two domains in sssd.conf. There is no check preventing this in sdap_idmap.c, it's simply: sdap_idmap_add_domain(idmap_ctx, dom_name,sid_str, 0). However, I believe here is the best place to check it since there may be different use of sss_idmap_calculate_ranges in the future.