### PR TITLE
intg: prevent "TypeError: must be type, not classobj"

### DIFF
--- a/src/config/SSSDConfig/ipachangeconf.py
+++ b/src/config/SSSDConfig/ipachangeconf.py
@@ -50,7 +50,7 @@ def openLocked(filename, perms, create = True):
     #TODO: put section delimiters as separating element of the list
     #      so that we can process multiple sections in one go
     #TODO: add a comment all but provided options as a section option
-class IPAChangeConf:
+class IPAChangeConf(object):
 
     def __init__(self, name):
         self.progname = name

--- a/src/sbus/sbus_codegen
+++ b/src/sbus/sbus_codegen
@@ -90,7 +90,7 @@ class DBusXmlException(Exception):
         else:
             return message
 
-class Base:
+class Base(object):
     def __init__(self, name):
         if not name:
             raise DBusXmlException('No name on element')
@@ -645,7 +645,7 @@ def expect_attr(attrs, name):
         raise DBusXmlException("Empty attribute '%s'" % name)
     return attrs[name]
 
-class DBusXMLParser:
+class DBusXMLParser(object):
     def __init__(self, filename):
         parser = xml.parsers.expat.ParserCreate()
         parser.CommentHandler = self.handle_comment


### PR DESCRIPTION
Changes
- src/config/SSSDConfig/ipachangeconf.py:class IPAChangeConf:
- src/sbus/sbus_codegen:class Base:
- src/sbus/sbus_codegen:class DBusXMLParser:

Resolves: https://pagure.io/SSSD/sssd/issue/3517