### PR TITLE
NSS: Add option to tune the memcache size

### DIFF
--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -108,6 +108,10 @@
 #define CONFDB_NSS_SHELL_FALLBACK "shell_fallback"
 #define CONFDB_NSS_DEFAULT_SHELL "default_shell"
 #define CONFDB_MEMCACHE_TIMEOUT "memcache_timeout"
+#define CONFDB_NSS_MEMCACHE_SIZE "memcache_size"
+#define CONFDB_NSS_MEMCACHE_SIZE_PASSWD "memcache_size_passwd"
+#define CONFDB_NSS_MEMCACHE_SIZE_GROUP "memcache_size_group"
+#define CONFDB_NSS_MEMCACHE_SIZE_INITGROUPS "memcache_size_initgroups"
 #define CONFDB_NSS_HOMEDIR_SUBSTRING "homedir_substring"
 #define CONFDB_DEFAULT_HOMEDIR_SUBSTRING "/home"
 

--- a/src/config/SSSDConfig/__init__.py.in
+++ b/src/config/SSSDConfig/__init__.py.in
@@ -85,6 +85,10 @@ option_strings = {
     'shell_fallback' : _('If a shell stored in central directory is allowed but not available, use this fallback'),
     'default_shell': _('Shell to use if the provider does not list one'),
     'memcache_timeout': _('How long will be in-memory cache records valid'),
+    'memcache_size': _('Number of slots in fast in-memory caches'),
+    'memcache_size_passwd': _('Number of slots in fast in-memory cache for passwd requests'),
+    'memcache_size_group': _('Number of slots in fast in-memory cache for group requests'),
+    'memcache_size_initgroups': _('Number of slots in fast in-memory cache for initgroups requests'),
     'user_attributes': _('List of user attributes the NSS responder is allowed to publish'),
 
     # [pam]

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -90,6 +90,10 @@ option = shell_fallback
 option = default_shell
 option = get_domains_timeout
 option = memcache_timeout
+option = memcache_size
+option = memcache_size_passwd
+option = memcache_size_group
+option = memcache_size_initgroups
 
 [rule/allowed_pam_options]
 validator = ini_allowed_options

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -988,6 +988,113 @@ fallback_homedir = /home/%u
                     </listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term>memcache_size (integer)</term>
+                    <listitem>
+                        <para>
+                            Number of slots allocated inside fast in-memory
+                            caches. Note that one entry in fast in-memory
+                            cache can occupy more than one slot. Setting
+                            the size to 0 will disable the in-memory caches.
+                            This option can be overriden by
+                            memcache_size_passwd, memcache_size_group and
+                            memcache_size_initgroups options for passwd, group
+                            and initgroups in-memory caches respectively.
+                        </para>
+                        <para>
+                            Default: 50000
+                        </para>
+                        <para>
+                            WARNING: Disabled or too small in-memory cache can
+                            have significant negative impact on SSSD's
+                            performance.
+                        </para>
+                        <para>
+                            NOTE: If the environment variable
+                            SSS_NSS_USE_MEMCACHE is set to "NO", client
+                            applications will not use the fast in-memory
+                            cache.
+                        </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>memcache_size_passwd (integer)</term>
+                    <listitem>
+                        <para>
+                            Number of slots allocated inside fast in-memory
+                            cache for passwd requests. Note that one entry
+                            in fast in-memory cache can occupy more than one slot.
+                            Setting the size to 0 will disable the passwd in-memory
+                            cache.
+                        </para>
+                        <para>
+                            Default: memcache_size
+                        </para>
+                        <para>
+                            WARNING: Disabled or too small in-memory cache can
+                            have significant negative impact on SSSD's
+                            performance.
+                        </para>
+                        <para>
+                            NOTE: If the environment variable
+                            SSS_NSS_USE_MEMCACHE is set to "NO", client
+                            applications will not use the fast in-memory
+                            cache.
+                        </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>memcache_size_group (integer)</term>
+                    <listitem>
+                        <para>
+                            Number of slots allocated inside fast in-memory
+                            cache for group requests. Note that one entry
+                            in fast in-memory cache can occupy more than one
+                            slot. Setting the size to 0 will disable the group
+                            in-memory cache.
+                        </para>
+                        <para>
+                            Default: memcache_size
+                        </para>
+                        <para>
+                            WARNING: Disabled or too small in-memory cache can
+                            have significant negative impact on SSSD's
+                            performance.
+                        </para>
+                        <para>
+                            NOTE: If the environment variable
+                            SSS_NSS_USE_MEMCACHE is set to "NO", client
+                            applications will not use the fast in-memory
+                            cache.
+                        </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>memcache_size_initgroups (integer)</term>
+                    <listitem>
+                        <para>
+                            Number of slots allocated inside fast in-memory
+                            cache for initgroups requests. Note that one entry
+                            in fast in-memory cache can occupy more than one
+                            slot. Setting the size to 0 will disable the
+                            initgroups in-memory cache.
+                        </para>
+                        <para>
+                            Default: memcache_size
+                        </para>
+                        <para>
+                            WARNING: Disabled or too small in-memory cache can
+                            have significant negative impact on SSSD's
+                            performance.
+                        </para>
+                        <para>
+                            NOTE: If the environment variable
+                            SSS_NSS_USE_MEMCACHE is set to "NO", client
+                            applications will not use the fast in-memory
+                            cache.
+                        </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
                     <term>user_attributes (string)</term>
                     <listitem>
                         <para>

--- a/src/responder/nss/nsssrv_mmap_cache.h
+++ b/src/responder/nss/nsssrv_mmap_cache.h
@@ -22,6 +22,9 @@
 #ifndef _NSSSRV_MMAP_CACHE_H_
 #define _NSSSRV_MMAP_CACHE_H_
 
+/* This is the default number of slots in all memcache types. It can be
+ * overriden using the memcache_size and memcache_size_* options in
+ * sssd.conf. */
 #define SSS_MC_CACHE_ELEMENTS 50000
 
 struct sss_mc_ctx;

--- a/src/tests/intg/test_memory_cache.py
+++ b/src/tests/intg/test_memory_cache.py
@@ -130,6 +130,110 @@ def load_data_to_ldap(request, ldap_conn):
 
 
 @pytest.fixture
+def disable_memcache_rfc2307(request, ldap_conn):
+    load_data_to_ldap(request, ldap_conn)
+
+    conf = unindent("""\
+        [sssd]
+        domains             = LDAP
+        services            = nss
+
+        [nss]
+        memcache_size = 0
+
+        [domain/LDAP]
+        ldap_auth_disable_tls_never_use_in_production = true
+        ldap_schema         = rfc2307
+        id_provider         = ldap
+        auth_provider       = ldap
+        sudo_provider       = ldap
+        ldap_uri            = {ldap_conn.ds_inst.ldap_url}
+        ldap_search_base    = {ldap_conn.ds_inst.base_dn}
+    """).format(**locals())
+    create_conf_fixture(request, conf)
+    create_sssd_fixture(request)
+    return None
+
+
+@pytest.fixture
+def disable_pwd_mc_rfc2307(request, ldap_conn):
+    load_data_to_ldap(request, ldap_conn)
+
+    conf = unindent("""\
+        [sssd]
+        domains             = LDAP
+        services            = nss
+
+        [nss]
+        memcache_size_passwd = 0
+
+        [domain/LDAP]
+        ldap_auth_disable_tls_never_use_in_production = true
+        ldap_schema         = rfc2307
+        id_provider         = ldap
+        auth_provider       = ldap
+        sudo_provider       = ldap
+        ldap_uri            = {ldap_conn.ds_inst.ldap_url}
+        ldap_search_base    = {ldap_conn.ds_inst.base_dn}
+    """).format(**locals())
+    create_conf_fixture(request, conf)
+    create_sssd_fixture(request)
+    return None
+
+
+@pytest.fixture
+def disable_grp_mc_rfc2307(request, ldap_conn):
+    load_data_to_ldap(request, ldap_conn)
+
+    conf = unindent("""\
+        [sssd]
+        domains             = LDAP
+        services            = nss
+
+        [nss]
+        memcache_size_group = 0
+
+        [domain/LDAP]
+        ldap_auth_disable_tls_never_use_in_production = true
+        ldap_schema         = rfc2307
+        id_provider         = ldap
+        auth_provider       = ldap
+        sudo_provider       = ldap
+        ldap_uri            = {ldap_conn.ds_inst.ldap_url}
+        ldap_search_base    = {ldap_conn.ds_inst.base_dn}
+    """).format(**locals())
+    create_conf_fixture(request, conf)
+    create_sssd_fixture(request)
+    return None
+
+
+@pytest.fixture
+def disable_initgr_mc_rfc2307(request, ldap_conn):
+    load_data_to_ldap(request, ldap_conn)
+
+    conf = unindent("""\
+        [sssd]
+        domains             = LDAP
+        services            = nss
+
+        [nss]
+        memcache_size_initgroups = 0
+
+        [domain/LDAP]
+        ldap_auth_disable_tls_never_use_in_production = true
+        ldap_schema         = rfc2307
+        id_provider         = ldap
+        auth_provider       = ldap
+        sudo_provider       = ldap
+        ldap_uri            = {ldap_conn.ds_inst.ldap_url}
+        ldap_search_base    = {ldap_conn.ds_inst.base_dn}
+    """).format(**locals())
+    create_conf_fixture(request, conf)
+    create_sssd_fixture(request)
+    return None
+
+
+@pytest.fixture
 def sanity_rfc2307(request, ldap_conn):
     load_data_to_ldap(request, ldap_conn)
 
@@ -320,6 +424,19 @@ def test_getgrnam_simple_with_mc(ldap_conn, sanity_rfc2307):
     test_getgrnam_simple(ldap_conn, sanity_rfc2307)
     stop_sssd()
     test_getgrnam_simple(ldap_conn, sanity_rfc2307)
+
+
+def test_getgrnam_simple_disabled_pwd_mc(ldap_conn, disable_pwd_mc_rfc2307):
+    test_getgrnam_simple(ldap_conn, disable_pwd_mc_rfc2307)
+    stop_sssd()
+    test_getgrnam_simple(ldap_conn, disable_pwd_mc_rfc2307)
+
+
+def test_getgrnam_simple_disabled_intitgr_mc(ldap_conn,
+                                             disable_initgr_mc_rfc2307):
+    test_getgrnam_simple(ldap_conn, disable_initgr_mc_rfc2307)
+    stop_sssd()
+    test_getgrnam_simple(ldap_conn, disable_initgr_mc_rfc2307)
 
 
 def test_getgrnam_membership(ldap_conn, sanity_rfc2307):
@@ -778,3 +895,120 @@ def test_removed_mc(ldap_conn, sanity_rfc2307):
         grp.getgrnam('group1')
     with pytest.raises(KeyError):
         grp.getgrgid(2001)
+
+
+def test_disabled_mc(ldap_conn, disable_memcache_rfc2307):
+    ent.assert_passwd_by_name(
+        'user1',
+        dict(name='user1', passwd='*', uid=1001, gid=2001,
+             gecos='1001', shell='/bin/bash'))
+    ent.assert_passwd_by_uid(
+        1001,
+        dict(name='user1', passwd='*', uid=1001, gid=2001,
+             gecos='1001', shell='/bin/bash'))
+
+    ent.assert_group_by_name("group1", dict(name="group1", gid=2001))
+    ent.assert_group_by_gid(2001, dict(name="group1", gid=2001))
+
+    assert_user_gids_equal('user1', [2000, 2001])
+
+    stop_sssd()
+
+    # sssd is stopped and the memory cache is disabled;
+    # so pytest should not be able to find anything
+    with pytest.raises(KeyError):
+        pwd.getpwnam('user1')
+    with pytest.raises(KeyError):
+        pwd.getpwuid(1001)
+
+    with pytest.raises(KeyError):
+        grp.getgrnam('group1')
+    with pytest.raises(KeyError):
+        grp.getgrgid(2001)
+
+    with pytest.raises(KeyError):
+        (res, errno, gids) = sssd_id.get_user_gids('user1')
+
+
+def test_disabled_passwd_mc(ldap_conn, disable_pwd_mc_rfc2307):
+    ent.assert_passwd_by_name(
+        'user1',
+        dict(name='user1', passwd='*', uid=1001, gid=2001,
+             gecos='1001', shell='/bin/bash'))
+    ent.assert_passwd_by_uid(
+        1001,
+        dict(name='user1', passwd='*', uid=1001, gid=2001,
+             gecos='1001', shell='/bin/bash'))
+
+    assert_user_gids_equal('user1', [2000, 2001])
+
+    stop_sssd()
+
+    # passwd cache is disabled
+    with pytest.raises(KeyError):
+        pwd.getpwnam('user1')
+    with pytest.raises(KeyError):
+        pwd.getpwuid(1001)
+
+    # Initgroups looks up the user first, hence KeyError from the
+    # passwd database even if the initgroups cache is active.
+    with pytest.raises(KeyError):
+        (res, errno, gids) = sssd_id.get_user_gids('user1')
+
+
+def test_disabled_group_mc(ldap_conn, disable_grp_mc_rfc2307):
+    ent.assert_passwd_by_name(
+        'user1',
+        dict(name='user1', passwd='*', uid=1001, gid=2001,
+             gecos='1001', shell='/bin/bash'))
+    ent.assert_passwd_by_uid(
+        1001,
+        dict(name='user1', passwd='*', uid=1001, gid=2001,
+             gecos='1001', shell='/bin/bash'))
+
+    ent.assert_group_by_name("group1", dict(name="group1", gid=2001))
+    ent.assert_group_by_gid(2001, dict(name="group1", gid=2001))
+
+    assert_user_gids_equal('user1', [2000, 2001])
+
+    stop_sssd()
+
+    # group cache is disabled, other caches should work
+    ent.assert_passwd_by_name(
+        'user1',
+        dict(name='user1', passwd='*', uid=1001, gid=2001,
+             gecos='1001', shell='/bin/bash'))
+    ent.assert_passwd_by_uid(
+        1001,
+        dict(name='user1', passwd='*', uid=1001, gid=2001,
+             gecos='1001', shell='/bin/bash'))
+
+    with pytest.raises(KeyError):
+        grp.getgrnam('group1')
+    with pytest.raises(KeyError):
+        grp.getgrgid(2001)
+
+    assert_user_gids_equal('user1', [2000, 2001])
+
+
+def test_disabled_initgr_mc(ldap_conn, disable_initgr_mc_rfc2307):
+    # Even if initgroups is disabled, passwd should work
+    ent.assert_passwd_by_name(
+        'user1',
+        dict(name='user1', passwd='*', uid=1001, gid=2001,
+             gecos='1001', shell='/bin/bash'))
+    ent.assert_passwd_by_uid(
+        1001,
+        dict(name='user1', passwd='*', uid=1001, gid=2001,
+             gecos='1001', shell='/bin/bash'))
+
+    stop_sssd()
+
+    ent.assert_passwd_by_name(
+        'user1',
+        dict(name='user1', passwd='*', uid=1001, gid=2001,
+             gecos='1001', shell='/bin/bash'))
+    ent.assert_passwd_by_uid(
+        1001,
+        dict(name='user1', passwd='*', uid=1001, gid=2001,
+             gecos='1001', shell='/bin/bash'))


### PR DESCRIPTION
Added option use_memcache to centrally disable memcache
for all clients without the need to specify SSS_NSS_USE_MEMCACHE=NO
environment variable.

Resolves:
https://pagure.io/SSSD/sssd/issue/3496