### PR TITLE
GPO: Don't use freed LDAPURLDesc if domain for AD DC cannot be found

### DIFF
--- a/src/providers/ad/ad_gpo.c
+++ b/src/providers/ad/ad_gpo.c
@@ -4354,7 +4354,7 @@ ad_gpo_get_sd_referral_send(TALLOC_CTX *mem_ctx,
     struct tevent_req *req;
     struct ad_gpo_get_sd_referral_state *state;
     struct tevent_req *subreq;
-    LDAPURLDesc *lud;
+    LDAPURLDesc *lud = NULL;
 
     req = tevent_req_create(mem_ctx, &state,
                             struct ad_gpo_get_sd_referral_state);
@@ -4390,14 +4390,17 @@ ad_gpo_get_sd_referral_send(TALLOC_CTX *mem_ctx,
      */
     state->ref_domain = find_domain_by_name(state->host_domain,
                                             lud->lud_host, true);
-    ldap_free_urldesc(lud);
     if (!state->ref_domain) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Could not find domain matching [%s]\n",
               lud->lud_host);
+        ldap_free_urldesc(lud);
         ret = EIO;
         goto done;
     }
+
+    ldap_free_urldesc(lud);
+    lud = NULL;
 
     state->conn = ad_get_dom_ldap_conn(state->access_ctx->ad_id_ctx,
                                        state->ref_domain);


### PR DESCRIPTION
If a referral returned during AD GPO processing cannot be assigned to a
known domain, at the moment SSSD accesses memory that was freed previously
with ldap_free_urldesc().

This patch moves the ldap_free_urldesc() call to both the error handler and
the success branch after we are done working with the LDAPURLDesc instance.