### PR TITLE
KCM: Three trivial fixes

### DIFF
--- a/src/responder/kcm/kcmsrv_ccache.c
+++ b/src/responder/kcm/kcmsrv_ccache.c
@@ -302,7 +302,7 @@ struct tevent_req *kcm_ccdb_nextid_send(TALLOC_CTX *mem_ctx,
         goto immediate;
     }
 
-    subreq = state->db->ops->nextid_send(mem_ctx, ev, state->db, client);
+    subreq = state->db->ops->nextid_send(state, ev, state->db, client);
     if (subreq == NULL) {
         ret = ENOMEM;
         goto immediate;
@@ -390,7 +390,7 @@ struct tevent_req *kcm_ccdb_list_send(TALLOC_CTX *mem_ctx,
         goto immediate;
     }
 
-    subreq = state->db->ops->list_send(mem_ctx,
+    subreq = state->db->ops->list_send(state,
                                        ev,
                                        state->db,
                                        client);
@@ -467,7 +467,7 @@ struct tevent_req *kcm_ccdb_get_default_send(TALLOC_CTX *mem_ctx,
         goto immediate;
     }
 
-    subreq = db->ops->get_default_send(mem_ctx, ev, db, client);
+    subreq = db->ops->get_default_send(state, ev, db, client);
     if (subreq == NULL) {
         ret = ENOMEM;
         goto immediate;
@@ -1034,7 +1034,7 @@ struct tevent_req *kcm_ccdb_create_cc_send(TALLOC_CTX *mem_ctx,
         goto immediate;
     }
 
-    subreq = state->db->ops->create_send(mem_ctx,
+    subreq = state->db->ops->create_send(state,
                                          ev,
                                          state->db,
                                          client,
@@ -1129,7 +1129,7 @@ struct tevent_req *kcm_ccdb_mod_cc_send(TALLOC_CTX *mem_ctx,
         goto immediate;
     }
 
-    subreq = state->db->ops->mod_send(mem_ctx,
+    subreq = state->db->ops->mod_send(state,
                                       ev,
                                       state->db,
                                       client,
@@ -1204,7 +1204,7 @@ struct tevent_req *kcm_ccdb_store_cred_blob_send(TALLOC_CTX *mem_ctx,
         goto immediate;
     }
 
-    subreq = state->db->ops->store_cred_send(mem_ctx,
+    subreq = state->db->ops->store_cred_send(state,
                                              ev,
                                              state->db,
                                              client,

--- a/src/responder/kcm/kcmsrv_ccache.c
+++ b/src/responder/kcm/kcmsrv_ccache.c
@@ -1291,6 +1291,10 @@ struct tevent_req *kcm_ccdb_delete_cc_send(TALLOC_CTX *mem_ctx,
                                          state->db,
                                          state->client,
                                          state->uuid);
+    if (subreq == NULL) {
+        ret = ENOMEM;
+        goto immediate;
+    }
     tevent_req_set_callback(subreq, kcm_ccdb_delete_done, req);
 
     return req;

--- a/src/responder/kcm/kcmsrv_ccache_mem.c
+++ b/src/responder/kcm/kcmsrv_ccache_mem.c
@@ -405,6 +405,7 @@ static struct tevent_req *ccdb_mem_getbyuuid_send(TALLOC_CTX *mem_ctx,
     struct ccdb_mem_getbyuuid_state *state = NULL;
     struct ccdb_mem *memdb = talloc_get_type(db->db_handle, struct ccdb_mem);
     struct ccache_mem_wrap *ccwrap = NULL;
+    errno_t ret;
 
     req = tevent_req_create(mem_ctx, &state, struct ccdb_mem_getbyuuid_state);
     if (req == NULL) {
@@ -414,9 +415,19 @@ static struct tevent_req *ccdb_mem_getbyuuid_send(TALLOC_CTX *mem_ctx,
     ccwrap = memdb_get_by_uuid(memdb, client, uuid);
     if (ccwrap != NULL) {
         state->cc = kcm_ccache_dup(state, ccwrap->cc);
+        if (state->cc == NULL) {
+            ret = ENOMEM;
+            goto immediate;
+        }
     }
 
-    tevent_req_done(req);
+    ret = EOK;
+immediate:
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else {
+        tevent_req_error(req, ret);
+    }
     tevent_req_post(req, ev);
     return req;
 }
@@ -447,6 +458,7 @@ static struct tevent_req *ccdb_mem_getbyname_send(TALLOC_CTX *mem_ctx,
     struct ccdb_mem_getbyname_state *state = NULL;
     struct ccache_mem_wrap *ccwrap = NULL;
     struct ccdb_mem *memdb = talloc_get_type(db->db_handle, struct ccdb_mem);
+    errno_t ret;
 
     req = tevent_req_create(mem_ctx, &state, struct ccdb_mem_getbyname_state);
     if (req == NULL) {
@@ -456,9 +468,19 @@ static struct tevent_req *ccdb_mem_getbyname_send(TALLOC_CTX *mem_ctx,
     ccwrap = memdb_get_by_name(memdb, client, name);
     if (ccwrap != NULL) {
         state->cc = kcm_ccache_dup(state, ccwrap->cc);
+        if (state->cc == NULL) {
+            ret = ENOMEM;
+            goto immediate;
+        }
     }
 
-    tevent_req_done(req);
+    ret = EOK;
+immediate:
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else {
+        tevent_req_error(req, ret);
+    }
     tevent_req_post(req, ev);
     return req;
 }


### PR DESCRIPTION
I've been working on the KCM responder lately and found some minor issues
that can be merged right away.

1) KCM: Add some forgotten NULL checks

Several memory allocations across the KCM codebase did not check their
result for NULL. This patch fixes that.

2) KCM: Use the right memory context

Inside the tevent request, we should use 'state' as the intermediate memory
context and steal the result up to 'mem_ctx' on success.
'mem_ctx' itself should only be used to create the tevent_req as the first
thing during the request creation.

However, this bug is not very severe as the mem_ctx was always the KCM
operation memory context, so the memory was freed when the operation
terminated.

3) KCM: Do not leak newly created ccache in case the name is malformed

This is not a big deal as the mem_ctx parameter of the operation is
typically just a short-lived operation context. Nonetheless, it is best
practice to not rely on how the memory context is set up in utility
functions.