### PR TITLE
CI: Add missing http-parser-devel dependency

### DIFF
--- a/contrib/ci/deps.sh
+++ b/contrib/ci/deps.sh
@@ -50,6 +50,12 @@ if [[ "$DISTRO_BRANCH" == -redhat-* ]]; then
         krb5-server
         krb5-workstation
     )
+
+    if [[ "$DISTRO_BRANCH" != -redhat-redhatenterprise*-6.*- ||
+          "$DISTRO_BRANCH" != -redhat-centos-6.*- ]]; then
+        DEPS_LIST+=(http-parser-devel)
+    fi
+
     _DEPS_LIST_SPEC=`
         sed -e 's/@PACKAGE_VERSION@/0/g' \
             -e 's/@PACKAGE_NAME@/package-name/g' \


### PR DESCRIPTION
As reported on #3526, running $ ./contrib/ci/run on CentOS 7 minimal
installation ends up in failure on configure because
./contrib/ci/deps.sh does not attempt to install http-parser-devel.

We don't have to worry about CentOS 6 as SSSD is built using
--without-secrets there, thus http-parser-devel is not required.

Resolves: https://pagure.io/SSSD/sssd/issue/3526

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>