### PR TITLE
PAM: Avoid overwriting pam_status in _lookup_by_cert_done()

### DIFF
--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -1568,12 +1568,12 @@ static void pam_forwarder_lookup_by_cert_done(struct tevent_req *req)
                                             preq->module_name,
                                             preq->key_id,
                                             SSS_PAM_CERT_INFO_WITH_HINT);
+                preq->pd->pam_status = PAM_SUCCESS;
                 if (ret != EOK) {
                     DEBUG(SSSDBG_OP_FAILURE, "add_pam_cert_response failed.\n");
                     preq->pd->pam_status = PAM_AUTHINFO_UNAVAIL;
                 }
                 ret = EOK;
-                preq->pd->pam_status = PAM_SUCCESS;
                 pam_reply(preq);
                 goto done;
             }


### PR DESCRIPTION
In case add_pam_cert_response() failed pam_status has to be set to
PAM_AUTHINFO_UNAVAIL. Although it's done properly in the code,
pam_status was overwritten just after the if block with PAM_SUCCESS.

The original faulty code was added as part of 32474fa2f0.

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>