### PR TITLE
LDAP: Allow autogenerating user-private groups

### DIFF
--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -936,6 +936,14 @@ static int confdb_get_domain_internal(struct confdb_ctx *cdb,
         goto done;
     }
 
+    ret = get_entry_as_bool(res->msgs[0], &domain->mpg,
+                            CONFDB_DOMAIN_AUTO_UPG, 0);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE,
+              "Invalid value for %s\n", CONFDB_DOMAIN_AUTO_UPG);
+        goto done;
+    }
+
     if (strcasecmp(domain->provider, "local") == 0) {
         /* If this is the local provider, we need to ensure that
          * no other provider was specified for other types, since

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -197,7 +197,6 @@
                                  "cache_credentials_minimal_first_factor_length"
 #define CONFDB_DEFAULT_CACHE_CREDS_MIN_FF_LENGTH 8
 #define CONFDB_DOMAIN_LEGACY_PASS "store_legacy_passwords"
-#define CONFDB_DOMAIN_MPG "magic_private_groups"
 #define CONFDB_DOMAIN_AUTO_UPG "auto_private_groups"
 #define CONFDB_DOMAIN_FQ "use_fully_qualified_names"
 #define CONFDB_DOMAIN_ENTRY_CACHE_TIMEOUT "entry_cache_timeout"

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -198,6 +198,7 @@
 #define CONFDB_DEFAULT_CACHE_CREDS_MIN_FF_LENGTH 8
 #define CONFDB_DOMAIN_LEGACY_PASS "store_legacy_passwords"
 #define CONFDB_DOMAIN_MPG "magic_private_groups"
+#define CONFDB_DOMAIN_AUTO_UPG "auto_private_groups"
 #define CONFDB_DOMAIN_FQ "use_fully_qualified_names"
 #define CONFDB_DOMAIN_ENTRY_CACHE_TIMEOUT "entry_cache_timeout"
 #define CONFDB_DOMAIN_ACCOUNT_CACHE_EXPIRATION "account_cache_expiration"

--- a/src/config/SSSDConfig/__init__.py.in
+++ b/src/config/SSSDConfig/__init__.py.in
@@ -195,6 +195,7 @@ option_strings = {
     'cached_auth_timeout' : _('How long can cached credentials be used for cached authentication'),
     'full_name_format' : _('Printf-compatible format for displaying fully-qualified names'),
     're_expression' : _('Regex to parse username and domain'),
+    'auto_private_groups' : _('Whether to automatically create private groups for users'),
 
     # [provider/ipa]
     'ipa_domain' : _('IPA domain'),

--- a/src/config/SSSDConfigTest.py
+++ b/src/config/SSSDConfigTest.py
@@ -624,7 +624,8 @@ class SSSDConfigTestSSSDDomain(unittest.TestCase):
             'subdomain_homedir',
             'full_name_format',
             're_expression',
-            'cached_auth_timeout']
+            'cached_auth_timeout',
+            'auto_private_groups']
 
         self.assertTrue(type(options) == dict,
                         "Options should be a dictionary")
@@ -994,7 +995,8 @@ class SSSDConfigTestSSSDDomain(unittest.TestCase):
             'subdomain_homedir',
             'full_name_format',
             're_expression',
-            'cached_auth_timeout']
+            'cached_auth_timeout',
+            'auto_private_groups']
 
         self.assertTrue(type(options) == dict,
                         "Options should be a dictionary")

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -382,6 +382,7 @@ option = cached_auth_timeout
 option = wildcard_limit
 option = full_name_format
 option = re_expression
+option = auto_private_groups
 
 #Entry cache timeouts
 option = entry_cache_user_timeout

--- a/src/config/etc/sssd.api.conf
+++ b/src/config/etc/sssd.api.conf
@@ -185,6 +185,7 @@ subdomain_homedir = str, None, false
 cached_auth_timeout = int, None, false
 full_name_format = str, None, false
 re_expression = str, None, false
+auto_private_groups = str, None, false
 
 #Entry cache timeouts
 entry_cache_user_timeout = int, None, false

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2816,6 +2816,26 @@ subdomain_inherit = ldap_purge_cache_timeout
                         </para>
                     </listitem>
                 </varlistentry>
+                <varlistentry>
+                    <term>auto_private_groups (string)</term>
+                    <listitem>
+                        <para>
+                            If this option is enabled, SSSD will automatically
+                            create user private groups based on user's
+                            UID number. The GID number is ignored in this case.
+                        </para>
+                        <para>
+                            NOTE: Because the GID number and the user private group
+                            are inferred frm the UID number, it is not supported
+                            to have multiple entries with the same UID or GID number
+                            with this option. In other words, enabling this option
+                            enforces uniqueness across the ID space.
+                        </para>
+                        <para>
+                            Default: False
+                        </para>
+                    </listitem>
+                </varlistentry>
             </variablelist>
         </para>
 

--- a/src/providers/ldap/sdap_async_users.c
+++ b/src/providers/ldap/sdap_async_users.c
@@ -136,6 +136,38 @@ static errno_t sdap_set_non_posix_flag(struct sysdb_attrs *attrs,
     return EOK;
 }
 
+static int sdap_user_set_mpg(struct sysdb_attrs *user_attrs,
+                             gid_t *_gid)
+{
+    errno_t ret;
+
+    if (_gid == NULL) {
+        return EINVAL;
+    }
+
+    if (*_gid == 0) {
+        /* The original entry had no GID number. This is OK, we just won't add
+         * the SYSDB_PRIMARY_GROUP_GIDNUM attribute
+         */
+        return EOK;
+    }
+
+    ret = sysdb_attrs_add_uint32(user_attrs,
+                                 SYSDB_PRIMARY_GROUP_GIDNUM,
+                                 (uint32_t) *_gid);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sysdb_attrs_add_uint32 failed.\n");
+        return ret;
+    }
+
+    /* We won't really store gidNumber=0, but the zero value tells
+     * the sysdb layer that no GID is set, which sysdb requires for
+     * MPG-enabled domains
+     */
+    *_gid = 0;
+    return EOK;
+}
+
 /* FIXME: support storing additional attributes */
 int sdap_save_user(TALLOC_CTX *memctx,
                    struct sdap_options *opts,
@@ -357,7 +389,7 @@ int sdap_save_user(TALLOC_CTX *memctx,
             goto done;
         }
 
-        if (IS_SUBDOMAIN(dom)) {
+        if (IS_SUBDOMAIN(dom) || dom->mpg == true) {
             /* For subdomain users, only create the private group as
              * the subdomain is an MPG domain.
              * But we have to save the GID of the original primary group
@@ -365,14 +397,13 @@ int sdap_save_user(TALLOC_CTX *memctx,
              * typically (Unix and AD) the user is not listed in his primary
              * group as a member.
              */
-            ret = sysdb_attrs_add_uint32(user_attrs, SYSDB_PRIMARY_GROUP_GIDNUM,
-                                         (uint32_t) gid);
+            ret = sdap_user_set_mpg(user_attrs, &gid);
             if (ret != EOK) {
-                DEBUG(SSSDBG_OP_FAILURE, "sysdb_attrs_add_uint32 failed.\n");
+                DEBUG(SSSDBG_OP_FAILURE,
+                      "sdap_user_set_mpg failed [%d]: %s\n", ret,
+                      sss_strerror(ret));
                 goto done;
             }
-
-            gid = 0;
         }
 
         /* Store the GID in the ldap_attrs so it doesn't get
@@ -380,6 +411,41 @@ int sdap_save_user(TALLOC_CTX *memctx,
         */
         ret = sysdb_attrs_add_uint32(attrs, SYSDB_GIDNUM, gid);
         if (ret != EOK) goto done;
+    } else if (dom->mpg) {
+        /* Likewise, if a domain is set to contain 'magic private groups', do
+         * not process the real GID, but save it in the cache as originalGID
+         * (if available)
+         */
+        ret = sysdb_attrs_get_uint32_t(attrs,
+                                       opts->user_map[SDAP_AT_USER_GID].sys_name,
+                                       &gid);
+        if (ret == ENOENT) {
+            DEBUG(SSSDBG_TRACE_LIBS,
+                  "Missing GID, won't save the %s attribute\n",
+                  SYSDB_PRIMARY_GROUP_GIDNUM);
+
+            /* Store the UID as GID (since we're in a MPG domain so that it doesn't
+             * get treated as a missing attribute and removed
+             */
+            ret = sdap_replace_id(attrs, SYSDB_GIDNUM, uid);
+            if (ret) {
+                DEBUG(SSSDBG_OP_FAILURE, "Cannot set the id-mapped UID\n");
+                goto done;
+            }
+            gid = 0;
+        } else if (ret != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "Cannot retrieve GID, won't save the %s attribute\n",
+                  SYSDB_PRIMARY_GROUP_GIDNUM);
+            gid = 0;
+        }
+
+        ret = sdap_user_set_mpg(user_attrs, &gid);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "sdap_user_set_mpg failed [%d]: %s\n", ret, sss_strerror(ret));
+            goto done;
+        }
     } else {
         ret = sysdb_attrs_get_uint32_t(attrs,
                                        opts->user_map[SDAP_AT_USER_GID].sys_name,
@@ -403,8 +469,9 @@ int sdap_save_user(TALLOC_CTX *memctx,
     }
 
     /* check that the gid is valid for this domain */
-    if (is_posix == true && IS_SUBDOMAIN(dom) == false &&
-            OUT_OF_ID_RANGE(gid, dom->id_min, dom->id_max)) {
+    if (is_posix == true && IS_SUBDOMAIN(dom) == false
+            && dom->mpg == false
+            && OUT_OF_ID_RANGE(gid, dom->id_min, dom->id_max)) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "User [%s] filtered out! (primary gid out of range)\n",
                user_name);


### PR DESCRIPTION
This PR exposes the already existing feature that generates private groups
for user objects for the generic LDAP provider. Most of the work in the
PR is tests and different corner cases, but there is also one commit that is
technically backwards incompatible:
    SYSDB: Prevent users and groups ID collision in MPG domains

Without checks for the collision, if an LDAP domain contains both a user
entry and a group with the same gidNumber and the group is cached first,
then the user is requested and cached, at that point the responder search
by ID would return two objects. Therefore we need to guard against the
duplicate IDs.

Instead of the backwards incompatible change, we could also enable the
check if the domain is neither subdomain nor a id_provider=local domain or
we could prefer the user object if a group-by-GID search returns two results.

But both alternatives seem like quite a hack to me and at the same time I
wasn't able to find a way where the change matters except for the local
domain -- and in that case I think the local domain doesn't matter as
a whole.

I've also sent a design page to the
sssd-devel mailing list, my WIP version is at
https://pagure.io/fork/jhrozek/SSSD/docs/blob/mpg/f/design_pages/auto_private_groups.rst