### PR TITLE
Log to syslog whether the DP is online or offline

### DIFF
--- a/src/providers/backend.h
+++ b/src/providers/backend.h
@@ -113,6 +113,11 @@ struct be_ctx {
     size_t check_online_ref_count;
 
     struct data_provider *provider;
+
+    /* Indicates whether the last state of the DP that has been logged is
+     * DP_ERR_OK or DP_ERR_OFFLINE. The only usage of this var, so far, is
+     * to log the DP status without spamming the syslog/journal. */
+    int last_dp_state;
 };
 
 bool be_is_offline(struct be_ctx *ctx);

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -249,7 +249,7 @@ static errno_t be_check_online_request(struct be_ctx *be_ctx)
 static void be_check_online_done(struct tevent_req *req)
 {
     struct be_ctx *be_ctx;
-    struct dp_reply_std reply;
+    struct dp_reply_std *reply;
     errno_t ret;
 
     be_ctx = tevent_req_callback_data(req, struct be_ctx);
@@ -260,7 +260,7 @@ static void be_check_online_done(struct tevent_req *req)
         goto done;
     }
 
-    switch (reply.dp_error) {
+    switch (reply->dp_error) {
     case DP_ERR_OK:
         DEBUG(SSSDBG_TRACE_FUNC, "Backend is online\n");
         break;
@@ -275,7 +275,7 @@ static void be_check_online_done(struct tevent_req *req)
 
     be_ctx->check_online_ref_count--;
 
-    if (reply.dp_error != DP_ERR_OK && be_ctx->check_online_ref_count > 0) {
+    if (reply->dp_error != DP_ERR_OK && be_ctx->check_online_ref_count > 0) {
         ret = be_check_online_request(be_ctx);
         if (ret != EOK) {
             DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create check online req.\n");
@@ -286,8 +286,8 @@ static void be_check_online_done(struct tevent_req *req)
 
 done:
     be_ctx->check_online_ref_count = 0;
-    if (reply.dp_error != DP_ERR_OFFLINE) {
-        if (reply.dp_error != DP_ERR_OK) {
+    if (reply->dp_error != DP_ERR_OFFLINE) {
+        if (reply->dp_error != DP_ERR_OK) {
             reset_fo(be_ctx);
         }
         be_reset_offline(be_ctx);

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -262,9 +262,17 @@ static void be_check_online_done(struct tevent_req *req)
 
     switch (reply->dp_error) {
     case DP_ERR_OK:
+        if (be_ctx->last_dp_state != DP_ERR_OK) {
+            be_ctx->last_dp_state = DP_ERR_OK;
+            sss_log(SSS_LOG_INFO, "Backend is online\n");
+        }
         DEBUG(SSSDBG_TRACE_FUNC, "Backend is online\n");
         break;
     case DP_ERR_OFFLINE:
+        if (be_ctx->last_dp_state != DP_ERR_OFFLINE) {
+            be_ctx->last_dp_state = DP_ERR_OFFLINE;
+            sss_log(SSS_LOG_INFO, "Backend is offline\n");
+        }
         DEBUG(SSSDBG_TRACE_FUNC, "Backend is offline\n");
         break;
     default:
@@ -397,6 +405,7 @@ errno_t be_process_init(TALLOC_CTX *mem_ctx,
         ret = ENOMEM;
         goto done;
     }
+    be_ctx->last_dp_state = -1;
 
     ret = be_init_failover(be_ctx);
     if (ret != EOK) {


### PR DESCRIPTION
This PR is supposed to cover a small bit of https://pagure.io/SSSD/sssd/issue/3155 and log to syslog whether the DP is online or offline.

Hopefully by logging this to syslog it'll help admins to find out those issues in a simpler way as nowadays they'd have to enable the logs, search for this info there ... which is not exactly handy.