### PR TITLE
 WATCHDOG: Restart providers with SIGUSR2 after time drift

### DIFF
--- a/src/util/util_watchdog.c
+++ b/src/util/util_watchdog.c
@@ -160,6 +160,10 @@ static void watchdog_fd_read_handler(struct tevent_context *ev,
               "[%d]: %s\n", ret, sss_strerror(ret));
         orderly_shutdown(1);
     }
+    if (strstr(debug_prg_name, "sssd[be[") != NULL) {
+        kill(getpid(), SIGUSR2);
+        DEBUG(SSSDBG_IMPORTANT_INFO, "SIGUSR2 sent to %s\n", debug_prg_name);
+    }
 }
 
 int setup_watchdog(struct tevent_context *ev, int interval)


### PR DESCRIPTION
 Restarting the providers using the already implemented SIGUSR2 (for
 method .resetOffline, used after netlink detects an interface change)
 when a time drift is detected, ensures that affected connection retries
 (e.g. LDAP) will be rescheduled immediately instead of having to wait
 the time shifted to return to its normal execution.

 Resolves:
 https://pagure.io/SSSD/sssd/issue/3285