### PR TITLE
sss_client: refactor internal timeout handling

### DIFF
--- a/src/sss_client/sss_cli.h
+++ b/src/sss_client/sss_cli.h
@@ -568,6 +568,12 @@ enum nss_status sss_nss_make_request(enum sss_cli_command cmd,
                                      uint8_t **repbuf, size_t *replen,
                                      int *errnop);
 
+enum nss_status sss_nss_make_request_timeout(enum sss_cli_command cmd,
+                      struct sss_cli_req_data *rd,
+                      int timeout,
+                      uint8_t **repbuf, size_t *replen,
+                      int *errnop);
+
 int sss_pam_make_request(enum sss_cli_command cmd,
                          struct sss_cli_req_data *rd,
                          uint8_t **repbuf, size_t *replen,


### PR DESCRIPTION
This patch adds a timeout option to the internal client calls so that
the timeout is not hard-coded anymore in the low level poll() calls but
can be set by the caller with sss_nss_make_request_timeout(). Since the
old timeout value is not changed by this patch there is no functional
change expected.

Related to https://pagure.io/SSSD/sssd/issue/2478