### PR TITLE
AD: Remember last site discovered

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -154,6 +154,7 @@
 #define SYSDB_SUBDOMAIN_FOREST "memberOfForest"
 #define SYSDB_SUBDOMAIN_TRUST_DIRECTION "trustDirection"
 #define SYSDB_UPN_SUFFIXES "upnSuffixes"
+#define SYSDB_SITE "site"
 
 #define SYSDB_BASE_ID "baseID"
 #define SYSDB_ID_RANGE_SIZE "idRangeSize"
@@ -508,6 +509,15 @@ errno_t sysdb_domain_update_domain_resolution_order(
                                         struct sysdb_ctx *sysdb,
                                         const char *domain_name,
                                         const char *domain_resolution_order);
+
+errno_t
+sysdb_get_site(TALLOC_CTX *mem_ctx,
+               struct sss_domain_info *dom,
+               const char **_site);
+
+errno_t
+sysdb_set_site(struct sss_domain_info *dom,
+               const char *site);
 
 errno_t sysdb_subdomain_store(struct sysdb_ctx *sysdb,
                               const char *name, const char *realm,

--- a/src/db/sysdb_subdomains.c
+++ b/src/db/sysdb_subdomains.c
@@ -1291,7 +1291,7 @@ sysdb_get_site(TALLOC_CTX *mem_ctx,
                const char **_site)
 {
     TALLOC_CTX *tmp_ctx;
-    struct ldb_res *res;
+    struct ldb_result *res;
     struct ldb_dn *dn;
     const char *attrs[] = { SYSDB_SITE, NULL };
     errno_t ret;

--- a/src/providers/ad/ad_init.c
+++ b/src/providers/ad/ad_init.c
@@ -199,7 +199,7 @@ static errno_t ad_init_srv_plugin(struct be_ctx *be_ctx,
         return EOK;
     }
 
-    srv_ctx = ad_srv_plugin_ctx_init(be_ctx, be_ctx->be_res,
+    srv_ctx = ad_srv_plugin_ctx_init(be_ctx, be_ctx, be_ctx->be_res,
                                      default_host_dbs, ad_options->id,
                                      hostname, ad_domain,
                                      ad_site_override);

--- a/src/providers/ad/ad_srv.c
+++ b/src/providers/ad/ad_srv.c
@@ -481,6 +481,7 @@ struct ad_srv_plugin_ctx {
     const char *hostname;
     const char *ad_domain;
     const char *ad_site_override;
+    const char *current_site;
 };
 
 struct ad_srv_plugin_ctx *
@@ -518,6 +519,11 @@ ad_srv_plugin_ctx_init(TALLOC_CTX *mem_ctx,
         if (ctx->ad_site_override == NULL) {
             goto fail;
         }
+
+        ctx->current_site = talloc_strdup(ctx, ad_site_override);
+        if (ctx->current_site == NULL) {
+            goto fail;
+        }
     }
 
     return ctx;
@@ -525,6 +531,32 @@ ad_srv_plugin_ctx_init(TALLOC_CTX *mem_ctx,
 fail:
     talloc_free(ctx);
     return NULL;
+}
+
+static errno_t
+ad_srv_plugin_ctx_switch_site(struct ad_srv_plugin_ctx *ctx,
+                              const char *new_site)
+{
+    const char *site;
+    errno_t ret;
+
+    if (new_site == NULL) {
+        return EOK;
+    }
+
+    if (ctx->current_site != NULL && strcmp(ctx->current_site, new_site) == 0) {
+        return EOK;
+    }
+
+    site = talloc_strdup(ctx, new_site);
+    if (site == NULL) {
+        return ENOMEM;
+    }
+
+    talloc_zfree(ctx->current_site);
+    ctx->current_site = site;
+
+    return EOK;
 }
 
 struct ad_srv_plugin_state {
@@ -613,7 +645,7 @@ struct tevent_req *ad_srv_plugin_send(TALLOC_CTX *mem_ctx,
 
     subreq = ad_get_dc_servers_send(state, ev, ctx->be_res->resolv,
                                     state->discovery_domain,
-                                    state->ctx->ad_site_override);
+                                    state->ctx->current_site);
     if (subreq == NULL) {
         ret = ENOMEM;
         goto immediately;
@@ -709,6 +741,16 @@ static void ad_srv_plugin_site_done(struct tevent_req *subreq)
     backup_domain = NULL;
 
     if (ret == EOK) {
+        /* Remember current site so it can be used during next lookup so
+         * we can contact directory controllers within a known reachable
+         * site first. */
+        ret = ad_srv_plugin_ctx_switch_site(state->ctx, state->site);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "Unable to set site [%d]: %s\n",
+                  ret, sss_strerror(ret));
+            goto done;
+        }
+
         if (strcmp(state->service, "gc") == 0) {
             if (state->forest != NULL) {
                 if (state->site != NULL) {

--- a/src/providers/ad/ad_srv.h
+++ b/src/providers/ad/ad_srv.h
@@ -25,6 +25,7 @@ struct ad_srv_plugin_ctx;
 
 struct ad_srv_plugin_ctx *
 ad_srv_plugin_ctx_init(TALLOC_CTX *mem_ctx,
+                       struct be_ctx *be_ctx,
                        struct be_resolv_ctx *be_res,
                        enum host_database *host_dbs,
                        struct sdap_options *opts,

--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -245,7 +245,7 @@ ad_subdom_ad_ctx_new(struct be_ctx *be_ctx,
     ad_options->id_ctx = ad_id_ctx;
 
     /* use AD plugin */
-    srv_ctx = ad_srv_plugin_ctx_init(be_ctx, be_ctx->be_res,
+    srv_ctx = ad_srv_plugin_ctx_init(be_ctx, be_ctx, be_ctx->be_res,
                                      default_host_dbs,
                                      ad_id_ctx->ad_options->id,
                                      hostname,

--- a/src/providers/ipa/ipa_subdomains_server.c
+++ b/src/providers/ipa/ipa_subdomains_server.c
@@ -305,7 +305,7 @@ ipa_ad_ctx_new(struct be_ctx *be_ctx,
     ad_site_override = dp_opt_get_string(ad_options->basic, AD_SITE);
 
     /* use AD plugin */
-    srv_ctx = ad_srv_plugin_ctx_init(be_ctx, be_ctx->be_res,
+    srv_ctx = ad_srv_plugin_ctx_init(be_ctx, be_ctx, be_ctx->be_res,
                                      default_host_dbs,
                                      ad_id_ctx->ad_options->id,
                                      id_ctx->server_mode->hostname,

--- a/src/tests/cmocka/test_sysdb_subdomains.c
+++ b/src/tests/cmocka/test_sysdb_subdomains.c
@@ -513,6 +513,31 @@ static void test_sysdb_link_ad_multidom(void **state)
 
 }
 
+static void test_sysdb_set_and_get_site(void **state)
+{
+    TALLOC_CTX *tmp_ctx;
+    struct subdom_test_ctx *test_ctx =
+        talloc_get_type(*state, struct subdom_test_ctx);
+    const char *site;
+    errno_t ret;
+
+    tmp_ctx = talloc_new(NULL);
+    assert_non_null(test_ctx);
+
+    ret = sysdb_get_site(test_ctx, test_ctx->tctx->dom, &site);
+    assert_int_equal(ret, EOK);
+    assert_null(site);
+
+    ret = sysdb_set_site(test_ctx->tctx->dom, "TestSite");
+    assert_int_equal(ret, EOK);
+
+    ret = sysdb_get_site(tmp_ctx, test_ctx->tctx->dom, &site);
+    assert_int_equal(ret, EOK);
+    assert_string_equal(site, "TestSite");
+
+    talloc_free(tmp_ctx);
+}
+
 int main(int argc, const char *argv[])
 {
     int rv;
@@ -544,6 +569,9 @@ int main(int argc, const char *argv[])
                                         test_sysdb_subdom_setup,
                                         test_sysdb_subdom_teardown),
         cmocka_unit_test_setup_teardown(test_sysdb_link_ad_multidom,
+                                        test_sysdb_subdom_setup,
+                                        test_sysdb_subdom_teardown),
+        cmocka_unit_test_setup_teardown(test_sysdb_set_and_get_site,
                                         test_sysdb_subdom_setup,
                                         test_sysdb_subdom_teardown),
     };


### PR DESCRIPTION
To discover Active Directory site for a client we must first contact any
directory controller for an LDAP ping. This is done by searching
domain-wide DNS tree which may however contain servers that are not
reachable from current site and than we face long timeouts or failure.

This patch makes sssd remember the last successfuly discovered site
and use this for DNS search to lookup a site and forest again similar
to what we do when ad_site option is set.

Resolves:
https://pagure.io/SSSD/sssd/issue/3265