### PR TITLE
mmap_cache: add SID and type to struct sss_mc_rec

### DIFF
--- a/src/responder/nss/nss_private.h
+++ b/src/responder/nss/nss_private.h
@@ -138,4 +138,10 @@ const char *
 nss_get_pwfield(struct nss_ctx *nctx,
                 struct sss_domain_info *dom);
 
+errno_t get_extra_data(TALLOC_CTX *mem_ctx,
+                       struct sss_domain_info *domain,
+                       const char override_space,
+                       struct ldb_message *msg,
+                       struct sized_data *extra_data);
+
 #endif /* _NSS_PRIVATE_H_ */

--- a/src/responder/nss/nss_protocol_grent.c
+++ b/src/responder/nss/nss_protocol_grent.c
@@ -201,6 +201,7 @@ nss_protocol_fill_grent(struct nss_ctx *nss_ctx,
     struct ldb_message *msg;
     struct sized_string *name;
     struct sized_string pwfield;
+    struct sized_string inputname;
     uint32_t gid;
     uint32_t num_results;
     uint32_t num_members;
@@ -285,6 +286,21 @@ nss_protocol_fill_grent(struct nss_ctx *nss_ctx,
                 DEBUG(SSSDBG_MINOR_FAILURE,
                       "Failed to store group %s (%s) in mem-cache [%d]: %s!\n",
                       name->str, result->domain->name, ret, sss_strerror(ret));
+            }
+
+            if (cmd_ctx->rawname != NULL
+                    && strcmp(name->str, cmd_ctx->rawname) != 0) {
+                inputname.str = cmd_ctx->rawname;
+                inputname.len = strlen(inputname.str) + 1;
+                ret = sss_mmap_cache_link_store(&nss_ctx->grp_mc_ctx, name,
+                                                &inputname);
+                if (ret != EOK) {
+                    DEBUG(SSSDBG_MINOR_FAILURE,
+                          "Failed to store link %s to group %s (%s) "
+                          "in mmap cache [%d]: %s!\n", cmd_ctx->rawname,
+                          name->str, result->domain->name, ret,
+                          sss_strerror(ret));
+                }
             }
         }
     }

--- a/src/responder/nss/nss_protocol_pwent.c
+++ b/src/responder/nss/nss_protocol_pwent.c
@@ -236,6 +236,7 @@ nss_protocol_fill_pwent(struct nss_ctx *nss_ctx,
     struct sized_string gecos;
     struct sized_string homedir;
     struct sized_string shell;
+    struct sized_string inputname;
     uint32_t gid;
     uint32_t uid;
     uint32_t num_results;
@@ -303,6 +304,21 @@ nss_protocol_fill_pwent(struct nss_ctx *nss_ctx,
                 DEBUG(SSSDBG_MINOR_FAILURE,
                       "Failed to store user %s (%s) in mmap cache [%d]: %s!\n",
                       name->str, result->domain->name, ret, sss_strerror(ret));
+            }
+
+            if (cmd_ctx->rawname != NULL
+                    && strcmp(name->str, cmd_ctx->rawname) != 0) {
+                inputname.str = cmd_ctx->rawname;
+                inputname.len = strlen(inputname.str) + 1;
+                ret = sss_mmap_cache_link_store(&nss_ctx->pwd_mc_ctx, name,
+                                                &inputname);
+                if (ret != EOK) {
+                    DEBUG(SSSDBG_MINOR_FAILURE,
+                          "Failed to store link %s to user %s (%s) "
+                          "in mmap cache [%d]: %s!\n", cmd_ctx->rawname,
+                          name->str, result->domain->name, ret,
+                          sss_strerror(ret));
+                }
             }
         }
     }

--- a/src/responder/nss/nss_utils.c
+++ b/src/responder/nss/nss_utils.c
@@ -36,3 +36,76 @@ nss_get_pwfield(struct nss_ctx *nctx,
 
     return nctx->pwfield;
 }
+
+errno_t get_extra_data(TALLOC_CTX *mem_ctx,
+                       struct sss_domain_info *domain,
+                       const char override_space,
+                       struct ldb_message *msg,
+                       struct sized_data *extra_data)
+{
+    const char *name;
+    char *short_name;
+    size_t len = 0;
+    size_t pos = 0;
+    uint8_t *data;
+    const char *flat_name;
+    const char *sid_str;
+
+    if (domain == NULL || domain->name == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Missing domain name.");
+        return EINVAL;
+    }
+
+    /* Use domain->name if domain->flat_name is undefined */
+    /* FIXME: or should it be better "" ? */
+    flat_name = domain->flat_name != NULL ? domain->flat_name : domain->name;
+
+    name = sss_get_name_from_msg(domain, msg);
+    if (name == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Object has no name.\n");
+        return EINVAL;
+    }
+
+    short_name = sss_output_name(mem_ctx, name, domain->case_preserve,
+                                 override_space);
+    if (short_name == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "sss_output_name failed.\n");
+        return ENOMEM;
+    }
+
+    /* If a SID cannot be found add an empty string */
+    sid_str = ldb_msg_find_attr_as_string(msg, SYSDB_SID_STR, "");
+
+    len = strlen(short_name) + strlen(domain->name) + strlen(flat_name)
+                             + strlen(sid_str) + 4 +  2 * sizeof(uint32_t);
+    data = talloc_size(mem_ctx, len);
+    if (data == NULL) {
+        talloc_free(short_name);
+        DEBUG(SSSDBG_OP_FAILURE, "talloc_size failed.\n");
+        return ENOMEM;
+    }
+
+    /* overall length of the extra data including the length itself */
+    SAFEALIGN_COPY_UINT32(data + pos, &len, &pos);
+    /* 4 0-terminated strings will follow */
+    SAFEALIGN_SET_UINT32(data + pos, 4, &pos);
+
+    memcpy(data + pos, short_name, strlen(short_name) + 1);
+    pos += strlen(short_name) + 1;
+    talloc_free(short_name);
+
+    memcpy(data + pos, domain->name, strlen(domain->name) + 1);
+    pos += strlen(domain->name) + 1;
+
+    memcpy(data + pos, flat_name, strlen(flat_name) + 1);
+    pos += strlen(flat_name) + 1;
+
+    memcpy(data + pos, sid_str, strlen(sid_str) + 1);
+    pos += strlen(sid_str) + 1;
+
+    extra_data->data = data;
+    extra_data->len = len;
+
+    return EOK;
+}
+

--- a/src/responder/nss/nsssrv_mmap_cache.c
+++ b/src/responder/nss/nsssrv_mmap_cache.c
@@ -315,8 +315,11 @@ static void sss_mc_invalidate_rec(struct sss_mc_ctx *mcc,
     rec->expire = MC_INVALID_VAL64;
     rec->next1 = MC_INVALID_VAL32;
     rec->next2 = MC_INVALID_VAL32;
+    rec->next3 = MC_INVALID_VAL32;
     rec->hash1 = MC_INVALID_VAL32;
     rec->hash2 = MC_INVALID_VAL32;
+    rec->hash3 = MC_INVALID_VAL32;
+    rec->type = MC_INVALID_VAL32;
     MC_LOWER_BARRIER(rec);
 }
 
@@ -621,7 +624,8 @@ static errno_t sss_mc_get_record(struct sss_mc_ctx **_mcc,
     rec->len = rec_len;
     rec->next1 = MC_INVALID_VAL;
     rec->next2 = MC_INVALID_VAL;
-    rec->padding = MC_INVALID_VAL;
+    rec->next3 = MC_INVALID_VAL;
+    rec->type = MC_INVALID_VAL;
     MC_LOWER_BARRIER(rec);
 
     /* and now mark slots as used */
@@ -641,8 +645,24 @@ static inline void sss_mmap_set_rec_header(struct sss_mc_ctx *mcc,
 {
     rec->len = len;
     rec->expire = time(NULL) + ttl;
+    rec->type = SSS_MC_REC_TYPE_DATA;
     rec->hash1 = sss_mc_hash(mcc, key1, key1_len);
     rec->hash2 = sss_mc_hash(mcc, key2, key2_len);
+    rec->hash3 = MC_INVALID_VAL;
+}
+
+static inline void sss_mmap_set_link_rec_header(struct sss_mc_ctx *mcc,
+                                                struct sss_mc_rec *rec,
+                                                size_t len, int ttl,
+                                                const char *key1,
+                                                size_t key1_len)
+{
+    rec->len = len;
+    rec->expire = time(NULL) + ttl;
+    rec->type = SSS_MC_REC_TYPE_LINK;
+    rec->hash1 = sss_mc_hash(mcc, key1, key1_len);
+    rec->hash2 = MC_INVALID_VAL;
+    rec->hash3 = MC_INVALID_VAL;
 }
 
 static inline void sss_mmap_chain_in_rec(struct sss_mc_ctx *mcc,
@@ -682,6 +702,53 @@ static errno_t sss_mmap_cache_invalidate(struct sss_mc_ctx *mcc,
 /***************************************************************************
  * passwd map
  ***************************************************************************/
+
+errno_t sss_mmap_cache_link_store(struct sss_mc_ctx **_mcc,
+                                  struct sized_string *canonical_name,
+                                  struct sized_string *name)
+{
+    struct sss_mc_ctx *mcc = *_mcc;
+    struct sss_mc_rec *rec;
+    size_t rec_len;
+    int ret;
+    struct sss_mc_link_data *data;
+
+    if (mcc == NULL) {
+        /* cache not initialized ? */
+        return EINVAL;
+    }
+
+    rec_len = sizeof(struct sss_mc_rec) + sizeof(struct sss_mc_link_data)
+                                        + name->len;
+
+    if (rec_len > mcc->dt_size) {
+        return ENOMEM;
+    }
+
+    ret = sss_mc_get_record(_mcc, rec_len, name, &rec);
+    if (ret != EOK) {
+        return ret;
+    }
+
+    data = (struct sss_mc_link_data *) rec->data;
+
+    MC_RAISE_BARRIER(rec);
+
+    /* header */
+    sss_mmap_set_link_rec_header(mcc, rec, rec_len, mcc->valid_time_slot,
+                                 name->str, name->len);
+
+    data->name = MC_PTR_DIFF(data->strs, data);
+    data->hash = sss_mc_hash(mcc, canonical_name->str, canonical_name->len);
+    memcpy(&data->strs[0], name->str, name->len);
+
+    MC_LOWER_BARRIER(rec);
+
+    /* finally chain the rec in the hash table */
+    sss_mc_add_rec_to_chain(mcc, rec, rec->hash1);
+
+    return EOK;
+}
 
 errno_t sss_mmap_cache_pw_store(struct sss_mc_ctx **_mcc,
                                 struct sized_string *name,

--- a/src/responder/nss/nsssrv_mmap_cache.c
+++ b/src/responder/nss/nsssrv_mmap_cache.c
@@ -756,7 +756,8 @@ errno_t sss_mmap_cache_pw_store(struct sss_mc_ctx **_mcc,
                                 uid_t uid, gid_t gid,
                                 struct sized_string *gecos,
                                 struct sized_string *homedir,
-                                struct sized_string *shell)
+                                struct sized_string *shell,
+                                struct sized_data *extra_data)
 {
     struct sss_mc_ctx *mcc = *_mcc;
     struct sss_mc_rec *rec;
@@ -779,7 +780,8 @@ errno_t sss_mmap_cache_pw_store(struct sss_mc_ctx **_mcc,
     }
     to_sized_string(&uidkey, uidstr);
 
-    data_len = name->len + pw->len + gecos->len + homedir->len + shell->len;
+    data_len = name->len + pw->len + gecos->len + homedir->len + shell->len
+                         + extra_data->len;
     rec_len = sizeof(struct sss_mc_rec) +
               sizeof(struct sss_mc_pwd_data) +
               data_len;
@@ -816,6 +818,8 @@ errno_t sss_mmap_cache_pw_store(struct sss_mc_ctx **_mcc,
     pos += homedir->len;
     memcpy(&data->strs[pos], shell->str, shell->len);
     pos += shell->len;
+    memcpy(&data->strs[pos], extra_data->data, extra_data->len);
+    pos += extra_data->len;
 
     MC_LOWER_BARRIER(rec);
 
@@ -899,7 +903,8 @@ int sss_mmap_cache_gr_store(struct sss_mc_ctx **_mcc,
                             struct sized_string *name,
                             struct sized_string *pw,
                             gid_t gid, size_t memnum,
-                            char *membuf, size_t memsize)
+                            char *membuf, size_t memsize,
+                            struct sized_data *extra_data)
 {
     struct sss_mc_ctx *mcc = *_mcc;
     struct sss_mc_rec *rec;
@@ -922,7 +927,7 @@ int sss_mmap_cache_gr_store(struct sss_mc_ctx **_mcc,
     }
     to_sized_string(&gidkey, gidstr);
 
-    data_len = name->len + pw->len + memsize;
+    data_len = name->len + pw->len + memsize + extra_data->len;
     rec_len = sizeof(struct sss_mc_rec) +
               sizeof(struct sss_mc_grp_data) +
               data_len;
@@ -955,6 +960,8 @@ int sss_mmap_cache_gr_store(struct sss_mc_ctx **_mcc,
     pos += pw->len;
     memcpy(&data->strs[pos], membuf, memsize);
     pos += memsize;
+    memcpy(&data->strs[pos], extra_data->data, extra_data->len);
+    pos += extra_data->len;
 
     MC_LOWER_BARRIER(rec);
 

--- a/src/responder/nss/nsssrv_mmap_cache.h
+++ b/src/responder/nss/nsssrv_mmap_cache.h
@@ -37,6 +37,10 @@ errno_t sss_mmap_cache_init(TALLOC_CTX *mem_ctx, const char *name,
                             enum sss_mc_type type, size_t n_elem,
                             time_t valid_time, struct sss_mc_ctx **mcc);
 
+errno_t sss_mmap_cache_link_store(struct sss_mc_ctx **_mcc,
+                                  struct sized_string *canonical_name,
+                                  struct sized_string *name);
+
 errno_t sss_mmap_cache_pw_store(struct sss_mc_ctx **_mcc,
                                 struct sized_string *name,
                                 struct sized_string *pw,

--- a/src/responder/nss/nsssrv_mmap_cache.h
+++ b/src/responder/nss/nsssrv_mmap_cache.h
@@ -47,13 +47,15 @@ errno_t sss_mmap_cache_pw_store(struct sss_mc_ctx **_mcc,
                                 uid_t uid, gid_t gid,
                                 struct sized_string *gecos,
                                 struct sized_string *homedir,
-                                struct sized_string *shell);
+                                struct sized_string *shell,
+                                struct sized_data *extra_data);
 
 errno_t sss_mmap_cache_gr_store(struct sss_mc_ctx **_mcc,
                                 struct sized_string *name,
                                 struct sized_string *pw,
                                 gid_t gid, size_t memnum,
-                                char *membuf, size_t memsize);
+                                char *membuf, size_t memsize,
+                                struct sized_data *extra_data);
 
 errno_t sss_mmap_cache_initgr_store(struct sss_mc_ctx **_mcc,
                                     struct sized_string *name,

--- a/src/sss_client/idmap/sss_nss_idmap.h
+++ b/src/sss_client/idmap/sss_nss_idmap.h
@@ -159,4 +159,12 @@ int sss_nss_getlistbycert(const char *cert, char ***fq_name,
  * @param[in] kv_list Key-value list returned by sss_nss_getorigbyname().
  */
 void sss_nss_free_kv(struct sss_nss_kv *kv_list);
+
+enum extra_data_item {
+    EX_DATA_SHORT_NAME = 0,
+    EX_DATA_DOMAIN_NAME,
+    EX_DATA_SHORT_DOMAIN_NAME,
+    EX_DATA_SID_STR,
+    EX_DATA_END
+};
 #endif /* SSS_NSS_IDMAP_H_ */

--- a/src/sss_client/nss_mc.h
+++ b/src/sss_client/nss_mc.h
@@ -76,17 +76,37 @@ errno_t sss_nss_mc_find_rec_by_hash(struct sss_cli_mc_ctx *ctx,
 errno_t sss_nss_mc_getpwnam(const char *name, size_t name_len,
                             struct passwd *result,
                             char *buffer, size_t buflen);
+errno_t sss_nss_mc_getpwnam_with_extra(const char *name, size_t name_len,
+                                       struct passwd *result,
+                                       char *buffer, size_t buflen,
+                                       char **extra_data,
+                                       uint32_t *extra_data_len);
 errno_t sss_nss_mc_getpwuid(uid_t uid,
                             struct passwd *result,
                             char *buffer, size_t buflen);
+errno_t sss_nss_mc_getpwuid_with_extra(uid_t uid,
+                                       struct passwd *result,
+                                       char *buffer, size_t buflen,
+                                       char **extra_data,
+                                       uint32_t *extra_data_len);
 
 /* group db */
 errno_t sss_nss_mc_getgrnam(const char *name, size_t name_len,
                             struct group *result,
                             char *buffer, size_t buflen);
+errno_t sss_nss_mc_getgrnam_with_extra(const char *name, size_t name_len,
+                                       struct group *result,
+                                       char *buffer, size_t buflen,
+                                       char **extra_data,
+                                       uint32_t *extra_data_len);
 errno_t sss_nss_mc_getgrgid(gid_t gid,
                             struct group *result,
                             char *buffer, size_t buflen);
+errno_t sss_nss_mc_getgrgid_with_extra(gid_t gid,
+                                       struct group *result,
+                                       char *buffer, size_t buflen,
+                                       char **extra_data,
+                                       uint32_t *extra_data_len);
 
 /* initgroups db */
 errno_t sss_nss_mc_initgroups_dyn(const char *name, size_t name_len,

--- a/src/sss_client/nss_mc.h
+++ b/src/sss_client/nss_mc.h
@@ -68,6 +68,9 @@ errno_t sss_nss_str_ptr_from_buffer(char **str, void **cookie,
                                     char *buf, size_t len);
 uint32_t sss_nss_mc_next_slot_with_hash(struct sss_mc_rec *rec,
                                         uint32_t hash);
+errno_t sss_nss_mc_find_rec_by_hash(struct sss_cli_mc_ctx *ctx,
+                                           uint32_t hash,
+                                           struct sss_mc_rec **_rec);
 
 /* passwd db */
 errno_t sss_nss_mc_getpwnam(const char *name, size_t name_len,

--- a/src/sss_client/nss_mc_passwd.c
+++ b/src/sss_client/nss_mc_passwd.c
@@ -100,13 +100,16 @@ errno_t sss_nss_mc_getpwnam(const char *name, size_t name_len,
                             char *buffer, size_t buflen)
 {
     struct sss_mc_rec *rec = NULL;
+    struct sss_mc_rec *new_rec = NULL;
     struct sss_mc_pwd_data *data;
+    struct sss_mc_link_data *link_data;
     char *rec_name;
     uint32_t hash;
     uint32_t slot;
     int ret;
     const size_t strs_offset = offsetof(struct sss_mc_pwd_data, strs);
     size_t data_size;
+    bool link = false;
 
     ret = sss_nss_mc_get_ctx("passwd", &pw_mc_ctx);
     if (ret) {
@@ -140,13 +143,33 @@ errno_t sss_nss_mc_getpwnam(const char *name, size_t name_len,
             continue;
         }
 
+        if (rec->type == SSS_MC_REC_TYPE_LINK) {
+            link_data = (struct sss_mc_link_data *) rec->data;
+            rec_name = (char *) link_data + link_data->name;
+            if (strcmp(name, rec_name) != 0) {
+                slot = sss_nss_mc_next_slot_with_hash(rec, hash);
+                continue;
+            }
+
+            ret = sss_nss_mc_find_rec_by_hash(&pw_mc_ctx, link_data->hash,
+                                              &new_rec);
+            if (ret) {
+                goto done;
+            }
+            free(rec);
+            rec = new_rec;
+            link = true;
+        }
+
         data = (struct sss_mc_pwd_data *)rec->data;
         /* Integrity check
+         * - record must be a data record
          * - name_len cannot be longer than all strings
          * - data->name cannot point outside strings
          * - all strings must be within copy of record
          * - size of record must be lower that data table size */
-        if (name_len > data->strs_len
+        if (rec->type != SSS_MC_REC_TYPE_DATA
+            || name_len > data->strs_len
             || (data->name + name_len) > (strs_offset + data->strs_len)
             || data->strs_len > rec->len
             || rec->len > data_size) {
@@ -155,7 +178,7 @@ errno_t sss_nss_mc_getpwnam(const char *name, size_t name_len,
         }
 
         rec_name = (char *)data + data->name;
-        if (strcmp(name, rec_name) == 0) {
+        if (link || strcmp(name, rec_name) == 0) {
             break;
         }
 

--- a/src/util/mmap_cache.h
+++ b/src/util/mmap_cache.h
@@ -37,6 +37,7 @@ typedef uint32_t rel_ptr_t;
 #define MC_ALIGN32(size) ( ((size) + MC_32 -1) & (~(MC_32 -1)) )
 #define MC_ALIGN64(size) ( ((size) + MC_64 -1) & (~(MC_64 -1)) )
 #define MC_HEADER_SIZE MC_ALIGN64(sizeof(struct sss_mc_header))
+#define MC_REC_SIZE MC_ALIGN64(sizeof(struct sss_mc_rec))
 
 #define MC_HT_SIZE(elems) ( (elems) * MC_32 )
 #define MC_HT_ELEMS(size) ( (size) / MC_32 )
@@ -73,7 +74,7 @@ typedef uint32_t rel_ptr_t;
 #define MC_VALID_BARRIER(val) (((val) & 0xff000000) == 0xf0000000)
 
 #define MC_CHECK_RECORD_LENGTH(mc_ctx, rec) \
-        ((rec)->len >= MC_HEADER_SIZE && (rec)->len != MC_INVALID_VAL32 \
+        ((rec)->len >= MC_REC_SIZE && (rec)->len != MC_INVALID_VAL32 \
          && ((rec)->len <= ((mc_ctx)->dt_size \
                             - MC_PTR_DIFF(rec, (mc_ctx)->data_table))))
 

--- a/src/util/mmap_cache.h
+++ b/src/util/mmap_cache.h
@@ -54,13 +54,13 @@ typedef uint32_t rel_ptr_t;
 #define MC_INVALID_VAL MC_INVALID_VAL32
 
 /*
- * 40 seem a good compromise for slot size
- * 4 blocks are enough for the average passwd entry of 42 bytes
- * passwd records have 84 bytes of overhead, 160 - 82 = 78 bytes
- * 3 blocks can contain a very minimal entry, 120 - 82 = 38 bytes
+ * 48 seem a good compromise for slot size
+ * 4 blocks are more than two times the average passwd entry of 42 bytes
+ * passwd records have 84 bytes of overhead, 192 - 82 = 110 bytes
+ * 3 blocks can contain a typical entry, 144 - 82 = 62 bytes
  *
  * 3 blocks are enough for groups w/o users (private user groups)
- * group records have 68 bytes of overhead, 120 - 66 = 54 bytes
+ * group records have 68 bytes of overhead, 144 - 66 = 78 bytes
  */
 #define MC_SLOT_SIZE 40
 #define MC_SIZE_TO_SLOTS(len) (((len) + (MC_SLOT_SIZE - 1)) / MC_SLOT_SIZE)
@@ -79,8 +79,8 @@ typedef uint32_t rel_ptr_t;
                             - MC_PTR_DIFF(rec, (mc_ctx)->data_table))))
 
 
-#define SSS_MC_MAJOR_VNO    1
-#define SSS_MC_MINOR_VNO    1
+#define SSS_MC_MAJOR_VNO    2
+#define SSS_MC_MINOR_VNO    0
 
 #define SSS_MC_HEADER_UNINIT    0   /* after ftruncate or before reset */
 #define SSS_MC_HEADER_ALIVE     1   /* current and in use */
@@ -103,6 +103,13 @@ struct sss_mc_header {
     uint32_t b2;            /* barrier 2 */
 };
 
+#define SSS_MC_REC_TYPE_DATA 0 /* record with the cache data */
+                               /* Would it make sense to use more specific
+                                * data types like SSS_MC_REC_TYPE_PWD_DATA,
+                                * SSS_MC_REC_TYPE_GRP_DATA and
+                                * SSS_MC_REC_TYPE_INITGR_DATA ? */
+#define SSS_MC_REC_TYPE_LINK 1 /* link record for an alias name */
+
 struct sss_mc_rec {
     uint32_t b1;            /* barrier 1 */
     uint32_t len;           /* total record length including record data */
@@ -111,10 +118,14 @@ struct sss_mc_rec {
                             /* next1 is related to hash1 */
     rel_ptr_t next2;        /* ptr of next record rel to data_table */
                             /* next2 is related to hash2 */
+    rel_ptr_t next3;        /* ptr of next record rel to data_table */
+                            /* next3 is related to hash3 */
     uint32_t hash1;         /* val of first hash (usually name of record) */
     uint32_t hash2;         /* val of second hash (usually id of record) */
-    uint32_t padding;       /* padding & reserved for future changes */
-    uint32_t b2;            /* barrier 2 - 32 bytes mark, fits a slot */
+    uint32_t hash3;         /* val of third hash (usually SID of record) */
+    uint32_t type;          /* type of record, SSS_MC_REC_TYPE_DATA or
+                             * SSS_MC_REC_TYPE_LINK */
+    uint32_t b2;            /* barrier 2 - 40 bytes mark, fits a slot */
     char data[0];
 };
 
@@ -148,6 +159,12 @@ struct sss_mc_initgr_data {
     uint32_t gids[0];       /* array of all groups
                              * string with name and unique_name is stored
                              * after gids */
+};
+
+struct sss_mc_link_data {
+    rel_ptr_t name;         /* ptr to name string, rel. to struct base addr */
+    uint32_t hash;          /* name hash of the related data record */
+    char strs[0];           /* zero terminated alias name */
 };
 
 #pragma pack()

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -521,6 +521,11 @@ struct sized_string {
     size_t len;
 };
 
+struct sized_data {
+    const uint8_t *data;
+    size_t len;
+};
+
 void to_sized_string(struct sized_string *out, const char *in);
 
 /* from domain_info.c */


### PR DESCRIPTION
This patchset updates the memory cache by adding some new members to struct
sss_mc_rec. One is the addition of a hash value for SID based lookup which will
be added in later patches.

The other is a new record type and a member indicating the type. The new type
is a link record which links an alias name, e.g. an UPN, to the original record
of the related user or group object.

Besides aliases this link record will be used in case in-sensitive setups. E.g.
if getpwnam() returns the name of an AD users as Administrator@ad.domain bit
some applications or users use administrator@ad.domain for lookups the memory
cache is currently never used because there is no entry with the hash of
'administrator@ad.domain'. With this patch the original data record is created
as before with the hash for 'Administrator@ad.domain' and a link record is
create with the hash of 'administrator@ad.domain'. Now both lookups can be
handled by the memory cache. If now another application uses
ADMINISTRATOR@AD.DOMAIN for lookups the first request will go to the NSS
responder but upcoming requests can use the memory cache as well because a link
record for ADMINISTRATOR@AD.DOMAIN is created.

The last patch in this series adds some additional data to the user and group
lookup requests, the short name, the domain name, the short domain name and the
SID. Those are needed to be able to support SID based lookups in the memory
cache and allow applications to not depend on the name format returned by
getpw{nam|uid}. Upcoming patches for libsss_nss_idmap will make those
additional values available to applications I added them already here to keep
the memory cache related changes in one PR. Application which will benefit here
are the interfaces SSSD provides e.g. to Samba related applications like SSSD's
version of libwbclient but also IPA plugins like extdom and slapi-nis.