### PR TITLE
NSS: Add a way to disable memory cache

### DIFF
--- a/src/conf_macros.m4
+++ b/src/conf_macros.m4
@@ -613,6 +613,7 @@ AC_ARG_ENABLE([all-experimental-features],
                               [build all experimental features])],
               [build_all_experimental_features=$enableval],
               [build_all_experimental_features=no])
+AM_CONDITIONAL([ENABLE_EXPERMINETAL], [test x"$build_all_experimental_features" = xyes])
 
 
 AC_DEFUN([WITH_UNICODE_LIB],

--- a/src/responder/nss/nsssrv_mmap_cache.c
+++ b/src/responder/nss/nsssrv_mmap_cache.c
@@ -1218,6 +1218,10 @@ errno_t sss_mmap_cache_init(TALLOC_CTX *mem_ctx, const char *name,
     int payload;
     int ret, dret;
 
+#ifdef ENABLE_EXPERMINETAL
+    if (timeout == 0) return EOK;
+#endif
+
     switch (type) {
     case SSS_MC_PASSWD:
         payload = SSS_AVG_PASSWD_PAYLOAD;


### PR DESCRIPTION
It is a temporary workaround for case where you hit corner case
when restarting sssd very often and different process open different
different memory cache.

Experimental features are enabled by default in upstream.

Resolves:
https://pagure.io/SSSD/sssd/issue/3496