### PR TITLE
Revert "IPA: Only generate kdcinfo files on clients"

### DIFF
--- a/src/providers/ipa/ipa_common.c
+++ b/src/providers/ipa/ipa_common.c
@@ -736,6 +736,15 @@ int ipa_get_auth_options(struct ipa_options *ipa_opts,
               ipa_opts->auth[KRB5_FAST_PRINCIPAL].opt_name, value);
     }
 
+    /* Set flag that controls whether we want to write the
+     * kdcinfo files at all
+     */
+    ipa_opts->service->krb5_service->write_kdcinfo = \
+        dp_opt_get_bool(ipa_opts->auth, KRB5_USE_KDCINFO);
+    DEBUG(SSSDBG_CONF_SETTINGS, "Option %s set to %s\n",
+          ipa_opts->auth[KRB5_USE_KDCINFO].opt_name,
+          ipa_opts->service->krb5_service->write_kdcinfo ? "true" : "false");
+
     *_opts = ipa_opts->auth;
     ret = EOK;
 

--- a/src/providers/ipa/ipa_init.c
+++ b/src/providers/ipa/ipa_init.c
@@ -405,24 +405,6 @@ static errno_t ipa_init_krb5_auth_ctx(TALLOC_CTX *mem_ctx,
         return ret;
     }
 
-    /* On clients, set flag that controls whether we want to write the
-     * kdcinfo files at all. Never write kdcinfo files on servers as
-     * we always want to talk to 'self' anyway and we've had broken
-     * sssd configurations with _srv_ on the server which wwould point
-     * to other KDCs with PKINIT certs not trusted on this IDM server.
-     */
-    if (server_mode) {
-        DEBUG(SSSDBG_TRACE_FUNC,
-              "Disabling kdcinfo files on IDM server\n");
-        dp_opt_set_bool(ipa_options->auth, KRB5_USE_KDCINFO, false);
-    }
-
-    ipa_options->service->krb5_service->write_kdcinfo = \
-        dp_opt_get_bool(ipa_options->auth, KRB5_USE_KDCINFO);
-    DEBUG(SSSDBG_CONF_SETTINGS, "Option %s set to %s\n",
-          ipa_options->auth[KRB5_USE_KDCINFO].opt_name,
-          ipa_options->service->krb5_service->write_kdcinfo ? "true" : "false");
-
     *_krb5_auth_ctx = krb5_auth_ctx;
     return EOK;
 }


### PR DESCRIPTION
This reverts commit a309525cc47da726461aec1f238165c17aade2a6.

Even though original patch was correct it is better to revert it
becuse otherwise we hit a bug in MIT krb5 when fallback to admin_server
if kpasswd_server is not set does not work.
And it would take some time to propagate krb5 fix to downstream
distributions.

https://bugzilla.redhat.com/show_bug.cgi?id=1498347