### PR TITLE
NSS: Memcache timeout equals zero

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -974,10 +974,16 @@ fallback_homedir = /home/%u
                     <listitem>
                         <para>
                             Specifies time in seconds for which records
-                            in the in-memory cache will be valid.
+                            in the in-memory cache will be valid. Setting this
+                            option to zero will disable the in-memory cache.
                         </para>
                         <para>
                             Default: 300
+                        </para>
+                        <para>
+                            WARNING: Disabling in-memory cache can
+                            have significant negative impact on SSSD's
+                            performance.
                         </para>
                         <para>
                             NOTE: If the environment variable

--- a/src/responder/nss/nsssrv.c
+++ b/src/responder/nss/nsssrv.c
@@ -277,6 +277,12 @@ static int setup_memcaches(struct nss_ctx *nctx)
         return ret;
     }
 
+    if (memcache_timeout == 0) {
+        DEBUG(SSSDBG_TRACE_FUNC,
+              "Fast in-memory cache will not be initialized.");
+        return EOK;
+    }
+
     /* TODO: read cache sizes from configuration */
     ret = sss_mmap_cache_init(nctx, "passwd", SSS_MC_PASSWD,
                               SSS_MC_CACHE_ELEMENTS, (time_t)memcache_timeout,


### PR DESCRIPTION
Hi,
these patches add new semantics to the memcache_timeout=0.
From users perspective there is basically no change, but with value 0 the memcache files are not created.