### PR TITLE
CACHE_REQ: Copy the cr_domain list for each request

### DIFF
--- a/src/responder/common/cache_req/cache_req_domain.c
+++ b/src/responder/common/cache_req/cache_req_domain.c
@@ -47,6 +47,44 @@ cache_req_domain_get_domain_by_name(struct cache_req_domain *domains,
     return ret;
 }
 
+errno_t
+cache_req_domain_copy_cr_domains(TALLOC_CTX *mem_ctx,
+                                 struct cache_req_domain *src,
+                                 struct cache_req_domain **_dest)
+{
+    struct cache_req_domain *cr_domains = NULL;
+    struct cache_req_domain *cr_domain;
+    struct cache_req_domain *iter;
+    errno_t ret;
+
+    if (src == NULL) {
+        return EINVAL;
+    }
+
+    DLIST_FOR_EACH(iter, src) {
+        cr_domain = talloc_zero(mem_ctx, struct cache_req_domain);
+        if (cr_domain == NULL) {
+            ret = ENOMEM;
+            goto done;
+        }
+
+        cr_domain->domain = iter->domain;
+        cr_domain->fqnames = iter->fqnames;
+
+        DLIST_ADD_END(cr_domains, cr_domain, struct cache_req_domain *);
+    }
+
+    *_dest = cr_domains;
+    ret = EOK;
+
+done:
+    if (ret != EOK) {
+        cache_req_domain_list_zfree(&cr_domains);
+    }
+
+    return ret;
+}
+
 void cache_req_domain_list_zfree(struct cache_req_domain **cr_domains)
 {
     struct cache_req_domain *p, *q, *r;

--- a/src/responder/common/cache_req/cache_req_domain.h
+++ b/src/responder/common/cache_req/cache_req_domain.h
@@ -50,6 +50,11 @@ cache_req_domain_new_list_from_domain_resolution_order(
                                         const char *domain_resolution_order,
                                         struct cache_req_domain **_cr_domains);
 
+errno_t
+cache_req_domain_copy_cr_domains(TALLOC_CTX *mem_ctx,
+                                 struct cache_req_domain *src,
+                                 struct cache_req_domain **_dest);
+
 void cache_req_domain_list_zfree(struct cache_req_domain **cr_domains);
 
 


### PR DESCRIPTION
Let's copy the cr_domain list for each request as this list may be
free'd due to a refresh domains request.

This is a cheap solution to avoid the crash but a proper one should be
implemented in the future, which is properly handling new domains being
inserted and existing domains disappearing from the list.

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>