### PR TITLE
sudo: document background activity

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2348,6 +2348,14 @@ pam_account_locked_message = Account locked, please contact help desk.
                                  <manvolnum>5</manvolnum>
                              </citerefentry>.
                         </para>
+                        <para>
+                            <emphasis>NOTE:</emphasis> Sudo rules are
+                            periodically downloaded in the background unless
+                            the sudo provider is explicitly disabled. Set
+                            <emphasis>sudo_provider = None</emphasis> to
+                            disable all sudo-related activity in SSSD if you do
+                            not want to use sudo with SSSD at all.
+                        </para>
                     </listitem>
                 </varlistentry>
                 <varlistentry>


### PR DESCRIPTION
When we introduced socket activation, we changed the internall behaviour.
Previously we disabled sudo if it was not listed in services, with
socket activation we removed this feature. Some users were confused
so this change documents current behaviour.