### PR TITLE
KCM: Fix typo in comments

### DIFF
--- a/src/responder/kcm/kcmsrv_ccache_json.c
+++ b/src/responder/kcm/kcmsrv_ccache_json.c
@@ -265,7 +265,7 @@ static json_t *princ_data_to_json(TALLOC_CTX *mem_ctx,
  *      {
  *          "type": "number",
  *          "realm": "string",
- *          "componenents": [ "elem1", "elem2", ...]
+ *          "components": [ "elem1", "elem2", ...]
  *      }
  */
 static json_t *princ_to_json(TALLOC_CTX *mem_ctx,
@@ -400,7 +400,7 @@ static json_t *creds_to_json_array(struct kcm_cred *creds)
  *      principal : {
  *          "type": "number",
  *          "realm": "string",
- *          "componenents": [ "elem1", "elem2", ...]
+ *          "components": [ "elem1", "elem2", ...]
  *      }
  *      creds : [
  *                  {


### PR DESCRIPTION
Noticed as part of review spelling errors in our documentation.