### PR TITLE
Add parameter --logger do daemons

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -91,7 +91,7 @@ sssdkcmdatadir = $(datadir)/sssd-kcm
 deskprofilepath = $(sss_statedir)/deskprofile
 
 if HAVE_SYSTEMD_UNIT
-ifp_exec_cmd = $(sssdlibexecdir)/sssd_ifp --uid 0 --gid 0 --debug-to-files --dbus-activated
+ifp_exec_cmd = $(sssdlibexecdir)/sssd_ifp --uid 0 --gid 0 --dbus-activated
 ifp_systemdservice = SystemdService=sssd-ifp.service
 ifp_restart = Restart=on-failure
 else
@@ -4483,10 +4483,6 @@ if BUILD_KCM
         src/sysv/systemd/sssd-kcm.service \
         $(NULL)
 endif
-if WITH_JOURNALD
-    systemdconf_DATA += \
-        src/sysv/systemd/journal.conf
-endif
 else
 if HAVE_SUSE
     init_SCRIPTS += \
@@ -4535,7 +4531,6 @@ replace_script = \
 
 EXTRA_DIST += \
     src/sysv/systemd/sssd.service.in \
-    src/sysv/systemd/journal.conf.in \
     src/sysv/systemd/sssd-nss.socket.in \
     src/sysv/systemd/sssd-nss.service.in \
     src/sysv/systemd/sssd-pam.socket.in \
@@ -4582,10 +4577,6 @@ EXTRA_DIST += \
 endif
 
 src/sysv/systemd/sssd.service: src/sysv/systemd/sssd.service.in Makefile
-	@$(MKDIR_P) src/sysv/systemd/
-	$(replace_script)
-
-src/sysv/systemd/journal.conf: src/sysv/systemd/journal.conf.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
 	$(replace_script)
 
@@ -4924,7 +4915,6 @@ endif
 	rm -f $(builddir)/src/sysv/systemd/sssd-secrets.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-kcm.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-kcm.service
-	rm -f $(builddir)/src/sysv/systemd/journal.conf
 	rm -f $(builddir)/src/tools/wrappers/sss_debuglevel
 
 CLEANFILES += *.X */*.X */*/*.X

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -971,10 +971,6 @@ done
 %attr(711,sssd,sssd) %dir %{_sysconfdir}/sssd
 %attr(711,sssd,sssd) %dir %{_sysconfdir}/sssd/conf.d
 %ghost %attr(0600,sssd,sssd) %config(noreplace) %{_sysconfdir}/sssd/sssd.conf
-%if (0%{?use_systemd} == 1)
-%attr(755,root,root) %dir %{_sysconfdir}/systemd/system/sssd.service.d
-%config(noreplace) %{_sysconfdir}/systemd/system/sssd.service.d/journal.conf
-%endif
 %dir %{_sysconfdir}/logrotate.d
 %config(noreplace) %{_sysconfdir}/logrotate.d/sssd
 %dir %{_sysconfdir}/rwtab.d

--- a/src/man/sssd.8.xml
+++ b/src/man/sssd.8.xml
@@ -90,6 +90,10 @@
                         log files are stored in <filename>/var/log/sssd</filename> and
                         there are separate log files for every SSSD service and domain.
                     </para>
+                    <para>
+                        This option is deprecated. It is replaced by
+                        <option>--logger=files</option>.
+                    </para>
                 </listitem>
             </varlistentry>
             <varlistentry>

--- a/src/man/sssd.8.xml
+++ b/src/man/sssd.8.xml
@@ -94,6 +94,37 @@
             </varlistentry>
             <varlistentry>
                 <term>
+                    <option>--logger=</option><replaceable>value</replaceable>
+                </term>
+                <listitem>
+                    <para>
+                        Location where SSSD will send log messages. This option
+                        overrides the value of the deprecated option
+                        <option>--debug-to-files</option>. The deprecated
+                        option will still work if the <option>--logger</option>
+                        is not used.
+                    </para>
+                    <para>
+                        <emphasis>stderr</emphasis>: Redirect debug messages to
+                        standard error output.
+                    </para>
+                    <para>
+                        <emphasis>files</emphasis>: Redirect debug messages to
+                        the log files. By default, the log files are stored in
+                        <filename>/var/log/sssd</filename> and there are
+                        separate log files for every SSSD service and domain.
+                    </para>
+                    <para>
+                        <emphasis>journald</emphasis>: Redirect debug messages
+                        to systemd-journald
+                    </para>
+                    <para>
+                        Default: not set
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term>
                     <option>-D</option>,<option>--daemon</option>
                 </term>
                 <listitem>

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -1211,22 +1211,11 @@ static int get_service_config(struct mt_ctx *ctx, const char *name,
             }
         }
 
-        if (debug_to_file) {
-            svc->command = talloc_strdup_append(
-                svc->command, " --debug-to-files"
-            );
-            if (!svc->command) {
-                talloc_free(svc);
-                return ENOMEM;
-            }
-        } else if (ctx->is_daemon == false) {
-            svc->command = talloc_strdup_append(
-                svc->command, " --debug-to-stderr"
-            );
-            if (!svc->command) {
-                talloc_free(svc);
-                return ENOMEM;
-            }
+        svc->command = talloc_asprintf_append(
+            svc->command, " --logger=%s", sss_logger_str[sss_logger]);
+        if (!svc->command) {
+            talloc_free(svc);
+            return ENOMEM;
         }
     }
 
@@ -1374,22 +1363,11 @@ static int get_provider_config(struct mt_ctx *ctx, const char *name,
             }
         }
 
-        if (debug_to_file) {
-            svc->command = talloc_strdup_append(
-                svc->command, " --debug-to-files"
-            );
-            if (!svc->command) {
-                talloc_free(svc);
-                return ENOMEM;
-            }
-        } else if (ctx->is_daemon == false) {
-            svc->command = talloc_strdup_append(
-                svc->command, " --debug-to-stderr"
-            );
-            if (!svc->command) {
-                talloc_free(svc);
-                return ENOMEM;
-            }
+        svc->command = talloc_asprintf_append(
+            svc->command, " --logger=%s", sss_logger_str[sss_logger]);
+        if (!svc->command) {
+            talloc_free(svc);
+            return ENOMEM;
         }
     }
 
@@ -2454,6 +2432,7 @@ int main(int argc, const char *argv[])
     int opt_version = 0;
     int opt_netlinkoff = 0;
     char *opt_config_file = NULL;
+    char *opt_logger = NULL;
     char *config_file = NULL;
     int flags = 0;
     struct main_context *main_ctx;
@@ -2465,6 +2444,7 @@ int main(int argc, const char *argv[])
     struct poptOption long_options[] = {
         POPT_AUTOHELP
         SSSD_MAIN_OPTS
+        SSSD_LOGGER_OPTS
         {"daemon", 'D', POPT_ARG_NONE, &opt_daemon, 0, \
          _("Become a daemon (default)"), NULL }, \
         {"interactive", 'i', POPT_ARG_NONE, &opt_interactive, 0, \
@@ -2551,6 +2531,8 @@ int main(int argc, const char *argv[])
         debug_to_stderr = 1;
     }
 
+    sss_set_logger(opt_logger);
+
     if (opt_config_file) {
         config_file = talloc_strdup(tmp_ctx, opt_config_file);
     } else {
@@ -2575,7 +2557,7 @@ int main(int argc, const char *argv[])
 
     /* Open before server_setup() does to have logging
      * during configuration checking */
-    if (debug_to_file) {
+    if (sss_logger == FILES_LOGGER) {
         ret = open_debug_file();
         if (ret) {
             return 7;

--- a/src/p11_child/p11_child_nss.c
+++ b/src/p11_child/p11_child_nss.c
@@ -537,6 +537,7 @@ int main(int argc, const char *argv[])
     int opt;
     poptContext pc;
     int debug_fd = -1;
+    char *opt_logger = NULL;
     errno_t ret;
     TALLOC_CTX *main_ctx = NULL;
     char *cert;
@@ -564,6 +565,7 @@ int main(int argc, const char *argv[])
         {"debug-to-stderr", 0, POPT_ARG_NONE | POPT_ARGFLAG_DOC_HIDDEN,
          &debug_to_stderr, 0,
          _("Send the debug output to stderr directly."), NULL },
+        SSSD_LOGGER_OPTS
         {"auth", 0, POPT_ARG_NONE, NULL, 'a', _("Run in auth mode"), NULL},
         {"pre", 0, POPT_ARG_NONE, NULL, 'p', _("Run in pre-auth mode"), NULL},
         {"pin", 0, POPT_ARG_NONE, NULL, 'i', _("Expect PIN on stdin"), NULL},
@@ -672,6 +674,7 @@ int main(int argc, const char *argv[])
             DEBUG(SSSDBG_CRIT_FAILURE, "set_debug_file_from_fd failed.\n");
         }
     }
+    sss_set_logger(opt_logger);
 
     DEBUG(SSSDBG_TRACE_FUNC, "p11_child started.\n");
 

--- a/src/providers/ad/ad_gpo_child.c
+++ b/src/providers/ad/ad_gpo_child.c
@@ -687,6 +687,7 @@ main(int argc, const char *argv[])
     int opt;
     poptContext pc;
     int debug_fd = -1;
+    char *opt_logger = NULL;
     errno_t ret;
     int sysvol_gpt_version;
     int result;
@@ -710,6 +711,7 @@ main(int argc, const char *argv[])
         {"debug-to-stderr", 0, POPT_ARG_NONE | POPT_ARGFLAG_DOC_HIDDEN,
          &debug_to_stderr, 0,
          _("Send the debug output to stderr directly."), NULL },
+        SSSD_LOGGER_OPTS
         POPT_TABLEEND
     };
 
@@ -743,6 +745,8 @@ main(int argc, const char *argv[])
             DEBUG(SSSDBG_CRIT_FAILURE, "set_debug_file_from_fd failed.\n");
         }
     }
+
+    sss_set_logger(opt_logger);
 
     DEBUG(SSSDBG_TRACE_FUNC, "gpo_child started.\n");
 

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -537,6 +537,7 @@ int main(int argc, const char *argv[])
 {
     int opt;
     poptContext pc;
+    char *opt_logger = NULL;
     char *be_domain = NULL;
     char *srv_name = NULL;
     struct main_context *main_ctx;
@@ -548,6 +549,7 @@ int main(int argc, const char *argv[])
     struct poptOption long_options[] = {
         POPT_AUTOHELP
         SSSD_MAIN_OPTS
+        SSSD_LOGGER_OPTS
         SSSD_SERVER_OPTS(uid, gid)
         {"domain", 0, POPT_ARG_STRING, &be_domain, 0,
          _("Domain of the information provider (mandatory)"), NULL },
@@ -581,6 +583,8 @@ int main(int argc, const char *argv[])
     /* set up things like debug , signals, daemonization, etc... */
     debug_log_file = talloc_asprintf(NULL, "sssd_%s", be_domain);
     if (!debug_log_file) return 2;
+
+    sss_set_logger(opt_logger);
 
     srv_name = talloc_asprintf(NULL, "sssd[be[%s]]", be_domain);
     if (!srv_name) return 2;

--- a/src/providers/ipa/selinux_child.c
+++ b/src/providers/ipa/selinux_child.c
@@ -206,6 +206,7 @@ int main(int argc, const char *argv[])
     struct response *resp = NULL;
     ssize_t written;
     bool needs_update;
+    char *opt_logger = NULL;
 
     struct poptOption long_options[] = {
         POPT_AUTOHELP
@@ -220,6 +221,7 @@ int main(int argc, const char *argv[])
         {"debug-to-stderr", 0, POPT_ARG_NONE | POPT_ARGFLAG_DOC_HIDDEN,
          &debug_to_stderr, 0,
          _("Send the debug output to stderr directly."), NULL },
+        SSSD_LOGGER_OPTS
         POPT_TABLEEND
     };
 
@@ -253,6 +255,8 @@ int main(int argc, const char *argv[])
             DEBUG(SSSDBG_CRIT_FAILURE, "set_debug_file_from_fd failed.\n");
         }
     }
+
+    sss_set_logger(opt_logger);
 
     DEBUG(SSSDBG_TRACE_FUNC, "selinux_child started.\n");
     DEBUG(SSSDBG_TRACE_INTERNAL,

--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -3020,6 +3020,7 @@ int main(int argc, const char *argv[])
     int opt;
     poptContext pc;
     int debug_fd = -1;
+    char *opt_logger = NULL;
     errno_t ret;
     krb5_error_code kerr;
     uid_t fast_uid;
@@ -3039,6 +3040,7 @@ int main(int argc, const char *argv[])
         {"debug-to-stderr", 0, POPT_ARG_NONE | POPT_ARGFLAG_DOC_HIDDEN,
          &debug_to_stderr, 0,
          _("Send the debug output to stderr directly."), NULL },
+        SSSD_LOGGER_OPTS
         {CHILD_OPT_FAST_CCACHE_UID, 0, POPT_ARG_INT, &fast_uid, 0,
           _("The user to create FAST ccache as"), NULL},
         {CHILD_OPT_FAST_CCACHE_GID, 0, POPT_ARG_INT, &fast_gid, 0,
@@ -3096,6 +3098,8 @@ int main(int argc, const char *argv[])
             DEBUG(SSSDBG_CRIT_FAILURE, "set_debug_file_from_fd failed.\n");
         }
     }
+
+    sss_set_logger(opt_logger);
 
     DEBUG(SSSDBG_TRACE_FUNC, "krb5_child started.\n");
 

--- a/src/providers/ldap/ldap_child.c
+++ b/src/providers/ldap/ldap_child.c
@@ -599,6 +599,7 @@ int main(int argc, const char *argv[])
     int kerr;
     int opt;
     int debug_fd = -1;
+    char *opt_logger = NULL;
     poptContext pc;
     TALLOC_CTX *main_ctx = NULL;
     uint8_t *buf = NULL;
@@ -622,6 +623,7 @@ int main(int argc, const char *argv[])
          _("An open file descriptor for the debug logs"), NULL},
         {"debug-to-stderr", 0, POPT_ARG_NONE | POPT_ARGFLAG_DOC_HIDDEN, &debug_to_stderr, 0, \
          _("Send the debug output to stderr directly."), NULL }, \
+        SSSD_LOGGER_OPTS
         POPT_TABLEEND
     };
 
@@ -656,6 +658,8 @@ int main(int argc, const char *argv[])
             DEBUG(SSSDBG_CRIT_FAILURE, "set_debug_file_from_fd failed.\n");
         }
     }
+
+    sss_set_logger(opt_logger);
 
     BlockSignals(false, SIGTERM);
     CatchSignal(SIGTERM, sig_term_handler);

--- a/src/providers/proxy/proxy_auth.c
+++ b/src/providers/proxy/proxy_auth.c
@@ -178,9 +178,9 @@ static struct tevent_req *proxy_child_init_send(TALLOC_CTX *mem_ctx,
 
     state->command = talloc_asprintf(req,
             "%s/proxy_child -d %#.4x --debug-timestamps=%d "
-            "--debug-microseconds=%d%s --domain %s --id %d",
+            "--debug-microseconds=%d --logger=%s --domain %s --id %d",
             SSSD_LIBEXEC_PATH, debug_level, debug_timestamps,
-            debug_microseconds, (debug_to_file ? " --debug-to-files" : ""),
+            debug_microseconds, sss_logger_str[sss_logger],
             auth_ctx->be->domain->name,
             child_ctx->id);
     if (state->command == NULL) {

--- a/src/providers/proxy/proxy_child.c
+++ b/src/providers/proxy/proxy_child.c
@@ -504,6 +504,7 @@ int main(int argc, const char *argv[])
 {
     int opt;
     poptContext pc;
+    char *opt_logger = NULL;
     char *domain = NULL;
     char *srv_name = NULL;
     char *conf_entry = NULL;
@@ -517,6 +518,7 @@ int main(int argc, const char *argv[])
     struct poptOption long_options[] = {
         POPT_AUTOHELP
         SSSD_MAIN_OPTS
+        SSSD_LOGGER_OPTS
         SSSD_SERVER_OPTS(uid, gid)
         {"domain", 0, POPT_ARG_STRING, &domain, 0,
          _("Domain of the information provider (mandatory)"), NULL },
@@ -560,6 +562,8 @@ int main(int argc, const char *argv[])
     /* set up things like debug , signals, daemonization, etc... */
     debug_log_file = talloc_asprintf(NULL, "proxy_child_%s", domain);
     if (!debug_log_file) return 2;
+
+    sss_set_logger(opt_logger);
 
     srv_name = talloc_asprintf(NULL, "sssd[proxy_child[%s]]", domain);
     if (!srv_name) return 2;

--- a/src/responder/autofs/autofssrv.c
+++ b/src/responder/autofs/autofssrv.c
@@ -185,6 +185,7 @@ int main(int argc, const char *argv[])
 {
     int opt;
     poptContext pc;
+    char *opt_logger = NULL;
     struct main_context *main_ctx;
     int ret;
     uid_t uid;
@@ -193,6 +194,7 @@ int main(int argc, const char *argv[])
     struct poptOption long_options[] = {
         POPT_AUTOHELP
         SSSD_MAIN_OPTS
+        SSSD_LOGGER_OPTS
         SSSD_SERVER_OPTS(uid, gid)
         SSSD_RESPONDER_OPTS
         POPT_TABLEEND
@@ -220,6 +222,8 @@ int main(int argc, const char *argv[])
 
     /* set up things like debug, signals, daemonization, etc... */
     debug_log_file = "sssd_autofs";
+
+    sss_set_logger(opt_logger);
 
     ret = server_setup("sssd[autofs]", 0, uid, gid,
                        CONFDB_AUTOFS_CONF_ENTRY, &main_ctx);

--- a/src/responder/ifp/ifpsrv.c
+++ b/src/responder/ifp/ifpsrv.c
@@ -355,6 +355,7 @@ int main(int argc, const char *argv[])
 {
     int opt;
     poptContext pc;
+    char *opt_logger = NULL;
     struct main_context *main_ctx;
     int ret;
     uid_t uid;
@@ -363,6 +364,7 @@ int main(int argc, const char *argv[])
     struct poptOption long_options[] = {
         POPT_AUTOHELP
         SSSD_MAIN_OPTS
+        SSSD_LOGGER_OPTS
         SSSD_SERVER_OPTS(uid, gid)
         SSSD_RESPONDER_OPTS
         POPT_TABLEEND
@@ -390,6 +392,8 @@ int main(int argc, const char *argv[])
 
     /* set up things like debug, signals, daemonization, etc... */
     debug_log_file = "sssd_ifp";
+
+    sss_set_logger(opt_logger);
 
     ret = server_setup("sssd[ifp]", 0, 0, 0,
                        CONFDB_IFP_CONF_ENTRY, &main_ctx);

--- a/src/responder/kcm/kcm.c
+++ b/src/responder/kcm/kcm.c
@@ -258,6 +258,7 @@ int main(int argc, const char *argv[])
 {
     int opt;
     poptContext pc;
+    char *opt_logger = NULL;
     struct main_context *main_ctx;
     int ret;
     uid_t uid;
@@ -266,6 +267,7 @@ int main(int argc, const char *argv[])
     struct poptOption long_options[] = {
         POPT_AUTOHELP
         SSSD_MAIN_OPTS
+        SSSD_LOGGER_OPTS
         SSSD_SERVER_OPTS(uid, gid)
         POPT_TABLEEND
     };
@@ -292,6 +294,8 @@ int main(int argc, const char *argv[])
 
     /* set up things like debug, signals, daemonization, etc... */
     debug_log_file = "sssd_kcm";
+
+    sss_set_logger(opt_logger);
 
     ret = server_setup("sssd[kcm]", 0, uid, gid, CONFDB_KCM_CONF_ENTRY,
                        &main_ctx);

--- a/src/responder/nss/nsssrv.c
+++ b/src/responder/nss/nsssrv.c
@@ -422,6 +422,7 @@ int main(int argc, const char *argv[])
 {
     int opt;
     poptContext pc;
+    char *opt_logger = NULL;
     struct main_context *main_ctx;
     int ret;
     uid_t uid;
@@ -430,6 +431,7 @@ int main(int argc, const char *argv[])
     struct poptOption long_options[] = {
         POPT_AUTOHELP
         SSSD_MAIN_OPTS
+        SSSD_LOGGER_OPTS
         SSSD_SERVER_OPTS(uid, gid)
         SSSD_RESPONDER_OPTS
         POPT_TABLEEND
@@ -457,6 +459,8 @@ int main(int argc, const char *argv[])
 
     /* set up things like debug, signals, daemonization, etc... */
     debug_log_file = "sssd_nss";
+
+    sss_set_logger(opt_logger);
 
     ret = server_setup("sssd[nss]", 0, uid, gid, CONFDB_NSS_CONF_ENTRY,
                        &main_ctx);

--- a/src/responder/pac/pacsrv.c
+++ b/src/responder/pac/pacsrv.c
@@ -209,6 +209,7 @@ int main(int argc, const char *argv[])
 {
     int opt;
     poptContext pc;
+    char *opt_logger = NULL;
     struct main_context *main_ctx;
     int ret;
     uid_t uid;
@@ -217,6 +218,7 @@ int main(int argc, const char *argv[])
     struct poptOption long_options[] = {
         POPT_AUTOHELP
         SSSD_MAIN_OPTS
+        SSSD_LOGGER_OPTS
         SSSD_SERVER_OPTS(uid, gid)
         SSSD_RESPONDER_OPTS
         POPT_TABLEEND
@@ -244,6 +246,8 @@ int main(int argc, const char *argv[])
 
     /* set up things like debug, signals, daemonization, etc... */
     debug_log_file = "sssd_pac";
+
+    sss_set_logger(opt_logger);
 
     ret = server_setup("sssd[pac]", 0, uid, gid,
                        CONFDB_PAC_CONF_ENTRY, &main_ctx);

--- a/src/responder/pam/pamsrv.c
+++ b/src/responder/pam/pamsrv.c
@@ -355,6 +355,7 @@ int main(int argc, const char *argv[])
 {
     int opt;
     poptContext pc;
+    char *opt_logger = NULL;
     struct main_context *main_ctx;
     int ret;
     uid_t uid;
@@ -365,6 +366,7 @@ int main(int argc, const char *argv[])
     struct poptOption long_options[] = {
         POPT_AUTOHELP
         SSSD_MAIN_OPTS
+        SSSD_LOGGER_OPTS
         SSSD_SERVER_OPTS(uid, gid)
         SSSD_RESPONDER_OPTS
         POPT_TABLEEND
@@ -392,6 +394,8 @@ int main(int argc, const char *argv[])
 
     /* set up things like debug, signals, daemonization, etc... */
     debug_log_file = "sssd_pam";
+
+    sss_set_logger(opt_logger);
 
     if (!is_socket_activated()) {
         /* Crate pipe file descriptors here before privileges are dropped

--- a/src/responder/secrets/secsrv.c
+++ b/src/responder/secrets/secsrv.c
@@ -324,6 +324,7 @@ int main(int argc, const char *argv[])
 {
     int opt;
     poptContext pc;
+    char *opt_logger = NULL;
     struct main_context *main_ctx;
     int ret;
     uid_t uid;
@@ -332,6 +333,7 @@ int main(int argc, const char *argv[])
     struct poptOption long_options[] = {
         POPT_AUTOHELP
         SSSD_MAIN_OPTS
+        SSSD_LOGGER_OPTS
         SSSD_SERVER_OPTS(uid, gid)
         POPT_TABLEEND
     };
@@ -358,6 +360,8 @@ int main(int argc, const char *argv[])
 
     /* set up things like debug, signals, daemonization, etc... */
     debug_log_file = "sssd_secrets";
+
+    sss_set_logger(opt_logger);
 
     ret = server_setup("sssd[secrets]", 0, uid, gid, CONFDB_SEC_CONF_ENTRY,
                        &main_ctx);

--- a/src/responder/ssh/sshsrv.c
+++ b/src/responder/ssh/sshsrv.c
@@ -177,6 +177,7 @@ int main(int argc, const char *argv[])
 {
     int opt;
     poptContext pc;
+    char *opt_logger = NULL;
     struct main_context *main_ctx;
     int ret;
     uid_t uid;
@@ -185,6 +186,7 @@ int main(int argc, const char *argv[])
     struct poptOption long_options[] = {
         POPT_AUTOHELP
         SSSD_MAIN_OPTS
+        SSSD_LOGGER_OPTS
         SSSD_SERVER_OPTS(uid, gid)
         SSSD_RESPONDER_OPTS
         POPT_TABLEEND
@@ -212,6 +214,8 @@ int main(int argc, const char *argv[])
 
     /* set up things like debug, signals, daemonization, etc... */
     debug_log_file = "sssd_ssh";
+
+    sss_set_logger(opt_logger);
 
     ret = server_setup("sssd[ssh]", 0, uid, gid,
                        CONFDB_SSH_CONF_ENTRY, &main_ctx);

--- a/src/responder/sudo/sudosrv.c
+++ b/src/responder/sudo/sudosrv.c
@@ -178,6 +178,7 @@ int main(int argc, const char *argv[])
 {
     int opt;
     poptContext pc;
+    char *opt_logger = NULL;
     struct main_context *main_ctx;
     int ret;
     uid_t uid;
@@ -186,6 +187,7 @@ int main(int argc, const char *argv[])
     struct poptOption long_options[] = {
         POPT_AUTOHELP
         SSSD_MAIN_OPTS
+        SSSD_LOGGER_OPTS
         SSSD_SERVER_OPTS(uid, gid)
         SSSD_RESPONDER_OPTS
         POPT_TABLEEND
@@ -213,6 +215,8 @@ int main(int argc, const char *argv[])
 
     /* set up things like debug, signals, daemonization, etc... */
     debug_log_file = "sssd_sudo";
+
+    sss_set_logger(opt_logger);
 
     ret = server_setup("sssd[sudo]", 0, uid, gid, CONFDB_SUDO_CONF_ENTRY,
                        &main_ctx);

--- a/src/sysv/systemd/journal.conf.in
+++ b/src/sysv/systemd/journal.conf.in
@@ -1,7 +1,0 @@
-[Service]
-# Uncomment *both* of the following lines to enable debug logging
-# to go to journald instead of /var/log/sssd. You will need to
-# run 'systemctl daemon-reload' and then restart the SSSD service
-# for this to take effect
-#ExecStart=
-#ExecStart=@sbindir@/sssd -i

--- a/src/sysv/systemd/sssd-autofs.service.in
+++ b/src/sysv/systemd/sssd-autofs.service.in
@@ -9,8 +9,9 @@ RefuseManualStart=true
 Also=sssd-autofs.socket
 
 [Service]
+Environment=DEBUG_LOGGER=--logger=files
 ExecStartPre=-/bin/chown @SSSD_USER@:@SSSD_USER@ @logpath@/sssd_autofs.log
-ExecStart=@libexecdir@/sssd/sssd_autofs --debug-to-files --socket-activated
+ExecStart=@libexecdir@/sssd/sssd_autofs ${DEBUG_LOGGER} --socket-activated
 Restart=on-failure
 User=@SSSD_USER@
 Group=@SSSD_USER@

--- a/src/sysv/systemd/sssd-autofs.service.in
+++ b/src/sysv/systemd/sssd-autofs.service.in
@@ -10,6 +10,7 @@ Also=sssd-autofs.socket
 
 [Service]
 Environment=DEBUG_LOGGER=--logger=files
+EnvironmentFile=-@environment_file@
 ExecStartPre=-/bin/chown @SSSD_USER@:@SSSD_USER@ @logpath@/sssd_autofs.log
 ExecStart=@libexecdir@/sssd/sssd_autofs ${DEBUG_LOGGER} --socket-activated
 Restart=on-failure

--- a/src/sysv/systemd/sssd-ifp.service.in
+++ b/src/sysv/systemd/sssd-ifp.service.in
@@ -5,7 +5,8 @@ After=sssd.service
 BindsTo=sssd.service
 
 [Service]
+Environment=DEBUG_LOGGER=--logger=files
 Type=dbus
 BusName=org.freedesktop.sssd.infopipe
-ExecStart=@ifp_exec_cmd@
+ExecStart=@ifp_exec_cmd@ ${DEBUG_LOGGER}
 @ifp_restart@

--- a/src/sysv/systemd/sssd-ifp.service.in
+++ b/src/sysv/systemd/sssd-ifp.service.in
@@ -6,6 +6,7 @@ BindsTo=sssd.service
 
 [Service]
 Environment=DEBUG_LOGGER=--logger=files
+EnvironmentFile=-@environment_file@
 Type=dbus
 BusName=org.freedesktop.sssd.infopipe
 ExecStart=@ifp_exec_cmd@ ${DEBUG_LOGGER}

--- a/src/sysv/systemd/sssd-kcm.service.in
+++ b/src/sysv/systemd/sssd-kcm.service.in
@@ -6,4 +6,5 @@ Documentation=man:sssd-kcm(5)
 Also=sssd-kcm.socket
 
 [Service]
-ExecStart=@libexecdir@/sssd/sssd_kcm --uid 0 --gid 0 --debug-to-files
+Environment=DEBUG_LOGGER=--logger=files
+ExecStart=@libexecdir@/sssd/sssd_kcm --uid 0 --gid 0 ${DEBUG_LOGGER}

--- a/src/sysv/systemd/sssd-nss.service.in
+++ b/src/sysv/systemd/sssd-nss.service.in
@@ -9,5 +9,6 @@ RefuseManualStart=true
 Also=sssd-nss.socket
 
 [Service]
-ExecStart=@libexecdir@/sssd/sssd_nss --debug-to-files --socket-activated
+Environment=DEBUG_LOGGER=--logger=files
+ExecStart=@libexecdir@/sssd/sssd_nss ${DEBUG_LOGGER} --socket-activated
 Restart=on-failure

--- a/src/sysv/systemd/sssd-nss.service.in
+++ b/src/sysv/systemd/sssd-nss.service.in
@@ -10,5 +10,6 @@ Also=sssd-nss.socket
 
 [Service]
 Environment=DEBUG_LOGGER=--logger=files
+EnvironmentFile=-@environment_file@
 ExecStart=@libexecdir@/sssd/sssd_nss ${DEBUG_LOGGER} --socket-activated
 Restart=on-failure

--- a/src/sysv/systemd/sssd-pac.service.in
+++ b/src/sysv/systemd/sssd-pac.service.in
@@ -10,6 +10,7 @@ Also=sssd-pac.socket
 
 [Service]
 Environment=DEBUG_LOGGER=--logger=files
+EnvironmentFile=-@environment_file@
 ExecStartPre=-/bin/chown @SSSD_USER@:@SSSD_USER@ @logpath@/sssd_pac.log
 ExecStart=@libexecdir@/sssd/sssd_pac ${DEBUG_LOGGER} --socket-activated
 Restart=on-failure

--- a/src/sysv/systemd/sssd-pac.service.in
+++ b/src/sysv/systemd/sssd-pac.service.in
@@ -9,8 +9,9 @@ RefuseManualStart=true
 Also=sssd-pac.socket
 
 [Service]
+Environment=DEBUG_LOGGER=--logger=files
 ExecStartPre=-/bin/chown @SSSD_USER@:@SSSD_USER@ @logpath@/sssd_pac.log
-ExecStart=@libexecdir@/sssd/sssd_pac --debug-to-files --socket-activated
+ExecStart=@libexecdir@/sssd/sssd_pac ${DEBUG_LOGGER} --socket-activated
 Restart=on-failure
 User=@SSSD_USER@
 Group=@SSSD_USER@

--- a/src/sysv/systemd/sssd-pam.service.in
+++ b/src/sysv/systemd/sssd-pam.service.in
@@ -9,8 +9,9 @@ RefuseManualStart=true
 Also=sssd-pam.socket sssd-pam-priv.socket
 
 [Service]
+Environment=DEBUG_LOGGER=--logger=files
 ExecStartPre=-/bin/chown @SSSD_USER@:@SSSD_USER@ @logpath@/sssd_pam.log
-ExecStart=@libexecdir@/sssd/sssd_pam --debug-to-files --socket-activated
+ExecStart=@libexecdir@/sssd/sssd_pam ${DEBUG_LOGGER} --socket-activated
 Restart=on-failure
 User=@SSSD_USER@
 Group=@SSSD_USER@

--- a/src/sysv/systemd/sssd-pam.service.in
+++ b/src/sysv/systemd/sssd-pam.service.in
@@ -10,6 +10,7 @@ Also=sssd-pam.socket sssd-pam-priv.socket
 
 [Service]
 Environment=DEBUG_LOGGER=--logger=files
+EnvironmentFile=-@environment_file@
 ExecStartPre=-/bin/chown @SSSD_USER@:@SSSD_USER@ @logpath@/sssd_pam.log
 ExecStart=@libexecdir@/sssd/sssd_pam ${DEBUG_LOGGER} --socket-activated
 Restart=on-failure

--- a/src/sysv/systemd/sssd-secrets.service.in
+++ b/src/sysv/systemd/sssd-secrets.service.in
@@ -6,4 +6,5 @@ Documentation=man:sssd-secrets(5)
 Also=sssd-secrets.socket
 
 [Service]
-ExecStart=@libexecdir@/sssd/sssd_secrets --uid 0 --gid 0 --debug-to-files
+Environment=DEBUG_LOGGER=--logger=files
+ExecStart=@libexecdir@/sssd/sssd_secrets --uid 0 --gid 0 ${DEBUG_LOGGER}

--- a/src/sysv/systemd/sssd-ssh.service.in
+++ b/src/sysv/systemd/sssd-ssh.service.in
@@ -10,6 +10,7 @@ Also=sssd-ssh.socket
 
 [Service]
 Environment=DEBUG_LOGGER=--logger=files
+EnvironmentFile=-@environment_file@
 ExecStartPre=-/bin/chown @SSSD_USER@:@SSSD_USER@ @logpath@/sssd_ssh.log
 ExecStart=@libexecdir@/sssd/sssd_ssh ${DEBUG_LOGGER} --socket-activated
 Restart=on-failure

--- a/src/sysv/systemd/sssd-ssh.service.in
+++ b/src/sysv/systemd/sssd-ssh.service.in
@@ -9,8 +9,9 @@ RefuseManualStart=true
 Also=sssd-ssh.socket
 
 [Service]
+Environment=DEBUG_LOGGER=--logger=files
 ExecStartPre=-/bin/chown @SSSD_USER@:@SSSD_USER@ @logpath@/sssd_ssh.log
-ExecStart=@libexecdir@/sssd/sssd_ssh --debug-to-files --socket-activated
+ExecStart=@libexecdir@/sssd/sssd_ssh ${DEBUG_LOGGER} --socket-activated
 Restart=on-failure
 User=@SSSD_USER@
 Group=@SSSD_USER@

--- a/src/sysv/systemd/sssd-sudo.service.in
+++ b/src/sysv/systemd/sssd-sudo.service.in
@@ -9,8 +9,9 @@ RefuseManualStart=true
 Also=sssd-sudo.socket
 
 [Service]
+Environment=DEBUG_LOGGER=--logger=files
 ExecStartPre=-/bin/chown @SSSD_USER@:@SSSD_USER@ @logpath@/sssd_sudo.log
-ExecStart=@libexecdir@/sssd/sssd_sudo --debug-to-files --socket-activated
+ExecStart=@libexecdir@/sssd/sssd_sudo --socket-activated
 Restart=on-failure
 User=@SSSD_USER@
 Group=@SSSD_USER@

--- a/src/sysv/systemd/sssd-sudo.service.in
+++ b/src/sysv/systemd/sssd-sudo.service.in
@@ -10,6 +10,7 @@ Also=sssd-sudo.socket
 
 [Service]
 Environment=DEBUG_LOGGER=--logger=files
+EnvironmentFile=-@environment_file@
 ExecStartPre=-/bin/chown @SSSD_USER@:@SSSD_USER@ @logpath@/sssd_sudo.log
 ExecStart=@libexecdir@/sssd/sssd_sudo --socket-activated
 Restart=on-failure

--- a/src/sysv/systemd/sssd.service.in
+++ b/src/sysv/systemd/sssd.service.in
@@ -5,8 +5,9 @@ Before=systemd-user-sessions.service nss-user-lookup.target
 Wants=nss-user-lookup.target
 
 [Service]
+Environment=DEBUG_LOGGER=--logger=files
 EnvironmentFile=-@environment_file@
-ExecStart=@sbindir@/sssd -i -f
+ExecStart=@sbindir@/sssd -i ${DEBUG_LOGGER}
 Type=notify
 NotifyAccess=main
 

--- a/src/tests/cmocka/dummy_child.c
+++ b/src/tests/cmocka/dummy_child.c
@@ -34,6 +34,7 @@ int main(int argc, const char *argv[])
 {
     int opt;
     int debug_fd = -1;
+    char *opt_logger = NULL;
     poptContext pc;
     ssize_t len;
     ssize_t written;
@@ -55,6 +56,7 @@ int main(int argc, const char *argv[])
          _("An open file descriptor for the debug logs"), NULL},
         {"debug-to-stderr", 0, POPT_ARG_NONE | POPT_ARGFLAG_DOC_HIDDEN, &debug_to_stderr, 0, \
          _("Send the debug output to stderr directly."), NULL },
+        SSSD_LOGGER_OPTS
         {"guitar", 0, POPT_ARG_STRING, &guitar, 0, _("Who plays guitar"), NULL },
         {"drums", 0, POPT_ARG_STRING, &drums, 0, _("Who plays drums"), NULL },
         POPT_TABLEEND
@@ -75,6 +77,8 @@ int main(int argc, const char *argv[])
         }
     }
     poptFreeContext(pc);
+
+    sss_set_logger(opt_logger);
 
     action = getenv("TEST_CHILD_ACTION");
     if (action) {

--- a/src/tests/debug-tests.c
+++ b/src/tests/debug-tests.c
@@ -343,6 +343,7 @@ START_TEST(test_debug_is_set_single_no_timestamp)
     debug_microseconds = 0;
     debug_to_file = 1;
     debug_prg_name = "sssd";
+    sss_set_logger(sss_logger_str[FILES_LOGGER]);
 
     for (i = 0; i <= 9; i++) {
         debug_level = levels[i];
@@ -385,6 +386,8 @@ START_TEST(test_debug_is_set_single_timestamp)
     debug_microseconds = 0;
     debug_to_file = 1;
     debug_prg_name = "sssd";
+    sss_set_logger(sss_logger_str[FILES_LOGGER]);
+
 
     for (i = 0; i <= 9; i++) {
         debug_level = levels[i];
@@ -432,6 +435,8 @@ START_TEST(test_debug_is_set_single_timestamp_microseconds)
     debug_microseconds = 1;
     debug_to_file = 1;
     debug_prg_name = "sssd";
+    sss_set_logger(sss_logger_str[FILES_LOGGER]);
+
 
     for (i = 0; i <= 9; i++) {
         debug_level = levels[i];
@@ -480,6 +485,8 @@ START_TEST(test_debug_is_notset_no_timestamp)
     debug_microseconds = 0;
     debug_to_file = 1;
     debug_prg_name = "sssd";
+    sss_set_logger(sss_logger_str[FILES_LOGGER]);
+
 
     for (i = 0; i <= 9; i++) {
         debug_level = all_set & ~levels[i];
@@ -525,6 +532,8 @@ START_TEST(test_debug_is_notset_timestamp)
     debug_microseconds = 0;
     debug_to_file = 1;
     debug_prg_name = "sssd";
+    sss_set_logger(sss_logger_str[FILES_LOGGER]);
+
 
     for (i = 0; i <= 9; i++) {
         debug_level = all_set & ~levels[i];
@@ -570,6 +579,7 @@ START_TEST(test_debug_is_notset_timestamp_microseconds)
     debug_microseconds = 1;
     debug_to_file = 1;
     debug_prg_name = "sssd";
+    sss_set_logger(sss_logger_str[FILES_LOGGER]);
 
     for (i = 0; i <= 9; i++) {
         debug_level = all_set & ~levels[i];

--- a/src/util/child_common.c
+++ b/src/util/child_common.c
@@ -676,7 +676,7 @@ static errno_t prepare_child_argv(TALLOC_CTX *mem_ctx,
         }
 
         if (child_debug_stderr) {
-            argv[--argc] = talloc_strdup(argv, "--debug-to-stderr");
+            argv[--argc] = talloc_strdup(argv, "--logger=stderr");
             if (argv[argc] == NULL) {
                 ret = ENOMEM;
                 goto fail;

--- a/src/util/debug.c
+++ b/src/util/debug.c
@@ -277,7 +277,7 @@ void sss_vdebug_fn(const char *file,
     errno_t ret;
     va_list ap_fallback;
 
-    if (!debug_file && !debug_to_stderr) {
+    if (sss_logger == JOURNALD_LOGGER) {
         /* If we are not outputting logs to files, we should be sending them
          * to journald.
          * NOTE: on modern systems, this is where stdout/stderr will end up
@@ -470,7 +470,7 @@ int rotate_debug_files(void)
     int ret;
     errno_t error;
 
-    if (!debug_to_file) return EOK;
+    if (sss_logger != FILES_LOGGER) return EOK;
 
     do {
         error = 0;

--- a/src/util/debug.h
+++ b/src/util/debug.h
@@ -101,7 +101,7 @@ int get_fd_from_debug_file(void);
 #define SSSD_DEBUG_OPTS \
         {"debug-level", 'd', POPT_ARG_INT, &debug_level, 0, \
          _("Debug level"), NULL}, \
-        {"debug-to-files", 'f', POPT_ARG_NONE, &debug_to_file, 0, \
+        {"debug-to-files", 'f', POPT_ARG_NONE | POPT_ARGFLAG_DOC_HIDDEN, &debug_to_file, 0, \
          _("Send the debug output to files instead of stderr"), NULL }, \
         {"debug-to-stderr", 0, POPT_ARG_NONE | POPT_ARGFLAG_DOC_HIDDEN, &debug_to_stderr, 0, \
          _("Send the debug output to stderr directly."), NULL }, \

--- a/src/util/debug.h
+++ b/src/util/debug.h
@@ -31,13 +31,26 @@
 
 #define APPEND_LINE_FEED 0x1
 
+enum sss_logger_t {
+    STDERR_LOGGER = 0,
+    FILES_LOGGER,
+#ifdef WITH_JOURNALD
+    JOURNALD_LOGGER,
+#endif
+};
+
+extern const char *sss_logger_str[];
 extern const char *debug_prg_name;
 extern int debug_level;
 extern int debug_timestamps;
 extern int debug_microseconds;
 extern int debug_to_file;
 extern int debug_to_stderr;
+extern enum sss_logger_t sss_logger;
 extern const char *debug_log_file;
+
+void sss_set_logger(const char *logger);
+
 void sss_vdebug_fn(const char *file,
                    long line,
                    const char *function,
@@ -79,6 +92,11 @@ int get_fd_from_debug_file(void);
 
 #define SSSDBG_MICROSECONDS_UNRESOLVED   -1
 #define SSSDBG_MICROSECONDS_DEFAULT       0
+
+#define SSSD_LOGGER_OPTS \
+        {"logger", '\0', POPT_ARG_STRING, &opt_logger, 0, \
+         _("Set logger"), "stderr|files|journald"},
+
 
 #define SSSD_DEBUG_OPTS \
         {"debug-level", 'd', POPT_ARG_INT, &debug_level, 0, \


### PR DESCRIPTION
Different binary handled information about logging differently
e,g, --debug-to-files --debug-to-stderr
And logging to journald was a special case of previous options
`(!debug_file && !debug_to_stderr)`. It was also tight to monitor option
"--daemon" and therefore loggind to stderr was used in interactive mode + systemd Type=notify.
    
Resolves:
https://pagure.io/SSSD/sssd/issue/3433