### PR TITLE
nss-idmap: add nss like calls with timeout and flags

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3623,6 +3623,7 @@ libnss_sss_la_SOURCES = \
     src/sss_client/nss_services.c \
     src/sss_client/sss_cli.h \
     src/sss_client/nss_compat.h \
+    src/sss_client/nss_common.h \
     src/sss_client/nss_mc_common.c \
     src/util/io.c \
     src/util/murmurhash3.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -1159,13 +1159,28 @@ pkgconfig_DATA += src/sss_client/idmap/sss_nss_idmap.pc
 libsss_nss_idmap_la_DEPENDENCIES = src/sss_client/idmap/sss_nss_idmap.exports
 libsss_nss_idmap_la_SOURCES = \
     src/sss_client/idmap/sss_nss_idmap.c \
+    src/sss_client/idmap/sss_nss_ex.c \
+    src/sss_client/idmap/sss_nss_idmap_private.h \
     src/sss_client/common.c \
-    src/util/strtonum.c
+    src/sss_client/idmap/common_ex.c \
+    src/sss_client/nss_mc_passwd.c \
+    src/sss_client/nss_passwd.c \
+    src/sss_client/nss_mc_group.c \
+    src/sss_client/nss_group.c \
+    src/sss_client/nss_mc_initgr.c \
+    src/sss_client/nss_mc_common.c \
+    src/util/strtonum.c \
+    src/util/murmurhash3.c \
+    src/util/io.c \
+    $(NULL)
 libsss_nss_idmap_la_LIBADD = \
-    $(CLIENT_LIBS)
+    $(LIBCLOCK_GETTIME) \
+    $(CLIENT_LIBS) \
+    -lpthread \
+    $(NULL)
 libsss_nss_idmap_la_LDFLAGS = \
     -Wl,--version-script,$(srcdir)/src/sss_client/idmap/sss_nss_idmap.exports \
-    -version-info 3:0:3
+    -version-info 4:0:4
 
 dist_noinst_DATA += src/sss_client/idmap/sss_nss_idmap.exports
 
@@ -3624,6 +3639,7 @@ libnss_sss_la_SOURCES = \
     src/sss_client/sss_cli.h \
     src/sss_client/nss_compat.h \
     src/sss_client/nss_common.h \
+    src/sss_client/common_private.h \
     src/sss_client/nss_mc_common.c \
     src/util/io.c \
     src/util/murmurhash3.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -2974,7 +2974,6 @@ test_sysdb_domain_resolution_order_LDADD = \
 
 test_wbc_calls_SOURCES = \
     src/tests/cmocka/test_wbc_calls.c \
-    src/sss_client/idmap/sss_nss_idmap.c \
     src/sss_client/libwbclient/wbc_sid_sssd.c \
     src/sss_client/libwbclient/wbclient_common.c \
     src/sss_client/libwbclient/wbc_sid_common.c \
@@ -2993,6 +2992,7 @@ test_wbc_calls_LDADD = \
     $(TALLOC_LIBS) \
     $(SSSD_INTERNAL_LTLIBS) \
     libsss_test_common.la \
+    libsss_nss_idmap.la \
     $(NULL)
 
 test_be_ptask_SOURCES = \

--- a/configure.ac
+++ b/configure.ac
@@ -75,6 +75,19 @@ AC_SEARCH_LIBS([timer_create], [rt posix4],
 AC_SUBST([LIBADD_TIMER])
 LIBS=$SAVE_LIBS
 
+# Check library for the clock_gettime function
+SAVE_LIBS=$LIBS
+LIBS=
+LIBCLOCK_GETTIME=
+AC_SEARCH_LIBS([clock_gettime], [rt posix4],
+    [AC_DEFINE([HAVE_LIBRT], [1],
+         [Define if you have the librt library or equivalent.])
+     LIBCLOCK_GETTIME="$LIBS"],
+    [AC_MSG_ERROR([unable to find library for the clock_gettime() function])])
+
+AC_SUBST([LIBCLOCK_GETTIME])
+LIBS=$SAVE_LIBS
+
 # Check for presence of modern functions for setting file timestamps
 AC_CHECK_FUNCS([ utimensat \
                  futimens ])

--- a/src/responder/common/cache_req/cache_req.h
+++ b/src/responder/common/cache_req/cache_req.h
@@ -127,6 +127,9 @@ void
 cache_req_data_set_bypass_cache(struct cache_req_data *data,
                                 bool bypass_cache);
 
+void
+cache_req_data_set_bypass_dp(struct cache_req_data *data,
+                             bool bypass_dp);
 /* Output data. */
 
 struct cache_req_result {

--- a/src/responder/common/cache_req/cache_req_data.c
+++ b/src/responder/common/cache_req/cache_req_data.c
@@ -365,3 +365,15 @@ cache_req_data_set_bypass_cache(struct cache_req_data *data,
 
     data->bypass_cache = bypass_cache;
 }
+
+void
+cache_req_data_set_bypass_dp(struct cache_req_data *data,
+                             bool bypass_dp)
+{
+    if (data == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "cache_req_data should never be NULL\n");
+        return;
+    }
+
+    data->bypass_dp = bypass_dp;
+}

--- a/src/responder/common/cache_req/cache_req_private.h
+++ b/src/responder/common/cache_req/cache_req_private.h
@@ -42,6 +42,7 @@ struct cache_req {
     struct sss_domain_info *domain;
     bool cache_first;
     bool bypass_cache;
+    bool bypass_dp;
     /* Only contact domains with this type */
     enum cache_req_dom_type req_dom_type;
 
@@ -90,6 +91,7 @@ struct cache_req_data {
     } svc;
 
     bool bypass_cache;
+    bool bypass_dp;
 };
 
 struct tevent_req *

--- a/src/responder/nss/nss_cmd.c
+++ b/src/responder/nss/nss_cmd.c
@@ -92,6 +92,10 @@ static errno_t nss_getby_name(struct cli_ctx *cli_ctx,
         goto done;
     }
 
+    if ((flags & SSS_NSS_EX_FLAG_NO_CACHE) != 0) {
+        cache_req_data_set_bypass_cache(data, true);
+    }
+
     subreq = nss_get_object_send(cmd_ctx, cli_ctx->ev, cli_ctx,
                                  data, memcache, rawname, 0);
     if (subreq == NULL) {
@@ -150,6 +154,10 @@ static errno_t nss_getby_id(struct cli_ctx *cli_ctx,
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to set cache request data!\n");
         ret = ENOMEM;
         goto done;
+    }
+
+    if ((flags & SSS_NSS_EX_FLAG_NO_CACHE) != 0) {
+        cache_req_data_set_bypass_cache(data, true);
     }
 
     subreq = nss_get_object_send(cmd_ctx, cli_ctx->ev, cli_ctx,

--- a/src/responder/nss/nss_get_object.c
+++ b/src/responder/nss/nss_get_object.c
@@ -86,7 +86,7 @@ memcache_delete_entry_by_id(struct nss_ctx *nss_ctx,
     return ret;
 }
 
-static errno_t
+errno_t
 memcache_delete_entry(struct nss_ctx *nss_ctx,
                       struct resp_ctx *rctx,
                       struct sss_domain_info *domain,

--- a/src/responder/nss/nss_private.h
+++ b/src/responder/nss/nss_private.h
@@ -92,6 +92,14 @@ struct sss_cmd_table *get_nss_cmds(void);
 
 int nss_connection_setup(struct cli_ctx *cli_ctx);
 
+errno_t
+memcache_delete_entry(struct nss_ctx *nss_ctx,
+                      struct resp_ctx *rctx,
+                      struct sss_domain_info *domain,
+                      const char *name,
+                      uint32_t id,
+                      enum sss_mc_type type);
+
 struct tevent_req *
 nss_get_object_send(TALLOC_CTX *mem_ctx,
                     struct tevent_context *ev,

--- a/src/responder/nss/nss_protocol.c
+++ b/src/responder/nss/nss_protocol.c
@@ -233,6 +233,7 @@ nss_protocol_parse_id_ex(struct cli_ctx *cli_ctx, uint32_t *_id,
     SAFEALIGN_COPY_UINT32(&flags, body + sizeof(uint32_t), NULL);
 
     *_id = id;
+    *_flags = flags;
 
     return EOK;
 }

--- a/src/responder/nss/nss_protocol.h
+++ b/src/responder/nss/nss_protocol.h
@@ -89,7 +89,15 @@ errno_t
 nss_protocol_parse_name(struct cli_ctx *cli_ctx, const char **_rawname);
 
 errno_t
+nss_protocol_parse_name_ex(struct cli_ctx *cli_ctx, const char **_rawname,
+                           uint32_t *_flags);
+
+errno_t
 nss_protocol_parse_id(struct cli_ctx *cli_ctx, uint32_t *_id);
+
+errno_t
+nss_protocol_parse_id_ex(struct cli_ctx *cli_ctx, uint32_t *_id,
+                         uint32_t *_flags);
 
 errno_t
 nss_protocol_parse_limit(struct cli_ctx *cli_ctx, uint32_t *_limit);

--- a/src/responder/nss/nss_protocol.h
+++ b/src/responder/nss/nss_protocol.h
@@ -50,6 +50,7 @@ struct nss_cmd_ctx {
     struct nss_ctx *nss_ctx;
     struct nss_state_ctx *state_ctx;
     nss_protocol_fill_packet_fn fill_fn;
+    uint32_t flags;
 
     /* For initgroups- */
     const char *rawname;

--- a/src/responder/nss/nss_protocol_grent.c
+++ b/src/responder/nss/nss_protocol_grent.c
@@ -274,8 +274,10 @@ nss_protocol_fill_grent(struct nss_ctx *nss_ctx,
 
         num_results++;
 
-        /* Do not store entry in memory cache during enumeration. */
-        if (!cmd_ctx->enumeration) {
+        /* Do not store entry in memory cache during enumeration or when
+         * requested. */
+        if (!cmd_ctx->enumeration
+                && (cmd_ctx->flags & SSS_NSS_EX_FLAG_INVALIDATE_CACHE) == 0) {
             members = (char *)&body[rp_members];
             members_size = body_len - rp_members;
             ret = sss_mmap_cache_gr_store(&nss_ctx->grp_mc_ctx, name, &pwfield,
@@ -390,7 +392,8 @@ nss_protocol_fill_initgr(struct nss_ctx *nss_ctx,
         num_results++;
     }
 
-    if (nss_ctx->initgr_mc_ctx) {
+    if (nss_ctx->initgr_mc_ctx
+                && (cmd_ctx->flags & SSS_NSS_EX_FLAG_INVALIDATE_CACHE) == 0) {
         to_sized_string(&rawname, cmd_ctx->rawname);
         to_sized_string(&unique_name, result->lookup_name);
 

--- a/src/responder/nss/nss_protocol_pwent.c
+++ b/src/responder/nss/nss_protocol_pwent.c
@@ -295,8 +295,10 @@ nss_protocol_fill_pwent(struct nss_ctx *nss_ctx,
 
         num_results++;
 
-        /* Do not store entry in memory cache during enumeration. */
-        if (!cmd_ctx->enumeration) {
+        /* Do not store entry in memory cache during enumeration or when
+         * requested. */
+        if (!cmd_ctx->enumeration
+                && (cmd_ctx->flags & SSS_NSS_EX_FLAG_INVALIDATE_CACHE) == 0) {
             ret = sss_mmap_cache_pw_store(&nss_ctx->pwd_mc_ctx, name, &pwfield,
                                           uid, gid, &gecos, &homedir, &shell);
             if (ret != EOK) {

--- a/src/sss_client/common.c
+++ b/src/sss_client/common.c
@@ -43,6 +43,7 @@
 #include <libintl.h>
 #define _(STRING) dgettext (PACKAGE, STRING)
 #include "sss_cli.h"
+#include "common_private.h"
 
 #if HAVE_PTHREAD
 #include <pthread.h>
@@ -1113,13 +1114,7 @@ errno_t sss_strnlen(const char *str, size_t maxlen, size_t *len)
 #if HAVE_PTHREAD
 typedef void (*sss_mutex_init)(void);
 
-struct sss_mutex {
-    pthread_mutex_t mtx;
-
-    int old_cancel_state;
-};
-
-static struct sss_mutex sss_nss_mtx = { .mtx  = PTHREAD_MUTEX_INITIALIZER };
+struct sss_mutex sss_nss_mtx = { .mtx  = PTHREAD_MUTEX_INITIALIZER };
 
 static struct sss_mutex sss_pam_mtx = { .mtx  = PTHREAD_MUTEX_INITIALIZER };
 

--- a/src/sss_client/common_private.h
+++ b/src/sss_client/common_private.h
@@ -1,0 +1,41 @@
+/*
+    SSSD
+
+    SSS client - private calls
+
+    Authors:
+        Sumit Bose <sbose@redhat.com>
+
+    Copyright (C) 2017 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef COMMON_PRIVATE_H_
+#define COMMON_PRIVATE_H_
+
+#include "config.h"
+
+#if HAVE_PTHREAD
+#include <pthread.h>
+
+struct sss_mutex {
+    pthread_mutex_t mtx;
+
+    int old_cancel_state;
+};
+
+#endif /* HAVE_PTHREAD */
+
+#endif /* COMMON_PRIVATE_H_ */

--- a/src/sss_client/idmap/common_ex.c
+++ b/src/sss_client/idmap/common_ex.c
@@ -1,0 +1,105 @@
+/*
+    Authors:
+        Sumit Bose <sbose@redhat.com>
+
+    Copyright (C) 2017 Red Hat
+
+    SSSD's enhanced NSS API
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <time.h>
+#include <errno.h>
+
+#include "sss_cli.h"
+#include "common_private.h"
+
+extern struct sss_mutex sss_nss_mtx;
+
+#define SEC_FROM_MSEC(ms) ((ms) / 1000)
+#define NSEC_FROM_MSEC(ms) (((ms) % 1000) * 1000 * 1000)
+
+/* adopted from timersub() defined in /usr/include/sys/time.h */
+#define TIMESPECSUB(a, b, result)                                             \
+  do {                                                                        \
+    (result)->tv_sec = (a)->tv_sec - (b)->tv_sec;                             \
+    (result)->tv_nsec = (a)->tv_nsec - (b)->tv_nsec;                          \
+    if ((result)->tv_nsec < 0) {                                              \
+      --(result)->tv_sec;                                                     \
+      (result)->tv_nsec += 1000000000;                                        \
+    }                                                                         \
+  } while (0)
+
+#define TIMESPEC_TO_MS(ts) (  ((ts)->tv_sec * 1000) \
+                            + ((ts)->tv_nsec) / (1000 * 1000) )
+
+static int sss_mt_timedlock(struct sss_mutex *m, struct timespec *endtime)
+{
+    int ret;
+
+    ret = pthread_mutex_timedlock(&m->mtx, endtime);
+    if (ret != 0) {
+        return ret;
+    }
+    pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &m->old_cancel_state);
+
+    return 0;
+}
+
+int sss_nss_timedlock(unsigned int timeout_ms, int *time_left_ms)
+{
+    int ret;
+    int left;
+    struct timespec starttime;
+    struct timespec endtime;
+    struct timespec diff;
+
+    /* make sure there is no overrun when calculating the time left */
+    if (timeout_ms > INT_MAX) {
+        timeout_ms = INT_MAX;
+    }
+
+    ret = clock_gettime(CLOCK_REALTIME, &starttime);
+    if (ret != 0) {
+        return ret;
+    }
+    endtime.tv_sec = starttime.tv_sec + SEC_FROM_MSEC(timeout_ms);
+    endtime.tv_nsec = starttime.tv_nsec + NSEC_FROM_MSEC(timeout_ms);
+
+    ret = sss_mt_timedlock(&sss_nss_mtx, &endtime);
+
+    if (ret == 0) {
+        ret = clock_gettime(CLOCK_REALTIME, &endtime);
+        if (ret != 0) {
+            return ret;
+        }
+
+        if (timeout_ms == 0) {
+            *time_left_ms = 0;
+        } else {
+            TIMESPECSUB(&endtime, &starttime, &diff);
+            left = timeout_ms - TIMESPEC_TO_MS(&diff);
+            if (left <= 0) {
+                return EIO;
+            } else if (left > SSS_CLI_SOCKET_TIMEOUT) {
+                *time_left_ms = SSS_CLI_SOCKET_TIMEOUT;
+            } else {
+                *time_left_ms = left;
+            }
+        }
+    }
+
+    return ret;
+}

--- a/src/sss_client/idmap/sss_nss_ex.c
+++ b/src/sss_client/idmap/sss_nss_ex.c
@@ -1,0 +1,402 @@
+/*
+    SSSD
+
+    Extended NSS Responder Interface
+
+    Authors:
+        Sumit Bose <sbose@redhat.com>
+
+    Copyright (C) 2017 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <stdlib.h>
+#include <errno.h>
+
+#include <sys/param.h> /* for MIN() */
+
+#include "sss_client/sss_cli.h"
+#include "sss_client/nss_mc.h"
+#include "sss_client/nss_common.h"
+#include "sss_client/idmap/sss_nss_idmap.h"
+#include "sss_client/idmap/sss_nss_idmap_private.h"
+
+#ifndef discard_const
+#define discard_const(ptr) ((void *)((uintptr_t)(ptr)))
+#endif
+
+struct sss_nss_initgr_rep {
+    gid_t *groups;
+    long int *ngroups;
+    long int *start;
+};
+
+struct nss_input {
+    union {
+        const char *name;
+        uid_t uid;
+        gid_t gid;
+    } input;
+    struct sss_cli_req_data rd;
+    enum sss_cli_command cmd;
+    union {
+        struct sss_nss_pw_rep pwrep;
+        struct sss_nss_gr_rep grrep;
+        struct sss_nss_initgr_rep initgrrep;
+    } result;
+};
+
+errno_t sss_nss_mc_get(struct nss_input *inp)
+{
+    switch(inp->cmd) {
+    case SSS_NSS_GETPWNAM:
+        return sss_nss_mc_getpwnam(inp->input.name, (inp->rd.len - 1),
+                                   inp->result.pwrep.result,
+                                   inp->result.pwrep.buffer,
+                                   inp->result.pwrep.buflen);
+        break;
+    case SSS_NSS_GETPWUID:
+        return sss_nss_mc_getpwuid(inp->input.uid,
+                                   inp->result.pwrep.result,
+                                   inp->result.pwrep.buffer,
+                                   inp->result.pwrep.buflen);
+        break;
+    case SSS_NSS_GETGRNAM:
+        return sss_nss_mc_getgrnam(inp->input.name, (inp->rd.len - 1),
+                                   inp->result.grrep.result,
+                                   inp->result.grrep.buffer,
+                                   inp->result.grrep.buflen);
+        break;
+    case SSS_NSS_GETGRGID:
+        return sss_nss_mc_getgrgid(inp->input.gid,
+                                   inp->result.grrep.result,
+                                   inp->result.grrep.buffer,
+                                   inp->result.grrep.buflen);
+        break;
+    case SSS_NSS_INITGR:
+        return sss_nss_mc_initgroups_dyn(inp->input.name, (inp->rd.len - 1),
+                                         -1 /* currently ignored */,
+                                         inp->result.initgrrep.start,
+                                         inp->result.initgrrep.ngroups,
+                                         &(inp->result.initgrrep.groups),
+                                         *(inp->result.initgrrep.ngroups));
+        break;
+    default:
+        return EINVAL;
+    }
+}
+
+int sss_get_ex(struct nss_input *inp, uint32_t flags, unsigned int timeout)
+{
+    uint8_t *repbuf = NULL;
+    size_t replen;
+    size_t len;
+    uint32_t num_results;
+    int ret;
+    int time_left;
+    int errnop;
+    size_t c;
+    gid_t *new_groups;
+    size_t idx;
+
+    ret = sss_nss_mc_get(inp);
+    switch (ret) {
+    case 0:
+        return 0;
+    case ERANGE:
+        return ERANGE;
+    case ENOENT:
+        /* fall through, we need to actively ask the parent
+         * if no entry is found */
+        break;
+    default:
+        /* if using the mmaped cache failed,
+         * fall back to socket based comms */
+        break;
+    }
+
+    sss_nss_timedlock(timeout, &time_left);
+
+    /* previous thread might already initialize entry in mmap cache */
+    ret = sss_nss_mc_get(inp);
+    switch (ret) {
+    case 0:
+        ret = 0;
+        goto out;
+    case ERANGE:
+        ret = ERANGE;
+        goto out;
+    case ENOENT:
+        /* fall through, we need to actively ask the parent
+         * if no entry is found */
+        break;
+    default:
+        /* if using the mmaped cache failed,
+         * fall back to socket based comms */
+        break;
+    }
+
+    ret = sss_nss_make_request_timeout(inp->cmd, &inp->rd, time_left,
+                                       &repbuf, &replen, &errnop);
+    if (ret != NSS_STATUS_SUCCESS) {
+        ret = errnop != 0 ? errnop : EIO;
+        goto out;
+    }
+
+    /* Get number of results from repbuf. */
+    SAFEALIGN_COPY_UINT32(&num_results, repbuf, NULL);
+
+    /* no results if not found */
+    if (num_results == 0) {
+        ret = ENOENT;
+        goto out;
+    }
+
+    if (inp->cmd == SSS_NSS_INITGR) {
+        if ((*(inp->result.initgrrep.ngroups) - *(inp->result.initgrrep.start))
+                    < num_results) {
+            new_groups = realloc(inp->result.initgrrep.groups,
+                                 (num_results + *(inp->result.initgrrep.start))
+                                    * sizeof(gid_t));
+            if (new_groups == NULL) {
+                ret = ENOMEM;
+                goto out;
+            }
+
+            inp->result.initgrrep.groups = new_groups;
+        }
+        *(inp->result.initgrrep.ngroups) = num_results
+                                            + *(inp->result.initgrrep.start);
+
+        idx = 2 * sizeof(uint32_t);
+        for (c = 0; c < num_results; c++) {
+            SAFEALIGN_COPY_UINT32(
+                &(inp->result.initgrrep.groups[*(inp->result.initgrrep.start)]),
+                repbuf + idx, &idx);
+            *(inp->result.initgrrep.start) += 1;
+        }
+
+        ret = 0;
+        goto out;
+    }
+
+    /* only 1 result is accepted for this function */
+    if (num_results != 1) {
+        ret = EBADMSG;
+        goto out;
+    }
+
+    len = replen - 8;
+    if (inp->cmd == SSS_NSS_GETPWNAM || inp->cmd == SSS_NSS_GETPWUID) {
+        ret = sss_nss_getpw_readrep(&(inp->result.pwrep), repbuf+8, &len);
+    } else if (inp->cmd == SSS_NSS_GETGRNAM || inp->cmd == SSS_NSS_GETGRGID) {
+        ret = sss_nss_getgr_readrep(&(inp->result.grrep), repbuf+8, &len);
+    } else {
+        ret = EINVAL;
+        goto out;
+    }
+    if (ret) {
+        goto out;
+    }
+
+    if (len == 0) {
+        /* no extra data */
+        ret = 0;
+        goto out;
+    }
+
+out:
+    free(repbuf);
+
+    sss_nss_unlock();
+    return ret;
+}
+
+int sss_nss_getpwnam_timeout(const char *name, struct passwd *pwd,
+                             char *buffer, size_t buflen,
+                             struct passwd **result,
+                             uint32_t flags, unsigned int timeout)
+{
+    int ret;
+    struct nss_input inp = {
+        .input.name = name,
+        .cmd = SSS_NSS_GETPWNAM,
+        .rd.data = name,
+        .result.pwrep.result = pwd,
+        .result.pwrep.buffer = buffer,
+        .result.pwrep.buflen = buflen};
+
+    if (buffer == NULL || buflen == 0) {
+        return ERANGE;
+    }
+
+    ret = sss_strnlen(name, SSS_NAME_MAX, &inp.rd.len);
+    if (ret != 0) {
+        return EINVAL;
+    }
+    inp.rd.len++;
+
+    *result = NULL;
+
+    ret = sss_get_ex(&inp, flags, timeout);
+    if (ret == 0) {
+        *result = inp.result.pwrep.result;
+    }
+    return ret;
+}
+
+int sss_nss_getpwuid_timeout(uid_t uid, struct passwd *pwd,
+                             char *buffer, size_t buflen,
+                             struct passwd **result,
+                             uint32_t flags, unsigned int timeout)
+{
+    int ret;
+    uint32_t user_uid = uid;
+    struct nss_input inp = {
+        .input.uid = uid,
+        .cmd = SSS_NSS_GETPWUID,
+        .rd.len = sizeof(uint32_t),
+        .rd.data = &user_uid,
+        .result.pwrep.result = pwd,
+        .result.pwrep.buffer = buffer,
+        .result.pwrep.buflen = buflen};
+
+    if (buffer == NULL || buflen == 0) {
+        return ERANGE;
+    }
+
+    *result = NULL;
+
+    ret = sss_get_ex(&inp, flags, timeout);
+    if (ret == 0) {
+        *result = inp.result.pwrep.result;
+    }
+    return ret;
+}
+
+int sss_nss_getgrnam_timeout(const char *name, struct group *grp,
+                             char *buffer, size_t buflen, struct group **result,
+                             uint32_t flags, unsigned int timeout)
+{
+    int ret;
+    struct nss_input inp = {
+        .input.name = name,
+        .cmd = SSS_NSS_GETGRNAM,
+        .rd.data = name,
+        .result.grrep.result = grp,
+        .result.grrep.buffer = buffer,
+        .result.grrep.buflen = buflen};
+
+    if (buffer == NULL || buflen == 0) {
+        return ERANGE;
+    }
+
+    ret = sss_strnlen(name, SSS_NAME_MAX, &inp.rd.len);
+    if (ret != 0) {
+        return EINVAL;
+    }
+    inp.rd.len++;
+
+    *result = NULL;
+
+    ret = sss_get_ex(&inp, flags, timeout);
+    if (ret == 0) {
+        *result = inp.result.grrep.result;
+    }
+    return ret;
+}
+
+int sss_nss_getgrgid_timeout(gid_t gid, struct group *grp,
+                             char *buffer, size_t buflen, struct group **result,
+                             uint32_t flags, unsigned int timeout)
+{
+    int ret;
+    uint32_t group_gid = gid;
+    struct nss_input inp = {
+        .input.gid = gid,
+        .cmd = SSS_NSS_GETGRGID,
+        .rd.len = sizeof(uint32_t),
+        .rd.data = &group_gid,
+        .result.grrep.result = grp,
+        .result.grrep.buffer = buffer,
+        .result.grrep.buflen = buflen};
+
+    if (buffer == NULL || buflen == 0) {
+        return ERANGE;
+    }
+
+    *result = NULL;
+
+    ret = sss_get_ex(&inp, flags, timeout);
+    if (ret == 0) {
+        *result = inp.result.grrep.result;
+    }
+    return ret;
+}
+
+int sss_nss_getgrouplist_timeout(const char *name, gid_t group,
+                                 gid_t *groups, int *ngroups,
+                                 uint32_t flags, unsigned int timeout)
+{
+    int ret;
+    gid_t *new_groups;
+    long int new_ngroups;
+    long int start = 1;
+    struct nss_input inp = {
+        .input.name = name,
+        .cmd = SSS_NSS_INITGR,
+        .rd.data = name};
+
+    if (groups == NULL || ngroups == NULL || *ngroups == 0) {
+        return EINVAL;
+    }
+
+    ret = sss_strnlen(name, SSS_NAME_MAX, &inp.rd.len);
+    if (ret != 0) {
+        return ret;
+    }
+    inp.rd.len++;
+
+    new_ngroups = MAX(1, *ngroups);
+    new_groups = malloc(new_ngroups * sizeof(gid_t));
+    if (new_groups == NULL) {
+        free(discard_const(inp.rd.data));
+        return ENOMEM;
+    }
+    new_groups[0] = group;
+
+    inp.result.initgrrep.groups = new_groups,
+    inp.result.initgrrep.ngroups = &new_ngroups;
+    inp.result.initgrrep.start = &start;
+
+
+    ret = sss_get_ex(&inp, flags, timeout);
+    free(discard_const(inp.rd.data));
+    if (ret != 0) {
+        free(new_groups);
+        return ret;
+    }
+
+    memcpy(groups, new_groups, MIN(*ngroups, start) * sizeof(gid_t));
+    free(new_groups);
+
+    if (start > *ngroups) {
+        ret = ERANGE;
+    } else {
+        ret = 0;
+    }
+    *ngroups = start;
+
+    return ret;
+}

--- a/src/sss_client/idmap/sss_nss_ex.c
+++ b/src/sss_client/idmap/sss_nss_ex.c
@@ -103,6 +103,18 @@ errno_t sss_nss_mc_get(struct nss_input *inp)
     }
 }
 
+static int check_flags(uint32_t flags)
+{
+    /* SSS_NSS_EX_FLAG_NO_CACHE and SSS_NSS_EX_FLAG_INVALIDATE_CACHE are
+     * mutually exclusive */
+    if ((flags & SSS_NSS_EX_FLAG_NO_CACHE) != 0
+            && (flags & SSS_NSS_EX_FLAG_INVALIDATE_CACHE) != 0) {
+        return EINVAL;
+    }
+
+    return 0;
+}
+
 int sss_get_ex(struct nss_input *inp, uint32_t flags, unsigned int timeout)
 {
     uint8_t *repbuf = NULL;
@@ -117,7 +129,13 @@ int sss_get_ex(struct nss_input *inp, uint32_t flags, unsigned int timeout)
     size_t idx;
     bool skip_mc = false;
 
-    if ((flags & SSS_NSS_EX_FLAG_NO_CACHE) != 0) {
+    ret = check_flags(flags);
+    if (ret != 0) {
+        return ret;
+    }
+
+    if ((flags & SSS_NSS_EX_FLAG_NO_CACHE) != 0
+            || (flags & SSS_NSS_EX_FLAG_INVALIDATE_CACHE) != 0) {
         skip_mc = true;
     }
 

--- a/src/sss_client/idmap/sss_nss_idmap.exports
+++ b/src/sss_client/idmap/sss_nss_idmap.exports
@@ -31,3 +31,13 @@ SSS_NSS_IDMAP_0.3.0 {
     global:
         sss_nss_getlistbycert;
 } SSS_NSS_IDMAP_0.2.0;
+
+SSS_NSS_IDMAP_0.4.0 {
+    # public functions
+    global:
+        sss_nss_getpwnam_timeout;
+        sss_nss_getpwuid_timeout;
+        sss_nss_getgrnam_timeout;
+        sss_nss_getgrgid_timeout;
+        sss_nss_getgrouplist_timeout;
+} SSS_NSS_IDMAP_0.3.0;

--- a/src/sss_client/idmap/sss_nss_idmap.exports
+++ b/src/sss_client/idmap/sss_nss_idmap.exports
@@ -40,4 +40,11 @@ SSS_NSS_IDMAP_0.4.0 {
         sss_nss_getgrnam_timeout;
         sss_nss_getgrgid_timeout;
         sss_nss_getgrouplist_timeout;
+        sss_nss_getsidbyname_timeout;
+        sss_nss_getsidbyid_timeout;
+        sss_nss_getnamebysid_timeout;
+        sss_nss_getidbysid_timeout;
+        sss_nss_getorigbyname_timeout;
+        sss_nss_getnamebycert_timeout;
+        sss_nss_getlistbycert_timeout;
 } SSS_NSS_IDMAP_0.3.0;

--- a/src/sss_client/idmap/sss_nss_idmap.h
+++ b/src/sss_client/idmap/sss_nss_idmap.h
@@ -169,6 +169,10 @@ void sss_nss_free_kv(struct sss_nss_kv *kv_list);
 
 #define SSS_NSS_EX_FLAG_NO_FLAGS 0
 
+/** Always request data from the server side, client must be privileged to do
+ *  so, see nss_trusted_users option in man sssd.conf for details */
+#define SSS_NSS_EX_FLAG_NO_CACHE (1 << 0)
+
 #ifdef IPA_389DS_PLUGIN_HELPER_CALLS
 
 /**

--- a/src/sss_client/idmap/sss_nss_idmap.h
+++ b/src/sss_client/idmap/sss_nss_idmap.h
@@ -303,5 +303,129 @@ int sss_nss_getgrgid_timeout(gid_t gid, struct group *grp,
 int sss_nss_getgrouplist_timeout(const char *name, gid_t group,
                                  gid_t *groups, int *ngroups,
                                  uint32_t flags, unsigned int timeout);
+/**
+ * @brief Find SID by fully qualified name with timeout
+ *
+ * @param[in] fq_name  Fully qualified name of a user or a group
+ * @param[in] timeout  timeout in milliseconds
+ * @param[out] sid     String representation of the SID of the requested user
+ *                     or group, must be freed by the caller
+ * @param[out] type    Type of the object related to the given name
+ *
+ * @return
+ *  - 0 (EOK): success, sid contains the requested SID
+ *  - ENOENT: requested object was not found in the domain extracted from the given name
+ *  - ENETUNREACH: SSSD does not know how to handle the domain extracted from the given name
+ *  - ENOSYS: this call is not supported by the configured provider
+ *  - EINVAL: input cannot be parsed
+ *  - EIO: remote servers cannot be reached
+ *  - EFAULT: any other error
+ *  - ETIME:     request timed out but was send to SSSD
+ *  - ETIMEDOUT: request timed out but was not send to SSSD
+ */
+int sss_nss_getsidbyname_timeout(const char *fq_name, unsigned int timeout,
+                                 char **sid, enum sss_id_type *type);
+
+/**
+ * @brief Find SID by a POSIX UID or GID with timeout
+ *
+ * @param[in] id       POSIX UID or GID
+ * @param[in] timeout  timeout in milliseconds
+ * @param[out] sid     String representation of the SID of the requested user
+ *                     or group, must be freed by the caller
+ * @param[out] type    Type of the object related to the given ID
+ *
+ * @return
+ *  - see #sss_nss_getsidbyname_timeout
+ */
+int sss_nss_getsidbyid_timeout(uint32_t id, unsigned int timeout,
+                               char **sid, enum sss_id_type *type);
+
+/**
+ * @brief Return the fully qualified name for the given SID with timeout
+ *
+ * @param[in] sid      String representation of the SID
+ * @param[in] timeout  timeout in milliseconds
+ * @param[out] fq_name Fully qualified name of a user or a group,
+ *                     must be freed by the caller
+ * @param[out] type    Type of the object related to the SID
+ *
+ * @return
+ *  - see #sss_nss_getsidbyname_timeout
+ */
+int sss_nss_getnamebysid_timeout(const char *sid, unsigned int timeout,
+                                 char **fq_name, enum sss_id_type *type);
+
+/**
+ * @brief Return the POSIX ID for the given SID with timeout
+ *
+ * @param[in] sid      String representation of the SID
+ * @param[in] timeout  timeout in milliseconds
+ * @param[out] id      POSIX ID related to the SID
+ * @param[out] id_type Type of the object related to the SID
+ *
+ * @return
+ *  - see #sss_nss_getsidbyname_timeout
+ */
+int sss_nss_getidbysid_timeout(const char *sid, unsigned int timeout,
+                               uint32_t *id, enum sss_id_type *id_type);
+
+/**
+ * @brief Find original data by fully qualified name with timeout
+ *
+ * @param[in] fq_name  Fully qualified name of a user or a group
+ * @param[in] timeout  timeout in milliseconds
+ * @param[out] kv_list A NULL terminate list of key-value pairs where the key
+ *                     is the attribute name in the cache of SSSD,
+ *                     must be freed by the caller with sss_nss_free_kv()
+ * @param[out] type    Type of the object related to the given name
+ *
+ * @return
+ *  - 0 (EOK): success, sid contains the requested SID
+ *  - ENOENT: requested object was not found in the domain extracted from the given name
+ *  - ENETUNREACH: SSSD does not know how to handle the domain extracted from the given name
+ *  - ENOSYS: this call is not supported by the configured provider
+ *  - EINVAL: input cannot be parsed
+ *  - EIO: remote servers cannot be reached
+ *  - EFAULT: any other error
+ *  - ETIME:     request timed out but was send to SSSD
+ *  - ETIMEDOUT: request timed out but was not send to SSSD
+ */
+int sss_nss_getorigbyname_timeout(const char *fq_name, unsigned int timeout,
+                                  struct sss_nss_kv **kv_list,
+                                  enum sss_id_type *type);
+
+/**
+ * @brief Return the fully qualified name for the given base64 encoded
+ * X.509 certificate in DER format with timeout
+ *
+ * @param[in] cert     base64 encoded certificate
+ * @param[in] timeout  timeout in milliseconds
+ * @param[out] fq_name Fully qualified name of a user or a group,
+ *                     must be freed by the caller
+ * @param[out] type    Type of the object related to the cert
+ *
+ * @return
+ *  - see #sss_nss_getsidbyname_timeout
+ */
+int sss_nss_getnamebycert_timeout(const char *cert, unsigned int timeout,
+                                  char **fq_name, enum sss_id_type *type);
+
+/**
+ * @brief Return a list of fully qualified names for the given base64 encoded
+ * X.509 certificate in DER format with timeout
+ *
+ * @param[in] cert     base64 encoded certificate
+ * @param[in] timeout  timeout in milliseconds
+ * @param[out] fq_name List of fully qualified name of users or groups,
+ *                     must be freed by the caller
+ * @param[out] type    List of types of the objects related to the cert
+ *
+ * @return
+ *  - see #sss_nss_getsidbyname_timeout
+ */
+int sss_nss_getlistbycert_timeout(const char *cert, unsigned int timeout,
+                                  char ***fq_name, enum sss_id_type **type);
+
 #endif /* IPA_389DS_PLUGIN_HELPER_CALLS */
 #endif /* SSS_NSS_IDMAP_H_ */

--- a/src/sss_client/idmap/sss_nss_idmap.h
+++ b/src/sss_client/idmap/sss_nss_idmap.h
@@ -170,8 +170,14 @@ void sss_nss_free_kv(struct sss_nss_kv *kv_list);
 #define SSS_NSS_EX_FLAG_NO_FLAGS 0
 
 /** Always request data from the server side, client must be privileged to do
- *  so, see nss_trusted_users option in man sssd.conf for details */
+ *  so, see nss_trusted_users option in man sssd.conf for details.
+ *  This flag cannot be used together with SSS_NSS_EX_FLAG_INVALIDATE_CACHE */
 #define SSS_NSS_EX_FLAG_NO_CACHE (1 << 0)
+
+/** Invalidate the data in the caches, client must be privileged to do
+ *  so, see nss_trusted_users option in man sssd.conf for details.
+ *  This flag cannot be used together with SSS_NSS_EX_FLAG_NO_CACHE */
+#define SSS_NSS_EX_FLAG_INVALIDATE_CACHE (1 << 1)
 
 #ifdef IPA_389DS_PLUGIN_HELPER_CALLS
 

--- a/src/sss_client/idmap/sss_nss_idmap.h
+++ b/src/sss_client/idmap/sss_nss_idmap.h
@@ -26,6 +26,9 @@
 #define SSS_NSS_IDMAP_H_
 
 #include <stdint.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include <grp.h>
 
 /**
  * Object types
@@ -159,4 +162,136 @@ int sss_nss_getlistbycert(const char *cert, char ***fq_name,
  * @param[in] kv_list Key-value list returned by sss_nss_getorigbyname().
  */
 void sss_nss_free_kv(struct sss_nss_kv *kv_list);
+
+/**
+ * Flags to control the behavior and the results for sss_*_ex() calls
+ */
+
+#define SSS_NSS_EX_FLAG_NO_FLAGS 0
+
+#ifdef IPA_389DS_PLUGIN_HELPER_CALLS
+
+/**
+ * @brief Return user information based on the user name
+ *
+ * @param[in]  name       same as for getpwnam_r(3)
+ * @param[in]  pwd        same as for getpwnam_r(3)
+ * @param[in]  buffer     same as for getpwnam_r(3)
+ * @param[in]  buflen     same as for getpwnam_r(3)
+ * @param[out] result     same as for getpwnam_r(3)
+ * @param[in]  flags      flags to control the behavior and the results of the
+ *                        call
+ * @param[in]  timeout    timeout in milliseconds
+ *
+ * @return
+ *  - 0:
+ *  - ENOENT:    no user with the given name found
+ *  - ERANGE:    Insufficient buffer space supplied
+ *  - ETIME:     request timed out but was send to SSSD
+ *  - ETIMEDOUT: request timed out but was not send to SSSD
+ */
+int sss_nss_getpwnam_timeout(const char *name, struct passwd *pwd,
+                             char *buffer, size_t buflen,
+                             struct passwd **result,
+                             uint32_t flags, unsigned int timeout);
+
+/**
+ * @brief Return user information based on the user uid
+ *
+ * @param[in]  uid        same as for getpwuid_r(3)
+ * @param[in]  pwd        same as for getpwuid_r(3)
+ * @param[in]  buffer     same as for getpwuid_r(3)
+ * @param[in]  buflen     same as for getpwuid_r(3)
+ * @param[out] result     same as for getpwuid_r(3)
+ * @param[in]  flags      flags to control the behavior and the results of the
+ *                        call
+ * @param[in]  timeout    timeout in milliseconds
+ *
+ * @return
+ *  - 0:
+ *  - ENOENT:    no user with the given uid found
+ *  - ERANGE:    Insufficient buffer space supplied
+ *  - ETIME:     request timed out but was send to SSSD
+ *  - ETIMEDOUT: request timed out but was not send to SSSD
+ */
+int sss_nss_getpwuid_timeout(uid_t uid, struct passwd *pwd,
+                             char *buffer, size_t buflen,
+                             struct passwd **result,
+                             uint32_t flags, unsigned int timeout);
+
+/**
+ * @brief Return group information based on the group name
+ *
+ * @param[in]  name       same as for getgrnam_r(3)
+ * @param[in]  pwd        same as for getgrnam_r(3)
+ * @param[in]  buffer     same as for getgrnam_r(3)
+ * @param[in]  buflen     same as for getgrnam_r(3)
+ * @param[out] result     same as for getgrnam_r(3)
+ * @param[in]  flags      flags to control the behavior and the results of the
+ *                        call
+ * @param[in]  timeout    timeout in milliseconds
+ *
+ * @return
+ *  - 0:
+ *  - ENOENT:    no group with the given name found
+ *  - ERANGE:    Insufficient buffer space supplied
+ *  - ETIME:     request timed out but was send to SSSD
+ *  - ETIMEDOUT: request timed out but was not send to SSSD
+ */
+int sss_nss_getgrnam_timeout(const char *name, struct group *grp,
+                             char *buffer, size_t buflen, struct group **result,
+                             uint32_t flags, unsigned int timeout);
+
+/**
+ * @brief Return group information based on the group gid
+ *
+ * @param[in]  gid        same as for getgrgid_r(3)
+ * @param[in]  pwd        same as for getgrgid_r(3)
+ * @param[in]  buffer     same as for getgrgid_r(3)
+ * @param[in]  buflen     same as for getgrgid_r(3)
+ * @param[out] result     same as for getgrgid_r(3)
+ * @param[in]  flags      flags to control the behavior and the results of the
+ *                        call
+ * @param[in]  timeout    timeout in milliseconds
+ *
+ * @return
+ *  - 0:
+ *  - ENOENT:    no group with the given gid found
+ *  - ERANGE:    Insufficient buffer space supplied
+ *  - ETIME:     request timed out but was send to SSSD
+ *  - ETIMEDOUT: request timed out but was not send to SSSD
+ */
+int sss_nss_getgrgid_timeout(gid_t gid, struct group *grp,
+                             char *buffer, size_t buflen, struct group **result,
+                             uint32_t flags, unsigned int timeout);
+
+/**
+ * @brief Return a list of groups to which a user belongs
+ *
+ * @param[in]      name       name of the user
+ * @param[in]      group      same as second argument of getgrouplist(3)
+ * @param[in]      groups     array of gid_t of size ngroups, will be filled
+ *                            with GIDs of groups the user belongs to
+ * @param[in,out]  ngroups    size of the groups array on input. On output it
+ *                            will contain the actual number of groups the
+ *                            user belongs to. With a return value of 0 the
+ *                            groups array was large enough to hold all group.
+ *                            With a return valu of ERANGE the array was not
+ *                            large enough and ngroups will have the needed
+ *                            size.
+ * @param[in]  flags          flags to control the behavior and the results of
+ *                            the call
+ * @param[in]  timeout        timeout in milliseconds
+ *
+ * @return
+ *  - 0:         success
+ *  - ENOENT:    no user with the given name found
+ *  - ERANGE:    Insufficient buffer space supplied
+ *  - ETIME:     request timed out but was send to SSSD
+ *  - ETIMEDOUT: request timed out but was not send to SSSD
+ */
+int sss_nss_getgrouplist_timeout(const char *name, gid_t group,
+                                 gid_t *groups, int *ngroups,
+                                 uint32_t flags, unsigned int timeout);
+#endif /* IPA_389DS_PLUGIN_HELPER_CALLS */
 #endif /* SSS_NSS_IDMAP_H_ */

--- a/src/sss_client/idmap/sss_nss_idmap.unit_tests
+++ b/src/sss_client/idmap/sss_nss_idmap.unit_tests
@@ -2,5 +2,5 @@
 UNIT_TEST_ONLY {
     # should not be part of installed library
     global:
-        sss_nss_make_request;
+        sss_nss_make_request_timeout;
 };

--- a/src/sss_client/idmap/sss_nss_idmap_private.h
+++ b/src/sss_client/idmap/sss_nss_idmap_private.h
@@ -1,0 +1,30 @@
+/*
+    SSSD
+
+    NSS Responder ID-mapping interface - private calls
+
+    Authors:
+        Sumit Bose <sbose@redhat.com>
+
+    Copyright (C) 2017 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SSS_NSS_IDMAP_PRIVATE_H_
+#define SSS_NSS_IDMAP_PRIVATE_H_
+
+int sss_nss_timedlock(unsigned int timeout_ms, int *time_left_ms);
+
+#endif /* SSS_NSS_IDMAP_PRIVATE_H_ */

--- a/src/sss_client/nss_common.h
+++ b/src/sss_client/nss_common.h
@@ -1,0 +1,43 @@
+/*
+   SSSD
+
+   Common routines for classical and enhanced NSS interface
+
+   Authors:
+        Sumit Bose <sbose@redhat.com>
+
+   Copyright (C) Red Hat, Inc 2007
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+
+struct sss_nss_pw_rep {
+    struct passwd *result;
+    char *buffer;
+    size_t buflen;
+};
+
+int sss_nss_getpw_readrep(struct sss_nss_pw_rep *pr,
+                          uint8_t *buf, size_t *len);
+
+struct sss_nss_gr_rep {
+    struct group *result;
+    char *buffer;
+    size_t buflen;
+};
+
+int sss_nss_getgr_readrep(struct sss_nss_gr_rep *pr,
+                          uint8_t *buf, size_t *len);

--- a/src/sss_client/nss_group.c
+++ b/src/sss_client/nss_group.c
@@ -29,6 +29,7 @@
 #include <stdbool.h>
 #include "sss_cli.h"
 #include "nss_mc.h"
+#include "nss_common.h"
 
 static struct sss_nss_getgrent_data {
     size_t len;
@@ -190,14 +191,9 @@ done:
  *
  *  FIXME: do we need to pad so that each result is 32 bit aligned ?
  */
-struct sss_nss_gr_rep {
-    struct group *result;
-    char *buffer;
-    size_t buflen;
-};
 
-static int sss_nss_getgr_readrep(struct sss_nss_gr_rep *pr,
-                                 uint8_t *buf, size_t *len)
+int sss_nss_getgr_readrep(struct sss_nss_gr_rep *pr,
+                          uint8_t *buf, size_t *len)
 {
     errno_t ret;
     size_t i, l, slen, ptmem, pad, dlen, glen;

--- a/src/sss_client/nss_passwd.c
+++ b/src/sss_client/nss_passwd.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include "sss_cli.h"
 #include "nss_mc.h"
+#include "nss_common.h"
 
 static struct sss_nss_getpwent_data {
     size_t len;
@@ -63,14 +64,8 @@ static void sss_nss_getpwent_data_clean(void) {
  *  8-X: sequence of 5, 0 terminated, strings (name, passwd, gecos, dir, shell)
  */
 
-struct sss_nss_pw_rep {
-    struct passwd *result;
-    char *buffer;
-    size_t buflen;
-};
-
-static int sss_nss_getpw_readrep(struct sss_nss_pw_rep *pr,
-                                 uint8_t *buf, size_t *len)
+int sss_nss_getpw_readrep(struct sss_nss_pw_rep *pr,
+                          uint8_t *buf, size_t *len)
 {
     errno_t ret;
     size_t i, slen, dlen;

--- a/src/sss_client/sss_cli.h
+++ b/src/sss_client/sss_cli.h
@@ -79,6 +79,9 @@ enum sss_cli_command {
     SSS_NSS_GETPWENT       = 0x0014,
     SSS_NSS_ENDPWENT       = 0x0015,
 
+    SSS_NSS_GETPWNAM_EX    = 0x0019,
+    SSS_NSS_GETPWUID_EX    = 0x001A,
+
 /* group */
 
     SSS_NSS_GETGRNAM       = 0x0021,
@@ -87,6 +90,10 @@ enum sss_cli_command {
     SSS_NSS_GETGRENT       = 0x0024,
     SSS_NSS_ENDGRENT       = 0x0025,
     SSS_NSS_INITGR         = 0x0026,
+
+    SSS_NSS_GETGRNAM_EX    = 0x0029,
+    SSS_NSS_GETGRGID_EX    = 0x002A,
+    SSS_NSS_INITGR_EX      = 0x002E,
 
 #if 0
 /* aliases */

--- a/src/tests/cmocka/sss_nss_idmap-tests.c
+++ b/src/tests/cmocka/sss_nss_idmap-tests.c
@@ -61,10 +61,11 @@ uint8_t buf_orig1[] = {0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0
  #error "unknow endianess"
 #endif
 
-enum nss_status sss_nss_make_request(enum sss_cli_command cmd,
-                      struct sss_cli_req_data *rd,
-                      uint8_t **repbuf, size_t *replen,
-                      int *errnop)
+enum nss_status sss_nss_make_request_timeout(enum sss_cli_command cmd,
+                                             struct sss_cli_req_data *rd,
+                                             int timeout,
+                                             uint8_t **repbuf, size_t *replen,
+                                             int *errnop)
 {
     struct sss_nss_make_request_test_data *d;
 
@@ -114,7 +115,7 @@ void test_getsidbyname(void **state)
     sid = NULL;
 
     for (c = 0; d[c].d.repbuf != NULL; c++) {
-        will_return(sss_nss_make_request, &d[0].d);
+        will_return(sss_nss_make_request_timeout, &d[0].d);
 
         ret = sss_nss_getsidbyname("test", &sid, &type);
         assert_int_equal(ret, d[0].ret);
@@ -134,7 +135,7 @@ void test_getorigbyname(void **state)
     enum sss_id_type type;
     struct sss_nss_make_request_test_data d = {buf_orig1, sizeof(buf_orig1), 0, NSS_STATUS_SUCCESS};
 
-    will_return(sss_nss_make_request, &d);
+    will_return(sss_nss_make_request_timeout, &d);
     ret = sss_nss_getorigbyname("test", &kv_list, &type);
     assert_int_equal(ret, EOK);
     assert_int_equal(type, SSS_ID_TYPE_UID);

--- a/src/tests/cmocka/test_nss_srv.c
+++ b/src/tests/cmocka/test_nss_srv.c
@@ -255,6 +255,45 @@ static void mock_input_user_or_group(const char *input)
     mock_parse_inp(shortname, domname, EOK);
 }
 
+static void mock_input_user_or_group_ex(bool do_parse_inp, const char *input,
+                                        uint32_t flags)
+{
+    const char *copy;
+    const char *shortname;
+    const char *domname;
+    char *separator;
+    uint8_t *data;
+    size_t len;
+
+    len = strlen(input);
+    len++;
+    data = talloc_size(nss_test_ctx, len + sizeof(uint32_t));
+    assert_non_null(data);
+    memcpy(data, input, len);
+    SAFEALIGN_COPY_UINT32(data + len, &flags, NULL);
+
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_WRAPPER);
+    will_return(__wrap_sss_packet_get_body, data);
+    will_return(__wrap_sss_packet_get_body, len + sizeof(uint32_t));
+
+    if (do_parse_inp) {
+        copy = talloc_strdup(nss_test_ctx, input);
+        assert_non_null(copy);
+
+        separator = strrchr(copy, '@');
+        if (separator == NULL) {
+            shortname = input;
+            domname = NULL;
+        } else {
+            *separator = '\0';
+            shortname = copy;
+            domname = separator + 1;
+        }
+
+        mock_parse_inp(shortname, domname, EOK);
+    }
+}
+
 static void mock_input_upn(const char *upn)
 {
     will_return(__wrap_sss_packet_get_body, WRAP_CALL_WRAPPER);
@@ -289,6 +328,20 @@ static void mock_input_id(TALLOC_CTX *mem_ctx, uint32_t id)
     will_return(__wrap_sss_packet_get_body, WRAP_CALL_WRAPPER);
     will_return(__wrap_sss_packet_get_body, body);
     will_return(__wrap_sss_packet_get_body, sizeof(uint32_t));
+}
+
+static void mock_input_id_ex(TALLOC_CTX *mem_ctx, uint32_t id, uint32_t flags)
+{
+    uint8_t *body;
+
+    body = talloc_zero_array(mem_ctx, uint8_t, 8);
+    if (body == NULL) return;
+
+    SAFEALIGN_SETMEM_UINT32(body, id, NULL);
+    SAFEALIGN_SETMEM_UINT32(body + sizeof(uint32_t), flags, NULL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_WRAPPER);
+    will_return(__wrap_sss_packet_get_body, body);
+    will_return(__wrap_sss_packet_get_body, 2 * sizeof(uint32_t));
 }
 
 static void mock_fill_user(void)
@@ -4143,6 +4196,482 @@ void test_nss_getsidbyname_neg(void **state)
     assert_int_equal(ret, ENOENT);
 }
 
+static int test_nss_EINVAL_check(uint32_t status, uint8_t *body, size_t blen)
+{
+    assert_int_equal(status, EINVAL);
+    assert_int_equal(blen, 0);
+
+    return EOK;
+}
+
+#define RESET_TCTX do { \
+    nss_test_ctx->tctx->done = false; \
+    nss_test_ctx->tctx->error = EIO; \
+} while (0)
+
+void test_nss_getpwnam_ex(void **state)
+{
+    errno_t ret;
+
+    ret = store_user(nss_test_ctx, nss_test_ctx->tctx->dom,
+                     &getpwnam_usr, NULL, 0);
+    assert_int_equal(ret, EOK);
+
+    mock_input_user_or_group_ex(true, "testuser", 0);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETPWNAM_EX);
+    mock_fill_user();
+
+    /* Query for that user, call a callback when command finishes */
+    set_cmd_cb(test_nss_getpwnam_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETPWNAM_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+    RESET_TCTX;
+
+    /* Use old input format, expect EINVAL */
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_WRAPPER);
+    will_return(__wrap_sss_packet_get_body, "testuser");
+    will_return(__wrap_sss_packet_get_body, 0);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETPWNAM_EX);
+
+    set_cmd_cb(test_nss_EINVAL_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETPWNAM_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+    RESET_TCTX;
+
+    /* Use unsupported flag combination, expect EINVAL */
+    mock_input_user_or_group_ex(false, "testuser",
+                                SSS_NSS_EX_FLAG_NO_CACHE
+                                    |SSS_NSS_EX_FLAG_INVALIDATE_CACHE);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETPWNAM_EX);
+
+    set_cmd_cb(test_nss_EINVAL_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETPWNAM_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+    RESET_TCTX;
+
+    /* Use flag SSS_NSS_EX_FLAG_NO_CACHE,
+     * will cause a backend lookup -> mock_account_recv_simple() */
+    mock_input_user_or_group_ex(true, "testuser", SSS_NSS_EX_FLAG_NO_CACHE);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETPWNAM_EX);
+    mock_fill_user();
+    mock_account_recv_simple();
+
+    set_cmd_cb(test_nss_getpwnam_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETPWNAM_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+    RESET_TCTX;
+
+    /* Use flag SSS_NSS_EX_FLAG_INVALIDATE_CACHE */
+    mock_input_user_or_group_ex(true, "testuser",
+                                SSS_NSS_EX_FLAG_INVALIDATE_CACHE);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETPWNAM_EX);
+    mock_fill_user();
+
+    set_cmd_cb(test_nss_getpwnam_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETPWNAM_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+}
+
+void test_nss_getpwuid_ex(void **state)
+{
+    errno_t ret;
+    uint32_t id = 101;
+
+    /* Prime the cache with a valid user */
+    ret = store_user(nss_test_ctx, nss_test_ctx->tctx->dom,
+                     &getpwuid_usr, NULL, 0);
+    assert_int_equal(ret, EOK);
+
+    mock_input_id_ex(nss_test_ctx, id, 0);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETPWUID_EX);
+    mock_fill_user();
+
+    /* Query for that id, call a callback when command finishes */
+    set_cmd_cb(test_nss_getpwuid_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETPWUID_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+    RESET_TCTX;
+
+    /* Use old input format, expect failure */
+    mock_input_id(nss_test_ctx, id);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETPWUID_EX);
+
+    set_cmd_cb(test_nss_EINVAL_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETPWUID_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+    RESET_TCTX;
+
+    /* Use unsupported flag combination, expect EINVAL */
+    mock_input_id_ex(nss_test_ctx, id, SSS_NSS_EX_FLAG_NO_CACHE
+                                            |SSS_NSS_EX_FLAG_INVALIDATE_CACHE);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETPWUID_EX);
+
+    set_cmd_cb(test_nss_EINVAL_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETPWUID_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+    RESET_TCTX;
+
+    /* Use flag SSS_NSS_EX_FLAG_NO_CACHE,
+     * will cause a backend lookup -> mock_account_recv_simple() */
+    mock_input_id_ex(nss_test_ctx, id, SSS_NSS_EX_FLAG_NO_CACHE);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETPWUID_EX);
+    mock_fill_user();
+    mock_account_recv_simple();
+
+    set_cmd_cb(test_nss_getpwuid_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETPWUID_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+    RESET_TCTX;
+
+    /* Use flag SSS_NSS_EX_FLAG_INVALIDATE_CACHE */
+    mock_input_id_ex(nss_test_ctx, id, SSS_NSS_EX_FLAG_INVALIDATE_CACHE);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETPWUID_EX);
+    mock_fill_user();
+
+    set_cmd_cb(test_nss_getpwuid_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETPWUID_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+}
+
+void test_nss_getgrnam_ex_no_members(void **state)
+{
+    errno_t ret;
+
+    /* Test group is still in the cache */
+
+    mock_input_user_or_group_ex(true, getgrnam_no_members.gr_name, 0);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETGRNAM_EX);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+
+    /* Query for that group, call a callback when command finishes */
+    set_cmd_cb(test_nss_getgrnam_no_members_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETGRNAM_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+    RESET_TCTX;
+
+    /* Use old input format, expect failure */
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_WRAPPER);
+    will_return(__wrap_sss_packet_get_body, "testgroup");
+    will_return(__wrap_sss_packet_get_body, 0);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETGRNAM_EX);
+
+    set_cmd_cb(test_nss_EINVAL_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETGRNAM_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+    RESET_TCTX;
+
+    /* Use unsupported flag combination, expect EINVAL */
+    mock_input_user_or_group_ex(false, getgrnam_no_members.gr_name,
+                                SSS_NSS_EX_FLAG_NO_CACHE
+                                    |SSS_NSS_EX_FLAG_INVALIDATE_CACHE);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETGRNAM_EX);
+
+    set_cmd_cb(test_nss_EINVAL_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETGRNAM_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+    RESET_TCTX;
+
+    /* Use flag SSS_NSS_EX_FLAG_NO_CACHE,
+     * will cause a backend lookup -> mock_account_recv_simple() */
+    mock_input_user_or_group_ex(true, getgrnam_no_members.gr_name,
+                                SSS_NSS_EX_FLAG_NO_CACHE);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETGRNAM_EX);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    mock_account_recv_simple();
+
+    set_cmd_cb(test_nss_getgrnam_no_members_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETGRNAM_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+    RESET_TCTX;
+
+    /* Use flag SSS_NSS_EX_FLAG_INVALIDATE_CACHE */
+    mock_input_user_or_group_ex(true, getgrnam_no_members.gr_name,
+                                SSS_NSS_EX_FLAG_INVALIDATE_CACHE);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETGRNAM_EX);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+
+    set_cmd_cb(test_nss_getgrnam_no_members_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETGRNAM_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+}
+
+void test_nss_getgrgid_ex_no_members(void **state)
+{
+    errno_t ret;
+
+    /* Test group is still in the cache */
+
+    mock_input_id_ex(nss_test_ctx, getgrnam_no_members.gr_gid, 0);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETGRGID_EX);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    mock_account_recv_simple();
+
+    /* Query for that group, call a callback when command finishes */
+    set_cmd_cb(test_nss_getgrnam_no_members_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETGRGID_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+    RESET_TCTX;
+
+    /* Use old input format, expect failure */
+    mock_input_id(nss_test_ctx, getgrnam_no_members.gr_gid);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETGRGID_EX);
+
+    set_cmd_cb(test_nss_EINVAL_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETGRGID_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+    RESET_TCTX;
+
+    /* Use unsupported flag combination, expect EINVAL */
+    mock_input_id_ex(nss_test_ctx, getgrnam_no_members.gr_gid,
+                     SSS_NSS_EX_FLAG_NO_CACHE
+                        |SSS_NSS_EX_FLAG_INVALIDATE_CACHE);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETGRGID_EX);
+
+    set_cmd_cb(test_nss_EINVAL_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETGRGID_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+    RESET_TCTX;
+
+    /* Use flag SSS_NSS_EX_FLAG_NO_CACHE,
+     * will cause a backend lookup -> mock_account_recv_simple() */
+    mock_input_id_ex(nss_test_ctx, getgrnam_no_members.gr_gid,
+                     SSS_NSS_EX_FLAG_NO_CACHE);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETGRGID_EX);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    mock_account_recv_simple();
+    mock_account_recv_simple();
+
+    set_cmd_cb(test_nss_getgrnam_no_members_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETGRGID_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+    RESET_TCTX;
+
+    /* Use flag SSS_NSS_EX_FLAG_INVALIDATE_CACHE */
+    mock_input_id_ex(nss_test_ctx, getgrnam_no_members.gr_gid,
+                     SSS_NSS_EX_FLAG_INVALIDATE_CACHE);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETGRGID_EX);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+
+    set_cmd_cb(test_nss_getgrnam_no_members_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETGRGID_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+}
+
+void test_nss_initgroups_ex(void **state)
+{
+    errno_t ret;
+    struct sysdb_attrs *attrs;
+
+    attrs = sysdb_new_attrs(nss_test_ctx);
+    assert_non_null(attrs);
+
+    ret = sysdb_attrs_add_time_t(attrs, SYSDB_INITGR_EXPIRE,
+                                 time(NULL) + 300);
+    assert_int_equal(ret, EOK);
+
+    ret = sysdb_attrs_add_string(attrs, SYSDB_UPN, "upninitgr@upndomain.test");
+    assert_int_equal(ret, EOK);
+
+    ret = store_user(nss_test_ctx, nss_test_ctx->tctx->dom,
+                     &testinitgr_usr, attrs, 0);
+    assert_int_equal(ret, EOK);
+
+    mock_input_user_or_group_ex(true, "testinitgr", 0);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_INITGR_EX);
+    mock_fill_user();
+
+    /* Query for that user, call a callback when command finishes */
+    set_cmd_cb(test_nss_initgr_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_INITGR_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+    RESET_TCTX;
+
+    /* Use old input format, expect failure */
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_WRAPPER);
+    will_return(__wrap_sss_packet_get_body, "testinitgr");
+    will_return(__wrap_sss_packet_get_body, 0);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_INITGR_EX);
+
+    set_cmd_cb(test_nss_EINVAL_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_INITGR_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+    RESET_TCTX;
+
+    /* Use unsupported flag combination, expect EINVAL */
+    mock_input_user_or_group_ex(false, "testinitgr",
+                                SSS_NSS_EX_FLAG_NO_CACHE
+                                    |SSS_NSS_EX_FLAG_INVALIDATE_CACHE);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_INITGR_EX);
+
+    set_cmd_cb(test_nss_EINVAL_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_INITGR_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+    RESET_TCTX;
+
+    /* Use flag SSS_NSS_EX_FLAG_NO_CACHE,
+     * will cause a backend lookup -> mock_account_recv_simple() */
+    mock_input_user_or_group_ex(true, "testinitgr",
+                                SSS_NSS_EX_FLAG_NO_CACHE);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_INITGR_EX);
+    mock_fill_user();
+    mock_account_recv_simple();
+
+    set_cmd_cb(test_nss_initgr_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_INITGR_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+    RESET_TCTX;
+
+    /* Use flag SSS_NSS_EX_FLAG_INVALIDATE_CACHE */
+    mock_input_user_or_group_ex(true, "testinitgr",
+                                SSS_NSS_EX_FLAG_INVALIDATE_CACHE);
+    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_INITGR_EX);
+    mock_fill_user();
+
+    set_cmd_cb(test_nss_initgr_check);
+    ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_INITGR_EX,
+                          nss_test_ctx->nss_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(nss_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+}
+
 int main(int argc, const char *argv[])
 {
     int rv;
@@ -4287,6 +4816,16 @@ int main(int argc, const char *argv[])
         cmocka_unit_test_setup_teardown(test_nss_getsidbyupn,
                                         nss_test_setup, nss_test_teardown),
         cmocka_unit_test_setup_teardown(test_nss_getsidbyname_neg,
+                                        nss_test_setup, nss_test_teardown),
+        cmocka_unit_test_setup_teardown(test_nss_getpwnam_ex,
+                                        nss_test_setup, nss_test_teardown),
+        cmocka_unit_test_setup_teardown(test_nss_getpwuid_ex,
+                                        nss_test_setup, nss_test_teardown),
+        cmocka_unit_test_setup_teardown(test_nss_getgrnam_ex_no_members,
+                                        nss_test_setup, nss_test_teardown),
+        cmocka_unit_test_setup_teardown(test_nss_getgrgid_ex_no_members,
+                                        nss_test_setup, nss_test_teardown),
+        cmocka_unit_test_setup_teardown(test_nss_initgroups_ex,
                                         nss_test_setup, nss_test_teardown),
     };
 


### PR DESCRIPTION
This patchset adds new called to libsss_nss_idmap to get NSS like user and
group information directly from SSSD without using the system's NSS interfaces.

Additionally a timeout and a flags options are added which are not
available for system's NSS.

Resolves https://pagure.io/SSSD/sssd/issue/2478