### PR TITLE
MAN: GPO Security Filtering limitation

### DIFF
--- a/src/man/sssd-ad.5.xml
+++ b/src/man/sssd-ad.5.xml
@@ -346,6 +346,13 @@ DOM:dom1:(memberOf:1.2.840.113556.1.4.1941:=cn=nestedgroup,ou=groups,dc=example,
                             host.
                         </para>
                         <para>
+                            NOTE: The current version of SSSD does not support
+                            host (computer) entries in the GPO 'Security
+                            Filtering' list. Only user and group entries are
+                            supported. Host entries in the list have no
+                            effect.
+                        </para>
+                        <para>
                             NOTE: If the operation mode is set to enforcing, it
                             is possible that users that were previously allowed
                             logon access will now be denied logon access (as


### PR DESCRIPTION
Note in the man pages that current version of SSSD does not support
host entries in the 'Security filtering' list.

Resolves:
https://pagure.io/SSSD/sssd/issue/3444