### PR TITLE
CI: Ignore source file generated by systemtap in coverage

### DIFF
--- a/contrib/ci/run
+++ b/contrib/ci/run
@@ -300,6 +300,7 @@ function build_coverage()
                                  --output-file ci-dirty.info
     stage lcov-clean        lcov --remove ci-dirty.info \
                                  "/usr/*" "src/tests/*" "/tmp/*" \
+                                 "*dtrace-temp.c" \
                                  --output-file ci.info
     stage genhtml           eval 'genhtml --output-directory \
                                           "$coverage_report_dir" \


### PR DESCRIPTION
There are some changes in systemtap 3.2 which generate temporary
source files and remove them later. We are not interested in code
coverage in this area. Lets ignore them.

...
genhtml:            failure  00:00:01 ci-build-coverage/ci-genhtml.log
FAILURE

sh$ cat ci-build-coverage/ci-genhtml.log
Start: Mon Oct 30 13:43:52 UTC 2017
+ eval 'genhtml --output-directory \
                "$coverage_report_dir" \
                --title "sssd" --show-details \
                --legend --prefix "$BASE_DIR" \
                ci.info |& tee ci-genhtml.out'
++ genhtml --output-directory ci-report-coverage --title sssd \
           --show-details --legend --prefix /home/build/sssd ci.info
++ tee ci-genhtml.out
Reading data file ci.info
Found 447 entries.
Using user-specified filename prefix "/home/build/sssd"
Writing .css and .png files.
Generating output.
genhtml: ERROR: cannot read /home/build/sssd/stap_generated_probes.o.dtrace-temp.c
Processing file stap_generated_probes.o.dtrace-temp.c
End: Mon Oct 30 13:43:53 UTC 2017

sh$ ls -l /home/build/sssd/stap_generated_probes.o.dtrace-temp.c
ls: cannot access '/home/build/sssd/stap_generated_probes.o.dtrace-temp.c': No such file or directory