### PR TITLE
CACHE_REQ: Better debugging for email conflicts

### DIFF
--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -640,7 +640,9 @@ int sysdb_search_user_by_upn_res(TALLOC_CTX *mem_ctx,
         goto done;
     } else if (res->count > 1) {
         DEBUG(SSSDBG_OP_FAILURE,
-              "Search for upn [%s] returns more than one result.\n", upn);
+              "Search for upn [%s] returns more than one result. One of the "
+              "possible reasons can be that several users share the same "
+              "email address.\n", upn);
         ret = EINVAL;
         goto done;
     }

--- a/src/db/sysdb_search.c
+++ b/src/db/sysdb_search.c
@@ -218,6 +218,21 @@ int sysdb_getpwnam(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
+    if (res->count > 1) {
+        /* We expected either 0 or 1 result for search with
+         * SYSDB_PWNAM_FILTER, but we got more. This error
+         * is handled individually depending on what function
+         * called sysdb_getpwnam, so we just print a message
+         * here and let the caller decide what error code to
+         * propagate based on res->count > 1. */
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Search for [%s] returned multiple results. It can be an email "
+              "address shared among multiple users or an email address of a "
+              "user that conflicts with another user's fully qualified name. "
+              "SSSD will not be able to handle those users properly.\n",
+              sanitized_name);
+    }
+
     /* Merge in the timestamps from the fast ts db */
     ret = sysdb_merge_res_ts_attrs(domain->sysdb, res, attrs);
     if (ret != EOK) {

--- a/src/man/sssd-ldap.5.xml
+++ b/src/man/sssd-ldap.5.xml
@@ -878,6 +878,15 @@
                             address of the user.
                         </para>
                         <para>
+                            Note: If an email address of a user conflicts with
+                            an email address or fully qualified name of another
+                            user, then SSSD will not be able to serve those
+                            users properly. If for some reason several users
+                            need to share the same email address then set
+                            this option to a nonexistent attribute name in
+                            order to disable user lookup/login by email.
+                        </para>
+                        <para>
                             Default: mail
                         </para>
                     </listitem>


### PR DESCRIPTION
Add DEBUG message when conflicts in FQ names or emails
are detected.

Also improve man page to hint on how to work around issue
with conflicting emails.

Resolves:
https://fedorahosted.org/sssd/ticket/3293