### PR TITLE
sudo: require sudoHost attribute and do not merge rules

### DIFF
--- a/src/providers/ldap/sdap_async_sudo.c
+++ b/src/providers/ldap/sdap_async_sudo.c
@@ -158,8 +158,9 @@ static char *sdap_sudo_build_host_filter(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    /* sudoHost is not specified */
-    filter = talloc_asprintf_append_buffer(filter, "(!(%s=*))",
+    /* sudoHost is not specified and it is a cn=defaults rule */
+    filter = talloc_asprintf_append_buffer(filter, "(&(!(%s=*))(%s=defaults))",
+                                           map[SDAP_AT_SUDO_HOST].name,
                                            map[SDAP_AT_SUDO_HOST].name);
     if (filter == NULL) {
         goto done;


### PR DESCRIPTION
The first patch solves customer's issue. Rule without sudoHost attribute will no longer be downloaded except cn=defaults where it is acceptable. 

The second patch makes sure that we do not try to merge two rules together
as it was side effect of `sysdb_store_custom` function and the result
of merging is non-deterministic as it depends on the ldap result order.

We might also add support for non-flat tree with non-unique cn as it is
supported by native sudo-ldap implementation but that sounds as a 2.0
feature to me.

For the record, the ticket says to print an error message which was my original suggestion, but this was much simpler and it also solve a possible issue with smart refresh which would not remove old attribute if it was removed from the ldap.