### PR TITLE
KCM: Fix restart during/after upgrade

### DIFF
--- a/src/sysv/systemd/sssd-kcm.service.in
+++ b/src/sysv/systemd/sssd-kcm.service.in
@@ -1,6 +1,8 @@
 [Unit]
 Description=SSSD Kerberos Cache Manager
 Documentation=man:sssd-kcm(5)
+Requires=sssd-kcm.socket
+After=sssd-kcm.socket
 
 [Install]
 Also=sssd-kcm.socket

--- a/src/sysv/systemd/sssd-secrets.service.in
+++ b/src/sysv/systemd/sssd-secrets.service.in
@@ -1,6 +1,8 @@
 [Unit]
 Description=SSSD Secrets Service responder
 Documentation=man:sssd-secrets(5)
+Requires=sssd-secrets.socket
+After=sssd-secrets.socket
 
 [Install]
 Also=sssd-secrets.socket


### PR DESCRIPTION
Oct 02 12:26:57 host systemd[1]: Closed SSSD Kerberos Cache Manager responder socket.
Oct 02 12:26:57 host systemd[1]: Stopping SSSD Kerberos Cache Manager responder socket.
Oct 02 12:26:57 host systemd[1]: sssd-kcm.socket: Socket service sssd-kcm.service already active, refusing.
Oct 02 12:26:57 host systemd[1]: Failed to listen on SSSD Kerberos Cache Manager responder socket.
Oct 02 12:26:57 host systemd[1]: Stopping SSSD Kerberos Cache Manager...
Oct 02 12:26:57 host sssd[kcm][21492]: Shutting down
Oct 02 12:26:57 host systemd[1]: Stopped SSSD Kerberos Cache Manager.

Resolves:
https://pagure.io/SSSD/sssd/issue/3529