### PR TITLE
krb5_child: Distinguish between expired & disabled AD user

### DIFF
--- a/src/providers/ad/ad_init.c
+++ b/src/providers/ad/ad_init.c
@@ -320,6 +320,7 @@ static errno_t ad_init_auth_ctx(TALLOC_CTX *mem_ctx,
     }
 
     krb5_auth_ctx->config_type = K5C_GENERIC;
+    krb5_auth_ctx->sss_creds_password = true;
     krb5_auth_ctx->service = ad_options->service->krb5_service;
 
     ret = ad_get_auth_options(krb5_auth_ctx, ad_options, be_ctx,

--- a/src/providers/krb5/krb5_auth.h
+++ b/src/providers/krb5/krb5_auth.h
@@ -46,6 +46,7 @@
 #define CHILD_OPT_USE_FAST "use-fast"
 #define CHILD_OPT_FAST_PRINCIPAL "fast-principal"
 #define CHILD_OPT_CANONICALIZE "canonicalize"
+#define CHILD_OPT_SSS_CREDS_PASSWORD "sss-creds-password"
 
 struct krb5child_req {
     struct pam_data *pd;

--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -3059,6 +3059,7 @@ int main(int argc, const char *argv[])
     uid_t fast_uid;
     gid_t fast_gid;
     struct cli_opts cli_opts = { 0 };
+    int sss_creds_password = 0;
 
     struct poptOption long_options[] = {
         POPT_AUTOHELP
@@ -3091,6 +3092,8 @@ int main(int argc, const char *argv[])
          _("Specifies the server principal to use for FAST"), NULL},
         {CHILD_OPT_CANONICALIZE, 0, POPT_ARG_NONE, NULL, 'C',
          _("Requests canonicalization of the principal name"), NULL},
+        {CHILD_OPT_SSS_CREDS_PASSWORD, 0, POPT_ARG_NONE, &sss_creds_password,
+         0, _("Use custom version of krb5_get_init_creds_password"), NULL},
         POPT_TABLEEND
     };
 

--- a/src/providers/krb5/krb5_child_handler.c
+++ b/src/providers/krb5/krb5_child_handler.c
@@ -306,7 +306,7 @@ errno_t set_extra_args(TALLOC_CTX *mem_ctx, struct krb5_ctx *krb5_ctx,
         return EINVAL;
     }
 
-    extra_args = talloc_zero_array(mem_ctx, const char *, 9);
+    extra_args = talloc_zero_array(mem_ctx, const char *, 10);
     if (extra_args == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "talloc_zero_array failed.\n");
         return ENOMEM;
@@ -394,6 +394,16 @@ errno_t set_extra_args(TALLOC_CTX *mem_ctx, struct krb5_ctx *krb5_ctx,
                                       "--" CHILD_OPT_CANONICALIZE);
         if (extra_args[c] == NULL) {
             DEBUG(SSSDBG_OP_FAILURE, "talloc_strdup failed.\n");
+            ret = ENOMEM;
+            goto done;
+        }
+        c++;
+    }
+
+    if (krb5_ctx->sss_creds_password) {
+        extra_args[c] = talloc_strdup(extra_args,
+                                      "--" CHILD_OPT_SSS_CREDS_PASSWORD);
+        if (extra_args[c] == NULL) {
             ret = ENOMEM;
             goto done;
         }

--- a/src/providers/krb5/krb5_common.h
+++ b/src/providers/krb5/krb5_common.h
@@ -124,6 +124,7 @@ struct krb5_ctx {
     struct deferred_auth_ctx *deferred_auth_ctx;
     struct renew_tgt_ctx *renew_tgt_ctx;
     bool use_fast;
+    bool sss_creds_password;
 
     hash_table_t *wait_queue_hash;
 


### PR DESCRIPTION
This is an updated version of patchset which was prepared a long time ago.

It had to be changed due to commit  78027feeb56d6fe216f699be86a4716aaef3f628
which introduced different handling of password due to conditional build in `password_or_responder`

I did not test with older version of krb5 which does not have defined`HAVE_KRB5_GET_INIT_CREDS_OPT_SET_RESPONDER`

It was initially discussed on sssd-devel https://lists.fedorahosted.org/archives/list/sssd-devel@lists.fedorahosted.org/message/ZKV7PR5MASG2R43A534BDZ6FNQJNH2TH/
as part of mail thread https://lists.fedorahosted.org/archives/list/sssd-devel@lists.fedorahosted.org/thread/OM2BME5DKH3HBD23BB5SC73I5VTATIGD/#M6E4V5PWMXNNTJIILOAJGX2H32RACPWJ

and @simo5 did most of review at that time. 