### PR TITLE
TOOLS: Double quote array expansions in sss_debuglevel

### DIFF
--- a/src/tools/wrappers/sss_debuglevel.in
+++ b/src/tools/wrappers/sss_debuglevel.in
@@ -1,4 +1,4 @@
 #!/bin/sh
 sbindir=@sbindir@
 echo "Redirecting to $sbindir/sssctl debug-level" >&2
-$sbindir/sssctl debug-level $@
+$sbindir/sssctl debug-level "$@"

--- a/src/tools/wrappers/sss_debuglevel.in
+++ b/src/tools/wrappers/sss_debuglevel.in
@@ -1,4 +1,4 @@
 #!/bin/sh
 sbindir=@sbindir@
 echo "Redirecting to $sbindir/sssctl debug-level" >&2
-$sbindir/sssctl debug-level "$@"
+exec $sbindir/sssctl debug-level "$@"


### PR DESCRIPTION
Otherwise they're like $* and break on spaces.

This issue has been caught by coverity:
    Defect type: SHELLCHECK_WARNING