### PR TITLE
CHILD: Pass information about logger to children

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1491,7 +1491,7 @@ EXTRA_DIST += \
     src/responder/ifp/org.freedesktop.sssd.infopipe.service.in \
     $(NULL)
 
-ifp_edit_cmd = $(SED) \
+ifp_edit_cmd = $(edit_cmd) \
         -e 's|@ifp_exec_cmd[@]|$(ifp_exec_cmd)|g' \
         -e 's|@ifp_systemdservice[@]|$(ifp_systemdservice)|g' \
         -e 's|@ifp_restart[@]|$(ifp_restart)|g'

--- a/src/p11_child/p11_child_nss.c
+++ b/src/p11_child/p11_child_nss.c
@@ -537,7 +537,7 @@ int main(int argc, const char *argv[])
     int opt;
     poptContext pc;
     int debug_fd = -1;
-    char *opt_logger = NULL;
+    const char *opt_logger = NULL;
     errno_t ret;
     TALLOC_CTX *main_ctx = NULL;
     char *cert;
@@ -673,7 +673,9 @@ int main(int argc, const char *argv[])
         if (ret != EOK) {
             DEBUG(SSSDBG_CRIT_FAILURE, "set_debug_file_from_fd failed.\n");
         }
+        opt_logger = sss_logger_str[FILES_LOGGER];
     }
+
     sss_set_logger(opt_logger);
 
     DEBUG(SSSDBG_TRACE_FUNC, "p11_child started.\n");

--- a/src/providers/ad/ad_gpo_child.c
+++ b/src/providers/ad/ad_gpo_child.c
@@ -687,7 +687,7 @@ main(int argc, const char *argv[])
     int opt;
     poptContext pc;
     int debug_fd = -1;
-    char *opt_logger = NULL;
+    const char *opt_logger = NULL;
     errno_t ret;
     int sysvol_gpt_version;
     int result;
@@ -744,6 +744,7 @@ main(int argc, const char *argv[])
         if (ret != EOK) {
             DEBUG(SSSDBG_CRIT_FAILURE, "set_debug_file_from_fd failed.\n");
         }
+        opt_logger = sss_logger_str[FILES_LOGGER];
     }
 
     sss_set_logger(opt_logger);

--- a/src/providers/ipa/selinux_child.c
+++ b/src/providers/ipa/selinux_child.c
@@ -206,7 +206,7 @@ int main(int argc, const char *argv[])
     struct response *resp = NULL;
     ssize_t written;
     bool needs_update;
-    char *opt_logger = NULL;
+    const char *opt_logger = NULL;
 
     struct poptOption long_options[] = {
         POPT_AUTOHELP
@@ -254,6 +254,7 @@ int main(int argc, const char *argv[])
         if (ret != EOK) {
             DEBUG(SSSDBG_CRIT_FAILURE, "set_debug_file_from_fd failed.\n");
         }
+        opt_logger = sss_logger_str[FILES_LOGGER];
     }
 
     sss_set_logger(opt_logger);

--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -3020,7 +3020,7 @@ int main(int argc, const char *argv[])
     int opt;
     poptContext pc;
     int debug_fd = -1;
-    char *opt_logger = NULL;
+    const char *opt_logger = NULL;
     errno_t ret;
     krb5_error_code kerr;
     uid_t fast_uid;
@@ -3097,6 +3097,7 @@ int main(int argc, const char *argv[])
         if (ret != EOK) {
             DEBUG(SSSDBG_CRIT_FAILURE, "set_debug_file_from_fd failed.\n");
         }
+        opt_logger = sss_logger_str[FILES_LOGGER] ;
     }
 
     sss_set_logger(opt_logger);

--- a/src/providers/ldap/ldap_child.c
+++ b/src/providers/ldap/ldap_child.c
@@ -599,7 +599,7 @@ int main(int argc, const char *argv[])
     int kerr;
     int opt;
     int debug_fd = -1;
-    char *opt_logger = NULL;
+    const char *opt_logger = NULL;
     poptContext pc;
     TALLOC_CTX *main_ctx = NULL;
     uint8_t *buf = NULL;
@@ -657,6 +657,7 @@ int main(int argc, const char *argv[])
         if (ret != EOK) {
             DEBUG(SSSDBG_CRIT_FAILURE, "set_debug_file_from_fd failed.\n");
         }
+        opt_logger = sss_logger_str[FILES_LOGGER];
     }
 
     sss_set_logger(opt_logger);

--- a/src/sysv/systemd/sssd.service.in
+++ b/src/sysv/systemd/sssd.service.in
@@ -10,6 +10,7 @@ EnvironmentFile=-@environment_file@
 ExecStart=@sbindir@/sssd -i ${DEBUG_LOGGER}
 Type=notify
 NotifyAccess=main
+PIDFile=@localstatedir@/run/sssd.pid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Variables debug_to_file or debug_to_stderr were not set
because back-end already user parameter --logger=%s.
And therefore logs were not sent to files.
    
It could only work in case of direct usage of --debug-to-files in back-end via
command configuration option.
    
Resolves:
https://pagure.io/SSSD/sssd/issue/3433