### PR TITLE
NSS: Use enum_ctx as memory_context in _setnetgrent_set_timeout()

### DIFF
--- a/src/responder/nss/nss_enum.c
+++ b/src/responder/nss/nss_enum.c
@@ -283,7 +283,7 @@ nss_setnetgrent_set_timeout(struct tevent_context *ev,
     timeout = enum_ctx->result[0]->domain->netgroup_timeout;
 
     tv = tevent_timeval_current_ofs(timeout, 0);
-    te = tevent_add_timer(ev, nss_ctx, tv, nss_setnetgrent_timeout, enum_ctx);
+    te = tevent_add_timer(ev, enum_ctx, tv, nss_setnetgrent_timeout, enum_ctx);
     if (te == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Could not set up life timer for enumeration object.\n");


### PR DESCRIPTION
We've noticed some crashes that happened because enum_ctx is already
freed, but the timeout handler is still called. In order to avoid that,
let's remove the timeout handler when enum_ctx is freed at other places.

Resolves: https://pagure.io/SSSD/sssd/issue/3523

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>

PS: While I wasn't able to reproduce the issue, a customer confirmed this patch solved their problem.