### PR TITLE
NSS: Use netgr as memory context in set_netgr_lifetime() - Patch for SSSD-1.14

### DIFF
--- a/src/responder/nss/nsssrv_netgroup.c
+++ b/src/responder/nss/nsssrv_netgroup.c
@@ -428,7 +428,7 @@ static void set_netgr_lifetime(uint32_t lifetime,
 
     tv = tevent_timeval_current_ofs(lifetime, 0);
     te = tevent_add_timer(step_ctx->nctx->rctx->ev,
-                          step_ctx->nctx->gctx, tv,
+                          step_ctx->nctx, tv,
                           setnetgrent_result_timeout,
                           netgr);
     if (!te) {


### PR DESCRIPTION
We've noticed some crashes that happened because netgr is already freed,
but the timeout handler is still called. In order to avoid that, let's
remove the timeout handler when enum_ctx is freed at other places.

Resolves: https://pagure.io/SSSD/sssd/issue/3523

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>