### PR TITLE
RESP: Add some missing NULL checks

### DIFF
--- a/src/responder/autofs/autofssrv_dp.c
+++ b/src/responder/autofs/autofssrv_dp.c
@@ -65,6 +65,10 @@ sss_dp_get_autofs_send(TALLOC_CTX *mem_ctx,
     }
 
     info = talloc_zero(state, struct sss_dp_get_autofs_info);
+    if (info == NULL) {
+        ret = ENOMEM;
+        goto error;
+    }
     info->fast_reply = fast_reply;
     info->type = type;
     info->name = name;

--- a/src/responder/common/responder_dp.c
+++ b/src/responder/common/responder_dp.c
@@ -536,6 +536,10 @@ sss_dp_get_account_send(TALLOC_CTX *mem_ctx,
     }
 
     info = talloc_zero(state, struct sss_dp_account_info);
+    if (info == NULL) {
+        ret = ENOMEM;
+        goto error;
+    }
     info->fast_reply = fast_reply;
     info->type = type;
     info->opt_name = opt_name;

--- a/src/responder/common/responder_dp_ssh.c
+++ b/src/responder/common/responder_dp_ssh.c
@@ -64,6 +64,10 @@ sss_dp_get_ssh_host_send(TALLOC_CTX *mem_ctx,
     }
 
     info = talloc_zero(state, struct sss_dp_get_ssh_host_info);
+    if (info == NULL) {
+        ret = ENOMEM;
+        goto error;
+    }
     info->fast_reply = fast_reply;
     info->name = name;
     info->alias = alias;

--- a/src/responder/sudo/sudosrv_dp.c
+++ b/src/responder/sudo/sudosrv_dp.c
@@ -72,6 +72,10 @@ sss_dp_get_sudoers_send(TALLOC_CTX *mem_ctx,
     }
 
     info = talloc_zero(state, struct sss_dp_get_sudoers_info);
+    if (info == NULL) {
+        ret = ENOMEM;
+        goto error;
+    }
     info->fast_reply = fast_reply;
     info->type = type;
     info->name = name;


### PR DESCRIPTION
This trivial bug was copied all around the responder code. Only when I
initially copied it for another time I noticed we should check the info
structure pointer after allocating it.