### PR TITLE
common: Correction of cache_req debug string ID format

### DIFF
--- a/src/responder/common/cache_req/plugins/cache_req_group_by_id.c
+++ b/src/responder/common/cache_req/plugins/cache_req_group_by_id.c
@@ -31,7 +31,7 @@ cache_req_group_by_id_create_debug_name(TALLOC_CTX *mem_ctx,
                                         struct cache_req_data *data,
                                         struct sss_domain_info *domain)
 {
-    return talloc_asprintf(mem_ctx, "GID:%d@%s", data->id, domain->name);
+    return talloc_asprintf(mem_ctx, "GID:%"PRIu32"@%s", data->id, domain->name);
 }
 
 static errno_t

--- a/src/responder/common/cache_req/plugins/cache_req_object_by_id.c
+++ b/src/responder/common/cache_req/plugins/cache_req_object_by_id.c
@@ -31,7 +31,7 @@ cache_req_object_by_id_create_debug_name(TALLOC_CTX *mem_ctx,
                                          struct cache_req_data *data,
                                          struct sss_domain_info *domain)
 {
-    return talloc_asprintf(mem_ctx, "ID:%d@%s", data->id, domain->name);
+    return talloc_asprintf(mem_ctx, "ID:%"PRIu32"@%s", data->id, domain->name);
 }
 
 static errno_t

--- a/src/responder/common/cache_req/plugins/cache_req_user_by_id.c
+++ b/src/responder/common/cache_req/plugins/cache_req_user_by_id.c
@@ -31,7 +31,7 @@ cache_req_user_by_id_create_debug_name(TALLOC_CTX *mem_ctx,
                                        struct cache_req_data *data,
                                        struct sss_domain_info *domain)
 {
-    return talloc_asprintf(mem_ctx, "UID:%d@%s", data->id, domain->name);
+    return talloc_asprintf(mem_ctx, "UID:%"PRIu32"@%s", data->id, domain->name);
 }
 
 static errno_t


### PR DESCRIPTION
The cache-req debug string representation uses a wrong format
specifier for by-ID requests.
%d should be replaced with  %"SPRIgid".

Resolves: https://pagure.io/SSSD/sssd/issue/3570