### PR TITLE
TESTS: Order list of entries in some lists

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -237,6 +237,7 @@ endif # HAVE_CHECK
 
 if HAVE_CMOCKA
     non_interactive_cmocka_based_tests = \
+        nss-srv-tests \
         test-find-uid \
         test-io \
         test-negcache \
@@ -259,6 +260,7 @@ if HAVE_CMOCKA
         test_sdap_certmap \
         sdap-tests \
         test_sysdb_ts_cache \
+        test_sysdb_views \
         test_sysdb_subdomains \
         test_sysdb_certmap \
         test_sysdb_sudo \

--- a/src/tests/cmocka/test_nss_srv.c
+++ b/src/tests/cmocka/test_nss_srv.c
@@ -585,6 +585,25 @@ static errno_t delete_group(struct nss_test_ctx *ctx,
     return ret;
 }
 
+static int cmp_func(const void *a, const void *b)
+{
+    char *str1 = *(char **)discard_const(a);
+    char *str2 = *(char **)discard_const(b);
+
+    return strcmp(str1, str2);
+}
+
+static void order_string_array(char **_list, int size)
+{
+    if (size < 2 || _list == NULL || *_list == NULL) {
+        /* Nothing to do */
+        return;
+    }
+
+    qsort(_list, size, sizeof(char *), cmp_func);
+    return;
+}
+
 static void assert_groups_equal(struct group *expected,
                                 struct group *gr, const int nmem)
 {
@@ -593,6 +612,9 @@ static void assert_groups_equal(struct group *expected,
     assert_int_equal(gr->gr_gid, expected->gr_gid);
     assert_string_equal(gr->gr_name, expected->gr_name);
     assert_string_equal(gr->gr_passwd, expected->gr_passwd);
+
+    order_string_array(gr->gr_mem, nmem);
+    order_string_array(expected->gr_mem, nmem);
 
     for (i = 0; i < nmem; i++) {
         assert_string_equal(gr->gr_mem[i], expected->gr_mem[i]);


### PR DESCRIPTION
Some tests started to fail becuase we depended on specific
order users in groups or messages in ldb results to be
returned and that order changed.

This patch adds a simple helper functions into these tests
that order the entries before comparison with expected results.
more deterministic.

Resolves:
https://pagure.io/SSSD/sssd/issue/3563