### PR TITLE
mmap_cache: make checks independent of input size

### DIFF
--- a/src/responder/nss/nss_protocol.c
+++ b/src/responder/nss/nss_protocol.c
@@ -160,6 +160,13 @@ nss_protocol_parse_name_ex(struct cli_ctx *cli_ctx, const char **_rawname,
     }
 
     p = memchr(body, '\0', blen);
+    /* Although body for sure is null terminated, let's add this check here
+     * so static analyzers are happier. */
+    if (p == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "memchr() returned NULL, body is not null terminated!\n");
+        return EINVAL;
+    }
 
     /* If the body isn't valid UTF-8, fail */
     if (!sss_utf8_check(body, (p - body))) {

--- a/src/responder/nss/nsssrv_mmap_cache.c
+++ b/src/responder/nss/nsssrv_mmap_cache.c
@@ -547,18 +547,32 @@ static struct sss_mc_rec *sss_mc_find_record(struct sss_mc_ctx *mcc,
             return NULL;
         }
 
+        if (key->len > strs_len) {
+            /* The string cannot be in current record */
+            slot = sss_mc_next_slot_with_hash(rec, hash);
+            continue;
+        }
+
         safealign_memcpy(&name_ptr, rec->data, sizeof(rel_ptr_t), NULL);
-        if (key->len > strs_len
-            || (name_ptr + key->len) > (strs_offset + strs_len)
-            || (uint8_t *)rec->data + strs_offset + strs_len > max_addr) {
+        t_key = (char *)rec->data + name_ptr;
+        /* name_ptr must point to some data in the strs/gids area of the data
+         * payload. Since it is a pointer relative to rec->data it must larger
+         * equal strs_offset and must be smaller then strs_offset + strs_len.
+         * Additionally the area must not end outside of the data table and
+         * t_key must be a zero-terminates string. */
+        if (name_ptr < strs_offset
+                || name_ptr >= strs_offset + strs_len
+                || (uint8_t *)rec->data > max_addr
+                || strs_offset > max_addr - (uint8_t *)rec->data
+                || strs_len > max_addr - (uint8_t *)rec->data - strs_offset) {
             DEBUG(SSSDBG_FATAL_FAILURE,
-                  "Corrupted fastcache. name_ptr value is %u.\n", name_ptr);
+                  "Corrupted fastcache entry at slot %u. "
+                  "name_ptr value is %u.\n", slot, name_ptr);
             sss_mc_save_corrupted(mcc);
             sss_mmap_cache_reset(mcc);
             return NULL;
         }
 
-        t_key = (char *)rec->data + name_ptr;
         if (strcmp(key->str, t_key) == 0) {
             break;
         }

--- a/src/sss_client/nss_mc_group.c
+++ b/src/sss_client/nss_mc_group.c
@@ -148,20 +148,22 @@ errno_t sss_nss_mc_getgrnam(const char *name, size_t name_len,
         }
 
         data = (struct sss_mc_grp_data *)rec->data;
+        rec_name = (char *)data + data->name;
         /* Integrity check
-         * - name_len cannot be longer than all strings
          * - data->name cannot point outside strings
          * - all strings must be within copy of record
-         * - size of record must be lower that data table size */
-        if (name_len > data->strs_len
-            || (data->name + name_len) > (strs_offset + data->strs_len)
+         * - record must not end outside data table
+         * - rec_name is a zero-terminated string */
+        if (data->name < strs_offset
+            || data->name >= strs_offset + data->strs_len
             || data->strs_len > rec->len
-            || rec->len > data_size) {
+            || (uint8_t *) rec + rec->len > gr_mc_ctx.data_table + data_size
+            || memchr(rec_name, '\0',
+                      (strs_offset + data->strs_len) - data->name) == NULL) {
             ret = ENOENT;
             goto done;
         }
 
-        rec_name = (char *)data + data->name;
         if (strcmp(name, rec_name) == 0) {
             break;
         }

--- a/src/sss_client/nss_mc_passwd.c
+++ b/src/sss_client/nss_mc_passwd.c
@@ -141,20 +141,22 @@ errno_t sss_nss_mc_getpwnam(const char *name, size_t name_len,
         }
 
         data = (struct sss_mc_pwd_data *)rec->data;
+        rec_name = (char *)data + data->name;
         /* Integrity check
-         * - name_len cannot be longer than all strings
          * - data->name cannot point outside strings
          * - all strings must be within copy of record
-         * - size of record must be lower that data table size */
-        if (name_len > data->strs_len
-            || (data->name + name_len) > (strs_offset + data->strs_len)
+         * - record must not end outside data table
+         * - rec_name is a zero-terminated string */
+        if (data->name < strs_offset
+            || data->name >= strs_offset + data->strs_len
             || data->strs_len > rec->len
-            || rec->len > data_size) {
+            || (uint8_t *) rec + rec->len > pw_mc_ctx.data_table + data_size
+            || memchr(rec_name, '\0',
+                      (strs_offset + data->strs_len) - data->name) == NULL ) {
             ret = ENOENT;
             goto done;
         }
 
-        rec_name = (char *)data + data->name;
         if (strcmp(name, rec_name) == 0) {
             break;
         }


### PR DESCRIPTION
Currently the consistency checks for the mmap_cache payload data on the
client and the responder side include the length of the input string of
the current request. Since there might be hash collisions which other
much longer or much shorter names those checks might fail although there
is no data corruption.

This patch removes the checks using the length of the input and adds a
check if the name found in the payload is zero-terminated inside of the
payload data.

Resolves https://pagure.io/SSSD/sssd/issue/3571