### PR TITLE
ipa: Removal of umask(0) in selinux_child

### DIFF
--- a/src/providers/ipa/selinux_child.c
+++ b/src/providers/ipa/selinux_child.c
@@ -146,13 +146,6 @@ static int sc_set_seuser(const char *login_name, const char *seuser_name,
                          const char *mls)
 {
     int ret;
-    mode_t old_mask;
-
-    /* This is a workaround for
-     * https://bugzilla.redhat.com/show_bug.cgi?id=1186422 to make sure
-     * the directories are created with the expected permissions
-     */
-    old_mask = umask(0);
     if (strcmp(seuser_name, "") == 0) {
         /* An empty SELinux user should cause SSSD to use the system
          * default. We need to remove the SELinux user from the DB
@@ -162,7 +155,6 @@ static int sc_set_seuser(const char *login_name, const char *seuser_name,
     } else {
         ret = set_seuser(login_name, seuser_name, mls);
     }
-    umask(old_mask);
     return ret;
 }
 


### PR DESCRIPTION
Code for calling umask(0) was added to address bugzilla
https://bugzilla.redhat.com/show_bug.cgi?id=1186422.
Now this bugzilla is fixed, removing the workaround.

Resolves: https://pagure.io/SSSD/sssd/issue/3583