### PR TITLE
overrides: fixes for sysdb_invalidate_overrides()

### DIFF
--- a/src/util/domain_info_utils.c
+++ b/src/util/domain_info_utils.c
@@ -174,8 +174,8 @@ sss_get_domain_by_sid_ldap_fallback(struct sss_domain_info *domain,
 }
 
 struct sss_domain_info *
-find_domain_by_object_name(struct sss_domain_info *domain,
-                           const char *object_name)
+find_domain_by_object_name_ex(struct sss_domain_info *domain,
+                              const char *object_name, bool strict)
 {
     TALLOC_CTX *tmp_ctx;
     struct sss_domain_info *dom = NULL;
@@ -197,7 +197,11 @@ find_domain_by_object_name(struct sss_domain_info *domain,
     }
 
     if (domainname == NULL) {
-        dom = domain;
+        if (strict) {
+            dom = NULL;
+        } else {
+            dom = domain;
+        }
     } else {
         dom = find_domain_by_name(domain, domainname, true);
     }
@@ -205,6 +209,13 @@ find_domain_by_object_name(struct sss_domain_info *domain,
 done:
     talloc_free(tmp_ctx);
     return dom;
+}
+
+struct sss_domain_info *
+find_domain_by_object_name(struct sss_domain_info *domain,
+                           const char *object_name)
+{
+    return find_domain_by_object_name_ex(domain, object_name, false);
 }
 
 errno_t sssd_domain_init(TALLOC_CTX *mem_ctx,

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -551,6 +551,10 @@ struct sss_domain_info *
 find_domain_by_object_name(struct sss_domain_info *domain,
                            const char *object_name);
 
+struct sss_domain_info *
+find_domain_by_object_name_ex(struct sss_domain_info *domain,
+                              const char *object_name, bool strict);
+
 bool subdomain_enumerates(struct sss_domain_info *parent,
                           const char *sd_name);
 


### PR DESCRIPTION
There were two issues in sysdb_invalidate_overrides().

First, SYSDB_CACHE_EXPIRE was only reset for the entry in the data cache
but not in the timestamp cache.

Second, if one of the steps in the combined replace and delete operation
failed no change was committed to the cache. If, for whatever reasons, a
user or group object didn't had SYSDB_OVERRIDE_DN set the delete failed and
hence SYSDB_CACHE_EXPIRE wasn't reset as well. To make sure the cache is in
a consistent state after a view change the replace and the delete
operations are don in two steps.

Related to https://pagure.io/SSSD/sssd/issue/3579