### PR TITLE
sysdb-test: Fix warning may be used uninitialized

### DIFF
--- a/src/tests/sysdb-tests.c
+++ b/src/tests/sysdb-tests.c
@@ -2220,7 +2220,7 @@ START_TEST (test_sysdb_search_all_users)
     int ret;
     int i;
     int j;
-    char *uid_str;
+    char *uid_str = NULL;
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);


### PR DESCRIPTION
It cannot be uninitialized because we will have some messages.

2243
2244     fail_unless(data->msgs_count == 10,
2245                 "wrong number of results, found [%d] expected [10]",
2246                 data->msgs_count);

and it cannot be NULL

2257         for (j = 0; j < data->msgs_count; j++) {
2258             uid_str = talloc_asprintf(data, "%d", 27010 + j);
2259             fail_unless(uid_str != NULL, "talloc_asprintf failed.");

src/tests/sysdb-tests.c: In function ‘test_sysdb_search_all_users’:
src/tests/sysdb-tests.c:2266:9: error: ‘uid_str’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
         fail_unless(strncmp(uid_str,
         ^~~~~~~~~~~