### PR TITLE
responder: Fix talloc hierarchy in sized_output_name

### DIFF
--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -1815,7 +1815,7 @@ int sized_output_name(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    ret = sss_output_fqname(mem_ctx, name_dom, orig_name,
+    ret = sss_output_fqname(name, name_dom, orig_name,
                             rctx->override_space, &name_str);
     if (ret != EOK) {
         goto done;

--- a/src/tests/cmocka/test_responder_common.c
+++ b/src/tests/cmocka/test_responder_common.c
@@ -316,6 +316,23 @@ void test_schedule_get_domains_task(void **state)
     talloc_free(dummy_ncache_ptr);
 }
 
+void test_sss_output_fqname(void **state)
+{
+    struct parse_inp_test_ctx *parse_inp_ctx = talloc_get_type(*state,
+                                                   struct parse_inp_test_ctx);
+    errno_t ret;
+    struct sized_string *res = NULL;
+
+    ret = sized_output_name(parse_inp_ctx, parse_inp_ctx->rctx, "dummy",
+                            parse_inp_ctx->tctx->dom, &res);
+    assert_int_equal(ret, EOK);
+    assert_non_null(res);
+    assert_string_equal("dummy", res->str);
+    assert_int_equal(6, res->len);
+
+    talloc_zfree(res);
+}
+
 int main(int argc, const char *argv[])
 {
     int rv;
@@ -344,6 +361,9 @@ int main(int argc, const char *argv[])
                                         parse_inp_test_setup,
                                         parse_inp_test_teardown),
         cmocka_unit_test_setup_teardown(test_schedule_get_domains_task,
+                                        parse_inp_test_setup,
+                                        parse_inp_test_teardown),
+        cmocka_unit_test_setup_teardown(test_sss_output_fqname,
                                         parse_inp_test_setup,
                                         parse_inp_test_teardown),
     };


### PR DESCRIPTION
responder: Fix talloc hierarchy in sized_output_name

sized_output_name was a called with NULL context in
memcache_delete_entry but returned data from sized_output_name
didn't have proper talloc hierarchy and we could not release all
all returned data.

==00:01:01:29.871 10088== 934,414 bytes in 8,731 blocks are definitely lost in loss record 121 of 121
==00:01:01:29.871 10088==    at 0x4C29BE3: malloc (vg_replace_malloc.c:299)
==00:01:01:29.871 10088==    by 0x8FF4EAB: talloc_strdup (in /usr/lib64/libtalloc.so.2.1.9)
==00:01:01:29.871 10088==    by 0x52933B9: sss_output_name (usertools.c:808)
==00:01:01:29.871 10088==    by 0x5293550: sss_output_fqname (usertools.c:863)
==00:01:01:29.871 10088==    by 0x1211F9: sized_output_name (responder_common.c:1708)
==00:01:01:29.871 10088==    by 0x1137E6: memcache_delete_entry (nss_get_object.c:112)
==00:01:01:29.871 10088==    by 0x113BB6: nss_get_object_done (nss_get_object.c:245)
==00:01:01:29.871 10088==    by 0x8DE5291: _tevent_req_error (in /usr/lib64/libtevent.so.0.9.31)
==00:01:01:29.871 10088==    by 0x1276CE: cache_req_done (cache_req.c:1047)
==00:01:01:29.871 10088==    by 0x8DE5291: _tevent_req_error (in /usr/lib64/libtevent.so.0.9.31)
==00:01:01:29.871 10088==    by 0x126AF6: cache_req_search_domains_done (cache_req.c:607)
==00:01:01:29.871 10088==    by 0x8DE4AB9: tevent_common_loop_immediate (in /usr/lib64/libtevent.so.0.9.31)
==00:01:01:29.871 10088==    by 0x8DE9C9C: ??? (in /usr/lib64/libtevent.so.0.9.31)
==00:01:01:29.871 10088==    by 0x8DE82A6: ??? (in /usr/lib64/libtevent.so.0.9.31)
==00:01:01:29.871 10088==    by 0x8DE40CC: _tevent_loop_once (in /usr/lib64/libtevent.so.0.9.31)
==00:01:01:29.871 10088==    by 0x8DE42FA: tevent_common_loop_wait (in /usr/lib64/libtevent.so.0.9.31)
==00:01:01:29.871 10088==    by 0x8DE8246: ??? (in /usr/lib64/libtevent.so.0.9.31)
==00:01:01:29.871 10088==    by 0x5291B32: server_loop (server.c:718)
==00:01:01:29.871 10088==    by 0x11004C: main (nsssrv.c:560)