### PR TITLE
confdb: Do not start implicit_files with proxy domain

### DIFF
--- a/src/tests/intg/test_files_provider.py
+++ b/src/tests/intg/test_files_provider.py
@@ -167,6 +167,9 @@ def no_files_domain(request):
 
         [domain/local]
         id_provider = local
+
+        [domain/disabled.files]
+        id_provider = files
     """).format(**locals())
     create_conf_fixture(request, conf)
     create_sssd_fixture(request)


### PR DESCRIPTION
id_provider = proxy + proxy_lib_name = files is equivalent
to id_provider = files. But requests to user hit implicit_files
domain instead of proxy domain and therefore it broke usage
of proxy domain with auth_provider = krb5.
    
Resolves:
https://pagure.io/SSSD/sssd/issue/3590