### PR TITLE
SYSDB: Properly handle name/gid override when using domain resolution order

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -258,6 +258,8 @@
                            SYSDB_OVERRIDE_OBJECT_DN, \
                            SYSDB_DEFAULT_OVERRIDE_NAME, \
                            SYSDB_UUID, \
+                           ORIGINALAD_PREFIX SYSDB_NAME, \
+                           ORIGINALAD_PREFIX SYSDB_GIDNUM, \
                            NULL}
 
 #define SYSDB_NETGR_ATTRS {SYSDB_NAME, SYSDB_NETGROUP_TRIPLE, \


### PR DESCRIPTION
When using name/gid override together with domain resolution order the
mpg name/gid may be returned instead of the overridden one.

In order to avoid that, let's add a check in case the domain supports
mpg so we can ensure that the originalADname and originalADgidNumber
attributes are the very same as the ones searched and then normally
proceed with the current flow in the code. In case those are not the
same, we *must* follow the code path for the non-mpg domains and then
return the proper values.

Resolves: https://pagure.io/SSSD/sssd/issue/3595

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>