### PR TITLE
p11_child: make sure OCSP checks are done

### DIFF
--- a/src/p11_child/p11_child_nss.c
+++ b/src/p11_child/p11_child_nss.c
@@ -338,6 +338,23 @@ int do_work(TALLOC_CTX *mem_ctx, const char *nss_db,
                       PR_GetError(), PORT_ErrorToString(PR_GetError()));
                 continue;
             }
+
+            /* with 'certificateUsageCheckAllUsages' set
+             * CERT_VerifyCertificateNow() does not do OCSP so it must be done
+             * explicitly */
+            if (cert_verify_opts->do_ocsp) {
+                rv = CERT_CheckOCSPStatus(handle, cert_list_node->cert,
+                                          PR_Now(), NULL);
+                if (rv != SECSuccess) {
+                    DEBUG(SSSDBG_OP_FAILURE,
+                          "Certificate [%s][%s] failed OCSP check [%d][%s], "
+                          "skipping.\n",
+                          cert_list_node->cert->nickname,
+                          cert_list_node->cert->subjectName,
+                          PR_GetError(), PORT_ErrorToString(PR_GetError()));
+                    continue;
+                }
+            }
         }
 
         if (key_id_in != NULL) {


### PR DESCRIPTION
If CERT_VerifyCertificateNow() is used with
'certificateUsageCheckAllUsages' OCSP checks are skipped even if OCSP
was enabled.

This patch calls CERT_CheckOCSPStatus() explicitly if OCSP checks are
enabled.

Related to https://pagure.io/SSSD/sssd/issue/3560