### PR TITLE
Remove the 'sshPublicKey' attribute from the cache when it's removed from IPA

### DIFF
--- a/src/providers/ipa/ipa_s2n_exop.c
+++ b/src/providers/ipa/ipa_s2n_exop.c
@@ -2193,7 +2193,12 @@ static errno_t ipa_s2n_save_objects(struct sss_domain_info *dom,
     struct sysdb_attrs *gid_override_attrs = NULL;
     struct ldb_message *msg;
     struct ldb_message_element *el = NULL;
-    const char *missing[] = {NULL, NULL};
+    /* The list of elements that might be missing are:
+     * - SYSDB_ORIG_MEMBEROF
+     * - SYSDB_SSH_PUBKEY
+     * Note that the list includes the trailing NULL at the end. */
+    size_t missing_count = 0;
+    const char *missing[] = {NULL, NULL, NULL};
 
     tmp_ctx = talloc_new(NULL);
     if (tmp_ctx == NULL) {
@@ -2435,7 +2440,13 @@ static errno_t ipa_s2n_save_objects(struct sss_domain_info *dom,
             ret = sysdb_attrs_get_el_ext(attrs->sysdb_attrs,
                                          SYSDB_ORIG_MEMBEROF, false, &el);
             if (ret == ENOENT) {
-                missing[0] = SYSDB_ORIG_MEMBEROF;
+                missing[missing_count++] = SYSDB_ORIG_MEMBEROF;
+            }
+
+            ret = sysdb_attrs_get_el_ext(attrs->sysdb_attrs,
+                                         SYSDB_SSH_PUBKEY, false, &el);
+            if (ret == ENOENT) {
+                missing[missing_count++] = SYSDB_SSH_PUBKEY;
             }
 
             ret = sysdb_transaction_start(dom->sysdb);


### PR DESCRIPTION
Those two patches provide a fix for https://pagure.io/SSSD/sssd/issue/3602.

When testing these patches, please, make sure you have this code built and installed on **server side**.