### PR TITLE
p11_child: properly check results of CERT_VerifyCertificateNow

### DIFF
--- a/src/p11_child/p11_child_nss.c
+++ b/src/p11_child/p11_child_nss.c
@@ -338,23 +338,6 @@ int do_work(TALLOC_CTX *mem_ctx, const char *nss_db,
                       PR_GetError(), PORT_ErrorToString(PR_GetError()));
                 continue;
             }
-
-            /* with 'certificateUsageCheckAllUsages' set
-             * CERT_VerifyCertificateNow() does not do OCSP so it must be done
-             * explicitly */
-            if (cert_verify_opts->do_ocsp) {
-                rv = CERT_CheckOCSPStatus(handle, cert_list_node->cert,
-                                          PR_Now(), NULL);
-                if (rv != SECSuccess) {
-                    DEBUG(SSSDBG_OP_FAILURE,
-                          "Certificate [%s][%s] failed OCSP check [%d][%s], "
-                          "skipping.\n",
-                          cert_list_node->cert->nickname,
-                          cert_list_node->cert->subjectName,
-                          PR_GetError(), PORT_ErrorToString(PR_GetError()));
-                    continue;
-                }
-            }
         }
 
         if (key_id_in != NULL) {


### PR DESCRIPTION
I'm sorry but my recent commit 'p11_child: make sure OCSP checks are done' was
not the right fix for the observed issue and might lead to do the OCSP check
twice. Hence this PR reverts this commit and adds a better fix (after checking
the related NSS code carefully and discussing it with NSS developers).

With certificateUsageCheckAllUsages not only the return code of
CERT_VerifyCertificateNow() should be checked but also the usages for which
the certificate was verified. The usages checked here will all involve CA
signature checks and OCSP checks if OCSP is enabled.

Related to https://pagure.io/SSSD/sssd/issue/3560