### PR TITLE
IPA: Handle empty nisDomainName

### DIFF
--- a/src/providers/ipa/ipa_netgroups.c
+++ b/src/providers/ipa/ipa_netgroups.c
@@ -953,7 +953,9 @@ static int ipa_netgr_process_all(struct ipa_get_netgroups_state *state)
 
         ret = sysdb_attrs_get_string(state->netgroups[i], SYSDB_NETGROUP_DOMAIN,
                                      &domain);
-        if (ret != EOK) {
+        if (ret == ENOENT) {
+            domain = NULL;
+        } else if (ret != EOK) {
             goto done;
         }
 
@@ -974,7 +976,7 @@ static int ipa_netgr_process_all(struct ipa_get_netgroups_state *state)
                 for (k = 0; k < hosts_count; k++) {
                     triple = talloc_asprintf(state, "(%s,%s,%s)",
                                              hosts[k], uids[j],
-                                             domain);
+                                             domain ? domain : "");
                     if (triple == NULL) {
                         ret = ENOMEM;
                         goto done;


### PR DESCRIPTION
Resolves: https://pagure.io/SSSD/sssd/issue/3573

If nisdomain=, i.e. a blank NIS domain name, sssd was not processing the
netgroup at all. This is not in agreement with man innetgr which says "Any
of the elements in a triple can be empty, which means that anything
matches. The functions described here allow access to the netgroup
databases".

This patch instead returns an empty domain as well, which eventually
produces the same output as if the netgroup was requested from the compat
tree.