### PR TITLE
SYSDB: Return EOK in case a non-fatal issue happened

### DIFF
--- a/src/db/sysdb_search.c
+++ b/src/db/sysdb_search.c
@@ -239,6 +239,7 @@ int sysdb_getpwnam(TALLOC_CTX *mem_ctx,
     if (ret != EOK) {
         DEBUG(SSSDBG_MINOR_FAILURE, "Cannot merge timestamp cache values\n");
         /* non-fatal */
+        ret = EOK;
     }
 
     *_res = talloc_steal(mem_ctx, res);
@@ -351,6 +352,7 @@ int sysdb_getpwuid(TALLOC_CTX *mem_ctx,
     if (ret != EOK) {
         DEBUG(SSSDBG_MINOR_FAILURE, "Cannot merge timestamp cache values\n");
         /* non-fatal */
+        ret = EOK;
     }
 
     *_res = talloc_steal(mem_ctx, res);
@@ -672,6 +674,7 @@ int sysdb_enumpwent_filter(TALLOC_CTX *mem_ctx,
     if (ret != EOK) {
         DEBUG(SSSDBG_MINOR_FAILURE, "Cannot merge timestamp cache values\n");
         /* non-fatal */
+        ret = EOK;
     }
 
     res = sss_merge_ldb_results(res, ts_cache_res);
@@ -1188,6 +1191,7 @@ int sysdb_enumgrent_filter(TALLOC_CTX *mem_ctx,
     if (ret != EOK) {
         DEBUG(SSSDBG_MINOR_FAILURE, "Cannot merge timestamp cache values\n");
         /* non-fatal */
+        ret = EOK;
     }
 
     res = sss_merge_ldb_results(res, ts_cache_res);
@@ -1591,6 +1595,7 @@ int sysdb_get_user_attr(TALLOC_CTX *mem_ctx,
     if (ret != EOK) {
         DEBUG(SSSDBG_MINOR_FAILURE, "Cannot merge timestamp cache values\n");
         /* non-fatal */
+        ret = EOK;
     }
 
     *_res = talloc_steal(mem_ctx, res);


### PR DESCRIPTION
There may be the case where we aren't able to merge the timestamps from
the fast ts db, which are treated as non-fatal issues. In case it
happens, let's return EOK instead of propagating the non-fatal error.

NOTE: I'm not sure whether it's an issue or not, but I've realized that while taking a look at a covscan issue found downstream.