### PR TITLE
ifp: use realloc in ifp_list_ctx_remaining_capacity()

### DIFF
--- a/src/responder/ifp/ifp_private.h
+++ b/src/responder/ifp/ifp_private.h
@@ -93,6 +93,7 @@ struct ifp_list_ctx {
     struct ifp_ctx *ctx;
 
     const char **paths;
+    size_t paths_max;
     size_t path_count;
 };
 


### PR DESCRIPTION
ifp_list_ctx_remaining_capacity() might be called multiple times if
results from multiple domains are added to the result list. The current
use of talloc_zero_array() will override results which are already in
the list. This patch replaces it with talloc_realloc().

Resolves https://pagure.io/SSSD/sssd/issue/3608