### PR TITLE
MAN: Document that auth and access IPA and AD providers rely on id_provider being set to the same type

### DIFF
--- a/src/man/sssd-ad.5.xml
+++ b/src/man/sssd-ad.5.xml
@@ -76,6 +76,12 @@
             is required on the client side.
         </para>
         <para>
+            If <quote>auth_provider=ad</quote> or
+            <quote>access_provider=ad</quote> is configured
+            in sssd.conf then the id_provider must also be set to
+            <quote>ad</quote>.
+        </para>
+        <para>
             By default, the AD provider will map UID and GID values from the
             objectSID parameter in Active Directory. For details on this, see
             the <quote>ID MAPPING</quote> section below. If you want to

--- a/src/man/sssd-ipa.5.xml
+++ b/src/man/sssd-ipa.5.xml
@@ -64,6 +64,12 @@
             configuration of access provider is required on the client side.
         </para>
         <para>
+            If <quote>auth_provider=ipa</quote> or
+            <quote>access_provider=ipa</quote> is configured
+            in sssd.conf then the id_provider must also be set to
+            <quote>ipa</quote>.
+        </para>
+        <para>
             The IPA provider will use the PAC responder if the Kerberos tickets
             of users from trusted realms contain a PAC. To make configuration
             easier the PAC responder is started automatically if the IPA ID


### PR DESCRIPTION
Resolves: https://pagure.io/SSSD/sssd/issue/3547

The IPA and AD auth and access providers rely (often for performance
reasons) on certain properties that are set during the user or group
resolution with the same provider type.

However, there are users who wish to combine different provider types,
typically to use identities from local UNIX files but authenticate against
a remote server. We should discourage that in our documentation

But at the same time, I think flat our failing would be too harsh...I was
also thinking about printing a DEBUG message during initialization, if the
reviewer thinks this is a good idea, I'll do that as well.