### PR TITLE
MAN: Describe the constrains of ipa_server_mode better in the man page

### DIFF
--- a/src/man/sssd-ipa.5.xml
+++ b/src/man/sssd-ipa.5.xml
@@ -537,6 +537,29 @@
                             it will ask an IPA server.
                         </para>
                         <para>
+                            NOTE: There are currently some assumptions that
+                            must be met when SSSD is running on an IPA server.
+                            <itemizedlist>
+                                <listitem>
+                                    <para>
+                                        The <quote>ipa_server</quote> option
+                                        must be configured to point to the
+                                        IPA server itself. This is already
+                                        the default set by the IPA installer,
+                                        so no manual change is required.
+                                    </para> 
+                                </listitem>
+                                <listitem>
+                                    <para>
+                                        The <quote>full_name_format</quote>
+                                        option must not be tweaked to only
+                                        print short names for users from
+                                        trusted domains.
+                                    </para>
+                                </listitem>
+                            </itemizedlist>
+                        </para>
+                        <para>
                             Default: false
                         </para>
                     </listitem>


### PR DESCRIPTION
Resolves: https://pagure.io/SSSD/sssd/issue/3484

Amends the sssd-ipa man page so that we explicitly say that:
   * SSSD needs to be pointed at the IPA server itself
   * SSSD currently needs to print fully qualified names for users for
     trusted domains.