### PR TITLE
gcc warnings: Getting rid of -Wsuggest-attribute=noreturn

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -118,7 +118,7 @@ if HAVE_GCC
     AM_CFLAGS += -Wall -Wshadow -Wstrict-prototypes -Wpointer-arith \
                  -Wcast-qual -Wcast-align -Wwrite-strings -Wundef \
                  -Werror-implicit-function-declaration -Winit-self \
-                 -Wmissing-include-dirs \
+                 -Wmissing-include-dirs -Wsuggest-attribute=noreturn \
                  -fno-strict-aliasing \
                  -std=gnu99
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -446,6 +446,23 @@ if test x"$sss_cv_attribute_warn_unused_result" = xyes ; then
              [whether compiler supports __attribute__((warn_unused_result))])
 fi
 
+AC_CACHE_CHECK([whether compiler supports __attribute__((noreturn))],
+               sss_cv_attribute_noreturn,
+               [AC_COMPILE_IFELSE(
+                    [AC_LANG_SOURCE(
+                        [ char _check_leaks(int bytes) __attribute__ ((noreturn)); ]
+                    )],
+                    [sss_cv_attribute_noreturn=yes],
+                    [
+                        AC_MSG_RESULT([no])
+                        AC_MSG_WARN([compiler does NOT support __attribute__((noreturn))])
+                    ])
+               ])
+if test x"$sss_cv_attribute_noreturn" = xyes ; then
+   AC_DEFINE(HAVE_FUNCTION_ATTRIBUTE_NORETURN, 1,
+             [whether compiler supports __attribute__((noreturn))])
+fi
+
 SAFE_CFLAGS=$CFLAGS
 CFLAGS="-Werror"
 AC_CACHE_CHECK(

--- a/src/tests/cmocka/test_dyndns.c
+++ b/src/tests/cmocka/test_dyndns.c
@@ -62,6 +62,9 @@ struct dyndns_test_ctx {
 
 static struct dyndns_test_ctx *dyndns_test_ctx;
 
+#if HAVE_FUNCTION_ATTRIBUTE_NORETURN
+__attribute__((__noreturn__))
+#endif
 void __wrap_execv(const char *path, char *const argv[])
 {
     int err;

--- a/src/util/child_common.c
+++ b/src/util/child_common.c
@@ -723,6 +723,9 @@ fail:
     return ret;
 }
 
+#if HAVE_FUNCTION_ATTRIBUTE_NORETURN
+__attribute__((__noreturn__))
+#endif
 void exec_child_ex(TALLOC_CTX *mem_ctx,
                    int *pipefd_to_child, int *pipefd_from_child,
                    const char *binary, int debug_fd,
@@ -765,6 +768,9 @@ void exec_child_ex(TALLOC_CTX *mem_ctx,
     exit(EXIT_FAILURE);
 }
 
+#if HAVE_FUNCTION_ATTRIBUTE_NORETURN
+__attribute__((__noreturn__))
+#endif
 void exec_child(TALLOC_CTX *mem_ctx,
                 int *pipefd_to_child, int *pipefd_from_child,
                 const char *binary, int debug_fd)

--- a/src/util/server.c
+++ b/src/util/server.c
@@ -244,6 +244,9 @@ int pidfile(const char *path, const char *name)
     return 0;
 }
 
+#if HAVE_FUNCTION_ATTRIBUTE_NORETURN
+__attribute__((__noreturn__))
+#endif
 void orderly_shutdown(int status)
 {
 #if HAVE_GETPGRP


### PR DESCRIPTION
-Wsuggest-attribute=noreturn warns about functions that might
be candidates for attributes "pure", "const" or "noreturn".
Warning will be thrown if a function returns contain an infinite
loop or return abnormally by throwing, calling "abort" or trapping.

Here we are sure that functions will not return we can use
GCC variant: __attribute__((__noreturn__))

Resolves: https://pagure.io/SSSD/sssd/issue/3604