### PR TITLE
 Support alternative sources for the files provider 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4575,7 +4575,8 @@ dist_sssdapiplugin_DATA = \
     src/config/etc/sssd.api.d/sssd-ldap.conf \
     src/config/etc/sssd.api.d/sssd-local.conf \
     src/config/etc/sssd.api.d/sssd-proxy.conf \
-    src/config/etc/sssd.api.d/sssd-simple.conf
+    src/config/etc/sssd.api.d/sssd-simple.conf \
+    src/config/etc/sssd.api.d/sssd-files.conf
 
 edit_cmd = $(SED) \
         -e 's|@sbindir[@]|$(sbindir)|g' \

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -242,6 +242,10 @@
 #define CONFDB_PROXY_FAST_ALIAS "proxy_fast_alias"
 #define CONFDB_PROXY_MAX_CHILDREN "proxy_max_children"
 
+/* Files Provider */
+#define CONFDB_FILES_PASSWD "passwd_files"
+#define CONFDB_FILES_GROUP "group_files"
+
 /* Secrets Service */
 #define CONFDB_SEC_CONF_ENTRY "config/secrets"
 #define CONFDB_SEC_CONTAINERS_NEST_LEVEL "containers_nest_level"

--- a/src/config/SSSDConfig/__init__.py.in
+++ b/src/config/SSSDConfig/__init__.py.in
@@ -473,7 +473,11 @@ option_strings = {
     'proxy_fast_alias' : _('Whether to look up canonical group name from cache if possible'),
 
     # [provider/proxy/auth]
-    'proxy_pam_target' : _('PAM stack to use')
+    'proxy_pam_target' : _('PAM stack to use'),
+
+    # [provider/files]
+    'passwd_files' : _('Path of passwd file sources.'),
+    'group_files' : _('Path of group file sources.')
 }
 
 def striplist(l):

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -404,6 +404,10 @@ option = dyndns_force_tcp
 option = dyndns_auth
 option = dyndns_server
 
+# files provider specific options
+option = passwd_files
+option = group_files
+
 # local provider specific options
 option = create_homedir
 option = remove_homedir

--- a/src/config/etc/sssd.api.d/sssd-files.conf
+++ b/src/config/etc/sssd.api.d/sssd-files.conf
@@ -1,0 +1,3 @@
+[provider/files]
+passwd_files = str, None, false
+group_files = str, None, false

--- a/src/man/sssd-files.5.xml
+++ b/src/man/sssd-files.5.xml
@@ -56,14 +56,46 @@
     <refsect1 id='configuration-options'>
         <title>CONFIGURATION OPTIONS</title>
         <para>
-            The files provider has no specific options of its own, however,
-            generic SSSD domain options can be set where applicable.
+            In addition to the options listed below, generic SSSD domain options
+            can be set where applicable.
             Refer to the section <quote>DOMAIN SECTIONS</quote> of the
             <citerefentry>
                 <refentrytitle>sssd.conf</refentrytitle>
                 <manvolnum>5</manvolnum>
             </citerefentry> manual page for details on the configuration
             of an SSSD domain.
+            <variablelist>
+                <varlistentry>
+                    <term>passwd_files (string)</term>
+                    <listitem>
+                        <para>
+                            Comma-separated list of one or multiple password
+                            filenames to be read and enumerated by the files
+                            provider, inotify monitor watches will be set on
+                            each file to detect changes dynamically.
+                        </para>
+                        <para>
+                            Default: /etc/passwd
+                        </para>
+                    </listitem>
+                </varlistentry>
+
+                <varlistentry>
+                    <term>group_files (string)</term>
+                    <listitem>
+                        <para>
+                            Comma-separated list of one or multiple group
+                            filenames to be read and enumerated by the files
+                            provider, inotify monitor watches will be set on
+                            each file to detect changes dynamically.
+                        </para>
+                        <para>
+                            Default: /etc/group
+                        </para>
+                    </listitem>
+                </varlistentry>
+
+            </variablelist>
         </para>
     </refsect1>
 

--- a/src/providers/files/files_init.c
+++ b/src/providers/files/files_init.c
@@ -21,6 +21,7 @@
 
 #include "providers/data_provider/dp.h"
 #include "providers/files/files_private.h"
+#include "util/util.h"
 
 int sssm_files_init(TALLOC_CTX *mem_ctx,
                     struct be_ctx *be_ctx,

--- a/src/providers/files/files_private.h
+++ b/src/providers/files/files_private.h
@@ -39,8 +39,8 @@ struct files_id_ctx {
     struct sss_domain_info *domain;
     struct files_ctx *fctx;
 
-    const char *passwd_file;
-    const char *group_file;
+    const char **passwd_files;
+    const char **group_files;
 
     bool updating_passwd;
     bool updating_groups;
@@ -53,8 +53,8 @@ struct files_id_ctx {
 /* files_ops.c */
 struct files_ctx *sf_init(TALLOC_CTX *mem_ctx,
                           struct tevent_context *ev,
-                          const char *passwd_file,
-                          const char *group_file,
+                          const char **passwd_files,
+                          const char **group_files,
                           struct files_id_ctx *id_ctx);
 
 /* files_id.c */


### PR DESCRIPTION
This PR allows the configuration of different(one or multiple) passwd and group files to be managed by the files provider with new options `alt_passwd_files` and `alt_group_files`.

Primary testing steps include ensuring that alternate passwd and group entries are consistently accessible with 'getent -s sss' commands, and testing that inotify watches dynamically detect changes to any alternate source files.

Ticket: https://pagure.io/SSSD/sssd/issue/3402