### PR TITLE
libnfsidmap: Use public plugin header file if available

### DIFF
--- a/src/external/libnfsidmap.m4
+++ b/src/external/libnfsidmap.m4
@@ -17,4 +17,13 @@ AS_IF([test x"$with_nfsv4_idmap" = xyes], [
             [AC_MSG_ERROR([libnfsidmap header files are not installed]
 If you want to build sssd without nfs idmap pluging then specify
 --without-nfsv4-idmapd-plugin when running configure.)])])
+
+    AC_CHECK_HEADERS([nfsidmap_plugin.h], [], [],
+        [#ifdef HAVE_STDLIB_H
+# include <stdlib.h>
+#endif
+#ifdef HAVE_STDINT_H
+# include <stdint.h>
+#endif
+#include <nfsidmap.h>])
 ])

--- a/src/sss_client/nfs/nfsidmap_internal.h
+++ b/src/sss_client/nfs/nfsidmap_internal.h
@@ -75,4 +75,4 @@ extern nfs4_idmap_log_function_t idmap_log_func;
  * Copyright (c) 1998, 1999, 2001 Niklas Hallqvist.  All rights reserved.
  * Copyright (c) 2000, 2003 H�kan Olsson.  All rights reserved.
  */
-extern char    *conf_get_str(char *, char *);
+extern const char    *conf_get_str(const char *, const char *);

--- a/src/sss_client/nfs/sss_nfs_client.c
+++ b/src/sss_client/nfs/sss_nfs_client.c
@@ -20,7 +20,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#define _GNU_SOURCE
+#include "config.h"
 
 #include <stddef.h>
 #include <stdlib.h>
@@ -29,7 +29,13 @@
 #include <string.h>
 
 #include <nfsidmap.h>
+
+#ifdef HAVE_NFSIDMAP_PLUGIN_H
+#include <nfsidmap_plugin.h>
+#else /* fallback to internal header file with older version of libnfsidmap */
 #include "nfsidmap_internal.h"
+#define nfsidmap_config_get conf_get_str
+#endif
 
 #include "sss_client/sss_cli.h"
 #include "sss_client/nss_mc.h"
@@ -382,13 +388,13 @@ static bool str_equal(const char *s1, const char *s2)
     return res;
 }
 
-static int nfs_conf_get_bool(char *sect, char *attr, int def)
+static int nfs_conf_get_bool(const char *sect, const char *attr, int def)
 {
     int res;
-    char *val;
+    const char *val;
 
     res = def;
-    val = conf_get_str(sect, attr);
+    val = nfsidmap_config_get(sect, attr);
     if (val) {
         res = (str_equal("1", val) ||
                str_equal("yes", val) ||


### PR DESCRIPTION
libnfsidmap was merged with nfs-utils in 2.1.2-rc7.

We used private internal interface but required internal functions
were dropped in nfs-utils-2.3.1. We need to use newly available public
interface.