### PR TITLE
AD: Inherit the MPG setting from the main domain

### DIFF
--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -391,6 +391,13 @@ ad_subdom_store(struct sdap_idmap_ctx *idmap_ctx,
     }
 
     mpg = sdap_idmap_domain_has_algorithmic_mapping(idmap_ctx, name, sid_str);
+    if (mpg == false) {
+        /* Domains that use the POSIX attributes set by the admin must
+         * inherit the MPG setting from the parent domain so that the
+         * auto_private_groups options works for trusted domains as well
+         */
+        mpg = domain->mpg;
+    }
 
     ret = sysdb_subdomain_store(domain->sysdb, name, realm, flat, sid_str,
                                 mpg, enumerate, domain->forest, 0, NULL);


### PR DESCRIPTION
Resolves: https://pagure.io/SSSD/sssd/issue/3613

If the auto_private_groups option was set in the domain section for direct
integration, it only had an effect on the joined domain, not any of the
subdomains, so requesting a user from the child domain would look like
this:
```
   $ id childuser@child.win.trust.test
   uid=30000(childuser@child.win.trust.test) gid=40000(usergroup@child.win.trust.test) groups=40000(usergroup@child.win.trust.test) ```
```

The expected result, visible
after this patch is:
```
   $ id childuser@child.win.trust.test
   uid=30000(childuser@child.win.trust.test) gid=30000(childuser@child.win.trust.test) groups=30000(childuser@child.win.trust.test),40000(usergroup@child.win.trust.test)
```