### PR TITLE
SYSDB: Use sysdb_domain_dn instead of raw ldb_dn_new_fmt

### DIFF
--- a/src/db/sysdb.c
+++ b/src/db/sysdb.c
@@ -1215,8 +1215,7 @@ errno_t sysdb_has_enumerated(struct sss_domain_info *domain,
         goto done;
     }
 
-    dn = ldb_dn_new_fmt(tmp_ctx, domain->sysdb->ldb, SYSDB_DOM_BASE,
-                        domain->name);
+    dn = sysdb_domain_dn(tmp_ctx, domain);
     if (!dn) {
         ret = ENOMEM;
         goto done;
@@ -1243,8 +1242,7 @@ errno_t sysdb_set_enumerated(struct sss_domain_info *domain,
         goto done;
     }
 
-    dn = ldb_dn_new_fmt(tmp_ctx, domain->sysdb->ldb, SYSDB_DOM_BASE,
-                        domain->name);
+    dn = sysdb_domain_dn(tmp_ctx, domain);
     if (!dn) {
         ret = ENOMEM;
         goto done;

--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -4811,8 +4811,7 @@ static errno_t sysdb_search_object_attr(TALLOC_CTX *mem_ctx,
         return ENOMEM;
     }
 
-    basedn = ldb_dn_new_fmt(tmp_ctx, domain->sysdb->ldb, SYSDB_DOM_BASE,
-                            domain->name);
+    basedn = sysdb_domain_dn(tmp_ctx, domain);
     if (basedn == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "ldb_dn_new_fmt failed.\n");
         ret = ENOMEM;

--- a/src/db/sysdb_search.c
+++ b/src/db/sysdb_search.c
@@ -904,8 +904,7 @@ int sysdb_getgrnam(TALLOC_CTX *mem_ctx,
 
     if (domain->mpg) {
         fmt_filter = SYSDB_GRNAM_MPG_FILTER;
-        base_dn = ldb_dn_new_fmt(tmp_ctx, domain->sysdb->ldb,
-                                 SYSDB_DOM_BASE, domain->name);
+        base_dn = sysdb_domain_dn(tmp_ctx, domain);
     } else {
         fmt_filter = SYSDB_GRNAM_FILTER;
         base_dn = sysdb_group_base_dn(tmp_ctx, domain);
@@ -1059,8 +1058,7 @@ int sysdb_getgrgid(TALLOC_CTX *mem_ctx,
 
     if (domain->mpg) {
         fmt_filter = SYSDB_GRGID_MPG_FILTER;
-        base_dn = ldb_dn_new_fmt(tmp_ctx, domain->sysdb->ldb,
-                                 SYSDB_DOM_BASE, domain->name);
+        base_dn = sysdb_domain_dn(tmp_ctx, domain);
     } else {
         fmt_filter = SYSDB_GRGID_FILTER;
         base_dn = sysdb_group_base_dn(tmp_ctx, domain);
@@ -1125,8 +1123,7 @@ int sysdb_enumgrent_filter(TALLOC_CTX *mem_ctx,
 
     if (domain->mpg) {
         base_filter = SYSDB_GRENT_MPG_FILTER;
-        base_dn = ldb_dn_new_fmt(tmp_ctx, domain->sysdb->ldb,
-                                 SYSDB_DOM_BASE, domain->name);
+        base_dn = sysdb_domain_dn(tmp_ctx, domain);
     } else {
         base_filter = SYSDB_GRENT_FILTER;
         base_dn = sysdb_group_base_dn(tmp_ctx, domain);

--- a/src/db/sysdb_subdomains.c
+++ b/src/db/sysdb_subdomains.c
@@ -556,8 +556,7 @@ errno_t sysdb_master_domain_update(struct sss_domain_info *domain)
         return ENOMEM;
     }
 
-    basedn = ldb_dn_new_fmt(tmp_ctx, domain->sysdb->ldb,
-                            SYSDB_DOM_BASE, domain->name);
+    basedn = sysdb_domain_dn(tmp_ctx, domain);
     if (basedn == NULL) {
         ret = EIO;
         goto done;
@@ -758,8 +757,7 @@ errno_t sysdb_master_domain_add_info(struct sss_domain_info *domain,
         goto done;
     }
 
-    msg->dn = ldb_dn_new_fmt(tmp_ctx, domain->sysdb->ldb,
-                             SYSDB_DOM_BASE, domain->name);
+    msg->dn = sysdb_domain_dn(tmp_ctx, domain);
     if (msg->dn == NULL) {
         ret = EIO;
         goto done;
@@ -1301,7 +1299,7 @@ sysdb_get_site(TALLOC_CTX *mem_ctx,
         return ENOMEM;
     }
 
-    dn = ldb_dn_new_fmt(tmp_ctx, dom->sysdb->ldb, SYSDB_DOM_BASE, dom->name);
+    dn = sysdb_domain_dn(tmp_ctx, dom);
     if (dn == NULL) {
         ret = ENOMEM;
         goto done;
@@ -1349,7 +1347,7 @@ sysdb_set_site(struct sss_domain_info *dom,
         return ENOMEM;
     }
 
-    dn = ldb_dn_new_fmt(tmp_ctx, dom->sysdb->ldb, SYSDB_DOM_BASE, dom->name);
+    dn = sysdb_domain_dn(tmp_ctx, dom);
     if (dn == NULL) {
         ret = ENOMEM;
         goto done;

--- a/src/tests/cmocka/test_sysdb_domain_resolution_order.c
+++ b/src/tests/cmocka/test_sysdb_domain_resolution_order.c
@@ -85,8 +85,8 @@ static void test_sysdb_domain_resolution_order_ops(void **state)
     const char *domains_out = NULL;
     struct ldb_dn *dn;
 
-    dn = ldb_dn_new_fmt(test_ctx, test_ctx->tctx->dom->sysdb->ldb,
-                        SYSDB_DOM_BASE, test_ctx->tctx->dom->name);
+    dn = sysdb_domain_dn(test_ctx, test_ctx->tctx->dom);
+    assert_non_null(dn);
 
     /* Adding domainResolutionOrder for the first time */
     domains_in = "foo:bar:foobar";


### PR DESCRIPTION
Using ldb should be as much as an implementation detail as possible. Plus,
it looks weird if one of the branch uses a sysdb function while another
code branch uses a raw ldb call.