### PR TITLE
nss-idmap: check timed muted return code

### DIFF
--- a/src/sss_client/idmap/common_ex.c
+++ b/src/sss_client/idmap/common_ex.c
@@ -83,6 +83,7 @@ int sss_nss_timedlock(unsigned int timeout_ms, int *time_left_ms)
     if (ret == 0) {
         ret = clock_gettime(CLOCK_REALTIME, &endtime);
         if (ret != 0) {
+            sss_nss_unlock();
             return ret;
         }
 
@@ -92,6 +93,7 @@ int sss_nss_timedlock(unsigned int timeout_ms, int *time_left_ms)
             TIMESPECSUB(&endtime, &starttime, &diff);
             left = timeout_ms - TIMESPEC_TO_MS(&diff);
             if (left <= 0) {
+                sss_nss_unlock();
                 return EIO;
             } else if (left > SSS_CLI_SOCKET_TIMEOUT) {
                 *time_left_ms = SSS_CLI_SOCKET_TIMEOUT;

--- a/src/sss_client/idmap/sss_nss_ex.c
+++ b/src/sss_client/idmap/sss_nss_ex.c
@@ -202,7 +202,10 @@ int sss_get_ex(struct nss_input *inp, uint32_t flags, unsigned int timeout)
         }
     }
 
-    sss_nss_timedlock(timeout, &time_left);
+    ret = sss_nss_timedlock(timeout, &time_left);
+    if (ret != 0) {
+        return ret;
+    }
 
     if (!skip_mc && !skip_data) {
         /* previous thread might already initialize entry in mmap cache */

--- a/src/sss_client/idmap/sss_nss_idmap.c
+++ b/src/sss_client/idmap/sss_nss_idmap.c
@@ -257,7 +257,10 @@ static int sss_nss_getyyybyxxx(union input inp, enum sss_cli_command cmd,
     if (timeout == NO_TIMEOUT) {
         sss_nss_lock();
     } else {
-        sss_nss_timedlock(timeout, &time_left);
+        ret = sss_nss_timedlock(timeout, &time_left);
+        if (ret != 0) {
+            return ret;
+        }
     }
 
     nret = sss_nss_make_request_timeout(cmd, &rd, time_left, &repbuf, &replen,


### PR DESCRIPTION
Check return values and make sure the mutex is released in case of
errors.

Related to https://pagure.io/SSSD/sssd/issue/2478