### PR TITLE
DESKPROFILE: Do not require CAP_DAC_OVERRIDE

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -968,7 +968,7 @@ done
 %if (0%{?with_secrets} == 1)
 %attr(700,root,root) %dir %{secdbpath}
 %endif
-%attr(755,sssd,sssd) %dir %{deskprofilepath}
+%attr(751,sssd,sssd) %dir %{deskprofilepath}
 %ghost %attr(0644,sssd,sssd) %verify(not md5 size mtime) %{mcpath}/passwd
 %ghost %attr(0644,sssd,sssd) %verify(not md5 size mtime) %{mcpath}/group
 %ghost %attr(0644,sssd,sssd) %verify(not md5 size mtime) %{mcpath}/initgroups

--- a/src/providers/ipa/ipa_deskprofile_rules_util.c
+++ b/src/providers/ipa/ipa_deskprofile_rules_util.c
@@ -229,6 +229,7 @@ ipa_deskprofile_rules_create_user_dir(
     char *domain;
     char *domain_dir;
     errno_t ret;
+    mode_t old_umask;
 
     tmp_ctx = talloc_new(NULL);
     if (tmp_ctx == NULL) {
@@ -243,8 +244,10 @@ ipa_deskprofile_rules_create_user_dir(
         goto done;
     }
 
-    ret = sss_create_dir(IPA_DESKPROFILE_RULES_USER_DIR, domain, 0755,
+    old_umask = umask(0026);
+    ret = sss_create_dir(IPA_DESKPROFILE_RULES_USER_DIR, domain, 0751,
                          getuid(), getgid());
+    umask(old_umask);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Failed to create the directory \"%s/%s\" that would be used to "

--- a/src/providers/ipa/ipa_deskprofile_rules_util.c
+++ b/src/providers/ipa/ipa_deskprofile_rules_util.c
@@ -264,7 +264,11 @@ ipa_deskprofile_rules_create_user_dir(
         goto done;
     }
 
-    ret = sss_create_dir(domain_dir, shortname, 0600, uid, gid);
+    /* In order to read, create and traverse the directory, we need to have its
+     * permissions set as 'rwx------' (700). */
+    old_umask = umask(0077);
+    ret = sss_create_dir(domain_dir, shortname, 0700, uid, gid);
+    umask(old_umask);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
                "Failed to create the directory \"%s/%s/%s\" that would be used "

--- a/src/providers/ipa/ipa_deskprofile_rules_util.c
+++ b/src/providers/ipa/ipa_deskprofile_rules_util.c
@@ -900,7 +900,7 @@ ipa_deskprofile_rules_save_rule_to_disk(
         goto done;
     }
 
-    fd = open(filename_path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    fd = open(filename_path, O_WRONLY | O_CREAT | O_TRUNC, 0400);
     if (fd == -1) {
         ret = errno;
         DEBUG(SSSDBG_CRIT_FAILURE,

--- a/src/providers/ipa/ipa_deskprofile_rules_util.h
+++ b/src/providers/ipa/ipa_deskprofile_rules_util.h
@@ -45,7 +45,9 @@ ipa_deskprofile_rules_save_rule_to_disk(
                                     uid_t uid,
                                     gid_t gid);
 errno_t
-ipa_deskprofile_rules_remove_user_dir(const char *user_dir);
+ipa_deskprofile_rules_remove_user_dir(const char *user_dir,
+                                      uid_t uid,
+                                      gid_t gid);
 
 errno_t
 deskprofile_get_cached_priority(struct sss_domain_info *domain,

--- a/src/providers/ipa/ipa_session.c
+++ b/src/providers/ipa/ipa_session.c
@@ -524,7 +524,9 @@ ipa_pam_session_handler_send(TALLOC_CTX *mem_ctx,
     /* As no proper merging mechanism has been implemented yet ...
      * let's just remove the user directory stored in the disk as it's
      * going to be created again in case there's any rule fetched. */
-    ret = ipa_deskprofile_rules_remove_user_dir(state->user_dir);
+    ret = ipa_deskprofile_rules_remove_user_dir(state->user_dir,
+                                                state->uid,
+                                                state->gid);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "ipa_deskprofile_rules_remove_user_dir() failed.\n");


### PR DESCRIPTION
See the attached patches.

Step-by-step on how to test this will be added later on.