### PR TITLE
dyndns_tests: Fix unit test with missing features in nsupdate

### DIFF
--- a/src/tests/cmocka/test_dyndns.c
+++ b/src/tests/cmocka/test_dyndns.c
@@ -406,7 +406,11 @@ void dyndns_test_create_fwd_msg(void **state)
 
     assert_string_equal(msg,
                         "server Winterfell\n"
+#ifdef HAVE_NSUPDATE_REALM
                         "realm North\n"
+#else
+                        "\n"
+#endif
                         "update delete bran_stark. in A\n"
                         "update add bran_stark. 1234 in A 192.168.0.2\n"
                         "send\n"
@@ -423,7 +427,11 @@ void dyndns_test_create_fwd_msg(void **state)
     assert_int_equal(ret, EOK);
 
     assert_string_equal(msg,
+#ifdef HAVE_NSUPDATE_REALM
                         "realm North\n"
+#else
+                        "\n"
+#endif
                         "update delete bran_stark. in A\n"
                         "update add bran_stark. 1234 in A 192.168.0.2\n"
                         "send\n"


### PR DESCRIPTION
We return different string in the function nsupdate_msg_add_realm_cmd
if realm command is not supported by nsupdate.
However cmocka based unit test did not expect such string and failed.