### PR TITLE
SYSDB: Read the ldb_message from loop's index counter when reading subdomain UPNs

### DIFF
--- a/src/db/sysdb_subdomains.c
+++ b/src/db/sysdb_subdomains.c
@@ -386,7 +386,7 @@ errno_t sysdb_update_subdomains(struct sss_domain_info *domain,
                                              SYSDB_SUBDOMAIN_FOREST, NULL);
 
         upn_suffixes = NULL;
-        tmp_el = ldb_msg_find_element(res->msgs[0], SYSDB_UPN_SUFFIXES);
+        tmp_el = ldb_msg_find_element(res->msgs[i], SYSDB_UPN_SUFFIXES);
         if (tmp_el != NULL) {
             upn_suffixes = sss_ldb_el_to_string_list(tmp_ctx, tmp_el);
             if (upn_suffixes == NULL) {


### PR DESCRIPTION
Related to: https://pagure.io/SSSD/sssd/issue/3431

There was a typo in code that read the UPN suffixes from the subdomain
ldb_message. As a result, the UPN suffixes from the first domain were
always consulted for all domains.