### PR TITLE
SDAP: Improve a DEBUG message about GC detection

### DIFF
--- a/src/man/sssd-ad.5.xml
+++ b/src/man/sssd-ad.5.xml
@@ -100,6 +100,9 @@ ldap_id_mapping = False
             domains in the forest sequentially. Please note that the
             <quote>cache_first</quote> option might be also helpful in
             speeding up domainless searches.
+            Note that if only a subset of POSIX attributes is present in
+            the Global Catalog, the non-replicated attributes are currently
+            not read from the LDAP port.
         </para>
         <para>
             Users, groups and other entities served by SSSD are always treated as

--- a/src/providers/ldap/sdap_async.c
+++ b/src/providers/ldap/sdap_async.c
@@ -2720,7 +2720,11 @@ static void sdap_gc_posix_check_done(struct tevent_req *subreq)
 
     /* Positive hit is definitive, no need to search other bases */
     if (state->has_posix == true) {
-        DEBUG(SSSDBG_FUNC_DATA, "Server has POSIX attributes\n");
+        DEBUG(SSSDBG_FUNC_DATA, "Server has POSIX attributes. Global Catalog will "
+                                "be used for user and group lookups. Note that if "
+                                "only a subset of POSIX attributes is present "
+                                "in GC, the non-replicated attributes are "
+                                "currently not read from the LDAP port\n");
         tevent_req_done(req);
         return;
     }


### PR DESCRIPTION
It was not entirely clear what the message means. We should improve the
debug message to make it clear that all or none attributes should be
replicated to the Global Catalog.

This patch can be reverted once we fix
https://pagure.io/SSSD/sssd/issue/3538 and only use the GC to look up the
entry DN, not the entry itself.