### PR TITLE
SELINUX: Check if SELinux is managed in selinux_child

### DIFF
--- a/src/providers/ipa/selinux_child.c
+++ b/src/providers/ipa/selinux_child.c
@@ -173,7 +173,7 @@ static bool seuser_needs_update(struct input_buffer *ibuf)
     char *db_mls_range = NULL;
     errno_t ret;
 
-    ret = getseuserbyname(ibuf->username, &db_seuser, &db_mls_range);
+    ret = sss_get_seuser(ibuf->username, &db_seuser, &db_mls_range);
     DEBUG(SSSDBG_TRACE_INTERNAL,
           "getseuserbyname: ret: %d seuser: %s mls: %s\n",
           ret, db_seuser ? db_seuser : "unknown",

--- a/src/providers/ipa/selinux_child.c
+++ b/src/providers/ipa/selinux_child.c
@@ -158,9 +158,9 @@ static int sc_set_seuser(const char *login_name, const char *seuser_name,
          * default. We need to remove the SELinux user from the DB
          * in that case
          */
-        ret = del_seuser(login_name);
+        ret = sss_del_seuser(login_name);
     } else {
-        ret = set_seuser(login_name, seuser_name, mls);
+        ret = sss_set_seuser(login_name, seuser_name, mls);
     }
     umask(old_mask);
     return ret;

--- a/src/tools/sss_useradd.c
+++ b/src/tools/sss_useradd.c
@@ -205,7 +205,7 @@ int main(int argc, const char **argv)
 
     /* Set SELinux login context - must be done after transaction is done
      * b/c libselinux calls getpwnam */
-    ret = set_seuser(tctx->octx->name, pc_selinux_user, NULL);
+    ret = sss_set_seuser(tctx->octx->name, pc_selinux_user, NULL);
     if (ret != EOK) {
         ERROR("Cannot set SELinux login context\n");
         ret = EXIT_FAILURE;

--- a/src/tools/sss_userdel.c
+++ b/src/tools/sss_userdel.c
@@ -254,7 +254,7 @@ int main(int argc, const char **argv)
 
     /* Set SELinux login context - must be done after transaction is done
      * b/c libselinux calls getpwnam */
-    ret = del_seuser(tctx->octx->name);
+    ret = sss_del_seuser(tctx->octx->name);
     if (ret != EOK) {
         ERROR("Cannot reset SELinux login context\n");
         ret = EXIT_FAILURE;

--- a/src/tools/sss_usermod.c
+++ b/src/tools/sss_usermod.c
@@ -300,7 +300,7 @@ int main(int argc, const char **argv)
 
     /* Set SELinux login context - must be done after transaction is done
      * b/c libselinux calls getpwnam */
-    ret = set_seuser(tctx->octx->name, pc_selinux_user, NULL);
+    ret = sss_set_seuser(tctx->octx->name, pc_selinux_user, NULL);
     if (ret != EOK) {
         ERROR("Cannot set SELinux login context\n");
         ret = EXIT_FAILURE;

--- a/src/util/sss_semanage.c
+++ b/src/util/sss_semanage.c
@@ -272,8 +272,8 @@ int sss_get_seuser(const char *linuxuser,
     return getseuserbyname(linuxuser, selinuxuser, level);
 }
 
-int set_seuser(const char *login_name, const char *seuser_name,
-               const char *mls)
+int sss_set_seuser(const char *login_name, const char *seuser_name,
+                   const char *mls)
 {
     semanage_handle_t *handle = NULL;
     semanage_seuser_key_t *key = NULL;
@@ -346,7 +346,7 @@ done:
     return ret;
 }
 
-int del_seuser(const char *login_name)
+int sss_del_seuser(const char *login_name)
 {
     semanage_handle_t *handle = NULL;
     semanage_seuser_key_t *key = NULL;
@@ -426,13 +426,13 @@ done:
     return ret;
 }
 #else /* HAVE_SEMANAGE */
-int set_seuser(const char *login_name, const char *seuser_name,
-               const char *mls)
+int sss_set_seuser(const char *login_name, const char *seuser_name,
+                   const char *mls)
 {
     return EOK;
 }
 
-int del_seuser(const char *login_name)
+int sss_del_seuser(const char *login_name)
 {
     return EOK;
 }

--- a/src/util/sss_semanage.c
+++ b/src/util/sss_semanage.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #ifdef HAVE_SEMANAGE
 #include <semanage/semanage.h>
+#include <selinux/selinux.h>
 #endif
 
 #include "util/util.h"
@@ -73,6 +74,26 @@ static void sss_semanage_close(semanage_handle_t *handle)
     semanage_handle_destroy(handle);
 }
 
+static int sss_is_selinux_managed(semanage_handle_t *handle)
+{
+    int ret;
+
+    if (handle == NULL) {
+        return EINVAL;
+    }
+
+    ret = semanage_is_managed(handle);
+    if (ret == 0) {
+        DEBUG(SSSDBG_TRACE_FUNC, "SELinux policy not managed via libsemanage\n");
+        return ERR_SELINUX_NOT_MANAGED;
+    } else if (ret == -1) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Call to semanage_is_managed failed\n");
+        return EIO;
+    }
+
+    return EOK;
+}
+
 static int sss_semanage_init(semanage_handle_t **_handle)
 {
     int ret;
@@ -89,14 +110,8 @@ static int sss_semanage_init(semanage_handle_t **_handle)
                               sss_semanage_error_callback,
                               NULL);
 
-    ret = semanage_is_managed(handle);
-    if (ret == 0) {
-        DEBUG(SSSDBG_TRACE_FUNC, "SELinux policy not managed via libsemanage\n");
-        ret = ERR_SELINUX_NOT_MANAGED;
-        goto done;
-    } else if (ret == -1) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Call to semanage_is_managed failed\n");
-        ret = EIO;
+    ret = sss_is_selinux_managed(handle);
+    if (ret != EOK) {
         goto done;
     }
 
@@ -227,6 +242,34 @@ static int sss_semanage_user_mod(semanage_handle_t *handle,
 done:
     semanage_seuser_free(seuser);
     return ret;
+}
+
+int sss_get_seuser(const char *linuxuser,
+                         char **selinuxuser,
+                         char **level)
+{
+    int ret;
+    semanage_handle_t *handle;
+
+    handle = semanage_handle_create();
+    if (handle == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Cannot create SELinux management handle\n");
+        return EIO;
+    }
+
+    semanage_msg_set_callback(handle,
+                              sss_semanage_error_callback,
+                              NULL);
+
+    /* We only needed the handle for this call. Close the handle right
+     * after it */
+    ret = sss_is_selinux_managed(handle);
+    sss_semanage_close(handle);
+    if (ret != EOK) {
+        return ret;
+    }
+
+    return getseuserbyname(linuxuser, selinuxuser, level);
 }
 
 int set_seuser(const char *login_name, const char *seuser_name,
@@ -390,6 +433,13 @@ int set_seuser(const char *login_name, const char *seuser_name,
 }
 
 int del_seuser(const char *login_name)
+{
+    return EOK;
+}
+
+int sss_get_seuser(const char *linuxuser,
+                   char **selinuxuser,
+                   char **level)
 {
     return EOK;
 }

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -651,9 +651,9 @@ errno_t restore_creds(struct sss_creds *saved_creds);
  * certain permissions. Therefore the caller should make sure the umask is
  * not too restricted (especially when called from the daemon code).
  */
-int set_seuser(const char *login_name, const char *seuser_name,
-               const char *mlsrange);
-int del_seuser(const char *login_name);
+int sss_set_seuser(const char *login_name, const char *seuser_name,
+                   const char *mlsrange);
+int sss_del_seuser(const char *login_name);
 int sss_get_seuser(const char *linuxuser,
                    char **selinuxuser,
                    char **level);

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -654,6 +654,9 @@ errno_t restore_creds(struct sss_creds *saved_creds);
 int set_seuser(const char *login_name, const char *seuser_name,
                const char *mlsrange);
 int del_seuser(const char *login_name);
+int sss_get_seuser(const char *linuxuser,
+                   char **selinuxuser,
+                   char **level);
 
 /* convert time from generalized form to unix time */
 errno_t sss_utc_to_time_t(const char *str, const char *format, time_t *unix_time);


### PR DESCRIPTION
If SELinux policy is not managed at all, don't call any SELinux user
handling functions and instead return that no update is needed.

Pair-Programmed-With: Jakub Hrozek <jhrozek@redhat.com>

Resolves:
https://pagure.io/SSSD/sssd/issue/3618