### PR TITLE
SPEC: Fix systemd executions/requirements

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -213,6 +213,7 @@ BuildRequires: nss_wrapper
 BuildRequires: libnl3-devel
 %if (0%{?use_systemd} == 1)
 BuildRequires: systemd-devel
+BuildRequires: systemd
 %endif
 %if (0%{?with_cifs_utils_plugin} == 1)
 BuildRequires: cifs-utils-devel
@@ -263,9 +264,7 @@ Requires: libsss_autofs%{?_isa} = %{version}-%{release}
 Requires: libsss_idmap = %{version}-%{release}
 Conflicts: sssd < %{version}-%{release}
 %if (0%{?use_systemd} == 1)
-Requires(post): systemd-units systemd-sysv
-Requires(preun): systemd-units
-Requires(postun): systemd-units
+%{?systemd_requires}
 %else
 Requires(post): initscripts chkconfig
 Requires(preun):  initscripts chkconfig
@@ -611,6 +610,7 @@ Summary: The D-Bus responder of the SSSD
 Group: Applications/System
 License: GPLv3+
 Requires: sssd-common = %{version}-%{release}
+%{?systemd_requires}
 
 %description dbus
 Provides the D-Bus responder of the SSSD, called the InfoPipe, that allows
@@ -710,6 +710,7 @@ Summary: An implementation of a Kerberos KCM server
 Group:  Applications/System
 License: GPLv3+
 Requires: sssd-common = %{version}-%{release}
+%{?systemd_requires}
 
 %description kcm
 An implementation of a Kerberos KCM server. Use this package if you want to


### PR DESCRIPTION
The rpm macro systemd_requires is even in el7 and using this macro
nicer then using different requires (systemd-units vs systemd)
There is a plan to remove provides for systemd-units from rawhide.

systemd was added to BuildRequires because it provides rpm macros
/usr/lib/rpm/macros.d/macros.systemd and it is unreliable to rely
on indirect dependency between systemd-devel and systemd

  sh$ rpm --eval "%{?systemd_requires}"

  Requires(post): systemd
  Requires(preun): systemd
  Requires(postun): systemd

  sh$ rpm -q --whatprovides systemd-units
  systemd-237-1.fc28.x86_64

  sh$ rpm -qf /usr/lib/rpm/macros.d/macros.systemd
  systemd-237-1.fc28.x86_64