### PR TITLE
Do not shutdown KCM/Secrets responders when activities are happening ...

### DIFF
--- a/contrib/ci/deps.sh
+++ b/contrib/ci/deps.sh
@@ -42,6 +42,7 @@ if [[ "$DISTRO_BRANCH" == -redhat-* ]]; then
         openldap-servers
         pytest
         python-ldap
+        python-psutil
         pyldb
         rpm-build
         uid_wrapper
@@ -120,6 +121,7 @@ if [[ "$DISTRO_BRANCH" == -debian-* ]]; then
         python-ldap
         python-ldb
         python-requests
+        python-psutil
         ldap-utils
         slapd
         systemtap-sdt-dev

--- a/src/responder/common/responder.h
+++ b/src/responder/common/responder.h
@@ -197,6 +197,11 @@ typedef int (*connection_setup_t)(struct cli_ctx *cctx);
 
 int sss_connection_setup(struct cli_ctx *cctx);
 
+void sss_client_fd_handler(void *ptr,
+                           void (*recv_fn) (struct cli_ctx *cctx),
+                           void (*send_fn) (struct cli_ctx *cctx),
+                           uint16_t flags);
+
 int sss_process_init(TALLOC_CTX *mem_ctx,
                      struct tevent_context *ev,
                      struct confdb_ctx *cdb,

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -441,29 +441,7 @@ static void client_fd_handler(struct tevent_context *ev,
                               struct tevent_fd *fde,
                               uint16_t flags, void *ptr)
 {
-    errno_t ret;
-    struct cli_ctx *cctx = talloc_get_type(ptr, struct cli_ctx);
-
-    /* Always reset the idle timer on any activity */
-    cctx->rctx->last_request_time = time(NULL);
-
-    /* Always reset the idle timer on any activity */
-    ret = reset_client_idle_timer(cctx);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Could not create idle timer for client. "
-               "This connection may not auto-terminate\n");
-        /* Non-fatal, continue */
-    }
-
-    if (flags & TEVENT_FD_READ) {
-        client_recv(cctx);
-        return;
-    }
-    if (flags & TEVENT_FD_WRITE) {
-        client_send(cctx);
-        return;
-    }
+    sss_client_fd_handler(ptr, client_recv, client_send, flags);
 }
 
 static errno_t setup_client_idle_timer(struct cli_ctx *cctx);

--- a/src/responder/kcm/kcmsrv_cmd.c
+++ b/src/responder/kcm/kcmsrv_cmd.c
@@ -612,29 +612,7 @@ static void kcm_fd_handler(struct tevent_context *ev,
                            struct tevent_fd *fde,
                            uint16_t flags, void *ptr)
 {
-    errno_t ret;
-    struct cli_ctx *cctx = talloc_get_type(ptr, struct cli_ctx);
-
-    /* Always reset the responder idle timer on any activity */
-    cctx->rctx->last_request_time = time(NULL);
-
-    /* Always reset the idle timer on any activity */
-    ret = reset_client_idle_timer(cctx);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Could not create idle timer for client. "
-              "This connection may not auto-terminate\n");
-        /* Non-fatal, continue */
-    }
-
-    if (flags & TEVENT_FD_READ) {
-        kcm_recv(cctx);
-        return;
-    }
-    if (flags & TEVENT_FD_WRITE) {
-        kcm_send(cctx);
-        return;
-    }
+    sss_client_fd_handler(ptr, kcm_recv, kcm_send, flags);
 }
 
 int kcm_connection_setup(struct cli_ctx *cctx)

--- a/src/responder/kcm/kcmsrv_cmd.c
+++ b/src/responder/kcm/kcmsrv_cmd.c
@@ -615,6 +615,9 @@ static void kcm_fd_handler(struct tevent_context *ev,
     errno_t ret;
     struct cli_ctx *cctx = talloc_get_type(ptr, struct cli_ctx);
 
+    /* Always reset the responder idle timer on any activity */
+    cctx->rctx->last_request_time = time(NULL);
+
     /* Always reset the idle timer on any activity */
     ret = reset_client_idle_timer(cctx);
     if (ret != EOK) {

--- a/src/responder/secrets/secsrv_cmd.c
+++ b/src/responder/secrets/secsrv_cmd.c
@@ -585,29 +585,7 @@ static void sec_fd_handler(struct tevent_context *ev,
                            struct tevent_fd *fde,
                            uint16_t flags, void *ptr)
 {
-    errno_t ret;
-    struct cli_ctx *cctx = talloc_get_type(ptr, struct cli_ctx);
-
-    /* Always reset the responder idle timer on any activity */
-    cctx->rctx->last_request_time = time(NULL);
-
-    /* Always reset the idle timer on any activity */
-    ret = reset_client_idle_timer(cctx);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Could not create idle timer for client. "
-               "This connection may not auto-terminate\n");
-        /* Non-fatal, continue */
-    }
-
-    if (flags & TEVENT_FD_READ) {
-        sec_recv(cctx);
-        return;
-    }
-    if (flags & TEVENT_FD_WRITE) {
-        sec_send(cctx);
-        return;
-    }
+    sss_client_fd_handler(ptr, sec_recv, sec_send, flags);
 }
 
 static http_parser_settings sec_callbacks = {

--- a/src/responder/secrets/secsrv_cmd.c
+++ b/src/responder/secrets/secsrv_cmd.c
@@ -588,6 +588,9 @@ static void sec_fd_handler(struct tevent_context *ev,
     errno_t ret;
     struct cli_ctx *cctx = talloc_get_type(ptr, struct cli_ctx);
 
+    /* Always reset the responder idle timer on any activity */
+    cctx->rctx->last_request_time = time(NULL);
+
     /* Always reset the idle timer on any activity */
     ret = reset_client_idle_timer(cctx);
     if (ret != EOK) {

--- a/src/tests/intg/test_secrets.py
+++ b/src/tests/intg/test_secrets.py
@@ -26,6 +26,7 @@ import subprocess
 import time
 import socket
 import pytest
+import psutil
 from requests import HTTPError
 
 from util import unindent
@@ -41,7 +42,7 @@ def create_conf_fixture(request, contents):
     request.addfinalizer(lambda: os.unlink(config.CONF_PATH))
 
 
-def create_sssd_secrets_fixture(request):
+def create_sssd_secrets_fixture(request, teardown=True):
     if subprocess.call(['sssd', "--genconf"]) != 0:
         raise Exception("failed to regenerate confdb")
 
@@ -72,13 +73,21 @@ def create_sssd_secrets_fixture(request):
 
         assert os.path.exists(sock_path)
 
+    def unlink_secdb():
+        for secdb_file in os.listdir(config.SECDB_PATH):
+            os.unlink(config.SECDB_PATH + "/" + secdb_file)
+
     def sec_teardown():
+        if teardown is False:
+            unlink_secdb()
+            return
+
         if secpid == 0:
             return
 
         os.kill(secpid, signal.SIGTERM)
-        for secdb_file in os.listdir(config.SECDB_PATH):
-            os.unlink(config.SECDB_PATH + "/" + secdb_file)
+        unlink_secdb()
+
     request.addfinalizer(sec_teardown)
     return secpid
 
@@ -602,3 +611,74 @@ def test_unlimited_quotas(setup_for_unlimited_quotas, secrets_cli):
     for i in range(DEFAULT_CONTAINERS_NEST_LEVEL):
         container += "%s/" % str(i)
         cli.create_container(container)
+
+
+@pytest.fixture
+def setup_for_resp_timeout_test(request):
+    """
+    Same as the generic setup, except a short responder_idle_timeout
+    so that the test_responder_idle_timeout() test verifies that the
+    responder has been shot down.
+    """
+    conf = generate_sec_config() + \
+        unindent("""
+        responder_idle_timeout = 60
+        """).format()
+
+    create_conf_fixture(request, conf)
+    return create_sssd_secrets_fixture(request, False)
+
+
+@pytest.mark.slow
+def test_resp_idle_timeout_shutdown_slow(setup_for_resp_timeout_test):
+    """
+    Test that the responder is shutdown after the respoder_idle_timeout is
+    over
+    """
+    secpid = setup_for_resp_timeout_test
+    p = psutil.Process(secpid)
+
+    # With the responder_idle_timeout set to 60 seconds, we need to wait at
+    # least 90, because the internal timer ticks every timeout/2 seconds, so
+    # so it would tick at 30, 60 and 90 seconds and the responder_idle_timeout
+    # uses a greater-than comparison, so the 60-seconds tick wouldn't yet
+    # trigger the process' shutdown.
+    p.wait(timeout=90)
+    assert p.is_running() is False
+
+
+@pytest.mark.slow
+def test_resp_idle_timeout_postpone_shutdown_slow(setup_for_resp_timeout_test,
+                                                  secrets_cli):
+    """
+    Test that the responder's shutdown is postponed in case an activity
+    happens, but it's still shutdown after the responder_idle_timeout is
+    over
+    """
+    cli = secrets_cli
+
+    secpid = setup_for_resp_timeout_test
+    p = psutil.Process(secpid)
+
+    # Wait for 65 seconds and then fire a request to the responder, so its
+    # last_request_time gets updated and the process doesn't get shutdown.
+    time.sleep(65)
+    cli.set_secret("foo", "bar")
+    try:
+        # Wait for the process to finish for more 25 seconds, which is the
+        # time it'd be shutdown in case the last_request_time is not updated.
+        p.wait(timeout=25)
+    except psutil.TimeoutExpired:
+        # In case the timeout expired, we're fine, it just means that the
+        # last_request_time has been updated properly.
+        pass
+
+    # Assert that the process is still running after the 60s idle timeout has
+    # expired but some activity happened (thus,the last_request_time has been
+    # updated).
+    assert p.is_running() is True
+
+    # Wait more 60s in order to be sure that the process actually is shutdown
+    # when it should be.
+    p.wait(timeout=60)
+    assert p.is_running() is False

--- a/src/tests/intg/test_secrets.py
+++ b/src/tests/intg/test_secrets.py
@@ -369,7 +369,7 @@ def get_fds(pid):
 def setup_for_cli_timeout_test(request):
     """
     Same as the generic setup, except a short client_idle_timeout so that
-    the test_idle_timeout() test closes the fd towards the client.
+    the test_cli_idle_timeout() test closes the fd towards the client.
     """
     conf = generate_sec_config() + \
         unindent("""
@@ -380,7 +380,7 @@ def setup_for_cli_timeout_test(request):
     return create_sssd_secrets_fixture(request)
 
 
-def test_idle_timeout(setup_for_cli_timeout_test):
+def test_cli_idle_timeout(setup_for_cli_timeout_test):
     """
     Test that idle file descriptors are reaped after the idle timeout
     passes


### PR DESCRIPTION
Firstly, I'd like to make it **explicit** that this PR is **missing tests**, but I won't write them down till we have an agreement whether the proposed patches do look right/good.

Basically, while trying to reproduce https://pagure.io/SSSD/sssd/issue/3470 I've noticed that both secrets and kcm responders were going down due to the responder_idle_timeout expiring ... even with a lot of activities happening on them.

Does this approach look right? If yes, then, what would be the easiest way to test:
- A responder actually goes down after x seconds;
- Any activity on that responder will make the responder alive for more x seconds;