### PR TITLE
Backport several UPN related patches to sssd-1-13

### DIFF
--- a/src/providers/ipa/ipa_subdomains_id.c
+++ b/src/providers/ipa/ipa_subdomains_id.c
@@ -1019,11 +1019,19 @@ errno_t get_object_from_cache(TALLOC_CTX *mem_ctx,
         case BE_REQ_INITGROUPS:
         case BE_REQ_USER:
         case BE_REQ_USER_AND_GROUP:
-            ret = sysdb_search_user_by_name(mem_ctx, dom, name, attrs, &msg);
-            if (ret == ENOENT && (ar->entry_type & BE_REQ_TYPE_MASK)
+            if (ar->extra_value
+                    && strcmp(ar->extra_value, EXTRA_NAME_IS_UPN) == 0) {
+                ret = sysdb_search_user_by_upn(mem_ctx, dom, name,
+                                               attrs, &msg);
+            } else {
+                ret = sysdb_search_user_by_name(mem_ctx, dom, name,
+                                                attrs, &msg);
+                if (ret == ENOENT && (ar->entry_type & BE_REQ_TYPE_MASK)
                                                      == BE_REQ_USER_AND_GROUP) {
-                ret = sysdb_search_group_by_name(mem_ctx, dom, name,
-                                                 attrs, &msg);
+                    ret = sysdb_search_group_by_name(mem_ctx, dom,
+                                                     name, attrs,
+                                                     &msg);
+                }
             }
             break;
         default:

--- a/src/responder/nss/nsssrv_cmd.c
+++ b/src/responder/nss/nsssrv_cmd.c
@@ -4386,7 +4386,11 @@ static int nss_cmd_initgroups_search(struct nss_dom_ctx *dctx)
                    name, dom->name);
             /* if a multidomain search, try with next */
             if (cmdctx->check_next) {
-                dom = get_next_domain(dom, 0);
+                if (cmdctx->name_is_upn) {
+                    dom = get_next_domain(dom, SSS_GND_DESCEND);
+                } else {
+                    dom = get_next_domain(dom, 0);
+                }
                 continue;
             }
             /* There are no further domains or this was a
@@ -4471,9 +4475,14 @@ static int nss_cmd_initgroups_search(struct nss_dom_ctx *dctx)
 
             /* if a multidomain search, try with next */
             if (cmdctx->check_next) {
-                dom = get_next_domain(dom, 0);
+                if (cmdctx->name_is_upn) {
+                    dom = get_next_domain(dom, SSS_GND_DESCEND);
+                } else {
+                    dom = get_next_domain(dom, 0);
+                }
                 if (dom) continue;
             }
+
 
             DEBUG(SSSDBG_OP_FAILURE, "No results for initgroups call\n");
 

--- a/src/responder/nss/nsssrv_cmd.c
+++ b/src/responder/nss/nsssrv_cmd.c
@@ -978,6 +978,7 @@ static int nss_cmd_getpwnam_search(struct nss_dom_ctx *dctx)
     struct ldb_message *msg;
     const char *extra_flag = NULL;
     char *neg_cache_name;
+    const char *sysdb_name;
 
     nctx = talloc_get_type(cctx->rctx->pvt_ctx, struct nss_ctx);
 
@@ -1080,6 +1081,23 @@ static int nss_cmd_getpwnam_search(struct nss_dom_ctx *dctx)
                 }
 
                 dctx->res->msgs[0] = talloc_steal(dctx->res->msgs, msg);
+
+                /* Since sysdb_search_user_by_upn() searches the whole cache we
+                 * have to set the domain so that it matches the result. */
+                sysdb_name = ldb_msg_find_attr_as_string(dctx->res->msgs[0],
+                                                         SYSDB_NAME, NULL);
+                if (sysdb_name == NULL) {
+                    DEBUG(SSSDBG_CRIT_FAILURE, "Cached entry has no name.\n");
+                    return EINVAL;
+                }
+                dctx->domain = find_domain_by_object_name(get_domains_head(dom),
+                                                          sysdb_name);
+                if (dctx->domain == NULL) {
+                    DEBUG(SSSDBG_CRIT_FAILURE,
+                          "Cannot find matching domain for [%s].\n",
+                          sysdb_name);
+                    return EINVAL;
+                }
             }
         } else {
             ret = sysdb_getpwnam_with_views(cmdctx, dom, name, &dctx->res);
@@ -4406,6 +4424,17 @@ static int nss_cmd_initgroups_search(struct nss_dom_ctx *dctx)
                 if (sysdb_name == NULL) {
                     DEBUG(SSSDBG_OP_FAILURE,
                         "Sysdb entry does not have a name.\n");
+                    return EINVAL;
+                }
+
+                /* Since sysdb_search_user_by_upn() searches the whole cache we
+                 * have to set the domain so that it matches the result. */
+                dctx->domain = find_domain_by_object_name(get_domains_head(dom),
+                                                          sysdb_name);
+                if (dctx->domain == NULL) {
+                    DEBUG(SSSDBG_CRIT_FAILURE,
+                          "Cannot find matching domain for [%s].\n",
+                          sysdb_name);
                     return EINVAL;
                 }
 


### PR DESCRIPTION
There are several patches that were applied to master, but never to sssd-1-13. The patches are needed to enable UPN logins in both direct join and trust-based setup.

The patches were already tested by one affected RHEL customer, so I'm quite certain they work. It would be nice to run CI and Coverity to make sure we don't introduce any regressions.

I did some basic sanity testing when backporting the fixes, but if you want to test the patches, first create a user with an 'enterprise principal', see e.g. https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc772007(v=ws.11) then create an UPN that is different than the realm name. Restart SSSD to make sure the subdomains are refreshed. With a trust setup, you also might need to run 'ipa trustdomain-fetch' to make sure the suffix shows up.

Then, login using the UPN as the username.