### PR TITLE
sssctl: Showing help even when sssd not configured

### DIFF
--- a/src/tools/common/sss_tools.c
+++ b/src/tools/common/sss_tools.c
@@ -346,7 +346,9 @@ errno_t sss_tool_route(int argc, const char **argv,
 
             if (!tool_ctx->print_help) {
                 ret = tool_cmd_init(tool_ctx, &commands[i]);
-                if (ret != EOK) {
+                if (ret == ERR_SYSDB_VERSION_TOO_OLD) {
+                    tool_ctx->init_err = ret;
+                } else if (ret != EOK) {
                     DEBUG(SSSDBG_FATAL_FAILURE,
                           "Command initialization failed [%d] %s\n",
                           ret, sss_strerror(ret));
@@ -516,9 +518,7 @@ int sss_tool_main(int argc, const char **argv,
     }
 
     ret = sss_tool_init(NULL, &argc, argv, &tool_ctx);
-    if (ret == ERR_SYSDB_VERSION_TOO_OLD) {
-        tool_ctx->init_err = ret;
-    } else if (ret != EOK) {
+    if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tool context\n");
         return EXIT_FAILURE;
     }

--- a/src/tools/common/sss_tools.h
+++ b/src/tools/common/sss_tools.h
@@ -29,6 +29,7 @@
 struct sss_tool_ctx {
     struct confdb_ctx *confdb;
 
+    bool print_help;
     errno_t init_err;
     char *default_domain;
     struct sss_domain_info *domains;


### PR DESCRIPTION
Current Issue:
On a clean and unconfigured system, it's not possible
to use --help.
`# dnf install sssd-tools`
`# sssctl cache-remove --help`
Shows:
[confdb_get_domains] (0x0010): No domains configured, fatal error!

Solution: Donot check for confdb initialization when sssctl 3rd
command line argument passed is '--help'.

Please note when we run 'sssctl --help' on unconfigured system
confdb check is not done and proper o/p is seen.
Also suggest if we have better alternative..

Resolves: https://pagure.io/SSSD/sssd/issue/3634