### PR TITLE
Fix two memory leaks in the AD provider

### DIFF
--- a/src/providers/ad/ad_common.c
+++ b/src/providers/ad/ad_common.c
@@ -1402,13 +1402,14 @@ ad_ldap_conn_list(TALLOC_CTX *mem_ctx,
 }
 
 struct sdap_id_conn_ctx **
-ad_user_conn_list(struct ad_id_ctx *ad_ctx,
+ad_user_conn_list(TALLOC_CTX *mem_ctx,
+                  struct ad_id_ctx *ad_ctx,
                   struct sss_domain_info *dom)
 {
     struct sdap_id_conn_ctx **clist;
     int cindex = 0;
 
-    clist = talloc_zero_array(ad_ctx, struct sdap_id_conn_ctx *, 3);
+    clist = talloc_zero_array(mem_ctx, struct sdap_id_conn_ctx *, 3);
     if (clist == NULL) {
         return NULL;
     }

--- a/src/providers/ad/ad_common.h
+++ b/src/providers/ad/ad_common.h
@@ -175,7 +175,8 @@ ad_ldap_conn_list(TALLOC_CTX *mem_ctx,
                   struct sss_domain_info *dom);
 
 struct sdap_id_conn_ctx **
-ad_user_conn_list(struct ad_id_ctx *ad_ctx,
+ad_user_conn_list(TALLOC_CTX *mem_ctx,
+                  struct ad_id_ctx *ad_ctx,
                   struct sss_domain_info *dom);
 
 struct sdap_id_conn_ctx *

--- a/src/providers/ad/ad_id.c
+++ b/src/providers/ad/ad_id.c
@@ -367,7 +367,7 @@ get_conn_list(TALLOC_CTX *mem_ctx, struct ad_id_ctx *ad_ctx,
 
     switch (ar->entry_type & BE_REQ_TYPE_MASK) {
     case BE_REQ_USER: /* user */
-        clist = ad_user_conn_list(ad_ctx, dom);
+        clist = ad_user_conn_list(mem_ctx, ad_ctx, dom);
         break;
     case BE_REQ_BY_SECID:   /* by SID */
     case BE_REQ_USER_AND_GROUP: /* get SID */

--- a/src/providers/ldap/sdap_async_initgroups_ad.c
+++ b/src/providers/ldap/sdap_async_initgroups_ad.c
@@ -372,7 +372,6 @@ immediately:
 
 static void sdap_get_ad_tokengroups_done(struct tevent_req *subreq)
 {
-    TALLOC_CTX *tmp_ctx = NULL;
     struct sdap_get_ad_tokengroups_state *state = NULL;
     struct tevent_req *req = NULL;
     struct sysdb_attrs **users = NULL;
@@ -386,7 +385,7 @@ static void sdap_get_ad_tokengroups_done(struct tevent_req *subreq)
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_get_ad_tokengroups_state);
 
-    ret = sdap_get_generic_recv(subreq, tmp_ctx, &num_users, &users);
+    ret = sdap_get_generic_recv(subreq, state, &num_users, &users);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_MINOR_FAILURE,
@@ -449,8 +448,6 @@ static void sdap_get_ad_tokengroups_done(struct tevent_req *subreq)
     ret = EOK;
 
 done:
-    talloc_free(tmp_ctx);
-
     if (ret != EOK) {
         tevent_req_error(req, ret);
         return;

--- a/src/tests/cmocka/test_ad_common.c
+++ b/src/tests/cmocka/test_ad_common.c
@@ -771,7 +771,7 @@ void test_user_conn_list(void **state)
                                                      struct ad_common_test_ctx);
     assert_non_null(test_ctx);
 
-    conn_list = ad_user_conn_list(test_ctx->ad_ctx,
+    conn_list = ad_user_conn_list(test_ctx, test_ctx->ad_ctx,
                                   test_ctx->dom);
     assert_non_null(conn_list);
 
@@ -780,7 +780,7 @@ void test_user_conn_list(void **state)
     assert_null(conn_list[1]);
     talloc_free(conn_list);
 
-    conn_list = ad_user_conn_list(test_ctx->ad_ctx,
+    conn_list = ad_user_conn_list(test_ctx, test_ctx->ad_ctx,
                                   test_ctx->subdom);
     assert_non_null(conn_list);
 


### PR DESCRIPTION
I found two memory leaks in the AD provider, one is triggered by every user
lookup the other during an initgroups request with tokenGroups.

To verify this just lookup a larger number of AD users, I took 500, or call
'id' for each of the users. When checking the memory consumption before and
after e.g. with 'ps' the increased memory usage should become obvious.

To analyse where the memory is used 'talloc_report_full' help. You can call it
directly inside of gdb or just use Pavel's 'sss-talloc-report' from
https://github.com/pbrezina/sssd-dev-utils.