### PR TITLE
PYSSS_MURMUR: Fix [-Wsign-compare] found by gcc

### DIFF
--- a/src/python/pysss_murmur.c
+++ b/src/python/pysss_murmur.c
@@ -47,7 +47,7 @@ static PyObject * py_murmurhash3(PyObject *module, PyObject *args)
     }
 
     if (seed > UINT32_MAX || key_len > INT_MAX || key_len < 0 ||
-        (size_t)key_len > input_len) {
+        key_len > input_len) {
         PyErr_Format(PyExc_ValueError, "Invalid value\n");
         return NULL;
     }


### PR DESCRIPTION
While building the project I've noticed the following warning:
../src/python/pysss_murmur.c: In function ‘py_murmurhash3’:
../src/python/pysss_murmur.c:50:25: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         (size_t)key_len > input_len) {
                         ^

Previously we were comparing key_len(long) with the output of strlen(key)
(size_t), thus the (size_t) cast.

Currently, we can jut compare key_len with input_len without issues and
without the needed to the cast.

Issue has been introduced as part of 41454a64c7.

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>