### PR TITLE
DEBUG: Print simple access provider allow and deny lists

### DIFF
--- a/src/providers/simple/simple_access.c
+++ b/src/providers/simple/simple_access.c
@@ -288,11 +288,36 @@ errno_t sssm_simple_access_init(TALLOC_CTX *mem_ctx,
                                 struct dp_method *dp_methods)
 {
     struct simple_ctx *ctx;
+    int ret;
+    int i;
+    char *simple_list_values = NULL;
+    char *simple_access_lists[] = {CONFDB_SIMPLE_ALLOW_USERS,
+                                  CONFDB_SIMPLE_DENY_USERS,
+                                  CONFDB_SIMPLE_ALLOW_GROUPS,
+                                  CONFDB_SIMPLE_DENY_GROUPS,
+                                  NULL};
 
     ctx = talloc_zero(mem_ctx, struct simple_ctx);
     if (ctx == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "talloc_zero() failed.\n");
         return ENOMEM;
+    }
+
+    for (i = 0; simple_access_lists[i] != NULL; i++) {
+        ret = confdb_get_string(be_ctx->cdb, mem_ctx, be_ctx->conf_path,
+                                simple_access_lists[i], NULL,
+                                &simple_list_values);
+
+        if (simple_list_values == NULL) {
+            continue;
+        } else if (ret != EOK) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "confdb_get_string failed.\n");
+            return ret;
+        }
+
+        DEBUG(SSSDBG_CONF_SETTINGS, "%s values: [%s]\n",
+                                     simple_access_lists[i],
+                                     simple_list_values);
     }
 
     ctx->domain = be_ctx->domain;

--- a/src/providers/simple/simple_access_check.c
+++ b/src/providers/simple/simple_access_check.c
@@ -55,6 +55,9 @@ simple_check_users(struct simple_ctx *ctx, const char *username,
     /* First, check whether the user is in the allowed users list */
     if (ctx->allow_users != NULL) {
         for(i = 0; ctx->allow_users[i] != NULL; i++) {
+            DEBUG(SSSDBG_TRACE_ALL,
+                  "Checking against allow list username [%s].\n",
+                  ctx->allow_users[i]);
             domain = find_domain_by_object_name(ctx->domain,
                                                 ctx->allow_users[i]);
             if (domain == NULL) {
@@ -85,13 +88,16 @@ simple_check_users(struct simple_ctx *ctx, const char *username,
          * unless a deny rule disables us below.
          */
         DEBUG(SSSDBG_TRACE_LIBS,
-              "No allow rule, assumuing allow unless explicitly denied\n");
+              "No allow rule, assuming allow unless explicitly denied\n");
         *access_granted = true;
     }
 
     /* Next check whether this user has been specifically denied */
     if (ctx->deny_users != NULL) {
         for(i = 0; ctx->deny_users[i] != NULL; i++) {
+            DEBUG(SSSDBG_TRACE_ALL,
+                  "Checking against deny list username [%s].\n",
+                  ctx->deny_users[i]);
             domain = find_domain_by_object_name(ctx->domain,
                                                 ctx->deny_users[i]);
             if (domain == NULL) {
@@ -133,6 +139,9 @@ simple_check_groups(struct simple_ctx *ctx, const char **group_names,
     if (ctx->allow_groups && !*access_granted) {
         matched = false;
         for (i = 0; ctx->allow_groups[i]; i++) {
+            DEBUG(SSSDBG_TRACE_ALL,
+                  "Checking against allow list group name [%s].\n",
+                  ctx->allow_groups[i]);
             domain = find_domain_by_object_name(ctx->domain,
                                                 ctx->allow_groups[i]);
             if (domain == NULL) {
@@ -169,6 +178,9 @@ simple_check_groups(struct simple_ctx *ctx, const char **group_names,
     if (ctx->deny_groups) {
         matched = false;
         for (i = 0; ctx->deny_groups[i]; i++) {
+            DEBUG(SSSDBG_TRACE_ALL,
+                  "Checking against deny list group name [%s].\n",
+                  ctx->deny_groups[i]);
             domain = find_domain_by_object_name(ctx->domain,
                                                 ctx->deny_groups[i]);
             if (domain == NULL) {


### PR DESCRIPTION
Prior to this PR, debug level 9 logs do not print the simple allow and deny user or group lists that are checked against during simple access checks when `access_provider = simple`

These debug statements helped to solve a downstream customer case where `simple_allow_users` was not working as expected, the administrator discovered when they saw the usernames printed in the logs that the `simple_allow_users` list was coming from a **/etc/sssd/conf.d/alternate.conf** file which was overriding what they set in **/etc/sssd/sssd.conf**.