### PR TITLE
DESKPROFILE: Fix 'Improper use of negative value'

### DIFF
--- a/src/providers/ipa/ipa_deskprofile_rules_util.c
+++ b/src/providers/ipa/ipa_deskprofile_rules_util.c
@@ -1065,6 +1065,7 @@ done:
     if (getegid() != orig_gid) {
         ret = setegid(orig_gid);
         if (ret == -1) {
+            ret = errno;
             DEBUG(SSSDBG_CRIT_FAILURE,
                   "Unable to set effective user id (%"PRIu32") of the "
                   "domain's process [%d]: %s\n",


### PR DESCRIPTION
This issue was found by Coverity. Similar as in code block before ret
must be set to errno to allow proper log messages since initial ret will
always be -1.