### PR TITLE
Avoid double semicolon warnings on older compilers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -459,7 +459,7 @@ AC_CACHE_CHECK(
              sss_cv_attribute_fallthrough_val="__attribute__ ((fallthrough))"
          ],[
              sss_cv_attribute_fallthrough=no
-             sss_cv_attribute_fallthrough_val=
+             sss_cv_attribute_fallthrough_val="((void)0)"
          ])
     ])
 CFLAGS=$SAFE_CFLAGS


### PR DESCRIPTION
Compilers that don't support fallthrough will end up with an empty
SSS_ATTRIBUTE_FALLTHROUGH define and just see a semicolon. The probably
will warn that there are double semicolons in the code.

Signed-off-by: Andreas Schneider <asn@redhat.com>