### PR TITLE
Prepare SSSD to support IPA in trust to Samba AD

### DIFF
--- a/src/tests/cmocka/test_ipa_subdomains_server.c
+++ b/src/tests/cmocka/test_ipa_subdomains_server.c
@@ -420,7 +420,7 @@ static void assert_trust_object(struct ipa_ad_server_ctx *trust,
         assert_null(s);
     }
 
-    /* the system keytab is always used with two-way trusts */
+    /* both one-way and two-way trust uses specialized keytab */
     s = dp_opt_get_string(trust->ad_id_ctx->ad_options->id->basic,
                           SDAP_KRB5_KEYTAB);
     if (keytab != NULL) {
@@ -474,23 +474,22 @@ static void test_ipa_server_create_trusts_twoway(struct tevent_req *req)
         s_trust = test_ctx->ipa_ctx->server_mode->trusts->next;
         c_trust = test_ctx->ipa_ctx->server_mode->trusts;
     }
-    /* Two-way trusts should use the system realm */
     assert_trust_object(c_trust,
                         CHILD_NAME,
-                        DOM_REALM,
+                        CHILD_REALM,
                         CHILD_SID,
-                        NULL,
-                        TEST_AUTHID,
-                        DOM_REALM);
+                        ONEWAY_KEYTAB,
+                        ONEWAY_PRINC,
+                        SUBDOM_REALM);
 
 
     assert_trust_object(s_trust,
                         SUBDOM_NAME,
-                        DOM_REALM,
+                        SUBDOM_REALM,
                         SUBDOM_SID,
-                        NULL,
-                        TEST_AUTHID,
-                        DOM_REALM);
+                        ONEWAY_KEYTAB,
+                        ONEWAY_PRINC,
+                        SUBDOM_REALM);
 
     /* No more trust objects */
     assert_null(test_ctx->ipa_ctx->server_mode->trusts->next->next);
@@ -505,11 +504,11 @@ static void test_ipa_server_create_trusts_twoway(struct tevent_req *req)
 
     assert_trust_object(test_ctx->ipa_ctx->server_mode->trusts,
                         SUBDOM_NAME,
-                        DOM_REALM,
+                        SUBDOM_REALM,
                         SUBDOM_SID,
-                        NULL,
-                        TEST_AUTHID,
-                        DOM_REALM);
+                        ONEWAY_KEYTAB,
+                        ONEWAY_PRINC,
+                        SUBDOM_REALM);
     assert_null(test_ctx->ipa_ctx->server_mode->trusts->next);
 
     test_ev_done(test_ctx->tctx, EOK);
@@ -562,22 +561,21 @@ static void test_ipa_server_trust_init(void **state)
         c_trust = test_ctx->ipa_ctx->server_mode->trusts;
     }
 
-    /* Two-way trusts should use the system realm */
     assert_trust_object(c_trust,
                         CHILD_NAME,
-                        DOM_REALM,
+                        CHILD_REALM,
                         CHILD_SID,
-                        NULL,
-                        TEST_AUTHID,
-                        DOM_REALM);
+                        ONEWAY_KEYTAB,
+                        ONEWAY_PRINC,
+                        SUBDOM_REALM);
 
     assert_trust_object(s_trust,
                         SUBDOM_NAME,
-                        DOM_REALM,
+                        SUBDOM_REALM,
                         SUBDOM_SID,
-                        NULL,
-                        TEST_AUTHID,
-                        DOM_REALM);
+                        ONEWAY_KEYTAB,
+                        ONEWAY_PRINC,
+                        SUBDOM_REALM);
 
     /* No more trust objects */
     assert_null(test_ctx->ipa_ctx->server_mode->trusts->next->next);


### PR DESCRIPTION
This pull request prepares SSSD ipa provider to support IPA in trust to Samba AD but the same changes are needed for a properly working bi-directional trust against Microsoft AD as well. To make everything fully working, one needs patches against FreeIPA too but SSSD changes are isolated.

@sumit-bose @jhrozek please review.

1. When IPA establishes a trust to an Active Directory forest, a number of special objects is created in a subtree of `cn=trusts,$SUFFIX`. These objects represent Kerberos principals for trusted domain objects (TDOs) used for both incoming and outgoing trusts. For bi-directional trust there is a requirement that one of them (`<REMOTE FLAT NAME>$@<OUR REALM>`) must have a POSIX identity because a remote domain controller will use it to authenticate against smbd running on IPA master.

SSSD only looks for user accounts in `cn=accounts,$SUFFIX`, so an attempt by smbd to resolve this principal name as a POSIX user via `getpwnam()` will fail. And the reason why smbd behaves this way is due to the fact that a Kerberos ticket used for authentication contains no MS-PAC record, thus not allowing Samba to build a local security token it needs. This is expected for the authentication using TDO account as it is used for bootstrapping reasons (AD DC couldn't create and sign MS-PAC record for an account in IPA realm) but the side effect is that TDO object must be known as a POSIX account on IPA master.

Thus, we extend user search base in IPA provider to search in both `cn=accounts,$SUFFIX` and `cn=trusts,$SUFFIX`. Changes on FreeIPA side will handle access controls and generation of the POSIX information for the TDO accounts.

2. For long time we relied on using cross-realm TGTs to talk to Active Directory domain controllers (LDAP and GC services) in case of bi-directional trust. Unfortunately, this is not something we can continue using as there are multiple reasons such access can be denied by a trusted AD side, including SID filtering and other security measurements. It also happens that right now Samba AD in Fedora has a bug in handling a cross-realm TGT generated by the FreeIPA KDC. As result, while technically IPA could establish a bi-directional trust to Samba AD, it does not work as any SSSD attempt to connect to AD DCs via LDAP with GSSAPI will fail (Samba AD DC answers error with PROCESS_TGS message on Kerberos level and authentication fails).

For this reason, we should remove any distinction when using bi-directional trust and simply always use a special keytab with a TDO object as we do in uni-directional trust case. While a more generic Kerberos authentication will not work in the outbound direction, SSSD will be able to resolve users/groups.