### PR TITLE
IPA: Drop unused ifdef HAVE_SELINUX_LOGIN_DIR

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -377,7 +377,6 @@ AM_PYTHON2_MODULE([ldap])
 
 if test x$HAVE_SELINUX != x; then
     AM_CHECK_SELINUX
-    AM_CHECK_SELINUX_LOGIN_DIR
 fi
 
 if test x$HAVE_SEMANAGE != x -a x$HAVE_SELINUX != x; then

--- a/src/external/selinux.m4
+++ b/src/external/selinux.m4
@@ -23,12 +23,3 @@ AC_DEFUN([AM_CHECK_SEMANAGE],
                      [AC_MSG_ERROR([libsemanage is missing])])
     AC_SUBST(SEMANAGE_LIBS)
 ])
-
-dnl Check if the SELinux login directory exists
-AC_DEFUN([AM_CHECK_SELINUX_LOGIN_DIR],
-[
-  AC_CHECK_FILE(/etc/selinux/targeted/logins/,
-                [AC_DEFINE([HAVE_SELINUX_LOGIN_DIR], [1],
-                           [The directory to store SELinux user login is available])],
-                [AC_MSG_WARN([SELinux login directory is not available])])
-])

--- a/src/providers/ipa/ipa_init.c
+++ b/src/providers/ipa/ipa_init.c
@@ -879,7 +879,7 @@ errno_t sssm_ipa_selinux_init(TALLOC_CTX *mem_ctx,
     return EOK;
 #else
     DEBUG(SSSDBG_MINOR_FAILURE, "SELinux init handler called but SSSD is "
-                                "built without SSH support, ignoring\n");
+                                "built without SELinux support, ignoring\n");
     return EOK;
 #endif
 }

--- a/src/providers/ipa/ipa_init.c
+++ b/src/providers/ipa/ipa_init.c
@@ -853,7 +853,7 @@ errno_t sssm_ipa_selinux_init(TALLOC_CTX *mem_ctx,
                               void *module_data,
                               struct dp_method *dp_methods)
 {
-#if defined HAVE_SELINUX && defined HAVE_SELINUX_LOGIN_DIR
+#if defined HAVE_SELINUX
     struct ipa_selinux_ctx *selinux_ctx;
     struct ipa_init_ctx *init_ctx;
     struct ipa_options *opts;

--- a/src/providers/ipa/ipa_selinux.h
+++ b/src/providers/ipa/ipa_selinux.h
@@ -27,13 +27,6 @@
 
 #include "providers/ldap/ldap_common.h"
 
-#ifdef HAVE_SELINUX_LOGIN_DIR
-
-#define ALL_SERVICES "*"
-#define selogin_path(mem_ctx, username) \
-    talloc_asprintf(mem_ctx, "%s/logins/%s", selinux_policy_root(), username)
-#endif /* HAVE_SELINUX_LOGIN_DIR */
-
 struct ipa_selinux_ctx {
     struct ipa_id_ctx *id_ctx;
     time_t last_update;


### PR DESCRIPTION
Macros ALL_SERVICES and selogin_path were conditionally defined
in case of existing selinux login directory at configure time
(defined macro AVE_SELINUX_LOGIN_DIR)
However, these macros were unused for quite a long 2.5 year
and last usage was removed in commit 9c47c8c59b5c9078f342f82367cd0ad7857acef8
"IPA: Use set_seuser instead of writing selinux login file"