### PR TITLE
CI: Add dbus into debian dependencies

### DIFF
--- a/contrib/ci/deps.sh
+++ b/contrib/ci/deps.sh
@@ -129,6 +129,7 @@ if [[ "$DISTRO_BRANCH" == -debian-* ]]; then
         krb5-admin-server
         krb5-user
         uuid-dev
+        dbus
         python-dbus
     )
     DEPS_INTGCHECK_SATISFIED=true


### PR DESCRIPTION
There is just weak dependency (recommends) between dbus
libraries and dbus daemon. It is installed by default but we should
not rely in integration tests on weak dependency if we directly need
binary dbus-daemon.

sh# apt-cache depends libdbus-1-dev libdbus-1-3
libdbus-1-dev
  Depends: libdbus-1-3
  Depends: pkg-config
    pkgconf
libdbus-1-3
  Depends: libc6
  Depends: libsystemd0
  Breaks: dbus
  Recommends: dbus