### PR TITLE
SSS_PYTHON: Use PyUnicode_FromString() with py3 code

### DIFF
--- a/src/util/sss_python.c
+++ b/src/util/sss_python.c
@@ -39,7 +39,11 @@ sss_exception_with_doc(char *name, char *doc, PyObject *base, PyObject *dict)
     }
 
     if (doc != NULL) {
+#ifdef IS_PY3K
+        docobj = PyUnicode_FromString(doc);
+#else
         docobj = PyString_FromString(doc);
+#endif
         if (docobj == NULL)
             goto failure;
         result = PyDict_SetItemString(dict, "__doc__", docobj);


### PR DESCRIPTION
As PyString_FromString() is not available in python3 aymore, let's
use PyUnicode_FromString() with py3 code.

Resolves:
https://pagure.io/SSSD/sssd/issue/3653

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>