### PR TITLE
PEP8 Fixes and enable PEP8 check in CI

### DIFF
--- a/contrib/ci/deps.sh
+++ b/contrib/ci/deps.sh
@@ -50,6 +50,7 @@ if [[ "$DISTRO_BRANCH" == -redhat-* ]]; then
         krb5-server
         krb5-workstation
         dbus-python
+        python-pep8
     )
     _DEPS_LIST_SPEC=`
         sed -e 's/@PACKAGE_VERSION@/0/g' \
@@ -130,6 +131,7 @@ if [[ "$DISTRO_BRANCH" == -debian-* ]]; then
         krb5-user
         uuid-dev
         python-dbus
+        pep8
     )
     DEPS_INTGCHECK_SATISFIED=true
 fi

--- a/contrib/ci/run
+++ b/contrib/ci/run
@@ -39,6 +39,19 @@ declare -r COVERAGE_MIN_LINES=15
 # Minimum percentage of code functions covered by tests
 declare -r COVERAGE_MIN_FUNCS=0
 
+# Those values are a sum up of the default warnings in all our
+# supported distros in our CI.
+# debian_testing: E121,E123,E126,E226,E24,E704,W503
+# fedora22:
+# fedora23:
+# fedora24: E121,E123,E126,E226,E24,E704
+# fedora25: E121,E123,E126,E226,E24,E704
+# fedora26: E121,E123,E126,E226,E24,E704
+# fedora27: E121,E123,E126,E226,E24,E704
+# fedora_rawhide: E121,E123,E126,E226,E24,E704
+# rhel6:
+# rhel7:
+declare PEP8_IGNORE="--ignore=E121,E123,E126,E226,E24,E704,W503"
 declare BASE_PFX=""
 declare DEPS=true
 declare BASE_DIR=`pwd`
@@ -379,6 +392,8 @@ export V=1
 if "$DEPS"; then
     stage install-deps  deps_install
 fi
+stage pep8          find . -path ./src/config -prune -o \
+                           -name \*.py -exec pep8 $PEP8_IGNORE {} +
 stage autoreconf    autoreconf --install --force
 run_build debug     build_debug
 if "$RIGOROUS"; then

--- a/contrib/ci/run
+++ b/contrib/ci/run
@@ -392,6 +392,11 @@ export V=1
 if "$DEPS"; then
     stage install-deps  deps_install
 fi
+if [[ "$DISTRO_BRANCH" != redhat-* ]]; then
+    # Ignore "E722 do not use bare except" exceptions
+    # that are only raised on debian_testing machines.
+    PEP8_IGNORE+=",E722"
+fi
 stage pep8          find . -path ./src/config -prune -o \
                            -name \*.py -exec pep8 $PEP8_IGNORE {} +
 stage autoreconf    autoreconf --install --force

--- a/contrib/gdb/sssd_gdb_plugin.py
+++ b/contrib/gdb/sssd_gdb_plugin.py
@@ -198,4 +198,5 @@ class TeventBreak(gdb.Command):
 
         b = gdb.Breakpoint("*%s" % fnaddr)
 
+
 TeventBreak()

--- a/contrib/gdb/sssd_gdb_plugin.py
+++ b/contrib/gdb/sssd_gdb_plugin.py
@@ -15,7 +15,8 @@ def gdb_printer_decorator(fn):
 
 
 def indent_string(s, indent):
-    return '\n'.join(["%s%s" % ("\t" * indent, part) for part in s.split('\n')])
+    return '\n'.join(["%s%s" % ("\t" * indent, part)
+                     for part in s.split('\n')])
 
 
 class StringPrinter(object):
@@ -31,7 +32,8 @@ class LdbDnPrinter(StringPrinter):
     " print an ldb dn "
 
     def as_string(self, indent=0):
-        ret = "{ <%s>\tlinearized:%s }" % (self.val.type, self.val['linearized'])
+        ret = "{ <%s>\tlinearized:%s }" % (self.val.type,
+                                           self.val['linearized'])
         return indent_string(ret, indent)
 
 
@@ -47,7 +49,8 @@ class LdbMessageElementPrinter(StringPrinter):
     " print a ldb message element "
 
     def as_string(self, indent=0):
-        ret = "flags = %(flags)s, name = %(name)s, num_values = %(num_values)s" % self.val
+        ret = "flags = %(flags)s, name = %(name)s, " \
+                "num_values = %(num_values)s" % self.val
         try:
             nvals = int(self.val['num_values'])
         except ValueError:
@@ -70,7 +73,8 @@ class LdbMessagePrinter(StringPrinter):
             return "num_elements is not numeric?"
 
         dn = LdbDnPrinter(self.val['dn'])
-        ret = "num_elements:\t%s\ndn:\t%s\nelements:\t" % (nels, dn.as_string(indent))
+        dn_str = dn.as_string(indent)
+        ret = "num_elements:\t%s\ndn:\t%s\nelements:\t" % (nels, dn_str)
 
         for i in range(nels):
             el = LdbMessageElementPrinter(self.val['elements'][i])
@@ -83,7 +87,8 @@ class LdbResultPrinter(StringPrinter):
     " print a ldb message element "
 
     def as_string(self, indent=0):
-        ret = "count = %(count)s, extended = %(extended)s, controls = %(controls)s, refs = %(refs)s" % self.val
+        ret = "count = %(count)s, extended = %(extended)s, " \
+                "controls = %(controls)s, refs = %(refs)s" % self.val
         try:
             count = int(self.val['count'])
         except ValueError:

--- a/src/tests/intg/sssd_group.py
+++ b/src/tests/intg/sssd_group.py
@@ -83,7 +83,7 @@ def set_group_dict(res, result_p):
     group_dict['mem'] = list()
 
     i = 0
-    while result_p[0].gr_mem[i] != None:
+    while result_p[0].gr_mem[i] is not None:
         grp_name = result_p[0].gr_mem[i].decode('utf-8')
         group_dict['mem'].append(grp_name)
         i = i+1

--- a/src/tests/intg/sssd_netgroup.py
+++ b/src/tests/intg/sssd_netgroup.py
@@ -47,6 +47,7 @@ class Idx(Union):
 class NameList(Structure):
     pass
 
+
 NameList._fields_ = [("next", POINTER(NameList)),
                      ("name", POINTER(c_char))]
 

--- a/src/tests/intg/test_enumeration.py
+++ b/src/tests/intg/test_enumeration.py
@@ -237,6 +237,7 @@ def sanity_rfc2307(request, ldap_conn):
     create_sssd_fixture(request)
     return None
 
+
 def populate_rfc2307bis(request, ldap_conn):
     ent_list = ldap_ent.List(ldap_conn.ds_inst.base_dn)
     ent_list.add_user("user1", 1001, 2001)

--- a/src/tests/intg/test_ldap.py
+++ b/src/tests/intg/test_ldap.py
@@ -1219,8 +1219,9 @@ def test_ldap_auto_private_groups_direct(ldap_conn, mpg_setup):
     ent.assert_group_by_gid(2001, dict(name="group1", mem=ent.contains_only()))
 
     # The user's secondary groups list must be correct as well
-    # Note that the original GID is listed as well -- this is correct and expected
-    # because we save the original GID in the SYSDB_PRIMARY_GROUP_GIDNUM attribute
+    # Note that the original GID is listed as well -- this is correct and
+    # expected because we save the original GID in the
+    # SYSDB_PRIMARY_GROUP_GIDNUM attribute
     user1_expected_gids = [1001, 2001, 2012, 2015]
     (res, errno, gids) = sssd_id.call_sssd_initgroups("user1", 1001)
     assert res == sssd_id.NssReturnCode.SUCCESS
@@ -1232,8 +1233,8 @@ def test_ldap_auto_private_groups_direct(ldap_conn, mpg_setup):
         )
 
     # Request user2's private group by GID without resolving the user first.
-    # This must trigger user resolution through by-GID resolution, since the GID
-    # doesn't exist on its own in LDAP
+    # This must trigger user resolution through by-GID resolution, since the
+    # GID doesn't exist on its own in LDAP
     ent.assert_group_by_gid(1002, dict(name="user2", mem=ent.contains_only()))
 
     # Test supplementary groups for user2 as well

--- a/src/tests/intg/test_ldap.py
+++ b/src/tests/intg/test_ldap.py
@@ -998,7 +998,7 @@ def test_zero_nesting_level(ldap_conn, rfc2307bis_no_nesting):
     assert res == sssd_id.NssReturnCode.SUCCESS, \
         "Could not find groups for user1, %d" % errno
 
-    ## test nestedgroup is not returned in group list
+    # test nestedgroup is not returned in group list
     assert sorted(grp_list) == sorted(["primarygroup", "parentgroup"])
 
 

--- a/src/tests/intg/test_ldap.py
+++ b/src/tests/intg/test_ldap.py
@@ -1002,7 +1002,6 @@ def test_zero_nesting_level(ldap_conn, rfc2307bis_no_nesting):
     assert sorted(grp_list) == sorted(["primarygroup", "parentgroup"])
 
 
-
 @pytest.fixture
 def sanity_nss_filter(request, ldap_conn):
     ent_list = ldap_ent.List(ldap_conn.ds_inst.base_dn)

--- a/src/tests/intg/test_session_recording.py
+++ b/src/tests/intg/test_session_recording.py
@@ -297,10 +297,10 @@ def test_all_nam(all):
 def test_all_uid(all):
     """Test "all" scope with getpwuid"""
     ent.assert_each_passwd_by_uid({
-        1001:dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
-        1002:dict(name="user2", uid=1002, shell=config.SESSION_RECORDING_SHELL),
-        1003:dict(name="user3", uid=1003, shell=config.SESSION_RECORDING_SHELL),
-        1004:dict(name="user4", uid=1004, shell=config.SESSION_RECORDING_SHELL),
+        1001: dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
+        1002: dict(name="user2", uid=1002, shell=config.SESSION_RECORDING_SHELL),
+        1003: dict(name="user3", uid=1003, shell=config.SESSION_RECORDING_SHELL),
+        1004: dict(name="user4", uid=1004, shell=config.SESSION_RECORDING_SHELL),
     })
 
 
@@ -372,10 +372,10 @@ def test_some_users_nam(some_users):
 def test_some_users_uid(some_users):
     """Test "some" scope with user list and getpwuid"""
     ent.assert_each_passwd_by_uid({
-        1001:dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
-        1002:dict(name="user2", uid=1002, shell=config.SESSION_RECORDING_SHELL),
-        1003:dict(name="user3", uid=1003, shell="/bin/sh3"),
-        1004:dict(name="user4", uid=1004, shell="/bin/sh4"),
+        1001: dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
+        1002: dict(name="user2", uid=1002, shell=config.SESSION_RECORDING_SHELL),
+        1003: dict(name="user3", uid=1003, shell="/bin/sh3"),
+        1004: dict(name="user4", uid=1004, shell="/bin/sh4"),
     })
 
 
@@ -434,12 +434,12 @@ def test_some_users_overridden_uid(some_users_overridden):
     overridden users, requested with getpwuid.
     """
     ent.assert_each_passwd_by_uid({
-        1001:dict(name="overridden_user1", uid=1001,
-                  shell=config.SESSION_RECORDING_SHELL),
-        1002:dict(name="overridden_user2", uid=1002,
-                  shell="/bin/sh2"),
-        1003:dict(name="user3", uid=1003, shell="/bin/sh3"),
-        1004:dict(name="user4", uid=1004, shell="/bin/sh4"),
+        1001: dict(name="overridden_user1", uid=1001,
+                   shell=config.SESSION_RECORDING_SHELL),
+        1002: dict(name="overridden_user2", uid=1002,
+                   shell="/bin/sh2"),
+        1003: dict(name="user3", uid=1003, shell="/bin/sh3"),
+        1004: dict(name="user4", uid=1004, shell="/bin/sh4"),
     })
 
 
@@ -539,10 +539,10 @@ def test_some_groups1_nam(some_groups1):
 def test_some_groups1_uid(some_groups1):
     """Test "some" scope with group list and getpwuid"""
     ent.assert_each_passwd_by_uid({
-        1001:dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
-        1002:dict(name="user2", uid=1002, shell=config.SESSION_RECORDING_SHELL),
-        1003:dict(name="user3", uid=1003, shell="/bin/sh3"),
-        1004:dict(name="user4", uid=1004, shell="/bin/sh4"),
+        1001: dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
+        1002: dict(name="user2", uid=1002, shell=config.SESSION_RECORDING_SHELL),
+        1003: dict(name="user3", uid=1003, shell="/bin/sh3"),
+        1004: dict(name="user4", uid=1004, shell="/bin/sh4"),
     })
 
 
@@ -571,10 +571,10 @@ def test_some_groups2_nam(some_groups2):
 def test_some_groups2_uid(some_groups2):
     """Test "some" scope with group list and getpwuid"""
     ent.assert_each_passwd_by_uid({
-        1001:dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
-        1002:dict(name="user2", uid=1002, shell=config.SESSION_RECORDING_SHELL),
-        1003:dict(name="user3", uid=1003, shell=config.SESSION_RECORDING_SHELL),
-        1004:dict(name="user4", uid=1004, shell="/bin/sh4"),
+        1001: dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
+        1002: dict(name="user2", uid=1002, shell=config.SESSION_RECORDING_SHELL),
+        1003: dict(name="user3", uid=1003, shell=config.SESSION_RECORDING_SHELL),
+        1004: dict(name="user4", uid=1004, shell="/bin/sh4"),
     })
 
 
@@ -603,10 +603,10 @@ def test_some_groups3_nam(some_groups3):
 def test_some_groups3_uid(some_groups3):
     """Test "some" scope with group list and getpwuid"""
     ent.assert_each_passwd_by_uid({
-        1001:dict(name="user1", uid=1001, shell="/bin/sh1"),
-        1002:dict(name="user2", uid=1002, shell="/bin/sh2"),
-        1003:dict(name="user3", uid=1003, shell="/bin/sh3"),
-        1004:dict(name="user4", uid=1004, shell=config.SESSION_RECORDING_SHELL),
+        1001: dict(name="user1", uid=1001, shell="/bin/sh1"),
+        1002: dict(name="user2", uid=1002, shell="/bin/sh2"),
+        1003: dict(name="user3", uid=1003, shell="/bin/sh3"),
+        1004: dict(name="user4", uid=1004, shell=config.SESSION_RECORDING_SHELL),
     })
 
 
@@ -635,10 +635,10 @@ def test_some_groups4_nam(some_groups4):
 def test_some_groups4_uid(some_groups4):
     """Test "some" scope with group list and getpwuid"""
     ent.assert_each_passwd_by_uid({
-        1001:dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
-        1002:dict(name="user2", uid=1002, shell="/bin/sh2"),
-        1003:dict(name="user3", uid=1003, shell=config.SESSION_RECORDING_SHELL),
-        1004:dict(name="user4", uid=1004, shell="/bin/sh4"),
+        1001: dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
+        1002: dict(name="user2", uid=1002, shell="/bin/sh2"),
+        1003: dict(name="user3", uid=1003, shell=config.SESSION_RECORDING_SHELL),
+        1004: dict(name="user4", uid=1004, shell="/bin/sh4"),
     })
 
 
@@ -695,10 +695,10 @@ def test_some_groups_overridden1_uid(some_groups_overridden1):
     overridden groups, and users requested with getpwuid.
     """
     ent.assert_each_passwd_by_uid({
-        1001:dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
-        1002:dict(name="user2", uid=1002, shell="/bin/sh2"),
-        1003:dict(name="user3", uid=1003, shell="/bin/sh3"),
-        1004:dict(name="user4", uid=1004, shell="/bin/sh4"),
+        1001: dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
+        1002: dict(name="user2", uid=1002, shell="/bin/sh2"),
+        1003: dict(name="user3", uid=1003, shell="/bin/sh3"),
+        1004: dict(name="user4", uid=1004, shell="/bin/sh4"),
     })
 
 
@@ -758,10 +758,10 @@ def test_some_groups_overridden2_uid(some_groups_overridden2):
     overridden groups, and users requested with getpwuid.
     """
     ent.assert_each_passwd_by_uid({
-        1001:dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
-        1002:dict(name="user2", uid=1002, shell="/bin/sh2"),
-        1003:dict(name="user3", uid=1003, shell="/bin/sh3"),
-        1004:dict(name="user4", uid=1004, shell="/bin/sh4"),
+        1001: dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
+        1002: dict(name="user2", uid=1002, shell="/bin/sh2"),
+        1003: dict(name="user3", uid=1003, shell="/bin/sh3"),
+        1004: dict(name="user4", uid=1004, shell="/bin/sh4"),
     })
 
 
@@ -821,10 +821,10 @@ def test_some_groups_overridden3_uid(some_groups_overridden3):
     overridden group, and users requested with getpwuid.
     """
     ent.assert_each_passwd_by_uid({
-        1001:dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
-        1002:dict(name="user2", uid=1002, shell="/bin/sh2"),
-        1003:dict(name="user3", uid=1003, shell="/bin/sh3"),
-        1004:dict(name="user4", uid=1004, shell="/bin/sh4"),
+        1001: dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
+        1002: dict(name="user2", uid=1002, shell="/bin/sh2"),
+        1003: dict(name="user3", uid=1003, shell="/bin/sh3"),
+        1004: dict(name="user4", uid=1004, shell="/bin/sh4"),
     })
 
 
@@ -884,10 +884,10 @@ def test_some_groups_overridden4_uid(some_groups_overridden3):
     overridden group, and users requested with getpwuid.
     """
     ent.assert_each_passwd_by_uid({
-        1001:dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
-        1002:dict(name="user2", uid=1002, shell="/bin/sh2"),
-        1003:dict(name="user3", uid=1003, shell="/bin/sh3"),
-        1004:dict(name="user4", uid=1004, shell="/bin/sh4"),
+        1001: dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
+        1002: dict(name="user2", uid=1002, shell="/bin/sh2"),
+        1003: dict(name="user3", uid=1003, shell="/bin/sh3"),
+        1004: dict(name="user4", uid=1004, shell="/bin/sh4"),
     })
 
 
@@ -940,10 +940,10 @@ def test_some_users_and_groups_uid(some_users_and_groups):
     Test "some" scope with user and group lists and getpwuid.
     """
     ent.assert_each_passwd_by_uid({
-        1001:dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
-        1002:dict(name="user2", uid=1002, shell="/bin/sh2"),
-        1003:dict(name="user3", uid=1003, shell=config.SESSION_RECORDING_SHELL),
-        1004:dict(name="user4", uid=1004, shell="/bin/sh4"),
+        1001: dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
+        1002: dict(name="user2", uid=1002, shell="/bin/sh2"),
+        1003: dict(name="user3", uid=1003, shell=config.SESSION_RECORDING_SHELL),
+        1004: dict(name="user4", uid=1004, shell="/bin/sh4"),
     })
 
 

--- a/src/tests/intg/test_session_recording.py
+++ b/src/tests/intg/test_session_recording.py
@@ -287,20 +287,28 @@ def all(request, ldap_conn, users_and_groups):
 def test_all_nam(all):
     """Test "all" scope with getpwnam"""
     ent.assert_each_passwd_by_name(dict(
-        user1=dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
-        user2=dict(name="user2", uid=1002, shell=config.SESSION_RECORDING_SHELL),
-        user3=dict(name="user3", uid=1003, shell=config.SESSION_RECORDING_SHELL),
-        user4=dict(name="user4", uid=1004, shell=config.SESSION_RECORDING_SHELL),
+        user1=dict(name="user1", uid=1001,
+                   shell=config.SESSION_RECORDING_SHELL),
+        user2=dict(name="user2", uid=1002,
+                   shell=config.SESSION_RECORDING_SHELL),
+        user3=dict(name="user3", uid=1003,
+                   shell=config.SESSION_RECORDING_SHELL),
+        user4=dict(name="user4", uid=1004,
+                   shell=config.SESSION_RECORDING_SHELL),
     ))
 
 
 def test_all_uid(all):
     """Test "all" scope with getpwuid"""
     ent.assert_each_passwd_by_uid({
-        1001: dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
-        1002: dict(name="user2", uid=1002, shell=config.SESSION_RECORDING_SHELL),
-        1003: dict(name="user3", uid=1003, shell=config.SESSION_RECORDING_SHELL),
-        1004: dict(name="user4", uid=1004, shell=config.SESSION_RECORDING_SHELL),
+        1001: dict(name="user1", uid=1001,
+                   shell=config.SESSION_RECORDING_SHELL),
+        1002: dict(name="user2", uid=1002,
+                   shell=config.SESSION_RECORDING_SHELL),
+        1003: dict(name="user3", uid=1003,
+                   shell=config.SESSION_RECORDING_SHELL),
+        1004: dict(name="user4", uid=1004,
+                   shell=config.SESSION_RECORDING_SHELL),
     })
 
 
@@ -362,8 +370,10 @@ def some_users(request, ldap_conn, users_and_groups):
 def test_some_users_nam(some_users):
     """Test "some" scope with user list and getpwnam"""
     ent.assert_each_passwd_by_name(dict(
-        user1=dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
-        user2=dict(name="user2", uid=1002, shell=config.SESSION_RECORDING_SHELL),
+        user1=dict(name="user1", uid=1001,
+                   shell=config.SESSION_RECORDING_SHELL),
+        user2=dict(name="user2", uid=1002,
+                   shell=config.SESSION_RECORDING_SHELL),
         user3=dict(name="user3", uid=1003, shell="/bin/sh3"),
         user4=dict(name="user4", uid=1004, shell="/bin/sh4"),
     ))
@@ -372,8 +382,10 @@ def test_some_users_nam(some_users):
 def test_some_users_uid(some_users):
     """Test "some" scope with user list and getpwuid"""
     ent.assert_each_passwd_by_uid({
-        1001: dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
-        1002: dict(name="user2", uid=1002, shell=config.SESSION_RECORDING_SHELL),
+        1001: dict(name="user1", uid=1001,
+                   shell=config.SESSION_RECORDING_SHELL),
+        1002: dict(name="user2", uid=1002,
+                   shell=config.SESSION_RECORDING_SHELL),
         1003: dict(name="user3", uid=1003, shell="/bin/sh3"),
         1004: dict(name="user4", uid=1004, shell="/bin/sh4"),
     })
@@ -529,8 +541,10 @@ def some_groups4(request, ldap_conn, users_and_groups):
 def test_some_groups1_nam(some_groups1):
     """Test "some" scope with group list and getpwnam"""
     ent.assert_each_passwd_by_name(dict(
-        user1=dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
-        user2=dict(name="user2", uid=1002, shell=config.SESSION_RECORDING_SHELL),
+        user1=dict(name="user1", uid=1001,
+                   shell=config.SESSION_RECORDING_SHELL),
+        user2=dict(name="user2", uid=1002,
+                   shell=config.SESSION_RECORDING_SHELL),
         user3=dict(name="user3", uid=1003, shell="/bin/sh3"),
         user4=dict(name="user4", uid=1004, shell="/bin/sh4"),
     ))
@@ -539,8 +553,10 @@ def test_some_groups1_nam(some_groups1):
 def test_some_groups1_uid(some_groups1):
     """Test "some" scope with group list and getpwuid"""
     ent.assert_each_passwd_by_uid({
-        1001: dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
-        1002: dict(name="user2", uid=1002, shell=config.SESSION_RECORDING_SHELL),
+        1001: dict(name="user1", uid=1001,
+                   shell=config.SESSION_RECORDING_SHELL),
+        1002: dict(name="user2", uid=1002,
+                   shell=config.SESSION_RECORDING_SHELL),
         1003: dict(name="user3", uid=1003, shell="/bin/sh3"),
         1004: dict(name="user4", uid=1004, shell="/bin/sh4"),
     })
@@ -561,9 +577,12 @@ def test_some_groups1_ent(some_groups1):
 def test_some_groups2_nam(some_groups2):
     """Test "some" scope with group list and getpwnam"""
     ent.assert_each_passwd_by_name(dict(
-        user1=dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
-        user2=dict(name="user2", uid=1002, shell=config.SESSION_RECORDING_SHELL),
-        user3=dict(name="user3", uid=1003, shell=config.SESSION_RECORDING_SHELL),
+        user1=dict(name="user1", uid=1001,
+                   shell=config.SESSION_RECORDING_SHELL),
+        user2=dict(name="user2", uid=1002,
+                   shell=config.SESSION_RECORDING_SHELL),
+        user3=dict(name="user3", uid=1003,
+                   shell=config.SESSION_RECORDING_SHELL),
         user4=dict(name="user4", uid=1004, shell="/bin/sh4"),
     ))
 
@@ -571,9 +590,12 @@ def test_some_groups2_nam(some_groups2):
 def test_some_groups2_uid(some_groups2):
     """Test "some" scope with group list and getpwuid"""
     ent.assert_each_passwd_by_uid({
-        1001: dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
-        1002: dict(name="user2", uid=1002, shell=config.SESSION_RECORDING_SHELL),
-        1003: dict(name="user3", uid=1003, shell=config.SESSION_RECORDING_SHELL),
+        1001: dict(name="user1", uid=1001,
+                   shell=config.SESSION_RECORDING_SHELL),
+        1002: dict(name="user2", uid=1002,
+                   shell=config.SESSION_RECORDING_SHELL),
+        1003: dict(name="user3", uid=1003,
+                   shell=config.SESSION_RECORDING_SHELL),
         1004: dict(name="user4", uid=1004, shell="/bin/sh4"),
     })
 
@@ -596,7 +618,8 @@ def test_some_groups3_nam(some_groups3):
         user1=dict(name="user1", uid=1001, shell="/bin/sh1"),
         user2=dict(name="user2", uid=1002, shell="/bin/sh2"),
         user3=dict(name="user3", uid=1003, shell="/bin/sh3"),
-        user4=dict(name="user4", uid=1004, shell=config.SESSION_RECORDING_SHELL),
+        user4=dict(name="user4", uid=1004,
+                   shell=config.SESSION_RECORDING_SHELL),
     ))
 
 
@@ -606,7 +629,8 @@ def test_some_groups3_uid(some_groups3):
         1001: dict(name="user1", uid=1001, shell="/bin/sh1"),
         1002: dict(name="user2", uid=1002, shell="/bin/sh2"),
         1003: dict(name="user3", uid=1003, shell="/bin/sh3"),
-        1004: dict(name="user4", uid=1004, shell=config.SESSION_RECORDING_SHELL),
+        1004: dict(name="user4", uid=1004,
+                   shell=config.SESSION_RECORDING_SHELL),
     })
 
 
@@ -625,9 +649,11 @@ def test_some_groups3_ent(some_groups3):
 def test_some_groups4_nam(some_groups4):
     """Test "some" scope with group list and getpwnam"""
     ent.assert_each_passwd_by_name(dict(
-        user1=dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
+        user1=dict(name="user1", uid=1001,
+                   shell=config.SESSION_RECORDING_SHELL),
         user2=dict(name="user2", uid=1002, shell="/bin/sh2"),
-        user3=dict(name="user3", uid=1003, shell=config.SESSION_RECORDING_SHELL),
+        user3=dict(name="user3", uid=1003,
+                   shell=config.SESSION_RECORDING_SHELL),
         user4=dict(name="user4", uid=1004, shell="/bin/sh4"),
     ))
 
@@ -635,9 +661,11 @@ def test_some_groups4_nam(some_groups4):
 def test_some_groups4_uid(some_groups4):
     """Test "some" scope with group list and getpwuid"""
     ent.assert_each_passwd_by_uid({
-        1001: dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
+        1001: dict(name="user1", uid=1001,
+                   shell=config.SESSION_RECORDING_SHELL),
         1002: dict(name="user2", uid=1002, shell="/bin/sh2"),
-        1003: dict(name="user3", uid=1003, shell=config.SESSION_RECORDING_SHELL),
+        1003: dict(name="user3", uid=1003,
+                   shell=config.SESSION_RECORDING_SHELL),
         1004: dict(name="user4", uid=1004, shell="/bin/sh4"),
     })
 
@@ -682,7 +710,8 @@ def test_some_groups_overridden1_nam(some_groups_overridden1):
     overridden groups, and users requested with getpwnam.
     """
     ent.assert_each_passwd_by_name(dict(
-        user1=dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
+        user1=dict(name="user1", uid=1001,
+                   shell=config.SESSION_RECORDING_SHELL),
         user2=dict(name="user2", uid=1002, shell="/bin/sh2"),
         user3=dict(name="user3", uid=1003, shell="/bin/sh3"),
         user4=dict(name="user4", uid=1004, shell="/bin/sh4"),
@@ -695,7 +724,8 @@ def test_some_groups_overridden1_uid(some_groups_overridden1):
     overridden groups, and users requested with getpwuid.
     """
     ent.assert_each_passwd_by_uid({
-        1001: dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
+        1001: dict(name="user1", uid=1001,
+                   shell=config.SESSION_RECORDING_SHELL),
         1002: dict(name="user2", uid=1002, shell="/bin/sh2"),
         1003: dict(name="user3", uid=1003, shell="/bin/sh3"),
         1004: dict(name="user4", uid=1004, shell="/bin/sh4"),
@@ -745,7 +775,8 @@ def test_some_groups_overridden2_nam(some_groups_overridden2):
     overridden groups, and users requested with getpwnam.
     """
     ent.assert_each_passwd_by_name(dict(
-        user1=dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
+        user1=dict(name="user1", uid=1001,
+                   shell=config.SESSION_RECORDING_SHELL),
         user2=dict(name="user2", uid=1002, shell="/bin/sh2"),
         user3=dict(name="user3", uid=1003, shell="/bin/sh3"),
         user4=dict(name="user4", uid=1004, shell="/bin/sh4"),
@@ -758,7 +789,8 @@ def test_some_groups_overridden2_uid(some_groups_overridden2):
     overridden groups, and users requested with getpwuid.
     """
     ent.assert_each_passwd_by_uid({
-        1001: dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
+        1001: dict(name="user1", uid=1001,
+                   shell=config.SESSION_RECORDING_SHELL),
         1002: dict(name="user2", uid=1002, shell="/bin/sh2"),
         1003: dict(name="user3", uid=1003, shell="/bin/sh3"),
         1004: dict(name="user4", uid=1004, shell="/bin/sh4"),
@@ -808,7 +840,8 @@ def test_some_groups_overridden3_nam(some_groups_overridden3):
     overridden group, and users requested with getpwnam.
     """
     ent.assert_each_passwd_by_name(dict(
-        user1=dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
+        user1=dict(name="user1", uid=1001,
+                   shell=config.SESSION_RECORDING_SHELL),
         user2=dict(name="user2", uid=1002, shell="/bin/sh2"),
         user3=dict(name="user3", uid=1003, shell="/bin/sh3"),
         user4=dict(name="user4", uid=1004, shell="/bin/sh4"),
@@ -821,7 +854,8 @@ def test_some_groups_overridden3_uid(some_groups_overridden3):
     overridden group, and users requested with getpwuid.
     """
     ent.assert_each_passwd_by_uid({
-        1001: dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
+        1001: dict(name="user1", uid=1001,
+                   shell=config.SESSION_RECORDING_SHELL),
         1002: dict(name="user2", uid=1002, shell="/bin/sh2"),
         1003: dict(name="user3", uid=1003, shell="/bin/sh3"),
         1004: dict(name="user4", uid=1004, shell="/bin/sh4"),
@@ -871,7 +905,8 @@ def test_some_groups_overridden4_nam(some_groups_overridden3):
     overridden group, and users requested with getpwnam.
     """
     ent.assert_each_passwd_by_name(dict(
-        user1=dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
+        user1=dict(name="user1", uid=1001,
+                   shell=config.SESSION_RECORDING_SHELL),
         user2=dict(name="user2", uid=1002, shell="/bin/sh2"),
         user3=dict(name="user3", uid=1003, shell="/bin/sh3"),
         user4=dict(name="user4", uid=1004, shell="/bin/sh4"),
@@ -884,7 +919,8 @@ def test_some_groups_overridden4_uid(some_groups_overridden3):
     overridden group, and users requested with getpwuid.
     """
     ent.assert_each_passwd_by_uid({
-        1001: dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
+        1001: dict(name="user1", uid=1001,
+                   shell=config.SESSION_RECORDING_SHELL),
         1002: dict(name="user2", uid=1002, shell="/bin/sh2"),
         1003: dict(name="user3", uid=1003, shell="/bin/sh3"),
         1004: dict(name="user4", uid=1004, shell="/bin/sh4"),
@@ -928,9 +964,11 @@ def test_some_users_and_groups_nam(some_users_and_groups):
     Test "some" scope with user and group lists and getpwnam.
     """
     ent.assert_each_passwd_by_name(dict(
-        user1=dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
+        user1=dict(name="user1", uid=1001,
+                   shell=config.SESSION_RECORDING_SHELL),
         user2=dict(name="user2", uid=1002, shell="/bin/sh2"),
-        user3=dict(name="user3", uid=1003, shell=config.SESSION_RECORDING_SHELL),
+        user3=dict(name="user3", uid=1003,
+                   shell=config.SESSION_RECORDING_SHELL),
         user4=dict(name="user4", uid=1004, shell="/bin/sh4"),
     ))
 
@@ -940,9 +978,11 @@ def test_some_users_and_groups_uid(some_users_and_groups):
     Test "some" scope with user and group lists and getpwuid.
     """
     ent.assert_each_passwd_by_uid({
-        1001: dict(name="user1", uid=1001, shell=config.SESSION_RECORDING_SHELL),
+        1001: dict(name="user1", uid=1001,
+                   shell=config.SESSION_RECORDING_SHELL),
         1002: dict(name="user2", uid=1002, shell="/bin/sh2"),
-        1003: dict(name="user3", uid=1003, shell=config.SESSION_RECORDING_SHELL),
+        1003: dict(name="user3", uid=1003,
+                   shell=config.SESSION_RECORDING_SHELL),
         1004: dict(name="user4", uid=1004, shell="/bin/sh4"),
     })
 

--- a/src/tests/pyhbac-test.py
+++ b/src/tests/pyhbac-test.py
@@ -552,4 +552,3 @@ if __name__ == "__main__":
         error |= 0x6
 
     sys.exit(error)
-

--- a/src/tests/pyhbac-test.py
+++ b/src/tests/pyhbac-test.py
@@ -65,7 +65,8 @@ class PyHbacImport(unittest.TestCase):
 
             import pyhbac
         except ImportError as e:
-            print("Could not load the pyhbac module. Please check if it is compiled", file=sys.stderr)
+            print("Could not load the pyhbac module. Please check if it is "
+                  "compiled", file=sys.stderr)
             raise e
         self.assertEqual(pyhbac.__file__, MODPATH + "/pyhbac.so")
 
@@ -118,7 +119,8 @@ class PyHbacRuleElementTest(unittest.TestCase):
         assert pyhbac.HBAC_CATEGORY_ALL in el.category
 
         # negative tests
-        self.assertRaises(TypeError, el.__setattr__, "category", [pyhbac.HBAC_CATEGORY_ALL])
+        self.assertRaises(TypeError, el.__setattr__, "category",
+                          [pyhbac.HBAC_CATEGORY_ALL])
         self.assertRaises(TypeError, el.__setattr__, "category", None)
         self.assertRaises(TypeError, el.__setattr__, "category", 1)
 
@@ -143,7 +145,8 @@ class PyHbacRuleElementTest(unittest.TestCase):
         el.category.add(pyhbac.HBAC_CATEGORY_ALL)
         el.names = ['foo']
         el.groups = ['bar, baz']
-        self.assertEquals(el.__repr__(), u'<category 1 names [foo] groups [bar, baz]>')
+        self.assertEquals(el.__repr__(),
+                          u'<category 1 names [foo] groups [bar, baz]>')
 
 class PyHbacRuleTest(unittest.TestCase):
     def testRuleGetSetName(self):
@@ -221,7 +224,8 @@ class PyHbacRuleTest(unittest.TestCase):
         self.assertCountEqual(rule.users.groups, user_groups)
 
     def testRuleElementInRuleReference(self):
-        " Test that references to RuleElement are kept even if element goes out of scope "
+        " Test that references to RuleElement are kept even if element goes"
+        " out of scope "
         def _get_rule():
             users = ["foo", "bar"]
             user_groups = ["abc", "def"]
@@ -236,11 +240,12 @@ class PyHbacRuleTest(unittest.TestCase):
 
     def testRepr(self):
         r = pyhbac.HbacRule('foo')
-        self.assertEqual(r.__repr__(), u"<name foo enabled 0 "
-                                        "users <category 0 names [] groups []> "
-                                        "services <category 0 names [] groups []> "
-                                        "targethosts <category 0 names [] groups []> "
-                                        "srchosts <category 0 names [] groups []>>")
+        self.assertEqual(r.__repr__(),
+                         u"<name foo enabled 0 "
+                         "users <category 0 names [] groups []> "
+                         "services <category 0 names [] groups []> "
+                         "targethosts <category 0 names [] groups []> "
+                         "srchosts <category 0 names [] groups []>>")
 
         name = "someuser"
         service = "ssh"
@@ -252,12 +257,13 @@ class PyHbacRuleTest(unittest.TestCase):
         r.srchosts.names = [srchost]
         r.targethosts.names = [targethost]
 
-        self.assertEqual(r.__repr__(), u"<name foo enabled 0 "
-                                        "users <category 0 names [%s] groups []> "
-                                        "services <category 0 names [%s] groups []> "
-                                        "targethosts <category 0 names [%s] groups []> "
-                                        "srchosts <category 0 names [%s] groups []>>" %
-                                        (name, service, targethost, srchost))
+        self.assertEqual(r.__repr__(),
+                         u"<name foo enabled 0 "
+                         "users <category 0 names [%s] groups []> "
+                         "services <category 0 names [%s] groups []> "
+                         "targethosts <category 0 names [%s] groups []> "
+                         "srchosts <category 0 names [%s] groups []>>" %
+                         (name, service, targethost, srchost))
 
     def testValidate(self):
         r = pyhbac.HbacRule('valid_rule')
@@ -365,7 +371,8 @@ class PyHbacRequestTest(unittest.TestCase):
         req = pyhbac.HbacRequest()
         self.assertEqual(req.rule_name, None)
         # python 2.4 raises TypError, 2.7 raises AttributeError
-        self.assertRaises((TypeError, AttributeError), req.__setattr__, "rule_name", "foo")
+        self.assertRaises((TypeError, AttributeError), req.__setattr__,
+                          "rule_name", "foo")
 
     def testEvaluate(self):
         name = "someuser"
@@ -526,27 +533,29 @@ if __name__ == "__main__":
     sys.path.insert(0, MODPATH)
     import pyhbac
 
-    suite = unittest.TestLoader().loadTestsFromTestCase(PyHbacRuleElementTest)
+    loadTestsFromTestCase = unittest.TestLoader().loadTestsFromTestCase
+
+    suite = loadTestsFromTestCase(PyHbacRuleElementTest)
     res = unittest.TextTestRunner().run(suite)
     if not res.wasSuccessful():
         error |= 0x2
 
-    suite = unittest.TestLoader().loadTestsFromTestCase(PyHbacRuleTest)
+    suite = loadTestsFromTestCase(PyHbacRuleTest)
     res = unittest.TextTestRunner().run(suite)
     if not res.wasSuccessful():
         error |= 0x3
 
-    suite = unittest.TestLoader().loadTestsFromTestCase(PyHbacRequestElementTest)
+    suite = loadTestsFromTestCase(PyHbacRequestElementTest)
     res = unittest.TextTestRunner().run(suite)
     if not res.wasSuccessful():
         error |= 0x4
 
-    suite = unittest.TestLoader().loadTestsFromTestCase(PyHbacRequestTest)
+    suite = loadTestsFromTestCase(PyHbacRequestTest)
     res = unittest.TextTestRunner().run(suite)
     if not res.wasSuccessful():
         error |= 0x5
 
-    suite = unittest.TestLoader().loadTestsFromTestCase(PyHbacModuleTest)
+    suite = loadTestsFromTestCase(PyHbacModuleTest)
     res = unittest.TextTestRunner().run(suite)
     if not res.wasSuccessful():
         error |= 0x6

--- a/src/tests/pyhbac-test.py
+++ b/src/tests/pyhbac-test.py
@@ -445,7 +445,7 @@ class PyHbacRequestTest(unittest.TestCase):
         req.user.name = name
 
         saveuser = req.user
-        req.user = None # need to catch this
+        req.user = None  # need to catch this
 
         # catch invalid category value
         savecat = copy.copy(allow_rule.users.category)
@@ -457,7 +457,7 @@ class PyHbacRequestTest(unittest.TestCase):
         self.assertRaises(TypeError, req.evaluate, (allow_rule,))
 
         req.user = saveuser
-        allow_rule.users = None # need to catch this
+        allow_rule.users = None  # need to catch this
         self.assertRaises(TypeError, req.evaluate, (allow_rule,))
 
         # catch invalid rule type

--- a/src/tests/pyhbac-test.py
+++ b/src/tests/pyhbac-test.py
@@ -23,6 +23,7 @@ def compat_assertIsInstance(this, obj, cls, msg=None):
 def compat_assertItemsEqual(this, expected_seq, actual_seq, msg=None):
     return this.assertEqual(sorted(expected_seq), sorted(actual_seq))
 
+
 # add compat assertIsInstance for old unittest.TestCase versions
 # (python < 2.7, RHEL6 for instance)
 if not hasattr(unittest.TestCase, "assertIsInstance"):

--- a/src/tests/pyhbac-test.py
+++ b/src/tests/pyhbac-test.py
@@ -44,7 +44,7 @@ class PyHbacImport(unittest.TestCase):
     def setUp(self):
         " Make sure we load the in-tree module "
         self.system_path = sys.path[:]
-        sys.path = [ MODPATH ]
+        sys.path = [MODPATH]
 
     def tearDown(self):
         " Restore the system path "
@@ -223,8 +223,8 @@ class PyHbacRuleTest(unittest.TestCase):
     def testRuleElementInRuleReference(self):
         " Test that references to RuleElement are kept even if element goes out of scope "
         def _get_rule():
-            users = [ "foo", "bar" ]
-            user_groups = [ "abc", "def" ]
+            users = ["foo", "bar"]
+            user_groups = ["abc", "def"]
             el = pyhbac.HbacRuleElement(names=users, groups=user_groups)
             rule = pyhbac.HbacRule("testRuleElement")
             rule.users = el
@@ -247,10 +247,10 @@ class PyHbacRuleTest(unittest.TestCase):
         srchost = "host1"
         targethost = "host2"
 
-        r.users.names = [ name ]
-        r.services.names = [ service ]
-        r.srchosts.names = [ srchost ]
-        r.targethosts.names = [ targethost ]
+        r.users.names = [name]
+        r.services.names = [service]
+        r.srchosts.names = [srchost]
+        r.targethosts.names = [targethost]
 
         self.assertEqual(r.__repr__(), u"<name foo enabled 0 "
                                         "users <category 0 names [%s] groups []> "
@@ -374,10 +374,10 @@ class PyHbacRequestTest(unittest.TestCase):
         targethost = "host2"
 
         allow_rule = pyhbac.HbacRule("allowRule", enabled=True)
-        allow_rule.users.names = [ name ]
-        allow_rule.services.names = [ service ]
-        allow_rule.srchosts.names = [ srchost ]
-        allow_rule.targethosts.names = [ targethost ]
+        allow_rule.users.names = [name]
+        allow_rule.services.names = [service]
+        allow_rule.srchosts.names = [srchost]
+        allow_rule.targethosts.names = [targethost]
 
         req = pyhbac.HbacRequest()
         req.user.name = name
@@ -433,10 +433,10 @@ class PyHbacRequestTest(unittest.TestCase):
         targethost = "host2"
 
         allow_rule = pyhbac.HbacRule("allowRule", enabled=True)
-        allow_rule.users.names = [ name ]
-        allow_rule.services.names = [ service ]
-        allow_rule.srchosts.names = [ srchost ]
-        allow_rule.targethosts.names = [ targethost ]
+        allow_rule.users.names = [name]
+        allow_rule.services.names = [service]
+        allow_rule.srchosts.names = [srchost]
+        allow_rule.targethosts.names = [targethost]
 
         req = pyhbac.HbacRequest()
         req.service.name = service
@@ -492,19 +492,19 @@ class PyHbacModuleTest(unittest.TestCase):
         assert hasattr(pyhbac, "HBAC_RULE_ELEMENT_SOURCEHOSTS")
 
     def testHbacResultString(self):
-        results = [ pyhbac.HBAC_EVAL_ALLOW, pyhbac.HBAC_EVAL_DENY,
-                    pyhbac.HBAC_EVAL_ERROR ]
+        results = [pyhbac.HBAC_EVAL_ALLOW, pyhbac.HBAC_EVAL_DENY,
+                   pyhbac.HBAC_EVAL_ERROR]
         for r in results:
             s = pyhbac.hbac_result_string(r)
             self.assertIsInstance(s, unicode)
             assert len(s) > 0
 
     def testHbacErrorString(self):
-        errors = [ pyhbac.HBAC_ERROR_UNKNOWN,
-                   pyhbac.HBAC_SUCCESS,
-                   pyhbac.HBAC_ERROR_NOT_IMPLEMENTED,
-                   pyhbac.HBAC_ERROR_OUT_OF_MEMORY,
-                   pyhbac.HBAC_ERROR_UNPARSEABLE_RULE ]
+        errors = [pyhbac.HBAC_ERROR_UNKNOWN,
+                  pyhbac.HBAC_SUCCESS,
+                  pyhbac.HBAC_ERROR_NOT_IMPLEMENTED,
+                  pyhbac.HBAC_ERROR_OUT_OF_MEMORY,
+                  pyhbac.HBAC_ERROR_UNPARSEABLE_RULE]
         for e in errors:
             s = pyhbac.hbac_error_string(e)
             self.assertIsInstance(s, unicode)

--- a/src/tests/pyhbac-test.py
+++ b/src/tests/pyhbac-test.py
@@ -148,6 +148,7 @@ class PyHbacRuleElementTest(unittest.TestCase):
         self.assertEquals(el.__repr__(),
                           u'<category 1 names [foo] groups [bar, baz]>')
 
+
 class PyHbacRuleTest(unittest.TestCase):
     def testRuleGetSetName(self):
         name = "testGetRule"
@@ -337,6 +338,7 @@ class PyHbacRequestElementTest(unittest.TestCase):
         r.groups = ['bar', 'baz']
         self.assertEqual(r.__repr__(), u"<name foo groups [bar,baz]>")
 
+
 class PyHbacRequestTest(unittest.TestCase):
     def testRequestElementHandling(self):
         name = "req_name"
@@ -469,6 +471,7 @@ class PyHbacRequestTest(unittest.TestCase):
 
         # catch invalid rule type
         self.assertRaises(TypeError, req.evaluate, (allow_rule, None))
+
 
 class PyHbacModuleTest(unittest.TestCase):
     @classmethod

--- a/src/tests/pysss_murmur-test.py
+++ b/src/tests/pysss_murmur-test.py
@@ -34,7 +34,7 @@ class PySssMurmurImport(unittest.TestCase):
         " Make sure we load the in-tree module "
         self.system_path = sys.path[:]
         sys.path = [MODPATH]
-        print (os.getcwd())
+        print(os.getcwd())
         print(MODPATH)
 
     def tearDown(self):

--- a/src/tests/pysss_murmur-test.py
+++ b/src/tests/pysss_murmur-test.py
@@ -56,7 +56,8 @@ class PySssMurmurImport(unittest.TestCase):
 
             import pysss_murmur
         except ImportError as e:
-            print("Could not load the pysss_murmur module. Please check if it is compiled", file=sys.stderr)
+            print("Could not load the pysss_murmur module. "
+                  "Please check if it is compiled", file=sys.stderr)
             raise e
         self.assertEqual(pysss_murmur.__file__, MODPATH + "/pysss_murmur.so")
 

--- a/src/tests/pysss_murmur-test.py
+++ b/src/tests/pysss_murmur-test.py
@@ -33,7 +33,7 @@ class PySssMurmurImport(unittest.TestCase):
     def setUp(self):
         " Make sure we load the in-tree module "
         self.system_path = sys.path[:]
-        sys.path = [ MODPATH ]
+        sys.path = [MODPATH]
         print (os.getcwd())
         print(MODPATH)
 

--- a/src/tests/python-test.py
+++ b/src/tests/python-test.py
@@ -189,7 +189,7 @@ class UseraddTest(LocalTest):
         username_path = "/home/%s" % self.username
         self.assertEquals(os.access(username_path, os.F_OK), False)
         self.local.userdel(self.username, remove=False)
-        self.username = None # fool tearDown into not removing the user
+        self.username = None  # fool tearDown into not removing the user
 
     def testUseraddAlternateSkeldir(self):
         "Test adding a local user and init his homedir from a custom location"

--- a/src/tests/python-test.py
+++ b/src/tests/python-test.py
@@ -50,7 +50,7 @@ class LocalTest(unittest.TestCase):
             return {}
 
         kw = {}
-        for key, value in [ l.split(':') for l in output.split('\n') if ":" in l ]:
+        for key, value in [l.split(':') for l in output.split('\n') if ":" in l]:
             kw[key] = value.strip()
 
         del kw['asq']
@@ -92,7 +92,7 @@ class LocalTest(unittest.TestCase):
         except subprocess.CalledProcessError:
             return []
 
-        members = [ value.strip() for key, value in [ l.split(':') for l in output.split('\n') if ":" in l ] if key == "memberof" ]
+        members = [value.strip() for key, value in [l.split(':') for l in output.split('\n') if ":" in l] if key == "memberof"]
         return members
 
     def _assertMembership(self, name, group_list, subtree, domain):

--- a/src/tests/python-test.py
+++ b/src/tests/python-test.py
@@ -43,7 +43,7 @@ class LocalTest(unittest.TestCase):
     def _get_object_info(self, name, subtree, domain):
         search_dn = "dn=name=%s,cn=%s,cn=%s,cn=sysdb" % (name, subtree, domain)
         try:
-            cmd = "ldbsearch -H %s %s" % (self.local_path,search_dn)
+            cmd = "ldbsearch -H %s %s" % (self.local_path, search_dn)
             output = subprocess.check_call(cmd, shell=True)
             output = output.decode('utf-8')
         except subprocess.CalledProcessError:
@@ -91,7 +91,7 @@ class LocalTest(unittest.TestCase):
     def _get_object_membership(self, name, subtree, domain):
         search_dn = "dn=name=%s,cn=%s,cn=%s,cn=sysdb" % (name, subtree, domain)
         try:
-            cmd = "ldbsearch -H %s %s" % (self.local_path,search_dn)
+            cmd = "ldbsearch -H %s %s" % (self.local_path, search_dn)
             output = subprocess.check_call(cmd, shell=True)
             output = output.decode('utf-8')
         except subprocess.CalledProcessError:
@@ -203,7 +203,7 @@ class UseraddTest(LocalTest):
         try:
             self.local.useradd(self.username, skel=skeldir)
             self.validate_user(self.username)
-            path = "/home/%s/%s"%(self.username,filename)
+            path = "/home/%s/%s"%(self.username, filename)
             self.assertEquals(os.access(path, os.F_OK), True)
         finally:
             shutil.rmtree(skeldir)
@@ -215,9 +215,9 @@ class UseraddTest(LocalTest):
         self.add_group("gr2")
         try:
             self.local.useradd(self.username,
-                               groups=["gr1","gr2"])
+                               groups=["gr1", "gr2"])
             self.assertUserMembership(self.username,
-                                      ["gr1","gr2"])
+                                      ["gr1", "gr2"])
         finally:
             self.remove_group("gr1")
             self.remove_group("gr2")
@@ -323,9 +323,9 @@ class UsermodTest(LocalTest):
 
         try:
             self.local.usermod(self.username,
-                               addgroups=["gr1","gr2"])
+                               addgroups=["gr1", "gr2"])
             self.assertUserMembership(self.username,
-                                      ["gr1","gr2"])
+                                      ["gr1", "gr2"])
             self.local.usermod(self.username,
                                rmgroups=["gr2"])
             self.assertUserMembership(self.username,
@@ -438,9 +438,9 @@ class GroupmodTest(LocalTest):
         self.add_group("gr2")
         try:
             self.local.groupmod(self.groupname,
-                                addgroups=["gr1","gr2"])
+                                addgroups=["gr1", "gr2"])
             self.assertGroupMembership(self.groupname,
-                                       ["gr1","gr2"])
+                                       ["gr1", "gr2"])
             self.local.groupmod(self.groupname,
                                 rmgroups=["gr2"])
             self.assertGroupMembership(self.groupname,

--- a/src/tests/python-test.py
+++ b/src/tests/python-test.py
@@ -180,12 +180,12 @@ class UseraddTest(LocalTest):
     def testUseraddNoHomedir(self):
         "Test adding a local user without creating his home dir"
         self.username = "testUseraddNoHomedir"
-        self.local.useradd(self.username, create_home = False)
+        self.local.useradd(self.username, create_home=False)
         self.validate_user(self.username)
         # check home directory was not created
         username_path = "/home/%s" % self.username
         self.assertEquals(os.access(username_path, os.F_OK), False)
-        self.local.userdel(self.username, remove = False)
+        self.local.userdel(self.username, remove=False)
         self.username = None # fool tearDown into not removing the user
 
     def testUseraddAlternateSkeldir(self):
@@ -201,7 +201,7 @@ class UseraddTest(LocalTest):
         filename = os.path.basename(path)
 
         try:
-            self.local.useradd(self.username, skel = skeldir)
+            self.local.useradd(self.username, skel=skeldir)
             self.validate_user(self.username)
             path = "/home/%s/%s"%(self.username,filename)
             self.assertEquals(os.access(path, os.F_OK), True)

--- a/src/tests/python-test.py
+++ b/src/tests/python-test.py
@@ -364,9 +364,9 @@ class GroupaddTest(LocalTest):
         "Test adding a local group with a custom GID"
         self.groupname = "testUseraddWithGID"
         self.local.groupadd(self.groupname,
-                           gid=1024)
+                            gid=1024)
         self.validate_group(self.groupname,
-                           gidNumber=1024)
+                            gidNumber=1024)
 
 class GroupaddTestNegative(LocalTest):
     def testGroupaddNoParams(self):
@@ -428,9 +428,9 @@ class GroupmodTest(LocalTest):
     def testGroupmodGID(self):
         "Test modifying UID"
         self.local.groupmod(self.groupname,
-                           gid=1024)
+                            gid=1024)
         self.validate_group(self.groupname,
-                           gidNumber=1024)
+                            gidNumber=1024)
 
     def testGroupmodGroupMembership(self):
         "Test adding to groups"

--- a/src/tests/python-test.py
+++ b/src/tests/python-test.py
@@ -30,6 +30,7 @@ import errno
 # module under test
 import pysss
 
+
 class LocalTest(unittest.TestCase):
     local_path = "/var/lib/sss/db/sssd.ldb"
 
@@ -144,11 +145,13 @@ class LocalTest(unittest.TestCase):
     def remove_user_not_home(self, username):
         self._run_and_check("sss_userdel -R %s" % (username))
 
+
 class SanityTest(unittest.TestCase):
     def testInstantiate(self):
         "Test that the local backed binding can be instantiated"
         local = pysss.local()
         self.assert_(local.__class__, "<type 'sss.local'>")
+
 
 class UseraddTest(LocalTest):
     def tearDown(self):
@@ -230,6 +233,7 @@ class UseraddTest(LocalTest):
         self.validate_user(self.username,
                            uidNumber=1024)
 
+
 class UseraddTestNegative(LocalTest):
     def testUseraddNoParams(self):
         "Test that local.useradd() requires the username parameter"
@@ -261,6 +265,7 @@ class UseraddTestNegative(LocalTest):
         finally:
             self.remove_user(self.username)
 
+
 class UserdelTest(LocalTest):
     def testUserdel(self):
         self.add_user("testUserdel")
@@ -288,6 +293,7 @@ class UserdelTest(LocalTest):
             self.assertEquals(e.errno, errno.ENOENT)
         else:
             fail("Was expecting exception")
+
 
 class UsermodTest(LocalTest):
     def setUp(self):
@@ -349,6 +355,7 @@ class UsermodTest(LocalTest):
         self.validate_user(self.username,
                            disabled="false")
 
+
 class GroupaddTest(LocalTest):
     def tearDown(self):
         if self.groupname:
@@ -367,6 +374,7 @@ class GroupaddTest(LocalTest):
                             gid=1024)
         self.validate_group(self.groupname,
                             gidNumber=1024)
+
 
 class GroupaddTestNegative(LocalTest):
     def testGroupaddNoParams(self):
@@ -398,6 +406,7 @@ class GroupaddTestNegative(LocalTest):
             self.fail("Was expecting exception")
         finally:
             self.remove_group(self.groupname)
+
 
 class GroupdelTest(LocalTest):
     def testGroupdel(self):

--- a/src/tests/python-test.py
+++ b/src/tests/python-test.py
@@ -463,6 +463,7 @@ class GroupmodTest(LocalTest):
             self.remove_group("gr1")
             self.remove_group("gr2")
 
+
 # -------------- run the test suite -------------- #
 if __name__ == "__main__":
     unittest.main()

--- a/src/tests/python-test.py
+++ b/src/tests/python-test.py
@@ -206,7 +206,7 @@ class UseraddTest(LocalTest):
         try:
             self.local.useradd(self.username, skel=skeldir)
             self.validate_user(self.username)
-            path = "/home/%s/%s"%(self.username, filename)
+            path = "/home/%s/%s" % (self.username, filename)
             self.assertEquals(os.access(path, os.F_OK), True)
         finally:
             shutil.rmtree(skeldir)

--- a/src/tests/python-test.py
+++ b/src/tests/python-test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#coding=utf-8
+# coding=utf-8
 
 # Authors:
 #   Jakub Hrozek <jhrozek@redhat.com>

--- a/src/tests/python-test.py
+++ b/src/tests/python-test.py
@@ -465,4 +465,3 @@ class GroupmodTest(LocalTest):
 # -------------- run the test suite -------------- #
 if __name__ == "__main__":
     unittest.main()
-

--- a/src/tests/python-test.py
+++ b/src/tests/python-test.py
@@ -43,14 +43,15 @@ class LocalTest(unittest.TestCase):
     def _get_object_info(self, name, subtree, domain):
         search_dn = "dn=name=%s,cn=%s,cn=%s,cn=sysdb" % (name, subtree, domain)
         try:
-            output = subprocess.check_call("ldbsearch -H %s %s" % (self.local_path,search_dn),
-                                           shell=True)
+            cmd = "ldbsearch -H %s %s" % (self.local_path,search_dn)
+            output = subprocess.check_call(cmd, shell=True)
             output = output.decode('utf-8')
         except subprocess.CalledProcessError:
             return {}
 
         kw = {}
-        for key, value in [l.split(':') for l in output.split('\n') if ":" in l]:
+        for key, value in \
+                [l.split(':') for l in output.split('\n') if ":" in l]:
             kw[key] = value.strip()
 
         del kw['asq']
@@ -65,13 +66,16 @@ class LocalTest(unittest.TestCase):
     def _validate_object(self, kw, name, **kwargs):
         if kw == {}: self.fail("Could not get %s info" % name)
         for key in kwargs.keys():
-            self.assert_(str(kwargs[key]) == str(kw[key]), "%s %s != %s %s" % (key, kwargs[key], key, kw[key]))
+            self.assert_(str(kwargs[key]) == str(kw[key]),
+                         "%s %s != %s %s" % (key, kwargs[key], key, kw[key]))
 
     def validate_user(self, username, **kwargs):
-        return self._validate_object(self.get_user_info(username), "user", **kwargs)
+        return self._validate_object(self.get_user_info(username), "user",
+                                     **kwargs)
 
     def validate_group(self, groupname, **kwargs):
-        return self._validate_object(self.get_group_info(groupname), "group", **kwargs)
+        return self._validate_object(self.get_group_info(groupname), "group",
+                                     **kwargs)
 
     def _validate_no_object(self, kw, name):
         if kw != {}:
@@ -81,18 +85,21 @@ class LocalTest(unittest.TestCase):
         return self._validate_no_object(self.get_user_info(username), "user")
 
     def validate_no_group(self, groupname):
-        return self._validate_no_object(self.get_group_info(groupname), "group")
+        return self._validate_no_object(self.get_group_info(groupname),
+                                        "group")
 
     def _get_object_membership(self, name, subtree, domain):
         search_dn = "dn=name=%s,cn=%s,cn=%s,cn=sysdb" % (name, subtree, domain)
         try:
-            output = subprocess.check_call("ldbsearch -H %s %s" % (self.local_path,search_dn),
-                                           shell=True)
+            cmd = "ldbsearch -H %s %s" % (self.local_path,search_dn)
+            output = subprocess.check_call(cmd, shell=True)
             output = output.decode('utf-8')
         except subprocess.CalledProcessError:
             return []
 
-        members = [value.strip() for key, value in [l.split(':') for l in output.split('\n') if ":" in l] if key == "memberof"]
+        members = [value.strip() for key, value in
+                   [l.split(':') for l in output.split('\n') if ":" in l]
+                   if key == "memberof"]
         return members
 
     def _assertMembership(self, name, group_list, subtree, domain):
@@ -176,7 +183,8 @@ class UseraddTest(LocalTest):
         self.local.useradd(self.username, create_home = False)
         self.validate_user(self.username)
         # check home directory was not created
-        self.assertEquals(os.access("/home/%s" % self.username, os.F_OK), False)
+        username_path = "/home/%s" % self.username
+        self.assertEquals(os.access(username_path, os.F_OK), False)
         self.local.userdel(self.username, remove = False)
         self.username = None # fool tearDown into not removing the user
 
@@ -195,7 +203,8 @@ class UseraddTest(LocalTest):
         try:
             self.local.useradd(self.username, skel = skeldir)
             self.validate_user(self.username)
-            self.assertEquals(os.access("/home/%s/%s"%(self.username,filename), os.F_OK), True)
+            path = "/home/%s/%s"%(self.username,filename)
+            self.assertEquals(os.access(path, os.F_OK), True)
         finally:
             shutil.rmtree(skeldir)
 

--- a/src/tests/python-test.py
+++ b/src/tests/python-test.py
@@ -65,7 +65,8 @@ class LocalTest(unittest.TestCase):
         return self._get_object_info(name, "groups", domain)
 
     def _validate_object(self, kw, name, **kwargs):
-        if kw == {}: self.fail("Could not get %s info" % name)
+        if kw == {}:
+            self.fail("Could not get %s info" % name)
         for key in kwargs.keys():
             self.assert_(str(kwargs[key]) == str(kw[key]),
                          "%s %s != %s %s" % (key, kwargs[key], key, kw[key]))

--- a/src/tests/python/docs/conf.py
+++ b/src/tests/python/docs/conf.py
@@ -40,6 +40,7 @@ def skip(app, what, name, obj, skip, options):
 def setup(app):
     app.connect("autodoc-skip-member", skip)
 
+
 # extensions = [
 #    'sphinx.ext.todo',
 #    'sphinx.ext.viewcode',

--- a/src/tests/python/sssd/testlib/common/utils.py
+++ b/src/tests/python/sssd/testlib/common/utils.py
@@ -921,12 +921,12 @@ class ADOperations(object):
 
 
 class SSHClient(paramiko.SSHClient):
-    """ This class Inherits paramiko.SSHClient and implements client.exec_commands
-    channel.exec_command """
+    """ This class Inherits paramiko.SSHClient and implements
+    client.exec_commands channel.exec_command """
 
     def __init__(self, hostname=None, port=None, username=None, password=None):
-        """ Initialize connection to Remote Host using Paramiko SSHClient. Can be
-        initialized with hostname, port, username and password.
+        """ Initialize connection to Remote Host using Paramiko SSHClient.
+        Can be initialized with hostname, port, username and password.
         """
         self.hostname = hostname
         self.username = username


### PR DESCRIPTION
Hi,

because @fidencio is on PTO I allowed myself to rebase and update his branch: https://github.com/fidencio/sssd/tree/wip/ci_enable_pep8_check

and present it here as new PR.

Here is link to the ticket: https://pagure.io/SSSD/sssd/issue/3605

What I did:
- reviewed all the patches that were not reviewed yet (some were already reviewed)
- rebased them on top of current master (there were only minor conflicts)
- if there are some missing patches that is because the issue that they fixed was no longer present in the current master, so I deleted them
- added "Resolves" and "Reviewed" tags (so the person that pushes it does not need to add them)
- pushed the patchset to CI (passed)
- added pep8 issue and tried the CI (issue was detected on all platforms)

The patchest is now fully ACKed.

Note: because of the way I rebased the patches, some are not in the original order