### PR TITLE
GPO: Add "thinlinc" to ad_gpo_map_remote_interactive

### DIFF
--- a/src/man/sssd-ad.5.xml
+++ b/src/man/sssd-ad.5.xml
@@ -566,6 +566,11 @@ ad_gpo_map_remote_interactive = +my_pam_service, -sshd
                                         cockpit
                                     </para>
                                 </listitem>
+                                <listitem>
+                                    <para>
+                                        thinlinc
+                                    </para>
+                                </listitem>
                             </itemizedlist>
                         </para>
                     </listitem>

--- a/src/providers/ad/ad_gpo.c
+++ b/src/providers/ad/ad_gpo.c
@@ -205,6 +205,7 @@ int ad_gpo_process_cse_recv(struct tevent_req *req);
 #define GPO_SUDO_I "sudo-i"
 #define GPO_SYSTEMD_USER "systemd-user"
 #define GPO_COCKPIT "cockpit"
+#define GPO_THINLINC "thinlinc"
 
 struct gpo_map_option_entry {
     enum gpo_map_type gpo_map_type;
@@ -219,7 +220,7 @@ const char *gpo_map_interactive_defaults[] =
      GPO_GDM_FINGERPRINT, GPO_GDM_PASSWORD, GPO_GDM_SMARTCARD, GPO_KDM,
      GPO_LIGHTDM, GPO_LXDM, GPO_SDDM, GPO_UNITY, GPO_XDM, NULL};
 const char *gpo_map_remote_interactive_defaults[] = {GPO_SSHD, GPO_COCKPIT,
-                                                     NULL};
+                                                     GPO_THINLINC, NULL};
 const char *gpo_map_network_defaults[] = {GPO_FTP, GPO_SAMBA, NULL};
 const char *gpo_map_batch_defaults[] = {GPO_CROND, NULL};
 const char *gpo_map_service_defaults[] = {NULL};


### PR DESCRIPTION
ThinLinc is a remote desktop server, very similar to the Remote Desktop
Services referenced in the Active Directory description for this policy.