### PR TITLE
Add the needed machinery to have automated builds for our COPR repos

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,3 @@
+srpm:
+	dnf -y install git rpm-build dnf-plugins-core libldb-devel
+	./contrib/fedora/make_srpm.sh --output $(outdir)

--- a/contrib/fedora/make_srpm.sh
+++ b/contrib/fedora/make_srpm.sh
@@ -26,6 +26,7 @@ usage(){
     echo -e "\t-d, --debug        Enable debugging."
     echo -e "\t-c, --clean        Remove directory rpmbuild and exit."
     echo -e "\t-P, --patches      Requires list of patches for SRPM."
+    echo -e "\t-o, --output       Moves the created srpm to a specific output directory."
     echo -e "\t-h, --help         Print this help and exit."
     echo -e "\t-?, --usage"
 
@@ -84,6 +85,11 @@ case $i in
     -P|--patches)
     shift
     patches=("$@")
+    break
+    ;;
+    -o|--output)
+    shift
+    OUTPUT=("$@")
     break
     ;;
     -h|--help|-\?|--usage)
@@ -164,3 +170,8 @@ add_patches "$RPMBUILD/SPECS/$PACKAGE_NAME.spec" \
 cd $RPMBUILD
 rpmbuild --define "_topdir $RPMBUILD" \
          -bs SPECS/$PACKAGE_NAME.spec
+
+if [ -n "$OUTPUT" ]; then
+    mv "$RPMBUILD/SRPMS/"*.src.rpm "$OUTPUT/"
+    echo "Package has been moved to the folder: $OUTPUT"
+fi


### PR DESCRIPTION
As the title says, these patches are introducing the needed machinery to have automated builds for our COPR repos.

The next steps are:
- On Pagure, someone who has admin rights will have to:
  - Go to the project's web page: https://pagure.io/SSSD/sssd
  - Click in the "Settings" button
  - Go down to the "Hook" section
  - Click in the "Fedmsg" field
  - Check the "Active" checkbox
  - Click in the "Update" button

- On COPR:
  - Go to the each project's webpage:
     - https://copr.fedorainfracloud.org/coprs/g/sssd/sssd-1-13/
     - https://copr.fedorainfracloud.org/coprs/g/sssd/sssd-1-14/
     - To be created
        - https://copr.fedorainfracloud.org/coprs/g/sssd/sssd-1-16/
        - https://copr.fedorainfracloud.org/coprs/g/sssd/sssd-master/
  - Go to the "Packages" tab
  - Click in "sssd" package
  - In "Default Build Source" section, click in the "Edit" button
  - In the SCM tab do:
    - Type: Git
    - Clone url: https://pagure.io/SSSD/sssd.git
    - Committish: <branch name> (eg, master, sssd-1-13, sssd-1-14, ...)
  - In the "How to build SRPM from the source" section, select:
    -  make srpm 
  - Click in the "Submit" button

After those steps, a new push would trigger a new copr build to the project.

The OSes that we're targeting are:
- el (all version, all arches)
- fedora (all versions, all arches)    