### PR TITLE
test_ca: add empty index.txt.attr file

### DIFF
--- a/src/tests/test_CA/Makefile.am
+++ b/src/tests/test_CA/Makefile.am
@@ -89,5 +89,6 @@ clean-local:
 
 serial: clean
 	touch index.txt
+	touch index.txt.attr
 	mkdir newcerts
 	echo -n 01 > serial


### PR DESCRIPTION
Although is does not harm because 'openssl ca' creates the
index.tx.tattr file with a suitable content automatically this patch
adds the file to the test_CA directory to silence a message like:

Can't open ./index.txt.attr for reading, No such file or directory
139867607979840:error:02001002:system library:fopen:No such file or
directory:crypto/bio/bss_file.c:74:fopen('./index.txt.attr','r')
139867607979840:error:2006D080:BIO routines:BIO_new_file:no such
file:crypto/bio/bss_file.c:81:

which is show by recent versions of OpenSSL.

Related to https://pagure.io/SSSD/sssd/issue/3436