### PR TITLE
confdb_expand_application_domains() related issues (round 1)

### DIFF
--- a/src/tests/intg/test_sssctl.py
+++ b/src/tests/intg/test_sssctl.py
@@ -28,7 +28,7 @@ import signal
 import ds_openldap
 import ldap_ent
 import config
-from util import unindent
+from util import unindent, get_call_output
 import sssd_netgroup
 
 LDAP_BASE_DN = "dc=example,dc=com"
@@ -201,13 +201,6 @@ def fqname_case_insensitive_rfc2307(request, ldap_conn):
     create_conf_fixture(request, conf)
     create_sssd_fixture(request)
     return None
-
-
-def get_call_output(cmd):
-    process = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                               stderr=subprocess.PIPE)
-    output, ret = process.communicate()
-    return output.decode('utf-8')
 
 
 def test_user_show_basic_sanity(ldap_conn, sanity_rfc2307, portable_LC_ALL):

--- a/src/tests/intg/util.py
+++ b/src/tests/intg/util.py
@@ -78,3 +78,10 @@ def restore_envvar_file(name):
     path = os.environ[name]
     backup_path = path + ".bak"
     os.rename(backup_path, path)
+
+
+def get_call_output(cmd):
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE)
+    output, ret = process.communicate()
+    return output.decode('utf-8')

--- a/src/tests/intg/util.py
+++ b/src/tests/intg/util.py
@@ -80,8 +80,8 @@ def restore_envvar_file(name):
     os.rename(backup_path, path)
 
 
-def get_call_output(cmd):
+def get_call_output(cmd, stderr_output=subprocess.PIPE):
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                               stderr=subprocess.PIPE)
+                               stderr=stderr_output)
     output, ret = process.communicate()
     return output.decode('utf-8')

--- a/src/tools/common/sss_tools.c
+++ b/src/tools/common/sss_tools.c
@@ -117,6 +117,14 @@ static errno_t sss_tool_domains_init(TALLOC_CTX *mem_ctx,
     struct sss_domain_info *dom;
     errno_t ret;
 
+    ret = confdb_expand_app_domains(confdb);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Unable to expand application domains [%d]: %s\n",
+              ret, sss_strerror(ret));
+        return ret;
+    }
+
     ret = confdb_get_domains(confdb, &domains);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to setup domains [%d]: %s\n",


### PR DESCRIPTION
The first patch fixes https://pagure.io/SSSD/sssd/issue/3660 by starting a ldb transaction before modifying ldb to expand the application domains.

The second patch fixes https://pagure.io/SSSD/sssd/issue/3658 by also expanding app domains when calling sssctl.

So, what's the best way to add test for those 2 patches?
Is it worth to add tests for the first patch? If yes, where? I couldn't find related tests ...
About the second patch ... I didn't find any `sssctl domain-list` related test in our repo ... is there a technical reason why `sssctl domain-list` tests were not written? is it tested downstream only?