### PR TITLE
NSS: Remove dead code

### DIFF
--- a/src/responder/nss/nss_protocol_netgr.c
+++ b/src/responder/nss/nss_protocol_netgr.c
@@ -107,7 +107,6 @@ nss_protocol_fill_netgrent(struct nss_ctx *nss_ctx,
                            struct sss_packet *packet,
                            struct cache_req_result *result)
 {
-    TALLOC_CTX *tmp_ctx;
     struct sysdb_netgroup_ctx **entries;
     struct sysdb_netgroup_ctx *entry;
     struct nss_enum_index *idx;
@@ -117,11 +116,6 @@ nss_protocol_fill_netgrent(struct nss_ctx *nss_ctx,
     uint8_t *body;
     errno_t ret;
     unsigned int start;
-
-    tmp_ctx = talloc_new(NULL);
-    if (tmp_ctx == NULL) {
-        return ENOMEM;
-    }
 
     idx = cmd_ctx->enum_index;
     entries = cmd_ctx->enum_ctx->netgroup;
@@ -148,7 +142,6 @@ nss_protocol_fill_netgrent(struct nss_ctx *nss_ctx,
             break;
         }
 
-        talloc_free_children(tmp_ctx);
         entry = entries[idx->result];
 
         switch (entry->type) {
@@ -174,8 +167,6 @@ nss_protocol_fill_netgrent(struct nss_ctx *nss_ctx,
     ret = EOK;
 
 done:
-    talloc_free(tmp_ctx);
-
     if (ret != EOK) {
         sss_packet_set_size(packet, 0);
         return ret;


### PR DESCRIPTION
This piece of code introduced as part of 4049b63f8c most likely by
mistake and can be removed without causing any harm.

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>