### PR TITLE
Make nss netgroup requests more robust

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -1219,7 +1219,8 @@ errno_t sysdb_attrs_to_list(TALLOC_CTX *mem_ctx,
 
 errno_t sysdb_netgr_to_entries(TALLOC_CTX *mem_ctx,
                                struct ldb_result *res,
-                               struct sysdb_netgroup_ctx ***entries);
+                               struct sysdb_netgroup_ctx ***entries,
+                               size_t *netgroup_count);
 
 errno_t sysdb_dn_sanitize(TALLOC_CTX *mem_ctx, const char *input,
                           char **sanitized);

--- a/src/db/sysdb_search.c
+++ b/src/db/sysdb_search.c
@@ -1831,7 +1831,8 @@ done:
 
 errno_t sysdb_netgr_to_entries(TALLOC_CTX *mem_ctx,
                                struct ldb_result *res,
-                               struct sysdb_netgroup_ctx ***entries)
+                               struct sysdb_netgroup_ctx ***entries,
+                               size_t *netgroup_count)
 {
     errno_t ret;
     size_t size = 0;
@@ -1935,6 +1936,8 @@ errno_t sysdb_netgr_to_entries(TALLOC_CTX *mem_ctx,
     tmp_entry[c] = NULL;
 
     *entries = talloc_steal(mem_ctx, tmp_entry);
+    *netgroup_count = c;
+
     ret = EOK;
 
 done:

--- a/src/responder/nss/nss_cmd.c
+++ b/src/responder/nss/nss_cmd.c
@@ -756,6 +756,9 @@ static errno_t nss_setnetgrent(struct cli_ctx *cli_ctx,
         goto done;
     }
 
+    state_ctx->netgrent.domain = 0;
+    state_ctx->netgrent.result = 0;
+
     talloc_zfree(state_ctx->netgroup);
     state_ctx->netgroup = talloc_strdup(state_ctx, netgroup);
     if (state_ctx->netgroup == NULL) {

--- a/src/responder/nss/nss_enum.c
+++ b/src/responder/nss/nss_enum.c
@@ -144,7 +144,8 @@ static void nss_setent_internal_done(struct tevent_req *subreq)
             /* We need to expand the netgroup into triples and members. */
             ret = sysdb_netgr_to_entries(state->enum_ctx,
                                          result[0]->ldb_result,
-                                         &state->enum_ctx->netgroup);
+                                         &state->enum_ctx->netgroup,
+                                         &state->enum_ctx->netgroup_count);
             if (ret != EOK) {
                 goto done;
             }

--- a/src/responder/nss/nss_private.h
+++ b/src/responder/nss/nss_private.h
@@ -41,6 +41,7 @@ struct nss_enum_index {
 struct nss_enum_ctx {
     struct cache_req_result **result;
     struct sysdb_netgroup_ctx **netgroup;
+    size_t netgroup_count;
 
     /* Ongoing cache request that is constructing enumeration result. */
     struct tevent_req *ongoing;

--- a/src/responder/nss/nss_protocol_netgr.c
+++ b/src/responder/nss/nss_protocol_netgr.c
@@ -126,6 +126,13 @@ nss_protocol_fill_netgrent(struct nss_ctx *nss_ctx,
     idx = cmd_ctx->enum_index;
     entries = cmd_ctx->enum_ctx->netgroup;
 
+    if (idx->result > cmd_ctx->enum_ctx->netgroup_count) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Unconsistent state while processing netgroups.\n");
+        ret = EINVAL;
+        goto done;
+    }
+
     /* First two fields (length and reserved), filled up later. */
     ret = sss_packet_grow(packet, 2 * sizeof(uint32_t));
     if (ret != EOK) {


### PR DESCRIPTION
I currently do not have a good reproducer for any issue but I hope to commit
messages can explain why I think the two patches make sense.

Related to https://pagure.io/SSSD/sssd/issue/3679