### PR TITLE
Fix python3 issue in the integration test

### DIFF
--- a/src/tests/intg/test_ts_cache.py
+++ b/src/tests/intg/test_ts_cache.py
@@ -212,12 +212,17 @@ def get_attrs(ldb_conn, type, name, domain, attr_list):
     ts_attrs = dict()
 
     for attr in attr_list:
-        sysdb_attrs[attr] = ldb_conn.get_entry_attr(
-                                     sssd_ldb.CacheType.sysdb,
-                                     type, name, domain, attr)
-        ts_attrs[attr] = ldb_conn.get_entry_attr(
-                                     sssd_ldb.CacheType.timestamps,
-                                     type, name, domain, attr)
+        val = ldb_conn.get_entry_attr(sssd_ldb.CacheType.sysdb,
+                                      type, name, domain, attr)
+        if val:
+            val = val.decode('utf-8')
+        sysdb_attrs[attr] = val
+
+        val = ldb_conn.get_entry_attr(sssd_ldb.CacheType.timestamps,
+                                      type, name, domain, attr)
+        if val:
+            val = val.decode('utf-8')
+        ts_attrs[attr] = val
     return (sysdb_attrs, ts_attrs)
 
 


### PR DESCRIPTION
With this patch the integration tests can run with python3.

To test make sure $(PYTHON2) in src/tests/intg/Makefile.am is replaced with
$(PYHTON3). Additionally the required python3 modules like e.g. python3-pytest,
python3-pyldap or python3-ldb must st installed.

At startup pytest will print a status line like

    platform linux -- Python 3.5.4, pytest-2.9.2, py-1.4.34, pluggy-0.3.1 -- /usr/bin/python3

where you can check if python3 is really used for testing.