### PR TITLE
memberof: keep memberOf attribute for nested member

### DIFF
--- a/src/ldb_modules/memberof.c
+++ b/src/ldb_modules/memberof.c
@@ -2055,11 +2055,7 @@ static int mbof_del_anc_callback(struct ldb_request *req,
                     talloc_free(valdn);
                     continue;
                 }
-                /* do not re-add the original deleted entry by mistake */
-                if (ldb_dn_compare(valdn, del_ctx->first->entry_dn) == 0) {
-                    talloc_free(valdn);
-                    continue;
-                }
+
                 new_list->dns = talloc_realloc(new_list,
                                                new_list->dns,
                                                struct ldb_dn *,


### PR DESCRIPTION
If we have a member that is both direct and nested member,
memberOf attribute was removed if the direct membership
was deleted.

1)
user ----------> groupB -> groupC
     -> groupA /

2)
user -> groupA -> groupB -> groupC

If we remove user->groupB from 1), we get 2) but groupB was still
removed from user memberOf attribute.

Resolves:
https://pagure.io/SSSD/sssd/issue/3636