### PR TITLE
SYSDB: When marking an entry as expired, also set the originalModifyTimestamp to 1

### DIFF
--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -5410,6 +5410,19 @@ errno_t sysdb_mark_entry_as_expired_ldb_dn(struct sss_domain_info *dom,
         goto done;
     }
 
+    ret = ldb_msg_add_empty(msg, SYSDB_ORIG_MODSTAMP,
+                            LDB_FLAG_MOD_REPLACE, NULL);
+    if (ret != LDB_SUCCESS) {
+        ret = sysdb_error_to_errno(ret);
+        goto done;
+    }
+
+    ret = ldb_msg_add_string(msg, SYSDB_ORIG_MODSTAMP, "1");
+    if (ret != LDB_SUCCESS) {
+        ret = sysdb_error_to_errno(ret);
+        goto done;
+    }
+
     ret = ldb_modify(dom->sysdb->ldb, msg);
     if (ret != LDB_SUCCESS) {
         ret = sysdb_error_to_errno(ret);


### PR DESCRIPTION
Resolves: https://pagure.io/SSSD/sssd/issue/3684

If the cleanup task removes a user who was a fully resolved member (not a
ghost), but then the group the user was a member of is requested, unless
the group had changed, the user doesn't appear as a member of the group
again. This is because the modify timestamp would prevent the group from
updating and therefore the ghost attribute is not readded.

To mitigate this, let's also set the originalModifyTimestamp attribute to
1, so that we never take the optimized path while updating the group.