### PR TITLE
IPA: Qualify the externalUser sudo attribute

### DIFF
--- a/src/providers/ipa/ipa_sudo_conversion.c
+++ b/src/providers/ipa/ipa_sudo_conversion.c
@@ -874,6 +874,15 @@ convert_user_fqdn(TALLOC_CTX *mem_ctx,
 }
 
 static const char *
+convert_ext_user(TALLOC_CTX *mem_ctx,
+                 struct ipa_sudo_conv *conv,
+                 const char *value,
+                 bool *skip_entry)
+{
+    return sss_create_internal_fqname(mem_ctx, value, conv->dom->name);
+}
+
+static const char *
 convert_group(TALLOC_CTX *mem_ctx,
               struct ipa_sudo_conv *conv,
               const char *value,
@@ -959,7 +968,7 @@ convert_attributes(struct ipa_sudo_conv *conv,
                  {SYSDB_IPA_SUDORULE_RUNASEXTUSER,       SYSDB_SUDO_CACHE_AT_RUNASUSER  , NULL},
                  {SYSDB_IPA_SUDORULE_RUNASEXTGROUP,      SYSDB_SUDO_CACHE_AT_RUNASGROUP , NULL},
                  {SYSDB_IPA_SUDORULE_RUNASEXTUSERGROUP,  SYSDB_SUDO_CACHE_AT_RUNASUSER  , convert_runasextusergroup},
-                 {SYSDB_IPA_SUDORULE_EXTUSER,            SYSDB_SUDO_CACHE_AT_USER       , NULL},
+                 {SYSDB_IPA_SUDORULE_EXTUSER,            SYSDB_SUDO_CACHE_AT_USER       , convert_ext_user},
                  {SYSDB_IPA_SUDORULE_ALLOWCMD,           SYSDB_IPA_SUDORULE_ORIGCMD     , NULL},
                  {SYSDB_IPA_SUDORULE_DENYCMD,            SYSDB_IPA_SUDORULE_ORIGCMD     , NULL},
                  {NULL, NULL, NULL}};


### PR DESCRIPTION
We broke the externalUser support with the introduction of the fully
qualified attributes, because the provider was saving the data verbatim,
but the sudo responder expects a fully qualified name.

Reproducer:
   on the server:
       ipa sudocmd-add --desc='For reading log files' /usr/bin/less
       ipa sudorule-add readfiles
       ipa sudorule-add-user --users=lcluser
       ipa sudorule-mod --hostcat=all readfiles

    then on the client:
       configure sssd with:
           id_provider = files
           sudo_provider = ipa
           ipa_domain = ipa.test

        run:
           sudo useradd lcluser
           sudo passwd lcluser
           su - lcluser
           sudo -l