### PR TITLE
TESTS: Re-add tests for `kdestroy -A`

### DIFF
--- a/src/tests/intg/test_kcm.py
+++ b/src/tests/intg/test_kcm.py
@@ -339,6 +339,21 @@ def collection_init_list_destroy(testenv):
     assert cc_coll['bob@KCMTEST'] == ['krbtgt/KCMTEST@KCMTEST']
     assert 'carol@KCMTEST' not in cc_coll
 
+    # Let's kinit a 3rd principal
+    out, _, _ = testenv.k5util.kinit("carol", "carolpw")
+    assert out == 0
+    cc_coll = testenv.k5util.list_all_princs()
+    assert len(cc_coll) == 3
+    assert cc_coll['alice@KCMTEST'] == ['krbtgt/KCMTEST@KCMTEST']
+    assert cc_coll['bob@KCMTEST'] == ['krbtgt/KCMTEST@KCMTEST']
+    assert cc_coll['carol@KCMTEST'] == ['krbtgt/KCMTEST@KCMTEST']
+
+    # Let's ensure `kdestroy -A` works with more than 2 principals
+    # https://pagure.io/SSSD/sssd/issue/3413
+    out = testenv.k5util.kdestroy(all_ccaches=True)
+    assert out == 0
+    assert testenv.k5util.num_princs() == 0
+
 
 def test_kcm_mem_collection_init_list_destroy(setup_for_kcm_mem):
     testenv = setup_for_kcm_mem


### PR DESCRIPTION
This reverts commit 89726be5a05493b7af312f0be9ac5ecb6f1822e1 and also do
a few modifications on it in order to ensure we don't have any
regression on https://pagure.io/SSSD/sssd/issue/3413

As this patch depends on a krb5 patch applied to the distros we run our internal CI on, I've opened a bug report providing patches for Fedora[0] and Debian[1].

[0]: https://bugzilla.redhat.com/show_bug.cgi?id=1561917
[1]: https://salsa.debian.org/debian/krb5/merge_requests/1