### PR TITLE
SERVER: Tone down shutdown messages for socket-activated responders

### DIFF
--- a/src/util/server.c
+++ b/src/util/server.c
@@ -248,8 +248,12 @@ void orderly_shutdown(int status)
 {
 #if HAVE_GETPGRP
     static int sent_sigterm;
+    int debug;
+
     if (sent_sigterm == 0 && getpgrp() == getpid()) {
-        DEBUG(SSSDBG_FATAL_FAILURE, "SIGTERM: killing children\n");
+        debug = is_socket_activated() ? SSSDBG_TRACE_INTERNAL
+                                      : SSSDBG_FATAL_FAILURE;
+        DEBUG(debug, "SIGTERM: killing children\n");
         sent_sigterm = 1;
         kill(-getpgrp(), SIGTERM);
     }


### PR DESCRIPTION
When dealing with socket-activated responders, those may be shut
themselves down after some inactivy period. And that's completely normal
and expected, thus should not be logged as an fatal error.

For the case when the responder is started by the monitor, however, it
still makes sense to keep the code as it is as the responders won't shut
themselves down in any normal scenario.