### PR TITLE
Respect ad_site option in GPO resolution

### DIFF
--- a/src/providers/ad/ad_access.h
+++ b/src/providers/ad/ad_access.h
@@ -23,6 +23,8 @@
 #ifndef AD_ACCESS_H_
 #define AD_ACCESS_H_
 
+#include "providers/data_provider.h"
+
 struct ad_access_ctx {
     struct dp_option *ad_options;
     struct sdap_access_ctx *sdap_access_ctx;

--- a/src/providers/ad/ad_gpo.c
+++ b/src/providers/ad/ad_gpo.c
@@ -146,6 +146,7 @@ struct tevent_req *ad_gpo_process_som_send(TALLOC_CTX *mem_ctx,
                                            struct ldb_context *ldb_ctx,
                                            struct sdap_id_op *sdap_op,
                                            struct sdap_options *opts,
+                                           struct dp_option *ad_options,
                                            int timeout,
                                            const char *target_dn,
                                            const char *domain_name);
@@ -1975,6 +1976,7 @@ ad_gpo_target_dn_retrieval_done(struct tevent_req *subreq)
                                      state->ldb_ctx,
                                      state->sdap_op,
                                      state->opts,
+                                     state->access_ctx->ad_options,
                                      state->timeout,
                                      state->target_dn,
                                      state->host_domain->name);
@@ -2701,6 +2703,7 @@ struct ad_gpo_process_som_state {
     struct tevent_context *ev;
     struct sdap_id_op *sdap_op;
     struct sdap_options *opts;
+    struct dp_option *ad_options;
     int timeout;
     bool allow_enforced_only;
     char *site_name;
@@ -2734,6 +2737,7 @@ ad_gpo_process_som_send(TALLOC_CTX *mem_ctx,
                         struct ldb_context *ldb_ctx,
                         struct sdap_id_op *sdap_op,
                         struct sdap_options *opts,
+                        struct dp_option *ad_options,
                         int timeout,
                         const char *target_dn,
                         const char *domain_name)
@@ -2752,6 +2756,7 @@ ad_gpo_process_som_send(TALLOC_CTX *mem_ctx,
     state->ev = ev;
     state->sdap_op = sdap_op;
     state->opts = opts;
+    state->ad_options = ad_options;
     state->timeout = timeout;
     state->som_index = 0;
     state->allow_enforced_only = 0;


### PR DESCRIPTION
GPO resolution requires AD site name to work properly.

We ignored the ad_site option to override autodiscovered ad site in the GPO code. This was most serious in a rare case when no AD site was autodiscovered (not evene the Default-First-Site).

Note: I have seen cases where DNS have not returned AD site, but I do not know how to setup DNS to not return the AD side, so to reproduce the issue I commented the autodiscovery in the code, which gave me the same debug logs as the ones I have seen in cases.

Note2: The first patch is just found nitpick. The other two patches can be merged, but I thought it was more readable if done separately.