### PR TITLE
MAN: Add sss-certmap man page regarding priority processing

### DIFF
--- a/src/man/sss-certmap.5.xml
+++ b/src/man/sss-certmap.5.xml
@@ -44,7 +44,9 @@
         <para>
             The rules are processed by priority while the number '0' (zero)
             indicates the highest priority. The higher the number the lower is
-            the priority. A missing value indicates the lowest priority.
+            the priority. A missing value indicates the lowest priority. The
+            rules processing is stopped when a matched rule is found and no
+            further rules are checked.
         </para>
         <para>
             Internally the priority is treated as unsigned 32bit integer, using


### PR DESCRIPTION
PR adds following text in PRIORITY section of man sss-certmap:
The processing is stopped when a matched rule is found and no
further rules are checked.

Resolves: https://pagure.io/SSSD/sssd/issue/3469