### PR TITLE
Several fixes for the files provider

### DIFF
--- a/src/providers/files/files_ops.c
+++ b/src/providers/files/files_ops.c
@@ -793,8 +793,7 @@ static int sf_passwd_cb(const char *filename, uint32_t flags, void *pvt)
 
     id_ctx = talloc_get_type(pvt, struct files_id_ctx);
     if (id_ctx == NULL) {
-        ret = EINVAL;
-        goto done;
+        return EINVAL;
     }
 
     DEBUG(SSSDBG_TRACE_FUNC, "passwd notification\n");
@@ -818,12 +817,11 @@ static int sf_passwd_cb(const char *filename, uint32_t flags, void *pvt)
         goto done;
     }
 
+    ret = EOK;
+done:
     id_ctx->updating_passwd = false;
     sf_cb_done(id_ctx);
     files_account_info_finished(id_ctx, BE_REQ_USER, ret);
-
-    ret = EOK;
-done:
     return ret;
 }
 
@@ -834,8 +832,7 @@ static int sf_group_cb(const char *filename, uint32_t flags, void *pvt)
 
     id_ctx = talloc_get_type(pvt, struct files_id_ctx);
     if (id_ctx == NULL) {
-        ret = EINVAL;
-        goto done;
+        return EINVAL;
     }
 
     DEBUG(SSSDBG_TRACE_FUNC, "group notification\n");
@@ -855,12 +852,11 @@ static int sf_group_cb(const char *filename, uint32_t flags, void *pvt)
         goto done;
     }
 
+    ret = EOK;
+done:
     id_ctx->updating_groups = false;
     sf_cb_done(id_ctx);
     files_account_info_finished(id_ctx, BE_REQ_GROUP, ret);
-
-    ret = EOK;
-done:
     return ret;
 }
 

--- a/src/providers/files/files_ops.c
+++ b/src/providers/files/files_ops.c
@@ -734,8 +734,15 @@ static errno_t sf_enum_files(struct files_id_ctx *id_ctx,
         /* All users were deleted, therefore we need to enumerate each file again */
         for (size_t i = 0; id_ctx->passwd_files[i] != NULL; i++) {
             ret = sf_enum_users(id_ctx, id_ctx->passwd_files[i]);
-            if (ret != EOK) {
-                DEBUG(SSSDBG_OP_FAILURE, "Cannot enumerate users\n");
+            if (ret == ENOENT) {
+                DEBUG(SSSDBG_MINOR_FAILURE,
+                      "The file %s does not exist (yet), skipping\n",
+                      id_ctx->passwd_files[i]);
+                continue;
+            } else if (ret != EOK) {
+                DEBUG(SSSDBG_OP_FAILURE,
+                      "Cannot enumerate users from %s, aborting\n",
+                      id_ctx->passwd_files[i]);
                 goto done;
             }
         }
@@ -750,8 +757,15 @@ static errno_t sf_enum_files(struct files_id_ctx *id_ctx,
         /* All groups were deleted, therefore we need to enumerate each file again */
         for (size_t i = 0; id_ctx->group_files[i] != NULL; i++) {
             ret = sf_enum_groups(id_ctx, id_ctx->group_files[i]);
-            if (ret != EOK) {
-                DEBUG(SSSDBG_OP_FAILURE, "Cannot enumerate groups\n");
+            if (ret == ENOENT) {
+                DEBUG(SSSDBG_MINOR_FAILURE,
+                      "The file %s does not exist (yet), skipping\n",
+                      id_ctx->group_files[i]);
+                continue;
+            } else if (ret != EOK) {
+                DEBUG(SSSDBG_OP_FAILURE,
+                      "Cannot enumerate groups from %s, aborting\n",
+                      id_ctx->group_files[i]);
                 goto done;
             }
         }

--- a/src/responder/common/responder_dp.c
+++ b/src/responder/common/responder_dp.c
@@ -598,11 +598,11 @@ static int sss_dp_account_files_params(struct sss_domain_info *dom,
                                        enum sss_dp_acct_type *_type_out,
                                        const char **_opt_name_out)
 {
-#if 0
     if (sss_domain_get_state(dom) != DOM_INCONSISTENT) {
+        DEBUG(SSSDBG_TRACE_INTERNAL,
+              "The entries in the files domain are up-to-date\n");
         return EOK;
     }
-#endif
 
     DEBUG(SSSDBG_TRACE_INTERNAL,
           "Domain files is not consistent, issuing update\n");


### PR DESCRIPTION
This PR contains several fixes for the files provider, mainly a performance
bug which is really embarassing - I have no idea why was the code #if-ed
out. I think I must have been experimenting with the provider update
and then forgot to remove the preprocessor macros. The rest is mostly code
cleanup and minor fixes.

btw initially I wanted to also include a fix to avoid removing cachedPassword
on updates, but I realized the current way where the files provider throws
away everything and then updates everything would force us to maintain
all the sssd-added attributes on our own. And because especially with 2FA
it might not be just cachedPassword, but also the factor length or offline
lockout counter etc, we might as well devise a better way to update the
cache than just throw away everything and recreate the entries, so I'll work
on that separately.