### PR TITLE
COVERITY: Add coverity support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: c
+compiler: gcc
+sudo: required
+dist: trusty
+
+services:
+  - docker
+
+addons:
+  apt:
+    packages:
+    - bash
+    - tar
+    - bzip2
+
+env:
+  global:
+    # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
+    # via the "travis encrypt" command using the project repo's public key
+      - secure: "gD4XB/tAquGTUFGvQ4+a+K9EbemQtyZs0Py+r7+HAEQ7h/B+fwwRX1h5bGzMUjyCUJ88u28wdRZ0TNxIiEVXuSi/0Ia9BOvdS9YurXdpZc7ha1OpYnJd1tYwxGrgozKW9qXB3R6XZmlcxVGzIHF3fwK9a1p+rNDUihWhasqeAPFFI3IhQhwDIIxO3paRGvHHO0UNlw0+lpgsiQLYIYFWYjHqq2voZ1UlV4Ga7LSP1Yh8F38hDSMk7ykSLedsV1kqxh3zky8p5fLSbDRI1y7PLNBYD63LagUCEk1o3nF+hF0l3nRfEApFJKUhBfccgNc2mdXbBdDxDCnwiArbTXQNxI2Iml85UJ/I5/CS3uE437A3H7ZdvL51w2592JGNMEwq9pxGK3vxcN8g/Yn2Xoo1F2KTVHBexT44LEnS0ADRj5K8AfDsyIUz/rB9+N05k5WXtqcDWblpC5gfD0nk3WQnpmc8hjeI2B9RTFTa3ydA4I5wfABkGfNARH39RxK10d+b176U8x3z05p/PgyraAYKi2kFpA3ha5fw9o1CIqcd5OpUcIWrIo5+FG8hYgtcIG+65PSOHz6gGVZkpZyR4vqIuHIfw4jdi68d6LfoophdhjuFSDTuwgXXGQNjdaYQSpeoZ5Gm9hvHbasabqIBpOfDo/Yjq6up20byvmDaGtoeojI="
+
+before_install:
+  - ./.travis/travis-docker-build.sh
+
+script:
+  - docker run -e COVERITY_SCAN_TOKEN=$COVERITY_SCAN_TOKEN --rm sssd/sssd

--- a/.travis/travis-docker-build.sh
+++ b/.travis/travis-docker-build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Create an archive of the current checkout
+TARBALL=`mktemp -p . tarball-XXXXXX.tar.bz2`
+git ls-files |xargs tar cfj $TARBALL .git
+
+sudo docker build -f Dockerfile.deps -t sssd/sssd-deps .
+
+sudo docker build -t sssd/sssd --build-arg TARBALL=$TARBALL .
+
+rm -f $TARBALL
+
+exit 0

--- a/.travis/travis-tasks.sh
+++ b/.travis/travis-tasks.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+#Exit on failures
+set -e
+
+pushd /builddir/
+
+# We have to define the _Float* types as those are not defined by coverity and as result
+# the codes linking agains those (pretty much anything linking against stdlib.h and math.h)
+# won't be covered.
+echo "#define _Float128 long double" > /tmp/coverity.h
+echo "#define _Float64x long double" >> /tmp/coverity.h
+echo "#define _Float64 double" >> /tmp/coverity.h
+echo "#define _Float32x double" >> /tmp/coverity.h
+echo "#define _Float32 float" >> /tmp/coverity.h
+
+# The coverity scan script returns an error despite succeeding...
+ CFLAGS="${CFLAGS:- -include /tmp/coverity.h}" \
+ TRAVIS_BRANCH="${TRAVIS_BRANCH:-master}" \
+ COVERITY_SCAN_PROJECT_NAME="${COVERITY_SCAN_PROJECT_NAME:-SSSD/sssd}" \
+ COVERITY_SCAN_NOTIFICATION_EMAIL="${COVERITY_SCAN_NOTIFICATION_EMAIL:-sssd-maint@redhat.com}" \
+ COVERITY_SCAN_BUILD_COMMAND_PREPEND="${COVERITY_SCAN_BUILD_COMMAND_PREPEND:-source contrib/fedora/bashrc_sssd && reconfig}" \
+ COVERITY_SCAN_BUILD_COMMAND="${COVERITY_SCAN_BUILD_COMMAND:-make all check TESTS= }" \
+ COVERITY_SCAN_BRANCH_PATTERN=${COVERITY_SCAN_BRANCH_PATTERN:-master} \
+ /usr/bin/travisci_build_coverity_scan.sh ||:
+
+popd #builddir

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM sssd/sssd-deps
+
+MAINTAINER SSSD Maintainers <sssd-maint@redhat.com>
+
+ARG TARBALL
+
+RUN  echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca- && curl -s https://scan.coverity.com/scripts/travisci_build_coverity_scan.sh -o /usr/bin/travisci_build_coverity_scan.sh && chmod a+x /usr/bin/travisci_build_coverity_scan.sh
+
+ADD $TARBALL /builddir/
+
+ENTRYPOINT /builddir/.travis/travis-tasks.sh

--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -1,0 +1,12 @@
+FROM fedora:latest
+
+MAINTAINER SSSD Maintainers <sssd-maint@redhat.com>
+
+ARG TARBALL
+
+RUN dnf -y install git openssl sudo curl wget ruby rubygems "rubygem(json)" wget rpm-build dnf-plugins-core libldb-devel && \
+    git clone --depth=50 --branch=master https://github.com/SSSD/sssd.git /tmp/sssd && \
+    cd /tmp/sssd && \
+    ./contrib/fedora/make_srpm.sh && \
+    dnf builddep -y rpmbuild/SRPMS/sssd-*.src.rpm && \
+    dnf -y clean all


### PR DESCRIPTION
Using travis-ci we can start doing coverity scans on every pushed code.
This is not something new as so far we have been relying on sgallagh's
internal infra to do so, unfortunatelly the infra is about to be
retired ... thus, start to use public coverity's instance is a hard
requirement for us.

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>
Signed-off-by: Edjunior Machado <emachado@redhat.com>