### PR TITLE
nss-idmap: use right group list pointer after sss_get_ex()

### DIFF
--- a/src/sss_client/idmap/sss_nss_ex.c
+++ b/src/sss_client/idmap/sss_nss_ex.c
@@ -96,7 +96,9 @@ errno_t sss_nss_mc_get(struct nss_input *inp)
                                          inp->result.initgrrep.start,
                                          inp->result.initgrrep.ngroups,
                                          &(inp->result.initgrrep.groups),
-                                         *(inp->result.initgrrep.ngroups));
+                                         /* no limit so that needed size can
+                                          * be returned properly */
+                                         -1);
         break;
     default:
         return EINVAL;


### PR DESCRIPTION
This pull-request fixes an memory management issue which might cause crashes in
long running processes and makes sure getgrouplist() returns the expected
results if the data is read from the memory mapped cache.

Related to https://pagure.io/SSSD/sssd/issue/3715

To verify the memory management issue you can run the following short test
program with valgrind:



```
int main(int argc, char *argv[])
{
    int ret;
    const char *name;
    uint32_t flags = 0;
    unsigned int timeout = 10000;
    gid_t groups[10];
    int ngroups = 10;
    int c;

    if (argc == 2) {
        name = (const char *) argv[1];
    } else {
        name = "testuser";
    }
    ret = sss_nss_getgrouplist_timeout(name, 112233, groups, &ngroups, flags,
                                       timeout);
    if (ret == 0) {
        printf("%s: %d\n", name, ngroups);
        for (c = 0; c < ngroups; c++) {
            printf("   %d\n", groups[c]);
        }
    } else {
        printf("%s: sss_nss_getgrouplist_ex %d: %s\n", name, ret,
                                                       strerror(ret));
    }

    return ret;
}
```

If the user is a member of more then 10 groups there will be a reallocation of
memory which will cause the issue and valgrind will report this. The first
tests should be run with 'SSS_NSS_USE_MEMCACHE=NO' to make sure the code path
which talks directly to SSSD's nss responder is used.

The second patch fixes an issue in the code path which read the data from the
memory mapped cached. Since an internal limit was set to the initial array size
there was no reallocation in this code path but the number of groups the user
is a member of couldn't be returned properly as well. If only the limit patch
is applied valgrind should report the memory management issue for this code
path as well.