### PR TITLE
NSS: close files after mmap

### DIFF
--- a/src/sss_client/nss_mc_common.c
+++ b/src/sss_client/nss_mc_common.c
@@ -185,6 +185,9 @@ static errno_t sss_nss_mc_init_ctx(const char *name,
     ret = 0;
 
 done:
+    if (ctx->fd) {
+        close(ctx->fd);
+    }
     if (ret) {
         sss_nss_mc_destroy_ctx(ctx);
     }


### PR DESCRIPTION
The files in MC cache folder were initialized by SSSD on startup, and mapped by using mmap function. due to the fact that they weren't closed afterwards, their File descriptors were still marker alive but marked as 'Deleted'.
This was noticed by a customer of SUSE, see more details here: https://bugzilla.suse.com/show_bug.cgi?id=1080156