### PR TITLE
Do not keep allocating external groups on a long-lived context

### DIFF
--- a/src/providers/ipa/ipa_subdomains_ext_groups.c
+++ b/src/providers/ipa/ipa_subdomains_ext_groups.c
@@ -583,14 +583,19 @@ static void ipa_get_ext_groups_done(struct tevent_req *subreq)
     DEBUG(SSSDBG_TRACE_FUNC, "[%zu] external groups found.\n",
                               state->reply_count);
 
-    ret = process_ext_groups(state->server_mode->ext_groups,
-                             state->reply_count, state->reply, &ext_group_hash);
+    ret = process_ext_groups(state,
+                             state->reply_count,
+                             state->reply,
+                             &ext_group_hash);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "process_ext_groups failed.\n");
         goto fail;
     }
 
-    state->server_mode->ext_groups->ext_groups = ext_group_hash;
+    talloc_free(state->server_mode->ext_groups->ext_groups);
+    state->server_mode->ext_groups->ext_groups = talloc_steal(
+            state->server_mode->ext_groups,
+            ext_group_hash);
     /* Do we have to make the update timeout configurable? */
     state->server_mode->ext_groups->next_update = time(NULL) + 10;
 


### PR DESCRIPTION
The hash table with the external groups was never freed, so the
server_mode->ext_groups context was growing over time.

This patch keeps the new hash on the state if something failed, then frees
the previous hash and finally steals the new hash onto the server mode.

Resolves: https://pagure.io/SSSD/sssd/issue/3719