### PR TITLE
CACHE_REQ: Do not fail the domain locator plugin if ID outside the domain range is looked up

### DIFF
--- a/src/responder/common/cache_req/cache_req.c
+++ b/src/responder/common/cache_req/cache_req.c
@@ -523,6 +523,7 @@ static void cache_req_locate_dom_cache_done(struct tevent_req *subreq)
         DEBUG(SSSDBG_TRACE_INTERNAL, "Result found in the cache\n");
         tevent_req_done(req);
         return;
+    case ERR_ID_OUTSIDE_RANGE:
     case ENOENT:
         /* Not cached and locator was requested, run the locator
          * DP request plugin

--- a/src/responder/common/cache_req/plugins/cache_req_common.c
+++ b/src/responder/common/cache_req/plugins/cache_req_common.c
@@ -27,7 +27,7 @@
 #include "responder/common/cache_req/cache_req_plugin.h"
 
 errno_t cache_req_idminmax_check(struct cache_req_data *data,
-	                         struct sss_domain_info *domain)
+                                 struct sss_domain_info *domain)
 {
    if (((domain->id_min != 0) && (data->id < domain->id_min)) ||
        ((domain->id_max != 0) && (data->id > domain->id_max))) {

--- a/src/responder/common/cache_req/plugins/cache_req_group_by_id.c
+++ b/src/responder/common/cache_req/plugins/cache_req_group_by_id.c
@@ -85,7 +85,7 @@ cache_req_group_by_id_lookup(TALLOC_CTX *mem_ctx,
 
     ret = cache_req_idminmax_check(data, domain);
     if (ret != EOK) {
-	return ret;
+        return ret;
     }
     return sysdb_getgrgid_with_views(mem_ctx, domain, data->id, _result);
 }


### PR DESCRIPTION
A fix for upstream bug #3569 and the domain-locator feature were both
developed in the context of the same upstream version and therefore touched
the same code, but the domain locator did not account for the
ERR_ID_OUTSIDE_RANGE error code.

Therefore lookups for IDs that are outside the range for the domain caused
the whole lookup to fail instead of carrying on to the next domain.

This patch just handles ERR_ID_OUTSIDE_RANGE the same way as if the ID was
not found at all. Also some whitespace errors are fixed.

Resolves: https://pagure.io/SSSD/sssd/issue/3728