### PR TITLE
NSS: nss_clear_netgroup_hash_table() do not free data

### DIFF
--- a/src/responder/nss/nsssrv.c
+++ b/src/responder/nss/nsssrv.c
@@ -142,7 +142,7 @@ static int nss_clear_netgroup_hash_table(struct sbus_request *dbus_req, void *da
 
     DEBUG(SSSDBG_TRACE_FUNC, "Invalidating netgroup hash table\n");
 
-    sss_ptr_hash_delete_all(nss_ctx->netgrent, true);
+    sss_ptr_hash_delete_all(nss_ctx->netgrent, false);
 
     return sbus_request_return_and_finish(dbus_req, DBUS_TYPE_INVALID);
 }


### PR DESCRIPTION
nss_clear_netgroup_hash_table() is called during the clearEnumCache SBUS
request, which is e.g. used during 'sss_cache -E', to remove netgroup
data cached in the memory of the NSS responder.

Currently nss_clear_netgroup_hash_table() calls
'sss_ptr_hash_delete_all(nss_ctx->netgrent, true);' which not only
removes all entries in the 'netgerent' hash table but frees them as
well.

The second step is not needed because nss_setnetgrent_set_timeout()
takes care that the data is freed after a timeout. Additionally freeing
the data in nss_clear_netgroup_hash_table() can even do harm when the
request is received by the NSS responder while waiting for the backend
to acquire the netgroup data. Because if the backend is done the NSS
responder tries do use enum_ctx which might have been freed in the
meantime.

Because of this nss_clear_netgroup_hash_table() should only remove the
data from the hash table but not free it.

Related to https://pagure.io/SSSD/sssd/issue/3731