### PR TITLE
NSS: remove timed event if related object is removed

### DIFF
--- a/src/responder/nss/nsssrv_netgroup.c
+++ b/src/responder/nss/nsssrv_netgroup.c
@@ -428,7 +428,7 @@ static void set_netgr_lifetime(uint32_t lifetime,
 
     tv = tevent_timeval_current_ofs(lifetime, 0);
     te = tevent_add_timer(step_ctx->nctx->rctx->ev,
-                          step_ctx->nctx, tv,
+                          netgr, tv,
                           setnetgrent_result_timeout,
                           netgr);
     if (!te) {


### PR DESCRIPTION
setnetgrent_result_timeout() is called as a timed event to free the
netgr data is the cache lifetime is exceeded. If the data is freed
earlier the timed event should be removed as well to avoid a double
free issue.

Since talloc is used here the most easy way to achieve this is to
allocate the timed event on the netgr object itself.

Related to https://pagure.io/SSSD/sssd/issue/3523