### PR TITLE
MAN: Clarify how comments work in sssd.conf

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -38,7 +38,7 @@
         </para>
 
         <para>
-            A line comment starts with a hash sign (<quote>#</quote>) or a
+            A comment line starts with a hash sign (<quote>#</quote>) or a
             semicolon (<quote>;</quote>).
             Inline comments are not supported.
         </para>


### PR DESCRIPTION
PR changes comment description in sssd.conf from:
'A line comment starts with a hash sign...'
to
'A comment line starts with a hash sign...'

Resolves: https://pagure.io/SSSD/sssd/issue/1117