### PR TITLE
winbind idmap plugin: support inferface version 6

### DIFF
--- a/contrib/ci/configure.sh
+++ b/contrib/ci/configure.sh
@@ -35,6 +35,7 @@ declare -a CONFIGURE_ARG_LIST=(
 if [[ "$DISTRO_BRANCH" == -redhat-redhatenterprise*-6.*- ||
       "$DISTRO_BRANCH" == -redhat-centos-6.*- ]]; then
     CONFIGURE_ARG_LIST+=(
+        "--with-smb-idmap-interface-version=5"
         "--disable-cifs-idmap-plugin"
         "--with-syslog=syslog"
         "--without-python3-bindings"
@@ -53,6 +54,14 @@ if [[ "$DISTRO_BRANCH" == -redhat-redhatenterprise*-7.*- ||
       "$DISTRO_BRANCH" == -redhat-centos-7.*- ]]; then
     CONFIGURE_ARG_LIST+=(
         "--without-python3-bindings"
+    )
+fi
+
+# Different versions of Debian might need different versions here but this is
+# sufficient to make the CI work
+if [[ "$DISTRO_BRANCH" == -debian-* ]]; then
+    CONFIGURE_ARG_LIST+=(
+        "--with-smb-idmap-interface-version=5"
     )
 fi
 

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -127,6 +127,14 @@
     %global with_gdm_pam_extensions 0
 %endif
 
+# Do not try to detect the idmap version on RHEL6 to avoid conflicts between
+# samba and samba4 package
+%if (0%{?fedora} || 0%{?rhel} >= 7)
+    %global detect_idmap_version 1
+%else
+    %global with_idmap_version --with-smb-idmap-interface-version=5
+%endif
+
 Name: @PACKAGE_NAME@
 Version: @PACKAGE_VERSION@
 Release: 0@PRERELEASE_VERSION@%{?dist}
@@ -235,6 +243,9 @@ BuildRequires: nfs-utils-lib-devel
 
 BuildRequires: samba4-devel
 BuildRequires: libsmbclient-devel
+%if (0%{?detect_idmap_version} == 1)
+BuildRequires: samba-winbind
+%endif
 
 %if (0%{?enable_systemtap} == 1)
 BuildRequires: systemtap-sdt-devel
@@ -757,6 +768,7 @@ autoreconf -ivf
     %{?enable_systemtap_opt} \
     %{?with_secret_responder} \
     %{?with_kcm_option} \
+    %{?with_idmap_version} \
     %{?experimental}
 
 make %{?_smp_mflags} all

--- a/src/external/samba.m4
+++ b/src/external/samba.m4
@@ -39,4 +39,86 @@ them. In this case, you will need to execute configure script with argument
 --without-samba
         ]])
     fi
+
+    AC_ARG_WITH([smb-idmap-interface-version],
+                [AC_HELP_STRING([--with-smb-idmap-interface-version=[5|6]],
+                                [Idmap interface version of installed Samba]
+                               )
+                ]
+               )
+
+    if test x"$with_smb_idmap_interface_version" != x; then
+        if test x"$with_smb_idmap_interface_version" = x5 -o x"$with_smb_idmap_interface_version" = x6; then
+            idmap_test_result=$with_smb_idmap_interface_version
+        else
+            AC_MSG_ERROR([Illegal value -$with_smb_idmap_interface_version- for option --with-smb-idmap-interface-version])
+        fi
+    else
+
+        AC_MSG_CHECKING([Samba's idmap plugin interface version])
+        sambalibdir="`$PKG_CONFIG --variable=libdir smbclient`"/samba
+        SAVE_CFLAGS=$CFLAGS
+        SAVE_LIBS=$LIBS
+        CFLAGS="$CFLAGS $SMBCLIENT_CFLAGS -I/usr/include/samba-4.0"
+        LIBS="$LIBS -L${sambalibdir} -lidmap-samba4 -Wl,-rpath ${sambalibdir}"
+        AC_RUN_IFELSE(
+            [AC_LANG_SOURCE([
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <tevent.h>
+#include <core/ntstatus.h>
+
+struct winbindd_domain;
+
+/* overwrite some winbind internal functions */
+struct winbindd_domain *find_domain_from_name(const char *domain_name)
+{
+    return NULL;
+}
+
+bool get_global_winbindd_state_offline(void) {
+    return false;
+}
+
+struct tevent_context *winbind_event_context(void)
+{
+       return NULL;
+}
+
+struct idmap_methods;
+
+NTSTATUS smb_register_idmap(int version, const char *name, struct idmap_methods *methods);
+
+int main(void)
+{
+    int v;
+    NTSTATUS ret;
+
+    /* Check the versions we know about */
+    for (v = 5; v <= 6; v++) {
+        ret = smb_register_idmap(v, NULL, NULL);
+        if (ret != NT_STATUS_OBJECT_TYPE_MISMATCH) {
+            return v;
+        }
+    }
+
+    return -1;
+}])],
+            [AC_MSG_ERROR([idmap version test program is not expected to return 0])],
+            [idmap_test_result=$?; AC_MSG_RESULT([idmap test result is: $idmap_test_result])]
+        )
+    fi
+
+    CFLAGS=$SAVE_CFLAGS
+    LIBS=$SAVE_LIBS
+
+    if test $idmap_test_result -eq 5 -o $idmap_test_result -eq 6 ; then
+        idmap_version=$idmap_test_result
+    else
+        AC_MSG_ERROR([Cannot determine Samba's idmap interface version, please use --with-smb-idmap-interface-version])
+    fi
+    AC_MSG_NOTICE([Samba's idmap interface version: $idmap_version])
+    AC_DEFINE_UNQUOTED(SMB_IDMAP_INTERFACE_VERSION, $idmap_version,
+                       [Detected version of Samba's idmap plugin interface])
 fi

--- a/src/lib/winbind_idmap_sss/winbind_idmap_sss.c
+++ b/src/lib/winbind_idmap_sss/winbind_idmap_sss.c
@@ -190,7 +190,13 @@ static struct idmap_methods sss_methods = {
     .sids_to_unixids = idmap_sss_sids_to_unixids,
 };
 
+#if SMB_IDMAP_INTERFACE_VERSION == 5
 NTSTATUS idmap_sss_init(void)
+#elif SMB_IDMAP_INTERFACE_VERSION == 6
+NTSTATUS idmap_sss_init(TALLOC_CTX *ctx)
+#else
+#error Unexpected Samba idmpa inferface version
+#endif
 {
     return smb_register_idmap(SMB_IDMAP_INTERFACE_VERSION, "sss", &sss_methods);
 }

--- a/src/lib/winbind_idmap_sss/winbind_idmap_sss.h
+++ b/src/lib/winbind_idmap_sss/winbind_idmap_sss.h
@@ -32,6 +32,8 @@
 #include <ndr.h>
 #include <gen_ndr/security.h>
 
+#include "config.h"
+
 /* The following definitions are taken from the Samba header files
  * - winbindd/idmap_proto.h
  * - idmap.d
@@ -64,7 +66,9 @@ struct id_map {
     enum id_mapping status;
 };
 
-#define SMB_IDMAP_INTERFACE_VERSION 5
+#ifndef SMB_IDMAP_INTERFACE_VERSION
+#error Missing Samba idmap interface version
+#endif
 
 struct idmap_domain {
     const char *name;


### PR DESCRIPTION
With Samba 4.7 the interface version of the idmap plugin was updated to
6. The patch adds support for this new version but can be complied with
the older version as well.

A configure option is added to select the version, if no version is
given configure tries to detect the version with the help of an internal
Samba library libidmap-samba4.so.

To make sure that always the right version is used configure will fail
if Samba is used (--with-samba, default) and no version can be
determined.

Resolves https://pagure.io/SSSD/sssd/issue/3741