### PR TITLE
cache_req: Don't force a fqname for files provider output

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -563,7 +563,8 @@
                                 Please, note that when this option is set the
                                 output format of all commands is always
                                 fully-qualified even when using short names
-                                for input.
+                                for input, for all users but the ones managed
+                                by the files provider.
                                 In case the administrator wants the output not
                                 fully-qualified, the full_name_format option
                                 can be used as shown below:

--- a/src/responder/common/cache_req/cache_req_domain.c
+++ b/src/responder/common/cache_req/cache_req_domain.c
@@ -202,9 +202,14 @@ cache_req_domain_new_list_from_string_list(TALLOC_CTX *mem_ctx,
         /* when using the domain resolution order, using shortnames as input
          * is allowed by default. However, we really want to use the fully
          * qualified name as output in order to avoid conflicts whith users
-         * who have the very same name. */
+         * who have the very same name.
+         *
+         * NOTE: we do *not* want to use fully qualified names for the
+         * files provider.*/
         if (resolution_order != NULL) {
-            sss_domain_info_set_output_fqnames(cr_domain->domain, true);
+            if (strcmp(cr_domain->domain->provider, "files") != 0) {
+                sss_domain_info_set_output_fqnames(cr_domain->domain, true);
+            }
         }
 
         DLIST_ADD_END(cr_domains, cr_domain, struct cache_req_domain *);

--- a/src/tests/intg/test_files_provider.py
+++ b/src/tests/intg/test_files_provider.py
@@ -294,6 +294,22 @@ def no_sssd_conf(request):
     return None
 
 
+@pytest.fixture
+def domain_resolution_order(request):
+    conf = unindent("""\
+        [sssd]
+        domains             = files
+        services            = nss
+        domain_resolution_order = foo
+
+        [domain/files]
+        id_provider = files
+    """).format(**locals())
+    create_conf_fixture(request, conf)
+    create_sssd_fixture(request)
+    return None
+
+
 def setup_pw_with_list(request, user_list):
     pwd_ops = passwd_ops_setup(request)
     for user in user_list:
@@ -1173,3 +1189,12 @@ def test_multiple_files_created_after_startup(add_user_with_canary,
 
     check_user(ALT_USER1)
     check_group(ALT_GROUP1)
+
+
+def test_files_with_domain_resolution_order(add_user_with_canary,
+                                            domain_resolution_order):
+    """
+    Test that when using domain_resolution_order the user won't be using
+    its fully-qualified name.
+    """
+    check_user(USER1)


### PR DESCRIPTION
    As we're enforcing the output of files provider to be fully-qualified we
    can face some weirdness when using domain_resolution_order as:
    [user@implicit_files@machine]$

    This is not only not coherent but also causes issues when the local
    user, which is managed by the files provider, tries to do a `sudo su`.
    In this scenario, the user is asked by the password (doesn't matter
    whether it's part of sudoers) and never is allowed to log-in.

    In order to avoid the issues described above, let's just not force the
    output of the files provider to be fully-qualified.

    NOTE: I do not understand clearly why the issue with sudo happens.
