### PR TITLE
selinux_child: workaround fqnames when using DRO

### DIFF
--- a/src/providers/ipa/selinux_child.c
+++ b/src/providers/ipa/selinux_child.c
@@ -165,21 +165,23 @@ static int sc_set_seuser(const char *login_name, const char *seuser_name,
     return ret;
 }
 
-static bool seuser_needs_update(struct input_buffer *ibuf)
+static bool seuser_needs_update(const char *username,
+                                const char *seuser,
+                                const char *mls_range)
 {
     bool needs_update = true;
     char *db_seuser = NULL;
     char *db_mls_range = NULL;
     errno_t ret;
 
-    ret = sss_get_seuser(ibuf->username, &db_seuser, &db_mls_range);
+    ret = sss_get_seuser(username, &db_seuser, &db_mls_range);
     DEBUG(SSSDBG_TRACE_INTERNAL,
           "getseuserbyname: ret: %d seuser: %s mls: %s\n",
           ret, db_seuser ? db_seuser : "unknown",
           db_mls_range ? db_mls_range : "unknown");
     if (ret == EOK && db_seuser && db_mls_range &&
-            strcmp(db_seuser, ibuf->seuser) == 0 &&
-            strcmp(db_mls_range, ibuf->mls_range) == 0) {
+            strcmp(db_seuser, seuser) == 0 &&
+            strcmp(db_mls_range, mls_range) == 0) {
         needs_update = false;
     }
     /* OR */
@@ -203,8 +205,10 @@ int main(int argc, const char *argv[])
     ssize_t len = 0;
     struct input_buffer *ibuf = NULL;
     struct response *resp = NULL;
+    struct passwd *passwd = NULL;
     ssize_t written;
     bool needs_update;
+    const char *username;
     const char *opt_logger = NULL;
 
     struct poptOption long_options[] = {
@@ -345,9 +349,28 @@ int main(int argc, const char *argv[])
 
     DEBUG(SSSDBG_TRACE_FUNC, "performing selinux operations\n");
 
-    needs_update = seuser_needs_update(ibuf);
+    /* When using domain_resolution_order the username will always be
+     * fully-qualified, what has been causing some SELinux issues as mappings
+     * for user 'admin' are not applied for 'admin@ipa.example'.
+     *
+     * In order to work this around we can take advantage that selinux_child
+     * queries SSSD since commit 92addd7ba and call getpwnam() in order to get
+     * the username in the correct format. */
+    passwd = getpwnam(ibuf->username);
+    if (passwd == NULL) {
+        username = ibuf->username;
+        DEBUG(SSSDBG_MINOR_FAILURE,
+              "getpwnam() failed to get info for the user \"%s\". SELinux label "
+              "setting might fail as well!\n",
+              ibuf->username);
+    } else {
+        username = passwd->pw_name;
+    }
+
+    needs_update = seuser_needs_update(username, ibuf->seuser,
+                                       ibuf->mls_range);
     if (needs_update == true) {
-        ret = sc_set_seuser(ibuf->username, ibuf->seuser, ibuf->mls_range);
+        ret = sc_set_seuser(username, ibuf->seuser, ibuf->mls_range);
         if (ret != EOK) {
             DEBUG(SSSDBG_CRIT_FAILURE, "Cannot set SELinux login context.\n");
             goto fail;


### PR DESCRIPTION
Although there was a comment saying that pam_selinux needs the username
in the same format getpwnam() would return it, it doesn't seem to be
the case anymore.

Just using fqname from selinux_child_setup allows us to have the
expected results.

One difference that I've spotted while doing this patch (which may or
may not be an issue) is that without this patch the output of `semanage
login --list` was always (with or without domain_resolution_order set):
[root@client1 x86_64]# semanage login --list

Login Name           SELinux User         MLS/MCS Range        Service

__default__          unconfined_u         s0-s0:c0.c1023       *
admin                staff_u              s0-s0:c0.c1023       *
root                 unconfined_u         s0-s0:c0.c1023       *

While now I can see:
[root@client1 x86_64]# semanage login --list

Login Name           SELinux User         MLS/MCS Range        Service

__default__          unconfined_u         s0-s0:c0.c1023       *
admin                staff_u              s0-s0:c0.c1023       *
admin@ipa.example    staff_u              s0-s0:c0.c1023       *
root                 unconfined_u         s0-s0:c0.c1023       *

Resolves:
https://pagure.io/SSSD/sssd/issue/3740

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>

NOTE: While I still have to run downstream tests to be sure it won't introduce regressions (although, it didn't in the very simple test that I've performed) ... I'd appreciate a review (even before the results of the tests) in order to have an early understanding of whether this is a valid approach or not.