### PR TITLE
proxy: proxy_child hardening

### DIFF
--- a/src/providers/proxy/proxy_child.c
+++ b/src/providers/proxy/proxy_child.c
@@ -530,6 +530,10 @@ int main(int argc, const char *argv[])
     /* Set debug level to invalid value so we can decide if -d 0 was used. */
     debug_level = SSSDBG_INVALID;
 
+    chdir("/");
+    clearenv();
+    umask(022);
+
     pc = poptGetContext(argv[0], argc, argv, long_options, 0);
     while((opt = poptGetNextOpt(pc)) != -1) {
         switch(opt) {


### PR DESCRIPTION
proxy_child will call chdir("/"), umask(022)
and reset the environment with clearenv().

The --domain argument to be sanitized.

Resolves: https://pagure.io/SSSD/sssd/issue/2689