### PR TITLE
Revert "CACHE_REQ: Don't force a fqname for files provider' output"

### DIFF
--- a/src/responder/common/cache_req/cache_req_domain.c
+++ b/src/responder/common/cache_req/cache_req_domain.c
@@ -170,17 +170,11 @@ cache_req_domain_new_list_from_string_list(TALLOC_CTX *mem_ctx,
                 cr_domain->fqnames =
                     cache_req_domain_use_fqnames(dom, enforce_non_fqnames);
 
-                /* When using the domain resolution order, using shortnames as
+                /* when using the domain resolution order, using shortnames as
                  * input is allowed by default. However, we really want to use
                  * the fully qualified name as output in order to avoid
-                 * conflicts whith users who have the very same name.
-                 *
-                 * NOTE: we do *not* want to use fully qualified names for the
-                 * files provider.*/
-                if (strcmp(cr_domain->domain->provider, "files") != 0) {
-                    sss_domain_info_set_output_fqnames(cr_domain->domain,
-                                                       true);
-                }
+                 * conflicts whith users who have the very same name. */
+                sss_domain_info_set_output_fqnames(cr_domain->domain, true);
 
                 DLIST_ADD_END(cr_domains, cr_domain,
                               struct cache_req_domain *);


### PR DESCRIPTION
This reverts commit d5c3070c3dd8664b23999f003adc7fd170d19f20.

The patch was pushed by mistake and should not be kept nor be part of
our tree.

Please, mind that we have a similar patch to this one which was reviewed and pushed. That one can be kept.