### PR TITLE
ipa: MPG realted fixes for lookups by GID

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -781,6 +781,12 @@ int sysdb_getgrgid(TALLOC_CTX *mem_ctx,
                    gid_t gid,
                    struct ldb_result **res);
 
+int sysdb_getgrgid_attrs(TALLOC_CTX *mem_ctx,
+                         struct sss_domain_info *domain,
+                         gid_t gid,
+                         const char **attrs,
+                         struct ldb_result **res);
+
 int sysdb_enumgrent(TALLOC_CTX *mem_ctx,
                     struct sss_domain_info *domain,
                     struct ldb_result **res);

--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -753,6 +753,9 @@ int sysdb_search_group_by_name(TALLOC_CTX *mem_ctx,
     return sysdb_search_by_name(mem_ctx, domain, name, SYSDB_GROUP, attrs, msg);
 }
 
+/* Please note that sysdb_search_group_by_gid() is not aware of MPGs. If MPG
+ * support is needed either the caller must handle it or sysdb_getgrgid() or
+ * sysdb_getgrgid_attrs() should be used. */
 int sysdb_search_group_by_gid(TALLOC_CTX *mem_ctx,
                               struct sss_domain_info *domain,
                               gid_t gid,

--- a/src/providers/ad/ad_common.c
+++ b/src/providers/ad/ad_common.c
@@ -1395,6 +1395,7 @@ ad_gc_conn_list(TALLOC_CTX *mem_ctx, struct ad_id_ctx *ad_ctx,
     if (dp_opt_get_bool(ad_ctx->ad_options->basic, AD_ENABLE_GC)) {
         clist[cindex] = ad_ctx->gc_ctx;
         clist[cindex]->ignore_mark_offline = true;
+        clist[cindex]->no_mpg_user_fallback = true;
         cindex++;
     }
 

--- a/src/providers/ipa/ipa_subdomains_id.c
+++ b/src/providers/ipa/ipa_subdomains_id.c
@@ -1108,7 +1108,14 @@ errno_t get_object_from_cache(TALLOC_CTX *mem_ctx,
 
         switch (ar->entry_type & BE_REQ_TYPE_MASK) {
         case BE_REQ_GROUP:
-            ret = sysdb_search_group_by_gid(mem_ctx, dom, id, attrs, &msg);
+            ret = sysdb_getgrgid_attrs(mem_ctx, dom, id, attrs, &res);
+            if (ret == EOK) {
+                if (res->count == 0) {
+                    ret = ENOENT;
+                } else {
+                    msg = res->msgs[0];
+                }
+            }
             break;
         case BE_REQ_INITGROUPS:
         case BE_REQ_USER:
@@ -1116,7 +1123,14 @@ errno_t get_object_from_cache(TALLOC_CTX *mem_ctx,
             ret = sysdb_search_user_by_uid(mem_ctx, dom, id, attrs, &msg);
             if (ret == ENOENT && (ar->entry_type & BE_REQ_TYPE_MASK)
                                                      == BE_REQ_USER_AND_GROUP) {
-                ret = sysdb_search_group_by_gid(mem_ctx, dom, id, attrs, &msg);
+                ret = sysdb_getgrgid_attrs(mem_ctx, dom, id, attrs, &res);
+                if (ret == EOK) {
+                    if (res->count == 0) {
+                        ret = ENOENT;
+                    } else {
+                        msg = res->msgs[0];
+                    }
+                }
             }
             break;
         default:

--- a/src/providers/ipa/ipa_subdomains_id.c
+++ b/src/providers/ipa/ipa_subdomains_id.c
@@ -973,9 +973,16 @@ apply_subdomain_homedir(TALLOC_CTX *mem_ctx, struct sss_domain_info *dom,
         goto done;
     }
 
+    /* The object is a user if SYSDB_OBJECTCATEGORY is SYSDB_USER_CLASS or in
+     * case of a MPG group lookup if SYSDB_OBJECTCATEGORY is SYSDB_GROUP_CLASS.
+     */
     for (c = 0; c < msg_el->num_values; c++) {
         if (strncmp(SYSDB_USER_CLASS, (const char *)msg_el->values[c].data,
-                    msg_el->values[c].length) == 0) {
+                    msg_el->values[c].length) == 0
+                || (dom->mpg
+                    && strncmp(SYSDB_GROUP_CLASS,
+                               (const char *)msg_el->values[c].data,
+                               msg_el->values[c].length) == 0)) {
             break;
         }
     }

--- a/src/providers/ldap/ldap_common.h
+++ b/src/providers/ldap/ldap_common.h
@@ -57,6 +57,8 @@ struct sdap_id_conn_ctx {
     struct sdap_id_conn_ctx *prev, *next;
     /* do not go offline, try another connection */
     bool ignore_mark_offline;
+    /* do not fall back to user lookups for mpg domains on this connection */
+    bool no_mpg_user_fallback;
 };
 
 struct sdap_id_ctx {

--- a/src/providers/ldap/ldap_id.c
+++ b/src/providers/ldap/ldap_id.c
@@ -1076,7 +1076,8 @@ static void groups_get_done(struct tevent_req *subreq)
     }
 
     if (ret == ENOENT
-            && state->domain->mpg == true) {
+            && state->domain->mpg == true
+            && !state->conn->no_mpg_user_fallback) {
         /* The requested filter did not find a group. Before giving up, we must
          * also check if the GID can be resolved through a primary group of a
          * user


### PR DESCRIPTION
There are a few issues when a trusted AD user with an expired cache entry is
indirectly looked up be a GID lookup for the primary user private group (mpg).

One if the issues was that sysdb_search_group_by_gid() is not aware of MPGs in
contrast to sysdb_search_group_by_name(). Since sysdb_search_group_by_gid() is
used at other places as well I added sysdb_getgrgid_attrs() to replace
sysdb_search_group_by_gid() in get_object_from_cache() instead of modifying to
avoid regressions in the other callers. Maybe it would be worth a ticket to
check if MPG support can be added safely to sysdb_search_group_by_gid().

Related to https://pagure.io/SSSD/sssd/issue/3748