### PR TITLE
sudo/sysdb regressions

### DIFF
--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -3430,7 +3430,12 @@ int sysdb_store_custom(struct sss_domain_info *domain,
                        struct sysdb_attrs *attrs)
 {
     TALLOC_CTX *tmp_ctx;
+    const char *search_attrs[] = { "*", NULL };
+    size_t resp_count = 0;
+    struct ldb_message **resp;
     struct ldb_message *msg;
+    struct ldb_message_element *el;
+    bool add_object = false;
     int ret;
     int i;
 
@@ -3449,10 +3454,15 @@ int sysdb_store_custom(struct sss_domain_info *domain,
         goto done;
     }
 
-    /* Always add a new object. */
-    ret = sysdb_delete_custom(domain, object_name, subtree_name);
-    if (ret != EOK) {
+    ret = sysdb_search_custom_by_name(tmp_ctx, domain,
+                                      object_name, subtree_name,
+                                      search_attrs, &resp_count, &resp);
+    if (ret != EOK && ret != ENOENT) {
         goto done;
+    }
+
+    if (ret == ENOENT) {
+       add_object = true;
     }
 
     msg = ldb_msg_new(tmp_ctx);
@@ -3476,11 +3486,24 @@ int sysdb_store_custom(struct sss_domain_info *domain,
 
     for (i = 0; i < attrs->num; i++) {
         msg->elements[i] = attrs->a[i];
-        msg->elements[i].flags = LDB_FLAG_MOD_ADD;
+        if (add_object) {
+            msg->elements[i].flags = LDB_FLAG_MOD_ADD;
+        } else {
+            el = ldb_msg_find_element(resp[0], attrs->a[i].name);
+            if (el == NULL) {
+                msg->elements[i].flags = LDB_FLAG_MOD_ADD;
+            } else {
+                msg->elements[i].flags = LDB_FLAG_MOD_REPLACE;
+            }
+        }
     }
     msg->num_elements = attrs->num;
 
-    ret = ldb_add(domain->sysdb->ldb, msg);
+    if (add_object) {
+        ret = ldb_add(domain->sysdb->ldb, msg);
+    } else {
+        ret = ldb_modify(domain->sysdb->ldb, msg);
+    }
     if (ret != LDB_SUCCESS) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Failed to store custom entry: %s(%d)[%s]\n",
                   ldb_strerror(ret), ret, ldb_errstring(domain->sysdb->ldb));

--- a/src/db/sysdb_sudo.c
+++ b/src/db/sysdb_sudo.c
@@ -956,6 +956,14 @@ sysdb_sudo_store_rule(struct sss_domain_info *domain,
         return ret;
     }
 
+    /* Always delete the old rule and add a new one */
+    ret = sysdb_delete_custom(domain, name, SUDORULE_SUBDIR);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "Unable to delete the old rule %s [%d]: %s\n",
+              name, ret, strerror(ret));
+        return ret;
+    }
+
     ret = sysdb_store_custom(domain, name, SUDORULE_SUBDIR, rule);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "Unable to store rule %s [%d]: %s\n",

--- a/src/providers/ldap/sdap_async_sudo.c
+++ b/src/providers/ldap/sdap_async_sudo.c
@@ -161,7 +161,7 @@ static char *sdap_sudo_build_host_filter(TALLOC_CTX *mem_ctx,
     /* sudoHost is not specified and it is a cn=defaults rule */
     filter = talloc_asprintf_append_buffer(filter, "(&(!(%s=*))(%s=defaults))",
                                            map[SDAP_AT_SUDO_HOST].name,
-                                           map[SDAP_AT_SUDO_HOST].name);
+                                           map[SDAP_AT_SUDO_NAME].name);
     if (filter == NULL) {
         goto done;
     }


### PR DESCRIPTION
This patch set consists in 3 patches:
- sudo_ldap: fix sudoHost=defaults -> cn=defaults: this is a typo that caused https://pagure.io/SSSD/sssd/issue/3742
- Revert "sysdb custom: completely replace old object instead of merging it": this one caused https://pagure.io/SSSD/sssd/issue/3733
- sysdb_sudo: completely replace old object instead of merging it: As far as I understand, the idea behind cd4590de was to never merged sudo rules. Instead, delete the old one and add the new one. However, doing this all over place caused the regression mentioned above. I've checked the other patches that leaded to this one and seems that keeping the "delete the old one and add the new one" approach may be the cleaner possible way.

@pbrezina, may I ask you to (re)test https://pagure.io/SSSD/sssd/issue/3558 in order to be sure that I won't be adding regressions while trying to fix regressions? Also, I do believe this approach is cleaner than adding a new boolean flag in sysdb_store_custom(), do you agree?