### PR TITLE
man: Add FILES as a valid config option for 'id_provider'

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2054,11 +2054,19 @@ pam_account_locked_message = Account locked, please contact help desk.
                             Supported ID providers are:
                         </para>
                         <para>
-                            <quote>proxy</quote>: Support a legacy NSS provider
+                            <quote>proxy</quote>: Support a legacy NSS provider.
                         </para>
                         <para>
                             <quote>local</quote>: SSSD internal provider for
-                            local users
+                            local users (DEPRECATED).
+                        </para>
+                        <para>
+                            <quote>files</quote>: FILES provider. See
+                            <citerefentry>
+                                <refentrytitle>sssd-files</refentrytitle>
+                                <manvolnum>5</manvolnum>
+                            </citerefentry> for more information on
+                            how to mirror local users and groups into SSSD.
                         </para>
                         <para>
                             <quote>ldap</quote>:  LDAP provider. See


### PR DESCRIPTION
The 'id_provider' config option can now also take 'files' as a valid value.
This should be mentioned in man 5 sssd.conf. With this change we are also
going to deprecate the 'id_provider = local' setting.

Resolves:
https://pagure.io/SSSD/sssd/issue/3749