### PR TITLE
SSH: Do not exit abruptly if SSHD closes its end of the pipe before reading all the SSH keys

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -331,6 +331,7 @@ endif   # HAVE_CMOCKA
 check_PROGRAMS = \
     stress-tests \
     krb5-child-test \
+    test_ssh_client \
     $(non_interactive_cmocka_based_tests) \
     $(non_interactive_check_based_tests)
 
@@ -2291,6 +2292,18 @@ krb5_child_test_LDADD = \
     $(SSSD_INTERNAL_LTLIBS) \
     libsss_test_common.la
 
+test_ssh_client_SOURCES = \
+    src/tests/test_ssh_client.c \
+    $(NULL)
+test_ssh_client_CFLAGS = \
+    $(AM_CFLAGS) \
+    -DSSH_CLIENT_DIR=\"$(abs_top_builddir)\" \
+    $(NULL)
+test_ssh_client_LDADD = \
+    $(SSSD_INTERNAL_LTLIBS) \
+    $(SSSD_LIBS) \
+    $(NULL)
+
 if BUILD_DBUS_TESTS
 
 sbus_tests_SOURCES = \
@@ -3446,7 +3459,6 @@ test_iobuf_LDADD = \
     $(SSSD_LIBS) \
     $(NULL)
 
-
 EXTRA_simple_access_tests_DEPENDENCIES = \
     $(ldblib_LTLIBRARIES)
 simple_access_tests_SOURCES = \
@@ -3655,6 +3667,7 @@ intgcheck-prepare:
 	    $(INTGCHECK_CONFIGURE_FLAGS) \
 	    CFLAGS="-O2 -g $$CFLAGS -DKCM_PEER_UID=$$(id -u)"; \
 	$(MAKE) $(AM_MAKEFLAGS) ; \
+	$(MAKE) $(AM_MAKEFLAGS) test_ssh_client; \
 	: Force single-thread install to workaround concurrency issues; \
 	$(MAKE) $(AM_MAKEFLAGS) -j1 install; \
 	: Remove .la files from LDB module directory to avoid loader warnings; \

--- a/src/sss_client/ssh/sss_ssh_authorizedkeys.c
+++ b/src/sss_client/ssh/sss_ssh_authorizedkeys.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <talloc.h>
 #include <popt.h>
+#include <signal.h>
 
 #include "util/util.h"
 #include "util/crypto/sss_crypto.h"
@@ -99,8 +100,16 @@ int main(int argc, const char **argv)
         goto fini;
     }
 
+    /* if sshd closes its end of the pipe, we don't want sss_ssh_authorizedkeys
+     * to exit abruptly, but to finish gracefully instead because the valid
+     * key can be present in the data already written
+     */
+    signal(SIGPIPE, SIG_IGN);
+
     /* print results */
     for (i = 0; i < ent->num_pubkeys; i++) {
+        char *repr_break = NULL;
+
         ret = sss_ssh_format_pubkey(mem_ctx, &ent->pubkeys[i], &repr);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE,
@@ -109,7 +118,31 @@ int main(int argc, const char **argv)
             continue;
         }
 
-        printf("%s\n", repr);
+        /* OpenSSH expects a linebreak after each key */
+        repr_break = talloc_asprintf(mem_ctx, "%s\n", repr);
+        talloc_zfree(repr);
+        if (repr_break == NULL) {
+            ret = ENOMEM;
+            goto fini;
+        }
+
+        ret = sss_atomic_write_s(STDOUT_FILENO, repr_break, strlen(repr_break));
+        /* Avoid spiking memory with too many large keys */
+        talloc_zfree(repr_break);
+        if (ret < 0) {
+            ret = errno;
+            if (ret == EPIPE) {
+                DEBUG(SSSDBG_MINOR_FAILURE,
+                      "SSHD closed the pipe before all keys could be written\n");
+                /* Return 0 so that openssh doesn't abort pubkey auth */
+                ret = 0;
+                goto fini;
+            }
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "sss_atomic_write_s() failed (%d): %s\n",
+                  ret, strerror(ret));
+            goto fini;
+        }
     }
 
     ret = EXIT_SUCCESS;

--- a/src/tests/intg/Makefile.am
+++ b/src/tests/intg/Makefile.am
@@ -36,6 +36,7 @@ dist_noinst_DATA = \
     data/ad_schema.ldif \
     test_pysss_nss_idmap.py \
     test_infopipe.py \
+    test_ssh_pubkey.py \
     $(NULL)
 
 EXTRA_DIST = data/cwrap-dbus-system.conf.in

--- a/src/tests/intg/data/ssh_schema.ldif
+++ b/src/tests/intg/data/ssh_schema.ldif
@@ -1,0 +1,11 @@
+dn: cn=openssh-lpk,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: openssh-lpk
+olcAttributeTypes: ( 1.3.6.1.4.1.24552.500.1.1.1.13 NAME 'sshPublicKey'
+  DESC 'MANDATORY: OpenSSH Public key'
+  EQUALITY octetStringMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 )
+olcObjectClasses: ( 1.3.6.1.4.1.24552.500.1.1.2.0 NAME 'ldapPublicKey' SUP top AUXILIARY
+  DESC 'MANDATORY: OpenSSH LPK objectclass'
+  MAY ( sshPublicKey $ uid )
+  )

--- a/src/tests/intg/ds_openldap.py
+++ b/src/tests/intg/ds_openldap.py
@@ -186,6 +186,12 @@ class DSOpenLDAP(DS):
         db_config_file.write(db_config)
         db_config_file.close()
 
+        # Import ad schema
+        subprocess.check_call(
+            ["slapadd", "-F", self.conf_slapd_d_dir, "-b", "cn=config",
+             "-l", "data/ssh_schema.ldif"],
+        )
+
     def _start_daemon(self):
         """Start the instance."""
         if subprocess.call(["slapd", "-F", self.conf_slapd_d_dir,

--- a/src/tests/intg/ldap_ent.py
+++ b/src/tests/intg/ldap_ent.py
@@ -24,7 +24,8 @@ def user(base_dn, uid, uidNumber, gidNumber,
          homeDirectory=None,
          loginShell=None,
          cn=None,
-         sn=None):
+         sn=None,
+         sshPubKey=()):
     """
     Generate an RFC2307(bis) user add-modlist for passing to ldap.add*
     """
@@ -33,7 +34,8 @@ def user(base_dn, uid, uidNumber, gidNumber,
     user = (
         "uid=" + uid + ",ou=Users," + base_dn,
         [
-            ('objectClass', [b'top', b'inetOrgPerson', b'posixAccount']),
+            ('objectClass', [b'top', b'inetOrgPerson',
+                             b'posixAccount', b'ldapPublicKey']),
             ('cn', [uidNumber if cn is None else cn.encode('utf-8')]),
             ('sn', [b'User' if sn is None else sn.encode('utf-8')]),
             ('uidNumber', [uidNumber]),
@@ -51,6 +53,9 @@ def user(base_dn, uid, uidNumber, gidNumber,
     )
     if gecos is not None:
         user[1].append(('gecos', [gecos.encode('utf-8')]))
+    if len(sshPubKey) > 0:
+        pubkeys = [key.encode('utf-8') for key in sshPubKey]
+        user[1].append(('sshPublicKey', pubkeys))
     return user
 
 
@@ -118,7 +123,8 @@ class List(list):
                  homeDirectory=None,
                  loginShell=None,
                  cn=None,
-                 sn=None):
+                 sn=None,
+                 sshPubKey=()):
         """Add an RFC2307(bis) user add-modlist."""
         self.append(user(base_dn or self.base_dn,
                          uid, uidNumber, gidNumber,
@@ -127,7 +133,8 @@ class List(list):
                          homeDirectory=homeDirectory,
                          loginShell=loginShell,
                          cn=cn,
-                         sn=sn))
+                         sn=sn,
+                         sshPubKey=sshPubKey))
 
     def add_group(self, cn, gidNumber, member_uids=[],
                   base_dn=None):

--- a/src/tests/intg/test_ssh_pubkey.py
+++ b/src/tests/intg/test_ssh_pubkey.py
@@ -1,0 +1,232 @@
+#
+# ssh public key integration test
+#
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 only
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import os
+import stat
+import signal
+import subprocess
+import time
+import ldap
+import ldap.modlist
+import pytest
+
+import config
+import ds_openldap
+import ent
+import ldap_ent
+from util import unindent, get_call_output
+
+LDAP_BASE_DN = "dc=example,dc=com"
+
+USER1_PUBKEY1 = "ssh-dss AAAAB3NzaC1kc3MAAACBAPMkvcU53RVhBtjwiC3IqeRIWR9Qwdv8\
+DmZzEsDD3Csd6jYxMsPZoXcPrHqwYcEj1s5MVqhdSFS0Cjz13e7gO6OMLInO3xMBSSFHjfp9RE1H\
+pgc4WisazzyJaW9EMkQo/DqvkFkKh31oqAmxcSbLAFJRg4TTIqm18qu8IRKS6m/RAAAAFQC97TA5\
+JSsMsaX1bRszC7y4PhMBvQAAAIEAt9Yo9v/h9W4nDbzUdkGwNRszlPEK+T12bJv0O9Fk6subD3Do\
+6A4Qru/Nr6voXoq8b018Wb7iFWvKOoz5uT/plWBKLXL2NN7ovTR+dUJIzvwurQZroukmU1EghNey\
+lkSHmDlxSoMK6Nh21uGu6l+b6x5pXNaZHMpsywG4kY8SoC0AAACAAWLHneEGvqkYA8La4Eob+Hjj\
+mAKilx8byxm3Kfb1XO+ZrR6XxadofZOaUYRMpPKgFjKAKPxJftPLiDjWM7lSe6h8df0dUMLVXt6m\
+eA83kE0uK5JOOGJfJDqmRed2YnfxUDNNFQGT4xFWGrNtYNbGyw9BWKbkooAsLqaO04zP3Rs= \
+user1@LDAP"
+
+USER1_PUBKEY2 = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAwHUUF3HPH+DkU6j8k7Q1wHG\
+RJY9NeLqSav3h95mTSCQYPSC7I9RTJ4OORgqCbEzrP/DYrrn4TtQ9dhRJar3ZY+F36SH5yFIXORb\
+lAIbFU+/anahBuFS9vHi1MqFPckGmwJ4QCpjQhdYxo1ro0e1RuGSaQNp/w9N6S/fDz4Cj4I99xDz\
+SeQeGHxYv0e60plQ8dUajmnaGmYRJHF9a6Ban7IWySActCja7eQP2zIRXEZMpuhl1E0U4y+gHTFI\
+gD3zQai3QrXm8RUrQURIJ0u6BlGS910OPbHqLpLTFWG08L8sNUcYzC+DY6yoCSO0n/Df3pVRS4C9\
+5Krf3FqppMTjdfQ== user1@LDAP"
+
+
+@pytest.fixture(scope="module")
+def ds_inst(request):
+    """LDAP server instance fixture"""
+    ds_inst = ds_openldap.DSOpenLDAP(
+        config.PREFIX, 10389, LDAP_BASE_DN,
+        "cn=admin", "Secret123"
+    )
+
+    try:
+        ds_inst.setup()
+    except:
+        ds_inst.teardown()
+        raise
+    request.addfinalizer(ds_inst.teardown)
+    return ds_inst
+
+
+@pytest.fixture(scope="module")
+def ldap_conn(request, ds_inst):
+    """LDAP server connection fixture"""
+    ldap_conn = ds_inst.bind()
+    ldap_conn.ds_inst = ds_inst
+    request.addfinalizer(ldap_conn.unbind_s)
+    return ldap_conn
+
+
+def create_ldap_entries(ldap_conn, ent_list=None):
+    """Add LDAP entries from ent_list"""
+    if ent_list is not None:
+        for entry in ent_list:
+            ldap_conn.add_s(entry[0], entry[1])
+
+
+def cleanup_ldap_entries(ldap_conn, ent_list=None):
+    """Remove LDAP entries added by create_ldap_entries"""
+    if ent_list is None:
+        for ou in ("Users", "Groups", "Netgroups", "Services", "Policies"):
+            for entry in ldap_conn.search_s("ou=" + ou + "," +
+                                            ldap_conn.ds_inst.base_dn,
+                                            ldap.SCOPE_ONELEVEL,
+                                            attrlist=[]):
+                ldap_conn.delete_s(entry[0])
+    else:
+        for entry in ent_list:
+            ldap_conn.delete_s(entry[0])
+
+
+def create_ldap_cleanup(request, ldap_conn, ent_list=None):
+    """Add teardown for removing all user/group LDAP entries"""
+    request.addfinalizer(lambda: cleanup_ldap_entries(ldap_conn, ent_list))
+
+
+def create_ldap_fixture(request, ldap_conn, ent_list=None):
+    """Add LDAP entries and add teardown for removing them"""
+    create_ldap_entries(ldap_conn, ent_list)
+    create_ldap_cleanup(request, ldap_conn, ent_list)
+
+
+SCHEMA_RFC2307_BIS = "rfc2307bis"
+
+
+def format_basic_conf(ldap_conn, schema):
+    """Format a basic SSSD configuration"""
+    schema_conf = "ldap_schema         = " + schema + "\n"
+    schema_conf += "ldap_group_object_class = groupOfNames\n"
+    return unindent("""\
+        [sssd]
+        domains             = LDAP
+        services            = nss, ssh
+
+        [nss]
+
+        [ssh]
+        debug_level=10
+
+        [domain/LDAP]
+        {schema_conf}
+        id_provider         = ldap
+        auth_provider       = ldap
+        ldap_uri            = {ldap_conn.ds_inst.ldap_url}
+        ldap_search_base    = {ldap_conn.ds_inst.base_dn}
+        ldap_sudo_use_host_filter = false
+        debug_level=10
+    """).format(**locals())
+
+
+def create_conf_file(contents):
+    """Create sssd.conf with specified contents"""
+    conf = open(config.CONF_PATH, "w")
+    conf.write(contents)
+    conf.close()
+    os.chmod(config.CONF_PATH, stat.S_IRUSR | stat.S_IWUSR)
+
+
+def cleanup_conf_file():
+    """Remove sssd.conf, if it exists"""
+    if os.path.lexists(config.CONF_PATH):
+        os.unlink(config.CONF_PATH)
+
+
+def create_conf_cleanup(request):
+    """Add teardown for removing sssd.conf"""
+    request.addfinalizer(cleanup_conf_file)
+
+
+def create_conf_fixture(request, contents):
+    """
+    Create sssd.conf with specified contents and add teardown for removing it
+    """
+    create_conf_file(contents)
+    create_conf_cleanup(request)
+
+
+def create_sssd_process():
+    """Start the SSSD process"""
+    if subprocess.call(["sssd", "-D", "-f"]) != 0:
+        raise Exception("sssd start failed")
+
+
+def get_sssd_pid():
+    pid_file = open(config.PIDFILE_PATH, "r")
+    pid = int(pid_file.read())
+    return pid
+
+
+def cleanup_sssd_process():
+    """Stop the SSSD process and remove its state"""
+    try:
+        pid = get_sssd_pid()
+        os.kill(pid, signal.SIGTERM)
+        while True:
+            try:
+                os.kill(pid, signal.SIGCONT)
+            except:
+                break
+            time.sleep(1)
+    except:
+        pass
+    for path in os.listdir(config.DB_PATH):
+        os.unlink(config.DB_PATH + "/" + path)
+    for path in os.listdir(config.MCACHE_PATH):
+        os.unlink(config.MCACHE_PATH + "/" + path)
+
+
+def create_sssd_fixture(request):
+    """Start SSSD and add teardown for stopping it and removing its state"""
+    create_sssd_process()
+    create_sssd_cleanup(request)
+
+
+def create_sssd_cleanup(request):
+    """Add teardown for stopping SSSD and removing its state"""
+    request.addfinalizer(cleanup_sssd_process)
+
+
+@pytest.fixture
+def add_user_with_ssh_key(request, ldap_conn):
+    ent_list = ldap_ent.List(ldap_conn.ds_inst.base_dn)
+    ent_list.add_user("user1", 1001, 2001,
+                      sshPubKey=(USER1_PUBKEY1, USER1_PUBKEY2))
+    ent_list.add_user("user2", 1002, 2001)
+    create_ldap_fixture(request, ldap_conn, ent_list)
+
+    conf = format_basic_conf(ldap_conn, SCHEMA_RFC2307_BIS)
+    create_conf_fixture(request, conf)
+    create_sssd_fixture(request)
+    return None
+
+
+def test_ssh_pubkey_retrieve(add_user_with_ssh_key):
+    """
+    Test that we can retrieve an SSH public key for a user who has one
+    and can't retrieve a key for a user who does not have one.
+    """
+    sshpubkey = get_call_output(["sss_ssh_authorizedkeys", "user1"])
+    assert sshpubkey == USER1_PUBKEY1 + '\n' + USER1_PUBKEY2 + '\n'
+
+    sshpubkey = get_call_output(["sss_ssh_authorizedkeys", "user2"])
+    assert len(sshpubkey) == 0

--- a/src/tests/test_ssh_client.c
+++ b/src/tests/test_ssh_client.c
@@ -1,0 +1,133 @@
+/*
+    Copyright (C) 2018 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <popt.h>
+#include <sys/wait.h>
+#include "util/util.h"
+
+#ifdef SSH_CLIENT_DIR
+#define SSH_AK_CLIENT_PATH SSH_CLIENT_DIR"/sss_ssh_authorizedkeys"
+#else
+#error "The path to the ssh authorizedkeys helper is not defined"
+#endif /* SSH_CLIENT_DIR */
+
+int main(int argc, const char *argv[])
+{
+    poptContext pc;
+    int opt;
+    struct poptOption long_options[] = {
+        POPT_AUTOHELP
+        SSSD_DEBUG_OPTS
+        POPT_TABLEEND
+    };
+    struct stat sb;
+    int ret;
+    int status;
+    int p[2];
+    pid_t pid;
+    const char *pc_user = NULL;
+    char *av[3];
+    char buf[5]; /* Ridiculously small buffer by design */
+
+    /* Set debug level to invalid value so we can decide if -d 0 was used. */
+    debug_level = SSSDBG_INVALID;
+
+    pc = poptGetContext(argv[0], argc, argv, long_options, 0);
+    poptSetOtherOptionHelp(pc, "USER");
+    while((opt = poptGetNextOpt(pc)) != -1) {
+        switch(opt) {
+        default:
+            fprintf(stderr, "\nInvalid option %s: %s\n\n",
+                    poptBadOption(pc, 0), poptStrerror(opt));
+            poptPrintUsage(pc, stderr, 0);
+            return 3;
+        }
+    }
+
+    pc_user = poptGetArg(pc);
+    if (pc_user == NULL) {
+        fprintf(stderr, "No user specified\n");
+        return 3;
+    }
+
+    poptFreeContext(pc);
+
+    DEBUG_CLI_INIT(debug_level);
+
+    ret = stat(SSH_AK_CLIENT_PATH, &sb);
+    if (ret != 0) {
+        ret = errno;
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Could not stat %s [%d]: %s\n",
+              SSH_AK_CLIENT_PATH, ret, strerror(ret));
+        return 3;
+    }
+
+    ret = pipe(p);
+    if (ret != 0) {
+        perror("pipe");
+        return 3;
+    }
+
+    switch (pid = fork()) {
+    case -1:
+        ret = errno;
+        close(p[0]);
+        close(p[1]);
+        DEBUG(SSSDBG_CRIT_FAILURE, "fork failed: %d\n", ret);
+        return 3;
+    case 0:
+        /* child */
+        av[0] = discard_const(SSH_AK_CLIENT_PATH);
+        av[1] = discard_const(pc_user);
+        av[2] = NULL;
+
+        close(p[0]);
+        ret = dup2(p[1], STDOUT_FILENO);
+        if (ret == -1) {
+            perror("dup2");
+            return 3;
+        }
+
+        execv(av[0], av);
+        return 3;
+    default:
+        /* parent */
+        break;
+    }
+
+    close(p[1]);
+    read(p[0], buf, sizeof(buf));
+    close(p[0]);
+
+    pid = waitpid(pid, &status, 0);
+    if (pid == -1) {
+        perror("waitpid");
+        return 3;
+    }
+
+    if (WIFEXITED(status)) {
+        printf("sss_ssh_authorizedkeys exited with return code %d\n", WEXITSTATUS(status));
+        return 0;
+    } else if (WIFSIGNALED(status)) {
+        printf("sss_ssh_authorizedkeys exited with signal %d\n", WTERMSIG(status));
+        return 1;
+    }
+
+    printf("sss_ssh_authorizedkeys exited for another reason\n");
+    return 2;
+}


### PR DESCRIPTION
Resolves: https://pagure.io/SSSD/sssd/issue/3747

Before writing the keys to sshd, ignore SIGPIPE so that if the pipe towards
the authorizedkeys helper is closed, the sss_ssh_authorizedkeys helper is
not terminated with SIGPIPE, but instead proceeds and then the write(2)
calls would non-terminally fail with EPIPE.

The other patch in this PR is not meant to be pushed. It is an easy way to
reproduce the bug. I would also like to write an integration test, but
I'm not sure if I can do that very soon and given that we try to release
in about a week I prefer to send the fix first.

In order to reproduce, load many SSH keys to a user object. I found it was
easiest to cheat during reproducing and do this:
    - first, set a long cache expire so that the cache doesn't expire
      and overwrite your local changes
    - ldbedit the cache
    - copy the ssh public key attribute and each time, change one character
      in the attribute (ldb would otherwise detect the duplicates)
    - save the ldbedit window
    - run the program from the second patch. With the sss_ssh_authorizedkeys
      patch in, the sss_ssh_authorizedkeys binary should finish gracefully,
      without the patch, it would fail with SIGPIPE.

In my testing, I needed about 30 ssh keys to reproduce the bug.