### PR TITLE
AUTOFS: remove timed event if related object is removed

### DIFF
--- a/src/responder/autofs/autofssrv_cmd.c
+++ b/src/responder/autofs/autofssrv_cmd.c
@@ -401,7 +401,7 @@ set_autofs_map_lifetime(uint32_t lifetime,
 
     tv = tevent_timeval_current_ofs(lifetime, 0);
     te = tevent_add_timer(lookup_ctx->rctx->ev,
-                          lookup_ctx->rctx, tv,
+                          map, tv,
                           autofs_map_result_timeout,
                           map);
     if (!te) {


### PR DESCRIPTION
autofs_map_result_timeout() is called as a timed event to free the autofs
map data is the cache lifetime is exceeded. If the data is freed earlier
the timed event should be removed as well to avoid a double free issue.

Since talloc is used here the most easy way to achieve this is to allocate
the timed event on the map object itself.

Resolves: https://pagure.io/SSSD/sssd/issue/3752