### PR TITLE
nss-imap: add sss_nss_getsidbyuid() and sss_nss_getsidbygid()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1175,7 +1175,7 @@ libsss_nss_idmap_la_LIBADD = \
     $(NULL)
 libsss_nss_idmap_la_LDFLAGS = \
     -Wl,--version-script,$(srcdir)/src/sss_client/idmap/sss_nss_idmap.exports \
-    -version-info 4:0:4
+    -version-info 5:0:5
 
 dist_noinst_DATA += src/sss_client/idmap/sss_nss_idmap.exports
 

--- a/src/lib/cifs_idmap_sss/cifs_idmap_sss.c
+++ b/src/lib/cifs_idmap_sss/cifs_idmap_sss.c
@@ -304,7 +304,18 @@ int cifs_idmap_ids_to_sids(void *handle, const struct cifs_uxid *cuxid,
     }
 
     for (i = 0; i < num; ++i) {
-        err = sss_nss_getsidbyid((uint32_t)cuxid[i].id.uid, &sid, &id_type);
+        switch (cuxid[i].type) {
+        case CIFS_UXID_TYPE_UID:
+            err = sss_nss_getsidbyuid((uint32_t)cuxid[i].id.uid,
+                                      &sid, &id_type);
+            break;
+        case CIFS_UXID_TYPE_GID:
+            err = sss_nss_getsidbygid((uint32_t)cuxid[i].id.gid,
+                                      &sid, &id_type);
+            break;
+        default:
+            err = sss_nss_getsidbyid((uint32_t)cuxid[i].id.uid, &sid, &id_type);
+        }
         if (err != 0)  {
             ctx_set_error(ctx, strerror(err));
             csid[i].revision = 0;

--- a/src/lib/winbind_idmap_sss/winbind_idmap_sss.c
+++ b/src/lib/winbind_idmap_sss/winbind_idmap_sss.c
@@ -85,7 +85,16 @@ static NTSTATUS idmap_sss_unixids_to_sids(struct idmap_domain *dom,
     }
 
     for (c = 0; map[c]; c++) {
-        ret = sss_nss_getsidbyid(map[c]->xid.id, &sid_str, &id_type);
+        switch (map[c]->xid.type) {
+        case ID_TYPE_UID:
+            ret = sss_nss_getsidbyuid(map[c]->xid.id, &sid_str, &id_type);
+            break;
+        case ID_TYPE_GID:
+            ret = sss_nss_getsidbygid(map[c]->xid.id, &sid_str, &id_type);
+            break;
+        default:
+            ret = sss_nss_getsidbyid(map[c]->xid.id, &sid_str, &id_type);
+        }
         if (ret != 0) {
             if (ret == ENOENT) {
                 map[c]->status = ID_UNMAPPED;

--- a/src/responder/nss/nss_cmd.c
+++ b/src/responder/nss/nss_cmd.c
@@ -1134,6 +1134,22 @@ static errno_t nss_cmd_getsidbyid(struct cli_ctx *cli_ctx)
                         SSS_MC_NONE, nss_protocol_fill_sid);
 }
 
+static errno_t nss_cmd_getsidbyuid(struct cli_ctx *cli_ctx)
+{
+    const char *attrs[] = { SYSDB_SID_STR, NULL };
+
+    return nss_getby_id(cli_ctx, false, CACHE_REQ_USER_BY_ID, attrs,
+                        SSS_MC_NONE, nss_protocol_fill_sid);
+}
+
+static errno_t nss_cmd_getsidbygid(struct cli_ctx *cli_ctx)
+{
+    const char *attrs[] = { SYSDB_SID_STR, NULL };
+
+    return nss_getby_id(cli_ctx, false, CACHE_REQ_GROUP_BY_ID, attrs,
+                        SSS_MC_NONE, nss_protocol_fill_sid);
+}
+
 static errno_t nss_cmd_getnamebysid(struct cli_ctx *cli_ctx)
 {
     return nss_getby_sid(cli_ctx, CACHE_REQ_OBJECT_BY_SID,
@@ -1225,6 +1241,8 @@ struct sss_cmd_table *get_nss_cmds(void)
         { SSS_NSS_ENDSERVENT, nss_cmd_endservent },
         { SSS_NSS_GETSIDBYNAME, nss_cmd_getsidbyname },
         { SSS_NSS_GETSIDBYID, nss_cmd_getsidbyid },
+        { SSS_NSS_GETSIDBYUID, nss_cmd_getsidbyuid },
+        { SSS_NSS_GETSIDBYGID, nss_cmd_getsidbygid },
         { SSS_NSS_GETNAMEBYSID, nss_cmd_getnamebysid },
         { SSS_NSS_GETIDBYSID, nss_cmd_getidbysid },
         { SSS_NSS_GETORIGBYNAME, nss_cmd_getorigbyname },

--- a/src/sss_client/idmap/sss_nss_idmap.c
+++ b/src/sss_client/idmap/sss_nss_idmap.c
@@ -246,6 +246,8 @@ static int sss_nss_getyyybyxxx(union input inp, enum sss_cli_command cmd,
 
         break;
     case SSS_NSS_GETSIDBYID:
+    case SSS_NSS_GETSIDBYUID:
+    case SSS_NSS_GETSIDBYGID:
         rd.len = sizeof(uint32_t);
         rd.data = &inp.id;
 
@@ -292,6 +294,8 @@ static int sss_nss_getyyybyxxx(union input inp, enum sss_cli_command cmd,
 
     switch(cmd) {
     case SSS_NSS_GETSIDBYID:
+    case SSS_NSS_GETSIDBYUID:
+    case SSS_NSS_GETSIDBYGID:
     case SSS_NSS_GETSIDBYNAME:
     case SSS_NSS_GETNAMEBYSID:
     case SSS_NSS_GETNAMEBYCERT:
@@ -412,6 +416,60 @@ int sss_nss_getsidbyid_timeout(uint32_t id, unsigned int timeout,
 int sss_nss_getsidbyid(uint32_t id, char **sid, enum sss_id_type *type)
 {
     return sss_nss_getsidbyid_timeout(id, NO_TIMEOUT, sid, type);
+}
+
+int sss_nss_getsidbyuid_timeout(uint32_t uid, unsigned int timeout,
+                                char **sid, enum sss_id_type *type)
+{
+    int ret;
+    union input inp;
+    struct output out;
+
+    if (sid == NULL) {
+        return EINVAL;
+    }
+
+    inp.id = uid;
+
+    ret = sss_nss_getyyybyxxx(inp, SSS_NSS_GETSIDBYUID, timeout, &out);
+    if (ret == EOK) {
+        *sid = out.d.str;
+        *type = out.type;
+    }
+
+    return ret;
+}
+
+int sss_nss_getsidbyuid(uint32_t uid, char **sid, enum sss_id_type *type)
+{
+    return sss_nss_getsidbyuid_timeout(uid, NO_TIMEOUT, sid, type);
+}
+
+int sss_nss_getsidbygid_timeout(uint32_t gid, unsigned int timeout,
+                                char **sid, enum sss_id_type *type)
+{
+    int ret;
+    union input inp;
+    struct output out;
+
+    if (sid == NULL) {
+        return EINVAL;
+    }
+
+    inp.id = gid;
+
+    ret = sss_nss_getyyybyxxx(inp, SSS_NSS_GETSIDBYGID, timeout, &out);
+    if (ret == EOK) {
+        *sid = out.d.str;
+        *type = out.type;
+    }
+
+    return ret;
+}
+
+int sss_nss_getsidbygid(uint32_t gid, char **sid, enum sss_id_type *type)
+{
+    return sss_nss_getsidbygid_timeout(gid, NO_TIMEOUT, sid, type);
 }
 
 int sss_nss_getnamebysid_timeout(const char *sid, unsigned int timeout,

--- a/src/sss_client/idmap/sss_nss_idmap.exports
+++ b/src/sss_client/idmap/sss_nss_idmap.exports
@@ -48,3 +48,12 @@ SSS_NSS_IDMAP_0.4.0 {
         sss_nss_getnamebycert_timeout;
         sss_nss_getlistbycert_timeout;
 } SSS_NSS_IDMAP_0.3.0;
+
+SSS_NSS_IDMAP_0.5.0 {
+    # public functions
+    global:
+        sss_nss_getsidbyuid;
+        sss_nss_getsidbyuid_timeout;
+        sss_nss_getsidbygid;
+        sss_nss_getsidbygid_timeout;
+} SSS_NSS_IDMAP_0.4.0;

--- a/src/sss_client/idmap/sss_nss_idmap.h
+++ b/src/sss_client/idmap/sss_nss_idmap.h
@@ -79,6 +79,32 @@ int sss_nss_getsidbyname(const char *fq_name, char **sid,
 int sss_nss_getsidbyid(uint32_t id, char **sid, enum sss_id_type *type);
 
 /**
+ * @brief Find SID by a POSIX UID
+ *
+ * @param[in] uid      POSIX UID
+ * @param[out] sid     String representation of the SID of the requested user,
+ *                     must be freed by the caller
+ * @param[out] type    Type of the object related to the given ID
+ *
+ * @return
+ *  - see #sss_nss_getsidbyname
+ */
+int sss_nss_getsidbyuid(uint32_t uid, char **sid, enum sss_id_type *type);
+
+/**
+ * @brief Find SID by a POSIX GID
+ *
+ * @param[in] gid      POSIX GID
+ * @param[out] sid     String representation of the SID of the requested group,
+ *                     must be freed by the caller
+ * @param[out] type    Type of the object related to the given ID
+ *
+ * @return
+ *  - see #sss_nss_getsidbyname
+ */
+int sss_nss_getsidbygid(uint32_t id, char **sid, enum sss_id_type *type);
+
+/**
  * @brief Return the fully qualified name for the given SID
  *
  * @param[in] sid      String representation of the SID
@@ -340,6 +366,36 @@ int sss_nss_getsidbyname_timeout(const char *fq_name, unsigned int timeout,
  */
 int sss_nss_getsidbyid_timeout(uint32_t id, unsigned int timeout,
                                char **sid, enum sss_id_type *type);
+/**
+ * @brief Find SID by a POSIX UID with timeout
+ *
+ * @param[in] uid      POSIX UID
+ * @param[in] timeout  timeout in milliseconds
+ * @param[out] sid     String representation of the SID of the requested user,
+ *                     must be freed by the caller
+ * @param[out] type    Type of the object related to the given ID
+ *
+ * @return
+ *  - see #sss_nss_getsidbyname_timeout
+ */
+int sss_nss_getsidbyuid_timeout(uint32_t uid, unsigned int timeout,
+                                char **sid, enum sss_id_type *type);
+
+/**
+ * @brief Find SID by a POSIX GID with timeout
+ *
+ * @param[in] gid      POSIX GID
+ * @param[in] timeout  timeout in milliseconds
+ * @param[out] sid     String representation of the SID of the requested group,
+ *                     must be freed by the caller
+ * @param[out] type    Type of the object related to the given ID
+ *
+ * @return
+ *  - see #sss_nss_getsidbyname_timeout
+ */
+int sss_nss_getsidbygid_timeout(uint32_t gid, unsigned int timeout,
+                                char **sid, enum sss_id_type *type);
+
 
 /**
  * @brief Return the fully qualified name for the given SID with timeout

--- a/src/sss_client/libwbclient/wbc_idmap_sssd.c
+++ b/src/sss_client/libwbclient/wbc_idmap_sssd.c
@@ -63,7 +63,7 @@ wbcErr wbcUidToSid(uid_t uid, struct wbcDomainSid *sid)
     enum sss_id_type type;
     wbcErr wbc_status;
 
-    ret = sss_nss_getsidbyid(uid, &str_sid, &type);
+    ret = sss_nss_getsidbyuid(uid, &str_sid, &type);
     if (ret != 0) {
         return WBC_ERR_UNKNOWN_FAILURE;
     }
@@ -127,7 +127,7 @@ wbcErr wbcGidToSid(gid_t gid, struct wbcDomainSid *sid)
     enum sss_id_type type;
     wbcErr wbc_status;
 
-    ret = sss_nss_getsidbyid(gid, &str_sid, &type);
+    ret = sss_nss_getsidbygid(gid, &str_sid, &type);
     if (ret != 0) {
         return WBC_ERR_UNKNOWN_FAILURE;
     }

--- a/src/sss_client/sss_cli.h
+++ b/src/sss_client/sss_cli.h
@@ -272,6 +272,14 @@ SSS_NSS_GETLISTBYCERT = 0x0117, /**< Takes the zero terminated string
                                      of a X509 certificate and returns a list
                                      of zero terminated fully qualified names
                                      of the related objects. */
+SSS_NSS_GETSIDBYUID   = 0x0118, /**< Takes an unsigned 32bit integer (POSIX UID)
+                                     and reurn the zero terminated string
+                                     representation of the SID of the object
+                                     with the given UID. */
+SSS_NSS_GETSIDBYGID   = 0x0119, /**< Takes an unsigned 32bit integer (POSIX GID)
+                                     and reurn the zero terminated string
+                                     representation of the SID of the object
+                                     with the given UID. */
 };
 
 /**

--- a/src/tests/intg/test_pysss_nss_idmap.py
+++ b/src/tests/intg/test_pysss_nss_idmap.py
@@ -215,6 +215,13 @@ def test_user_operations(ldap_conn, simple_ad):
     assert output[pysss_nss_idmap.TYPE_KEY] == pysss_nss_idmap.ID_USER
     assert output[pysss_nss_idmap.SID_KEY] == user_sid
 
+    output = pysss_nss_idmap.getsidbyuid(user_id)[user_id]
+    assert output[pysss_nss_idmap.TYPE_KEY] == pysss_nss_idmap.ID_USER
+    assert output[pysss_nss_idmap.SID_KEY] == user_sid
+
+    output = pysss_nss_idmap.getsidbygid(user_id)
+    assert len(output) == 0
+
     output = pysss_nss_idmap.getidbysid(user_sid)[user_sid]
     assert output[pysss_nss_idmap.TYPE_KEY] == pysss_nss_idmap.ID_USER
     assert output[pysss_nss_idmap.ID_KEY] == user_id
@@ -236,6 +243,13 @@ def test_group_operations(ldap_conn, simple_ad):
     output = pysss_nss_idmap.getsidbyid(group_id)[group_id]
     assert output[pysss_nss_idmap.TYPE_KEY] == pysss_nss_idmap.ID_GROUP
     assert output[pysss_nss_idmap.SID_KEY] == group_sid
+
+    output = pysss_nss_idmap.getsidbygid(group_id)[group_id]
+    assert output[pysss_nss_idmap.TYPE_KEY] == pysss_nss_idmap.ID_GROUP
+    assert output[pysss_nss_idmap.SID_KEY] == group_sid
+
+    output = pysss_nss_idmap.getsidbyuid(group_id)
+    assert len(output) == 0
 
     output = pysss_nss_idmap.getidbysid(group_sid)[group_sid]
     assert output[pysss_nss_idmap.TYPE_KEY] == pysss_nss_idmap.ID_GROUP
@@ -259,6 +273,13 @@ def test_case_insensitive(ldap_conn, simple_ad):
     output = pysss_nss_idmap.getsidbyid(group_id)[group_id]
     assert output[pysss_nss_idmap.TYPE_KEY] == pysss_nss_idmap.ID_GROUP
     assert output[pysss_nss_idmap.SID_KEY] == group_sid
+
+    output = pysss_nss_idmap.getsidbygid(group_id)[group_id]
+    assert output[pysss_nss_idmap.TYPE_KEY] == pysss_nss_idmap.ID_GROUP
+    assert output[pysss_nss_idmap.SID_KEY] == group_sid
+
+    output = pysss_nss_idmap.getsidbyuid(group_id)
+    assert len(output) == 0
 
     output = pysss_nss_idmap.getidbysid(group_sid)[group_sid]
     assert output[pysss_nss_idmap.TYPE_KEY] == pysss_nss_idmap.ID_GROUP


### PR DESCRIPTION
Two new calls are added to allow the caller to specify if the given POSIX
ID is a UID or a GID and the expected result is a user or a group
respectively. This is needed because on POSIX a user and a group may share
numerically the same ID value but might have different SIDs assigned.

Related to https://pagure.io/SSSD/sssd/issue/3629