### PR TITLE
sss_obuscate: Fix traceback while reading space in sssd.conf

### DIFF
--- a/src/config/SSSDConfig/ipachangeconf.py
+++ b/src/config/SSSDConfig/ipachangeconf.py
@@ -474,7 +474,7 @@ class IPAChangeConf(object):
 # An SSSD-specific subclass of IPAChangeConf
 class SSSDChangeConf(IPAChangeConf):
     OPTCRE = re.compile(
-            r'(?P<option>[^:=\s][^:=]*)'          # very permissive!
+            r'\s*(?P<option>[^:=\s][^:=]*)'       # very permissive!
             r'\s*=\s*'                            # any number of space/tab,
                                                   # followed by separator
                                                   # followed by any # space/tab


### PR DESCRIPTION
If sssd.conf file contains configuration directives
preceded with whitespace characters sss_obfuscate generates traceback.

How Fix is tested?
`# vim /usr/lib/python2.7/site-packages/SSSDConfig/ipachangeconf.py`
Updated: r'(?P<option>[^:=\s][^:=]*)'
to: r'\s*(?P<option>[^:=\s][^:=]*)'

`# /usr/local/sbin/sss_obfuscate --domain gsslab.pnq.redhat.com`
Enter password:
Re-enter password:
<<<<<<<<<No traceback seen>>>>>>>>>>

Resolves: https://pagure.io/SSSD/sssd/issue/1391