### PR TITLE
KCM: be aware that size_t might have different size than other integers

### DIFF
--- a/src/tests/cmocka/test_kcm_json_marshalling.c
+++ b/src/tests/cmocka/test_kcm_json_marshalling.c
@@ -113,7 +113,7 @@ static void assert_cc_princ_equal(struct kcm_ccache *cc1,
     krb5_error_code kerr;
 
     p1 = kcm_cc_get_client_principal(cc1);
-    p2 = kcm_cc_get_client_principal(cc1);
+    p2 = kcm_cc_get_client_principal(cc2);
 
     kerr = krb5_unparse_name(NULL, p1, &name1);
     assert_int_equal(kerr, 0);


### PR DESCRIPTION
The memory assignment for the size_t type might be larger on some
platforms than for 32bit integer values and even for value of unsigned
int type. When converting/casting size_t to those values special care
has to be taken especially when pointers to those values are used.

The patch also contains a fix for a unit test which now should detect
the issue properly.

Related to https://pagure.io/SSSD/sssd/issue/3757