### PR TITLE
sudo: allow use of default domain suffix (sssd-1-13)

### DIFF
--- a/src/db/sysdb_sudo.h
+++ b/src/db/sysdb_sudo.h
@@ -86,8 +86,7 @@
 #define SYSDB_SUDO_FILTER_INCLUDE_DFL    0x40       /* include cn=default   */
 #define SYSDB_SUDO_FILTER_USERINFO       SYSDB_SUDO_FILTER_USERNAME \
                                        | SYSDB_SUDO_FILTER_UID \
-                                       | SYSDB_SUDO_FILTER_GROUPS \
-                                       | SYSDB_SUDO_FILTER_NGRS
+                                       | SYSDB_SUDO_FILTER_GROUPS
 
 errno_t sysdb_sudo_filter_rules_by_time(TALLOC_CTX *mem_ctx,
                                         uint32_t in_num_rules,


### PR DESCRIPTION
This patch is based on post 1.13 work. The purpose is to allow combination of fully qualified names and  default domain suffix when user log in with a short name.

Similarly to later version, we add #uid value to sudoUser attribute.
