### PR TITLE
[CONFDB]:[RFE] Add "enabled" option to domain section

### DIFF
--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -232,6 +232,7 @@
 #define CONFDB_DOMAIN_TYPE_POSIX "posix"
 #define CONFDB_DOMAIN_TYPE_APP "application"
 #define CONFDB_DOMAIN_INHERIT_FROM "inherit_from"
+#define CONFDB_DOMAIN_ENABLED "enabled"
 
 /* Local Provider */
 #define CONFDB_LOCAL_DEFAULT_SHELL   "default_shell"

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -233,6 +233,7 @@
 #define CONFDB_DOMAIN_TYPE_APP "application"
 #define CONFDB_DOMAIN_INHERIT_FROM "inherit_from"
 #define CONFDB_DOMAIN_ENABLED "enabled"
+#define CONFDB_DEFAULT_DOMAIN_ENABLED 0
 
 /* Local Provider */
 #define CONFDB_LOCAL_DEFAULT_SHELL   "default_shell"

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -383,6 +383,7 @@ option = wildcard_limit
 option = full_name_format
 option = re_expression
 option = auto_private_groups
+option = enabled
 
 #Entry cache timeouts
 option = entry_cache_user_timeout


### PR DESCRIPTION
Upstream Request:
Instead of enabling domains using the "domains" option in [sssd]
section we could have [domain/*] option "enabled". This would allow
admins to configure and enable domain in the same snippet file.

This Fix would be submitted in 2 patches:
Patch-1(This Patch):
- Introduces 'enabled' option in domain section
- Introduces 'CONFDB_DOMAIN_ENABLED' variable to retrieve enabled value
from confdb
- Code to call start_service() routine only for domains having enabled=1

Patch-2(Upcoming):
- Would remove 'domains' option from sssd section.
- Would remove corresponding code to parse 'domains' option
- Providing a check that atlest One domain have enabled option set.

Resolves: https://pagure.io/SSSD/sssd/issue/3735