### PR TITLE
utils: add libsss_child dependency to libsss_cert

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -975,6 +975,7 @@ libsss_cert_la_LIBADD = \
     $(TALLOC_LIBS) \
     $(TEVENT_LIBS) \
     libsss_crypt.la \
+    libsss_child.la \
     libsss_debug.la \
     libsss_certmap.la \
     $(NULL)


### PR DESCRIPTION
Since the refactoring of the ssh responder to call p11_child to
validate certificates there is a dependency between libss_cert and
libsss_child. In some environments, e.g. gentoo or the OpenSUSE build
service, this dependency must be declared explicitly even if it is
resolved otherwise while linking the binaries.