### PR TITLE
intg: Do not hardcode nsslibdir

### DIFF
--- a/src/tests/intg/Makefile.am
+++ b/src/tests/intg/Makefile.am
@@ -73,6 +73,7 @@ cwrap-dbus-system.conf: data/cwrap-dbus-system.conf.in Makefile
 config.py: config.py.m4
 	m4 -D "prefix=\`$(prefix)'" \
 	   -D "sysconfdir=\`$(sysconfdir)'" \
+	   -D "nsslibdir=\`$(nsslibdir)'" \
 	   -D "dbpath=\`$(dbpath)'" \
 	   -D "pidpath=\`$(pidpath)'" \
 	   -D "logpath=\`$(logpath)'" \

--- a/src/tests/intg/config.py.m4
+++ b/src/tests/intg/config.py.m4
@@ -4,7 +4,7 @@ Build configuration variables.
 
 PREFIX = "prefix"
 SYSCONFDIR = "sysconfdir"
-NSS_MODULE_DIR = PREFIX + "/lib"
+NSS_MODULE_DIR = "nsslibdir"
 SSSDCONFDIR = SYSCONFDIR + "/sssd"
 CONF_PATH = SSSDCONFDIR + "/sssd.conf"
 DB_PATH = "dbpath"


### PR DESCRIPTION
This change is needed in order to have make intgcheck-run properly
running on opensuse systems.

CI: http://vm-031.${abc}/logs/job/90/35/summary.html
