### PR TITLE
AD/LDAP: Do not misuse the ignore_mark_offline to check if a connection needs to be checked for POSIX attribute presence

### DIFF
--- a/src/providers/ad/ad_common.c
+++ b/src/providers/ad/ad_common.c
@@ -1408,6 +1408,7 @@ ad_gc_conn_list(TALLOC_CTX *mem_ctx, struct ad_id_ctx *ad_ctx,
         clist[cindex] = ad_ctx->gc_ctx;
         clist[cindex]->ignore_mark_offline = true;
         clist[cindex]->no_mpg_user_fallback = true;
+        clist[cindex]->check_posix_attrs = true;
         cindex++;
     }
 
@@ -1454,6 +1455,7 @@ ad_user_conn_list(TALLOC_CTX *mem_ctx,
             && IS_SUBDOMAIN(dom)) {
         clist[cindex] = ad_ctx->gc_ctx;
         clist[cindex]->ignore_mark_offline = true;
+        clist[cindex]->check_posix_attrs = true;
         cindex++;
     }
 

--- a/src/providers/ldap/ldap_common.c
+++ b/src/providers/ldap/ldap_common.c
@@ -893,7 +893,7 @@ bool should_run_posix_check(struct sdap_id_ctx *ctx,
     if (use_id_mapping == false &&
             posix_request == true &&
             ctx->opts->schema_type == SDAP_SCHEMA_AD &&
-            conn->ignore_mark_offline == true &&
+            conn->check_posix_attrs == true &&
             ctx->srv_opts &&
             ctx->srv_opts->posix_checked == false) {
         return true;

--- a/src/providers/ldap/ldap_common.h
+++ b/src/providers/ldap/ldap_common.h
@@ -59,6 +59,8 @@ struct sdap_id_conn_ctx {
     bool ignore_mark_offline;
     /* do not fall back to user lookups for mpg domains on this connection */
     bool no_mpg_user_fallback;
+    /* check if this connection contains POSIX attributes */
+    bool check_posix_attrs;
 };
 
 struct sdap_id_ctx {


### PR DESCRIPTION
The logic behind deciding whether to check if a server contains any POSIX
attributes used the ignore_mark_offline flag. This was OK for some time,
because this flag was only set for to true for Global Catalog connections,
which are those that we need to check.

However, in recent releases, the flag was also set for any connection
towards a trusted domain. This had the unintended effect that any lookup,
LDAP or GC against a trusted domain ran the wide POSIX presence check.

Resolves: https://pagure.io/SSSD/sssd/issue/3754