### PR TITLE
MAN: Document the re_expression needed to suport @-signs in the groupnames

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2630,18 +2630,6 @@ pam_account_locked_message = Account locked, please contact help desk.
                             the <quote>@</quote> sign, the domain everything
                             after that"
                         </para>
-                        <para>
-                            PLEASE NOTE: the support for non-unique named
-                            subpatterns is not available on all platforms
-                            (e.g. RHEL5 and SLES10). Only platforms with
-                            libpcre version 7 or higher can support non-unique
-                            named subpatterns.
-                        </para>
-                        <para>
-                            PLEASE NOTE ALSO: older version of libpcre only
-                            support the Python syntax (?P&lt;name&gt;) to label
-                            subpatterns.
-                        </para>
                     </listitem>
                 </varlistentry>
                 <varlistentry>

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2630,6 +2630,15 @@ pam_account_locked_message = Account locked, please contact help desk.
                             the <quote>@</quote> sign, the domain everything
                             after that"
                         </para>
+                        <para>
+                            NOTE: Some Active Directory groups, typically
+                            those used for MS Exchange contain an
+                            <quote>@</quote> sign in the name, which
+                            clashes with the default re_expression value for
+                            the AD and IPA providers. To support these groups,
+                            consider changing the re_expression value to:
+                            <quote>((?P&lt;name&gt;.+)@(?P&lt;domain&gt;[^@]+$))</quote>.
+                        </para>
                     </listitem>
                 </varlistentry>
                 <varlistentry>


### PR DESCRIPTION
In the 2.0 release we will be able to change the default regular expression
that will allow to consume @-signs in the name, but since the 1.x branches
need to stay backwards compatible, let's only document the regex for now.

Related: https://pagure.io/SSSD/sssd/issue/3219

According to comments in https://bugzilla.redhat.com/show_bug.cgi?id=1383520
the modified regular expression already helped some users, but not all.

So, more work and investigation is needed (for example it is not clear to me
whether the issue in parsing is in the extdom plugin or on the sssd side),
but we can document the changed default already.