### PR TITLE
IPA: Populate kdcinfo files on trust clients with configured AD servers

### DIFF
--- a/src/man/sssd-ipa.5.xml
+++ b/src/man/sssd-ipa.5.xml
@@ -728,6 +728,98 @@
         </para>
     </refsect1>
 
+    <refsect1 id='trusted_domains'>
+        <title>TRUSTED DOMAINS CONFIGURATION</title>
+        <para>
+            Some configuration options can be also set for a trusted domain.
+            A trusted domain configuration can either be done using
+            a subsection, for example:
+<programlisting>
+[domain/ipa.domain.com/ad.domain.com]
+ad_server = dc.ad.domain.com
+</programlisting>
+        </para>
+        <para>
+            In addition, some options can be set in the parent domain
+            and inherited by the trusted domain using the
+            <quote>subdomain_inherit</quote> option. For more details,
+            see the
+            <citerefentry>
+                <refentrytitle>sssd.conf</refentrytitle>
+                <manvolnum>5</manvolnum>
+            </citerefentry> manual page.
+        </para>
+        <para>
+            Different configuration options are tunable for a trusted
+            domain depending on whether you are configuring SSSD on an
+            IPA server or an IPA client.
+        </para>
+        <refsect2 id='server_configuration'>
+            <title>OPTIONS TUNABLE ON IPA MASTERS</title>
+            <para>
+                The following options can be set in a subdomain
+                section on an IPA master:
+                <itemizedlist>
+                    <listitem>
+                        <para>ad_server</para>
+                    </listitem>
+                    <listitem>
+                        <para>ad_backup_server</para>
+                    </listitem>
+                    <listitem>
+                        <para>ad_site</para>
+                    </listitem>
+                    <listitem>
+                        <para>ldap_search_base</para>
+                    </listitem>
+                    <listitem>
+                        <para>ldap_user_search_base</para>
+                    </listitem>
+                    <listitem>
+                        <para>ldap_group_search_base</para>
+                    </listitem>
+                    <listitem>
+                        <para>use_fully_qualified_names</para>
+                    </listitem>
+                </itemizedlist>
+            </para>
+        </refsect2>
+        <refsect2 id='client_configuration'>
+            <title>OPTIONS TUNABLE ON IPA CLIENTS</title>
+            <para>
+                The following options can be set in a subdomain
+                section on an IPA client:
+                <itemizedlist>
+                    <listitem>
+                        <para>ad_server</para>
+                    </listitem>
+                    <listitem>
+                        <para>ad_site</para>
+                    </listitem>
+                </itemizedlist>
+            </para>
+            <para>
+                Note that if both options are set, only
+                <quote>ad_server</quote> is evaluated.
+            </para>
+            <para>
+                Since any request for a user or a group identity from a
+                trusted domain triggered from an IPA client is resolved
+                by the IPA server, the <quote>ad_server</quote> and
+                <quote>ad_site</quote> options only affect which AD DC will
+                the authentication be performed against. In particular,
+                the addresses resolved from these lists will be written to
+                <quote>kdcinfo</quote> files read by the Kerberos locator
+                plugin. Please refer to the
+                <citerefentry>
+                    <refentrytitle>sssd_krb5_locator_plugin</refentrytitle>
+                    <manvolnum>8</manvolnum>
+                </citerefentry> manual page for more details on the Kerberos
+                locator plugin.
+            </para>
+        </refsect2>
+    </refsect1>
+
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="include/failover.xml" />
 
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="include/service_discovery.xml" />

--- a/src/providers/ad/ad_common.c
+++ b/src/providers/ad/ad_common.c
@@ -757,19 +757,13 @@ ad_failover_init(TALLOC_CTX *mem_ctx, struct be_ctx *bectx,
         goto done;
     }
 
-    service->krb5_service = talloc_zero(service, struct krb5_service);
+    service->krb5_service = krb5_service_new(service, bectx,
+                                             ad_service, krb5_realm,
+                                             use_kdcinfo);
     if (!service->krb5_service) {
         ret = ENOMEM;
         goto done;
     }
-
-    /* Set flag that controls whether we want to write the
-     * kdcinfo files at all
-     */
-    service->krb5_service->write_kdcinfo = use_kdcinfo;
-    DEBUG(SSSDBG_CONF_SETTINGS, "write_kdcinfo for realm %s set to %s\n",
-                       krb5_realm,
-                       service->krb5_service->write_kdcinfo ? "true" : "false");
 
     ret = be_fo_add_service(bectx, ad_service, ad_user_data_cmp);
     if (ret != EOK) {
@@ -783,12 +777,6 @@ ad_failover_init(TALLOC_CTX *mem_ctx, struct be_ctx *bectx,
         goto done;
     }
 
-    service->krb5_service->name = talloc_strdup(service->krb5_service,
-                                                ad_service);
-    if (!service->krb5_service->name) {
-        ret = ENOMEM;
-        goto done;
-    }
     service->sdap->kinit_service_name = service->krb5_service->name;
     service->gc->kinit_service_name = service->krb5_service->name;
 
@@ -797,14 +785,6 @@ ad_failover_init(TALLOC_CTX *mem_ctx, struct be_ctx *bectx,
         ret = EINVAL;
         goto done;
     }
-    service->krb5_service->realm =
-        talloc_strdup(service->krb5_service, krb5_realm);
-    if (!service->krb5_service->realm) {
-        ret = ENOMEM;
-        goto done;
-    }
-
-    service->krb5_service->be_ctx = bectx;
 
     if (!primary_servers) {
         DEBUG(SSSDBG_CONF_SETTINGS,

--- a/src/providers/ad/ad_common.c
+++ b/src/providers/ad/ad_common.c
@@ -848,7 +848,7 @@ ad_resolve_callback(void *private_data, struct fo_server *server)
     struct resolv_hostent *srvaddr;
     struct sockaddr_storage *sockaddr;
     char *address;
-    const char *safe_address;
+    char *safe_addr_list[2] = { NULL, NULL };
     char *new_uri;
     int new_port;
     const char *srv_name;
@@ -957,17 +957,17 @@ ad_resolve_callback(void *private_data, struct fo_server *server)
     if ((sdata == NULL || sdata->gc == false) &&
         service->krb5_service->write_kdcinfo) {
         /* Write krb5 info files */
-        safe_address = sss_escape_ip_address(tmp_ctx,
-                                            srvaddr->family,
-                                            address);
-        if (safe_address == NULL) {
+        safe_addr_list[0] = sss_escape_ip_address(tmp_ctx,
+                                                  srvaddr->family,
+                                                  address);
+        if (safe_addr_list[0] == NULL) {
             DEBUG(SSSDBG_CRIT_FAILURE, "sss_escape_ip_address failed.\n");
             ret = ENOMEM;
             goto done;
         }
 
         ret = write_krb5info_file(service->krb5_service,
-                                  safe_address,
+                                  safe_addr_list,
                                   SSS_KRB5KDC_FO_SRV);
         if (ret != EOK) {
             DEBUG(SSSDBG_MINOR_FAILURE,

--- a/src/providers/ad/ad_srv.c
+++ b/src/providers/ad/ad_srv.c
@@ -38,6 +38,13 @@
 
 #define AD_SITE_DOMAIN_FMT "%s._sites.%s"
 
+char *ad_site_dns_discovery_domain(TALLOC_CTX *mem_ctx,
+                                   const char *site,
+                                   const char *domain)
+{
+    return talloc_asprintf(mem_ctx, AD_SITE_DOMAIN_FMT, site, domain);
+}
+
 static errno_t ad_sort_servers_by_dns(TALLOC_CTX *mem_ctx,
                                       const char *domain,
                                       struct fo_server_info **_srv,
@@ -154,8 +161,8 @@ static struct tevent_req *ad_get_dc_servers_send(TALLOC_CTX *mem_ctx,
         DEBUG(SSSDBG_TRACE_FUNC, "Looking up domain controllers in domain "
               "%s and site %s\n", discovery_domain, site);
 
-        domains[0] = talloc_asprintf(state, AD_SITE_DOMAIN_FMT,
-                                     site, discovery_domain);
+        domains[0] = ad_site_dns_discovery_domain(domains,
+                                                  site, discovery_domain);
         if (domains[0] == NULL) {
             ret = ENOMEM;
             goto immediately;
@@ -775,9 +782,10 @@ static void ad_srv_plugin_site_done(struct tevent_req *subreq)
         if (strcmp(state->service, "gc") == 0) {
             if (state->forest != NULL) {
                 if (state->site != NULL) {
-                    primary_domain = talloc_asprintf(state, AD_SITE_DOMAIN_FMT,
-                                                     state->site,
-                                                     state->forest);
+                    primary_domain = ad_site_dns_discovery_domain(
+                                                            state,
+                                                            state->site,
+                                                            state->forest);
                     if (primary_domain == NULL) {
                         ret = ENOMEM;
                         goto done;
@@ -791,7 +799,8 @@ static void ad_srv_plugin_site_done(struct tevent_req *subreq)
             }
         } else {
             if (state->site != NULL) {
-                primary_domain = talloc_asprintf(state, AD_SITE_DOMAIN_FMT,
+                primary_domain = ad_site_dns_discovery_domain(
+                                                 state,
                                                  state->site,
                                                  state->discovery_domain);
                 if (primary_domain == NULL) {

--- a/src/providers/ad/ad_srv.h
+++ b/src/providers/ad/ad_srv.h
@@ -49,4 +49,8 @@ errno_t ad_srv_plugin_recv(TALLOC_CTX *mem_ctx,
                             struct fo_server_info **_backup_servers,
                             size_t *_num_backup_servers);
 
+char *ad_site_dns_discovery_domain(TALLOC_CTX *mem_ctx,
+                                   const char *site,
+                                   const char *domain);
+
 #endif /* __AD_SRV_H__ */

--- a/src/providers/ipa/ipa_common.c
+++ b/src/providers/ipa/ipa_common.c
@@ -766,7 +766,7 @@ static void ipa_resolve_callback(void *private_data, struct fo_server *server)
     struct resolv_hostent *srvaddr;
     struct sockaddr_storage *sockaddr;
     char *address;
-    const char *safe_address;
+    char *safe_addr_list[2] = { NULL, NULL };
     char *new_uri;
     const char *srv_name;
     int ret;
@@ -829,17 +829,17 @@ static void ipa_resolve_callback(void *private_data, struct fo_server *server)
     service->sdap->sockaddr = talloc_steal(service, sockaddr);
 
     if (service->krb5_service->write_kdcinfo) {
-        safe_address = sss_escape_ip_address(tmp_ctx,
+        safe_addr_list[0] = sss_escape_ip_address(tmp_ctx,
                                              srvaddr->family,
                                              address);
-        if (safe_address == NULL) {
+        if (safe_addr_list[0] == NULL) {
             DEBUG(SSSDBG_CRIT_FAILURE, "sss_escape_ip_address failed.\n");
             talloc_free(tmp_ctx);
             return;
         }
 
         ret = write_krb5info_file(service->krb5_service,
-                                  safe_address,
+                                  safe_addr_list,
                                   SSS_KRB5KDC_FO_SRV);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE,

--- a/src/providers/ipa/ipa_common.h
+++ b/src/providers/ipa/ipa_common.h
@@ -175,6 +175,13 @@ enum ipa_sudocmd_attrs {
     IPA_OPTS_SUDOCMD
 };
 
+enum ipa_cli_ad_subdom_attrs {
+    IPA_CLI_AD_SERVER,
+    IPA_CLI_AD_SITE,
+
+    IPA_OPTS_CLI_AD_SUBDOM
+};
+
 struct ipa_auth_ctx {
     struct krb5_ctx *krb5_auth_ctx;
     struct sdap_id_ctx *sdap_id_ctx;

--- a/src/providers/ipa/ipa_opts.c
+++ b/src/providers/ipa/ipa_opts.c
@@ -389,3 +389,9 @@ struct sdap_attr_map ipa_sudocmd_map[] = {
     { "ipa_sudocmd_memberof", "memberOf", SYSDB_MEMBEROF, NULL },
     SDAP_ATTR_MAP_TERMINATOR
 };
+
+struct dp_option ipa_cli_ad_subdom_opts [] = {
+    { "ad_server", DP_OPT_STRING, NULL_STRING, NULL_STRING },
+    { "ad_site", DP_OPT_STRING, NULL_STRING, NULL_STRING },
+    DP_OPTION_TERMINATOR
+};

--- a/src/providers/ipa/ipa_opts.h
+++ b/src/providers/ipa/ipa_opts.h
@@ -64,4 +64,6 @@ extern struct sdap_attr_map ipa_sudocmdgroup_map[];
 
 extern struct sdap_attr_map ipa_sudocmd_map[];
 
+extern struct dp_option ipa_cli_ad_subdom_opts[];
+
 #endif /* IPA_OPTS_H_ */

--- a/src/providers/krb5/krb5_common.h
+++ b/src/providers/krb5/krb5_common.h
@@ -161,7 +161,7 @@ errno_t sss_krb5_get_options(TALLOC_CTX *memctx, struct confdb_ctx *cdb,
                              const char *conf_path, struct dp_option **_opts);
 
 errno_t write_krb5info_file(struct krb5_service *krb5_service,
-                            const char *server,
+                            char **server_list,
                             const char *service);
 
 struct krb5_service *krb5_service_new(TALLOC_CTX *mem_ctx,

--- a/src/providers/krb5/krb5_common.h
+++ b/src/providers/krb5/krb5_common.h
@@ -164,6 +164,12 @@ errno_t write_krb5info_file(struct krb5_service *krb5_service,
                             const char *server,
                             const char *service);
 
+struct krb5_service *krb5_service_new(TALLOC_CTX *mem_ctx,
+                                      struct be_ctx *be_ctx,
+                                      const char *service_name,
+                                      const char *realm,
+                                      bool use_kdcinfo);
+
 int krb5_service_init(TALLOC_CTX *memctx, struct be_ctx *ctx,
                       const char *service_name,
                       const char *primary_servers,

--- a/src/resolv/async_resolv.h
+++ b/src/resolv/async_resolv.h
@@ -112,6 +112,36 @@ int resolv_gethostbyname_recv(struct tevent_req *req, TALLOC_CTX *mem_ctx,
                               int *status, int *timeouts,
                               struct resolv_hostent **rhostent);
 
+struct resolv_hostport {
+    const char *host;
+    int port;
+};
+
+struct resolv_hostport_addr {
+    struct resolv_hostport origin;
+    struct resolv_hostent *reply;
+};
+
+/* Resolves a list of resolv_hostport tuples into a list of
+ * resolv_hostport_addr. Any unresolvable addresses are skipped.
+ *
+ * Optionally takes a limit argument and stops after the request
+ * had resolved addresses up to the limit.
+ */
+struct tevent_req *resolv_hostport_list_send(TALLOC_CTX *mem_ctx,
+                                             struct tevent_context *ev,
+                                             struct resolv_ctx *ctx,
+                                             struct resolv_hostport *hostport_list,
+                                             size_t list_size,
+                                             size_t limit,
+                                             enum restrict_family family_order,
+                                             enum host_database *db);
+
+int resolv_hostport_list_recv(struct tevent_req *req,
+                              TALLOC_CTX *mem_ctx,
+                              size_t *_rhp_len,
+                              struct resolv_hostport_addr ***_rhp_addrs);
+
 char *
 resolv_get_string_address_index(TALLOC_CTX *mem_ctx,
                                 struct resolv_hostent *hostent,


### PR DESCRIPTION
Resolves: https://pagure.io/SSSD/sssd/issue/3291

Adds a new request into the IPA subdomains provider. This request runs on
IPA clients only.

The request looks into the configuration for either the ad_site or
ad_server options for each subdomain. If none are found, the subdomain is
skipped.

If either is found, the request resolves the server names, or first the
site and then the server names from the site and writes their addresses to
the kdcinfo files for each subdomain. This allows programs such as kinit
but also SSSD's krb5_child to use the configured servers.