### PR TITLE
nss_protocol_fill_initgr: skip incomplete groups instead of bailing out

### DIFF
--- a/src/responder/nss/nss_protocol_grent.c
+++ b/src/responder/nss/nss_protocol_grent.c
@@ -365,11 +365,10 @@ nss_protocol_fill_initgr(struct nss_ctx *nss_ctx,
             if (posix != NULL && strcmp(posix, "FALSE") == 0) {
                 continue;
             } else {
-                DEBUG(SSSDBG_CRIT_FAILURE,
+                DEBUG(SSSDBG_MINOR_FAILURE,
                       "Incomplete group object [%s] for initgroups! "
-                      "Aborting.\n", ldb_dn_get_linearized(msg->dn));
-                ret = EINVAL;
-                goto done;
+                      "Skipping.\n", ldb_dn_get_linearized(msg->dn));
+                continue;
             }
         }
 


### PR DESCRIPTION
Suppose the user U is a member of (AD) groups D1\A, D1\B, D2\X, and no
domain controllers in the domain D2 can be reached at the moment (and
there are no cached info). As of now initgroups won't assign any groups
at all. To improve the behavior skip the incomplete groups so initgroup
assigns at least some groups (D1\A, D1\B in the above example).