### PR TITLE
become_user_ex: add supplementary groups so ad provider can access keytab

### DIFF
--- a/src/providers/ldap/ldap_child.c
+++ b/src/providers/ldap/ldap_child.c
@@ -701,7 +701,7 @@ int main(int argc, const char *argv[])
     }
     DEBUG(SSSDBG_TRACE_INTERNAL, "Kerberos context initialized\n");
 
-    kerr = become_user(ibuf->uid, ibuf->gid);
+    kerr = become_user_ex(ibuf->uid, ibuf->gid, true);
     if (kerr != 0) {
         DEBUG(SSSDBG_CRIT_FAILURE, "become_user failed.\n");
         goto fail;

--- a/src/tests/cwrap/group
+++ b/src/tests/cwrap/group
@@ -1,2 +1,3 @@
 sssd:x:123:
+_keytab:x:321:_sssd
 foogroup:x:10001:

--- a/src/tests/cwrap/passwd
+++ b/src/tests/cwrap/passwd
@@ -1,2 +1,3 @@
 sssd:x:123:456:sssd unprivileged user:/:/sbin/nologin
+_sssd:x:987:654:sssd unprivileged user:/:/sbin/nologin
 foobar:x:10001:10001:User for SSSD testing:/home/foobar:/bin/bash

--- a/src/util/server.c
+++ b/src/util/server.c
@@ -484,7 +484,7 @@ int server_setup(const char *name, int flags,
                   "Cannot chown the debug files, debugging might not work!\n");
         }
 
-        ret = become_user(uid, gid);
+        ret = become_user_ex(uid, gid, true);
         if (ret != EOK) {
             DEBUG(SSSDBG_FUNC_DATA,
                   "Cannot become user [%"SPRIuid"][%"SPRIgid"].\n", uid, gid);

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -641,6 +641,7 @@ char **concatenate_string_array(TALLOC_CTX *mem_ctx,
                                 char **arr2, size_t len2);
 
 /* from become_user.c */
+errno_t become_user_ex(uid_t uid, gid_t gid, bool suppl_groups);
 errno_t become_user(uid_t uid, gid_t gid);
 struct sss_creds;
 errno_t switch_creds(TALLOC_CTX *mem_ctx,


### PR DESCRIPTION
For security reasons one might want to run providers as a non-privileged
user (say, _sssd). However some providers (in particular ad) might need
an access to restricted (non world-readable) files (for instance,
/etc/krb5.keytab). One of the possible ways to solve the problem is to
 - add a special group (for instance, _keytab)
 - set the owner:group of the file in question to root:_keytab
 - set the permissions of the file in question to 640
 - make the _sssd user a member of the _keytab group

For this to work become_user should assign supplementary groups, which
is what this patch does.