### PR TITLE
deskprofile: don't bail if we fail to save one profile

### DIFF
--- a/src/providers/ipa/ipa_session.c
+++ b/src/providers/ipa/ipa_session.c
@@ -768,7 +768,7 @@ ipa_pam_session_handler_save_deskprofile_rules(
             DEBUG(SSSDBG_OP_FAILURE,
                   "Failed to save a Desktop Profile Rule to disk [%d]: %s\n",
                   ret, sss_strerror(ret));
-            goto done;
+            continue;
         }
     }
 


### PR DESCRIPTION
Due to different reasons (a bug on fleet-commander, for instance?) we
may face the situation where one profile ends up stored in freeipa on a
half-broken state (with no data, for instance).

In case it happens, we should try our best to save the not broken
profiles and just skip the broken ones instead of bailing the whole 
operation.

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>