### PR TITLE
Add an option to only print the host public keys for sss_ssh_knownhostsproxy

### DIFF
--- a/src/man/sss_ssh_knownhostsproxy.1.xml
+++ b/src/man/sss_ssh_knownhostsproxy.1.xml
@@ -84,6 +84,16 @@ GlobalKnownHostsFile /var/lib/sss/pubconf/known_hosts
                     </para>
                 </listitem>
             </varlistentry>
+            <varlistentry>
+                <term>
+                    <option>-k</option>,<option>--pubkeys</option>
+                </term>
+                <listitem>
+                    <para>
+                        Print the host ssh public keys for host <replaceable>HOST</replaceable>.
+                    </para>
+                </listitem>
+            </varlistentry>
             <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="include/param_help.xml" />
         </variablelist>
     </refsect1>

--- a/src/util/sss_ssh.c
+++ b/src/util/sss_ssh.c
@@ -213,3 +213,58 @@ done:
 
     return ret;
 }
+
+errno_t
+sss_ssh_print_pubkey(struct sss_ssh_pubkey *pubkey)
+{
+    TALLOC_CTX *tmp_ctx;
+    char *repr = NULL;
+    char *repr_break = NULL;
+    errno_t ret;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    ret = sss_ssh_format_pubkey(tmp_ctx, pubkey, &repr);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "sss_ssh_format_pubkey() failed (%d): %s\n",
+              ret, strerror(ret));
+        goto end;
+    }
+
+    /* OpenSSH expects a linebreak after each key */
+    repr_break = talloc_asprintf(tmp_ctx, "%s\n", repr);
+    talloc_zfree(repr);
+    if (repr_break == NULL) {
+        ret = ENOMEM;
+        goto end;
+    }
+
+    ret = sss_atomic_write_s(STDOUT_FILENO, repr_break, strlen(repr_break));
+    /* Avoid spiking memory with too many large keys */
+    talloc_zfree(repr_break);
+    if (ret < 0) {
+        ret = errno;
+        if (ret == EPIPE) {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "SSHD closed the pipe before all keys could be written\n");
+            /* Return 0 so that openssh doesn't abort pubkey auth */
+            ret = 0;
+            goto end;
+        }
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "sss_atomic_write_s() failed (%d): %s\n",
+              ret, strerror(ret));
+        goto end;
+    }
+
+    ret = EOK;
+
+ end:
+    talloc_zfree(tmp_ctx);
+
+    return ret;
+}

--- a/src/util/sss_ssh.h
+++ b/src/util/sss_ssh.h
@@ -50,4 +50,7 @@ sss_ssh_format_pubkey(TALLOC_CTX *mem_ctx,
                       struct sss_ssh_pubkey *pubkey,
                       char **result);
 
+errno_t
+sss_ssh_print_pubkey(struct sss_ssh_pubkey *pubkey);
+
 #endif /* _SSS_SSH_H_ */


### PR DESCRIPTION
Please, check the patchset.

Resolves:
https://pagure.io/SSSD/sssd/issue/3542