### PR TITLE
Add pam_cert_pam_services option

### DIFF
--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -131,6 +131,7 @@
 #define CONFDB_PAM_CERT_DB_PATH "pam_cert_db_path"
 #define CONFDB_PAM_P11_CHILD_TIMEOUT "p11_child_timeout"
 #define CONFDB_PAM_APP_SERVICES "pam_app_services"
+#define CONFDB_PAM_CERT_PAM_SERVICES "pam_cert_pam_services"
 
 /* SUDO */
 #define CONFDB_SUDO_CONF_ENTRY "config/sudo"

--- a/src/config/SSSDConfig/__init__.py.in
+++ b/src/config/SSSDConfig/__init__.py.in
@@ -103,6 +103,7 @@ option_strings = {
     'pam_cert_db_path' : _('Path to certificate database with PKCS#11 modules.'),
     'p11_child_timeout' : _('How many seconds will pam_sss wait for p11_child to finish'),
     'pam_app_services' : _('Which PAM services are permitted to contact application domains'),
+    'pam_cert_pam_services' : _('Which PAM services are permitted to perform smart card authentication'),
 
     # [sudo]
     'sudo_timed' : _('Whether to evaluate the time-based attributes in sudo rules'),

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -126,6 +126,7 @@ option = pam_cert_auth
 option = pam_cert_db_path
 option = p11_child_timeout
 option = pam_app_services
+option = pam_cert_pam_services
 
 [rule/allowed_sudo_options]
 validator = ini_allowed_options

--- a/src/config/etc/sssd.api.conf
+++ b/src/config/etc/sssd.api.conf
@@ -75,6 +75,7 @@ pam_cert_auth = bool, None, false
 pam_cert_db_path = str, None, false
 p11_child_timeout = int, None, false
 pam_app_services = str, None, false
+pam_cert_pam_services = list, str, false
 
 [sudo]
 # sudo service

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -1389,6 +1389,20 @@ pam_account_locked_message = Account locked, please contact help desk.
                         </para>
                     </listitem>
                 </varlistentry>
+                <varlistentry>
+                    <term>pam_cert_pam_services (list)</term>
+                    <listitem>
+                        <para>
+                            Which PAM services are permitted to perform
+                            certificate based Smartcard authentication.
+                        </para>
+                        <para>
+                            Default: login, su, su-l, gdm-smartcard,
+                                     gdm-password, kdm, sudo, sudo-i,
+                                     gnome-screensaver
+                        </para>
+                    </listitem>
+                </varlistentry>
 
             </variablelist>
         </refsect2>


### PR DESCRIPTION
Allow customizing which PAM services are allowed to perform smartcard
authentication.

Fixes: https://pagure.io/SSSD/sssd/issue/3775
