### PR TITLE
MC: Remove check if record is in the mapped address space

### DIFF
--- a/src/sss_client/nss_mc_group.c
+++ b/src/sss_client/nss_mc_group.c
@@ -152,12 +152,10 @@ errno_t sss_nss_mc_getgrnam(const char *name, size_t name_len,
         /* Integrity check
          * - data->name cannot point outside strings
          * - all strings must be within copy of record
-         * - record must not end outside data table
          * - rec_name is a zero-terminated string */
         if (data->name < strs_offset
             || data->name >= strs_offset + data->strs_len
-            || data->strs_len > rec->len
-            || (uint8_t *) rec + rec->len > gr_mc_ctx.data_table + data_size) {
+            || data->strs_len > rec->len) {
             ret = ENOENT;
             goto done;
         }

--- a/src/sss_client/nss_mc_initgr.c
+++ b/src/sss_client/nss_mc_initgr.c
@@ -133,15 +133,12 @@ errno_t sss_nss_mc_initgroups_dyn(const char *name, size_t name_len,
         /* Integrity check
          * - data->name cannot point outside all strings or data
          * - all data must be within copy of record
-         * - size of record must be lower that data table size
          * - data->strs cannot point outside strings
          * - rec_name is a zero-terminated string */
         if (data->name < data_offset
             || data->name >= data_offset + data->data_len
             || data->strs_len > data->data_len
-            || data->data_len > rec->len
-            || (uint8_t *) rec + rec->len
-                                      > initgr_mc_ctx.data_table + data_size) {
+            || data->data_len > rec->len) {
             ret = ENOENT;
             goto done;
         }

--- a/src/sss_client/nss_mc_passwd.c
+++ b/src/sss_client/nss_mc_passwd.c
@@ -145,12 +145,10 @@ errno_t sss_nss_mc_getpwnam(const char *name, size_t name_len,
         /* Integrity check
          * - data->name cannot point outside strings
          * - all strings must be within copy of record
-         * - record must not end outside data table
          * - rec_name is a zero-terminated string */
         if (data->name < strs_offset
             || data->name >= strs_offset + data->strs_len
-            || data->strs_len > rec->len
-            || (uint8_t *) rec + rec->len > pw_mc_ctx.data_table + data_size) {
+            || data->strs_len > rec->len) {
             ret = ENOENT;
             goto done;
         }


### PR DESCRIPTION
There is a check in the memory cache code that checks if a record pointer
points to the mmapped region . But since some time ago, we return not a
pointer to the mmapped region itself, but a copy to avoid issues with
invalidating an entry while the same entry is being returned.

In most cases, the check is correct, simply because of how memory is laid
out on Linux, but in some cases the check was failing and causing a high
load of SSSD.

Signed-off-by: Jakub Hrozek <jhrozek@redhat.com>

Resolves: https://pagure.io/SSSD/sssd/issue/3776