### PR TITLE
Fix "test-find-uid" and "find_uid-tests" tests

### DIFF
--- a/src/util/find_uid.c
+++ b/src/util/find_uid.c
@@ -90,8 +90,15 @@ static errno_t get_uid_from_pid(const pid_t pid, uid_t *uid)
                       path);
             return EOK;
         }
+        // case of hidepid=1 mount option for /proc
+        if (error == EPERM) {
+            DEBUG(SSSDBG_TRACE_LIBS,
+                  "Proc file [%s] is not permissible, continuing.\n",
+                      path);
+            return EOK;
+        }
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "open failed [%d][%s].\n", error, strerror(error));
+              "open failed [%s][%d][%s].\n", path, error, strerror(error));
         return error;
     }
 


### PR DESCRIPTION
Handle a "hidepid=1" mount option for procfs. One of the affects - this
option makes impermissible non own pid subdirectories on /proc.

Resolves:
https://pagure.io/SSSD/sssd/issue/3789