### PR TITLE
Revert "CRYPTO: Suppress warning Wstringop-truncation"

### DIFF
--- a/src/util/crypto/libcrypto/crypto_sha512crypt.c
+++ b/src/util/crypto/libcrypto/crypto_sha512crypt.c
@@ -277,7 +277,7 @@ static int sha512_crypt_r(const char *key,
         goto done;
     }
 
-    cp = memcpy(buffer, sha512_salt_prefix, SALT_PREF_SIZE);
+    cp = stpncpy(buffer, sha512_salt_prefix, SALT_PREF_SIZE);
     buflen -= SALT_PREF_SIZE;
 
     if (rounds_custom) {

--- a/src/util/crypto/nss/nss_sha512crypt.c
+++ b/src/util/crypto/nss/nss_sha512crypt.c
@@ -267,7 +267,7 @@ static int sha512_crypt_r(const char *key,
         goto done;
     }
 
-    cp = memcpy(buffer, sha512_salt_prefix, SALT_PREF_SIZE);
+    cp = stpncpy(buffer, sha512_salt_prefix, SALT_PREF_SIZE);
     buflen -= SALT_PREF_SIZE;
 
     if (rounds_custom) {


### PR DESCRIPTION
This reverts commit 2951a9a84bd85f384213a3e071ffc167907df2d7.

The original use stpncpy was correct. Changing it to memcpy
changed the resulting hash. This resulted in users from
local domain to not be able to authenticate (offline
authentication was also probably broken) if their hash was
created before this change.

https://pagure.io/SSSD/sssd/issue/3791