### PR TITLE
KCM/SECRETS: Use a library to access the secrets storage instead of the secrets responder, deprecate secrets responder

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3942,7 +3942,7 @@ intgcheck-prepare:
 	    --with-session-recording-shell=/bin/false \
 	    --enable-local-provider \
 	    $(INTGCHECK_CONFIGURE_FLAGS) \
-	    CFLAGS="-O2 -g $$CFLAGS -DKCM_PEER_UID=$$(id -u)"; \
+	    CFLAGS="-O2 -g $$CFLAGS"; \
 	$(MAKE) $(AM_MAKEFLAGS) ; \
 	$(MAKE) $(AM_MAKEFLAGS) test_ssh_client; \
 	: Force single-thread install to workaround concurrency issues; \

--- a/Makefile.am
+++ b/Makefile.am
@@ -682,6 +682,8 @@ dist_noinst_HEADERS = \
     src/util/inotify.h \
     src/util/sss_iobuf.h \
     src/util/tev_curl.h \
+    src/util/secrets/secrets.h \
+    src/util/secrets/sec_pvt.h \
     src/monitor/monitor.h \
     src/responder/common/responder.h \
     src/responder/common/responder_packet.h \
@@ -1204,6 +1206,26 @@ libsss_iface_sync_la_CFLAGS = \
     $(DBUS_CFLAGS) \
     $(NULL)
 libsss_iface_sync_la_LDFLAGS = \
+    -avoid-version \
+    $(NULL)
+
+pkglib_LTLIBRARIES += libsss_secrets.la
+
+libsss_secrets_la_SOURCES = \
+    src/util/secrets/secrets.c \
+    src/util/secrets/config.c \
+    $(NULL)
+libsss_secrets_la_CFLAGS = \
+    $(AM_CFLAGS) \
+    $(NULL)
+libsss_secrets_la_LIBADD = \
+    $(TALLOC_LIBS) \
+    $(LDB_LIBS) \
+    libsss_crypt.la \
+    libsss_debug.la \
+    libsss_util.la \
+    $(NULL)
+libsss_secrets_la_LDFLAGS = \
     -avoid-version \
     $(NULL)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1209,6 +1209,7 @@ libsss_iface_sync_la_LDFLAGS = \
     -avoid-version \
     $(NULL)
 
+if BUILD_WITH_LIBSECRET
 pkglib_LTLIBRARIES += libsss_secrets.la
 
 libsss_secrets_la_SOURCES = \
@@ -1228,6 +1229,7 @@ libsss_secrets_la_LIBADD = \
 libsss_secrets_la_LDFLAGS = \
     -avoid-version \
     $(NULL)
+endif
 
 pkglib_LTLIBRARIES += libsss_util.la
 libsss_util_la_SOURCES = \
@@ -1800,13 +1802,11 @@ sssd_kcm_SOURCES = \
     src/responder/kcm/kcmsrv_ccache_mem.c \
     src/responder/kcm/kcmsrv_ccache_json.c \
     src/responder/kcm/kcmsrv_ccache_secdb.c \
-    src/responder/kcm/kcmsrv_ccache_secrets.c \
     src/responder/kcm/kcmsrv_ops.c \
     src/responder/kcm/kcmsrv_op_queue.c \
     src/util/sss_sockets.c \
     src/util/sss_krb5.c \
     src/util/sss_iobuf.c \
-    src/util/tev_curl.c \
     $(SSSD_RESPONDER_OBJ) \
     $(NULL)
 sssd_kcm_CFLAGS = \
@@ -1818,7 +1818,6 @@ sssd_kcm_CFLAGS = \
     $(NULL)
 sssd_kcm_LDADD = \
     $(KRB5_LIBS) \
-    $(CURL_LIBS) \
     $(JANSSON_LIBS) \
     $(SSSD_LIBS) \
     $(UUID_LIBS) \
@@ -1828,6 +1827,17 @@ sssd_kcm_LDADD = \
     libsss_sbus.la \
     libsss_secrets.la \
     $(NULL)
+
+if BUILD_SECRETS
+sssd_kcm_SOURCES += \
+    src/responder/kcm/kcmsrv_ccache_secrets.c \
+    src/util/tev_curl.c \
+    $(NULL)
+sssd_kcm_LDADD += \
+    $(CURL_LIBS) \
+    $(NULL)
+endif
+
 endif
 
 sssd_be_SOURCES = \
@@ -3939,6 +3949,7 @@ intgcheck-prepare:
 	    --with-ldb-lib-dir="$$prefix"/lib/ldb \
 	    --enable-intgcheck-reqs \
 	    --without-semanage \
+	    --with-secrets \
 	    --with-session-recording-shell=/bin/false \
 	    --enable-local-provider \
 	    $(INTGCHECK_CONFIGURE_FLAGS) \
@@ -4876,8 +4887,6 @@ if HAVE_SYSTEMD_UNIT
         src/sysv/systemd/sssd-pam.socket \
         src/sysv/systemd/sssd-pam-priv.socket \
         src/sysv/systemd/sssd-pam.service \
-        src/sysv/systemd/sssd-secrets.socket \
-        src/sysv/systemd/sssd-secrets.service \
         $(NULL)
 if BUILD_AUTOFS
     systemdunit_DATA += \
@@ -4894,6 +4903,12 @@ if BUILD_PAC_RESPONDER
     systemdunit_DATA += \
         src/sysv/systemd/sssd-pac.socket \
         src/sysv/systemd/sssd-pac.service \
+        $(NULL)
+endif
+if BUILD_SECRETS
+    systemdunit_DATA += \
+        src/sysv/systemd/sssd-secrets.socket \
+        src/sysv/systemd/sssd-secrets.service \
         $(NULL)
 endif
 if BUILD_SSH
@@ -5033,6 +5048,7 @@ src/sysv/systemd/sssd-pam.service: src/sysv/systemd/sssd-pam.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
 	$(replace_script)
 
+if BUILD_SECRETS
 src/sysv/systemd/sssd-secrets.socket: src/sysv/systemd/sssd-secrets.socket.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
 	$(replace_script)
@@ -5040,6 +5056,7 @@ src/sysv/systemd/sssd-secrets.socket: src/sysv/systemd/sssd-secrets.socket.in Ma
 src/sysv/systemd/sssd-secrets.service: src/sysv/systemd/sssd-secrets.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
 	$(replace_script)
+endif
 
 if BUILD_AUTOFS
 src/sysv/systemd/sssd-autofs.socket: src/sysv/systemd/sssd-autofs.socket.in Makefile
@@ -5088,9 +5105,25 @@ src/sysv/systemd/sssd-sudo.service: src/sysv/systemd/sssd-sudo.service.in Makefi
 endif
 
 if BUILD_KCM
+if BUILD_SECRETS
+kcm_socket_requires = Requires=sssd-secrets.socket
+else
+kcm_socket_requires =
+endif
+
+kcm_edit_cmd = $(edit_cmd) \
+        -e 's|@kcm_socket_requires[@]|$(kcm_socket_requires)|g'
+
+kcm_replace_script = \
+    @rm -f $@ $@.tmp; \
+    srcdir=''; \
+        test -f ./$@.in || srcdir=$(srcdir)/; \
+        $(kcm_edit_cmd) $${srcdir}$@.in >$@.tmp; \
+    mv $@.tmp $@
+
 src/sysv/systemd/sssd-kcm.socket: src/sysv/systemd/sssd-kcm.socket.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
-	$(replace_script)
+	$(kcm_replace_script)
 
 src/sysv/systemd/sssd-kcm.service: src/sysv/systemd/sssd-kcm.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
@@ -5155,7 +5188,7 @@ endif
 	$(INSTALL) -d -m 0711 $(DESTDIR)$(sssdconfdir) \
                           $(DESTDIR)$(sssdconfdir)/conf.d \
                           $(DESTDIR)$(sssdconfdir)/pki
-if BUILD_SECRETS
+if BUILD_WITH_LIBSECRET
 	$(MKDIR_P) $(DESTDIR)$(secdbpath)
 endif
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1799,6 +1799,7 @@ sssd_kcm_SOURCES = \
     src/responder/kcm/kcmsrv_ccache.c \
     src/responder/kcm/kcmsrv_ccache_mem.c \
     src/responder/kcm/kcmsrv_ccache_json.c \
+    src/responder/kcm/kcmsrv_ccache_secdb.c \
     src/responder/kcm/kcmsrv_ccache_secrets.c \
     src/responder/kcm/kcmsrv_ops.c \
     src/responder/kcm/kcmsrv_op_queue.c \
@@ -1825,6 +1826,7 @@ sssd_kcm_LDADD = \
     $(SSSD_INTERNAL_LTLIBS) \
     libsss_iface.la \
     libsss_sbus.la \
+    libsss_secrets.la \
     $(NULL)
 endif
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1788,6 +1788,7 @@ sssd_secrets_LDADD = \
     $(CURL_LIBS) \
     libsss_iface.la \
     libsss_sbus.la \
+    libsss_secrets.la \
     $(NULL)
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -212,6 +212,7 @@ m4_include([src/external/test_ca.m4])
 
 if test x$with_secrets = xyes; then
     m4_include([src/external/libhttp_parser.m4])
+    m4_include([src/external/libcurl.m4])
 fi
 
 if test x$with_kcm = xyes; then
@@ -219,9 +220,13 @@ if test x$with_kcm = xyes; then
 fi
 
 if test x$with_kcm = xyes -o x$with_secrets = xyes; then
-    m4_include([src/external/libcurl.m4])
+    BUILD_WITH_LIBSECRET=1
+    AC_DEFINE_UNQUOTED(BUILD_WITH_LIBSECRET, 1, [libsecret will be built])
     m4_include([src/external/libjansson.m4])
 fi
+
+AM_CONDITIONAL([BUILD_WITH_LIBSECRET],
+               [test x"$BUILD_WITH_LIBSECRET" != "x"])
 
 # This variable is defined by external/libcurl.m4, but conditionals
 # must be always evaluated

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -118,11 +118,8 @@
     %global enable_systemtap_opt --enable-systemtap
 %endif
 
-%if (0%{?fedora} || 0%{?rhel} >= 7)
-    %global with_secrets 1
-%else
-    %global with_secret_responder --without-secrets
-%endif
+%global with_secrets 0
+%global with_secret_responder --without-secrets
 
 %if (0%{?fedora} >= 23 || 0%{?rhel} >= 7)
     %global with_kcm 1
@@ -284,13 +281,13 @@ BuildRequires: systemtap-sdt-devel
 %endif
 %if (0%{?with_secrets} == 1)
 BuildRequires: http-parser-devel
+BuildRequires: libcurl-devel
 %endif
 %if (0%{?with_kcm} == 1)
 BuildRequires: libuuid-devel
 %endif
 %if (0%{?with_secrets} == 1 || 0%{?with_kcm} == 1)
 BuildRequires: jansson-devel
-BuildRequires: libcurl-devel
 %endif
 %if (0%{?with_gdm_pam_extensions} == 1)
 BuildRequires: gdm-pam-extensions-devel
@@ -1028,7 +1025,9 @@ done
 %{_libdir}/%{name}/libsss_iface_sync.so
 %{_libdir}/%{name}/libifp_iface.so
 %{_libdir}/%{name}/libifp_iface_sync.so
+%if (0%{?with_secrets} == 1 || 0%{?with_kcm} == 1)
 %{_libdir}/%{name}/libsss_secrets.so
+%endif
 
 %{ldb_modulesdir}/memberof.so
 %{_bindir}/sss_ssh_authorizedkeys
@@ -1360,9 +1359,7 @@ done
 
 %if (0%{?with_kcm} == 1)
 %files kcm -f sssd_kcm.lang
-%if (0%{?with_secrets} == 1)
 %attr(700,root,root) %dir %{secdbpath}
-%endif
 %{_libexecdir}/%{servicename}/sssd_kcm
 %if (0%{?with_secrets} == 1)
 %{_libexecdir}/%{servicename}/sssd_secrets
@@ -1371,10 +1368,10 @@ done
 %{_datadir}/sssd-kcm/kcm_default_ccache
 %{_unitdir}/sssd-kcm.socket
 %{_unitdir}/sssd-kcm.service
-%{_unitdir}/sssd-secrets.socket
-%{_unitdir}/sssd-secrets.service
 %{_mandir}/man8/sssd-kcm.8*
 %if (0%{?with_secrets} == 1)
+%{_unitdir}/sssd-secrets.socket
+%{_unitdir}/sssd-secrets.service
 %{_mandir}/man5/sssd-secrets.5*
 %endif
 %endif
@@ -1392,7 +1389,6 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d / -s /sbin/nologin -c "Us
 %systemd_post sssd-pac.socket
 %systemd_post sssd-pam.socket
 %systemd_post sssd-pam-priv.socket
-%systemd_post sssd-secrets.socket
 %systemd_post sssd-ssh.socket
 %systemd_post sssd-sudo.socket
 
@@ -1403,7 +1399,6 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d / -s /sbin/nologin -c "Us
 %systemd_preun sssd-pac.socket
 %systemd_preun sssd-pam.socket
 %systemd_preun sssd-pam-priv.socket
-%systemd_preun sssd-secrets.socket
 %systemd_preun sssd-ssh.socket
 %systemd_preun sssd-sudo.socket
 
@@ -1418,8 +1413,6 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d / -s /sbin/nologin -c "Us
 %systemd_postun_with_restart sssd-pam.socket
 %systemd_postun_with_restart sssd-pam-priv.socket
 %systemd_postun_with_restart sssd-pam.service
-%systemd_postun_with_restart sssd-secrets.socket
-%systemd_postun_with_restart sssd-secrets.service
 %systemd_postun_with_restart sssd-ssh.socket
 %systemd_postun_with_restart sssd-ssh.service
 %systemd_postun_with_restart sssd-sudo.socket
@@ -1444,6 +1437,18 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d / -s /sbin/nologin -c "Us
 %postun kcm
 %systemd_postun_with_restart sssd-kcm.socket
 %systemd_postun_with_restart sssd-kcm.service
+%endif
+
+%if (0%{?with_secrets} == 1)
+%post secrets
+%systemd_postun_with_restart sssd-secrets.socket
+
+%preun secrets
+%systemd_preun_with_restart sssd-secrets.socket
+
+%postun secrets
+%systemd_postun_with_restart sssd-secrets.socket
+%systemd_postun_with_restart sssd-secrets.service
 %endif
 
 %else

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -1028,6 +1028,7 @@ done
 %{_libdir}/%{name}/libsss_iface_sync.so
 %{_libdir}/%{name}/libifp_iface.so
 %{_libdir}/%{name}/libifp_iface_sync.so
+%{_libdir}/%{name}/libsss_secrets.so
 
 %{ldb_modulesdir}/memberof.so
 %{_bindir}/sss_ssh_authorizedkeys

--- a/src/conf_macros.m4
+++ b/src/conf_macros.m4
@@ -883,11 +883,11 @@ AC_DEFUN([SSSD_RUNSTATEDIR],
 AC_DEFUN([WITH_SECRETS],
   [ AC_ARG_WITH([secrets],
                 [AC_HELP_STRING([--with-secrets],
-                                [Whether to build with secrets support [yes]]
+                                [Whether to build with secrets support [no]]
                                )
                 ],
                 [with_secrets=$withval],
-                with_secrets=yes
+                with_secrets=no
                )
 
     if test x"$with_secrets" = xyes; then

--- a/src/man/sssd-kcm.8.xml
+++ b/src/man/sssd-kcm.8.xml
@@ -121,17 +121,9 @@ systemctl enable sssd-kcm.socket
     <refsect1 id='storage'>
         <title>THE CREDENTIAL CACHE STORAGE</title>
         <para>
-            The credential caches are stored in the SSSD secrets service (see
-            <citerefentry>
-                <refentrytitle>sssd-secrets</refentrytitle><manvolnum>5</manvolnum>
-            </citerefentry>
-            for more details). Therefore it is important that also the sssd-secrets
-            service is enabled and its socket is started:
-            <programlisting>
-systemctl start sssd-secrets.socket
-systemctl enable sssd-secrets.socket
-            </programlisting>
-            Your distribution should already set the dependencies between the services.
+            The credential caches are stored in a database, much like SSSD
+            caches user or group entries. The database is typically
+            located at <quote>/var/lib/sss/secrets</quote>.
         </para>
     </refsect1>
 

--- a/src/responder/kcm/kcm.c
+++ b/src/responder/kcm/kcm.c
@@ -57,7 +57,7 @@ static errno_t kcm_get_ccdb_be(struct kcm_ctx *kctx)
                             kctx->rctx,
                             kctx->rctx->confdb_service_path,
                             CONFDB_KCM_DB,
-                            "secrets",
+                            "secdb",
                             &str_db);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,

--- a/src/responder/kcm/kcm.c
+++ b/src/responder/kcm/kcm.c
@@ -70,6 +70,9 @@ static errno_t kcm_get_ccdb_be(struct kcm_ctx *kctx)
     if (strcasecmp(str_db, "memory") == 0) {
         kctx->cc_be = CCDB_BE_MEMORY;
         return EOK;
+    } else if (strcasecmp(str_db, "secdb") == 0) {
+        kctx->cc_be = CCDB_BE_SECDB;
+        return EOK;
     } else if (strcasecmp(str_db, "secrets") == 0) {
         kctx->cc_be = CCDB_BE_SECRETS;
         return EOK;
@@ -134,7 +137,7 @@ static int kcm_get_config(struct kcm_ctx *kctx)
         goto done;
     }
 
-    if (kctx->cc_be == CCDB_BE_SECRETS) {
+    if (kctx->cc_be == CCDB_BE_SECRETS || kctx->cc_be == CCDB_BE_SECDB) {
         ret = responder_setup_idle_timeout_config(kctx->rctx);
         if (ret != EOK) {
             DEBUG(SSSDBG_MINOR_FAILURE,

--- a/src/responder/kcm/kcmsrv_ccache.c
+++ b/src/responder/kcm/kcmsrv_ccache.c
@@ -247,10 +247,12 @@ struct kcm_ccdb *kcm_ccdb_init(TALLOC_CTX *mem_ctx,
         DEBUG(SSSDBG_FUNC_DATA, "KCM back end: memory\n");
         ccdb->ops = &ccdb_mem_ops;
         break;
+#ifdef BUILD_SECRETS
     case CCDB_BE_SECRETS:
         DEBUG(SSSDBG_FUNC_DATA, "KCM back end: sssd-secrets\n");
         ccdb->ops = &ccdb_sec_ops;
         break;
+#endif /* BUILD_SECRETS */
     case CCDB_BE_SECDB:
         DEBUG(SSSDBG_FUNC_DATA, "KCM back end: libsss_secrets\n");
         ccdb->ops = &ccdb_secdb_ops;

--- a/src/responder/kcm/kcmsrv_ccache.c
+++ b/src/responder/kcm/kcmsrv_ccache.c
@@ -251,6 +251,10 @@ struct kcm_ccdb *kcm_ccdb_init(TALLOC_CTX *mem_ctx,
         DEBUG(SSSDBG_FUNC_DATA, "KCM back end: sssd-secrets\n");
         ccdb->ops = &ccdb_sec_ops;
         break;
+    case CCDB_BE_SECDB:
+        DEBUG(SSSDBG_FUNC_DATA, "KCM back end: libsss_secrets\n");
+        ccdb->ops = &ccdb_secdb_ops;
+        break;
     default:
         DEBUG(SSSDBG_CRIT_FAILURE, "Unknown ccache database\n");
         break;

--- a/src/responder/kcm/kcmsrv_ccache.h
+++ b/src/responder/kcm/kcmsrv_ccache.h
@@ -34,6 +34,9 @@
 #define UUID_BYTES    16
 #define UUID_STR_SIZE 37
 
+/* Just to keep the name of the ccache readable */
+#define MAX_CC_NUM          99999
+
 /*
  * Credentials are opaque to the KCM server
  *
@@ -319,17 +322,9 @@ const char *sec_key_get_name(const char *sec_key);
 errno_t sec_key_get_uuid(const char *sec_key,
                          uuid_t uuid);
 
-/* Create a URL for the default client's ccache */
-const char *sec_dfl_url_create(TALLOC_CTX *mem_ctx,
-                               struct cli_creds *client);
-
-/* Create a URL for the client's ccache container */
-const char *sec_container_url_create(TALLOC_CTX *mem_ctx,
-                                     struct cli_creds *client);
-
-const char *sec_cc_url_create(TALLOC_CTX *mem_ctx,
-                              struct cli_creds *client,
-                              const char *sec_key);
+const char *sec_key_create(TALLOC_CTX *mem_ctx,
+                           const char *name,
+                           uuid_t uuid);
 
 /*
  * sec_key is a concatenation of the ccache's UUID and name
@@ -345,7 +340,6 @@ errno_t sec_kv_to_ccache(TALLOC_CTX *mem_ctx,
 errno_t kcm_ccache_to_sec_input(TALLOC_CTX *mem_ctx,
                                 struct kcm_ccache *cc,
                                 struct cli_creds *client,
-                                const char **_url,
                                 struct sss_iobuf **_payload);
 
 #endif /* _KCMSRV_CCACHE_H_ */

--- a/src/responder/kcm/kcmsrv_ccache_be.h
+++ b/src/responder/kcm/kcmsrv_ccache_be.h
@@ -201,5 +201,6 @@ struct kcm_ccdb_ops {
 
 extern const struct kcm_ccdb_ops ccdb_mem_ops;
 extern const struct kcm_ccdb_ops ccdb_sec_ops;
+extern const struct kcm_ccdb_ops ccdb_secdb_ops;
 
 #endif /* _KCMSRV_CCACHE_BE_ */

--- a/src/responder/kcm/kcmsrv_ccache_secdb.c
+++ b/src/responder/kcm/kcmsrv_ccache_secdb.c
@@ -226,6 +226,11 @@ struct ccdb_secdb {
     struct sss_sec_ctx *sctx;
 };
 
+/* Since with the synchronous database, the database operations are just
+ * fake-async wrappers around otherwise sync operations, we don't often
+ * need any state structure, unless the _recv() function returns anything,
+ * so we use this empty structure instead
+ */
 struct ccdb_secdb_state {
 };
 
@@ -531,6 +536,7 @@ static errno_t ccdb_secdb_init(struct kcm_ccdb *db)
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Cannot initialize the security database\n");
+        talloc_free(secdb);
         return ret;
     }
 

--- a/src/responder/kcm/kcmsrv_ccache_secdb.c
+++ b/src/responder/kcm/kcmsrv_ccache_secdb.c
@@ -1,0 +1,1460 @@
+/*
+   SSSD
+
+   KCM Server - ccache storage using libsss_secrets
+
+   Copyright (C) Red Hat, 2016
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <talloc.h>
+#include <stdio.h>
+
+#include "util/util.h"
+#include "util/secrets/secrets.h"
+#include "util/crypto/sss_crypto.h"
+#include "responder/kcm/kcmsrv_ccache_pvt.h"
+#include "responder/kcm/kcmsrv_ccache_be.h"
+
+#define KCM_SECDB_URL        "/kcm/persistent"
+#define KCM_SECDB_BASE_FMT    KCM_SECDB_URL"/%"SPRIuid"/"
+#define KCM_SECDB_CCACHE_FMT  KCM_SECDB_BASE_FMT"ccache/"
+#define KCM_SECDB_DFL_FMT     KCM_SECDB_BASE_FMT"default"
+
+static errno_t sec_get_b64(TALLOC_CTX *mem_ctx,
+                           struct sss_sec_req *req,
+                           struct sss_iobuf **_buf)
+{
+    errno_t ret;
+    TALLOC_CTX *tmp_ctx;
+    char *b64_sec;
+    uint8_t *data;
+    size_t data_size;
+    struct sss_iobuf *buf;
+
+    tmp_ctx = talloc_new(mem_ctx);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    ret = sss_sec_get(tmp_ctx, req, &b64_sec);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Cannot retrieve the secret [%d]: %s\n", ret, sss_strerror(ret));
+        goto done;
+    }
+
+    data = sss_base64_decode(tmp_ctx, b64_sec, &data_size);
+    if (data == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Cannot decode secret from base64\n");
+        ret = EIO;
+        goto done;
+    }
+
+    buf = sss_iobuf_init_readonly(tmp_ctx, data, data_size);
+    if (buf == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Cannot init the iobuf\n");
+        ret = EIO;
+        goto done;
+    }
+
+    ret = EOK;
+    *_buf = talloc_steal(mem_ctx, buf);
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+static errno_t sec_put_b64(TALLOC_CTX *mem_ctx,
+                           struct sss_sec_req *req,
+                           struct sss_iobuf *buf)
+{
+    errno_t ret;
+    TALLOC_CTX *tmp_ctx;
+    char *secret;
+
+    tmp_ctx = talloc_new(mem_ctx);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    secret = sss_base64_encode(tmp_ctx,
+                               sss_iobuf_get_data(buf),
+                               sss_iobuf_get_size(buf));
+    if (secret == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Cannot encode secret to base64\n");
+        ret = EIO;
+        goto done;
+    }
+
+    ret = sss_sec_put(req, secret);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Cannot write the secret [%d]: %s\n", ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = EOK;
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+static errno_t sec_update_b64(TALLOC_CTX *mem_ctx,
+                              struct sss_sec_req *req,
+                              struct sss_iobuf *buf)
+{
+    errno_t ret;
+    TALLOC_CTX *tmp_ctx;
+    char *secret;
+
+    tmp_ctx = talloc_new(mem_ctx);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    secret = sss_base64_encode(tmp_ctx,
+                               sss_iobuf_get_data(buf),
+                               sss_iobuf_get_size(buf));
+    if (secret == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Cannot encode secret to base64\n");
+        ret = EIO;
+        goto done;
+    }
+
+    ret = sss_sec_update(req, secret);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Cannot write the secret [%d]: %s\n", ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = EOK;
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+static const char *secdb_container_url_create(TALLOC_CTX *mem_ctx,
+                                              struct cli_creds *client)
+{
+    return talloc_asprintf(mem_ctx,
+                           KCM_SECDB_CCACHE_FMT,
+                           cli_creds_get_uid(client));
+}
+
+static const char *secdb_cc_url_create(TALLOC_CTX *mem_ctx,
+                                       struct cli_creds *client,
+                                       const char *secdb_key)
+{
+    return talloc_asprintf(mem_ctx,
+                           KCM_SECDB_CCACHE_FMT"%s",
+                           cli_creds_get_uid(client),
+                           secdb_key);
+}
+
+static const char *secdb_dfl_url_create(TALLOC_CTX *mem_ctx,
+                                        struct cli_creds *client)
+{
+    return talloc_asprintf(mem_ctx,
+                           KCM_SECDB_DFL_FMT,
+                           cli_creds_get_uid(client));
+}
+
+static errno_t kcm_ccache_to_secdb_kv(TALLOC_CTX *mem_ctx,
+                                      struct kcm_ccache *cc,
+                                      struct cli_creds *client,
+                                      const char **_url,
+                                      struct sss_iobuf **_payload)
+{
+    errno_t ret;
+    const char *url;
+    const char *key;
+    TALLOC_CTX *tmp_ctx;
+    struct sss_iobuf *payload;
+
+    tmp_ctx = talloc_new(mem_ctx);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    key = sec_key_create(tmp_ctx, cc->name, cc->uuid);
+    if (key == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Cannot create key for %s\n", cc->name);
+        ret = ENOMEM;
+        goto done;
+    }
+
+    url = secdb_cc_url_create(tmp_ctx, client, key);
+    if (url == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Cannot create URL from %s\n", key);
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = kcm_ccache_to_sec_input(mem_ctx, cc, client, &payload);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Cannot convert ccache to a secret [%d][%s]\n", ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = EOK;
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Created URL %s\n", url);
+    *_url = talloc_steal(mem_ctx, url);
+    *_payload = talloc_steal(mem_ctx, payload);
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+struct ccdb_secdb {
+    struct sss_sec_ctx *sctx;
+};
+
+struct ccdb_secdb_state {
+};
+
+static errno_t secdb_container_url_req(TALLOC_CTX *mem_ctx,
+                                       struct sss_sec_ctx *sctx,
+                                       struct cli_creds *client,
+                                       struct sss_sec_req **_sreq)
+{
+    const char *url;
+    struct sss_sec_req *sreq;
+    errno_t ret;
+    TALLOC_CTX *tmp_ctx;
+
+    tmp_ctx = talloc_new(mem_ctx);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    url = secdb_container_url_create(tmp_ctx, client);
+    if (url == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = sss_sec_new_req(tmp_ctx, sctx, url, geteuid(), &sreq);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    ret = EOK;
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Created request for URL %s\n", url);
+    *_sreq = talloc_steal(mem_ctx, sreq);
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+static errno_t secdb_cc_url_req(TALLOC_CTX *mem_ctx,
+                                struct sss_sec_ctx *sctx,
+                                struct cli_creds *client,
+                                const char *secdb_url,
+                                struct sss_sec_req **_sreq)
+{
+    struct sss_sec_req *sreq;
+    errno_t ret;
+    TALLOC_CTX *tmp_ctx;
+
+    tmp_ctx = talloc_new(mem_ctx);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    ret = sss_sec_new_req(tmp_ctx, sctx, secdb_url, geteuid(), &sreq);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    ret = EOK;
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Created request for URL %s\n", secdb_url);
+    *_sreq = talloc_steal(mem_ctx, sreq);
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+static errno_t secdb_cc_key_req(TALLOC_CTX *mem_ctx,
+                                struct sss_sec_ctx *sctx,
+                                struct cli_creds *client,
+                                const char *secdb_key,
+                                struct sss_sec_req **_sreq)
+{
+    const char *url;
+    struct sss_sec_req *sreq;
+    errno_t ret;
+    TALLOC_CTX *tmp_ctx;
+
+    tmp_ctx = talloc_new(mem_ctx);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    url = secdb_cc_url_create(tmp_ctx, client, secdb_key);
+    if (url == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = secdb_cc_url_req(tmp_ctx, sctx, client, url, &sreq);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    ret = EOK;
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Created request for URL %s\n", url);
+    *_sreq = talloc_steal(mem_ctx, sreq);
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+static errno_t secdb_dfl_url_req(TALLOC_CTX *mem_ctx,
+                                 struct sss_sec_ctx *sctx,
+                                 struct cli_creds *client,
+                                 struct sss_sec_req **_sreq)
+{
+    const char *url;
+    struct sss_sec_req *sreq;
+    errno_t ret;
+    TALLOC_CTX *tmp_ctx;
+
+    tmp_ctx = talloc_new(mem_ctx);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    url = secdb_dfl_url_create(tmp_ctx, client);
+    if (url == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = sss_sec_new_req(tmp_ctx, sctx, url, geteuid(), &sreq);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    ret = EOK;
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Created request for URL %s\n", url);
+    *_sreq = talloc_steal(mem_ctx, sreq);
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+static errno_t key_by_uuid(TALLOC_CTX *mem_ctx,
+                           struct sss_sec_ctx *sctx,
+                           struct cli_creds *client,
+                           uuid_t uuid,
+                           char **_key)
+{
+    TALLOC_CTX *tmp_ctx;
+    errno_t ret;
+    char *key_match = NULL;
+    char **keys = NULL;
+    size_t nkeys;
+    struct sss_sec_req *sreq = NULL;
+
+    tmp_ctx = talloc_new(mem_ctx);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    ret = secdb_container_url_req(tmp_ctx, sctx, client, &sreq);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    ret = sss_sec_list(tmp_ctx, sreq, &keys, &nkeys);
+    if (ret == ENOENT) {
+        DEBUG(SSSDBG_MINOR_FAILURE, "The container was not found\n");
+        goto done;
+    } else if (ret != EOK) {
+        goto done;
+    }
+
+    for (size_t i = 0; i < nkeys; i++) {
+        if (sec_key_match_uuid(keys[i], uuid)) {
+            key_match = keys[i];
+            break;
+        }
+    }
+
+    if (key_match == NULL) {
+        DEBUG(SSSDBG_TRACE_INTERNAL, "No key matched\n");
+        ret = ENOENT;
+        goto done;
+    }
+
+    ret = EOK;
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Found key %s\n", key_match);
+    *_key = talloc_steal(mem_ctx, key_match);
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+static errno_t key_by_name(TALLOC_CTX *mem_ctx,
+                           struct sss_sec_ctx *sctx,
+                           struct cli_creds *client,
+                           const char *name,
+                           char **_key)
+{
+    TALLOC_CTX *tmp_ctx;
+    errno_t ret;
+    char *key_match = NULL;
+    char **keys = NULL;
+    size_t nkeys;
+    struct sss_sec_req *sreq = NULL;
+
+    tmp_ctx = talloc_new(mem_ctx);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    ret = secdb_container_url_req(tmp_ctx, sctx, client, &sreq);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    ret = sss_sec_list(tmp_ctx, sreq, &keys, &nkeys);
+    if (ret == ENOENT) {
+        DEBUG(SSSDBG_MINOR_FAILURE, "The container was not found\n");
+        goto done;
+    } else if (ret != EOK) {
+        goto done;
+    }
+
+    for (size_t i = 0; i < nkeys; i++) {
+        if (sec_key_match_name(keys[i], name)) {
+            key_match = keys[i];
+            break;
+        }
+    }
+
+    if (key_match == NULL) {
+        DEBUG(SSSDBG_TRACE_INTERNAL, "No key matched\n");
+        ret = ENOENT;
+        goto done;
+    }
+
+    ret = EOK;
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Found key %s\n", key_match);
+    *_key = talloc_steal(mem_ctx, key_match);
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+static errno_t secdb_get_cc(TALLOC_CTX *mem_ctx,
+                            struct sss_sec_ctx *sctx,
+                            const char *secdb_key,
+                            struct cli_creds *client,
+                            struct kcm_ccache **_cc)
+{
+    errno_t ret;
+    TALLOC_CTX *tmp_ctx = NULL;
+    struct kcm_ccache *cc = NULL;
+    struct sss_sec_req *sreq = NULL;
+    struct sss_iobuf *ccbuf;
+
+    tmp_ctx = talloc_new(mem_ctx);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    ret = secdb_cc_key_req(tmp_ctx, sctx, client, secdb_key, &sreq);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Cannot create secdb request [%d][%s]\n", ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = sec_get_b64(tmp_ctx, sreq, &ccbuf);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Cannot get the secret [%d][%s]\n", ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = sec_kv_to_ccache(tmp_ctx,
+                           secdb_key,
+                           (const char *) sss_iobuf_get_data(ccbuf),
+                           client,
+                           &cc);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Cannot convert JSON keyval to ccache blob [%d]: %s\n",
+              ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = EOK;
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Fetched the ccache\n");
+    *_cc = talloc_steal(mem_ctx, cc);
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+static errno_t ccdb_secdb_init(struct kcm_ccdb *db)
+{
+    struct ccdb_secdb *secdb = NULL;
+    errno_t ret;
+
+    secdb = talloc_zero(db, struct ccdb_secdb);
+    if (secdb == NULL) {
+        return ENOMEM;
+    }
+
+    /* TODO: read configuration from the config file, adjust quotas */
+
+    ret = sss_sec_init(db, NULL, &secdb->sctx);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Cannot initialize the security database\n");
+        return ret;
+    }
+
+    DEBUG(SSSDBG_TRACE_INTERNAL, "secdb initialized\n");
+    db->db_handle = secdb;
+    return EOK;
+}
+
+struct ccdb_secdb_nextid_state {
+    unsigned int nextid;
+};
+
+static bool is_in_use(char **keys, size_t nkeys, const char *nextid_name)
+{
+    for (size_t i = 0; i < nkeys; i++) {
+        if (sec_key_match_name(keys[i], nextid_name) == true) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static struct tevent_req *ccdb_secdb_nextid_send(TALLOC_CTX *mem_ctx,
+                                               struct tevent_context *ev,
+                                               struct kcm_ccdb *db,
+                                               struct cli_creds *client)
+{
+    struct tevent_req *req = NULL;
+    struct ccdb_secdb_nextid_state *state = NULL;
+    struct ccdb_secdb *secdb = NULL;
+    const int maxtries = 3;
+    int numtry;
+    errno_t ret;
+    struct sss_sec_req *sreq = NULL;
+    char **keys = NULL;
+    size_t nkeys;
+    char *nextid_name = NULL;
+
+    DEBUG(SSSDBG_TRACE_LIBS, "Generating a new ID\n");
+
+    req = tevent_req_create(mem_ctx, &state, struct ccdb_secdb_nextid_state);
+    if (req == NULL) {
+        return NULL;
+    }
+
+    secdb = talloc_get_type(db->db_handle, struct ccdb_secdb);
+    if (secdb == NULL) {
+        ret = EIO;
+        goto immediate;
+    }
+
+    ret = secdb_container_url_req(state, secdb->sctx, client, &sreq);
+    if (ret != EOK) {
+        goto immediate;
+    }
+
+    ret = sss_sec_list(state, sreq, &keys, &nkeys);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Cannot list keys [%d]: %s\n",
+              ret, sss_strerror(ret));
+        goto immediate;
+    }
+
+    for (numtry = 0; numtry  < maxtries; numtry++) {
+        state->nextid = rand() % MAX_CC_NUM;
+        nextid_name = talloc_asprintf(state, "%"SPRIuid":%u",
+                                      cli_creds_get_uid(client),
+                                      state->nextid);
+        if (nextid_name == NULL) {
+            ret = ENOMEM;
+            goto immediate;
+        }
+
+        if (!is_in_use(keys, nkeys, nextid_name)) {
+            break;
+        }
+    }
+
+    if (numtry >= maxtries) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Failed to find a random ccache in %d tries\n", numtry);
+        ret = EBUSY;
+        goto immediate;
+    }
+
+    ret = EOK;
+    DEBUG(SSSDBG_TRACE_LIBS, "Generated next ID %d\n", state->nextid);
+immediate:
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else {
+        tevent_req_error(req, ret);
+    }
+    tevent_req_post(req, ev);
+    return req;
+}
+
+static errno_t ccdb_secdb_nextid_recv(struct tevent_req *req,
+                                    unsigned int *_nextid)
+{
+    struct ccdb_secdb_nextid_state *state = tevent_req_data(req,
+                                                struct ccdb_secdb_nextid_state);
+
+    TEVENT_REQ_RETURN_ON_ERROR(req);
+    *_nextid = state->nextid;
+    return EOK;
+}
+
+static struct tevent_req *ccdb_secdb_set_default_send(TALLOC_CTX *mem_ctx,
+                                                      struct tevent_context *ev,
+                                                      struct kcm_ccdb *db,
+                                                      struct cli_creds *client,
+                                                      uuid_t uuid)
+{
+    struct tevent_req *req = NULL;
+    struct ccdb_secdb_state *state = NULL;
+    struct ccdb_secdb *secdb = talloc_get_type(db->db_handle, struct ccdb_secdb);
+    errno_t ret;
+    char uuid_str[UUID_STR_SIZE];
+    struct sss_sec_req *sreq = NULL;
+    struct sss_iobuf *iobuf;
+    char *cur_default;
+
+    uuid_unparse(uuid, uuid_str);
+    DEBUG(SSSDBG_TRACE_INTERNAL,
+          "Setting the default ccache to %s\n", uuid_str);
+
+    req = tevent_req_create(mem_ctx, &state, struct ccdb_secdb_state);
+    if (req == NULL) {
+        return NULL;
+    }
+
+    ret = secdb_dfl_url_req(state, secdb->sctx, client, &sreq);
+    if (ret != EOK) {
+        goto immediate;
+    }
+
+    iobuf = sss_iobuf_init_readonly(state,
+                                    (const uint8_t *) uuid_str,
+                                    UUID_STR_SIZE);
+    if (iobuf == NULL) {
+        ret = ENOMEM;
+        goto immediate;
+    }
+
+    ret = sss_sec_get(state, sreq, &cur_default);
+    if (ret == ENOENT) {
+        ret = sec_put_b64(state, sreq, iobuf);
+    } else if (ret == EOK) {
+        ret = sec_update_b64(state, sreq, iobuf);
+    }
+
+    if (ret != EOK) {
+        goto immediate;
+    }
+
+    ret = EOK;
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Set the default ccache\n");
+immediate:
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else {
+        tevent_req_error(req, ret);
+    }
+    tevent_req_post(req, ev);
+    return req;
+}
+
+static errno_t ccdb_secdb_set_default_recv(struct tevent_req *req)
+{
+    TEVENT_REQ_RETURN_ON_ERROR(req);
+    return EOK;
+}
+
+struct ccdb_secdb_get_default_state {
+    uuid_t uuid;
+};
+
+static struct tevent_req *ccdb_secdb_get_default_send(TALLOC_CTX *mem_ctx,
+                                                      struct tevent_context *ev,
+                                                      struct kcm_ccdb *db,
+                                                      struct cli_creds *client)
+{
+    struct ccdb_secdb *secdb = talloc_get_type(db->db_handle, struct ccdb_secdb);
+    struct tevent_req *req = NULL;
+    struct ccdb_secdb_get_default_state *state = NULL;
+    errno_t ret;
+    struct sss_sec_req *sreq = NULL;
+    struct sss_iobuf *dfl_iobuf = NULL;
+    size_t uuid_size;
+
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Getting the default ccache\n");
+
+    req = tevent_req_create(mem_ctx, &state, struct ccdb_secdb_get_default_state);
+    if (req == NULL) {
+        return NULL;
+    }
+
+    ret = secdb_dfl_url_req(state, secdb->sctx, client, &sreq);
+    if (ret != EOK) {
+        goto immediate;
+    }
+
+    ret = sec_get_b64(state, sreq, &dfl_iobuf);
+    if (ret == ENOENT) {
+        uuid_clear(state->uuid);
+        ret = EOK;
+        goto immediate;
+    } else if (ret != EOK) {
+        goto immediate;
+    }
+
+    uuid_size = sss_iobuf_get_size(dfl_iobuf);
+    if (uuid_size != UUID_STR_SIZE) {
+        DEBUG(SSSDBG_OP_FAILURE, "Unexpected UUID size %zu\n", uuid_size);
+        ret = EIO;
+        goto immediate;
+    }
+
+    uuid_parse((const char *) sss_iobuf_get_data(dfl_iobuf), state->uuid);
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Got the default ccache\n");
+    ret = EOK;
+immediate:
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else {
+        tevent_req_error(req, ret);
+    }
+    tevent_req_post(req, ev);
+    return req;
+}
+
+static errno_t ccdb_secdb_get_default_recv(struct tevent_req *req,
+                                           uuid_t uuid)
+{
+    struct ccdb_secdb_get_default_state *state = tevent_req_data(req,
+                                                struct ccdb_secdb_get_default_state);
+
+    TEVENT_REQ_RETURN_ON_ERROR(req);
+
+    uuid_copy(uuid, state->uuid);
+    return EOK;
+}
+
+struct ccdb_secdb_list_state {
+    uuid_t *uuid_list;
+};
+
+static struct tevent_req *ccdb_secdb_list_send(TALLOC_CTX *mem_ctx,
+                                               struct tevent_context *ev,
+                                               struct kcm_ccdb *db,
+                                               struct cli_creds *client)
+{
+    struct ccdb_secdb *secdb = talloc_get_type(db->db_handle, struct ccdb_secdb);
+    struct tevent_req *req = NULL;
+    struct ccdb_secdb_list_state *state = NULL;
+    errno_t ret;
+    char **keys = NULL;
+    size_t nkeys;
+    struct sss_sec_req *sreq = NULL;
+
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Listing all ccaches\n");
+
+    req = tevent_req_create(mem_ctx, &state, struct ccdb_secdb_list_state);
+    if (req == NULL) {
+        return NULL;
+    }
+
+    ret = secdb_container_url_req(state, secdb->sctx, client, &sreq);
+    if (ret != EOK) {
+        goto immediate;
+    }
+
+    ret = sss_sec_list(state, sreq, &keys, &nkeys);
+    if (ret == ENOENT) {
+        nkeys = 0;
+        /* Fall through and return an empty list */
+    } else if (ret != EOK) {
+        goto immediate;
+    }
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Found %zu ccaches\n", nkeys);
+
+    state->uuid_list = talloc_array(state, uuid_t, nkeys + 1);
+    if (state->uuid_list == NULL) {
+        ret = ENOMEM;
+        goto immediate;
+    }
+
+    for (size_t i = 0; i < nkeys; i++) {
+        ret = sec_key_get_uuid(keys[i],
+                               state->uuid_list[i]);
+        if (ret != EOK) {
+            goto immediate;
+        }
+    }
+    /* Sentinel */
+    uuid_clear(state->uuid_list[nkeys]);
+
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Listing all caches done\n");
+    ret = EOK;
+immediate:
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else {
+        tevent_req_error(req, ret);
+    }
+    tevent_req_post(req, ev);
+    return req;
+}
+
+static errno_t ccdb_secdb_list_recv(struct tevent_req *req,
+                                  TALLOC_CTX *mem_ctx,
+                                  uuid_t **_uuid_list)
+{
+    struct ccdb_secdb_list_state *state = tevent_req_data(req,
+                                                struct ccdb_secdb_list_state);
+
+    TEVENT_REQ_RETURN_ON_ERROR(req);
+    *_uuid_list = talloc_steal(mem_ctx, state->uuid_list);
+    return EOK;
+}
+
+struct ccdb_secdb_getbyuuid_state {
+    struct kcm_ccache *cc;
+};
+
+static struct tevent_req *ccdb_secdb_getbyuuid_send(TALLOC_CTX *mem_ctx,
+                                                    struct tevent_context *ev,
+                                                    struct kcm_ccdb *db,
+                                                    struct cli_creds *client,
+                                                    uuid_t uuid)
+{
+    struct ccdb_secdb *secdb = talloc_get_type(db->db_handle, struct ccdb_secdb);
+    struct tevent_req *req = NULL;
+    struct ccdb_secdb_getbyuuid_state *state = NULL;
+    errno_t ret;
+    char *secdb_key = NULL;
+
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Getting ccache by UUID\n");
+
+    req = tevent_req_create(mem_ctx, &state, struct ccdb_secdb_getbyuuid_state);
+    if (req == NULL) {
+        return NULL;
+    }
+
+    ret = key_by_uuid(state, secdb->sctx, client, uuid, &secdb_key);
+    if (ret == ENOENT) {
+        state->cc = NULL;
+        ret = EOK;
+        goto immediate;
+    } else if (ret != EOK) {
+        goto immediate;
+    }
+
+    ret = secdb_get_cc(state, secdb->sctx, secdb_key, client, &state->cc);
+    if (ret != EOK) {
+        goto immediate;
+    }
+
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Got ccache by UUID\n");
+    ret = EOK;
+immediate:
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else {
+        tevent_req_error(req, ret);
+    }
+    tevent_req_post(req, ev);
+    return req;
+}
+
+static errno_t ccdb_secdb_getbyuuid_recv(struct tevent_req *req,
+                                         TALLOC_CTX *mem_ctx,
+                                         struct kcm_ccache **_cc)
+{
+    struct ccdb_secdb_getbyuuid_state *state = tevent_req_data(req,
+                                            struct ccdb_secdb_getbyuuid_state);
+
+    TEVENT_REQ_RETURN_ON_ERROR(req);
+    *_cc = talloc_steal(mem_ctx, state->cc);
+    return EOK;
+}
+
+struct ccdb_secdb_getbyname_state {
+    struct kcm_ccache *cc;
+};
+
+static struct tevent_req *ccdb_secdb_getbyname_send(TALLOC_CTX *mem_ctx,
+                                                    struct tevent_context *ev,
+                                                    struct kcm_ccdb *db,
+                                                    struct cli_creds *client,
+                                                    const char *name)
+{
+    struct ccdb_secdb *secdb = talloc_get_type(db->db_handle, struct ccdb_secdb);
+    struct tevent_req *req = NULL;
+    struct ccdb_secdb_getbyname_state *state = NULL;
+    errno_t ret;
+    char *secdb_key = NULL;
+
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Getting ccache by name\n");
+
+    req = tevent_req_create(mem_ctx, &state, struct ccdb_secdb_getbyname_state);
+    if (req == NULL) {
+        return NULL;
+    }
+
+    ret = key_by_name(state, secdb->sctx, client, name, &secdb_key);
+    if (ret == ENOENT) {
+        state->cc = NULL;
+        ret = EOK;
+        goto immediate;
+    } else if (ret != EOK) {
+        goto immediate;
+    }
+
+    ret = secdb_get_cc(state, secdb->sctx, secdb_key, client, &state->cc);
+    if (ret != EOK) {
+        goto immediate;
+    }
+
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Got ccache by name\n");
+    ret = EOK;
+immediate:
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else {
+        tevent_req_error(req, ret);
+    }
+    tevent_req_post(req, ev);
+    return req;
+}
+
+static errno_t ccdb_secdb_getbyname_recv(struct tevent_req *req,
+                                       TALLOC_CTX *mem_ctx,
+                                       struct kcm_ccache **_cc)
+{
+    struct ccdb_secdb_getbyname_state *state = tevent_req_data(req,
+                                                struct ccdb_secdb_getbyname_state);
+
+    TEVENT_REQ_RETURN_ON_ERROR(req);
+    *_cc = talloc_steal(mem_ctx, state->cc);
+    return EOK;
+}
+
+
+struct ccdb_secdb_name_by_uuid_state {
+    const char *name;
+};
+
+struct tevent_req *ccdb_secdb_name_by_uuid_send(TALLOC_CTX *mem_ctx,
+                                                struct tevent_context *ev,
+                                                struct kcm_ccdb *db,
+                                                struct cli_creds *client,
+                                                uuid_t uuid)
+{
+    struct ccdb_secdb *secdb = talloc_get_type(db->db_handle, struct ccdb_secdb);
+    struct tevent_req *req = NULL;
+    struct ccdb_secdb_name_by_uuid_state *state = NULL;
+    errno_t ret;
+    char *key;
+    const char *name;
+
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Translating UUID to name\n");
+
+    req = tevent_req_create(mem_ctx, &state, struct ccdb_secdb_name_by_uuid_state);
+    if (req == NULL) {
+        return NULL;
+    }
+
+    ret = key_by_uuid(state, secdb->sctx, client, uuid, &key);
+    if (ret == ENOENT) {
+        ret = ERR_NO_CREDS;
+        goto immediate;
+    } else if (ret != EOK) {
+        goto immediate;
+    }
+
+    name = sec_key_get_name(key);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Malformed key, cannot get name\n");
+        goto immediate;
+    }
+
+    state->name = talloc_strdup(state, name);
+    if (state->name == NULL) {
+        ret = ENOMEM;
+        goto immediate;
+    }
+
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Got ccache by UUID\n");
+    ret = EOK;
+immediate:
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else {
+        tevent_req_error(req, ret);
+    }
+    tevent_req_post(req, ev);
+    return req;
+}
+
+errno_t ccdb_secdb_name_by_uuid_recv(struct tevent_req *req,
+                                     TALLOC_CTX *sec_ctx,
+                                     const char **_name)
+{
+    struct ccdb_secdb_name_by_uuid_state *state = tevent_req_data(req,
+                                                struct ccdb_secdb_name_by_uuid_state);
+    TEVENT_REQ_RETURN_ON_ERROR(req);
+    *_name = talloc_steal(sec_ctx, state->name);
+    return EOK;
+}
+
+struct ccdb_secdb_uuid_by_name_state {
+    uuid_t uuid;
+};
+
+struct tevent_req *ccdb_secdb_uuid_by_name_send(TALLOC_CTX *mem_ctx,
+                                                struct tevent_context *ev,
+                                                struct kcm_ccdb *db,
+                                                struct cli_creds *client,
+                                                const char *name)
+{
+    struct ccdb_secdb *secdb = talloc_get_type(db->db_handle, struct ccdb_secdb);
+    struct tevent_req *req = NULL;
+    struct ccdb_secdb_uuid_by_name_state *state = NULL;
+    errno_t ret;
+    char *key;
+
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Translating name to UUID\n");
+
+    req = tevent_req_create(mem_ctx, &state, struct ccdb_secdb_uuid_by_name_state);
+    if (req == NULL) {
+        return NULL;
+    }
+
+    ret = key_by_name(state, secdb->sctx, client, name, &key);
+    if (ret == ENOENT) {
+        ret = ERR_NO_CREDS;
+        goto immediate;
+    } else if (ret != EOK) {
+        goto immediate;
+    }
+
+    ret = sec_key_get_uuid(key, state->uuid);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+                "Malformed key, cannot get UUID\n");
+        goto immediate;
+    }
+
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Got ccache by UUID\n");
+    ret = EOK;
+immediate:
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else {
+        tevent_req_error(req, ret);
+    }
+    tevent_req_post(req, ev);
+    return req;
+}
+
+static errno_t ccdb_secdb_uuid_by_name_recv(struct tevent_req *req,
+                                            TALLOC_CTX *sec_ctx,
+                                            uuid_t _uuid)
+{
+    struct ccdb_secdb_uuid_by_name_state *state = tevent_req_data(req,
+                                                struct ccdb_secdb_uuid_by_name_state);
+    TEVENT_REQ_RETURN_ON_ERROR(req);
+    uuid_copy(_uuid, state->uuid);
+    return EOK;
+}
+
+
+static struct tevent_req *ccdb_secdb_create_send(TALLOC_CTX *mem_ctx,
+                                                 struct tevent_context *ev,
+                                                 struct kcm_ccdb *db,
+                                                 struct cli_creds *client,
+                                                 struct kcm_ccache *cc)
+{
+    struct ccdb_secdb *secdb = talloc_get_type(db->db_handle, struct ccdb_secdb);
+    struct tevent_req *req = NULL;
+    struct ccdb_secdb_state *state = NULL;
+    errno_t ret;
+    struct sss_sec_req *container_req = NULL;
+    struct sss_sec_req *ccache_req = NULL;
+    const char *url;
+    struct sss_iobuf *ccache_payload;
+
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Creating ccache storage for %s\n", cc->name);
+
+    req = tevent_req_create(mem_ctx, &state, struct ccdb_secdb_state);
+    if (req == NULL) {
+        return NULL;
+    }
+
+    /* Do the encoding asap so that if we fail, we don't even attempt any
+     * writes */
+    ret = kcm_ccache_to_secdb_kv(state, cc, client, &url, &ccache_payload);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Cannot convert cache %s to JSON [%d]: %s\n",
+              cc->name, ret, sss_strerror(ret));
+        goto immediate;
+    }
+
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Creating the ccache container\n");
+    ret = secdb_container_url_req(state, secdb->sctx, client, &container_req);
+    if (ret != EOK) {
+        goto immediate;
+    }
+
+    ret = sss_sec_create_container(container_req);
+    if (ret == EEXIST) {
+        DEBUG(SSSDBG_TRACE_INTERNAL, "Container already exists, ignoring\n");
+    } else if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to create the ccache container\n");
+        goto immediate;
+    }
+
+    DEBUG(SSSDBG_TRACE_INTERNAL, "ccache container created\n");
+    DEBUG(SSSDBG_TRACE_INTERNAL, "creating empty ccache payload\n");
+
+    ret = secdb_cc_url_req(state, secdb->sctx, client, url, &ccache_req);
+    if (ret != EOK) {
+        goto immediate;
+    }
+
+    ret = sec_put_b64(state, ccache_req, ccache_payload);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to add the payload\n");
+        goto immediate;
+    }
+
+    DEBUG(SSSDBG_TRACE_INTERNAL, "payload created\n");
+    ret = EOK;
+immediate:
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else {
+        tevent_req_error(req, ret);
+    }
+    tevent_req_post(req, ev);
+    return req;
+}
+
+static errno_t ccdb_secdb_create_recv(struct tevent_req *req)
+{
+    TEVENT_REQ_RETURN_ON_ERROR(req);
+    return EOK;
+}
+
+static struct tevent_req *ccdb_secdb_mod_send(TALLOC_CTX *mem_ctx,
+                                              struct tevent_context *ev,
+                                              struct kcm_ccdb *db,
+                                              struct cli_creds *client,
+                                              uuid_t uuid,
+                                              struct kcm_mod_ctx *mod_cc)
+{
+    struct ccdb_secdb *secdb = talloc_get_type(db->db_handle, struct ccdb_secdb);
+    struct tevent_req *req = NULL;
+    struct ccdb_secdb_state *state = NULL;
+    errno_t ret;
+    char *secdb_key = NULL;
+    struct kcm_ccache *cc = NULL;
+    struct sss_iobuf *payload = NULL;
+    struct sss_sec_req *sreq = NULL;
+
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Modifying ccache\n");
+
+    req = tevent_req_create(mem_ctx, &state, struct ccdb_secdb_state);
+    if (req == NULL) {
+        return NULL;
+    }
+
+    ret = key_by_uuid(state, secdb->sctx, client, uuid, &secdb_key);
+    if (ret == ENOENT) {
+        ret = ERR_NO_CREDS;
+        goto immediate;
+    } else if (ret != EOK) {
+        goto immediate;
+    }
+
+    ret = secdb_get_cc(state, secdb->sctx, secdb_key, client, &cc);
+    if (ret != EOK) {
+        goto immediate;
+    }
+
+    kcm_mod_cc(cc, mod_cc);
+
+    ret = kcm_ccache_to_sec_input(state, cc, client, &payload);
+    if (ret != EOK) {
+        goto immediate;
+    }
+
+    ret = secdb_cc_key_req(state, secdb->sctx, client, secdb_key, &sreq);
+    if (ret != EOK) {
+        goto immediate;
+    }
+
+    ret = sec_update_b64(state, sreq, payload);
+    if (ret != EOK) {
+        goto immediate;
+    }
+
+    ret = EOK;
+immediate:
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else {
+        tevent_req_error(req, ret);
+    }
+    tevent_req_post(req, ev);
+    return req;
+}
+
+static errno_t ccdb_secdb_mod_recv(struct tevent_req *req)
+{
+    TEVENT_REQ_RETURN_ON_ERROR(req);
+    return EOK;
+}
+
+static struct tevent_req *ccdb_secdb_store_cred_send(TALLOC_CTX *mem_ctx,
+                                                     struct tevent_context *ev,
+                                                     struct kcm_ccdb *db,
+                                                     struct cli_creds *client,
+                                                     uuid_t uuid,
+                                                     struct sss_iobuf *cred_blob)
+{
+    struct ccdb_secdb *secdb = talloc_get_type(db->db_handle, struct ccdb_secdb);
+    struct tevent_req *req = NULL;
+    struct ccdb_secdb_state *state = NULL;
+    char *secdb_key = NULL;
+    struct kcm_ccache *cc = NULL;
+    struct sss_iobuf *payload = NULL;
+    struct sss_sec_req *sreq = NULL;
+    errno_t ret;
+
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Storing creds in ccache\n");
+
+    req = tevent_req_create(mem_ctx, &state, struct ccdb_secdb_state);
+    if (req == NULL) {
+        return NULL;
+    }
+
+    ret = key_by_uuid(state, secdb->sctx, client, uuid, &secdb_key);
+    if (ret == ENOENT) {
+        ret = ERR_NO_CREDS;
+        goto immediate;
+    } else if (ret != EOK) {
+        goto immediate;
+    }
+
+    ret = secdb_get_cc(state, secdb->sctx, secdb_key, client, &cc);
+    if (ret != EOK) {
+        goto immediate;
+    }
+
+    ret = kcm_cc_store_cred_blob(cc, cred_blob);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Cannot store credentials to ccache [%d]: %s\n",
+              ret, sss_strerror(ret));
+        goto immediate;
+    }
+
+    ret = kcm_ccache_to_sec_input(state, cc, client, &payload);
+    if (ret != EOK) {
+        goto immediate;
+    }
+
+    ret = secdb_cc_key_req(state, secdb->sctx, client, secdb_key, &sreq);
+    if (ret != EOK) {
+        goto immediate;
+    }
+
+    ret = sec_update_b64(state, sreq, payload);
+    if (ret != EOK) {
+        goto immediate;
+    }
+
+    ret = EOK;
+immediate:
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else {
+        tevent_req_error(req, ret);
+    }
+    tevent_req_post(req, ev);
+    return req;
+}
+
+static errno_t ccdb_secdb_store_cred_recv(struct tevent_req *req)
+{
+    TEVENT_REQ_RETURN_ON_ERROR(req);
+    return EOK;
+}
+
+static struct tevent_req *ccdb_secdb_delete_send(TALLOC_CTX *mem_ctx,
+                                                 struct tevent_context *ev,
+                                                 struct kcm_ccdb *db,
+                                                 struct cli_creds *client,
+                                                 uuid_t uuid)
+{
+    struct tevent_req *req = NULL;
+    struct ccdb_secdb_state *state = NULL;
+    struct ccdb_secdb *secdb = talloc_get_type(db->db_handle, struct ccdb_secdb);
+    struct sss_sec_req *container_req = NULL;
+    struct sss_sec_req *sreq = NULL;
+    char *secdb_key = NULL;
+    char **keys = NULL;
+    size_t nkeys;
+    errno_t ret;
+
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Deleting ccache\n");
+
+    req = tevent_req_create(mem_ctx, &state, struct ccdb_secdb_state);
+    if (req == NULL) {
+        return NULL;
+    }
+
+    ret = secdb_container_url_req(state, secdb->sctx, client, &container_req);
+    if (ret != EOK) {
+        goto immediate;
+    }
+
+    ret = sss_sec_list(state, container_req, &keys, &nkeys);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_MINOR_FAILURE, "No ccaches to delete\n");
+        goto immediate;
+    }
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Found %zu ccaches\n", nkeys);
+
+    if (nkeys == 0) {
+        ret = EOK;
+        goto immediate;
+    }
+
+    ret = key_by_uuid(state, secdb->sctx, client, uuid, &secdb_key);
+    if (ret == ENOENT) {
+        ret = ERR_NO_CREDS;
+        goto immediate;
+    } else if (ret != EOK) {
+        goto immediate;
+    }
+
+    ret = secdb_cc_key_req(state, secdb->sctx, client, secdb_key, &sreq);
+    if (ret != EOK) {
+        goto immediate;
+    }
+
+    ret = sss_sec_delete(sreq);
+    if (ret != EOK) {
+        goto immediate;
+    }
+
+    if (nkeys > 1) {
+        DEBUG(SSSDBG_TRACE_INTERNAL, "There are other ccaches, done\n");
+        ret = EOK;
+        goto immediate;
+    }
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Removing ccache container\n");
+
+    ret = sss_sec_delete(container_req);
+    if (ret != EOK) {
+        goto immediate;
+    }
+
+    ret = EOK;
+immediate:
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else {
+        tevent_req_error(req, ret);
+    }
+    tevent_req_post(req, ev);
+    return req;
+}
+
+static errno_t ccdb_secdb_delete_recv(struct tevent_req *req)
+{
+    TEVENT_REQ_RETURN_ON_ERROR(req);
+    return EOK;
+}
+
+const struct kcm_ccdb_ops ccdb_secdb_ops = {
+    .init = ccdb_secdb_init,
+
+    .nextid_send = ccdb_secdb_nextid_send,
+    .nextid_recv = ccdb_secdb_nextid_recv,
+
+    .set_default_send = ccdb_secdb_set_default_send,
+    .set_default_recv = ccdb_secdb_set_default_recv,
+
+    .get_default_send = ccdb_secdb_get_default_send,
+    .get_default_recv = ccdb_secdb_get_default_recv,
+
+    .list_send = ccdb_secdb_list_send,
+    .list_recv = ccdb_secdb_list_recv,
+
+    .getbyname_send = ccdb_secdb_getbyname_send,
+    .getbyname_recv = ccdb_secdb_getbyname_recv,
+
+    .getbyuuid_send = ccdb_secdb_getbyuuid_send,
+    .getbyuuid_recv = ccdb_secdb_getbyuuid_recv,
+
+    .name_by_uuid_send = ccdb_secdb_name_by_uuid_send,
+    .name_by_uuid_recv = ccdb_secdb_name_by_uuid_recv,
+
+    .uuid_by_name_send = ccdb_secdb_uuid_by_name_send,
+    .uuid_by_name_recv = ccdb_secdb_uuid_by_name_recv,
+
+    .create_send = ccdb_secdb_create_send,
+    .create_recv = ccdb_secdb_create_recv,
+
+    .mod_send = ccdb_secdb_mod_send,
+    .mod_recv = ccdb_secdb_mod_recv,
+
+    .store_cred_send = ccdb_secdb_store_cred_send,
+    .store_cred_recv = ccdb_secdb_store_cred_recv,
+
+    .delete_send = ccdb_secdb_delete_send,
+    .delete_recv = ccdb_secdb_delete_recv,
+};

--- a/src/responder/kcm/kcmsrv_ccache_secrets.c
+++ b/src/responder/kcm/kcmsrv_ccache_secrets.c
@@ -847,10 +847,9 @@ static void ccdb_sec_nextid_list_done(struct tevent_req *subreq)
         }
     }
 
-    DEBUG(SSSDBG_MINOR_FAILURE,
-          "Failed to find a random key, trying again..\n");
     if (i < sec_key_list_len) {
-        /* Try again */
+        DEBUG(SSSDBG_MINOR_FAILURE,
+            "Failed to find a random key, trying again..\n");
         ret = ccdb_sec_nextid_generate(req);
         if (ret != EOK) {
             tevent_req_error(req, ret);

--- a/src/responder/kcm/kcmsrv_ccache_secrets.c
+++ b/src/responder/kcm/kcmsrv_ccache_secrets.c
@@ -1302,7 +1302,7 @@ static void ccdb_sec_getbyname_done(struct tevent_req *subreq)
         return;
     }
 
-    DEBUG(SSSDBG_TRACE_INTERNAL, "Got ccache by UUID\n");
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Got ccache by name\n");
     tevent_req_done(req);
 }
 

--- a/src/responder/kcm/kcmsrv_pvt.h
+++ b/src/responder/kcm/kcmsrv_pvt.h
@@ -54,6 +54,7 @@ struct kcm_resp_ctx {
 enum kcm_ccdb_be {
     CCDB_BE_MEMORY,
     CCDB_BE_SECRETS,
+    CCDB_BE_SECDB,
 };
 
 /*

--- a/src/responder/secrets/local.c
+++ b/src/responder/secrets/local.c
@@ -27,871 +27,7 @@
 #include "db/sysdb.h"
 #include "responder/secrets/secsrv_private.h"
 #include "util/crypto/sss_crypto.h"
-
-#define MKEY_SIZE (256 / 8)
-
-#define SECRETS_BASEDN  "cn=secrets"
-#define KCM_BASEDN      "cn=kcm"
-
-struct local_context {
-    struct ldb_context *ldb;
-    struct sec_data master_key;
-
-    struct sec_quota *quota_secrets;
-    struct sec_quota *quota_kcm;
-};
-
-static int local_decrypt(struct local_context *lctx, TALLOC_CTX *mem_ctx,
-                         const char *secret, const char *enctype,
-                         char **plain_secret)
-{
-    char *output;
-
-    if (enctype && strcmp(enctype, "masterkey") == 0) {
-        DEBUG(SSSDBG_TRACE_INTERNAL, "Decrypting with masterkey\n");
-
-        struct sec_data _secret;
-        size_t outlen;
-        int ret;
-
-        _secret.data = (char *)sss_base64_decode(mem_ctx, secret,
-                                                 &_secret.length);
-        if (!_secret.data) {
-            DEBUG(SSSDBG_OP_FAILURE, "sss_base64_decode failed\n");
-            return EINVAL;
-        }
-
-        ret = sss_decrypt(mem_ctx, AES256CBC_HMAC_SHA256,
-                          (uint8_t *)lctx->master_key.data,
-                          lctx->master_key.length,
-                          (uint8_t *)_secret.data, _secret.length,
-                          (uint8_t **)&output, &outlen);
-        if (ret) {
-            DEBUG(SSSDBG_OP_FAILURE,
-                  "sss_decrypt failed [%d]: %s\n", ret, sss_strerror(ret));
-            return ret;
-        }
-
-        if (((strnlen(output, outlen) + 1) != outlen) ||
-            output[outlen - 1] != '\0') {
-            DEBUG(SSSDBG_CRIT_FAILURE,
-                  "Output length mismatch or output not NULL-terminated\n");
-            return EIO;
-        }
-    } else {
-        output = talloc_strdup(mem_ctx, secret);
-        if (!output) return ENOMEM;
-    }
-
-    *plain_secret = output;
-    return EOK;
-}
-
-static int local_encrypt(struct local_context *lctx, TALLOC_CTX *mem_ctx,
-                         const char *secret, const char *enctype,
-                         char **ciphertext)
-{
-    struct sec_data _secret;
-    char *output;
-    int ret;
-
-    if (enctype == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "No encryption type\n");
-        return EINVAL;
-    }
-
-    if (strcmp(enctype, "masterkey") != 0) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unknown encryption type '%s'\n", enctype);
-        return EINVAL;
-    }
-
-    ret = sss_encrypt(mem_ctx, AES256CBC_HMAC_SHA256,
-                      (uint8_t *)lctx->master_key.data,
-                      lctx->master_key.length,
-                      (const uint8_t *)secret, strlen(secret) + 1,
-                      (uint8_t **)&_secret.data, &_secret.length);
-    if (ret) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "sss_encrypt failed [%d]: %s\n", ret, sss_strerror(ret));
-        return ret;
-    }
-
-    output = sss_base64_encode(mem_ctx,
-                               (uint8_t *)_secret.data, _secret.length);
-    if (!output) return ENOMEM;
-
-    *ciphertext = output;
-    return EOK;
-}
-
-static int local_db_dn(TALLOC_CTX *mem_ctx,
-                       struct ldb_context *ldb,
-                       const char *basedn,
-                       const char *req_path,
-                       struct ldb_dn **req_dn)
-{
-    struct ldb_dn *dn;
-    const char *s, *e;
-    int ret;
-
-    dn = ldb_dn_new(mem_ctx, ldb, basedn);
-    if (!dn) {
-        ret = ENOMEM;
-        goto done;
-    }
-
-    s = req_path;
-
-    while (s && *s) {
-        e = strchr(s, '/');
-        if (e) {
-            if (e == s) {
-                s++;
-                continue;
-            }
-            if (!ldb_dn_add_child_fmt(dn, "cn=%.*s", (int)(e - s), s)) {
-                ret = ENOMEM;
-                goto done;
-            }
-            s = e + 1;
-        } else {
-            if (!ldb_dn_add_child_fmt(dn, "cn=%s", s)) {
-                ret = ENOMEM;
-                goto done;
-            }
-            s = NULL;
-        }
-    }
-
-    DEBUG(SSSDBG_TRACE_INTERNAL,
-          "Local path for [%s] is [%s]\n",
-          req_path, ldb_dn_get_linearized(dn));
-    *req_dn = dn;
-    ret = EOK;
-
-done:
-    return ret;
-}
-
-static char *local_dn_to_path(TALLOC_CTX *mem_ctx,
-                              struct ldb_dn *basedn,
-                              struct ldb_dn *dn)
-{
-    int basecomps;
-    int dncomps;
-    char *path = NULL;
-
-    basecomps = ldb_dn_get_comp_num(basedn);
-    dncomps = ldb_dn_get_comp_num(dn);
-
-    for (int i = dncomps - basecomps; i > 0; i--) {
-        const struct ldb_val *val;
-
-        val = ldb_dn_get_component_val(dn, i - 1);
-        if (!val) return NULL;
-
-        if (path) {
-            path = talloc_strdup_append_buffer(path, "/");
-            if (!path) return NULL;
-            path = talloc_strndup_append_buffer(path, (char *)val->data,
-                                                val->length);
-        } else {
-            path = talloc_strndup(mem_ctx, (char *)val->data, val->length);
-        }
-        if (!path) return NULL;
-    }
-
-    DEBUG(SSSDBG_TRACE_INTERNAL,
-          "Secrets path for [%s] is [%s]\n",
-          ldb_dn_get_linearized(dn), path);
-    return path;
-}
-
-struct local_db_req {
-    char *path;
-    const char *basedn;
-    struct ldb_dn *req_dn;
-    struct sec_quota *quota;
-};
-
-#define LOCAL_SIMPLE_FILTER "(type=simple)"
-#define LOCAL_CONTAINER_FILTER "(type=container)"
-
-static int local_db_get_simple(TALLOC_CTX *mem_ctx,
-                               struct local_context *lctx,
-                               struct local_db_req *lc_req,
-                               char **secret)
-{
-    TALLOC_CTX *tmp_ctx;
-    static const char *attrs[] = { "secret", "enctype", NULL };
-    struct ldb_result *res;
-    const char *attr_secret;
-    const char *attr_enctype;
-    int ret;
-
-    DEBUG(SSSDBG_TRACE_FUNC, "Retrieving a secret from [%s]\n", lc_req->path);
-
-    tmp_ctx = talloc_new(mem_ctx);
-    if (!tmp_ctx) return ENOMEM;
-
-    DEBUG(SSSDBG_TRACE_INTERNAL,
-          "Searching for [%s] at [%s] with scope=base\n",
-          LOCAL_SIMPLE_FILTER, ldb_dn_get_linearized(lc_req->req_dn));
-
-    ret = ldb_search(lctx->ldb, tmp_ctx, &res, lc_req->req_dn, LDB_SCOPE_BASE,
-                     attrs, "%s", LOCAL_SIMPLE_FILTER);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_TRACE_LIBS,
-              "ldb_search returned [%d]: %s\n", ret, ldb_strerror(ret));
-        ret = ENOENT;
-        goto done;
-    }
-
-    switch (res->count) {
-    case 0:
-        DEBUG(SSSDBG_TRACE_LIBS, "No secret found\n");
-        ret = ENOENT;
-        goto done;
-    case 1:
-        break;
-    default:
-        DEBUG(SSSDBG_OP_FAILURE,
-              "Too many secrets returned with BASE search\n");
-        ret = E2BIG;
-        goto done;
-    }
-
-    attr_secret = ldb_msg_find_attr_as_string(res->msgs[0], "secret", NULL);
-    if (!attr_secret) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "The 'secret' attribute is missing\n");
-        ret = ENOENT;
-        goto done;
-    }
-
-    attr_enctype = ldb_msg_find_attr_as_string(res->msgs[0], "enctype", NULL);
-
-    if (attr_enctype) {
-        ret = local_decrypt(lctx, mem_ctx, attr_secret, attr_enctype, secret);
-        if (ret) goto done;
-    } else {
-        *secret = talloc_strdup(mem_ctx, attr_secret);
-    }
-    ret = EOK;
-
-done:
-    talloc_free(tmp_ctx);
-    return ret;
-}
-
-static int local_db_list_keys(TALLOC_CTX *mem_ctx,
-                              struct local_context *lctx,
-                              struct local_db_req *lc_req,
-                              char ***_keys,
-                              int *num_keys)
-{
-    TALLOC_CTX *tmp_ctx;
-    static const char *attrs[] = { "secret", NULL };
-    struct ldb_result *res;
-    char **keys;
-    int ret;
-
-    tmp_ctx = talloc_new(mem_ctx);
-    if (!tmp_ctx) return ENOMEM;
-
-    DEBUG(SSSDBG_TRACE_FUNC, "Listing keys at [%s]\n", lc_req->path);
-
-    DEBUG(SSSDBG_TRACE_INTERNAL,
-          "Searching for [%s] at [%s] with scope=subtree\n",
-          LOCAL_SIMPLE_FILTER, ldb_dn_get_linearized(lc_req->req_dn));
-
-    ret = ldb_search(lctx->ldb, tmp_ctx, &res, lc_req->req_dn, LDB_SCOPE_SUBTREE,
-                     attrs, "%s", LOCAL_SIMPLE_FILTER);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_TRACE_LIBS,
-              "ldb_search returned [%d]: %s\n", ret, ldb_strerror(ret));
-        ret = ENOENT;
-        goto done;
-    }
-
-    if (res->count == 0) {
-        DEBUG(SSSDBG_TRACE_LIBS, "No secrets found\n");
-        ret = ENOENT;
-        goto done;
-    }
-
-    keys = talloc_array(mem_ctx, char *, res->count);
-    if (!keys) {
-        ret = ENOMEM;
-        goto done;
-    }
-
-    for (unsigned i = 0; i < res->count; i++) {
-        keys[i] = local_dn_to_path(keys, lc_req->req_dn, res->msgs[i]->dn);
-        if (!keys[i]) {
-            ret = ENOMEM;
-            goto done;
-        }
-    }
-
-    *_keys = keys;
-    DEBUG(SSSDBG_TRACE_LIBS, "Returning %d secrets\n", res->count);
-    *num_keys = res->count;
-    ret = EOK;
-
-done:
-    talloc_free(tmp_ctx);
-    return ret;
-}
-
-static int local_db_check_containers(TALLOC_CTX *mem_ctx,
-                                     struct local_context *lctx,
-                                     struct ldb_dn *leaf_dn)
-{
-    TALLOC_CTX *tmp_ctx;
-    static const char *attrs[] = { NULL};
-    struct ldb_result *res = NULL;
-    struct ldb_dn *dn;
-    int num;
-    int ret;
-
-    tmp_ctx = talloc_new(mem_ctx);
-    if (!tmp_ctx) return ENOMEM;
-
-    dn = ldb_dn_copy(tmp_ctx, leaf_dn);
-    if (!dn) {
-        ret = ENOMEM;
-        goto done;
-    }
-
-    /* We need to exclude the leaf as that will be the new child entry,
-     * We also do not care for the synthetic containers that constitute the
-     * base path (cn=<uidnumber>,cn=users,cn=secrets), so in total we remove
-     * 4 components */
-    num = ldb_dn_get_comp_num(dn) - 4;
-
-    for (int i = 0; i < num; i++) {
-        /* remove the child first (we do not want to check the leaf) */
-        if (!ldb_dn_remove_child_components(dn, 1)) return EFAULT;
-
-        /* and check the parent container exists */
-        DEBUG(SSSDBG_TRACE_INTERNAL,
-              "Searching for [%s] at [%s] with scope=base\n",
-              LOCAL_CONTAINER_FILTER, ldb_dn_get_linearized(dn));
-
-        ret = ldb_search(lctx->ldb, tmp_ctx, &res, dn, LDB_SCOPE_BASE,
-                         attrs, LOCAL_CONTAINER_FILTER);
-        if (ret != LDB_SUCCESS || res->count != 1) {
-            DEBUG(SSSDBG_TRACE_LIBS,
-                  "DN [%s] does not exist\n", ldb_dn_get_linearized(dn));
-            return ENOENT;
-        }
-    }
-
-    ret = EOK;
-
-done:
-    talloc_free(tmp_ctx);
-    return ret;
-}
-
-static int local_db_check_containers_nest_level(struct local_db_req *lc_req,
-                                                struct ldb_dn *leaf_dn)
-{
-    int nest_level;
-
-    if (lc_req->quota->containers_nest_level == 0) {
-        return EOK;
-    }
-
-    /* We need do not care for the synthetic containers that constitute the
-     * base path (cn=<uidnumber>,cn=user,cn=secrets). */
-    nest_level = ldb_dn_get_comp_num(leaf_dn) - 3;
-    if (nest_level > lc_req->quota->containers_nest_level) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "Cannot create a nested container of depth %d as the maximum"
-              "allowed number of nested containers is %d.\n",
-              nest_level, lc_req->quota->containers_nest_level);
-
-        return ERR_SEC_INVALID_CONTAINERS_NEST_LEVEL;
-    }
-
-    return EOK;
-}
-
-static struct ldb_dn *per_uid_container(TALLOC_CTX *mem_ctx,
-                                        struct ldb_dn *req_dn)
-{
-    int user_comp;
-    int num_comp;
-    struct ldb_dn *uid_base_dn;
-
-    uid_base_dn = ldb_dn_copy(mem_ctx, req_dn);
-    if (uid_base_dn == NULL) {
-        return NULL;
-    }
-
-    /* Remove all the components up to the per-user base path which consists
-     * of three components:
-     *  cn=<uidnumber>,cn=users,cn=secrets
-     */
-    user_comp = ldb_dn_get_comp_num(uid_base_dn) - 3;
-
-    if (!ldb_dn_remove_child_components(uid_base_dn, user_comp)) {
-        DEBUG(SSSDBG_OP_FAILURE, "Cannot remove child components\n");
-        talloc_free(uid_base_dn);
-        return NULL;
-    }
-
-    num_comp = ldb_dn_get_comp_num(uid_base_dn);
-    if (num_comp != 3) {
-        DEBUG(SSSDBG_OP_FAILURE, "Expected 3 components got %d\n", num_comp);
-        talloc_free(uid_base_dn);
-        return NULL;
-    }
-
-    return uid_base_dn;
-}
-
-static int local_db_check_peruid_number_of_secrets(TALLOC_CTX *mem_ctx,
-                                                   struct local_context *lctx,
-                                                   struct local_db_req *lc_req)
-{
-    TALLOC_CTX *tmp_ctx;
-    static const char *attrs[] = { NULL };
-    struct ldb_result *res = NULL;
-    struct ldb_dn *cli_basedn = NULL;
-    int ret;
-
-    if (lc_req->quota->max_uid_secrets == 0) {
-        return EOK;
-    }
-
-    tmp_ctx = talloc_new(mem_ctx);
-    if (tmp_ctx == NULL) {
-        return ENOMEM;
-    }
-
-    cli_basedn = per_uid_container(tmp_ctx, lc_req->req_dn);
-    if (cli_basedn == NULL) {
-        ret = ENOMEM;
-        goto done;
-    }
-
-    ret = ldb_search(lctx->ldb, tmp_ctx, &res, cli_basedn, LDB_SCOPE_SUBTREE,
-                     attrs, LOCAL_SIMPLE_FILTER);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_TRACE_LIBS,
-              "ldb_search returned %d: %s\n", ret, ldb_strerror(ret));
-        goto done;
-    }
-
-    if (res->count >= lc_req->quota->max_uid_secrets) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "Cannot store any more secrets for this client (basedn %s) "
-              "as the maximum allowed limit (%d) has been reached\n",
-              ldb_dn_get_linearized(cli_basedn),
-              lc_req->quota->max_uid_secrets);
-        ret = ERR_SEC_INVALID_TOO_MANY_SECRETS;
-        goto done;
-    }
-
-    ret = EOK;
-done:
-    talloc_free(tmp_ctx);
-    return ret;
-}
-
-static int local_db_check_number_of_secrets(TALLOC_CTX *mem_ctx,
-                                            struct local_context *lctx,
-                                            struct local_db_req *lc_req)
-{
-    TALLOC_CTX *tmp_ctx;
-    static const char *attrs[] = { NULL };
-    struct ldb_result *res = NULL;
-    struct ldb_dn *dn;
-    int ret;
-
-    if (lc_req->quota->max_secrets == 0) {
-        return EOK;
-    }
-
-    tmp_ctx = talloc_new(mem_ctx);
-    if (!tmp_ctx) return ENOMEM;
-
-    dn = ldb_dn_new(tmp_ctx, lctx->ldb, lc_req->basedn);
-    if (!dn) {
-        ret = ENOMEM;
-        goto done;
-    }
-
-    ret = ldb_search(lctx->ldb, tmp_ctx, &res, dn, LDB_SCOPE_SUBTREE,
-                     attrs, LOCAL_SIMPLE_FILTER);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_TRACE_LIBS,
-              "ldb_search returned %d: %s\n", ret, ldb_strerror(ret));
-        goto done;
-    }
-
-    if (res->count >= lc_req->quota->max_secrets) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "Cannot store any more secrets as the maximum allowed limit (%d) "
-              "has been reached\n", lc_req->quota->max_secrets);
-        ret = ERR_SEC_INVALID_TOO_MANY_SECRETS;
-        goto done;
-    }
-
-    ret = EOK;
-
-done:
-    talloc_free(tmp_ctx);
-    return ret;
-}
-
-static int local_check_max_payload_size(struct local_db_req *lc_req,
-                                        int payload_size)
-{
-    int max_payload_size;
-
-    if (lc_req->quota->max_payload_size == 0) {
-        return EOK;
-    }
-
-    max_payload_size = lc_req->quota->max_payload_size * 1024; /* kb */
-    if (payload_size > max_payload_size) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "Secrets' payload size [%d kb (%d)] exceeds the maximum allowed "
-              "payload size [%d kb (%d)]\n",
-              payload_size * 1024, /* kb */
-              payload_size,
-              lc_req->quota->max_payload_size, /* kb */
-              max_payload_size);
-
-        return ERR_SEC_PAYLOAD_SIZE_IS_TOO_LARGE;
-    }
-
-    return EOK;
-}
-
-static int local_db_put_simple(TALLOC_CTX *mem_ctx,
-                               struct local_context *lctx,
-                               struct local_db_req *lc_req,
-                               const char *secret)
-{
-    struct ldb_message *msg;
-    const char *enctype = "masterkey";
-    char *enc_secret;
-    int ret;
-
-    DEBUG(SSSDBG_TRACE_FUNC, "Adding a secret to [%s]\n", lc_req->path);
-
-    msg = ldb_msg_new(mem_ctx);
-    if (!msg) {
-        ret = ENOMEM;
-        goto done;
-    }
-    msg->dn = lc_req->req_dn;
-
-    /* make sure containers exist */
-    ret = local_db_check_containers(msg, lctx, msg->dn);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "local_db_check_containers failed for [%s]: [%d]: %s\n",
-              ldb_dn_get_linearized(msg->dn), ret, sss_strerror(ret));
-        goto done;
-    }
-
-    ret = local_db_check_number_of_secrets(msg, lctx, lc_req);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "local_db_check_number_of_secrets failed [%d]: %s\n",
-              ret, sss_strerror(ret));
-        goto done;
-    }
-
-    ret = local_db_check_peruid_number_of_secrets(msg, lctx, lc_req);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "local_db_check_number_of_secrets failed [%d]: %s\n",
-              ret, sss_strerror(ret));
-        goto done;
-    }
-
-    ret = local_check_max_payload_size(lc_req, strlen(secret));
-    if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "local_check_max_payload_size failed [%d]: %s\n",
-              ret, sss_strerror(ret));
-        goto done;
-    }
-
-    ret = local_encrypt(lctx, msg, secret, enctype, &enc_secret);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "local_encrypt failed [%d]: %s\n", ret, sss_strerror(ret));
-        goto done;
-    }
-
-    ret = ldb_msg_add_string(msg, "type", "simple");
-    if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "ldb_msg_add_string failed adding type:simple [%d]: %s\n",
-              ret, sss_strerror(ret));
-        goto done;
-    }
-
-    ret = ldb_msg_add_string(msg, "enctype", enctype);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "ldb_msg_add_string failed adding enctype [%d]: %s\n",
-              ret, sss_strerror(ret));
-        goto done;
-    }
-
-    ret = ldb_msg_add_string(msg, "secret", enc_secret);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "ldb_msg_add_string failed adding secret [%d]: %s\n",
-              ret, sss_strerror(ret));
-        goto done;
-    }
-
-
-    ret = ldb_msg_add_fmt(msg, "creationTime", "%lu", time(NULL));
-    if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "ldb_msg_add_string failed adding creationTime [%d]: %s\n",
-              ret, sss_strerror(ret));
-        goto done;
-    }
-
-    ret = ldb_add(lctx->ldb, msg);
-    if (ret != EOK) {
-        if (ret == LDB_ERR_ENTRY_ALREADY_EXISTS) {
-            DEBUG(SSSDBG_OP_FAILURE,
-                  "Secret %s already exists\n", ldb_dn_get_linearized(msg->dn));
-            ret = EEXIST;
-        } else {
-            DEBUG(SSSDBG_CRIT_FAILURE,
-                  "Failed to add secret [%s]: [%d]: %s\n",
-                  ldb_dn_get_linearized(msg->dn), ret, ldb_strerror(ret));
-            ret = EIO;
-        }
-        goto done;
-    }
-
-    ret = EOK;
-done:
-    talloc_free(msg);
-    return ret;
-}
-
-static int local_db_delete(TALLOC_CTX *mem_ctx,
-                           struct local_context *lctx,
-                           struct local_db_req *lc_req)
-{
-    TALLOC_CTX *tmp_ctx;
-    static const char *attrs[] = { NULL };
-    struct ldb_result *res;
-    int ret;
-
-    DEBUG(SSSDBG_TRACE_FUNC, "Removing a secret from [%s]\n", lc_req->path);
-
-    tmp_ctx = talloc_new(mem_ctx);
-    if (!tmp_ctx) return ENOMEM;
-
-    DEBUG(SSSDBG_TRACE_INTERNAL,
-          "Searching for [%s] at [%s] with scope=base\n",
-          LOCAL_CONTAINER_FILTER, ldb_dn_get_linearized(lc_req->req_dn));
-
-    ret = ldb_search(lctx->ldb, tmp_ctx, &res, lc_req->req_dn, LDB_SCOPE_BASE,
-                     attrs, LOCAL_CONTAINER_FILTER);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_TRACE_LIBS,
-              "ldb_search returned %d: %s\n", ret, ldb_strerror(ret));
-        goto done;
-    }
-
-    if (res->count == 1) {
-        DEBUG(SSSDBG_TRACE_INTERNAL,
-              "Searching for children of [%s]\n", ldb_dn_get_linearized(lc_req->req_dn));
-        ret = ldb_search(lctx->ldb, tmp_ctx, &res, lc_req->req_dn, LDB_SCOPE_ONELEVEL,
-                         attrs, NULL);
-        if (ret != EOK) {
-            DEBUG(SSSDBG_TRACE_LIBS,
-                  "ldb_search returned %d: %s\n", ret, ldb_strerror(ret));
-            goto done;
-        }
-
-        if (res->count > 0) {
-            ret = EEXIST;
-            DEBUG(SSSDBG_OP_FAILURE,
-                  "Failed to remove '%s': Container is not empty\n",
-                  ldb_dn_get_linearized(lc_req->req_dn));
-
-            goto done;
-        }
-    }
-
-    ret = ldb_delete(lctx->ldb, lc_req->req_dn);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_TRACE_LIBS,
-              "ldb_delete returned %d: %s\n", ret, ldb_strerror(ret));
-        /* fall through */
-    }
-    ret = sysdb_error_to_errno(ret);
-
-done:
-    talloc_free(tmp_ctx);
-    return ret;
-}
-
-static int local_db_create(TALLOC_CTX *mem_ctx,
-                           struct local_context *lctx,
-                           struct local_db_req *lc_req)
-{
-    struct ldb_message *msg;
-    int ret;
-
-    DEBUG(SSSDBG_TRACE_FUNC, "Creating a container at [%s]\n", lc_req->path);
-
-    msg = ldb_msg_new(mem_ctx);
-    if (!msg) {
-        ret = ENOMEM;
-        goto done;
-    }
-    msg->dn = lc_req->req_dn;
-
-    /* make sure containers exist */
-    ret = local_db_check_containers(msg, lctx, msg->dn);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "local_db_check_containers failed for [%s]: [%d]: %s\n",
-              ldb_dn_get_linearized(msg->dn), ret, sss_strerror(ret));
-        goto done;
-    }
-
-    ret = local_db_check_containers_nest_level(lc_req, msg->dn);
-    if (ret != EOK) goto done;
-
-    ret = ldb_msg_add_string(msg, "type", "container");
-    if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "ldb_msg_add_string failed adding type:container [%d]: %s\n",
-              ret, sss_strerror(ret));
-        goto done;
-    }
-
-    ret = ldb_msg_add_fmt(msg, "creationTime", "%lu", time(NULL));
-    if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "ldb_msg_add_string failed adding creationTime [%d]: %s\n",
-              ret, sss_strerror(ret));
-        goto done;
-    }
-
-    ret = ldb_add(lctx->ldb, msg);
-    if (ret != EOK) {
-        if (ret == LDB_ERR_ENTRY_ALREADY_EXISTS) {
-            DEBUG(SSSDBG_OP_FAILURE,
-                  "Secret %s already exists\n", ldb_dn_get_linearized(msg->dn));
-            ret = EEXIST;
-        } else {
-            DEBUG(SSSDBG_CRIT_FAILURE,
-                  "Failed to add secret [%s]: [%d]: %s\n",
-                  ldb_dn_get_linearized(msg->dn), ret, ldb_strerror(ret));
-            ret = EIO;
-        }
-        goto done;
-    }
-
-    ret = EOK;
-
-done:
-    talloc_free(msg);
-    return ret;
-}
-
-static int local_secrets_map_path(TALLOC_CTX *mem_ctx,
-                                  struct local_context *lctx,
-                                  struct sec_req_ctx *secreq,
-                                  struct local_db_req **_lc_req)
-{
-    int ret;
-    struct local_db_req *lc_req;
-    struct ldb_context *ldb = lctx->ldb;
-
-    /* be strict for now */
-    if (secreq->parsed_url.fragment != NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Unrecognized URI fragments: [%s]\n",
-              secreq->parsed_url.fragment);
-        return EINVAL;
-    }
-
-    if (secreq->parsed_url.userinfo != NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Unrecognized URI userinfo: [%s]\n",
-              secreq->parsed_url.userinfo);
-        return EINVAL;
-    }
-
-    /* only type simple for now */
-    if (secreq->parsed_url.query != NULL) {
-        ret = strcmp(secreq->parsed_url.query, "type=simple");
-        if (ret != 0) {
-            DEBUG(SSSDBG_CRIT_FAILURE,
-                  "Invalid URI query: [%s]\n",
-                  secreq->parsed_url.query);
-            return EINVAL;
-        }
-    }
-
-    lc_req = talloc(mem_ctx, struct local_db_req);
-    if (lc_req == NULL) {
-        return ENOMEM;
-    }
-
-    /* drop the prefix and select a basedn instead */
-    if (strncmp(secreq->mapped_path,
-                SEC_BASEPATH, sizeof(SEC_BASEPATH) - 1) == 0) {
-        lc_req->path = talloc_strdup(lc_req,
-                                     secreq->mapped_path + (sizeof(SEC_BASEPATH) - 1));
-        lc_req->basedn = SECRETS_BASEDN;
-        lc_req->quota = lctx->quota_secrets;
-    } else if (strncmp(secreq->mapped_path,
-               SEC_KCM_BASEPATH, sizeof(SEC_KCM_BASEPATH) - 1) == 0) {
-        lc_req->path = talloc_strdup(lc_req,
-                                     secreq->mapped_path + (sizeof(SEC_KCM_BASEPATH) - 1));
-        lc_req->basedn = KCM_BASEDN;
-        lc_req->quota = lctx->quota_kcm;
-    } else {
-        ret = EINVAL;
-        goto done;
-    }
-
-    if (lc_req->path == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Failed to map request to local db path\n");
-        ret = ENOMEM;
-        goto done;
-    }
-
-    ret = local_db_dn(mem_ctx, ldb, lc_req->basedn, lc_req->path, &lc_req->req_dn);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Failed to map request to local db DN\n");
-        goto done;
-    }
-
-    DEBUG(SSSDBG_TRACE_LIBS, "Local DB path is %s\n", lc_req->path);
-    ret = EOK;
-    *_lc_req = lc_req;
-done:
-    if (ret != EOK) {
-        talloc_free(lc_req);
-    }
-    return ret;
-}
+#include "util/secrets/secrets.h"
 
 struct local_secret_state {
     struct tevent_context *ev;
@@ -905,15 +41,14 @@ static struct tevent_req *local_secret_req(TALLOC_CTX *mem_ctx,
 {
     struct tevent_req *req;
     struct local_secret_state *state;
-    struct local_context *lctx;
+    struct sss_sec_ctx *sec_ctx;
     struct sec_data body = { 0 };
     const char *content_type;
     bool body_is_json;
-    struct local_db_req *lc_req;
+    struct sss_sec_req *ssec_req;
     char *secret;
     char **keys;
-    int nkeys;
-    int plen;
+    size_t nkeys;
     int ret;
 
     req = tevent_req_create(mem_ctx, &state, struct local_secret_state);
@@ -922,8 +57,8 @@ static struct tevent_req *local_secret_req(TALLOC_CTX *mem_ctx,
     state->ev = ev;
     state->secreq = secreq;
 
-    lctx = talloc_get_type(provider_ctx, struct local_context);
-    if (!lctx) {
+    sec_ctx = talloc_get_type(provider_ctx, struct sss_sec_ctx);
+    if (!sec_ctx) {
         ret = EIO;
         goto done;
     }
@@ -945,17 +80,51 @@ static struct tevent_req *local_secret_req(TALLOC_CTX *mem_ctx,
     }
     DEBUG(SSSDBG_TRACE_LIBS, "Content-Type: %s\n", content_type);
 
-    ret = local_secrets_map_path(state, lctx, secreq, &lc_req);
-    if (ret) {
-        DEBUG(SSSDBG_OP_FAILURE, "Cannot map request path to local path\n");
+    /* be strict for now */
+    if (secreq->parsed_url.fragment != NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Unrecognized URI fragments: [%s]\n",
+              secreq->parsed_url.fragment);
+        ret = EINVAL;
+        goto done;
+    }
+
+    if (secreq->parsed_url.userinfo != NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Unrecognized URI userinfo: [%s]\n",
+              secreq->parsed_url.userinfo);
+        ret = EINVAL;
+        goto done;
+    }
+
+    /* only type simple for now */
+    if (secreq->parsed_url.query != NULL) {
+        ret = strcmp(secreq->parsed_url.query, "type=simple");
+        if (ret != 0) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Invalid URI query: [%s]\n",
+                  secreq->parsed_url.query);
+            ret = EINVAL;
+            goto done;
+        }
+    }
+
+    ret = sss_sec_new_req(state,
+                          sec_ctx,
+                          secreq->parsed_url.path,
+                          client_euid(secreq->cctx->creds),
+                          &ssec_req);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Cannot create libsecret request [%d]: %s\n", ret, sss_strerror(ret));
         goto done;
     }
 
     switch (secreq->method) {
     case HTTP_GET:
-        DEBUG(SSSDBG_TRACE_LIBS, "Processing HTTP GET at [%s]\n", lc_req->path);
-        if (lc_req->path[strlen(lc_req->path) - 1] == '/') {
-            ret = local_db_list_keys(state, lctx, lc_req, &keys, &nkeys);
+        DEBUG(SSSDBG_TRACE_LIBS, "Processing HTTP GET\n"); /* todo: make sure the library prints the path */
+        if (sss_sec_req_is_list(ssec_req)) {
+            ret = sss_sec_list(state, ssec_req, &keys, &nkeys);
             if (ret) goto done;
 
             ret = sec_array_to_json(state, keys, nkeys, &body.data);
@@ -965,7 +134,7 @@ static struct tevent_req *local_secret_req(TALLOC_CTX *mem_ctx,
             break;
         }
 
-        ret = local_db_get_simple(state, lctx, lc_req, &secret);
+        ret = sss_sec_get(state, ssec_req, &secret);
         if (ret) goto done;
 
         if (body_is_json) {
@@ -988,7 +157,7 @@ static struct tevent_req *local_secret_req(TALLOC_CTX *mem_ctx,
             goto done;
         }
 
-        DEBUG(SSSDBG_TRACE_LIBS, "Processing HTTP PUT at [%s]\n", lc_req->path);
+        DEBUG(SSSDBG_TRACE_LIBS, "Processing HTTP PUT\n"); /* todo path */
         if (body_is_json) {
             ret = sec_json_to_simple_secret(state, secreq->body.data,
                                             &secret);
@@ -999,27 +168,18 @@ static struct tevent_req *local_secret_req(TALLOC_CTX *mem_ctx,
         }
         if (ret) goto done;
 
-        ret = local_db_put_simple(state, lctx, lc_req, secret);
+        ret = sss_sec_put(ssec_req, secret);
         if (ret) goto done;
         break;
 
     case HTTP_DELETE:
-        ret = local_db_delete(state, lctx, lc_req);
+        ret = sss_sec_delete(ssec_req);
         if (ret) goto done;
         break;
 
     case HTTP_POST:
-        DEBUG(SSSDBG_TRACE_LIBS, "Processing HTTP POST at [%s]\n", lc_req->path);
-        plen = strlen(lc_req->path);
-
-        if (lc_req->path[plen - 1] != '/') {
-            ret = EINVAL;
-            goto done;
-        }
-
-        lc_req->path[plen - 1] = '\0';
-
-        ret = local_db_create(state, lctx, lc_req);
+        DEBUG(SSSDBG_TRACE_LIBS, "Processing HTTP POST\n"); /* todo */
+        ret = sss_sec_create_container(ssec_req);
         if (ret) goto done;
         break;
 
@@ -1054,62 +214,13 @@ done:
     return tevent_req_post(req, state->ev);
 }
 
-static int generate_master_key(const char *filename, size_t size)
-{
-    uint8_t buf[size];
-    ssize_t rsize;
-    int ret;
-    int fd;
-
-    ret = generate_csprng_buffer(buf, size);
-    if (ret) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "generate_csprng_buffer failed [%d]: %s\n",
-              ret, sss_strerror(ret));
-        return ret;
-    }
-
-    fd = open(filename, O_CREAT|O_EXCL|O_WRONLY, 0600);
-    if (fd == -1) {
-        ret = errno;
-        DEBUG(SSSDBG_OP_FAILURE,
-              "open(%s) failed [%d]: %s\n",
-              filename, ret, strerror(ret));
-        return ret;
-    }
-
-    rsize = sss_atomic_write_s(fd, buf, size);
-    close(fd);
-    if (rsize != size) {
-        ret = errno;
-        DEBUG(SSSDBG_OP_FAILURE,
-              "sss_atomic_write_s failed [%d]: %s\n",
-              ret, strerror(ret));
-
-        ret = unlink(filename);
-        /* non-fatal failure */
-        if (ret != EOK) {
-            ret = errno;
-            DEBUG(SSSDBG_MINOR_FAILURE,
-                  "Failed to remove file: %s - %d [%s]!\n",
-                  filename, ret, sss_strerror(ret));
-        }
-        return EFAULT;
-    }
-
-    return EOK;
-}
-
 int local_secrets_provider_handle(struct sec_ctx *sctx,
                                   struct provider_handle **out_handle)
 {
-    const char *mkey = SECRETS_DB_PATH"/.secrets.mkey";
-    const char *dbpath = SECRETS_DB_PATH"/secrets.ldb";
     struct provider_handle *handle;
-    struct local_context *lctx;
-    ssize_t size;
-    int mfd;
+    struct sss_sec_ctx *ss_ctx;
     int ret;
+    struct sss_sec_hive_config **hive_config;
 
     DEBUG(SSSDBG_TRACE_INTERNAL, "Creating a local provider handle\n");
 
@@ -1119,52 +230,22 @@ int local_secrets_provider_handle(struct sec_ctx *sctx,
     handle->name = "LOCAL";
     handle->fn = local_secret_req;
 
-    lctx = talloc_zero(handle, struct local_context);
-    if (!lctx) return ENOMEM;
+    hive_config = talloc_zero_array(handle, struct sss_sec_hive_config *, 3);
+    if (hive_config == NULL) {
+        talloc_free(handle);
+        return ENOMEM;
+    }
+    hive_config[0] = &sctx->sec_config;
+    hive_config[1] = &sctx->kcm_config;
+    hive_config[2] = NULL;
 
-    lctx->ldb = ldb_init(lctx, NULL);
-    if (!lctx->ldb) return ENOMEM;
-
-    ret = ldb_connect(lctx->ldb, dbpath, 0, NULL);
-    if (ret != LDB_SUCCESS) {
-        DEBUG(SSSDBG_TRACE_LIBS,
-              "ldb_connect(%s) returned %d: %s\n",
-              dbpath, ret, ldb_strerror(ret));
-        talloc_free(lctx->ldb);
-        return EIO;
+    ret = sss_sec_init(handle, hive_config, &ss_ctx);
+    if (ret != EOK) {
+        talloc_free(handle);
+        return ret;
     }
 
-    lctx->quota_secrets = &sctx->sec_config.quota;
-    lctx->quota_kcm = &sctx->kcm_config.quota;
-
-    lctx->master_key.data = talloc_size(lctx, MKEY_SIZE);
-    if (!lctx->master_key.data) return ENOMEM;
-    lctx->master_key.length = MKEY_SIZE;
-
-    ret = check_and_open_readonly(mkey, &mfd, 0, 0,
-                                  S_IFREG|S_IRUSR|S_IWUSR, 0);
-    if (ret == ENOENT) {
-        DEBUG(SSSDBG_TRACE_FUNC, "No master key, generating a new one..\n");
-
-        ret = generate_master_key(mkey, MKEY_SIZE);
-        if (ret) return EFAULT;
-        ret = check_and_open_readonly(mkey, &mfd, 0, 0,
-                                      S_IFREG|S_IRUSR|S_IWUSR, 0);
-    }
-    if (ret) {
-        DEBUG(SSSDBG_OP_FAILURE, "Cannot generate a master key: %d\n", ret);
-        return EFAULT;
-    }
-
-    size = sss_atomic_read_s(mfd, lctx->master_key.data,
-                             lctx->master_key.length);
-    close(mfd);
-    if (size < 0 || size != lctx->master_key.length) {
-        DEBUG(SSSDBG_OP_FAILURE, "Cannot read a master key: %d\n", ret);
-        return EIO;
-    }
-
-    handle->context = lctx;
+    handle->context = ss_ctx;
 
     *out_handle = handle;
     DEBUG(SSSDBG_TRACE_INTERNAL, "Local provider handle created\n");

--- a/src/responder/secrets/secsrv.c
+++ b/src/responder/secrets/secsrv.c
@@ -29,123 +29,10 @@
 #include "resolv/async_resolv.h"
 
 #define DEFAULT_SEC_FD_LIMIT 2048
-#define DEFAULT_SEC_CONTAINERS_NEST_LEVEL 4
 
-#define DEFAULT_SEC_MAX_SECRETS      1024
-#define DEFAULT_SEC_MAX_UID_SECRETS  256
-#define DEFAULT_SEC_MAX_PAYLOAD_SIZE 16
-
-/* The number of secrets in the /kcm hive should be quite small,
- * but the secret size must be large because one secret in the /kcm
- * hive holds the whole ccache which consists of several credentials
- */
-#define DEFAULT_SEC_KCM_MAX_SECRETS      256
-#define DEFAULT_SEC_KCM_MAX_UID_SECRETS  64
-#define DEFAULT_SEC_KCM_MAX_PAYLOAD_SIZE 65536
-
-static int sec_get_quota(struct sec_ctx *sctx,
-                         const char *section_config_path,
-                         int default_max_containers_nest_level,
-                         int default_max_num_secrets,
-                         int default_max_num_uid_secrets,
-                         int default_max_payload,
-                         struct sec_quota *quota)
+static void adjust_global_quota(struct sec_ctx *sctx,
+                                struct sss_sec_hive_config *hive_config)
 {
-    int ret;
-
-    ret = confdb_get_int(sctx->rctx->cdb,
-                         section_config_path,
-                         CONFDB_SEC_CONTAINERS_NEST_LEVEL,
-                         default_max_containers_nest_level,
-                         &quota->containers_nest_level);
-
-    if (ret != EOK) {
-        DEBUG(SSSDBG_FATAL_FAILURE,
-              "Failed to get container nesting level for %s\n",
-              section_config_path);
-        return ret;
-    }
-
-    ret = confdb_get_int(sctx->rctx->cdb,
-                         section_config_path,
-                         CONFDB_SEC_MAX_SECRETS,
-                         default_max_num_secrets,
-                         &quota->max_secrets);
-
-    if (ret != EOK) {
-        DEBUG(SSSDBG_FATAL_FAILURE,
-              "Failed to get maximum number of entries for %s\n",
-              section_config_path);
-        return ret;
-    }
-
-    ret = confdb_get_int(sctx->rctx->cdb,
-                         section_config_path,
-                         CONFDB_SEC_MAX_UID_SECRETS,
-                         default_max_num_uid_secrets,
-                         &quota->max_uid_secrets);
-
-    if (ret != EOK) {
-        DEBUG(SSSDBG_FATAL_FAILURE,
-              "Failed to get maximum number of per-UID entries for %s\n",
-              section_config_path);
-        return ret;
-    }
-
-    ret = confdb_get_int(sctx->rctx->cdb,
-                         section_config_path,
-                         CONFDB_SEC_MAX_PAYLOAD_SIZE,
-                         default_max_payload,
-                         &quota->max_payload_size);
-
-    if (ret != EOK) {
-        DEBUG(SSSDBG_FATAL_FAILURE,
-              "Failed to get payload's maximum size for an entry in %s\n",
-              section_config_path);
-        return ret;
-    }
-
-    return EOK;
-}
-
-static int sec_get_hive_config(struct sec_ctx *sctx,
-                               const char *hive_name,
-                               struct sec_hive_config *hive_config,
-                               int default_max_containers_nest_level,
-                               int default_max_num_secrets,
-                               int default_max_num_uid_secrets,
-                               int default_max_payload)
-{
-    int ret;
-    TALLOC_CTX *tmp_ctx;
-
-    tmp_ctx = talloc_new(sctx);
-    if (tmp_ctx == NULL) {
-        return ENOMEM;
-    }
-
-    hive_config->confdb_section = talloc_asprintf(sctx,
-                                                  "config/secrets/%s",
-                                                  hive_name);
-    if (hive_config->confdb_section == NULL) {
-        ret = ENOMEM;
-        goto done;
-    }
-
-    ret = sec_get_quota(sctx,
-                        hive_config->confdb_section,
-                        default_max_containers_nest_level,
-                        default_max_num_secrets,
-                        default_max_num_uid_secrets,
-                        default_max_payload,
-                        &hive_config->quota);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "Cannot read quota settings for %s [%d]: %s\n",
-              hive_name, ret, sss_strerror(ret));
-        goto done;
-    }
-
     if (hive_config->quota.max_payload_size == 0
              || (sctx->max_payload_size != 0
                  && hive_config->quota.max_payload_size > sctx->max_payload_size)) {
@@ -155,12 +42,6 @@ static int sec_get_hive_config(struct sec_ctx *sctx,
          */
         sctx->max_payload_size = hive_config->quota.max_payload_size;
     }
-
-    ret = EOK;
-
-done:
-    talloc_free(tmp_ctx);
-    return ret;
 }
 
 static int sec_get_config(struct sec_ctx *sctx)
@@ -187,13 +68,13 @@ static int sec_get_config(struct sec_ctx *sctx)
     /* Note that this sets the defaults for the sec_config quota to be used
      * in sec_get_hive_config()
      */
-    ret = sec_get_quota(sctx,
-                        sctx->rctx->confdb_service_path,
-                        DEFAULT_SEC_CONTAINERS_NEST_LEVEL,
-                        DEFAULT_SEC_MAX_SECRETS,
-                        DEFAULT_SEC_MAX_UID_SECRETS,
-                        DEFAULT_SEC_MAX_PAYLOAD_SIZE,
-                        &sctx->sec_config.quota);
+    ret = sss_sec_get_quota(sctx->rctx->cdb,
+                            sctx->rctx->confdb_service_path,
+                            DEFAULT_SEC_CONTAINERS_NEST_LEVEL,
+                            DEFAULT_SEC_MAX_SECRETS,
+                            DEFAULT_SEC_MAX_UID_SECRETS,
+                            DEFAULT_SEC_MAX_PAYLOAD_SIZE,
+                            &sctx->sec_config.quota);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
               "Failed to get legacy global quotas\n");
@@ -201,31 +82,33 @@ static int sec_get_config(struct sec_ctx *sctx)
     }
 
     /* Read the per-hive configuration */
-    ret = sec_get_hive_config(sctx,
-                              "secrets",
-                              &sctx->sec_config,
-                              sctx->sec_config.quota.containers_nest_level,
-                              sctx->sec_config.quota.max_secrets,
-                              sctx->sec_config.quota.max_uid_secrets,
-                              sctx->sec_config.quota.max_payload_size);
+    ret = sss_sec_get_hive_config(sctx->rctx->cdb,
+                                 "secrets",
+                                 sctx->sec_config.quota.containers_nest_level,
+                                 sctx->sec_config.quota.max_secrets,
+                                 sctx->sec_config.quota.max_uid_secrets,
+                                 sctx->sec_config.quota.max_payload_size,
+                                 &sctx->sec_config);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
               "Failed to get configuration of the secrets hive\n");
         goto fail;
     }
+    adjust_global_quota(sctx, &sctx->sec_config);
 
-    ret = sec_get_hive_config(sctx,
-                              "kcm",
-                              &sctx->kcm_config,
-                              DEFAULT_SEC_CONTAINERS_NEST_LEVEL,
-                              DEFAULT_SEC_KCM_MAX_SECRETS,
-                              DEFAULT_SEC_KCM_MAX_UID_SECRETS,
-                              DEFAULT_SEC_KCM_MAX_PAYLOAD_SIZE);
+    ret = sss_sec_get_hive_config(sctx->rctx->cdb,
+                                  "kcm",
+                                  DEFAULT_SEC_CONTAINERS_NEST_LEVEL,
+                                  DEFAULT_SEC_KCM_MAX_SECRETS,
+                                  DEFAULT_SEC_KCM_MAX_UID_SECRETS,
+                                  DEFAULT_SEC_KCM_MAX_PAYLOAD_SIZE,
+                                  &sctx->kcm_config);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
-              "Failed to get configuration of the secrets hive\n");
+              "Failed to get configuration of the kcm hive\n");
         goto fail;
     }
+    adjust_global_quota(sctx, &sctx->kcm_config);
 
     ret = confdb_get_int(sctx->rctx->cdb, sctx->rctx->confdb_service_path,
                          CONFDB_RESPONDER_CLI_IDLE_TIMEOUT,

--- a/src/responder/secrets/secsrv.h
+++ b/src/responder/secrets/secsrv.h
@@ -30,25 +30,14 @@
 #include <tevent.h>
 #include <ldb.h>
 
-struct sec_quota {
-    int max_secrets;
-    int max_uid_secrets;
-    int max_payload_size;
-    int containers_nest_level;
-};
-
-struct sec_hive_config {
-    const char *confdb_section;
-
-    struct sec_quota quota;
-};
+#include "util/secrets/secrets.h"
 
 struct sec_ctx {
     struct resp_ctx *rctx;
     int fd_limit;
 
-    struct sec_hive_config sec_config;
-    struct sec_hive_config kcm_config;
+    struct sss_sec_hive_config sec_config;
+    struct sss_sec_hive_config kcm_config;
     int max_payload_size;
 
     struct provider_handle **providers;

--- a/src/responder/secrets/secsrv_private.h
+++ b/src/responder/secrets/secsrv_private.h
@@ -104,14 +104,6 @@ int sec_get_provider(struct sec_ctx *sctx, const char *name,
 int sec_add_provider(struct sec_ctx *sctx, struct provider_handle *handle);
 
 #define SEC_BASEPATH            "/secrets/"
-#define SEC_KCM_BASEPATH        "/kcm/"
-
-/* The KCM responder must "impersonate" the owner of the credentials.
- * Only a trusted UID can do that -- root by default, but unit
- * tests might choose otherwise */
-#ifndef KCM_PEER_UID
-#define KCM_PEER_UID            0
-#endif /* KCM_PEER_UID */
 
 /* providers.c */
 int sec_req_routing(TALLOC_CTX *mem_ctx, struct sec_req_ctx *secreq,

--- a/src/sysv/systemd/sssd-kcm.socket.in
+++ b/src/sysv/systemd/sssd-kcm.socket.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=SSSD Kerberos Cache Manager responder socket
 Documentation=man:sssd-kcm(8)
-Requires=sssd-secrets.socket
+@kcm_socket_requires@
 
 [Socket]
 ListenStream=@runstatedir@/.heim_org.h5l.kcm-socket

--- a/src/tests/cmocka/test_kcm_json_marshalling.c
+++ b/src/tests/cmocka/test_kcm_json_marshalling.c
@@ -153,11 +153,11 @@ static void test_kcm_ccache_marshall_unmarshall(void **state)
     struct cli_creds owner;
     struct kcm_ccache *cc;
     struct kcm_ccache *cc2;
-    const char *url;
     struct sss_iobuf *payload;
     const char *name;
     const char *key;
     uint8_t *data;
+    uuid_t uuid;
 
     owner.ucred.uid = getuid();
     owner.ucred.gid = getuid();
@@ -176,15 +176,16 @@ static void test_kcm_ccache_marshall_unmarshall(void **state)
     ret = kcm_ccache_to_sec_input(test_ctx,
                                   cc,
                                   &owner,
-                                  &url,
                                   &payload);
     assert_int_equal(ret, EOK);
 
-    key = strrchr(url, '/') + 1;
-    assert_non_null(key);
-
     data = sss_iobuf_get_data(payload);
     assert_non_null(data);
+
+    ret = kcm_cc_get_uuid(cc, uuid);
+    assert_int_equal(ret, EOK);
+    key = sec_key_create(test_ctx, name, uuid);
+    assert_non_null(key);
 
     ret = sec_kv_to_ccache(test_ctx,
                            key,

--- a/src/tests/cmocka/test_kcm_json_marshalling.c
+++ b/src/tests/cmocka/test_kcm_json_marshalling.c
@@ -40,6 +40,7 @@
 
 const struct kcm_ccdb_ops ccdb_mem_ops;
 const struct kcm_ccdb_ops ccdb_sec_ops;
+const struct kcm_ccdb_ops ccdb_secdb_ops;
 
 struct kcm_marshalling_test_ctx {
     krb5_context kctx;

--- a/src/tests/dlopen-tests.c
+++ b/src/tests/dlopen-tests.c
@@ -46,8 +46,10 @@ struct so {
     { "libsss_nss_idmap.so", { LIBPFX"libsss_nss_idmap.so", NULL } },
     { "libnss_sss.so", { LIBPFX"libnss_sss.so", NULL } },
     { "libsss_certmap.so", { LIBPFX"libsss_certmap.so", NULL } },
-    { "libsss_secrets.so", { LIBPFX"libsss_secrets.so", NULL } },
     { "pam_sss.so", { LIBPFX"pam_sss.so", NULL } },
+#ifdef BUILD_WITH_LIBSECRET
+    { "libsss_secrets.so", { LIBPFX"libsss_secrets.so", NULL } },
+#endif /* BUILD_WITH_LIBSECRET */
 #ifdef BUILD_LIBWBCLIENT
     { "libwbclient.so", { LIBPFX"libwbclient.so", NULL } },
 #endif /* BUILD_LIBWBCLIENT */

--- a/src/tests/dlopen-tests.c
+++ b/src/tests/dlopen-tests.c
@@ -46,6 +46,7 @@ struct so {
     { "libsss_nss_idmap.so", { LIBPFX"libsss_nss_idmap.so", NULL } },
     { "libnss_sss.so", { LIBPFX"libnss_sss.so", NULL } },
     { "libsss_certmap.so", { LIBPFX"libsss_certmap.so", NULL } },
+    { "libsss_secrets.so", { LIBPFX"libsss_secrets.so", NULL } },
     { "pam_sss.so", { LIBPFX"pam_sss.so", NULL } },
 #ifdef BUILD_LIBWBCLIENT
     { "libwbclient.so", { LIBPFX"libwbclient.so", NULL } },

--- a/src/tests/intg/test_kcm.py
+++ b/src/tests/intg/test_kcm.py
@@ -24,6 +24,7 @@ import pytest
 import socket
 import time
 import signal
+import sys
 from requests import HTTPError
 
 import kdc

--- a/src/tests/intg/test_kcm.py
+++ b/src/tests/intg/test_kcm.py
@@ -179,6 +179,12 @@ def setup_for_kcm_sec(request, kdc_instance):
     Just set up the local provider for tests and enable the KCM
     responder
     """
+    sec_resp_path = os.path.join(config.LIBEXEC_PATH, "sssd", "sssd_secrets")
+    if not os.access(sec_resp_path, os.X_OK):
+        # It would be cleaner to use pytest.mark.skipif on the package level
+        # but upstream insists on supporting RHEL-6.
+        pytest.skip("No Secrets responder, skipping")
+
     kcm_path = os.path.join(config.RUNSTATEDIR, "kcm.socket")
     sssd_conf = create_sssd_conf(kcm_path, "secrets")
     return common_setup_for_kcm_mem(request, kdc_instance, kcm_path, sssd_conf)

--- a/src/tests/intg/test_kcm.py
+++ b/src/tests/intg/test_kcm.py
@@ -184,6 +184,16 @@ def setup_for_kcm_sec(request, kdc_instance):
     return common_setup_for_kcm_mem(request, kdc_instance, kcm_path, sssd_conf)
 
 
+@pytest.fixture
+def setup_for_kcm_secdb(request, kdc_instance):
+    """
+    Set up the KCM responder backed by libsss_secrets
+    """
+    kcm_path = os.path.join(config.RUNSTATEDIR, "kcm.socket")
+    sssd_conf = create_sssd_conf(kcm_path, "secdb")
+    return common_setup_for_kcm_mem(request, kdc_instance, kcm_path, sssd_conf)
+
+
 def kcm_init_list_destroy(testenv):
     """
     Test that kinit, kdestroy and klist work with KCM
@@ -224,6 +234,11 @@ def test_kcm_sec_init_list_destroy(setup_for_kcm_sec,
     kcm_init_list_destroy(testenv)
 
 
+def test_kcm_secdb_init_list_destroy(setup_for_kcm_secdb):
+    testenv = setup_for_kcm_secdb
+    kcm_init_list_destroy(testenv)
+
+
 def kcm_overwrite(testenv):
     """
     Test that reusing a ccache reinitializes the cache and doesn't
@@ -251,6 +266,11 @@ def test_kcm_mem_overwrite(setup_for_kcm_mem):
 def test_kcm_sec_overwrite(setup_for_kcm_sec,
                            setup_secrets):
     testenv = setup_for_kcm_sec
+    kcm_overwrite(testenv)
+
+
+def test_kcm_secdb_overwrite(setup_for_kcm_secdb):
+    testenv = setup_for_kcm_secdb
     kcm_overwrite(testenv)
 
 
@@ -325,6 +345,11 @@ def test_kcm_sec_collection_init_list_destroy(setup_for_kcm_sec,
     collection_init_list_destroy(testenv)
 
 
+def test_kcm_secdb_collection_init_list_destroy(setup_for_kcm_secdb):
+    testenv = setup_for_kcm_secdb
+    collection_init_list_destroy(testenv)
+
+
 def exercise_kswitch(testenv):
     """
     Test switching between principals
@@ -378,6 +403,11 @@ def test_kcm_mem_kswitch(setup_for_kcm_mem):
 def test_kcm_sec_kswitch(setup_for_kcm_sec,
                          setup_secrets):
     testenv = setup_for_kcm_sec
+    exercise_kswitch(testenv)
+
+
+def test_kcm_secdb_kswitch(setup_for_kcm_secdb):
+    testenv = setup_for_kcm_secdb
     exercise_kswitch(testenv)
 
 
@@ -436,6 +466,11 @@ def test_kcm_sec_subsidiaries(setup_for_kcm_sec,
     exercise_subsidiaries(testenv)
 
 
+def test_kcm_secdb_subsidiaries(setup_for_kcm_secdb):
+    testenv = setup_for_kcm_secdb
+    exercise_subsidiaries(testenv)
+
+
 def kdestroy_nocache(testenv):
     """
     Destroying a non-existing ccache should not throw an error
@@ -458,6 +493,11 @@ def test_kcm_mem_kdestroy_nocache(setup_for_kcm_mem):
 def test_kcm_sec_kdestroy_nocache(setup_for_kcm_sec,
                                   setup_secrets):
     testenv = setup_for_kcm_sec
+    exercise_subsidiaries(testenv)
+
+
+def test_kcm_secdb_kdestroy_nocache(setup_for_kcm_secdb):
+    testenv = setup_for_kcm_secdb
     exercise_subsidiaries(testenv)
 
 

--- a/src/tests/intg/test_kcm.py
+++ b/src/tests/intg/test_kcm.py
@@ -110,6 +110,11 @@ def create_sssd_kcm_fixture(sock_path, request):
         if kcm_pid == 0:
             return
         os.kill(kcm_pid, signal.SIGTERM)
+        try:
+            os.unlink(os.path.join(config.SECDB_PATH, "secrets.ldb"))
+        except OSError as osex:
+            if osex.errno == 2:
+                pass
 
     request.addfinalizer(kcm_teardown)
     return kcm_pid

--- a/src/tests/intg/test_kcm.py
+++ b/src/tests/intg/test_kcm.py
@@ -167,7 +167,10 @@ def setup_for_kcm_mem(request, kdc_instance):
 
 @pytest.fixture
 def setup_secrets(request):
-    create_sssd_secrets_fixture(request)
+    kcm_env = dict(os.environ)
+    # Tell sssd-secrets it's root talking
+    kcm_env['SSSD_INTG_SECRETS_PEER'] = '0'
+    create_sssd_secrets_fixture(request, env=kcm_env)
 
 
 @pytest.fixture

--- a/src/tests/intg/test_secrets.py
+++ b/src/tests/intg/test_secrets.py
@@ -43,7 +43,7 @@ def create_conf_fixture(request, contents):
     request.addfinalizer(lambda: os.unlink(config.CONF_PATH))
 
 
-def create_sssd_secrets_fixture(request, teardown=True):
+def create_sssd_secrets_fixture(request, teardown=True, env=None):
     if subprocess.call(['sssd', "--genconf"]) != 0:
         raise Exception("failed to regenerate confdb")
 
@@ -57,7 +57,9 @@ def create_sssd_secrets_fixture(request, teardown=True):
     assert secpid >= 0
 
     if secpid == 0:
-        os.execv(resp_path, (resp_path, "--uid=0", "--gid=0"))
+        if env is None:
+            env = os.environ
+        os.execve(resp_path, (resp_path, "--uid=0", "--gid=0"), env)
         print("sssd_secrets failed to start")
         sys.exit(99)
     else:

--- a/src/tests/intg/test_secrets.py
+++ b/src/tests/intg/test_secrets.py
@@ -57,7 +57,7 @@ def create_sssd_secrets_fixture(request, teardown=True):
     assert secpid >= 0
 
     if secpid == 0:
-        os.execv(resp_path, ("--uid=0", "--gid=0"))
+        os.execv(resp_path, (resp_path, "--uid=0", "--gid=0"))
         print("sssd_secrets failed to start")
         sys.exit(99)
     else:

--- a/src/util/secrets/config.c
+++ b/src/util/secrets/config.c
@@ -1,0 +1,142 @@
+/*
+   SSSD
+
+   Local secrets database -- configuration
+
+   Copyright (C) Red Hat 2018
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "util/util.h"
+#include "util/secrets/secrets.h"
+
+errno_t sss_sec_get_quota(struct confdb_ctx *cdb,
+                          const char *section_config_path,
+                          int default_max_containers_nest_level,
+                          int default_max_num_secrets,
+                          int default_max_num_uid_secrets,
+                          int default_max_payload,
+                          struct sss_sec_quota *quota)
+{
+    int ret;
+
+    if (cdb == NULL || section_config_path == NULL || quota == NULL) {
+        return EINVAL;
+    }
+
+    ret = confdb_get_int(cdb,
+                         section_config_path,
+                         CONFDB_SEC_CONTAINERS_NEST_LEVEL,
+                         default_max_containers_nest_level,
+                         &quota->containers_nest_level);
+
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE,
+              "Failed to get container nesting level for %s\n",
+              section_config_path);
+        return ret;
+    }
+
+    ret = confdb_get_int(cdb,
+                         section_config_path,
+                         CONFDB_SEC_MAX_SECRETS,
+                         default_max_num_secrets,
+                         &quota->max_secrets);
+
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE,
+              "Failed to get maximum number of entries for %s\n",
+              section_config_path);
+        return ret;
+    }
+
+    ret = confdb_get_int(cdb,
+                         section_config_path,
+                         CONFDB_SEC_MAX_UID_SECRETS,
+                         default_max_num_uid_secrets,
+                         &quota->max_uid_secrets);
+
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE,
+              "Failed to get maximum number of per-UID entries for %s\n",
+              section_config_path);
+        return ret;
+    }
+
+    ret = confdb_get_int(cdb,
+                         section_config_path,
+                         CONFDB_SEC_MAX_PAYLOAD_SIZE,
+                         default_max_payload,
+                         &quota->max_payload_size);
+
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE,
+              "Failed to get payload's maximum size for an entry in %s\n",
+              section_config_path);
+        return ret;
+    }
+
+    return EOK;
+}
+
+errno_t sss_sec_get_hive_config(struct confdb_ctx *cdb,
+                                const char *hive_name,
+                                int default_max_containers_nest_level,
+                                int default_max_num_secrets,
+                                int default_max_num_uid_secrets,
+                                int default_max_payload,
+                                struct sss_sec_hive_config *hive_config)
+{
+    int ret;
+    TALLOC_CTX *tmp_ctx;
+    const char *confdb_section;
+
+    if (cdb == NULL || hive_name == NULL || hive_config == NULL) {
+        return EINVAL;
+    }
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    hive_config->hive_name = hive_name;
+
+    confdb_section = talloc_asprintf(tmp_ctx, "config/secrets/%s", hive_name);
+    if (confdb_section == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = sss_sec_get_quota(cdb,
+                            confdb_section,
+                            default_max_containers_nest_level,
+                            default_max_num_secrets,
+                            default_max_num_uid_secrets,
+                            default_max_payload,
+                            &hive_config->quota);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Cannot read quota settings for %s [%d]: %s\n",
+              hive_name, ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = EOK;
+
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}

--- a/src/util/secrets/sec_pvt.h
+++ b/src/util/secrets/sec_pvt.h
@@ -1,0 +1,59 @@
+/*
+   SSSD
+
+   Local secrets database - private header
+
+   Copyright (C) Red Hat 2018
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __SECRETS_PVT_H_
+#define __SECRETS_PVT_H_
+
+#include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/types.h>
+
+#include "util/secrets/secrets.h"
+
+#define SSS_SEC_BASEPATH            "/secrets/"
+#define SSS_SEC_KCM_BASEPATH        "/kcm/"
+
+struct sss_sec_data {
+    char *data;
+    size_t length;
+};
+
+struct sss_sec_ctx {
+    struct ldb_context *ldb;
+    struct sss_sec_data master_key;
+
+    struct sss_sec_quota *quota_secrets;
+    struct sss_sec_quota *quota_kcm;
+};
+
+struct sss_sec_req {
+    char *mapped_path;
+
+    char *path;
+    const char *basedn;
+    struct ldb_dn *req_dn;
+    struct sss_sec_quota *quota;
+
+    struct sss_sec_ctx *sctx;
+};
+
+#endif /* __SECRETS_PVT_H_ */

--- a/src/util/secrets/secrets.c
+++ b/src/util/secrets/secrets.c
@@ -1,0 +1,1243 @@
+/*
+   SSSD
+
+   Local secrets database
+
+   Copyright (C) Red Hat 2018
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include "config.h"
+
+#include "util/util.h"
+#include "util/crypto/sss_crypto.h"
+#include "util/secrets/sec_pvt.h"
+#include "util/secrets/secrets.h"
+
+/* The KCM responder must "impersonate" the owner of the credentials.
+ * Only a trusted UID can do that -- root by default, but unit
+ * tests might choose otherwise */
+#ifndef KCM_PEER_UID
+#define KCM_PEER_UID            0
+#endif /* KCM_PEER_UID */
+
+#define MKEY_SIZE (256 / 8)
+
+#define SECRETS_BASEDN  "cn=secrets"
+#define KCM_BASEDN      "cn=kcm"
+
+#define LOCAL_SIMPLE_FILTER "(type=simple)"
+#define LOCAL_CONTAINER_FILTER "(type=container)"
+
+typedef int (*url_mapper_fn)(TALLOC_CTX *mem_ctx,
+                             const char *url,
+                             uid_t client,
+                             char **mapped_path);
+
+struct url_pfx_router {
+    const char *prefix;
+    url_mapper_fn mapper_fn;
+};
+
+static struct sss_sec_quota default_sec_quota = {
+    .max_secrets = DEFAULT_SEC_MAX_SECRETS,
+    .max_uid_secrets = DEFAULT_SEC_MAX_UID_SECRETS,
+    .max_payload_size = DEFAULT_SEC_MAX_PAYLOAD_SIZE,
+    .containers_nest_level = DEFAULT_SEC_CONTAINERS_NEST_LEVEL,
+};
+
+static struct sss_sec_quota default_kcm_quota = {
+    .max_secrets = DEFAULT_SEC_KCM_MAX_SECRETS,
+    .max_uid_secrets = DEFAULT_SEC_KCM_MAX_UID_SECRETS,
+    .max_payload_size = DEFAULT_SEC_KCM_MAX_PAYLOAD_SIZE,
+    .containers_nest_level = DEFAULT_SEC_CONTAINERS_NEST_LEVEL,
+};
+
+static int local_decrypt(struct sss_sec_ctx *sctx, TALLOC_CTX *mem_ctx,
+                         const char *secret, const char *enctype,
+                         char **plain_secret)
+{
+    char *output;
+
+    if (enctype && strcmp(enctype, "masterkey") == 0) {
+        DEBUG(SSSDBG_TRACE_INTERNAL, "Decrypting with masterkey\n");
+
+        struct sss_sec_data _secret;
+        size_t outlen;
+        int ret;
+
+        _secret.data = (char *)sss_base64_decode(mem_ctx, secret,
+                                                 &_secret.length);
+        if (!_secret.data) {
+            DEBUG(SSSDBG_OP_FAILURE, "sss_base64_decode failed\n");
+            return EINVAL;
+        }
+
+        ret = sss_decrypt(mem_ctx, AES256CBC_HMAC_SHA256,
+                          (uint8_t *)sctx->master_key.data,
+                          sctx->master_key.length,
+                          (uint8_t *)_secret.data, _secret.length,
+                          (uint8_t **)&output, &outlen);
+        if (ret) {
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "sss_decrypt failed [%d]: %s\n", ret, sss_strerror(ret));
+            return ret;
+        }
+
+        if (((strnlen(output, outlen) + 1) != outlen) ||
+            output[outlen - 1] != '\0') {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Output length mismatch or output not NULL-terminated\n");
+            return EIO;
+        }
+    } else {
+        output = talloc_strdup(mem_ctx, secret);
+        if (!output) return ENOMEM;
+    }
+
+    *plain_secret = output;
+    return EOK;
+}
+
+static int local_encrypt(struct sss_sec_ctx *sec_ctx, TALLOC_CTX *mem_ctx,
+                         const char *secret, const char *enctype,
+                         char **ciphertext)
+{
+    struct sss_sec_data _secret;
+    char *output;
+    int ret;
+
+    if (enctype == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "No encryption type\n");
+        return EINVAL;
+    }
+
+    if (strcmp(enctype, "masterkey") != 0) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unknown encryption type '%s'\n", enctype);
+        return EINVAL;
+    }
+
+    ret = sss_encrypt(mem_ctx, AES256CBC_HMAC_SHA256,
+                      (uint8_t *)sec_ctx->master_key.data,
+                      sec_ctx->master_key.length,
+                      (const uint8_t *)secret, strlen(secret) + 1,
+                      (uint8_t **)&_secret.data, &_secret.length);
+    if (ret) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "sss_encrypt failed [%d]: %s\n", ret, sss_strerror(ret));
+        return ret;
+    }
+
+    output = sss_base64_encode(mem_ctx,
+                               (uint8_t *)_secret.data, _secret.length);
+    if (!output) return ENOMEM;
+
+    *ciphertext = output;
+    return EOK;
+}
+
+static int local_db_check_containers(TALLOC_CTX *mem_ctx,
+                                     struct sss_sec_ctx *sec_ctx,
+                                     struct ldb_dn *leaf_dn)
+{
+    TALLOC_CTX *tmp_ctx;
+    static const char *attrs[] = { NULL};
+    struct ldb_result *res = NULL;
+    struct ldb_dn *dn;
+    int num;
+    int ret;
+
+    tmp_ctx = talloc_new(mem_ctx);
+    if (!tmp_ctx) return ENOMEM;
+
+    dn = ldb_dn_copy(tmp_ctx, leaf_dn);
+    if (!dn) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    /* We need to exclude the leaf as that will be the new child entry,
+     * We also do not care for the synthetic containers that constitute the
+     * base path (cn=<uidnumber>,cn=users,cn=secrets), so in total we remove
+     * 4 components */
+    num = ldb_dn_get_comp_num(dn) - 4;
+
+    for (int i = 0; i < num; i++) {
+        /* remove the child first (we do not want to check the leaf) */
+        if (!ldb_dn_remove_child_components(dn, 1)) return EFAULT;
+
+        /* and check the parent container exists */
+        DEBUG(SSSDBG_TRACE_INTERNAL,
+              "Searching for [%s] at [%s] with scope=base\n",
+              LOCAL_CONTAINER_FILTER, ldb_dn_get_linearized(dn));
+
+        ret = ldb_search(sec_ctx->ldb, tmp_ctx, &res, dn, LDB_SCOPE_BASE,
+                         attrs, LOCAL_CONTAINER_FILTER);
+        if (ret != LDB_SUCCESS || res->count != 1) {
+            DEBUG(SSSDBG_TRACE_LIBS,
+                  "DN [%s] does not exist\n", ldb_dn_get_linearized(dn));
+            ret = ENOENT;
+            goto done;
+        }
+    }
+
+    ret = EOK;
+
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+static int local_db_check_number_of_secrets(TALLOC_CTX *mem_ctx,
+                                            struct sss_sec_req *req)
+{
+    TALLOC_CTX *tmp_ctx;
+    static const char *attrs[] = { NULL };
+    struct ldb_result *res = NULL;
+    struct ldb_dn *dn;
+    int ret;
+
+    if (req->quota->max_secrets == 0) {
+        return EOK;
+    }
+
+    tmp_ctx = talloc_new(mem_ctx);
+    if (!tmp_ctx) return ENOMEM;
+
+    dn = ldb_dn_new(tmp_ctx, req->sctx->ldb, req->basedn);
+    if (!dn) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = ldb_search(req->sctx->ldb, tmp_ctx, &res, dn, LDB_SCOPE_SUBTREE,
+                     attrs, LOCAL_SIMPLE_FILTER);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_TRACE_LIBS,
+              "ldb_search returned %d: %s\n", ret, ldb_strerror(ret));
+        goto done;
+    }
+
+    if (res->count >= req->quota->max_secrets) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Cannot store any more secrets as the maximum allowed limit (%d) "
+              "has been reached\n", req->quota->max_secrets);
+        ret = ERR_SEC_INVALID_TOO_MANY_SECRETS;
+        goto done;
+    }
+
+    ret = EOK;
+
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+static struct ldb_dn *per_uid_container(TALLOC_CTX *mem_ctx,
+                                        struct ldb_dn *req_dn)
+{
+    int user_comp;
+    int num_comp;
+    struct ldb_dn *uid_base_dn;
+
+    uid_base_dn = ldb_dn_copy(mem_ctx, req_dn);
+    if (uid_base_dn == NULL) {
+        return NULL;
+    }
+
+    /* Remove all the components up to the per-user base path which consists
+     * of three components:
+     *  cn=<uidnumber>,cn=users,cn=secrets
+     */
+    user_comp = ldb_dn_get_comp_num(uid_base_dn) - 3;
+
+    if (!ldb_dn_remove_child_components(uid_base_dn, user_comp)) {
+        DEBUG(SSSDBG_OP_FAILURE, "Cannot remove child components\n");
+        talloc_free(uid_base_dn);
+        return NULL;
+    }
+
+    num_comp = ldb_dn_get_comp_num(uid_base_dn);
+    if (num_comp != 3) {
+        DEBUG(SSSDBG_OP_FAILURE, "Expected 3 components got %d\n", num_comp);
+        talloc_free(uid_base_dn);
+        return NULL;
+    }
+
+    return uid_base_dn;
+}
+
+static int local_db_check_peruid_number_of_secrets(TALLOC_CTX *mem_ctx,
+                                                   struct sss_sec_req *req)
+{
+    TALLOC_CTX *tmp_ctx;
+    static const char *attrs[] = { NULL };
+    struct ldb_result *res = NULL;
+    struct ldb_dn *cli_basedn = NULL;
+    int ret;
+
+    if (req->quota->max_uid_secrets == 0) {
+        return EOK;
+    }
+
+    tmp_ctx = talloc_new(mem_ctx);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    cli_basedn = per_uid_container(tmp_ctx, req->req_dn);
+    if (cli_basedn == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = ldb_search(req->sctx->ldb, tmp_ctx, &res, cli_basedn, LDB_SCOPE_SUBTREE,
+                     attrs, LOCAL_SIMPLE_FILTER);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_TRACE_LIBS,
+              "ldb_search returned %d: %s\n", ret, ldb_strerror(ret));
+        goto done;
+    }
+
+    if (res->count >= req->quota->max_uid_secrets) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Cannot store any more secrets for this client (basedn %s) "
+              "as the maximum allowed limit (%d) has been reached\n",
+              ldb_dn_get_linearized(cli_basedn),
+              req->quota->max_uid_secrets);
+        ret = ERR_SEC_INVALID_TOO_MANY_SECRETS;
+        goto done;
+    }
+
+    ret = EOK;
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+static int local_check_max_payload_size(struct sss_sec_req *req,
+                                        int payload_size)
+{
+    int max_payload_size;
+
+    if (req->quota->max_payload_size == 0) {
+        return EOK;
+    }
+
+    max_payload_size = req->quota->max_payload_size * 1024; /* kb */
+    if (payload_size > max_payload_size) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Secrets' payload size [%d kb (%d)] exceeds the maximum allowed "
+              "payload size [%d kb (%d)]\n",
+              payload_size * 1024, /* kb */
+              payload_size,
+              req->quota->max_payload_size, /* kb */
+              max_payload_size);
+
+        return ERR_SEC_PAYLOAD_SIZE_IS_TOO_LARGE;
+    }
+
+    return EOK;
+}
+
+static int local_db_check_containers_nest_level(struct sss_sec_req *req,
+                                                struct ldb_dn *leaf_dn)
+{
+    int nest_level;
+
+    if (req->quota->containers_nest_level == 0) {
+        return EOK;
+    }
+
+    /* We need do not care for the synthetic containers that constitute the
+     * base path (cn=<uidnumber>,cn=user,cn=secrets). */
+    nest_level = ldb_dn_get_comp_num(leaf_dn) - 3;
+    if (nest_level > req->quota->containers_nest_level) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Cannot create a nested container of depth %d as the maximum"
+              "allowed number of nested containers is %d.\n",
+              nest_level, req->quota->containers_nest_level);
+
+        return ERR_SEC_INVALID_CONTAINERS_NEST_LEVEL;
+    }
+
+    return EOK;
+}
+
+static int local_db_create(struct sss_sec_req *req)
+{
+    struct ldb_message *msg;
+    int ret;
+
+    DEBUG(SSSDBG_TRACE_FUNC, "Creating a container at [%s]\n", req->path);
+
+    msg = ldb_msg_new(req);
+    if (!msg) {
+        ret = ENOMEM;
+        goto done;
+    }
+    msg->dn = req->req_dn;
+
+    /* make sure containers exist */
+    ret = local_db_check_containers(msg, req->sctx, msg->dn);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "local_db_check_containers failed for [%s]: [%d]: %s\n",
+              ldb_dn_get_linearized(msg->dn), ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = local_db_check_containers_nest_level(req, msg->dn);
+    if (ret != EOK) goto done;
+
+    ret = ldb_msg_add_string(msg, "type", "container");
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "ldb_msg_add_string failed adding type:container [%d]: %s\n",
+              ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = ldb_msg_add_fmt(msg, "creationTime", "%lu", time(NULL));
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "ldb_msg_add_string failed adding creationTime [%d]: %s\n",
+              ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = ldb_add(req->sctx->ldb, msg);
+    if (ret != EOK) {
+        if (ret == LDB_ERR_ENTRY_ALREADY_EXISTS) {
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "Secret %s already exists\n", ldb_dn_get_linearized(msg->dn));
+            ret = EEXIST;
+        } else {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Failed to add secret [%s]: [%d]: %s\n",
+                  ldb_dn_get_linearized(msg->dn), ret, ldb_strerror(ret));
+            ret = EIO;
+        }
+        goto done;
+    }
+
+    ret = EOK;
+
+done:
+    talloc_free(msg);
+    return ret;
+}
+
+static int sec_map_url_to_user_path(TALLOC_CTX *mem_ctx,
+                                    const char *url,
+                                    uid_t client,
+                                    char **mapped_path)
+{
+    /* change path to be user specific */
+    *mapped_path =
+        talloc_asprintf(mem_ctx, SSS_SEC_BASEPATH"users/%"SPRIuid"/%s",
+                        client,
+                        &url[sizeof(SSS_SEC_BASEPATH) - 1]);
+    if (!*mapped_path) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Failed to map request to user specific url\n");
+        return ENOMEM;
+    }
+
+    DEBUG(SSSDBG_TRACE_LIBS,
+          "User-specific secrets path is [%s]\n", *mapped_path);
+    return EOK;
+}
+
+static int kcm_map_url_to_path(TALLOC_CTX *mem_ctx,
+                               const char *url,
+                               uid_t client,
+                               char **mapped_path)
+{
+    if (client != KCM_PEER_UID) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "UID %"SPRIuid" is not allowed to access "
+              "the "SSS_SEC_KCM_BASEPATH" hive\n",
+              client);
+        return EPERM;
+    }
+
+    *mapped_path = talloc_strdup(mem_ctx, url);
+    if (!*mapped_path) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Failed to map request to user specific url\n");
+        return ENOMEM;
+    }
+
+    DEBUG(SSSDBG_TRACE_LIBS,
+          "User-specific KCM path is [%s]\n", *mapped_path);
+    return EOK;
+}
+
+static struct url_pfx_router secrets_url_mapping[] = {
+    { SSS_SEC_BASEPATH, sec_map_url_to_user_path },
+    { SSS_SEC_KCM_BASEPATH, kcm_map_url_to_path },
+    { NULL, NULL },
+};
+
+errno_t sss_sec_map_path(TALLOC_CTX *mem_ctx,
+                         const char *url,
+                         uid_t client,
+                         char **_mapped_path)
+{
+    url_mapper_fn mapper_fn = NULL;
+    errno_t ret;
+
+    if (url == NULL || _mapped_path == NULL) {
+        return EINVAL;
+    }
+
+    for (int i = 0; secrets_url_mapping[i].prefix != NULL; i++) {
+        if (strncasecmp(url,
+                        secrets_url_mapping[i].prefix,
+                        strlen(secrets_url_mapping[i].prefix)) == 0) {
+            DEBUG(SSSDBG_TRACE_LIBS,
+                  "Mapping prefix %s\n", secrets_url_mapping[i].prefix);
+            mapper_fn = secrets_url_mapping[i].mapper_fn;
+            break;
+        }
+    }
+
+    if (mapper_fn == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Path [%s] does not start with any allowed prefix\n",
+              url);
+        return EPERM;
+    }
+
+    ret = mapper_fn(mem_ctx, url, client, _mapped_path);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Failed to map the user path [%d]: %s\n",
+              ret, sss_strerror(ret));
+        return ret;
+    }
+
+    return ret;
+}
+
+static int generate_master_key(const char *filename, size_t size)
+{
+    uint8_t buf[size];
+    ssize_t rsize;
+    int ret;
+    int fd;
+
+    ret = generate_csprng_buffer(buf, size);
+    if (ret) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "generate_csprng_buffer failed [%d]: %s\n",
+              ret, sss_strerror(ret));
+        return ret;
+    }
+
+    fd = open(filename, O_CREAT|O_EXCL|O_WRONLY, 0600);
+    if (fd == -1) {
+        ret = errno;
+        DEBUG(SSSDBG_OP_FAILURE,
+              "open(%s) failed [%d]: %s\n",
+              filename, ret, strerror(ret));
+        return ret;
+    }
+
+    rsize = sss_atomic_write_s(fd, buf, size);
+    close(fd);
+    if (rsize != size) {
+        ret = errno;
+        DEBUG(SSSDBG_OP_FAILURE,
+              "sss_atomic_write_s failed [%d]: %s\n",
+              ret, strerror(ret));
+
+        ret = unlink(filename);
+        /* non-fatal failure */
+        if (ret != EOK) {
+            ret = errno;
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "Failed to remove file: %s - %d [%s]!\n",
+                  filename, ret, sss_strerror(ret));
+        }
+        return EFAULT;
+    }
+
+    return EOK;
+}
+
+static errno_t lcl_read_mkey(TALLOC_CTX *mem_ctx,
+                             struct sss_sec_data *master_key)
+{
+    int mfd;
+    ssize_t size;
+    errno_t ret;
+    const char *mkey = SECRETS_DB_PATH"/.secrets.mkey";
+
+    master_key->data = talloc_size(mem_ctx, MKEY_SIZE);
+    if (master_key->data == NULL) {
+        return ENOMEM;
+    }
+
+    master_key->length = MKEY_SIZE;
+
+    ret = check_and_open_readonly(mkey, &mfd, 0, 0,
+                                  S_IFREG|S_IRUSR|S_IWUSR, 0);
+    if (ret == ENOENT) {
+        DEBUG(SSSDBG_TRACE_FUNC, "No master key, generating a new one..\n");
+
+        ret = generate_master_key(mkey, MKEY_SIZE);
+        if (ret) return EFAULT;
+        ret = check_and_open_readonly(mkey, &mfd, 0, 0,
+                                      S_IFREG|S_IRUSR|S_IWUSR, 0);
+    }
+    if (ret) {
+        DEBUG(SSSDBG_OP_FAILURE, "Cannot generate a master key: %d\n", ret);
+        return EFAULT;
+    }
+
+    size = sss_atomic_read_s(mfd, master_key->data,
+                             master_key->length);
+    close(mfd);
+    if (size < 0 || size != master_key->length) {
+        DEBUG(SSSDBG_OP_FAILURE, "Cannot read a master key: %d\n", ret);
+        return EIO;
+    }
+
+    return EOK;
+}
+
+static int set_quotas(struct sss_sec_ctx *sec_ctx,
+                      struct sss_sec_hive_config **config_list)
+{
+    sec_ctx->quota_secrets = &default_sec_quota;
+    sec_ctx->quota_kcm = &default_kcm_quota;
+
+    if (config_list == NULL) {
+        DEBUG(SSSDBG_TRACE_LIBS, "No custom quota set, using defaults\n");
+        return EOK;
+    }
+
+    for (int i = 0; config_list[i] != NULL; i++) {
+        if (strcasecmp(config_list[i]->hive_name, "kcm") == 0) {
+            sec_ctx->quota_kcm = &config_list[i]->quota;
+        } else if (strcasecmp(config_list[i]->hive_name, "secrets") == 0) {
+            sec_ctx->quota_secrets = &config_list[i]->quota;
+        } else {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "Uknown hive %s, skipping\n", config_list[i]->hive_name);
+        }
+    }
+
+    return EOK;
+}
+
+errno_t sss_sec_init(TALLOC_CTX *mem_ctx,
+                     struct sss_sec_hive_config **config_list,
+                     struct sss_sec_ctx **_sec_ctx)
+{
+    const char *dbpath = SECRETS_DB_PATH"/secrets.ldb";
+    struct sss_sec_ctx *sec_ctx;
+    TALLOC_CTX *tmp_ctx;
+    errno_t ret;
+
+    if (_sec_ctx == NULL) {
+        return EINVAL;
+    }
+
+    tmp_ctx = talloc_new(mem_ctx);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    sec_ctx = talloc_zero(tmp_ctx, struct sss_sec_ctx);
+    if (sec_ctx == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = set_quotas(sec_ctx, config_list);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_MINOR_FAILURE, "Failed to set quotas\n");
+        /* Not fatal */
+    }
+
+    sec_ctx->ldb = ldb_init(sec_ctx, NULL);
+    if (sec_ctx->ldb == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = ldb_connect(sec_ctx->ldb, dbpath, 0, NULL);
+    if (ret != LDB_SUCCESS) {
+        DEBUG(SSSDBG_TRACE_LIBS,
+              "ldb_connect(%s) returned %d: %s\n",
+              dbpath, ret, ldb_strerror(ret));
+        talloc_free(sec_ctx->ldb);
+        ret = EIO;
+        goto done;
+    }
+
+    ret = lcl_read_mkey(sec_ctx, &sec_ctx->master_key);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "Cannot get the master key\n");
+        goto done;
+    }
+
+    ret = EOK;
+    *_sec_ctx = talloc_steal(mem_ctx, sec_ctx);
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+static int local_db_dn(TALLOC_CTX *mem_ctx,
+                       struct ldb_context *ldb,
+                       const char *basedn,
+                       const char *req_path,
+                       struct ldb_dn **req_dn)
+{
+    struct ldb_dn *dn;
+    const char *s, *e;
+    int ret;
+
+    dn = ldb_dn_new(mem_ctx, ldb, basedn);
+    if (!dn) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    s = req_path;
+
+    while (s && *s) {
+        e = strchr(s, '/');
+        if (e) {
+            if (e == s) {
+                s++;
+                continue;
+            }
+            if (!ldb_dn_add_child_fmt(dn, "cn=%.*s", (int)(e - s), s)) {
+                ret = ENOMEM;
+                goto done;
+            }
+            s = e + 1;
+        } else {
+            if (!ldb_dn_add_child_fmt(dn, "cn=%s", s)) {
+                ret = ENOMEM;
+                goto done;
+            }
+            s = NULL;
+        }
+    }
+
+    DEBUG(SSSDBG_TRACE_INTERNAL,
+          "Local path for [%s] is [%s]\n",
+          req_path, ldb_dn_get_linearized(dn));
+    *req_dn = dn;
+    ret = EOK;
+
+done:
+    return ret;
+}
+
+errno_t sss_sec_new_req(TALLOC_CTX *mem_ctx,
+                        struct sss_sec_ctx *sec_ctx,
+                        const char *url,
+                        uid_t client,
+                        struct sss_sec_req **_req)
+{
+    struct sss_sec_req *req;
+    TALLOC_CTX *tmp_ctx;
+    errno_t ret;
+
+    if (sec_ctx == NULL || url == NULL || _req == NULL) {
+        return EINVAL;
+    }
+
+    tmp_ctx = talloc_new(mem_ctx);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    req = talloc_zero(tmp_ctx, struct sss_sec_req);
+    if (req == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+    req->sctx = sec_ctx;
+
+    ret = sss_sec_map_path(req, url, client, &req->mapped_path);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "Mapping URL to path failed\n");
+        goto done;
+    }
+
+    if (req->mapped_path == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "The path was not mapped properly!\n");
+        ret = EINVAL;
+        goto done;
+    }
+
+    /* drop the prefix and select a basedn instead */
+    if (strncmp(req->mapped_path,
+                SSS_SEC_BASEPATH,
+                sizeof(SSS_SEC_BASEPATH) - 1) == 0) {
+
+        if (geteuid() != 0 && client != geteuid()) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "Only root can impersonate other users\n");
+            ret = EPERM;
+            goto done;
+        }
+
+        req->path = talloc_strdup(req,
+                                     req->mapped_path + (sizeof(SSS_SEC_BASEPATH) - 1));
+        req->basedn = SECRETS_BASEDN;
+        req->quota = sec_ctx->quota_secrets;
+    } else if (strncmp(req->mapped_path,
+                       SSS_SEC_KCM_BASEPATH,
+                       sizeof(SSS_SEC_KCM_BASEPATH) - 1) == 0) {
+
+        if (geteuid() != KCM_PEER_UID && client != KCM_PEER_UID) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "UID %"SPRIuid" is not allowed to access "
+                  "the "SSS_SEC_KCM_BASEPATH" hive\n",
+                  client);
+            ret = EPERM;
+            goto done;
+        }
+
+        req->path = talloc_strdup(req,
+                                  req->mapped_path + (sizeof(SSS_SEC_KCM_BASEPATH) - 1));
+        req->basedn = KCM_BASEDN;
+        req->quota = sec_ctx->quota_kcm;
+    } else {
+        ret = EINVAL;
+        goto done;
+    }
+
+    if (req->path == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Failed to map request to local db path\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = local_db_dn(req, sec_ctx->ldb, req->basedn, req->path, &req->req_dn);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Failed to map request to local db DN\n");
+        goto done;
+    }
+
+    DEBUG(SSSDBG_TRACE_LIBS, "Local DB path is %s\n", req->path);
+
+    ret = EOK;
+    *_req = talloc_steal(mem_ctx, req);
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+static char *local_dn_to_path(TALLOC_CTX *mem_ctx,
+                              struct ldb_dn *basedn,
+                              struct ldb_dn *dn)
+{
+    int basecomps;
+    int dncomps;
+    char *path = NULL;
+
+    basecomps = ldb_dn_get_comp_num(basedn);
+    dncomps = ldb_dn_get_comp_num(dn);
+
+    for (int i = dncomps - basecomps; i > 0; i--) {
+        const struct ldb_val *val;
+
+        val = ldb_dn_get_component_val(dn, i - 1);
+        if (!val) return NULL;
+
+        if (path) {
+            path = talloc_strdup_append_buffer(path, "/");
+            if (!path) return NULL;
+            path = talloc_strndup_append_buffer(path, (char *)val->data,
+                                                val->length);
+        } else {
+            path = talloc_strndup(mem_ctx, (char *)val->data, val->length);
+        }
+        if (!path) return NULL;
+    }
+
+    DEBUG(SSSDBG_TRACE_INTERNAL,
+          "Secrets path for [%s] is [%s]\n",
+          ldb_dn_get_linearized(dn), path);
+    return path;
+}
+
+errno_t sss_sec_list(TALLOC_CTX *mem_ctx,
+                     struct sss_sec_req *req,
+                     char ***_keys,
+                     size_t *_num_keys)
+{
+    TALLOC_CTX *tmp_ctx;
+    static const char *attrs[] = { "secret", NULL };
+    struct ldb_result *res;
+    char **keys;
+    int ret;
+
+    if (req == NULL || _keys == NULL || _num_keys == NULL) {
+        return EINVAL;
+    }
+
+    tmp_ctx = talloc_new(mem_ctx);
+    if (!tmp_ctx) return ENOMEM;
+
+    DEBUG(SSSDBG_TRACE_FUNC, "Listing keys at [%s]\n", req->path);
+
+    DEBUG(SSSDBG_TRACE_INTERNAL,
+          "Searching for [%s] at [%s] with scope=subtree\n",
+          LOCAL_SIMPLE_FILTER, ldb_dn_get_linearized(req->req_dn));
+
+    ret = ldb_search(req->sctx->ldb, tmp_ctx, &res, req->req_dn, LDB_SCOPE_SUBTREE,
+                     attrs, "%s", LOCAL_SIMPLE_FILTER);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_TRACE_LIBS,
+              "ldb_search returned [%d]: %s\n", ret, ldb_strerror(ret));
+        ret = ENOENT;
+        goto done;
+    }
+
+    if (res->count == 0) {
+        DEBUG(SSSDBG_TRACE_LIBS, "No secrets found\n");
+        ret = ENOENT;
+        goto done;
+    }
+
+    keys = talloc_array(mem_ctx, char *, res->count);
+    if (!keys) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    for (unsigned i = 0; i < res->count; i++) {
+        keys[i] = local_dn_to_path(keys, req->req_dn, res->msgs[i]->dn);
+        if (!keys[i]) {
+            ret = ENOMEM;
+            goto done;
+        }
+    }
+
+    *_keys = keys;
+    DEBUG(SSSDBG_TRACE_LIBS, "Returning %d secrets\n", res->count);
+    *_num_keys = res->count;
+    ret = EOK;
+
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+errno_t sss_sec_get(TALLOC_CTX *mem_ctx,
+                    struct sss_sec_req *req,
+                    char **_secret)
+{
+    TALLOC_CTX *tmp_ctx;
+    static const char *attrs[] = { "secret", "enctype", NULL };
+    struct ldb_result *res;
+    const char *attr_secret;
+    const char *attr_enctype;
+    int ret;
+
+    if (req == NULL || _secret == NULL) {
+        return EINVAL;
+    }
+
+    DEBUG(SSSDBG_TRACE_FUNC, "Retrieving a secret from [%s]\n", req->path);
+
+    tmp_ctx = talloc_new(mem_ctx);
+    if (!tmp_ctx) return ENOMEM;
+
+    DEBUG(SSSDBG_TRACE_INTERNAL,
+          "Searching for [%s] at [%s] with scope=base\n",
+          LOCAL_SIMPLE_FILTER, ldb_dn_get_linearized(req->req_dn));
+
+    ret = ldb_search(req->sctx->ldb, tmp_ctx, &res, req->req_dn, LDB_SCOPE_BASE,
+                     attrs, "%s", LOCAL_SIMPLE_FILTER);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_TRACE_LIBS,
+              "ldb_search returned [%d]: %s\n", ret, ldb_strerror(ret));
+        ret = ENOENT;
+        goto done;
+    }
+
+    switch (res->count) {
+    case 0:
+        DEBUG(SSSDBG_TRACE_LIBS, "No secret found\n");
+        ret = ENOENT;
+        goto done;
+    case 1:
+        break;
+    default:
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Too many secrets returned with BASE search\n");
+        ret = E2BIG;
+        goto done;
+    }
+
+    attr_secret = ldb_msg_find_attr_as_string(res->msgs[0], "secret", NULL);
+    if (!attr_secret) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "The 'secret' attribute is missing\n");
+        ret = ENOENT;
+        goto done;
+    }
+
+    attr_enctype = ldb_msg_find_attr_as_string(res->msgs[0], "enctype", NULL);
+
+    if (attr_enctype) {
+        ret = local_decrypt(req->sctx, mem_ctx, attr_secret, attr_enctype, _secret);
+        if (ret) goto done;
+    } else {
+        *_secret = talloc_strdup(mem_ctx, attr_secret);
+    }
+    ret = EOK;
+
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+errno_t sss_sec_put(struct sss_sec_req *req,
+                    const char *secret)
+{
+    struct ldb_message *msg;
+    const char *enctype = "masterkey";
+    char *enc_secret;
+    int ret;
+
+    if (req == NULL || secret == NULL) {
+        return EINVAL;
+    }
+
+    DEBUG(SSSDBG_TRACE_FUNC, "Adding a secret to [%s]\n", req->path);
+
+    msg = ldb_msg_new(req);
+    if (!msg) {
+        ret = ENOMEM;
+        goto done;
+    }
+    msg->dn = req->req_dn;
+
+    /* make sure containers exist */
+    ret = local_db_check_containers(msg, req->sctx, msg->dn);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "local_db_check_containers failed for [%s]: [%d]: %s\n",
+              ldb_dn_get_linearized(msg->dn), ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = local_db_check_number_of_secrets(msg, req);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "local_db_check_number_of_secrets failed [%d]: %s\n",
+              ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = local_db_check_peruid_number_of_secrets(msg, req);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "local_db_check_number_of_secrets failed [%d]: %s\n",
+              ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = local_check_max_payload_size(req, strlen(secret));
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "local_check_max_payload_size failed [%d]: %s\n",
+              ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = local_encrypt(req->sctx, msg, secret, enctype, &enc_secret);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "local_encrypt failed [%d]: %s\n", ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = ldb_msg_add_string(msg, "type", "simple");
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "ldb_msg_add_string failed adding type:simple [%d]: %s\n",
+              ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = ldb_msg_add_string(msg, "enctype", enctype);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "ldb_msg_add_string failed adding enctype [%d]: %s\n",
+              ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = ldb_msg_add_string(msg, "secret", enc_secret);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "ldb_msg_add_string failed adding secret [%d]: %s\n",
+              ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = ldb_msg_add_fmt(msg, "creationTime", "%lu", time(NULL));
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "ldb_msg_add_string failed adding creationTime [%d]: %s\n",
+              ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = ldb_add(req->sctx->ldb, msg);
+    if (ret != EOK) {
+        if (ret == LDB_ERR_ENTRY_ALREADY_EXISTS) {
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "Secret %s already exists\n", ldb_dn_get_linearized(msg->dn));
+            ret = EEXIST;
+        } else {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Failed to add secret [%s]: [%d]: %s\n",
+                  ldb_dn_get_linearized(msg->dn), ret, ldb_strerror(ret));
+            ret = EIO;
+        }
+        goto done;
+    }
+
+    ret = EOK;
+done:
+    talloc_free(msg);
+    return ret;
+}
+
+errno_t sss_sec_delete(struct sss_sec_req *req)
+{
+    TALLOC_CTX *tmp_ctx;
+    static const char *attrs[] = { NULL };
+    struct ldb_result *res;
+    int ret;
+
+    if (req == NULL) {
+        return EINVAL;
+    }
+
+    DEBUG(SSSDBG_TRACE_FUNC, "Removing a secret from [%s]\n", req->path);
+
+    tmp_ctx = talloc_new(req);
+    if (!tmp_ctx) return ENOMEM;
+
+    DEBUG(SSSDBG_TRACE_INTERNAL,
+          "Searching for [%s] at [%s] with scope=base\n",
+          LOCAL_CONTAINER_FILTER, ldb_dn_get_linearized(req->req_dn));
+
+    ret = ldb_search(req->sctx->ldb, tmp_ctx, &res, req->req_dn, LDB_SCOPE_BASE,
+                     attrs, LOCAL_CONTAINER_FILTER);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_TRACE_LIBS,
+              "ldb_search returned %d: %s\n", ret, ldb_strerror(ret));
+        goto done;
+    }
+
+    if (res->count == 1) {
+        DEBUG(SSSDBG_TRACE_INTERNAL,
+              "Searching for children of [%s]\n", ldb_dn_get_linearized(req->req_dn));
+        ret = ldb_search(req->sctx->ldb, tmp_ctx, &res, req->req_dn, LDB_SCOPE_ONELEVEL,
+                         attrs, NULL);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_TRACE_LIBS,
+                  "ldb_search returned %d: %s\n", ret, ldb_strerror(ret));
+            goto done;
+        }
+
+        if (res->count > 0) {
+            ret = EEXIST;
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "Failed to remove '%s': Container is not empty\n",
+                  ldb_dn_get_linearized(req->req_dn));
+
+            goto done;
+        }
+    }
+
+    ret = ldb_delete(req->sctx->ldb, req->req_dn);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_TRACE_LIBS,
+              "ldb_delete returned %d: %s\n", ret, ldb_strerror(ret));
+        /* fall through */
+    }
+
+    switch (ret) {
+    case LDB_SUCCESS:
+        ret = EOK;
+        break;
+    case LDB_ERR_NO_SUCH_OBJECT:
+        ret = ENOENT;
+        break;
+    default:
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "LDB returned unexpected error: [%s]\n",
+               ldb_strerror(ret));
+        ret = EFAULT;
+        break;
+    }
+
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+errno_t sss_sec_create_container(struct sss_sec_req *req)
+{
+    int plen;
+
+    if (req == NULL) {
+        return EINVAL;
+    }
+
+    plen = strlen(req->path);
+
+    if (req->path[plen - 1] != '/') {
+        return EINVAL;
+    }
+
+    req->path[plen - 1] = '\0';
+    return local_db_create(req);
+}
+
+bool sss_sec_req_is_list(struct sss_sec_req *req)
+{
+    if (req == NULL || req->mapped_path == NULL) {
+        return false;
+    }
+
+    if (req->mapped_path[strlen(req->mapped_path) - 1] == '/') {
+        return true;
+    }
+
+    return false;
+}

--- a/src/util/secrets/secrets.c
+++ b/src/util/secrets/secrets.c
@@ -30,14 +30,8 @@
 #include "util/secrets/sec_pvt.h"
 #include "util/secrets/secrets.h"
 
-/* The KCM responder must "impersonate" the owner of the credentials.
- * Only a trusted UID can do that -- root by default, but unit
- * tests might choose otherwise */
-#ifndef KCM_PEER_UID
 #define KCM_PEER_UID            0
-#endif /* KCM_PEER_UID */
-
-#define MKEY_SIZE (256 / 8)
+#define MKEY_SIZE               (256 / 8)
 
 #define SECRETS_BASEDN  "cn=secrets"
 #define KCM_BASEDN      "cn=kcm"

--- a/src/util/secrets/secrets.h
+++ b/src/util/secrets/secrets.h
@@ -88,6 +88,9 @@ errno_t sss_sec_get(TALLOC_CTX *mem_ctx,
 errno_t sss_sec_put(struct sss_sec_req *req,
                     const char *secret);
 
+errno_t sss_sec_update(struct sss_sec_req *req,
+                       const char *secret);
+
 errno_t sss_sec_create_container(struct sss_sec_req *req);
 
 bool sss_sec_req_is_list(struct sss_sec_req *req);

--- a/src/util/secrets/secrets.h
+++ b/src/util/secrets/secrets.h
@@ -1,0 +1,112 @@
+/*
+   SSSD
+
+   Local secrets database
+
+   Copyright (C) Red Hat 2018
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __SECRETS_H_
+#define __SECRETS_H_
+
+#include <errno.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <talloc.h>
+
+#include "confdb/confdb.h"
+
+#define DEFAULT_SEC_CONTAINERS_NEST_LEVEL 4
+
+#define DEFAULT_SEC_MAX_SECRETS      1024
+#define DEFAULT_SEC_MAX_UID_SECRETS  256
+#define DEFAULT_SEC_MAX_PAYLOAD_SIZE 16
+
+/* The number of secrets in the /kcm hive should be quite small,
+ * but the secret size must be large because one secret in the /kcm
+ * hive holds the whole ccache which consists of several credentials
+ */
+#define DEFAULT_SEC_KCM_MAX_SECRETS      256
+#define DEFAULT_SEC_KCM_MAX_UID_SECRETS  64
+#define DEFAULT_SEC_KCM_MAX_PAYLOAD_SIZE 65536
+
+struct sss_sec_ctx;
+
+struct sss_sec_req;
+
+struct sss_sec_quota {
+    int max_secrets;
+    int max_uid_secrets;
+    int max_payload_size;
+    int containers_nest_level;
+};
+
+struct sss_sec_hive_config {
+    const char *hive_name;
+    struct sss_sec_quota quota;
+};
+
+errno_t sss_sec_map_path(TALLOC_CTX *mem_ctx,
+                         const char *url,
+                         uid_t client,
+                         char **_mapped_path);
+
+errno_t sss_sec_init(TALLOC_CTX *mem_ctx,
+                     struct sss_sec_hive_config **config_list,
+                     struct sss_sec_ctx **_sec_ctx);
+
+errno_t sss_sec_new_req(TALLOC_CTX *mem_ctx,
+                        struct sss_sec_ctx *sec_ctx,
+                        const char *url,
+                        uid_t client,
+                        struct sss_sec_req **_req);
+
+errno_t sss_sec_delete(struct sss_sec_req *req);
+
+errno_t sss_sec_list(TALLOC_CTX *mem_ctx,
+                     struct sss_sec_req *req,
+                     char ***_keys,
+                     size_t *num_keys);
+
+errno_t sss_sec_get(TALLOC_CTX *mem_ctx,
+                    struct sss_sec_req *req,
+                    char **_secret);
+
+errno_t sss_sec_put(struct sss_sec_req *req,
+                    const char *secret);
+
+errno_t sss_sec_create_container(struct sss_sec_req *req);
+
+bool sss_sec_req_is_list(struct sss_sec_req *req);
+
+
+errno_t sss_sec_get_quota(struct confdb_ctx *cdb,
+                          const char *section_config_path,
+                          int default_max_containers_nest_level,
+                          int default_max_num_secrets,
+                          int default_max_num_uid_secrets,
+                          int default_max_payload,
+                          struct sss_sec_quota *quota);
+
+errno_t sss_sec_get_hive_config(struct confdb_ctx *cdb,
+                                const char *hive_name,
+                                int default_max_containers_nest_level,
+                                int default_max_num_secrets,
+                                int default_max_num_uid_secrets,
+                                int default_max_payload,
+                                struct sss_sec_hive_config *hive_config);
+
+#endif /* __SECRETS_H_ */


### PR DESCRIPTION
Resolves:
https://pagure.io/SSSD/sssd/issue/3685

This patch set splits parts of the secrets responder to a library which
is used by the secrets responder in place of the native code. The library
also forms a basis of a new KCM back end, which is made the default towards
the end of the patch.

The benefit of this PR is fewer build dependencies in the default
configuration, smaller default sssd footprint and better performance as
we no longer need to go through the sssd-secrets REST API.

The PR is "almost" finished. I will add quota management as a separate
patch and the man page needs to be adjusted. But hte patches already
present should be ready.