### PR TITLE
nss: remove unused label

### DIFF
--- a/src/responder/nss/nss_protocol_grent.c
+++ b/src/responder/nss/nss_protocol_grent.c
@@ -403,13 +403,9 @@ nss_protocol_fill_initgr(struct nss_ctx *nss_ctx,
             DEBUG(SSSDBG_MINOR_FAILURE,
                   "Failed to store initgroups %s (%s) in mem-cache [%d]: %s!\n",
                   rawname.str, domain->name, ret, sss_strerror(ret));
+            sss_packet_set_size(packet, 0);
+            return ret;
         }
-    }
-
-done:
-    if (ret != EOK) {
-        sss_packet_set_size(packet, 0);
-        return ret;
     }
 
     sss_packet_get_body(packet, &body, &body_len);


### PR DESCRIPTION
After 4937f2c6, Sumit noticed the following warning/breakage:

    make[2]: Leaving directory '/home/sbose/sssd/master_build/src/man'
    Making check in .
    make[2]: Entering directory '/home/sbose/sssd/master_build'
      CC       src/responder/nss/nss_protocol_grent.o
    ../src/responder/nss/nss_protocol_grent.c: In function 'nss_protocol_fill_initgr':
    ../src/responder/nss/nss_protocol_grent.c:409:1: error: label 'done' defined but not used [-Werror=unused-label]
     done:
     ^~~~
    cc1: all warnings being treated as errors
    Makefile:17808: recipe for target 'src/responder/nss/nss_protocol_grent.o' failed
    make[2]: *** [src/responder/nss/nss_protocol_grent.o] Error 1
    make[2]: Leaving directory '/home/sbose/sssd/master_build'

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>