### PR TITLE
tests: fix sss_nss_idmap-tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1903,8 +1903,14 @@ check_LTLIBRARIES += \
     $(NULL)
 endif
 
+# libdlopen_test_providers is a helper library to provide missing symbols for
+# dlopen_tests. It is mainly used for the backend modules but is used as well
+# to provide __wrap_sss_nss_make_request_timeout needed make make dlopen_tests
+# pass for libsss_nss_idmap_tests.
 libdlopen_test_providers_la_SOURCES = \
-    $(sssd_be_SOURCES)
+    $(sssd_be_SOURCES) \
+    src/tests/cmocka/wrap_sss_nss_make_request_timeout.c \
+    $(NULL)
 libdlopen_test_providers_la_CFLAGS = \
     $(AM_CFLAGS) \
     $(CHECK_CFLAGS) \
@@ -1932,6 +1938,7 @@ libsss_nss_idmap_tests_la_LDFLAGS = \
     $(libsss_nss_idmap_la_LDFLAGS) \
     -shared \
     -rpath $(libdir) \
+    -Wl,-wrap,sss_nss_make_request_timeout \
     -Wl,--version-script,$(srcdir)/src/sss_client/idmap/sss_nss_idmap.unit_tests
 
 dist_noinst_DATA += src/sss_client/idmap/sss_nss_idmap.unit_tests

--- a/src/tests/cmocka/sss_nss_idmap-tests.c
+++ b/src/tests/cmocka/sss_nss_idmap-tests.c
@@ -61,11 +61,12 @@ uint8_t buf_orig1[] = {0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0
  #error "unknow endianess"
 #endif
 
-enum nss_status sss_nss_make_request_timeout(enum sss_cli_command cmd,
-                                             struct sss_cli_req_data *rd,
-                                             int timeout,
-                                             uint8_t **repbuf, size_t *replen,
-                                             int *errnop)
+enum nss_status __wrap_sss_nss_make_request_timeout(enum sss_cli_command cmd,
+                                                    struct sss_cli_req_data *rd,
+                                                    int timeout,
+                                                    uint8_t **repbuf,
+                                                    size_t *replen,
+                                                    int *errnop)
 {
     struct sss_nss_make_request_test_data *d;
 
@@ -115,7 +116,7 @@ void test_getsidbyname(void **state)
     sid = NULL;
 
     for (c = 0; d[c].d.repbuf != NULL; c++) {
-        will_return(sss_nss_make_request_timeout, &d[0].d);
+        will_return(__wrap_sss_nss_make_request_timeout, &d[0].d);
 
         ret = sss_nss_getsidbyname("test", &sid, &type);
         assert_int_equal(ret, d[0].ret);
@@ -135,7 +136,7 @@ void test_getorigbyname(void **state)
     enum sss_id_type type;
     struct sss_nss_make_request_test_data d = {buf_orig1, sizeof(buf_orig1), 0, NSS_STATUS_SUCCESS};
 
-    will_return(sss_nss_make_request_timeout, &d);
+    will_return(__wrap_sss_nss_make_request_timeout, &d);
     ret = sss_nss_getorigbyname("test", &kv_list, &type);
     assert_int_equal(ret, EOK);
     assert_int_equal(type, SSS_ID_TYPE_UID);

--- a/src/tests/cmocka/wrap_sss_nss_make_request_timeout.c
+++ b/src/tests/cmocka/wrap_sss_nss_make_request_timeout.c
@@ -1,0 +1,37 @@
+/*
+    Authors:
+        Sumit Bose <sbose@redhat.com>
+
+    Copyright (C) 2018 Red Hat
+
+    Helper to make dlopen-tests pass for libsss_nss_idmap_tests.so.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdint.h>
+#include <unistd.h>
+#include <nss.h>
+
+#include "sss_client/sss_cli.h"
+
+enum nss_status __wrap_sss_nss_make_request_timeout(enum sss_cli_command cmd,
+                                                    struct sss_cli_req_data *rd,
+                                                    int timeout,
+                                                    uint8_t **repbuf,
+                                                    size_t *replen,
+                                                    int *errnop)
+{
+    return NSS_STATUS_SUCCESS;
+}

--- a/src/tests/dlopen-tests.c
+++ b/src/tests/dlopen-tests.c
@@ -120,7 +120,8 @@ struct so {
     /* for testing purposes */
     { "libdlopen_test_providers.so", { LIBPFX"libdlopen_test_providers.so",
                                        NULL } },
-    { "libsss_nss_idmap_tests.so", { LIBPFX"libsss_nss_idmap_tests.so",
+    { "libsss_nss_idmap_tests.so", { LIBPFX"libdlopen_test_providers.so",
+                                     LIBPFX"libsss_nss_idmap_tests.so",
                                      NULL } },
 #ifdef BUILD_SAMBA
     { "libdlopen_test_winbind_idmap.so",


### PR DESCRIPTION
If sss_nss_idmap-tests is complied with -Wl,-Bsymbolic-functions it
fails because sss_nss_make_request_timeout() is not properly wrapped but
the tests expects that the replacement call it provides is picked by the
linker and not the original function.

This patch wraps the call in the corresponding test library. As a
consequence a small helper function had to be added to make dlopen-tests
pass for the test library as well.

Resolves https://pagure.io/SSSD/sssd/issue/3801