### PR TITLE
nss_protocol_fill_initgr: fix label ‘done’ defined but not used

### DIFF
--- a/src/responder/nss/nss_protocol_grent.c
+++ b/src/responder/nss/nss_protocol_grent.c
@@ -406,7 +406,6 @@ nss_protocol_fill_initgr(struct nss_ctx *nss_ctx,
         }
     }
 
-done:
     if (ret != EOK) {
         sss_packet_set_size(packet, 0);
         return ret;


### PR DESCRIPTION
CC       src/responder/nss/nss_protocol_netgr.o
/home/pbrezina/workspace/sssd/src/responder/nss/nss_protocol_grent.c: In function ‘nss_protocol_fill_initgr’:
/home/pbrezina/workspace/sssd/src/responder/nss/nss_protocol_grent.c:409:1: error: label ‘done’ defined but not used [-Werror=unused-label]
 done: