### PR TITLE
P11: Don't return int failure from a bool function

### DIFF
--- a/src/p11_child/p11_child_nss.c
+++ b/src/p11_child/p11_child_nss.c
@@ -220,7 +220,7 @@ bool do_verification_b64(struct p11_ctx *p11_ctx, const char *cert_b64)
     ret = b64_to_cert(p11_ctx, cert_b64, &cert);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to convert certificate.\n");
-        return EINVAL;
+        return false;
     }
 
     res = do_verification(p11_ctx, cert);

--- a/src/p11_child/p11_child_openssl.c
+++ b/src/p11_child/p11_child_openssl.c
@@ -209,7 +209,7 @@ bool do_verification_b64(struct p11_ctx *p11_ctx, const char *cert_b64)
     ret = b64_to_cert(cert_b64, &cert);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to convert certificate.\n");
-        return EINVAL;
+        return false;
     }
 
     res = do_verification(p11_ctx, cert);


### PR DESCRIPTION
The functions return bool as per their prototype, but returning EINVAL on
failure meant that EINVAL (typically 22) was converted to 'true', so a
certificate that was not processable was considered valid.

Luckily this code only converts certificates into SSH public keys, so there
are no security implications.