### PR TITLE
sss_ssh_knownhostsproxy: fix typo pubkey -> pubkeys

### DIFF
--- a/src/man/sss_ssh_knownhostsproxy.1.xml
+++ b/src/man/sss_ssh_knownhostsproxy.1.xml
@@ -86,7 +86,7 @@ GlobalKnownHostsFile /var/lib/sss/pubconf/known_hosts
             </varlistentry>
             <varlistentry>
                 <term>
-                    <option>-k</option>,<option>--pubkeys</option>
+                    <option>-k</option>,<option>--pubkey</option>
                 </term>
                 <listitem>
                     <para>


### PR DESCRIPTION
In commit 36f2fe8f63 a discrepancy between the command line option and
the manpage has been introduced.

Related:
https://pagure.io/SSSD/sssd/issue/3542

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>