### PR TITLE
KCM: Don't error out if creating a new ID as the first step

### DIFF
--- a/src/responder/kcm/kcmsrv_ccache_secdb.c
+++ b/src/responder/kcm/kcmsrv_ccache_secdb.c
@@ -595,7 +595,10 @@ static struct tevent_req *ccdb_secdb_nextid_send(TALLOC_CTX *mem_ctx,
     }
 
     ret = sss_sec_list(state, sreq, &keys, &nkeys);
-    if (ret != EOK) {
+    if (ret == ENOENT) {
+        keys = NULL;
+        nkeys = 0;
+    } else if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
               "Cannot list keys [%d]: %s\n",
               ret, sss_strerror(ret));


### PR DESCRIPTION
We need to handle the case where the nextID operation is ran, but the secdb
is totally empty, otherwise logins with sssd's krb5_child would fail.

Resolves: https://pagure.io/SSSD/sssd/issue/3815