### PR TITLE
When multiple UIDs exist, use the username provided by the user as the first lookup

### DIFF
--- a/src/db/sysdb.c
+++ b/src/db/sysdb.c
@@ -29,8 +29,7 @@
 #include "util/probes.h"
 #include <time.h>
 
-//This is the global definition for the userLoginAttempt variable
-#include "globals/globals.h"
+//This is the global definition for the userLoginAttempt variabl
 char userLoginAttempt[];
 
 errno_t sysdb_dn_sanitize(TALLOC_CTX *mem_ctx, const char *input,

--- a/src/globals/globals.h
+++ b/src/globals/globals.h
@@ -1,0 +1,6 @@
+#ifndef GLOBAL_H
+#define GLOBAL_H
+
+extern char hotcakes[];
+
+#endif

--- a/src/globals/globals.h
+++ b/src/globals/globals.h
@@ -1,6 +1,6 @@
 #ifndef GLOBAL_H
 #define GLOBAL_H
 
-extern char hotcakes[];
+extern char userLoginAttempt[];
 
 #endif

--- a/src/providers/data_provider/dp_target_id.c
+++ b/src/providers/data_provider/dp_target_id.c
@@ -28,6 +28,10 @@
 #include "providers/backend.h"
 #include "util/util.h"
 
+#include "globals/globals.h"
+char userLoginAttempt[40];
+
+
 #define FILTER_TYPE(str, type) {str "=", sizeof(str "=") - 1, type}
 
 static bool check_and_parse_filter(struct dp_id_data *data,
@@ -451,6 +455,13 @@ dp_get_account_info_send(TALLOC_CTX *mem_ctx,
           "Got request for [%#"PRIx32"][%s][%s]\n",
           state->data->entry_type, be_req2str(state->data->entry_type),
           filter);
+
+    DEBUG(SSSDBG_FUNC_DATA,"Storing the login value in a global:  [%s]\n", filter);
+
+
+    strcpy(userLoginAttempt,filter);
+    DEBUG(SSSDBG_FUNC_DATA,"The global variable now contains:  [%s]\n", userLoginAttempt);
+
 
     if ((state->data->entry_type & BE_REQ_TYPE_MASK) == BE_REQ_INITGROUPS) {
         state->request_name = "Initgroups";

--- a/src/providers/data_provider/dp_target_id.c
+++ b/src/providers/data_provider/dp_target_id.c
@@ -28,7 +28,7 @@
 #include "providers/backend.h"
 #include "util/util.h"
 
-#include "globals/globals.h"
+
 char userLoginAttempt[40];
 
 

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -719,6 +719,9 @@ int reset_selinux_file_context(void);
 /* from util_preauth.c */
 errno_t create_preauth_indicator(void);
 
+/* global variable used at user login */
+extern char userLoginAttempt[];
+
 #ifdef SSSD_LIBEXEC_PATH
 #define P11_CHILD_LOG_FILE "p11_child"
 #define P11_CHILD_PATH SSSD_LIBEXEC_PATH"/p11_child"


### PR DESCRIPTION
The current state of the code has no way of determining the "correct" UID to use when there are multiple values.   If there are multiple values, and the RDN doesn't match, this update checks the UID's returned against the username that was provided by the user at the prompt. If that matches, it's used.  If that doesn't match, it falls back to the existing code. 

Example:  
My ldap record includes multiple uid values, ["genericemployee1", "itstaff1"]
I need access to machines as "itstaff1".  "genericemployee1" is used as an identifier in other systems/services.

If I log in with "itstaff1" at the prompt, and my ldap lookup with filter (uid=itstaff1) is successful, the array of UID's are checked against "itstaff1" and that's what *_primary is set to.

With the current code, if I try to log in with "itstaff1" at the prompt, I'm actually logged into the system as "genericemployee1".  Based on the order that the values are returned... some other staff are logged into their "genericemployee" or the "itstaff" accounts.