### PR TITLE
sbus: register filter on new connection

### DIFF
--- a/src/sbus/router/sbus_router.c
+++ b/src/sbus/router/sbus_router.c
@@ -364,6 +364,13 @@ errno_t
 sbus_router_reset(struct sbus_connection *conn)
 {
     errno_t ret;
+    bool bret;
+
+    bret = sbus_router_filter_add(conn->router);
+    if (!bret) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to register message filter!\n");
+        return EFAULT;
+    }
 
     ret = sbus_router_reset_listeners(conn);
     if (ret != EOK) {


### PR DESCRIPTION
The filter is not again registered on new connection when the old connection
was lost. This caused a segfault when the router is destroyed during shutdown.

It also would not allow to recieve and process any messages as the filter
function is needed for that. However, this was not very visible with
current sssd architecture.

Steps to reproduce:
1. Run SSSD
2. pkill sssd_be
3. Wait for responders to reconnect to backend
4. Shutdown SSSD
5. It will crash without this patch

Resolves:
https://pagure.io/SSSD/sssd/issue/3821