### PR TITLE
sudo: respect case sensitivity in sudo responder

### DIFF
--- a/src/db/sysdb_sudo.c
+++ b/src/db/sysdb_sudo.c
@@ -418,7 +418,17 @@ sysdb_get_sudo_user_info(TALLOC_CTX *mem_ctx,
         ret = EINVAL;
         goto done;
     }
-    DEBUG(SSSDBG_TRACE_FUNC, "original name: %s\n", orig_name);
+
+    DEBUG(SSSDBG_TRACE_FUNC, "Original name: %s\n", orig_name);
+
+    orig_name = sss_get_cased_name(tmp_ctx, orig_name, domain->case_sensitive);
+    if (orig_name == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    DEBUG(SSSDBG_TRACE_FUNC, "Cased name: %s\n", orig_name);
 
     if (_uid != NULL) {
         uid = ldb_msg_find_attr_as_uint64(res->msgs[0], SYSDB_UIDNUM, 0);
@@ -450,8 +460,9 @@ sysdb_get_sudo_user_info(TALLOC_CTX *mem_ctx,
                     continue;
                 }
 
-                sysdb_groupnames[num_groups] = talloc_strdup(sysdb_groupnames,
-                                                             groupname);
+                sysdb_groupnames[num_groups] = \
+                    sss_get_cased_name(sysdb_groupnames, groupname,
+                                       domain->case_sensitive);
                 if (sysdb_groupnames[num_groups] == NULL) {
                     DEBUG(SSSDBG_MINOR_FAILURE, "Cannot strdup %s\n", groupname);
                     continue;


### PR DESCRIPTION
If the domain is not case sensitive and the case of the original user
or group name differs from the name in the rule we failed to find the
rule.

Now we filter the rule only with lower cased values in such domain.

Steps to reproduce:
1. Add user/group with upper case, e.g. USER-1
2. Add sudo rule with lower cased name, e.g. sudoUser: user-1
3. Login to system with lower case, e.g. user-1
4. Run sudo -l

Without the patch, rule is not found.

Resolves:
https://pagure.io/SSSD/sssd/issue/3820