### PR TITLE
sbus: dectect python binary for sbus_generate.sh

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1020,14 +1020,14 @@ libsss_cert_la_LDFLAGS = \
     $(NULL)
 
 generate-sbus-code:
-	$(srcdir)/sbus_generate.sh $(abs_srcdir)
+	$(builddir)/sbus_generate.sh $(abs_srcdir)
 
 .PHONY: generate-sbus-code
 
 BUILT_SOURCES += generate-sbus-code
 
 EXTRA_DIST += \
-    sbus_generate.sh \
+    sbus_generate.sh.in \
     src/sbus/codegen/dbus.xml \
     src/sbus/codegen/sbus_CodeGen.py \
     src/sbus/codegen/sbus_DataType.py \

--- a/configure.ac
+++ b/configure.ac
@@ -373,6 +373,13 @@ them please use argument --without-python3-bindings when running configure.])])
     SSS_CLEAN_PYTHON_VARIABLES
 fi
 
+if test x$HAVE_PYTHON3_BINDINGS = x1; then
+    PYTHON_EXEC=$PYTHON3
+else
+    PYTHON_EXEC=$PYTHON2
+fi
+AC_SUBST(PYTHON_EXEC)
+
 AM_CONDITIONAL([BUILD_PYTHON_BINDINGS],
                [test x"$with_python2_bindings" = xyes \
                      -o x"$with_python3_bindings" = xyes])
@@ -524,4 +531,5 @@ AC_CONFIG_FILES([Makefile contrib/sssd.spec src/examples/rwtab src/doxy.config
                  src/config/setup.py
                  src/systemtap/sssd.stp
                  src/config/SSSDConfig/__init__.py])
+AC_CONFIG_FILES([sbus_generate.sh], [chmod +x sbus_generate.sh])
 AC_OUTPUT

--- a/sbus_generate.sh.in
+++ b/sbus_generate.sh.in
@@ -13,7 +13,7 @@ generate() {
 
     echo "Generating sbus code for: $XML"
 
-    python $CODEGEN --sbus sbus --util util \
+    @PYTHON_EXEC@ $CODEGEN --sbus sbus --util util \
         --headers "$HEADERS" \
         --dest "$SRCDIR/src/$DEST" \
         --fileprefix "sbus_${PREFIX}_" \


### PR DESCRIPTION
We already detect python2 and python3 binaries during configure. With
this patch PYTHON_EXEC is set to the python3 binary if python3 bindings
are generated and to the python2 binary otherwise. With the help of an
environment variable sbus_generate.sh is made aware of it.

Related to https://pagure.io/SSSD/sssd/issue/3807