### PR TITLE
pep8: Ignore W504 and W605 to silence warnings on Debian

### DIFF
--- a/contrib/ci/run
+++ b/contrib/ci/run
@@ -41,7 +41,7 @@ declare -r COVERAGE_MIN_FUNCS=0
 
 # Those values are a sum up of the default warnings in all our
 # supported distros in our CI.
-# debian_testing: E121,E123,E126,E226,E24,E704,W503
+# debian_testing: E121,E123,E126,E226,E24,E704,W503,W504,W605
 # fedora22:
 # fedora23:
 # fedora24: E121,E123,E126,E226,E24,E704
@@ -51,7 +51,7 @@ declare -r COVERAGE_MIN_FUNCS=0
 # fedora_rawhide: E121,E123,E126,E226,E24,E704
 # rhel6:
 # rhel7:
-declare PEP8_IGNORE="--ignore=E121,E123,E126,E226,E24,E704,W503"
+declare PEP8_IGNORE="--ignore=E121,E123,E126,E226,E24,E704,W503,W504,W605"
 declare BASE_PFX=""
 declare DEPS=true
 declare BASE_DIR=`pwd`


### PR DESCRIPTION
This code:
    pkcs11_txt.write("library=libsoftokn3.so\nname=soft\n" +
                     "parameters=configdir='sql:" + config.ABS_BUILDDIR +
                     "/../test_CA/p11_nssdb' " +
                     "dbSlotDescription='SSSD Test Slot' " +
                     "dbTokenDescription='SSSD Test Token' " +
                     "secmod='secmod.db' flags=readOnly)\n\n")
    pkcs11_txt.close()

Was producing warnings such as:
./src/tests/intg/test_pam_responder.py:143:22: W504 line break after binary operator

Even though it looks OK visually and conforms to pep8's written form.

Additionaly, this regular expression compilation:
 Template = re.compile(
            ' *<template name="(\S+)">(.*?)</template>\r?\n?',
            re.MULTILINE | re.DOTALL
        )

Was producing a warning such as:
./src/sbus/codegen/sbus_Template.py:156:29: W605 invalid escape sequence '\S'

Since the \S literal is part of a regular expression, let's suppress
this warning as well.