### PR TITLE
ci: add http-parser-devel for Fedora

### DIFF
--- a/contrib/ci/deps.sh
+++ b/contrib/ci/deps.sh
@@ -54,6 +54,13 @@ if [[ "$DISTRO_BRANCH" == -redhat-* ]]; then
         dbus-python
         python-pep8
     )
+
+    if [[ "$DISTRO_BRANCH" == -redhat-fedora-* ]]; then
+        DEPS_LIST+=(
+            http-parser-devel
+        )
+    fi
+
     _DEPS_LIST_SPEC=`
         sed -e 's/@PACKAGE_VERSION@/0/g' \
             -e 's/@PACKAGE_NAME@/package-name/g' \


### PR DESCRIPTION
After adding a new CI worker the CI run failed because http_parser.h was not
found. Instead of adding http-parser-devel to the worker host directly I think
it makes more sense to add it to the list of required packages at least for
Fedora.