### PR TITLE
UTIL: rename & cleanup sysdb_error_to_errno

### DIFF
--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -839,7 +839,7 @@ static int confdb_get_domain_section(TALLOC_CTX *mem_ctx,
     ret = ldb_search(cdb->ldb, tmp_ctx, &res, dn,
                      LDB_SCOPE_BASE, NULL, NULL);
     if (ret != LDB_SUCCESS) {
-        ret = sysdb_error_to_errno(ret);
+        ret = sss_ldb_error_to_errno(ret);
         goto done;
     }
 
@@ -2072,7 +2072,7 @@ static int confdb_merge_parent_domain(const char *name,
 
         ret = ldb_modify(cdb->ldb, replace_msg);
         if (ret != LDB_SUCCESS) {
-            ret = sysdb_error_to_errno(ret);
+            ret = sss_ldb_error_to_errno(ret);
             DEBUG(SSSDBG_OP_FAILURE,
                 "Inheriting options from parent domain failed [%d]: %s\n",
                 ret, sss_strerror(ret));
@@ -2127,7 +2127,7 @@ static int confdb_merge_parent_domain(const char *name,
      */
     ret = sss_ldb_modify_permissive(cdb->ldb, app_msg);
     if (ret != LDB_SUCCESS) {
-        ret = sysdb_error_to_errno(ret);
+        ret = sss_ldb_error_to_errno(ret);
         DEBUG(SSSDBG_OP_FAILURE,
               "Adding app-specific options failed [%d]: %s\n",
               ret, sss_strerror(ret));

--- a/src/confdb/confdb_setup.c
+++ b/src/confdb/confdb_setup.c
@@ -96,7 +96,7 @@ static int confdb_purge(struct confdb_ctx *cdb)
     ret = ldb_search(cdb->ldb, tmp_ctx, &res, dn,
                      LDB_SCOPE_SUBTREE, attrs, NULL);
     if (ret != LDB_SUCCESS) {
-        ret = sysdb_error_to_errno(ret);
+        ret = sss_ldb_error_to_errno(ret);
         goto done;
     }
 
@@ -104,7 +104,7 @@ static int confdb_purge(struct confdb_ctx *cdb)
         /* Delete this DN */
         ret = ldb_delete(cdb->ldb, res->msgs[i]->dn);
         if (ret != LDB_SUCCESS) {
-            ret = sysdb_error_to_errno(ret);
+            ret = sss_ldb_error_to_errno(ret);
             goto done;
         }
     }
@@ -313,7 +313,7 @@ static int confdb_init_db(const char *config_file, const char *config_dir,
         DEBUG(SSSDBG_FATAL_FAILURE,
               "Failed to start a transaction for "
                "updating the configuration\n");
-        ret = sysdb_error_to_errno(ret);
+        ret = sss_ldb_error_to_errno(ret);
         goto done;
     }
     in_transaction = true;

--- a/src/db/sysdb.c
+++ b/src/db/sysdb.c
@@ -871,31 +871,6 @@ char *sysdb_group_strdn(TALLOC_CTX *mem_ctx,
     return build_dom_dn_str_escape(mem_ctx, SYSDB_TMPL_GROUP, domain, name);
 }
 
-/* TODO: make a more complete and precise mapping */
-int sysdb_error_to_errno(int ldberr)
-{
-    switch (ldberr) {
-    case LDB_SUCCESS:
-        return EOK;
-    case LDB_ERR_OPERATIONS_ERROR:
-        return EIO;
-    case LDB_ERR_NO_SUCH_OBJECT:
-        return ENOENT;
-    case LDB_ERR_BUSY:
-        return EBUSY;
-    case LDB_ERR_ATTRIBUTE_OR_VALUE_EXISTS:
-    case LDB_ERR_ENTRY_ALREADY_EXISTS:
-        return EEXIST;
-    case LDB_ERR_INVALID_ATTRIBUTE_SYNTAX:
-        return EINVAL;
-    default:
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "LDB returned unexpected error: [%s]\n",
-               ldb_strerror(ldberr));
-        return EFAULT;
-    }
-}
-
 /* =Transactions========================================================== */
 
 int sysdb_transaction_start(struct sysdb_ctx *sysdb)

--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -454,9 +454,6 @@ errno_t sysdb_get_highest_usn(TALLOC_CTX *mem_ctx,
                               size_t num_attrs,
                               char **_usn);
 
-/* convert an ldb error into an errno error */
-int sysdb_error_to_errno(int ldberr);
-
 /* DNs related helper functions */
 errno_t sysdb_get_rdn(struct sysdb_ctx *sysdb, TALLOC_CTX *mem_ctx,
                       const char *dn, char **_name, char **_val);
@@ -1433,5 +1430,8 @@ errno_t sysdb_handle_original_uuid(const char *orig_name,
                                    const char *src_name,
                                    struct sysdb_attrs *dest_attrs,
                                    const char *dest_name);
+
+/* define old name for backward compatibility */
+#define sysdb_error_to_errno(ldberr) sss_ldb_error_to_errno(ldberr)
 
 #endif /* __SYS_DB_H__ */

--- a/src/responder/common/cache_req/cache_req_sr_overlay.c
+++ b/src/responder/common/cache_req/cache_req_sr_overlay.c
@@ -192,7 +192,7 @@ static errno_t cache_req_sr_overlay_match_users(
             }
             lret = ldb_msg_add_string(msg, SYSDB_SESSION_RECORDING, enabled_str);
             if (lret != LDB_SUCCESS) {
-                ret = sysdb_error_to_errno(lret);
+                ret = sss_ldb_error_to_errno(lret);
                 CACHE_REQ_DEBUG(SSSDBG_CRIT_FAILURE, cr,
                                 "Failed adding %s attribute: %s\n",
                                 SYSDB_SESSION_RECORDING, sss_strerror(ret));
@@ -279,7 +279,7 @@ static void cache_req_sr_overlay_match_all_step_done(
         }
         lret = ldb_msg_add_string(msg, SYSDB_SESSION_RECORDING, enabled_copy);
         if (lret != LDB_SUCCESS) {
-            ret = sysdb_error_to_errno(lret);
+            ret = sss_ldb_error_to_errno(lret);
             CACHE_REQ_DEBUG(SSSDBG_CRIT_FAILURE, state->cr,
                             "Failed adding %s attribute: %s\n",
                             SYSDB_SESSION_RECORDING, sss_strerror(ret));

--- a/src/responder/ifp/ifp_cache.c
+++ b/src/responder/ifp/ifp_cache.c
@@ -119,7 +119,7 @@ ifp_cache_get_cached_objects(TALLOC_CTX *mem_ctx,
                          SYSDB_IFP_CACHED);
     if (ldb_ret != LDB_SUCCESS) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to search the cache\n");
-        ret = sysdb_error_to_errno(ldb_ret);
+        ret = sss_ldb_error_to_errno(ldb_ret);
         goto done;
     }
 

--- a/src/tools/sss_override.c
+++ b/src/tools/sss_override.c
@@ -936,7 +936,7 @@ static errno_t override_object_del(struct sss_domain_info *domain,
     ret = ldb_msg_add_empty(msg, SYSDB_OVERRIDE_DN, LDB_FLAG_MOD_DELETE, NULL);
     if (ret != LDB_SUCCESS) {
         DEBUG(SSSDBG_OP_FAILURE, "ldb_msg_add_empty() failed\n");
-        ret = sysdb_error_to_errno(ret);
+        ret = sss_ldb_error_to_errno(ret);
         goto done;
     }
 
@@ -945,7 +945,7 @@ static errno_t override_object_del(struct sss_domain_info *domain,
         DEBUG(SSSDBG_OP_FAILURE,
               "ldb_modify() failed: [%s](%d)[%s]\n",
               ldb_strerror(ret), ret, ldb_errstring(ldb));
-        ret = sysdb_error_to_errno(ret);
+        ret = sss_ldb_error_to_errno(ret);
         goto done;
     }
 
@@ -1025,7 +1025,7 @@ static errno_t append_name(struct sss_domain_info *domain,
 
     ret = ldb_msg_add_string(override, ORIGNAME, fqname);
     if (ret != LDB_SUCCESS) {
-        ret = sysdb_error_to_errno(ret);
+        ret = sss_ldb_error_to_errno(ret);
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to add attribute to msg\n");
         goto done;
     }

--- a/src/util/util_errors.c
+++ b/src/util/util_errors.c
@@ -19,6 +19,7 @@
 */
 
 #include "util/util.h"
+#include <ldb.h>
 
 struct err_string {
     const char *msg;
@@ -146,3 +147,27 @@ const char *sss_strerror(errno_t error)
     return strerror(error);
 }
 
+/* TODO: make a more complete and precise mapping */
+errno_t sss_ldb_error_to_errno(int ldberr)
+{
+    switch (ldberr) {
+    case LDB_SUCCESS:
+        return EOK;
+    case LDB_ERR_OPERATIONS_ERROR:
+        return EIO;
+    case LDB_ERR_NO_SUCH_OBJECT:
+        return ENOENT;
+    case LDB_ERR_BUSY:
+        return EBUSY;
+    case LDB_ERR_ATTRIBUTE_OR_VALUE_EXISTS:
+    case LDB_ERR_ENTRY_ALREADY_EXISTS:
+        return EEXIST;
+    case LDB_ERR_INVALID_ATTRIBUTE_SYNTAX:
+        return EINVAL;
+    default:
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "LDB returned unexpected error: [%i]\n",
+              ldberr);
+        return EFAULT;
+    }
+}

--- a/src/util/util_errors.h
+++ b/src/util/util_errors.h
@@ -178,4 +178,7 @@ enum sssd_errors {
  */
 const char *sss_strerror(errno_t error);
 
+/* return ldb error converted to an errno */
+errno_t sss_ldb_error_to_errno(int ldberr);
+
 #endif /* __SSSD_UTIL_ERRORS_H__ */


### PR DESCRIPTION
* UTIL: move and rename sysdb_error_to_errno to utils
* UTIL: Use new ldb_error_to_errno function in code