### PR TITLE
FILES: The files provider should not enumerate

### DIFF
--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -875,7 +875,6 @@ static int confdb_get_domain_internal(struct confdb_ctx *cdb,
     char *default_domain;
     bool fqnames_default = false;
     int memcache_timeout;
-    bool enum_default;
 
     tmp_ctx = talloc_new(mem_ctx);
     if (!tmp_ctx) return ENOMEM;
@@ -1009,10 +1008,8 @@ static int confdb_get_domain_internal(struct confdb_ctx *cdb,
                   "Interpreting as true\n", domain->name);
         domain->enumerate = true;
     } else { /* assume the new format */
-        enum_default = is_files_provider(domain);
-
         ret = get_entry_as_bool(res->msgs[0], &domain->enumerate,
-                                CONFDB_DOMAIN_ENUMERATE, enum_default);
+                                CONFDB_DOMAIN_ENUMERATE, 0);
         if(ret != EOK) {
             DEBUG(SSSDBG_FATAL_FAILURE,
                   "Invalid value for %s\n", CONFDB_DOMAIN_ENUMERATE);

--- a/src/tests/intg/test_files_provider.py
+++ b/src/tests/intg/test_files_provider.py
@@ -32,7 +32,6 @@ import ent
 import sssd_id
 from sssd_nss import NssReturnCode
 from sssd_passwd import (call_sssd_getpwnam,
-                         call_sssd_enumeration,
                          call_sssd_getpwuid)
 from sssd_group import call_sssd_getgrnam, call_sssd_getgrgid
 from files_ops import passwd_ops_setup, group_ops_setup, PasswdOps, GroupOps
@@ -631,27 +630,6 @@ def test_mod_user_shell(add_user_with_canary, files_domain_only):
     add_user_with_canary.usermod(**moduser)
 
     check_user(moduser)
-
-
-def test_enum_users(setup_pw_with_canary, files_domain_only):
-    """
-    Test that enumerating all users works with the default configuration. Also
-    test that removing all entries and then enumerating again returns an empty
-    set
-    """
-    num_users = 10
-    for i in range(1, num_users+1):
-        user = user_generator(i)
-        setup_pw_with_canary.useradd(**user)
-
-    # syncing with the help of the canary is not reliable after adding
-    # multiple users because the canary might still be in some caches so that
-    # the data is not refreshed properly.
-    subprocess.call(["sss_cache", "-E"])
-    sssd_getpwnam_sync(CANARY["name"])
-    user_list = call_sssd_enumeration()
-    # +1 because the canary is added
-    assert len(user_list) == num_users+1
 
 
 def incomplete_user_setup(pwd_ops, del_field, exp_field):

--- a/src/tests/multihost/basic/test_files.py
+++ b/src/tests/multihost/basic/test_files.py
@@ -1,0 +1,33 @@
+"""
+Files test provider cases
+"""
+import pytest
+from sssd.testlib.common.utils import SSHClient
+
+
+def get_sss_entry(multihost, db, ent_name):
+    cmd = multihost.master[0].run_command(
+                                    'getent %s -s sss %s' % (db, ent_name),
+                                    raiseonerr=False)
+    return cmd.returncode, cmd.stdout_text
+
+
+def get_sss_user(multihost, username):
+    return get_sss_entry(multihost, 'passwd', username)
+
+
+@pytest.mark.usefixtures('enable_files_domain', 'files_domain_users_class')
+class TestImplicitFilesProvider(object):
+    """
+    Test the files provider. This test runs the implicit files provider
+    together with another domain to stick close to what users use in Fedora
+    """
+    def test_files_does_not_handle_root(self, multihost):
+        """ The files provider does not handle root """
+        exit_status, _ = get_sss_user(multihost, 'root')
+        assert exit_status == 2
+
+    def test_files_sanity(self, multihost):
+        """ Test that the files provider can resolve a user """
+        exit_status, _ = get_sss_user(multihost, 'lcl1')
+        assert exit_status == 0

--- a/src/tests/multihost/basic/test_files.py
+++ b/src/tests/multihost/basic/test_files.py
@@ -31,3 +31,11 @@ class TestImplicitFilesProvider(object):
         """ Test that the files provider can resolve a user """
         exit_status, _ = get_sss_user(multihost, 'lcl1')
         assert exit_status == 0
+
+    def test_files_enumeration(self, multihost):
+        """
+        Since nss_files enumerates and libc would concatenate the results,
+        the files provider of SSSD should not enumerate
+        """
+        cmd = multihost.master[0].run_command('getent passwd -s sss')
+        assert len(cmd.stdout_text) == 0


### PR DESCRIPTION
Resolves: https://pagure.io/SSSD/sssd/issue/3849

For reason I cannot explain now, the files provider always enumerates.
There is commit a60e6ec which implements this, but it's clearly wrong,
because then the plain getent passwd output contains duplicates from
nss_files and nss_sss:

$ getent passwd | sort adm:x:3:4:adm:/var/adm:/sbin/nologin
adm:x:3:4:adm:/var/adm:/sbin/nologin bin:x:1:1:bin:/bin:/sbin/nologin
bin:x:1:1:bin:/bin:/sbin/nologin
certuser:x:10329:10330::/home/certuser:/bin/bash
certuser:x:10329:10330::/home/certuser:/bin/bash
chrony:x:997:994::/var/lib/chrony:/sbin/nologin
chrony:x:997:994::/var/lib/chrony:/sbin/nologin
daemon:x:2:2:daemon:/sbin:/sbin/nologin
daemon:x:2:2:daemon:/sbin:/sbin/nologin