### PR TITLE
PAM: use PKCS#11 URIs to restrict certificate selection

### DIFF
--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -133,6 +133,7 @@
 #define CONFDB_PAM_WAIT_FOR_CARD_TIMEOUT "p11_wait_for_card_timeout"
 #define CONFDB_PAM_APP_SERVICES "pam_app_services"
 #define CONFDB_PAM_P11_ALLOWED_SERVICES "pam_p11_allowed_services"
+#define CONFDB_PAM_P11_URI "p11_uri"
 
 /* SUDO */
 #define CONFDB_SUDO_CONF_ENTRY "config/sudo"

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -130,6 +130,7 @@
 #define CONFDB_PAM_CERT_AUTH "pam_cert_auth"
 #define CONFDB_PAM_CERT_DB_PATH "pam_cert_db_path"
 #define CONFDB_PAM_P11_CHILD_TIMEOUT "p11_child_timeout"
+#define CONFDB_PAM_WAIT_FOR_CARD_TIMEOUT "p11_wait_for_card_timeout"
 #define CONFDB_PAM_APP_SERVICES "pam_app_services"
 #define CONFDB_PAM_P11_ALLOWED_SERVICES "pam_p11_allowed_services"
 

--- a/src/config/SSSDConfig/__init__.py.in
+++ b/src/config/SSSDConfig/__init__.py.in
@@ -105,6 +105,7 @@ option_strings = {
     'pam_app_services' : _('Which PAM services are permitted to contact application domains'),
     'pam_p11_allowed_services' : _('Allowed services for using smartcards'),
     'p11_wait_for_card_timeout' : _('Additional timeout to wait for a card if requested'),
+    'p11_uri' : _('PKCS#11 URI to restrict the selection of devices for Smartcard authentication'),
 
     # [sudo]
     'sudo_timed' : _('Whether to evaluate the time-based attributes in sudo rules'),

--- a/src/config/SSSDConfig/__init__.py.in
+++ b/src/config/SSSDConfig/__init__.py.in
@@ -104,6 +104,7 @@ option_strings = {
     'p11_child_timeout' : _('How many seconds will pam_sss wait for p11_child to finish'),
     'pam_app_services' : _('Which PAM services are permitted to contact application domains'),
     'pam_p11_allowed_services' : _('Allowed services for using smartcards'),
+    'p11_wait_for_card_timeout' : _('Additional timeout to wait for a card if requested'),
 
     # [sudo]
     'sudo_timed' : _('Whether to evaluate the time-based attributes in sudo rules'),

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -127,6 +127,7 @@ option = pam_cert_db_path
 option = p11_child_timeout
 option = pam_app_services
 option = pam_p11_allowed_services
+option = p11_wait_for_card_timeout
 
 [rule/allowed_sudo_options]
 validator = ini_allowed_options

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -128,6 +128,7 @@ option = p11_child_timeout
 option = pam_app_services
 option = pam_p11_allowed_services
 option = p11_wait_for_card_timeout
+option = p11_uri
 
 [rule/allowed_sudo_options]
 validator = ini_allowed_options

--- a/src/config/etc/sssd.api.conf
+++ b/src/config/etc/sssd.api.conf
@@ -76,6 +76,7 @@ pam_cert_db_path = str, None, false
 p11_child_timeout = int, None, false
 pam_app_services = str, None, false
 pam_p11_allowed_services = str, None, false
+p11_wait_for_card_timeout = int, None, false
 
 [sudo]
 # sudo service

--- a/src/config/etc/sssd.api.conf
+++ b/src/config/etc/sssd.api.conf
@@ -77,6 +77,7 @@ p11_child_timeout = int, None, false
 pam_app_services = str, None, false
 pam_p11_allowed_services = str, None, false
 p11_wait_for_card_timeout = int, None, false
+p11_uri = str, None, false
 
 [sudo]
 # sudo service

--- a/src/man/pam_sss.8.xml
+++ b/src/man/pam_sss.8.xml
@@ -50,6 +50,9 @@
             <arg choice='opt'>
                 <replaceable>prompt_always</replaceable>
             </arg>
+            <arg choice='opt'>
+                <replaceable>try_cert_auth</replaceable>
+            </arg>
         </cmdsynopsis>
     </refsynopsisdiv>
 
@@ -197,6 +200,26 @@ auth sufficient pam_sss.so allow_missing_name
                         prompt for credentials again. Based on the pre-auth
                         reply by SSSD pam_sss might prompt for a password, a
                         Smartcard PIN or other credentials.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term>
+                    <option>try_cert_auth</option>
+                </term>
+                <listitem>
+                    <para>
+                        Try to use certificate based authentication, i.e.
+                        authentication with a Smartcard or similar devices. If a
+                        Smartcard is available and the service is allowed for
+                        Smartcard authentication the use will be prompted for a
+                        PIN and the certificate based authentication will
+                        continue
+                    </para>
+                    <para>
+                        If no Smartcard is available or certificate based
+                        authentication is not allowed for the current service
+                        PAM_AUTHINFO_UNAVAIL is returned.
                     </para>
                 </listitem>
             </varlistentry>

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -1464,6 +1464,20 @@ pam_p11_allowed_services = +my_pam_service, -login
                         </para>
                     </listitem>
                 </varlistentry>
+                <varlistentry>
+                    <term>p11_wait_for_card_timeout (integer)</term>
+                    <listitem>
+                        <para>
+                            If Smartcard authentication is required how many
+                            extra seconds in addition to p11_child_timeout
+                            should the PAM responder wait until a Smartcard is
+                            inserted.
+                        </para>
+                        <para>
+                            Default: 60
+                        </para>
+                    </listitem>
+                </varlistentry>
             </variablelist>
         </refsect2>
 

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -1478,6 +1478,39 @@ pam_p11_allowed_services = +my_pam_service, -login
                         </para>
                     </listitem>
                 </varlistentry>
+                <varlistentry>
+                    <term>p11_uri (string)</term>
+                    <listitem>
+                        <para>
+                            PKCS#11 URI (see RFC-7512 for details) which can be
+                            used to restrict the selection of devices used for
+                            Smartcard authentication. By default SSSD's
+                            p11_child will search for a PKCS#11 slot (reader)
+                            where the 'removable' flags is set and read the
+                            certificates from the inserted token from the first
+                            slot found. If multiple readers are connected
+                            p11_uri can be use to tell p11_child to use a
+                            specific reader.
+                        </para>
+                        <para>
+                            Example:
+                            <programlisting>
+p11_uri = slot-description=My%20Smartcar%20Reader
+                            </programlisting>
+                            or
+                            <programlisting>
+p11_uri = library-description=OpenSC%20smartcard%20framework;slot-id=2
+                            </programlisting>
+                            To find suitable URI please check the debug output
+                            of p11_child. As an alternative the GnuTLS utility
+                            'p11tool' with e.g. the '--list-all' will show
+                            PKCS#11 URIs as well.
+                        </para>
+                        <para>
+                            Default: none
+                        </para>
+                    </listitem>
+                </varlistentry>
             </variablelist>
         </refsect2>
 

--- a/src/p11_child/p11_child.h
+++ b/src/p11_child/p11_child.h
@@ -54,5 +54,5 @@ bool do_verification_b64(struct p11_ctx *p11_ctx, const char *cert_b64);
 errno_t do_card(TALLOC_CTX *mem_ctx, struct p11_ctx *p11_ctx,
                 enum op_mode mode, const char *pin,
                 const char *module_name_in, const char *token_name_in,
-                const char *key_id_in, char **_multi);
+                const char *key_id_in, const char *uri, char **_multi);
 #endif /* __P11_CHILD_H__ */

--- a/src/p11_child/p11_child.h
+++ b/src/p11_child/p11_child.h
@@ -25,6 +25,9 @@
 #ifndef __P11_CHILD_H__
 #define __P11_CHILD_H__
 
+/* Time to wait during a C_Finalize C_Initialize cycle to discover
+ * new slots. */
+#define PKCS11_FINIALIZE_INITIALIZE_WAIT_TIME 3
 struct p11_ctx;
 
 enum op_mode {
@@ -41,7 +44,7 @@ enum pin_mode {
 };
 
 errno_t init_p11_ctx(TALLOC_CTX *mem_ctx, const char *nss_db,
-                     struct p11_ctx **p11_ctx);
+                     bool wait_for_card, struct p11_ctx **p11_ctx);
 
 errno_t init_verification(struct p11_ctx *p11_ctx,
                           struct cert_verify_opts *cert_verify_opts);

--- a/src/p11_child/p11_child_common.c
+++ b/src/p11_child/p11_child_common.c
@@ -57,6 +57,7 @@ static const char *op_mode_str(enum op_mode mode)
 
 static int do_work(TALLOC_CTX *mem_ctx, enum op_mode mode, const char *ca_db,
                    struct cert_verify_opts *cert_verify_opts,
+                   bool wait_for_card,
                    const char *cert_b64, const char *pin,
                    const char *module_name, const char *token_name,
                    const char *key_id, char **multi)
@@ -64,7 +65,7 @@ static int do_work(TALLOC_CTX *mem_ctx, enum op_mode mode, const char *ca_db,
     int ret;
     struct p11_ctx *p11_ctx;
 
-    ret = init_p11_ctx(mem_ctx, ca_db, &p11_ctx);
+    ret = init_p11_ctx(mem_ctx, ca_db, wait_for_card, &p11_ctx);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "init_p11_ctx failed.\n");
         return ret;
@@ -157,6 +158,7 @@ int main(int argc, const char *argv[])
     char *token_name = NULL;
     char *key_id = NULL;
     char *cert_b64 = NULL;
+    bool wait_for_card = false;
 
     struct poptOption long_options[] = {
         POPT_AUTOHELP
@@ -174,6 +176,7 @@ int main(int argc, const char *argv[])
         SSSD_LOGGER_OPTS
         {"auth", 0, POPT_ARG_NONE, NULL, 'a', _("Run in auth mode"), NULL},
         {"pre", 0, POPT_ARG_NONE, NULL, 'p', _("Run in pre-auth mode"), NULL},
+        {"wait_for_card", 0, POPT_ARG_NONE, NULL, 'w', _("Wait until card is available"), NULL},
         {"verification", 0, POPT_ARG_NONE, NULL, 'v', _("Run in verification mode"),
          NULL},
         {"pin", 0, POPT_ARG_NONE, NULL, 'i', _("Expect PIN on stdin"), NULL},
@@ -257,6 +260,9 @@ int main(int argc, const char *argv[])
                 _exit(-1);
             }
             pin_mode = PIN_KEYPAD;
+            break;
+        case 'w':
+            wait_for_card = true;
             break;
         default:
             fprintf(stderr, "\nInvalid option %s: %s\n\n",
@@ -360,8 +366,8 @@ int main(int argc, const char *argv[])
         }
     }
 
-    ret = do_work(main_ctx, mode, nss_db, cert_verify_opts, cert_b64,
-                 pin, module_name, token_name, key_id, &multi);
+    ret = do_work(main_ctx, mode, nss_db, cert_verify_opts, wait_for_card,
+                  cert_b64, pin, module_name, token_name, key_id, &multi);
     if (ret != 0) {
         DEBUG(SSSDBG_OP_FAILURE, "do_work failed.\n");
         goto fail;

--- a/src/p11_child/p11_child_common.c
+++ b/src/p11_child/p11_child_common.c
@@ -60,7 +60,7 @@ static int do_work(TALLOC_CTX *mem_ctx, enum op_mode mode, const char *ca_db,
                    bool wait_for_card,
                    const char *cert_b64, const char *pin,
                    const char *module_name, const char *token_name,
-                   const char *key_id, char **multi)
+                   const char *key_id, const char *uri, char **multi)
 {
     int ret;
     struct p11_ctx *p11_ctx;
@@ -90,7 +90,7 @@ static int do_work(TALLOC_CTX *mem_ctx, enum op_mode mode, const char *ca_db,
         }
     } else {
         ret = do_card(mem_ctx, p11_ctx, mode, pin,
-                      module_name, token_name, key_id, multi);
+                      module_name, token_name, key_id, uri, multi);
     }
 
 done:
@@ -159,6 +159,7 @@ int main(int argc, const char *argv[])
     char *key_id = NULL;
     char *cert_b64 = NULL;
     bool wait_for_card = false;
+    char *uri = NULL;
 
     struct poptOption long_options[] = {
         POPT_AUTOHELP
@@ -194,6 +195,8 @@ int main(int argc, const char *argv[])
          _("Key ID for authentication"), NULL},
         {"certificate", 0, POPT_ARG_STRING, &cert_b64, 0,
          _("certificate to verify, base64 encoded"), NULL},
+        {"uri", 0, POPT_ARG_STRING, &uri, 0,
+         _("PKCS#11 URI to restrict selection"), NULL},
         POPT_TABLEEND
     };
 
@@ -367,7 +370,7 @@ int main(int argc, const char *argv[])
     }
 
     ret = do_work(main_ctx, mode, nss_db, cert_verify_opts, wait_for_card,
-                  cert_b64, pin, module_name, token_name, key_id, &multi);
+                  cert_b64, pin, module_name, token_name, key_id, uri, &multi);
     if (ret != 0) {
         DEBUG(SSSDBG_OP_FAILURE, "do_work failed.\n");
         goto fail;

--- a/src/p11_child/p11_child_nss.c
+++ b/src/p11_child/p11_child_nss.c
@@ -480,7 +480,7 @@ bool do_verification_b64(struct p11_ctx *p11_ctx, const char *cert_b64)
 errno_t do_card(TALLOC_CTX *mem_ctx, struct p11_ctx *p11_ctx,
                 enum op_mode mode, const char *pin,
                 const char *module_name_in, const char *token_name_in,
-                const char *key_id_in, char **_multi)
+                const char *key_id_in, const char *uri, char **_multi)
 {
     int ret;
     SECStatus rv;

--- a/src/p11_child/p11_child_nss.c
+++ b/src/p11_child/p11_child_nss.c
@@ -39,6 +39,7 @@
 #include <pk11pub.h>
 #include <prerror.h>
 #include <ocsp.h>
+#include <pkcs11uri.h>
 
 #include "util/child_common.h"
 #include "providers/backend.h"
@@ -62,6 +63,239 @@ struct p11_ctx {
                     | certificateUsageObjectSigner \
                     | certificateUsageStatusResponder \
                     | certificateUsageSSLCA )
+
+
+static char *get_pkcs11_string(TALLOC_CTX *mem_ctx, const char *in, size_t len)
+{
+    size_t c = len;
+
+    if (in == NULL || len == 0) {
+        return NULL;
+    }
+
+    while(c > 0 && in[c - 1] == ' ') {
+        c--;
+    }
+
+    return talloc_strndup(mem_ctx, in, c);
+}
+
+static char *pct_encode(TALLOC_CTX *mem_ctx, SECItem *data)
+{
+    char *pct;
+    size_t c;
+    int ret;
+
+    pct = talloc_zero_size(mem_ctx, sizeof(char) * (3*data->len + 1));
+    if (pct == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "talloc_zero_size failed.\n");
+        return NULL;
+    }
+
+    for (c = 0; c < data->len; c++) {
+        ret = snprintf(pct + 3*c, 4, "%%%02X", data->data[c]);
+        if (ret != 3) {
+            DEBUG(SSSDBG_OP_FAILURE, "snprintf failed.\n");
+            talloc_free(pct);
+            return NULL;
+        }
+    }
+
+    return pct;
+}
+
+static char *get_key_id_pct(TALLOC_CTX *mem_ctx, PK11SlotInfo *slot,
+                            CERTCertificate *cert)
+{
+    SECItem *key_id = NULL;
+    char *key_id_str = NULL;
+
+    key_id = PK11_GetLowLevelKeyIDForCert(slot, cert, NULL);
+    if (key_id == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "PK11_GetLowLevelKeyIDForCert failed [%d][%s].\n",
+              PR_GetError(), PORT_ErrorToString(PR_GetError()));
+        return NULL;
+    }
+
+    key_id_str = pct_encode(mem_ctx, key_id);
+    SECITEM_FreeItem(key_id, PR_TRUE);
+    if (key_id_str == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "pct_encode failed.\n");
+        return NULL;
+    }
+
+    return key_id_str;
+}
+
+static char *get_pkcs11_uri(TALLOC_CTX *mem_ctx, SECMODModule *mod,
+                            PK11SlotInfo *slot,
+                            const char *label, CERTCertificate *cert)
+{
+    CK_INFO module_info;
+    CK_SLOT_INFO slot_info;
+    CK_TOKEN_INFO token_info;
+    char *values[13];
+    PK11URIAttribute attrs[13];
+    size_t nattrs = 0;
+    SECStatus rv;
+    char *tmp_str;
+    char *uri_str;
+    PK11URI *uri;
+    CK_SLOT_ID slot_id;
+    char *id_pct;
+
+    rv = PK11_GetModInfo(mod, &module_info);
+    if (rv != SECSuccess) {
+        DEBUG(SSSDBG_OP_FAILURE, "PK11_GetModInfo failed.\n");
+        return NULL;
+    }
+
+    rv = PK11_GetSlotInfo(slot, &slot_info);
+    if (rv != SECSuccess) {
+        DEBUG(SSSDBG_OP_FAILURE, "PK11_GetSlotInfo failed.\n");
+        return NULL;
+    }
+
+    rv = PK11_GetTokenInfo(slot, &token_info);
+    if (rv != SECSuccess) {
+        DEBUG(SSSDBG_OP_FAILURE, "PK11_GetTokenInfo failed.\n");
+        return NULL;
+    }
+    values[nattrs] = get_pkcs11_string(mem_ctx,
+                                       (char *)module_info.libraryDescription,
+                                       sizeof(module_info.libraryDescription));
+    if (values[nattrs] != NULL && *values[nattrs] != '\0') {
+        attrs[nattrs].name = PK11URI_PATTR_LIBRARY_DESCRIPTION;
+        attrs[nattrs].value = values[nattrs];
+        nattrs++;
+    }
+
+    values[nattrs] = get_pkcs11_string(mem_ctx,
+                                       (char *)module_info.manufacturerID,
+                                       sizeof(module_info.manufacturerID));
+    if (values[nattrs] != NULL && *values[nattrs] != '\0') {
+        attrs[nattrs].name = PK11URI_PATTR_LIBRARY_MANUFACTURER;
+        attrs[nattrs].value = values[nattrs];
+        nattrs++;
+    }
+
+    values[nattrs] = talloc_asprintf(mem_ctx, "%d.%d",
+                                     module_info.libraryVersion.major,
+                                     module_info.libraryVersion.minor);
+    if (values[nattrs] != NULL && *values[nattrs] != '\0') {
+        attrs[nattrs].name = PK11URI_PATTR_LIBRARY_VERSION;
+        attrs[nattrs].value = values[nattrs];
+        nattrs++;
+    }
+
+    values[nattrs] = get_pkcs11_string(mem_ctx,
+                                       (char *)slot_info.slotDescription,
+                                       sizeof(slot_info.slotDescription));
+    if (values[nattrs] != NULL && *values[nattrs] != '\0') {
+        attrs[nattrs].name = PK11URI_PATTR_SLOT_DESCRIPTION;
+        attrs[nattrs].value = values[nattrs];
+        nattrs++;
+    }
+
+    values[nattrs] = get_pkcs11_string(mem_ctx,
+                                       (char *)slot_info.manufacturerID,
+                                       sizeof(slot_info.manufacturerID));
+    if (values[nattrs] != NULL && *values[nattrs] != '\0') {
+        attrs[nattrs].name = PK11URI_PATTR_SLOT_MANUFACTURER;
+        attrs[nattrs].value = values[nattrs];
+        nattrs++;
+    }
+
+    slot_id = PK11_GetSlotID(slot);
+    values[nattrs] = talloc_asprintf(mem_ctx, "%d", (int) slot_id);
+    if (values[nattrs] != NULL && *values[nattrs] != '\0') {
+        attrs[nattrs].name = PK11URI_PATTR_SLOT_ID;
+        attrs[nattrs].value = values[nattrs];
+        nattrs++;
+    }
+
+    values[nattrs] = get_pkcs11_string(mem_ctx, (char *)token_info.model,
+                                       sizeof(token_info.model));
+    if (values[nattrs] != NULL && *values[nattrs] != '\0') {
+        attrs[nattrs].name = PK11URI_PATTR_MODEL;
+        attrs[nattrs].value = values[nattrs];
+        nattrs++;
+    }
+
+    values[nattrs] = get_pkcs11_string(mem_ctx,
+                                       (char *)token_info.manufacturerID,
+                                       sizeof(token_info.manufacturerID));
+    if (values[nattrs] != NULL && *values[nattrs] != '\0') {
+        attrs[nattrs].name = PK11URI_PATTR_MANUFACTURER;
+        attrs[nattrs].value = values[nattrs];
+        nattrs++;
+    }
+
+    values[nattrs] = get_pkcs11_string(mem_ctx,
+                                       (char *)token_info.serialNumber,
+                                       sizeof(token_info.serialNumber));
+    if (values[nattrs] != NULL && *values[nattrs] != '\0') {
+        attrs[nattrs].name = PK11URI_PATTR_SERIAL;
+        attrs[nattrs].value = values[nattrs];
+        nattrs++;
+    }
+
+    values[nattrs] = get_pkcs11_string(mem_ctx, (char *)token_info.label,
+                                       sizeof(token_info.label));
+    if (values[nattrs] != NULL && *values[nattrs] != '\0') {
+        attrs[nattrs].name = PK11URI_PATTR_TOKEN;
+        attrs[nattrs].value = values[nattrs];
+        nattrs++;
+    }
+
+    if (label != NULL && *label != '\0') {
+        attrs[nattrs].name = PK11URI_PATTR_OBJECT;
+        attrs[nattrs].value = label;
+        nattrs++;
+    }
+
+    attrs[nattrs].name = PK11URI_PATTR_TYPE;
+    attrs[nattrs].value = "cert";
+    nattrs++;
+
+    uri = PK11URI_CreateURI(attrs, nattrs, NULL, 0);
+    if (uri == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "PK11URI_CreateURI failed.\n");
+        return NULL;
+    }
+
+    tmp_str = PK11URI_FormatURI(NULL, uri);
+    PK11URI_DestroyURI(uri);
+    if (tmp_str == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "PK11URI_FormatURI failed.\n");
+        return NULL;
+    }
+
+    /* Currently I have no idea how to get the ID properly formatted with the
+     * NSS  PK11 calls. Since all attribute values are treated as strings zeros
+     * in the IDs cannot be handled. And the IDs cannot be set percent-encoded
+     * since all attribute values will be escaped which means the '%' sign
+     * will be escaped to '%25'. Hence for the time being the ID is added
+     * manually to the end of the URI. */
+    id_pct = get_key_id_pct(mem_ctx, slot, cert);
+    if (id_pct == NULL || *id_pct == '\0') {
+        DEBUG(SSSDBG_OP_FAILURE, "get_key_id_pct failed.\n");
+        PORT_Free(tmp_str);
+        return NULL;
+    }
+
+    uri_str = talloc_asprintf(mem_ctx, "%s;%s=%s", tmp_str,
+                                                   PK11URI_PATTR_ID, id_pct);
+    talloc_free(id_pct);
+    if (uri_str == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "talloc_asprintf failed.\n");
+        return NULL;
+    }
+
+    return uri_str;
+
+}
 
 static char *password_passthrough(PK11SlotInfo *slot, PRBool retry, void *arg)
 {
@@ -465,6 +699,9 @@ errno_t do_card(TALLOC_CTX *mem_ctx, struct p11_ctx *p11_ctx,
               cert_list_node->cert->nickname,
               cert_list_node->cert->subjectName);
 
+        DEBUG(SSSDBG_TRACE_ALL, "module uri: %s.\n", PK11_GetModuleURI(module));
+        DEBUG(SSSDBG_TRACE_ALL, "token uri: %s.\n", PK11_GetTokenURI(slot));
+
         if (p11_ctx->handle != NULL) {
             if (!do_verification(p11_ctx, cert_list_node->cert)) {
                 DEBUG(SSSDBG_OP_FAILURE,
@@ -651,6 +888,9 @@ errno_t do_card(TALLOC_CTX *mem_ctx, struct p11_ctx *p11_ctx,
 
         DEBUG(SSSDBG_TRACE_ALL, "Found certificate has key id [%s].\n",
               key_id_str);
+        DEBUG(SSSDBG_TRACE_ALL, "uri: %s.\n", get_pkcs11_uri(mem_ctx, module,
+                                                             slot, label,
+                                                             found_cert));
 
         multi = talloc_asprintf_append(multi, "%s\n%s\n%s\n%s\n%s\n",
                                        token_name, module_name, key_id_str,

--- a/src/p11_child/p11_child_openssl.c
+++ b/src/p11_child/p11_child_openssl.c
@@ -85,7 +85,7 @@ static char *get_pkcs11_uri(TALLOC_CTX *mem_ctx, CK_INFO *module_info,
     memcpy(p11_kit_uri_get_token_info(uri), token_info, sizeof(CK_TOKEN_INFO));
 
     memcpy(p11_kit_uri_get_slot_info(uri), slot_info, sizeof(CK_SLOT_INFO));
-    ret = p11_kit_uri_set_slot_id(uri, slot_id);
+    p11_kit_uri_set_slot_id(uri, slot_id);
 
     memcpy(p11_kit_uri_get_module_info(uri), module_info, sizeof(CK_INFO));
 
@@ -662,7 +662,7 @@ static errno_t wait_for_card(CK_FUNCTION_LIST *module, CK_SLOT_ID *slot_id)
 errno_t do_card(TALLOC_CTX *mem_ctx, struct p11_ctx *p11_ctx,
                 enum op_mode mode, const char *pin,
                 const char *module_name_in, const char *token_name_in,
-                const char *key_id_in, char **_multi)
+                const char *key_id_in, const char *uri_str, char **_multi)
 {
     int ret;
     size_t c;
@@ -674,6 +674,7 @@ errno_t do_card(TALLOC_CTX *mem_ctx, struct p11_ctx *p11_ctx,
     CK_ULONG num_slots;
     CK_SLOT_ID slots[MAX_SLOTS];
     CK_SLOT_ID slot_id;
+    CK_SLOT_ID uri_slot_id;
     CK_SLOT_INFO info;
     CK_TOKEN_INFO token_info;
     CK_INFO module_info;
@@ -690,6 +691,19 @@ errno_t do_card(TALLOC_CTX *mem_ctx, struct p11_ctx *p11_ctx,
     char *multi = NULL;
     bool pkcs11_session = false;
     bool pkcs11_login = false;
+    P11KitUri *uri = NULL;
+
+    if (uri_str != NULL) {
+        uri = p11_kit_uri_new();
+        ret = p11_kit_uri_parse(uri_str, P11_KIT_URI_FOR_ANY, uri);
+        if (ret != P11_KIT_URI_OK) {
+            DEBUG(SSSDBG_OP_FAILURE, "p11_kit_uri_parse failed [%d][%s].\n",
+                                     ret, p11_kit_uri_message(ret));
+            ret = EINVAL;
+            goto done;
+        }
+    }
+
 
     /* Maybe use P11_KIT_MODULE_TRUSTED ? */
     modules = p11_kit_modules_load_and_initialize(0);
@@ -708,6 +722,18 @@ errno_t do_card(TALLOC_CTX *mem_ctx, struct p11_ctx *p11_ctx,
             DEBUG(SSSDBG_TRACE_ALL, "dll name: [%s].\n", mod_file_name);
             free(mod_name);
             free(mod_file_name);
+
+            if (uri != NULL) {
+                memset(&module_info, 0, sizeof(CK_INFO));
+                modules[c]->C_GetInfo(&module_info);
+
+                /* Skip modules which do not match the PKCS#11 URI */
+                if (p11_kit_uri_match_module_info(uri, &module_info) != 1) {
+                    DEBUG(SSSDBG_TRACE_ALL,
+                          "Not matching URI [%s], skipping.\n", uri_str);
+                    continue;
+                }
+            }
 
             num_slots = MAX_SLOTS;
             rv = modules[c]->C_GetSlotList(CK_FALSE, slots, &num_slots);
@@ -730,6 +756,37 @@ errno_t do_card(TALLOC_CTX *mem_ctx, struct p11_ctx *p11_ctx,
                       info.slotDescription, info.manufacturerID, info.flags,
                       (info.flags & CKF_REMOVABLE_DEVICE) ? "true": "false",
                       (info.flags & CKF_TOKEN_PRESENT) ? "true": "false");
+
+                /* Skip slots which do not match the PKCS#11 URI */
+                if (uri != NULL) {
+                    uri_slot_id = p11_kit_uri_get_slot_id(uri);
+                    if ((uri_slot_id != (CK_SLOT_ID)-1
+                                && uri_slot_id != slots[s])
+                            || p11_kit_uri_match_slot_info(uri, &info) != 1) {
+                        DEBUG(SSSDBG_TRACE_ALL,
+                              "Not matching URI [%s], skipping.\n", uri_str);
+                        continue;
+                    }
+                }
+
+                if ((info.flags & CKF_TOKEN_PRESENT) && uri != NULL) {
+                    rv = modules[c]->C_GetTokenInfo(slots[s], &token_info);
+                    if (rv != CKR_OK) {
+                        DEBUG(SSSDBG_OP_FAILURE, "C_GetTokenInfo failed.\n");
+                        ret = EIO;
+                        goto done;
+                    }
+                    DEBUG(SSSDBG_TRACE_ALL, "Token label [%s].\n",
+                          token_info.label);
+
+                    if (p11_kit_uri_match_token_info(uri, &token_info) != 1) {
+                        DEBUG(SSSDBG_CONF_SETTINGS,
+                              "No matching uri [%s], skipping.\n", uri_str);
+                        continue;
+                    }
+
+                }
+
                 if ((info.flags & CKF_REMOVABLE_DEVICE)) {
                     break;
                 }
@@ -785,6 +842,13 @@ errno_t do_card(TALLOC_CTX *mem_ctx, struct p11_ctx *p11_ctx,
     if (rv != CKR_OK) {
         DEBUG(SSSDBG_OP_FAILURE, "C_GetTokenInfo failed.\n");
         ret = EIO;
+        goto done;
+    }
+
+    if (uri != NULL && p11_kit_uri_match_token_info(uri, &token_info) != 1) {
+        DEBUG(SSSDBG_CONF_SETTINGS, "No token matching uri [%s] found.",
+                                    uri_str);
+        ret = ENOENT;
         goto done;
     }
 
@@ -970,6 +1034,7 @@ done:
     free(token_name);
     free(module_file_name);
     p11_kit_modules_finalize_and_release(modules);
+    p11_kit_uri_free(uri);
 
     return ret;
 }

--- a/src/responder/pam/pamsrv.h
+++ b/src/responder/pam/pamsrv.h
@@ -103,6 +103,7 @@ struct tevent_req *pam_check_cert_send(TALLOC_CTX *mem_ctx,
                                        time_t timeout,
                                        const char *verify_opts,
                                        struct sss_certmap_ctx *sss_certmap_ctx,
+                                       const char *uri,
                                        struct pam_data *pd);
 errno_t pam_check_cert_recv(struct tevent_req *req, TALLOC_CTX *mem_ctx,
                             struct cert_auth_info **cert_list);

--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -1297,6 +1297,7 @@ static errno_t check_cert(TALLOC_CTX *mctx,
                           struct pam_data *pd)
 {
     int p11_child_timeout;
+    int wait_for_card_timeout;
     char *cert_verification_opts;
     errno_t ret;
     struct tevent_req *req;
@@ -1310,6 +1311,20 @@ static errno_t check_cert(TALLOC_CTX *mctx,
               "Failed to read p11_child_timeout from confdb: [%d]: %s\n",
               ret, sss_strerror(ret));
         return ret;
+    }
+    if ((pd->cli_flags & PAM_CLI_FLAGS_REQUIRE_CERT_AUTH) && pd->priv == 1) {
+        ret = confdb_get_int(pctx->rctx->cdb, CONFDB_PAM_CONF_ENTRY,
+                             CONFDB_PAM_WAIT_FOR_CARD_TIMEOUT,
+                             P11_WAIT_FOR_CARD_TIMEOUT_DEFAULT,
+                             &wait_for_card_timeout);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Failed to read wait_for_card_timeout from confdb: [%d]: %s\n",
+                  ret, sss_strerror(ret));
+            return ret;
+        }
+
+        p11_child_timeout += wait_for_card_timeout;
     }
 
     ret = confdb_get_string(pctx->rctx->cdb, mctx, CONFDB_MONITOR_CONF_ENTRY,

--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -1306,6 +1306,7 @@ static errno_t check_cert(TALLOC_CTX *mctx,
     char *cert_verification_opts;
     errno_t ret;
     struct tevent_req *req;
+    char *uri = NULL;
 
     ret = confdb_get_int(pctx->rctx->cdb, CONFDB_PAM_CONF_ENTRY,
                          CONFDB_PAM_P11_CHILD_TIMEOUT,
@@ -1342,10 +1343,19 @@ static errno_t check_cert(TALLOC_CTX *mctx,
         return ret;
     }
 
+    ret = confdb_get_string(pctx->rctx->cdb, mctx, CONFDB_PAM_CONF_ENTRY,
+                            CONFDB_PAM_P11_URI, NULL, &uri);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Failed to read certificate_verification from confdb: [%d]: %s\n",
+              ret, sss_strerror(ret));
+        return ret;
+    }
+
     req = pam_check_cert_send(mctx, ev, pctx->p11_child_debug_fd,
                               pctx->nss_db, p11_child_timeout,
                               cert_verification_opts, pctx->sss_certmap_ctx,
-                              pd);
+                              uri, pd);
     if (req == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "pam_check_cert_send failed.\n");
         return ENOMEM;

--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -317,6 +317,11 @@ static int pam_parse_in_data_v2(struct pam_data *pd,
                                              size, body, blen, &c);
                     if (ret != EOK) return ret;
                     break;
+                case SSS_PAM_ITEM_FLAGS:
+                    ret = extract_uint32_t(&pd->cli_flags, size,
+                                           body, blen, &c);
+                    if (ret != EOK) return ret;
+                    break;
                 default:
                     DEBUG(SSSDBG_CRIT_FAILURE,
                           "Ignoring unknown data type [%d].\n", type);
@@ -1447,6 +1452,13 @@ static void pam_forwarder_cert_cb(struct tevent_req *req)
                   "No certificate found and no logon name given, " \
                   "authentication not possible.\n");
             ret = ENOENT;
+        } else if (pd->cli_flags & PAM_CLI_FLAGS_TRY_CERT_AUTH) {
+            DEBUG(SSSDBG_TRACE_ALL,
+                  "try_cert_auth flag set but no certificate available, "
+                  "request finished.\n");
+            preq->pd->pam_status = PAM_AUTHINFO_UNAVAIL;
+            pam_reply(preq);
+            return;
         } else {
             if (pd->cmd == SSS_PAM_AUTHENTICATE) {
                 DEBUG(SSSDBG_CRIT_FAILURE,

--- a/src/responder/pam/pamsrv_p11.c
+++ b/src/responder/pam/pamsrv_p11.c
@@ -711,6 +711,7 @@ struct tevent_req *pam_check_cert_send(TALLOC_CTX *mem_ctx,
                                        time_t timeout,
                                        const char *verify_opts,
                                        struct sss_certmap_ctx *sss_certmap_ctx,
+                                       const char *uri,
                                        struct pam_data *pd)
 {
     errno_t ret;
@@ -721,7 +722,7 @@ struct tevent_req *pam_check_cert_send(TALLOC_CTX *mem_ctx,
     struct timeval tv;
     int pipefd_to_child[2] = PIPE_INIT;
     int pipefd_from_child[2] = PIPE_INIT;
-    const char *extra_args[14] = { NULL };
+    const char *extra_args[16] = { NULL };
     uint8_t *write_buf = NULL;
     size_t write_buf_len = 0;
     size_t arg_c;
@@ -748,6 +749,12 @@ struct tevent_req *pam_check_cert_send(TALLOC_CTX *mem_ctx,
 
     /* extra_args are added in revers order */
     arg_c = 0;
+    if (uri != NULL) {
+        DEBUG(SSSDBG_TRACE_ALL, "Adding PKCS#11 URI [%s].\n", uri);
+        extra_args[arg_c++] = uri;
+        extra_args[arg_c++] = "--uri";
+    }
+
     if ((pd->cli_flags & PAM_CLI_FLAGS_REQUIRE_CERT_AUTH) && pd->priv == 1) {
         extra_args[arg_c++] = "--wait_for_card";
     }

--- a/src/responder/pam/pamsrv_p11.c
+++ b/src/responder/pam/pamsrv_p11.c
@@ -721,7 +721,7 @@ struct tevent_req *pam_check_cert_send(TALLOC_CTX *mem_ctx,
     struct timeval tv;
     int pipefd_to_child[2] = PIPE_INIT;
     int pipefd_from_child[2] = PIPE_INIT;
-    const char *extra_args[13] = { NULL };
+    const char *extra_args[14] = { NULL };
     uint8_t *write_buf = NULL;
     size_t write_buf_len = 0;
     size_t arg_c;
@@ -748,6 +748,9 @@ struct tevent_req *pam_check_cert_send(TALLOC_CTX *mem_ctx,
 
     /* extra_args are added in revers order */
     arg_c = 0;
+    if ((pd->cli_flags & PAM_CLI_FLAGS_REQUIRE_CERT_AUTH) && pd->priv == 1) {
+        extra_args[arg_c++] = "--wait_for_card";
+    }
     extra_args[arg_c++] = nss_db;
     extra_args[arg_c++] = "--nssdb";
     if (verify_opts != NULL) {

--- a/src/sss_client/pam_message.c
+++ b/src/sss_client/pam_message.c
@@ -126,6 +126,7 @@ int pack_message_v3(struct pam_items *pi, size_t *size, uint8_t **buffer)
     len += 3*sizeof(uint32_t); /* cli_pid */
     len += *pi->requested_domains != '\0' ?
                 2*sizeof(uint32_t) + pi->requested_domains_size : 0;
+    len += 3*sizeof(uint32_t); /* flags */
 
     buf = malloc(len);
     if (buf == NULL) {
@@ -163,6 +164,9 @@ int pack_message_v3(struct pam_items *pi, size_t *size, uint8_t **buffer)
     rp += add_authtok_item(SSS_PAM_ITEM_NEWAUTHTOK, pi->pam_newauthtok_type,
                            pi->pam_newauthtok, pi->pam_newauthtok_size,
                            &buf[rp]);
+
+    rp += add_uint32_t_item(SSS_PAM_ITEM_FLAGS, (uint32_t) pi->flags,
+                            &buf[rp]);
 
     SAFEALIGN_SETMEM_UINT32(buf + rp, SSS_END_OF_PAM_REQUEST, &rp);
 

--- a/src/sss_client/pam_message.h
+++ b/src/sss_client/pam_message.h
@@ -51,6 +51,7 @@ struct pam_items {
     enum sss_authtok_type pam_newauthtok_type;
     size_t pam_newauthtok_size;
     pid_t cli_pid;
+    uint32_t flags;
     const char *login_name;
     char *domain_name;
     const char *requested_domains;

--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -1997,6 +1997,8 @@ static void eval_argv(pam_handle_t *pamh, int argc, const char **argv,
             *flags |= PAM_CLI_FLAGS_ALLOW_MISSING_NAME;
         } else if (strcmp(*argv, "prompt_always") == 0) {
             *flags |= PAM_CLI_FLAGS_PROMPT_ALWAYS;
+        } else if (strcmp(*argv, "try_cert_auth") == 0) {
+            *flags |= PAM_CLI_FLAGS_TRY_CERT_AUTH;
         } else {
             logger(pamh, LOG_WARNING, "unknown option: %s", *argv);
         }
@@ -2403,6 +2405,13 @@ static int pam_sss(enum sss_cli_command task, pam_handle_t *pamh,
                          * as a fallback, errors can be ignored here.
                          */
                     }
+                }
+
+                if (flags & PAM_CLI_FLAGS_TRY_CERT_AUTH
+                        && pi.cert_list == NULL) {
+                    D(("No certificates for authentication available."));
+                    overwrite_and_free_pam_items(&pi);
+                    return PAM_AUTHINFO_UNAVAIL;
                 }
 
                 if (strcmp(pi.pam_service, "gdm-smartcard") == 0) {

--- a/src/sss_client/sss_cli.h
+++ b/src/sss_client/sss_cli.h
@@ -363,6 +363,7 @@ enum pam_item_type {
     SSS_PAM_ITEM_CLI_LOCALE,
     SSS_PAM_ITEM_CLI_PID,
     SSS_PAM_ITEM_REQUESTED_DOMAINS,
+    SSS_PAM_ITEM_FLAGS,
 };
 
 #define PAM_CLI_FLAGS_USE_FIRST_PASS (1 << 0)
@@ -374,6 +375,7 @@ enum pam_item_type {
 #define PAM_CLI_FLAGS_ALLOW_MISSING_NAME (1 << 6)
 #define PAM_CLI_FLAGS_PROMPT_ALWAYS (1 << 7)
 #define PAM_CLI_FLAGS_TRY_CERT_AUTH (1 << 8)
+#define PAM_CLI_FLAGS_REQUIRE_CERT_AUTH (1 << 9)
 
 #define SSS_NSS_MAX_ENTRIES 256
 #define SSS_NSS_HEADER_SIZE (sizeof(uint32_t) * 4)

--- a/src/sss_client/sss_cli.h
+++ b/src/sss_client/sss_cli.h
@@ -365,6 +365,15 @@ enum pam_item_type {
     SSS_PAM_ITEM_REQUESTED_DOMAINS,
 };
 
+#define PAM_CLI_FLAGS_USE_FIRST_PASS (1 << 0)
+#define PAM_CLI_FLAGS_FORWARD_PASS   (1 << 1)
+#define PAM_CLI_FLAGS_USE_AUTHTOK    (1 << 2)
+#define PAM_CLI_FLAGS_IGNORE_UNKNOWN_USER (1 << 3)
+#define PAM_CLI_FLAGS_IGNORE_AUTHINFO_UNAVAIL (1 << 4)
+#define PAM_CLI_FLAGS_USE_2FA (1 << 5)
+#define PAM_CLI_FLAGS_ALLOW_MISSING_NAME (1 << 6)
+#define PAM_CLI_FLAGS_PROMPT_ALWAYS (1 << 7)
+
 #define SSS_NSS_MAX_ENTRIES 256
 #define SSS_NSS_HEADER_SIZE (sizeof(uint32_t) * 4)
 struct sss_cli_req_data {

--- a/src/sss_client/sss_cli.h
+++ b/src/sss_client/sss_cli.h
@@ -373,6 +373,7 @@ enum pam_item_type {
 #define PAM_CLI_FLAGS_USE_2FA (1 << 5)
 #define PAM_CLI_FLAGS_ALLOW_MISSING_NAME (1 << 6)
 #define PAM_CLI_FLAGS_PROMPT_ALWAYS (1 << 7)
+#define PAM_CLI_FLAGS_TRY_CERT_AUTH (1 << 8)
 
 #define SSS_NSS_MAX_ENTRIES 256
 #define SSS_NSS_HEADER_SIZE (sizeof(uint32_t) * 4)

--- a/src/tests/intg/Makefile.am
+++ b/src/tests/intg/Makefile.am
@@ -113,6 +113,20 @@ pam_sss_service:
 	echo "password required       $(DESTDIR)$(pammoddir)/pam_sss.so" >> $(PAM_SERVICE_DIR)/$@
 	echo "session  required       $(DESTDIR)$(pammoddir)/pam_sss.so" >> $(PAM_SERVICE_DIR)/$@
 
+pam_sss_sc_required:
+	$(MKDIR_P) $(PAM_SERVICE_DIR)
+	echo "auth     required       $(DESTDIR)$(pammoddir)/pam_sss.so require_cert_auth retry=1"  > $(PAM_SERVICE_DIR)/$@
+	echo "account  required       $(DESTDIR)$(pammoddir)/pam_sss.so" >> $(PAM_SERVICE_DIR)/$@
+	echo "password required       $(DESTDIR)$(pammoddir)/pam_sss.so" >> $(PAM_SERVICE_DIR)/$@
+	echo "session  required       $(DESTDIR)$(pammoddir)/pam_sss.so" >> $(PAM_SERVICE_DIR)/$@
+
+pam_sss_try_sc:
+	$(MKDIR_P) $(PAM_SERVICE_DIR)
+	echo "auth     required       $(DESTDIR)$(pammoddir)/pam_sss.so try_cert_auth"  > $(PAM_SERVICE_DIR)/$@
+	echo "account  required       $(DESTDIR)$(pammoddir)/pam_sss.so" >> $(PAM_SERVICE_DIR)/$@
+	echo "password required       $(DESTDIR)$(pammoddir)/pam_sss.so" >> $(PAM_SERVICE_DIR)/$@
+	echo "session  required       $(DESTDIR)$(pammoddir)/pam_sss.so" >> $(PAM_SERVICE_DIR)/$@
+
 CLEANFILES=config.py config.pyc passwd group
 
 clean-local:
@@ -127,7 +141,7 @@ PAM_CERT_DB_PATH="$(abs_builddir)/../test_CA/SSSD_test_CA.pem"
 SOFTHSM2_CONF="$(abs_builddir)/../test_CA/softhsm2_one.conf"
 endif
 
-intgcheck-installed: config.py passwd group pam_sss_service
+intgcheck-installed: config.py passwd group pam_sss_service pam_sss_sc_required pam_sss_try_sc
 	pipepath="$(DESTDIR)$(pipepath)"; \
 	if test $${#pipepath} -gt 80; then \
 	    echo "error: Pipe directory path too long," \

--- a/src/tests/test_CA/Makefile.am
+++ b/src/tests/test_CA/Makefile.am
@@ -24,7 +24,7 @@ pkcs12 = $(addprefix SSSD_test_cert_pkcs12_,$(addsuffix .pem,$(ids)))
 if HAVE_NSS
 extra = p11_nssdb p11_nssdb_2certs
 else
-extra = softhsm2_none softhsm2_one softhsm2_two
+extra = softhsm2_none softhsm2_one softhsm2_two softhsm2_2tokens
 endif
 
 # If openssl is run in parallel there might be conflicts with the serial
@@ -111,6 +111,20 @@ softhsm2_two: softhsm2_two.conf
 
 softhsm2_two.conf:
 	@echo "directories.tokendir = "$(abs_top_builddir)"/src/tests/test_CA/softhsm2_two" > $@
+	@echo "objectstore.backend = file" >> $@
+	@echo "slots.removable = true" >> $@
+
+softhsm2_2tokens: softhsm2_2tokens.conf
+	mkdir $@
+	SOFTHSM2_CONF=./$< $(SOFTHSM2_UTIL) --init-token  --label "SSSD Test Token" --pin 123456 --so-pin 123456 --free
+	GNUTLS_PIN=123456 SOFTHSM2_CONF=./$< $(P11TOOL) --provider=$(SOFTHSM2_PATH) --write --no-mark-private --load-certificate=SSSD_test_cert_x509_0001.pem --login  --label 'SSSD test cert 0001' --id 'C554C9F82C2A9D58B70921C143304153A8A42F17' pkcs11:token=SSSD%20Test%20Token
+	GNUTLS_PIN=123456 SOFTHSM2_CONF=./$< $(P11TOOL) --provider=$(SOFTHSM2_PATH) --write --load-privkey=$(srcdir)/SSSD_test_cert_key_0001.pem --login  --label 'SSSD test cert 0001' --id 'C554C9F82C2A9D58B70921C143304153A8A42F17' pkcs11:token=SSSD%20Test%20Token
+	SOFTHSM2_CONF=./$< $(SOFTHSM2_UTIL) --init-token  --label "SSSD Test Token Number 2" --pin 654321 --so-pin 654321 --free
+	GNUTLS_PIN=654321 SOFTHSM2_CONF=./$< $(P11TOOL) --provider=$(SOFTHSM2_PATH) --write --no-mark-private --load-certificate=SSSD_test_cert_x509_0002.pem --login  --label 'SSSD test cert 0002' --id '5405842D56CF31F0BB025A695C5F3E907051C5B9' pkcs11:token=SSSD%20Test%20Token%20Number%202
+	GNUTLS_PIN=654321 SOFTHSM2_CONF=./$< $(P11TOOL) --provider=$(SOFTHSM2_PATH) --write --load-privkey=$(srcdir)/SSSD_test_cert_key_0002.pem --login  --label 'SSSD test cert 0002' --id '5405842D56CF31F0BB025A695C5F3E907051C5B9' pkcs11:token=SSSD%20Test%20Token%20Number%202
+
+softhsm2_2tokens.conf:
+	@echo "directories.tokendir = "$(abs_top_builddir)"/src/tests/test_CA/softhsm2_2tokens" > $@
 	@echo "objectstore.backend = file" >> $@
 	@echo "slots.removable = true" >> $@
 

--- a/src/util/sss_pam_data.c
+++ b/src/util/sss_pam_data.c
@@ -176,6 +176,7 @@ void pam_print_data(int l, struct pam_data *pd)
     DEBUG(l, "priv: %d\n", pd->priv);
     DEBUG(l, "cli_pid: %d\n", pd->cli_pid);
     DEBUG(l, "logon name: %s\n", PAM_SAFE_ITEM(pd->logon_name));
+    DEBUG(l, "flags: %d\n", pd->cli_flags);
 }
 
 int pam_add_response(struct pam_data *pd, enum response_type type,

--- a/src/util/sss_pam_data.h
+++ b/src/util/sss_pam_data.h
@@ -58,6 +58,7 @@ struct pam_data {
     struct sss_auth_token *newauthtok;
     uint32_t cli_pid;
     char *logon_name;
+    uint32_t cli_flags;
 
     int pam_status;
     int response_delay;

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -724,6 +724,7 @@ errno_t create_preauth_indicator(void);
 #define P11_CHILD_LOG_FILE "p11_child"
 #define P11_CHILD_PATH SSSD_LIBEXEC_PATH"/p11_child"
 #define P11_CHILD_TIMEOUT_DEFAULT 10
+#define P11_WAIT_FOR_CARD_TIMEOUT_DEFAULT 60
 #endif  /* SSSD_LIBEXEC_PATH */
 
 #endif /* __SSSD_UTIL_H__ */


### PR DESCRIPTION
With the new option 'p11_uri' to the PAM responder can be used to restrict the
selection of certificates in p11_child with the help of a PKCS#11 URI.

The implementation of for the NSS version of p11_child is not available in this
PR. As you can see in the first patch the support for PKCS#11 URIs in NSS is
limited and I have to talk to NSS developers first if this will change of if it
would make more sense to use the PKCS#11 URI calls form libp11kit for the NSS
version as well.

To avoid rebase issues this PR is already on top of PR#668.

Related to https://pagure.io/SSSD/sssd/issue/3814