### PR TITLE
p11_child: add OCSP and CRL check ot the OpenSSL version

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -503,6 +503,30 @@
                                         pam_cert_db_path.</para>
                                     </listitem>
                                 </varlistentry>
+                                <varlistentry>
+                                    <term>crl_file=/PATH/TO/CRL/FILE</term>
+                                    <listitem>
+                                        <para>(NSS Version) This option is
+                                        ignored, please see
+                                            <citerefentry>
+                                                <refentrytitle>crlutil</refentrytitle>
+                                                <manvolnum>1</manvolnum>
+                                            </citerefentry>
+                                        how to import a Certificate Revocation
+                                        List (CRL) into a NSS database.</para>
+
+                                        <para>(OpenSSL Version) Use the
+                                        Certificate Revocation List (CRL) from
+                                        the given file during the verification
+                                        of the certificate. The CRL must be
+                                        given in PEM format, see
+                                            <citerefentry>
+                                                <refentrytitle>crl</refentrytitle>
+                                                <manvolnum>1ssl</manvolnum>
+                                            </citerefentry>
+                                        for details.</para>
+                                    </listitem>
+                                </varlistentry>
                                 </variablelist>
                             </para>
                             <para condition="with_nss">

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -479,8 +479,8 @@
                                         be replaced with the URL of the OCSP
                                         default responder e.g.
                                         http://example.com:80/ocsp.</para>
-                                        <para>This option must be used together
-                                        with
+                                        <para>(NSS Version) This option must be
+                                        used together with
                                         ocsp_default_responder_signing_cert.
                                         </para>
                                     </listitem>
@@ -489,16 +489,28 @@
                                     <term>
                                     ocsp_default_responder_signing_cert=NAME</term>
                                     <listitem>
-                                        <para>The nickname of the cert to trust
-                                        (expected) to sign the OCSP responses.
-                                        The certificate with the given nickname
-                                        must be available in the systems NSS
-                                        database.</para>
+                                        <para>(NSS Version) The nickname of the
+                                        cert to trust (expected) to sign the
+                                        OCSP responses.  The certificate with
+                                        the given nickname must be available in
+                                        the systems NSS database.</para>
                                         <para>This option must be used together
                                         with ocsp_default_responder.</para>
+                                        <para>(OpenSSL version) This option is
+                                        currently ignored. All needed
+                                        certificates must be available in the
+                                        PEM file given by
+                                        pam_cert_db_path.</para>
                                     </listitem>
                                 </varlistentry>
                                 </variablelist>
+                            </para>
+                            <para condition="with_nss">
+                                This man page was generated for the NSS version.
+                            </para>
+                            <para condition="with_openssl">
+                                This man page was generated for the OpenSSL
+                                version.
                             </para>
                             <para>
                                 Unknown options are reported but ignored.

--- a/src/p11_child/p11_child_common.c
+++ b/src/p11_child/p11_child_common.c
@@ -48,7 +48,7 @@ static const char *op_mode_str(enum op_mode mode)
         return "pre-auth";
         break;
     case OP_VERIFIY:
-        return "verifiy";
+        return "verify";
         break;
     default:
         return "unknown";
@@ -219,7 +219,7 @@ int main(int argc, const char *argv[])
         case 'a':
             if (mode != OP_NONE) {
                 fprintf(stderr,
-                        "\n--verifiy, --auth and --pre are mutually " \
+                        "\n--verify, --auth and --pre are mutually " \
                         "exclusive and should be only used once.\n\n");
                 poptPrintUsage(pc, stderr, 0);
                 _exit(-1);
@@ -229,7 +229,7 @@ int main(int argc, const char *argv[])
         case 'p':
             if (mode != OP_NONE) {
                 fprintf(stderr,
-                        "\n--verifiy, --auth and --pre are mutually " \
+                        "\n--verify, --auth and --pre are mutually " \
                         "exclusive and should be only used once.\n\n");
                 poptPrintUsage(pc, stderr, 0);
                 _exit(-1);
@@ -239,7 +239,7 @@ int main(int argc, const char *argv[])
         case 'v':
             if (mode != OP_NONE) {
                 fprintf(stderr,
-                        "\n--verifiy, --auth and --pre are mutually " \
+                        "\n--verify, --auth and --pre are mutually " \
                         "exclusive and should be only used once.\n\n");
                 poptPrintUsage(pc, stderr, 0);
                 _exit(-1);
@@ -283,7 +283,7 @@ int main(int argc, const char *argv[])
 
     if (mode == OP_NONE) {
         fprintf(stderr, "\nMissing operation mode, either " \
-                        "--verifiy, --auth or --pre must be specified.\n\n");
+                        "--verify, --auth or --pre must be specified.\n\n");
         poptPrintUsage(pc, stderr, 0);
         _exit(-1);
     } else if (mode == OP_AUTH && pin_mode == PIN_NONE) {
@@ -350,7 +350,7 @@ int main(int argc, const char *argv[])
 
     ret = parse_cert_verify_opts(main_ctx, verify_opts, &cert_verify_opts);
     if (ret != EOK) {
-        DEBUG(SSSDBG_FATAL_FAILURE, "Failed to parse verifiy option.\n");
+        DEBUG(SSSDBG_FATAL_FAILURE, "Failed to parse verify option.\n");
         goto fail;
     }
 

--- a/src/tests/cmocka/test_utils.c
+++ b/src/tests/cmocka/test_utils.c
@@ -1567,6 +1567,7 @@ static void test_parse_cert_verify_opts(void **state)
     assert_true(cv_opts->do_ocsp);
     assert_null(cv_opts->ocsp_default_responder);
     assert_null(cv_opts->ocsp_default_responder_signing_cert);
+    assert_null(cv_opts->crl_file);
     talloc_free(cv_opts);
 
     ret = parse_cert_verify_opts(global_talloc_context, "wedfkwefjk", &cv_opts);
@@ -1575,6 +1576,7 @@ static void test_parse_cert_verify_opts(void **state)
     assert_true(cv_opts->do_ocsp);
     assert_null(cv_opts->ocsp_default_responder);
     assert_null(cv_opts->ocsp_default_responder_signing_cert);
+    assert_null(cv_opts->crl_file);
     talloc_free(cv_opts);
 
     ret = parse_cert_verify_opts(global_talloc_context, "no_ocsp", &cv_opts);
@@ -1583,6 +1585,7 @@ static void test_parse_cert_verify_opts(void **state)
     assert_false(cv_opts->do_ocsp);
     assert_null(cv_opts->ocsp_default_responder);
     assert_null(cv_opts->ocsp_default_responder_signing_cert);
+    assert_null(cv_opts->crl_file);
     talloc_free(cv_opts);
 
     ret = parse_cert_verify_opts(global_talloc_context, "no_verification",
@@ -1592,6 +1595,7 @@ static void test_parse_cert_verify_opts(void **state)
     assert_true(cv_opts->do_ocsp);
     assert_null(cv_opts->ocsp_default_responder);
     assert_null(cv_opts->ocsp_default_responder_signing_cert);
+    assert_null(cv_opts->crl_file);
     talloc_free(cv_opts);
 
     ret = parse_cert_verify_opts(global_talloc_context,
@@ -1601,6 +1605,7 @@ static void test_parse_cert_verify_opts(void **state)
     assert_false(cv_opts->do_ocsp);
     assert_null(cv_opts->ocsp_default_responder);
     assert_null(cv_opts->ocsp_default_responder_signing_cert);
+    assert_null(cv_opts->crl_file);
     talloc_free(cv_opts);
 
     ret = parse_cert_verify_opts(global_talloc_context,
@@ -1633,6 +1638,17 @@ static void test_parse_cert_verify_opts(void **state)
     assert_true(cv_opts->do_ocsp);
     assert_string_equal(cv_opts->ocsp_default_responder, "abc");
     assert_string_equal(cv_opts->ocsp_default_responder_signing_cert, "def");
+    assert_null(cv_opts->crl_file);
+    talloc_free(cv_opts);
+
+    ret = parse_cert_verify_opts(global_talloc_context, "crl_file=hij",
+                                 &cv_opts);
+    assert_int_equal(ret, EOK);
+    assert_true(cv_opts->do_verification);
+    assert_true(cv_opts->do_ocsp);
+    assert_null(cv_opts->ocsp_default_responder);
+    assert_null(cv_opts->ocsp_default_responder_signing_cert);
+    assert_string_equal(cv_opts->crl_file, "hij");
     talloc_free(cv_opts);
 }
 

--- a/src/tests/cmocka/test_utils.c
+++ b/src/tests/cmocka/test_utils.c
@@ -1612,6 +1612,8 @@ static void test_parse_cert_verify_opts(void **state)
                                  &cv_opts);
     assert_int_equal(ret, EINVAL);
 
+/* Only NSS requires that both are set */
+#ifdef HAVE_NSS
     ret = parse_cert_verify_opts(global_talloc_context,
                                  "ocsp_default_responder=abc", &cv_opts);
     assert_int_equal(ret, EINVAL);
@@ -1620,6 +1622,7 @@ static void test_parse_cert_verify_opts(void **state)
                                  "ocsp_default_responder_signing_cert=def",
                                  &cv_opts);
     assert_int_equal(ret, EINVAL);
+#endif
 
     ret = parse_cert_verify_opts(global_talloc_context,
                                  "ocsp_default_responder=abc,"

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -1024,6 +1024,7 @@ static struct cert_verify_opts *init_cert_verify_opts(TALLOC_CTX *mem_ctx)
     cert_verify_opts->do_verification = true;
     cert_verify_opts->ocsp_default_responder = NULL;
     cert_verify_opts->ocsp_default_responder_signing_cert = NULL;
+    cert_verify_opts->crl_file = NULL;
 
     return cert_verify_opts;
 }
@@ -1035,6 +1036,8 @@ static struct cert_verify_opts *init_cert_verify_opts(TALLOC_CTX *mem_ctx)
                                           "ocsp_default_responder_signing_cert="
 #define OCSP_DEFAUL_RESPONDER_SIGNING_CERT_LEN \
                                 (sizeof(OCSP_DEFAUL_RESPONDER_SIGNING_CERT) - 1)
+#define CRL_FILE "crl_file="
+#define CRL_FILE_LEN (sizeof(CRL_FILE) -1)
 
 errno_t parse_cert_verify_opts(TALLOC_CTX *mem_ctx, const char *verify_opts,
                                struct cert_verify_opts **_cert_verify_opts)
@@ -1116,6 +1119,16 @@ errno_t parse_cert_verify_opts(TALLOC_CTX *mem_ctx, const char *verify_opts,
             DEBUG(SSSDBG_TRACE_ALL,
                   "Using OCSP default responder signing cert nickname [%s]\n",
                   cert_verify_opts->ocsp_default_responder_signing_cert);
+        } else if (strncasecmp(opts[c], CRL_FILE, CRL_FILE_LEN) == 0) {
+            cert_verify_opts->crl_file = talloc_strdup(cert_verify_opts,
+                                                       &opts[c][CRL_FILE_LEN]);
+            if (cert_verify_opts->crl_file == NULL
+                    || *cert_verify_opts->crl_file == '\0') {
+                DEBUG(SSSDBG_CRIT_FAILURE,
+                      "Failed to parse crl_file option [%s].\n", opts[c]);
+                ret = EINVAL;
+                goto done;
+            }
         } else {
             DEBUG(SSSDBG_CRIT_FAILURE,
                   "Unsupported certificate verification option [%s], " \

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -1123,6 +1123,7 @@ errno_t parse_cert_verify_opts(TALLOC_CTX *mem_ctx, const char *verify_opts,
         }
     }
 
+#ifdef HAVE_NSS
     if ((cert_verify_opts->ocsp_default_responder == NULL
             && cert_verify_opts->ocsp_default_responder_signing_cert != NULL)
         || (cert_verify_opts->ocsp_default_responder != NULL
@@ -1135,6 +1136,7 @@ errno_t parse_cert_verify_opts(TALLOC_CTX *mem_ctx, const char *verify_opts,
         ret = EINVAL;
         goto done;
     }
+#endif
 
     ret = EOK;
 

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -371,6 +371,7 @@ struct cert_verify_opts {
     bool do_verification;
     char *ocsp_default_responder;
     char *ocsp_default_responder_signing_cert;
+    char *crl_file;
 };
 
 errno_t parse_cert_verify_opts(TALLOC_CTX *mem_ctx, const char *verify_opts,


### PR DESCRIPTION
Two methods to check if certificates are revoked are added.

Since the two patches are only about certificate validation they can be tested
by calling p11child with the --verification and --certificate option to just
verify the given certificate. OCSP is used by default if there is the URL of a
responder in the certificate. the CRL check must be enabled by specifying a PEM
CRL file with the new crl_file sub-option.

Related to https://pagure.io/SSSD/sssd/issue/3489