### PR TITLE
p11: Fix -Wmaybe-uninitialized in p11_child_openssl.c

### DIFF
--- a/src/p11_child/p11_child_openssl.c
+++ b/src/p11_child/p11_child_openssl.c
@@ -666,8 +666,8 @@ errno_t do_card(TALLOC_CTX *mem_ctx, struct p11_ctx *p11_ctx,
 {
     int ret;
     size_t c;
-    size_t s;
-    CK_FUNCTION_LIST **modules;
+    size_t s = 0;
+    CK_FUNCTION_LIST **modules = NULL;
     CK_FUNCTION_LIST *module = NULL;
     char *mod_name;
     char *mod_file_name;


### PR DESCRIPTION
If uri_str was passed to the p11_child and parsing the URI failed, then
modules would be uninitialized, but freed in the done handler with
p11_kit_modules_finalize_and_release()