### PR TITLE
pcre: port to pcre2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -662,6 +662,7 @@ dist_noinst_HEADERS = \
     src/util/sss_nss.h \
     src/util/sss_ldap.h \
     src/util/sss_python.h \
+    src/util/sss_regexp.h \
     src/util/sss_krb5.h \
     src/util/sss_selinux.h \
     src/util/sss_sockets.h \
@@ -1265,6 +1266,7 @@ libsss_util_la_SOURCES = \
     src/util/sss_ptr_hash.c \
     src/util/files.c \
     src/util/selinux.c \
+    src/util/sss_regexp.c \
     $(NULL)
 libsss_util_la_CFLAGS = \
     $(AM_CFLAGS) \

--- a/contrib/ci/sssd.supp
+++ b/contrib/ci/sssd.supp
@@ -64,6 +64,8 @@
    Memcheck:Leak
    fun:malloc
    fun:pcre_compile2
+   fun:sss_regexp_pcre1_compile
+   fun:sss_regexp_new
    fun:sss_names_init_from_args
    ...
 }

--- a/src/external/libpcre.m4
+++ b/src/external/libpcre.m4
@@ -1,13 +1,45 @@
 AC_SUBST(PCRE_LIBS)
 AC_SUBST(PCRE_CFLAGS)
 
-PKG_CHECK_MODULES([PCRE], [libpcre], [found_libpcre=yes], [found_libpcre=no])
-PKG_CHECK_EXISTS(libpcre >= 7,
-                 [AC_MSG_NOTICE([PCRE version is 7 or higher])],
-                 [AC_MSG_NOTICE([PCRE version is below 7])
-                  AC_DEFINE([HAVE_LIBPCRE_LESSER_THAN_7],
-                            1,
-                            [Define if libpcre version is less than 7])])
+PKG_CHECK_MODULES(
+    [PCRE],
+    [libpcre],
+    [
+        found_libpcre=yes
+        PKG_CHECK_EXISTS(
+            libpcre >= 7,
+            [AC_MSG_NOTICE([PCRE version is 7 or higher])],
+            [
+                AC_MSG_NOTICE([PCRE version is below 7])
+                AC_DEFINE(
+                    [HAVE_LIBPCRE_LESSER_THAN_7],
+                    1,
+                    [Define if libpcre version is less than 7]
+                )
+            ]
+        )
+    ],
+    [
+        PKG_CHECK_MODULES(
+            [PCRE2],
+            [libpcre2-8],
+            [
+                found_libpcre=yes
+                AC_DEFINE(
+                    [HAVE_LIBPCRE2],
+                    1,
+                    [Define if libpcre2 is present]
+                )
+                AC_DEFINE(
+                    [PCRE2_CODE_UNIT_WIDTH],
+                    8,
+                    [Define libpcre2 unit size]
+                )
+            ],
+            [found_libpcre=no]
+        )
+    ]
+)
 
 SSS_AC_EXPAND_LIB_DIR()
 AS_IF([test x"$found_libpcre" != xyes],

--- a/src/providers/krb5/krb5_auth.h
+++ b/src/providers/krb5/krb5_auth.h
@@ -26,8 +26,8 @@
 #ifndef __KRB5_AUTH_H__
 #define __KRB5_AUTH_H__
 
-#include <pcre.h>
 
+#include "util/sss_regexp.h"
 #include "util/sss_krb5.h"
 #include "providers/backend.h"
 #include "util/child_common.h"

--- a/src/providers/krb5/krb5_common.h
+++ b/src/providers/krb5/krb5_common.h
@@ -121,7 +121,7 @@ struct krb5_ctx {
     struct krb5_service *kpasswd_service;
     int child_debug_fd;
 
-    pcre *illegal_path_re;
+    sss_regexp_t *illegal_path_re;
 
     struct deferred_auth_ctx *deferred_auth_ctx;
     struct renew_tgt_ctx *renew_tgt_ctx;

--- a/src/providers/krb5/krb5_init.c
+++ b/src/providers/krb5/krb5_init.c
@@ -108,16 +108,6 @@ static errno_t krb5_init_kdc(struct krb5_ctx *ctx, struct be_ctx *be_ctx)
     return EOK;
 }
 
-int krb5_ctx_re_destructor(struct krb5_ctx *ctx)
-{
-    if (ctx->illegal_path_re != NULL) {
-        pcre_free(ctx->illegal_path_re);
-        ctx->illegal_path_re = NULL;
-    }
-
-    return 0;
-}
-
 errno_t sssm_krb5_init(TALLOC_CTX *mem_ctx,
                        struct be_ctx *be_ctx,
                        struct data_provider *provider,
@@ -125,9 +115,6 @@ errno_t sssm_krb5_init(TALLOC_CTX *mem_ctx,
                        void **_module_data)
 {
     struct krb5_ctx *ctx;
-    const char *errstr;
-    int errval;
-    int errpos;
     errno_t ret;
 
     ctx = talloc_zero(mem_ctx, struct krb5_ctx);
@@ -166,15 +153,11 @@ errno_t sssm_krb5_init(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    ctx->illegal_path_re = pcre_compile2(ILLEGAL_PATH_PATTERN, 0,
-                                         &errval, &errstr, &errpos, NULL);
-    if (ctx->illegal_path_re == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Invalid Regular Expression pattern "
-              "at position %d. (Error: %d [%s])\n", errpos, errval, errstr);
+    ret = sss_regexp_new(ctx, ILLEGAL_PATH_PATTERN, 0, &(ctx->illegal_path_re));
+    if (ret != EOK) {
         ret = EFAULT;
         goto done;
     }
-    talloc_set_destructor(ctx, krb5_ctx_re_destructor);
 
     ret = be_fo_set_dns_srv_lookup_plugin(be_ctx, NULL);
     if (ret != EOK) {

--- a/src/providers/krb5/krb5_utils.c
+++ b/src/providers/krb5/krb5_utils.c
@@ -203,29 +203,29 @@ done:
 #define L_EXP_USERNAME (sizeof(S_EXP_USERNAME) - 1)
 
 static errno_t
-check_ccache_re(const char *filename, pcre *illegal_re)
+check_ccache_re(const char *filename, sss_regexp_t *illegal_re)
 {
     errno_t ret;
 
-    ret = pcre_exec(illegal_re, NULL, filename, strlen(filename),
-                    0, 0, NULL, 0);
+    ret = sss_regexp_match(illegal_re, filename, 0, 0);
+
     if (ret == 0) {
         DEBUG(SSSDBG_OP_FAILURE,
               "Illegal pattern in ccache directory name [%s].\n", filename);
         return EINVAL;
-    } else if (ret == PCRE_ERROR_NOMATCH) {
+    } else if (ret == SSS_REGEXP_ERROR_NOMATCH) {
         DEBUG(SSSDBG_TRACE_LIBS,
               "Ccache directory name [%s] does not contain "
                "illegal patterns.\n", filename);
         return EOK;
     }
 
-    DEBUG(SSSDBG_CRIT_FAILURE, "pcre_exec failed [%d].\n", ret);
+    DEBUG(SSSDBG_CRIT_FAILURE, "regexp match failed [%d].\n", ret);
     return EFAULT;
 }
 
 char *expand_ccname_template(TALLOC_CTX *mem_ctx, struct krb5child_req *kr,
-                             const char *template, pcre *illegal_re,
+                             const char *template, sss_regexp_t *illegal_re,
                              bool file_mode, bool case_sensitive)
 {
     char *copy;

--- a/src/providers/krb5/krb5_utils.h
+++ b/src/providers/krb5/krb5_utils.h
@@ -43,7 +43,7 @@ errno_t check_if_cached_upn_needs_update(struct sysdb_ctx *sysdb,
                                          const char *upn);
 
 char *expand_ccname_template(TALLOC_CTX *mem_ctx, struct krb5child_req *kr,
-                             const char *template, pcre *illegal_re,
+                             const char *template, sss_regexp_t *illegal_re,
                              bool file_mode, bool case_sensitive);
 
 errno_t get_domain_or_subdomain(struct be_ctx *be_ctx,

--- a/src/responder/common/responder.h
+++ b/src/responder/common/responder.h
@@ -26,13 +26,13 @@
 
 #include <stdint.h>
 #include <sys/un.h>
-#include <pcre.h>
 #include <sys/resource.h>
 #include <talloc.h>
 #include <tevent.h>
 #include <ldb.h>
 #include <dhash.h>
 
+#include "util/sss_regexp.h"
 #include "sss_iface/sss_iface_async.h"
 #include "responder/common/negcache.h"
 #include "sss_client/sss_cli.h"

--- a/src/tests/krb5_child-test.c
+++ b/src/tests/krb5_child-test.c
@@ -82,39 +82,20 @@ setup_krb5_child_test(TALLOC_CTX *mem_ctx, struct krb5_child_test_ctx **_ctx)
     return EOK;
 }
 
-int re_destructor(void *memctx)
-{
-    struct krb5_ctx *ctx = (struct krb5_ctx *) memctx;
-
-    if (ctx->illegal_path_re) {
-        pcre_free(ctx->illegal_path_re);
-        ctx->illegal_path_re = NULL;
-    }
-    return 0;
-}
-
 static struct krb5_ctx *
 create_dummy_krb5_ctx(TALLOC_CTX *mem_ctx, const char *realm)
 {
     struct krb5_ctx *krb5_ctx;
-    const char *errstr;
-    int errval;
-    int errpos;
     int i;
     errno_t ret;
 
     krb5_ctx = talloc_zero(mem_ctx, struct krb5_ctx);
     if (!krb5_ctx) return NULL;
 
-    krb5_ctx->illegal_path_re = pcre_compile2(ILLEGAL_PATH_PATTERN, 0,
-                                        &errval, &errstr, &errpos, NULL);
-    if (krb5_ctx->illegal_path_re == NULL) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "Invalid Regular Expression pattern at position %d. "
-               "(Error: %d [%s])\n", errpos, errval, errstr);
+    ret = sss_regexp_new(krb5_ctx, ILLEGAL_PATH_PATTERN, 0, &(krb5_ctx->illegal_path_re));
+    if (ret != EOK) {
         goto fail;
     }
-    talloc_set_destructor((TALLOC_CTX *) krb5_ctx, re_destructor);
 
     /* Kerberos options */
     krb5_ctx->opts = talloc_zero_array(krb5_ctx, struct dp_option, KRB5_OPTS);

--- a/src/tests/krb5_utils-tests.c
+++ b/src/tests/krb5_utils-tests.c
@@ -191,17 +191,15 @@ START_TEST(test_illegal_patterns)
     char *cwd;
     char *dirname;
     char *filename;
-    pcre *illegal_re;
-    const char *errstr;
-    int errval;
-    int errpos;
+    sss_regexp_t *illegal_re;
+    int err;
     char *result = NULL;
 
-    illegal_re = pcre_compile2(ILLEGAL_PATH_PATTERN, 0,
-                               &errval, &errstr, &errpos, NULL);
-    fail_unless(illegal_re != NULL, "Invalid Regular Expression pattern at "
-                                    " position %d. (Error: %d [%s])\n",
-                                    errpos, errval, errstr);
+
+    err = sss_regexp_new(NULL, ILLEGAL_PATH_PATTERN, 0, &illegal_re);
+
+    fail_unless(err == 0, "Invalid Regular Expression pattern error %d.\n", err);
+    fail_unless(illegal_re != NULL, "No error but illegal_re is NULL.\n");
 
     cwd = getcwd(NULL, 0);
     fail_unless(cwd != NULL, "getcwd failed.");
@@ -233,7 +231,7 @@ START_TEST(test_illegal_patterns)
                                 "illegal pattern '//' in filename [%s].",
                                 filename);
 
-    pcre_free(illegal_re);
+    talloc_free(illegal_re);
 }
 END_TEST
 
@@ -816,4 +814,3 @@ int main(int argc, const char *argv[])
 
     return EXIT_FAILURE;
 }
-

--- a/src/util/sss_regexp.c
+++ b/src/util/sss_regexp.c
@@ -1,0 +1,293 @@
+/*
+    SSSD
+
+    Authors:
+        Tomas Halman <thalman@redhat.com>
+
+    Copyright (C) 2019 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "util/sss_regexp.h"
+#include <string.h>
+#include "util/util_errors.h"
+#include "util/debug.h"
+
+#define SSS_REGEXP_OVEC_SIZE 30
+#define SSS_REGEXP_ERR_MSG_SIZE 120 /* 120 is recomended by pcre2 doc */
+
+#ifndef EOK
+#define EOK 0
+#endif
+
+#ifdef HAVE_LIBPCRE2
+/*
+ * sss_regexp with pcre2
+ */
+struct _sss_regexp_t {
+    pcre2_code *re;
+    pcre2_match_data *match_data;
+    char *matched_string;
+};
+
+int sss_regexp_pcre2_destroy(sss_regexp_t *self)
+{
+    if (self->re) {
+        pcre2_code_free(self->re);
+    }
+    if (self->match_data) {
+        pcre2_match_data_free(self->match_data);
+    }
+    if (self->matched_string) {
+        pcre2_substring_free((PCRE2_UCHAR *)self->matched_string);
+    }
+    return 0;
+}
+
+int sss_regexp_pcre2_compile(sss_regexp_t *self,
+                             const char *pattern,
+                             int options)
+{
+    int errorcode;
+    unsigned char errormsg[SSS_REGEXP_ERR_MSG_SIZE];
+    size_t erroroffset;
+
+    self->re = pcre2_compile((PCRE2_SPTR)pattern,
+                             strlen(pattern),
+                             options,
+                             &errorcode,
+                             &erroroffset,
+                             NULL);
+    if (self->re == NULL) {
+        pcre2_get_error_message(errorcode,
+                                errormsg,
+                                SSS_REGEXP_ERR_MSG_SIZE);
+        DEBUG(SSSDBG_CRIT_FAILURE, "Invalid Regular Expression pattern "
+              "at position %zu. (Error: %d [%s])\n", erroroffset, errorcode, errormsg);
+        return errorcode;
+    }
+    return EOK;
+}
+
+int sss_regexp_pcre2_match(sss_regexp_t *self,
+                           const char *subject,
+                           int startoffset,
+                           int options)
+{
+    if (!self->re) {
+        return SSS_REGEXP_ERROR_NOMATCH;
+    }
+    if (self->match_data) {
+        pcre2_match_data_free(self->match_data);
+    }
+    self->match_data = pcre2_match_data_create_from_pattern(self->re, NULL);
+    if (!self->match_data) {
+        return SSS_REGEXP_ERROR_NOMEMORY;
+    }
+    return pcre2_match(self->re,
+                       (PCRE2_SPTR)subject,
+                       strlen(subject),
+                       startoffset,
+                       options,
+                       self->match_data,
+                       NULL);
+}
+
+int sss_regexp_pcre2_get_named_substring(sss_regexp_t *self,
+                                         const char *name,
+                                         const char **value)
+{
+    PCRE2_SIZE length;
+    int rc;
+
+    if (self->matched_string) {
+        pcre2_substring_free((PCRE2_UCHAR *)(self->matched_string));
+        self->matched_string = NULL;
+    }
+    rc = pcre2_substring_get_byname(self->match_data,
+                                    (PCRE2_SPTR)name,
+                                    (PCRE2_UCHAR **) &self->matched_string,
+                                    &length);
+    *value = self->matched_string;
+    return rc;
+}
+
+#else /* !HAVE_LIBPCRE2 */
+/*
+ * sss_regexp with pcre
+ */
+struct _sss_regexp_t {
+    pcre *re;
+    int ovector[SSS_REGEXP_OVEC_SIZE];
+    const char *matched_string;
+    const char *subject;
+};
+
+int sss_regexp_pcre1_destroy(sss_regexp_t *self)
+{
+    if (self->re) {
+        pcre_free(self->re);
+    }
+    if (self->matched_string) {
+        pcre_free_substring(self->matched_string);
+    }
+    return 0;
+}
+
+int sss_regexp_pcre1_compile(sss_regexp_t *self,
+                             const char *pattern,
+                             int options)
+{
+    int errorcode;
+    const char *errormsg;
+    int erroroffset;
+
+    self->re = pcre_compile2(pattern,
+                             options,
+                             &errorcode,
+                             &errormsg,
+                             &erroroffset,
+                             NULL);
+    if (self->re == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Invalid Regular Expression pattern "
+              "at position %d. (Error: %d [%s])\n", erroroffset, errorcode, errormsg);
+        return errorcode;
+    }
+    return EOK;
+}
+
+int sss_regexp_pcre1_match(sss_regexp_t *self,
+                           const char *subject,
+                           int startoffset,
+                           int options)
+{
+    if (!self->re) {
+        return SSS_REGEXP_ERROR_NOMATCH;
+    }
+    self->subject = subject;
+    return pcre_exec(self->re,
+                     NULL,
+                     subject,
+                     strlen(subject),
+                     startoffset,
+                     options,
+                     self->ovector,
+                     SSS_REGEXP_OVEC_SIZE);
+}
+
+int sss_regexp_pcre1_get_named_substring(sss_regexp_t *self,
+                                         const char *name,
+                                         const char **value)
+{
+    int rc;
+
+    if (self->matched_string) {
+        pcre_free_substring(self->matched_string);
+        self->matched_string = NULL;
+    }
+    rc = pcre_get_named_substring(self->re,
+                                  self->subject,
+                                  self->ovector,
+                                  SSS_REGEXP_OVEC_SIZE,
+                                  name,
+                                  &self->matched_string);
+    *value = self->matched_string;
+    return rc;
+}
+
+#endif /* !HAVE_LIBPCRE2 */
+
+/*
+ * sss_regexp talloc destructor
+ */
+int sss_regexp_destroy(sss_regexp_t *self)
+{
+    if (!self) return -1;
+#ifdef HAVE_LIBPCRE2
+    return sss_regexp_pcre2_destroy(self);
+#else
+    return sss_regexp_pcre1_destroy(self);
+#endif
+}
+
+/*
+ * sss_regexp constructor
+ */
+int sss_regexp_new(TALLOC_CTX *mem_ctx,
+                   const char *pattern,
+                   int options,
+                   sss_regexp_t **self_p)
+{
+    int ret;
+    sss_regexp_t *self = talloc_zero(mem_ctx, sss_regexp_t);
+    if (!self) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Not enough memory for sss_regexp_t.\n");
+        *self_p = NULL;
+        return SSS_REGEXP_ERROR_NOMEMORY;
+    }
+    talloc_set_destructor(self, sss_regexp_destroy);
+
+#ifdef HAVE_LIBPCRE2
+    ret = sss_regexp_pcre2_compile(self,
+                                   pattern,
+                                   options);
+#else
+    ret = sss_regexp_pcre1_compile(self,
+                                   pattern,
+                                   options);
+#endif
+    if (ret != EOK) {
+        talloc_free(self);
+        self = NULL;
+    }
+    *self_p = self;
+    return ret;
+}
+
+/*
+ * sss_regexp match function
+ */
+int sss_regexp_match(sss_regexp_t *self,
+                     const char *subject,
+                     int startoffset,
+                     int options)
+{
+    if (!self || !self->re || !subject) return SSS_REGEXP_ERROR_NOMATCH;
+
+#ifdef HAVE_LIBPCRE2
+    return sss_regexp_pcre2_match(self, subject, startoffset, options);
+#else
+    return sss_regexp_pcre1_match(self, subject, startoffset, options);
+#endif
+}
+
+
+/*
+ * sss_regexp get named substring
+ */
+int sss_regexp_get_named_substring(sss_regexp_t *self,
+                                   const char *name,
+                                   const char **value)
+{
+    if (!self || !self->re || !name) {
+        *value = NULL;
+        return SSS_REGEXP_ERROR_NOMATCH;
+    }
+#ifdef HAVE_LIBPCRE2
+    return sss_regexp_pcre2_get_named_substring(self, name, value);
+#else
+    return sss_regexp_pcre1_get_named_substring(self, name, value);
+#endif
+}

--- a/src/util/sss_regexp.h
+++ b/src/util/sss_regexp.h
@@ -1,0 +1,96 @@
+/*
+    SSSD
+
+    Authors:
+        Tomas Halman <thalman@redhat.com>
+
+    Copyright (C) 2018 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SSS_REGEXP_H_
+#define SSS_REGEXP_H_
+
+#include <stddef.h>
+#include <talloc.h>
+#include "config.h"
+
+/* regexp class */
+typedef struct _sss_regexp_t sss_regexp_t;
+
+#ifdef HAVE_LIBPCRE2
+#  include <pcre2.h>
+#  define SSS_REGEXP_ERROR_NOMATCH  PCRE2_ERROR_NOMATCH
+#  define SSS_REGEXP_ERROR_NOMEMORY PCRE2_ERROR_NOMEMORY
+#  define SSS_REGEXP_NOTEMPTY       PCRE2_NOTEMPTY
+#  define SSS_REGEXP_EXTENDED       PCRE2_EXTENDED
+#  define SSS_REGEXP_DUPNAMES       PCRE2_DUPNAMES
+#else /* ! HAVE_LIBPCRE2 */
+#  include <pcre.h>
+#  define SSS_REGEXP_ERROR_NOMATCH  PCRE_ERROR_NOMATCH
+#  define SSS_REGEXP_ERROR_NOMEMORY PCRE_ERROR_NOMEMORY
+#  define SSS_REGEXP_NOTEMPTY       PCRE_NOTEMPTY
+#  define SSS_REGEXP_EXTENDED       PCRE_EXTENDED
+#  ifdef HAVE_LIBPCRE_LESSER_THAN_7
+#    define SSS_REGEXP_DUPNAMES     0
+#  else
+#    define SSS_REGEXP_DUPNAMES     PCRE_DUPNAMES
+#  endif
+#endif  /* HAVE_LIBPCRE2 */
+
+/* how to use sss_regexp:
+ *
+ *  int err;
+ *  const char *found;
+ *
+ *  sss_regexp_t *re
+ *  err = sss_regexp_new (NULL, "#(?P<myname>.+)#", 0, &re);
+ *  if (err != EOK) {
+ *      goto fail;
+ *  }
+ *  int rc = sss_regexp_match (re,
+ *                             "a#findthis#b",
+ *                             0,
+ *                             0);
+ *  if (rc != 0) { ... }
+ *  rc = sss_regexp_get_named_substring (re, "myname", &found);
+ *  ...
+ *  talloc_free (re);
+ */
+
+/*
+ * Create new compiled regexp object.
+ */
+int sss_regexp_new(TALLOC_CTX *mem_ctx,
+                   const char *pattern,
+                   int options,
+                   sss_regexp_t **self_p);
+
+/*
+ * Search subject with previously created regexp.
+ */
+int sss_regexp_match(sss_regexp_t *self,
+                     const char *subject,
+                     int startoffset,
+                     int options);
+
+/*
+ * Get named substring from last sss_regexp_match.
+ */
+int sss_regexp_get_named_substring(sss_regexp_t *self,
+                                   const char *name,
+                                   const char **value);
+
+#endif /* SSS_REGEXP_H_ */

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -28,7 +28,6 @@
 #include <libintl.h>
 #include <locale.h>
 #include <time.h>
-#include <pcre.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <netinet/in.h>
@@ -44,6 +43,7 @@
 #include "util/atomic_io.h"
 #include "util/util_errors.h"
 #include "util/sss_format.h"
+#include "util/sss_regexp.h"
 #include "util/debug.h"
 
 /* name of the monitor server instance */
@@ -209,7 +209,7 @@ struct sss_names_ctx {
     char *re_pattern;
     char *fq_fmt;
 
-    pcre *re;
+    sss_regexp_t *re;
 };
 
 /* initialize sss_names_ctx directly from arguments */


### PR DESCRIPTION
Some distributions want to drop pcre support. Sssd should work with
pcre2. With this patch sssd tries to use pcre2 if pcre is not present.

Resolves:
https://pagure.io/SSSD/sssd/issue/3833