### PR TITLE
files: add session recording flag

### DIFF
--- a/src/providers/data_provider/dp_iface.h
+++ b/src/providers/data_provider/dp_iface.h
@@ -188,4 +188,7 @@ errno_t
 dp_access_control_refresh_rules_recv(TALLOC_CTX *mem_ctx,
                                      struct tevent_req *req);
 
+
+errno_t
+dp_add_sr_attribute(struct be_ctx *be_ctx);
 #endif /* DP_IFACE_H_ */

--- a/src/providers/files/files_ops.c
+++ b/src/providers/files/files_ops.c
@@ -26,6 +26,7 @@
 #include "db/sysdb.h"
 #include "util/inotify.h"
 #include "util/util.h"
+#include "providers/data_provider/dp_iface.h"
 
 /* When changing this constant, make sure to also adjust the files integration
  * test for reallocation branch
@@ -769,6 +770,12 @@ static errno_t sf_enum_files(struct files_id_ctx *id_ctx,
                 goto done;
             }
         }
+    }
+
+    ret = dp_add_sr_attribute(id_ctx->be);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Failed to add session recording attribute, ignored.\n");
     }
 
     ret = sysdb_transaction_commit(id_ctx->domain->sysdb);


### PR DESCRIPTION
If session recording is configured for a group the NSS ans PAM
responder rely on a attribute in the cache set by the backend to
determine is session recording is configured for the user or not. This
flag is typically set during the initgroups request.

Since the files provider does not have a dedicated initgroups request
the attribute must be set otherwise. This patch sets is for all users
after the files are reloaded.

Related to https://pagure.io/SSSD/sssd/issue/3855