### PR TITLE
UTIL: Suppress Coverity warning

### DIFF
--- a/src/util/domain_info_utils.c
+++ b/src/util/domain_info_utils.c
@@ -931,6 +931,7 @@ bool sss_domain_info_get_output_fqnames(struct sss_domain_info *domain)
 
 bool is_files_provider(struct sss_domain_info *domain)
 {
-    return domain->provider != NULL &&
+    return domain != NULL &&
+           domain->provider != NULL &&
            strcasecmp(domain->provider, "files") == 0;
 }


### PR DESCRIPTION
We recently added this code:
        if (domain_name != NULL
               &&  is_files_provider(find_domain_by_name(dom,
                                                         domain_name,
                                                         false)))

find_domain_by_name returns NULL if the domain_name can't be found. This of
course makes mostly sense for trusted domains that can appear and
disappear. And is_files_provider() didn't handle the situation where the
domain pointer was NULL and would directly dereference it.

This commit just adds a NULL check for the domain pointer so that
is_files_provider() returns 'false' if the domain pointer was NULL.

Another alternative might be to check the return value of
find_domain_by_name(), but I don't think it's worth the trouble.