### PR TITLE
DYNDNS: Drop support for legacy NSUPDATE

### DIFF
--- a/src/external/nsupdate.m4
+++ b/src/external/nsupdate.m4
@@ -7,10 +7,9 @@ if test -x "$NSUPDATE"; then
   AC_MSG_CHECKING(for nsupdate 'realm' support')
   if AC_RUN_LOG([echo realm |$NSUPDATE >&2]); then
     AC_MSG_RESULT([yes])
-    AC_DEFINE_UNQUOTED([HAVE_NSUPDATE_REALM], 1, [Whether to use the 'realm' directive with nsupdate])
   else
     AC_MSG_RESULT([no])
-    AC_MSG_WARN([Will build without the 'realm' directive])
+    AC_MSG_ERROR([nsupdate does not support 'realm'])
   fi
 
 else

--- a/src/providers/be_dyndns.c
+++ b/src/providers/be_dyndns.c
@@ -400,12 +400,11 @@ static char *nsupdate_msg_add_ptr(char *update_msg,
 static char *
 nsupdate_msg_add_realm_cmd(TALLOC_CTX *mem_ctx, const char *realm)
 {
-#ifdef HAVE_NSUPDATE_REALM
     if (realm != NULL) {
         return talloc_asprintf(mem_ctx, "realm %s\n", realm);
+    } else {
+        return talloc_asprintf(mem_ctx, "\n");
     }
-#endif
-    return talloc_asprintf(mem_ctx, "\n");
 }
 
 static char *

--- a/src/tests/cmocka/test_dyndns.c
+++ b/src/tests/cmocka/test_dyndns.c
@@ -406,11 +406,7 @@ void dyndns_test_create_fwd_msg(void **state)
 
     assert_string_equal(msg,
                         "server Winterfell\n"
-#ifdef HAVE_NSUPDATE_REALM
                         "realm North\n"
-#else
-                        "\n"
-#endif
                         "update delete bran_stark. in A\n"
                         "update add bran_stark. 1234 in A 192.168.0.2\n"
                         "send\n"
@@ -427,11 +423,7 @@ void dyndns_test_create_fwd_msg(void **state)
     assert_int_equal(ret, EOK);
 
     assert_string_equal(msg,
-#ifdef HAVE_NSUPDATE_REALM
                         "realm North\n"
-#else
-                        "\n"
-#endif
                         "update delete bran_stark. in A\n"
                         "update add bran_stark. 1234 in A 192.168.0.2\n"
                         "send\n"


### PR DESCRIPTION
We should drop support for legacy versions of NSUPDATE that doesn't
support 'realm' option. The option 'realm' was added in
BIND 9.8.0a1.

Resolves:
https://pagure.io/SSSD/sssd/issue/2817