### PR TITLE
Allow re-reading kcm configuration by just restarting the sssd-kcm service

### DIFF
--- a/src/confdb/confdb_setup.h
+++ b/src/confdb/confdb_setup.h
@@ -49,6 +49,7 @@ errno_t confdb_setup(TALLOC_CTX *mem_ctx,
                      const char *cdb_file,
                      const char *config_file,
                      const char *config_dir,
+                     const char *only_section,
                      struct confdb_ctx **_cdb);
 
 #endif /* CONFDB_SETUP_H_ */

--- a/src/man/sssd-kcm.8.xml
+++ b/src/man/sssd-kcm.8.xml
@@ -127,6 +127,39 @@ systemctl enable sssd-kcm.socket
         </para>
     </refsect1>
 
+    <refsect1 id='debugging'>
+        <title>OBTAINING DEBUG LOGS</title>
+        <para>
+            The sssd-kcm service is typically socket-activated
+            <citerefentry>
+                <refentrytitle>systemd</refentrytitle>
+                <manvolnum>1</manvolnum>
+            </citerefentry>. To generate debug logs, add the following
+            either to the <filename>/etc/sssd/sssd.conf</filename>
+            file directly or as a configuration snippet to
+            <filename>/etc/sssd/conf.d/</filename> directory:
+            <programlisting>
+[kcm]
+debug_level = 10
+            </programlisting>
+            Then, restart the sssd-kcm service:
+            <programlisting>
+systemctl restart sssd-kcm.service
+            </programlisting>
+            Finally, run whatever use-case doesn't work for you. The KCM
+            logs will be generated at
+            <filename>/var/log/sssd/sssd_kcm.log</filename>. It is
+            recommended to disable the debug logs when you no longer need
+            the debugging to be enabled as the sssd-kcm service can generate
+            quite a large amount of debugging information.
+        </para>
+        <para>
+            Please note that configuration snippets are, at the moment,
+            only processed if the main configuration file at
+            <filename>/etc/sssd/sssd.conf</filename> exists at all.
+        </para>
+    </refsect1>
+
     <refsect1 id='options'>
         <title>CONFIGURATION OPTIONS</title>
         <para>

--- a/src/man/sssd.8.xml
+++ b/src/man/sssd.8.xml
@@ -164,6 +164,33 @@
                     </para>
                 </listitem>
             </varlistentry>
+            <varlistentry>
+                <term>
+                    <option>-g</option>,<option>--genconf</option>
+                </term>
+                <listitem>
+                    <para>
+                        Do not start the SSSD, but refresh the configuration
+                        database from the contents of
+                        <filename>/etc/sssd/sssd.conf</filename> and exit.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term>
+                    <option>-s</option>,<option>--genconf-section</option>
+                </term>
+                <listitem>
+                    <para>
+                        Similar to <quote>--genconf</quote>, but only refresh
+                        a single section from the configuration file.  This
+                        option is useful mainly to be called from systemd
+                        unit files to allow socket-activated responders
+                        to refresh their configuration without requiring
+                        the administrator to restart the whole SSSD.
+                    </para>
+                </listitem>
+            </varlistentry>
             <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="include/param_help.xml" />
             <varlistentry>
                 <term>

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -2514,13 +2514,17 @@ int main(int argc, const char *argv[])
         }
     }
 
-    /* Check if the SSSD is already running */
-    ret = check_file(SSSD_PIDFILE, 0, 0, S_IFREG|0600, 0, NULL, false);
-    if (ret == EOK) {
-        DEBUG(SSSDBG_FATAL_FAILURE,
-              "pidfile exists at %s\n", SSSD_PIDFILE);
-        ERROR("SSSD is already running\n");
-        return 2;
+    /* Check if the SSSD is already running unless we're only interested
+     * in re-reading the configuration
+     */
+    if (opt_genconf == 0) {
+        ret = check_file(SSSD_PIDFILE, 0, 0, S_IFREG|0600, 0, NULL, false);
+        if (ret == EOK) {
+            DEBUG(SSSDBG_FATAL_FAILURE,
+                "pidfile exists at %s\n", SSSD_PIDFILE);
+            ERROR("SSSD is already running\n");
+            return 2;
+        }
     }
 
     /* Parse config file, fail if cannot be done */

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -1579,6 +1579,7 @@ static int monitor_ctx_destructor(void *mem)
 errno_t load_configuration(TALLOC_CTX *mem_ctx,
                            const char *config_file,
                            const char *config_dir,
+                           const char *only_section,
                            struct mt_ctx **monitor)
 {
     errno_t ret;
@@ -1600,7 +1601,8 @@ errno_t load_configuration(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    ret = confdb_setup(ctx, cdb_file, config_file, config_dir, &ctx->cdb);
+    ret = confdb_setup(ctx, cdb_file, config_file, config_dir, only_section,
+                       &ctx->cdb);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Unable to setup ConfDB [%d]: %s\n",
              ret, sss_strerror(ret));
@@ -2329,6 +2331,7 @@ int main(int argc, const char *argv[])
     char *opt_config_file = NULL;
     char *opt_logger = NULL;
     char *config_file = NULL;
+    char *opt_genconf_section = NULL;
     int flags = 0;
     struct main_context *main_ctx;
     TALLOC_CTX *tmp_ctx;
@@ -2351,6 +2354,9 @@ int main(int argc, const char *argv[])
          _("Specify a non-default config file"), NULL}, \
         {"genconf", 'g', POPT_ARG_NONE, &opt_genconf, 0, \
          _("Refresh the configuration database, then exit"), \
+         NULL}, \
+        {"genconf-section", 's', POPT_ARG_STRING, &opt_genconf_section, 0, \
+         _("Similar to --genconf, but only refreshes the given section"), \
          NULL}, \
         {"version", '\0', POPT_ARG_NONE, &opt_version, 0, \
          _("Print version number and exit"), NULL }, \
@@ -2376,6 +2382,13 @@ int main(int argc, const char *argv[])
     if (opt_version) {
         puts(VERSION""PRERELEASE_VERSION);
         return EXIT_SUCCESS;
+    }
+
+    if (opt_genconf_section) {
+        /* --genconf-section implies genconf, just restricted to a single
+         * section
+         */
+        opt_genconf = 1;
     }
 
     /* If the level or timestamps was passed at the command-line, we want
@@ -2529,7 +2542,7 @@ int main(int argc, const char *argv[])
 
     /* Parse config file, fail if cannot be done */
     ret = load_configuration(tmp_ctx, config_file, CONFDB_DEFAULT_CONFIG_DIR,
-                             &monitor);
+                             opt_genconf_section, &monitor);
     if (ret != EOK) {
         switch (ret) {
         case EPERM:

--- a/src/sysv/systemd/sssd-kcm.service.in
+++ b/src/sysv/systemd/sssd-kcm.service.in
@@ -9,4 +9,5 @@ Also=sssd-kcm.socket
 
 [Service]
 Environment=DEBUG_LOGGER=--logger=files
+ExecStartPre=-@sbindir@/sssd --genconf-section=kcm
 ExecStart=@libexecdir@/sssd/sssd_kcm --uid 0 --gid 0 ${DEBUG_LOGGER}

--- a/src/tests/multihost/basic/test_config.py
+++ b/src/tests/multihost/basic/test_config.py
@@ -1,0 +1,98 @@
+""" SSSD Configuration-related Test Cases """
+import configparser as ConfigParser
+import pytest
+from utils_config import set_param, remove_section
+
+
+class TestSSSDConfig(object):
+    """
+    Test cases around SSSD config management
+    """
+    def _assert_config_value(self, multihost, section, key, value):
+        # This would really be much, much nicer to implement using python-ldb
+        # but at the moment, the multihost tests rely on a virtual environment
+        # where everything is pip-installed..and python-ldb is not present in
+        # pip
+        confdb_dn = 'cn=%s,cn=config' % (section)
+        ldb_cmd = 'ldbsearch -H /var/lib/sss/db/config.ldb -b %s' % (confdb_dn)
+        cmd = multihost.master[0].run_command(ldb_cmd)
+        check_str = '%s: %s' % (key, value)
+        assert check_str in cmd.stdout_text
+
+    def test_sssd_genconf_sssd_running(self, multihost):
+        """
+        Test that sssd --genconf is able to re-generate the configuration
+        even while SSSD is running.
+        """
+        multihost.master[0].service_sssd('restart')
+
+        self._assert_config_value(multihost, 'pam', 'debug_level', '9')
+
+        set_param(multihost, 'pam', 'debug_level', '1')
+        multihost.master[0].run_command('/usr/sbin/sssd --genconf')
+        self._assert_config_value(multihost, 'pam', 'debug_level', '1')
+
+        set_param(multihost, 'pam', 'debug_level', '9')
+
+    def test_sssd_genconf_section_only(self, multihost):
+        """
+        Test that --genconf-section only refreshes those sections given
+        on the command line
+        """
+        multihost.master[0].service_sssd('restart')
+
+        self._assert_config_value(multihost, 'pam', 'debug_level', '9')
+        self._assert_config_value(multihost, 'nss', 'debug_level', '9')
+
+        set_param(multihost, 'pam', 'debug_level', '1')
+        set_param(multihost, 'nss', 'debug_level', '1')
+        multihost.master[0].run_command(
+                '/usr/sbin/sssd --genconf-section=pam')
+
+        # We only told genconf to touch the pam section..
+        self._assert_config_value(multihost, 'pam', 'debug_level', '1')
+        # ..so the NSS section shouldn't be updated at all
+        self._assert_config_value(multihost, 'nss', 'debug_level', '9')
+
+        set_param(multihost, 'nss', 'debug_level', '9')
+        set_param(multihost, 'pam', 'debug_level', '9')
+
+    def test_sssd_genconf_add_remove_section(self, multihost):
+        """
+        Test that --genconf-section can not only modify existing
+        configuration sections, but also add a new section
+        """
+        # Establish a baseline
+        multihost.master[0].service_sssd('restart')
+        self._assert_config_value(multihost, 'pam', 'debug_level', '9')
+        self._assert_config_value(multihost, 'nss', 'debug_level', '9')
+
+        set_param(multihost, 'foo', 'bar', 'baz')
+
+        multihost.master[0].run_command(
+                '/usr/sbin/sssd --genconf-section=foo')
+
+        ldb_cmd = 'ldbsearch -H /var/lib/sss/db/config.ldb -b cn=foo,cn=config'
+        cmd = multihost.master[0].run_command(ldb_cmd)
+        assert 'bar: baz' in cmd.stdout_text
+
+        remove_section(multihost, 'foo')
+        multihost.master[0].run_command(
+                '/usr/sbin/sssd --genconf-section=foo')
+
+        ldb_cmd = 'ldbsearch -H /var/lib/sss/db/config.ldb -b cn=foo,cn=config'
+        cmd = multihost.master[0].run_command(ldb_cmd)
+        assert 'foo' not in cmd.stdout_text
+        # Also make sure the existing sections were intact
+        self._assert_config_value(multihost, 'pam', 'debug_level', '9')
+        self._assert_config_value(multihost, 'nss', 'debug_level', '9')
+
+    def test_sssd_genconf_no_such_section(self, multihost):
+        """
+        Referencing a non-existant section must not fail, because
+        we want to call this command from the systemd unit files
+        and by default the sections don't have to be present
+        """
+        multihost.master[0].service_sssd('restart')
+        multihost.master[0].run_command(
+                '/usr/sbin/sssd --genconf-section=xyz')

--- a/src/tests/multihost/basic/test_kcm.py
+++ b/src/tests/multihost/basic/test_kcm.py
@@ -2,14 +2,45 @@
 from sssd.testlib.common.utils import SSHClient
 import paramiko
 import pytest
+import os
+from utils_config import set_param, remove_section
 
 
 class TestSanityKCM(object):
     """ KCM Sanity Test cases """
-    def test_kinit_kcm(self, multihost):
+    def _kcm_service_op(self, multihost, svc_op):
+        systemd_kcm_op = 'systemctl %s sssd-kcm' % (svc_op)
+        multihost.master[0].run_command(systemd_kcm_op)
+
+    def _start_kcm(self, multihost):
+        self._kcm_service_op(multihost, 'start')
+
+    def _stop_kcm(self, multihost):
+        self._kcm_service_op(multihost, 'stop')
+
+    def _restart_kcm(self, multihost):
+        self._kcm_service_op(multihost, 'restart')
+
+    def _remove_kcm_log_file(self, multihost):
+        multihost.master[0].run_command('rm -f /var/log/sssd/sssd_kcm.log')
+
+    def _kcm_log_length(self, multihost):
+        basename = 'sssd_kcm.log'
+        kcm_log_file = '/var/log/sssd/' + basename
+        local_kcm_log_file = '/tmp/kcm.log'
+        try:
+            multihost.master[0].transport.get_file(kcm_log_file,
+                                                   local_kcm_log_file)
+        except FileNotFoundError:
+            return 0
+
+        nlines = sum(1 for line in open(local_kcm_log_file))
+        os.remove(local_kcm_log_file)
+        return nlines
+
+    def test_kinit_kcm(self, multihost, enable_kcm):
         """ Run kinit with KRB5CCNAME=KCM: """
-        start_kcm = 'systemctl start sssd-kcm'
-        multihost.master[0].run_command(start_kcm)
+        self._start_kcm(multihost)
         try:
             ssh = SSHClient(multihost.master[0].sys_hostname,
                             username='foo3', password='Secret123')
@@ -43,3 +74,51 @@ class TestSanityKCM(object):
         else:
             assert True
             ssh.close()
+
+    def test_kcm_debug_level_set(self, multihost, enable_kcm):
+        """
+        Test that just adding a [kcm] section and restarting the kcm
+        service enables debugging without having to restart the
+        whole sssd
+        """
+        # Start from a known-good state where the configuration is refreshed
+        # by the monitor and logging is completely disabled
+        multihost.master[0].service_sssd('stop')
+        self._stop_kcm(multihost)
+        self._remove_kcm_log_file(multihost)
+        set_param(multihost, 'kcm', 'debug_level', '0')
+        multihost.master[0].service_sssd('start')
+        self._start_kcm(multihost)
+
+        log_lines_pre = self._kcm_log_length(multihost)
+
+        # Debugging is disabled, kinit and make sure that no debug messages
+        # were produced
+        try:
+            ssh = SSHClient(multihost.master[0].sys_hostname,
+                            username='foo3', password='Secret123')
+        except paramiko.ssh_exception.AuthenticationException:
+            pytest.fail("Authentication Failed as user %s" % ('foo3'))
+        else:
+            ssh.execute_cmd('kdestroy')
+            ssh.close()
+
+        log_lines_nodebug = self._kcm_log_length(multihost)
+        assert log_lines_nodebug == log_lines_pre
+
+        # Enable debugging, restart only the kcm service, make sure some
+        # debug messages were produced
+        set_param(multihost, 'kcm', 'debug_level', '9')
+        self._restart_kcm(multihost)
+
+        try:
+            ssh = SSHClient(multihost.master[0].sys_hostname,
+                            username='foo3', password='Secret123')
+        except paramiko.ssh_exception.AuthenticationException:
+            pytest.fail("Authentication Failed as user %s" % ('foo3'))
+        else:
+            ssh.execute_cmd('kdestroy')
+            ssh.close()
+
+        log_lines_debug = self._kcm_log_length(multihost)
+        assert log_lines_debug > log_lines_pre + 100

--- a/src/tests/multihost/basic/utils_config.py
+++ b/src/tests/multihost/basic/utils_config.py
@@ -1,0 +1,32 @@
+""" Various utilities for manipulating SSSD configuration """
+import configparser as ConfigParser
+
+
+def set_param(multihost, section, key, value):
+    multihost.master[0].transport.get_file('/etc/sssd/sssd.conf',
+                                           '/tmp/sssd.conf')
+    sssdconfig = ConfigParser.ConfigParser()
+    sssdconfig.read('/tmp/sssd.conf')
+    if section not in sssdconfig.sections():
+        sssdconfig.add_section(section)
+
+    sssdconfig.set(section, key, value)
+    with open(str('/tmp/sssd.conf'), "w") as sssconf:
+        sssdconfig.write(sssconf)
+
+    multihost.master[0].transport.put_file('/tmp/sssd.conf',
+                                           '/etc/sssd/sssd.conf')
+
+
+def remove_section(multihost, section):
+    multihost.master[0].transport.get_file('/etc/sssd/sssd.conf',
+                                           '/tmp/sssd.conf')
+    sssdconfig = ConfigParser.ConfigParser()
+    sssdconfig.read('/tmp/sssd.conf')
+    sssdconfig.remove_section(section)
+
+    with open(str('/tmp/sssd.conf'), "w") as sssconf:
+        sssdconfig.write(sssconf)
+
+    multihost.master[0].transport.put_file('/tmp/sssd.conf',
+                                           '/etc/sssd/sssd.conf')

--- a/src/tools/common/sss_tools.c
+++ b/src/tools/common/sss_tools.c
@@ -98,6 +98,7 @@ static errno_t sss_tool_confdb_init(TALLOC_CTX *mem_ctx,
 
     ret = confdb_setup(mem_ctx, path,
                        SSSD_CONFIG_FILE, CONFDB_DEFAULT_CONFIG_DIR,
+                       NULL,
                        &confdb);
     talloc_zfree(path);
     if (ret != EOK) {

--- a/src/util/sss_ini.c
+++ b/src/util/sss_ini.c
@@ -156,8 +156,13 @@ int sss_ini_get_stat(struct sss_ini_initdata *init_data)
 
     return EOK;
 #else
+    int ret;
 
-    return fstat(init_data->file, &init_data->cstat);
+    ret = fstat(init_data->file, &init_data->cstat);
+    if (ret != 0) {
+        return errno;
+    }
+    return EOK;
 #endif
 }
 

--- a/src/util/sss_ini.h
+++ b/src/util/sss_ini.h
@@ -77,6 +77,7 @@ void sss_ini_config_destroy(struct sss_ini_initdata *init_data);
 /* Create LDIF */
 int sss_confdb_create_ldif(TALLOC_CTX *mem_ctx,
                            struct sss_ini_initdata *init_data,
+                           const char *only_section,
                            const char **config_ldif);
 
 /* Validate sssd.conf if libini_config support it */


### PR DESCRIPTION
this PR allows the administrator to only restart the KCM service in order
to apply changes in sssd.conf's [kcm] section.

I think this would be nice for admins, but the code feels already a bit
hackish to me. I think we should keep on working on the static files with
the read-only configuration, because then:
    - we could get rid of the special case to remove the section, because
      the section would always be there
    - we could remove different cases for adding/replacing sections
    - ..and of course the other things like config-show or running with
      no config file, just snippets

I also didn't enable this functionality for the other responders. I don't
know if it makes sense without more testing and in general I don't think
there are too many users of socket activated responders except kcm.