### PR TITLE
Allow non-privileged sssd user connect to private dbus

### DIFF
--- a/src/sbus/connection/sbus_connection_connect.c
+++ b/src/sbus/connection/sbus_connection_connect.c
@@ -158,7 +158,7 @@ sbus_connect_system(TALLOC_CTX *mem_ctx,
 
     sbus_conn = sbus_connection_init(mem_ctx, ev, dbus_conn, NULL, dbus_name,
                                      SBUS_CONNECTION_SYSBUS,
-                                     last_activity_time);
+                                     last_activity_time, 0);
     dbus_connection_unref(dbus_conn);
     if (sbus_conn == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create connection context!\n");
@@ -181,7 +181,8 @@ sbus_connect_private(TALLOC_CTX *mem_ctx,
                      struct tevent_context *ev,
                      const char *address,
                      const char *dbus_name,
-                     time_t *last_activity_time)
+                     time_t *last_activity_time,
+                     uid_t uid)
 {
     struct sbus_connection *sbus_conn;
     DBusConnection *dbus_conn;
@@ -194,7 +195,7 @@ sbus_connect_private(TALLOC_CTX *mem_ctx,
 
     sbus_conn = sbus_connection_init(mem_ctx, ev, dbus_conn, address, dbus_name,
                                      SBUS_CONNECTION_ADDRESS,
-                                     last_activity_time);
+                                     last_activity_time, uid);
     dbus_connection_unref(dbus_conn);
     if (sbus_conn == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create connection context!\n");
@@ -223,7 +224,8 @@ sbus_connect_private_send(TALLOC_CTX *mem_ctx,
                           struct tevent_context *ev,
                           const char *address,
                           const char *dbus_name,
-                          time_t *last_activity_time)
+                          time_t *last_activity_time,
+                          uid_t uid)
 {
     struct sbus_connect_private_state *state;
     DBusConnection *dbus_conn;
@@ -246,7 +248,7 @@ sbus_connect_private_send(TALLOC_CTX *mem_ctx,
 
     state->conn = sbus_connection_init(state, ev, dbus_conn, address,
                                        dbus_name, SBUS_CONNECTION_ADDRESS,
-                                       last_activity_time);
+                                       last_activity_time, uid);
     dbus_connection_unref(dbus_conn);
     if (state->conn == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create connection context!\n");
@@ -365,7 +367,7 @@ sbus_server_create_and_connect_send(TALLOC_CTX *mem_ctx,
     }
 
     subreq = sbus_connect_private_send(state, ev, address, dbus_name,
-                                       last_activity_time);
+                                       last_activity_time, uid);
     if (subreq == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
         ret = ENOMEM;

--- a/src/sbus/sbus.h
+++ b/src/sbus/sbus.h
@@ -82,7 +82,8 @@ sbus_connect_private(TALLOC_CTX *mem_ctx,
                      struct tevent_context *ev,
                      const char *address,
                      const char *dbus_name,
-                     time_t *last_activity_time);
+                     time_t *last_activity_time,
+                     uid_t uid);
 
 /**
  * Connect to a private D-Bus bus at @address an perform its initialization
@@ -112,7 +113,8 @@ sbus_connect_private_send(TALLOC_CTX *mem_ctx,
                           struct tevent_context *ev,
                           const char *address,
                           const char *dbus_name,
-                          time_t *last_activity_time);
+                          time_t *last_activity_time,
+                          uid_t uid);
 
 /**
  * Recieve reply from @sbus_connect_private_send.

--- a/src/sbus/sbus_private.h
+++ b/src/sbus/sbus_private.h
@@ -177,7 +177,8 @@ sbus_connection_init(TALLOC_CTX *mem_ctx,
                      const char *address,
                      const char *dbus_name,
                      enum sbus_connection_type type,
-                     time_t *last_activity_time);
+                     time_t *last_activity_time,
+                     uid_t uid);
 
 /* Replace current D-Bus connection context with a new one. */
 errno_t sbus_connection_replace(struct sbus_connection *sbus_conn,

--- a/src/sbus/server/sbus_server.c
+++ b/src/sbus/server/sbus_server.c
@@ -431,7 +431,7 @@ sbus_server_new_connection(DBusServer *dbus_server,
 
     sbus_conn = sbus_connection_init(sbus_server, sbus_server->ev, dbus_conn,
                                      NULL, NULL, SBUS_CONNECTION_CLIENT,
-                                     NULL);
+                                     NULL, sbus_server->uid);
     if (sbus_conn == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Closing connection, unable to setup\n");
         dbus_connection_close(dbus_conn);

--- a/src/sss_iface/sss_iface.c
+++ b/src/sss_iface/sss_iface.c
@@ -111,7 +111,7 @@ sss_iface_connect_address(TALLOC_CTX *mem_ctx,
     }
 
     conn = sbus_connect_private(mem_ctx, ev, address,
-                                conn_name, last_request_time);
+                                conn_name, last_request_time, geteuid());
     if (conn == NULL) {
         return ENOMEM;
     }


### PR DESCRIPTION
During startup SSSD monitor launches the children and stands on
a private dbus to waiting for a reply from them. But by default
dbus auth rules connection is allowed if the client is root or
has the same UID or anonymous is allowed. The forked children drop
their root privileges in favor of non-privileged user (e.g sssd).
In such a case there is no access to the monitor dbus connection
to say: "Hey, i'm here.". Thus, sssd service becomes
failed.

This patch changes the default dbus authorization rules for a
private connections to allow incomings from root or sssd user.

Fixes: https://pagure.io/SSSD/sssd/issue/3871