### PR TITLE
SSSCTL: user-show says that user is expired

### DIFF
--- a/src/tools/sssctl/sssctl_cache.c
+++ b/src/tools/sssctl/sssctl_cache.c
@@ -154,6 +154,11 @@ static errno_t get_attr_expire(TALLOC_CTX *mem_ctx,
         return ret;
     }
 
+    if (is_files_provider(dom)) {
+        *_value = "Never";
+        return EOK;
+    }
+
     if (value < time(NULL)) {
         *_value = "Expired";
         return EOK;
@@ -177,6 +182,11 @@ static errno_t attr_initgr(TALLOC_CTX *mem_ctx,
         return EOK;
     } else if (ret != EOK) {
         return ret;
+    }
+
+    if (is_files_provider(dom)) {
+        *_value = "Never";
+        return EOK;
     }
 
     if (value < time(NULL)) {


### PR DESCRIPTION
sssctl user-show says that user is expired if the user comes from files
provider. This is ok because files user's expiration time is always set
to 0 but we should print a better, less confusing message.

The same change apply to groups.

Resolves:
https://pagure.io/SSSD/sssd/issue/3858