### PR TITLE
sss_iface: prevent from using invalid names that start with digits

### DIFF
--- a/src/sss_iface/sss_iface.c
+++ b/src/sss_iface/sss_iface.c
@@ -56,7 +56,9 @@ sss_iface_domain_bus(TALLOC_CTX *mem_ctx,
         return NULL;
     }
 
-    bus_name = talloc_asprintf(mem_ctx, "sssd.domain.%s", safe_name);
+    /* Parts of bus names must not start with digit thus we concatenate
+     * the name with underscore instead of period. */
+    bus_name = talloc_asprintf(mem_ctx, "sssd.domain_%s", safe_name);
     talloc_free(safe_name);
 
     return bus_name;
@@ -66,7 +68,9 @@ char *
 sss_iface_proxy_bus(TALLOC_CTX *mem_ctx,
                     uint32_t id)
 {
-    return talloc_asprintf(mem_ctx, "sssd.proxy.%"PRIu32, id);
+    /* Parts of bus names must not start with digit thus we concatenate
+     * the name with underscore instead of period. */
+    return talloc_asprintf(mem_ctx, "sssd.proxy_%"PRIu32, id);
 }
 
 errno_t


### PR DESCRIPTION
From:
https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names

- Bus names that start with a colon (':') character are unique connection names. Other bus names are called well-known bus names.
- Bus names are composed of 1 or more elements separated by a period ('.') character. All elements must contain at least one character.
- Each element must only contain the ASCII characters "[A-Z][a-z][0-9]_-", with "-" discouraged in new bus names. Only elements that are part of a unique connection name may begin with a digit, elements in other bus names must not begin with a digit.
- Bus names must contain at least one '.' (period) character (and thus at least two elements).
- Bus names must not begin with a '.' (period) character.
- Bus names must not exceed the maximum name length (255).

Resolves:
https://pagure.io/SSSD/sssd/issue/3872