### PR TITLE
ci: add ability to run tests in jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,89 @@
+def untrusted = false
+
+pipeline {
+  agent none
+  options {
+    timeout(time: 10, unit: 'HOURS')
+    checkoutToSubdirectory('sssd')
+  }
+  environment {
+    NAME       = "$BRANCH_NAME/$BUILD_ID"
+    BASE_DIR   = "/home/fedora"
+    GH_CONTEXT = "sssd-ci"
+    GH_SUCCESS = "Success."
+    GH_PENDING = "Build is pending."
+    GH_FAILURE = "Build failed."
+    GH_URL     = "https://pagure.io/SSSD/sssd"
+    AWS_BASE   = "https://s3.eu-central-1.amazonaws.com/sssd-ci"
+    SUITE_DIR  = "$BASE_DIR/sssd-test-suite"
+    ARCHIVE    = "$BASE_DIR/scripts/archive.sh"
+    RUN        = "./sssd/contrib/test-suite/run.sh"
+  }
+  stages {
+    stage('Prepare') {
+      steps {
+        githubNotify status: 'PENDING', context: "$GH_CONTEXT", description: 'Running tests.', targetUrl: "$GH_URL"
+      }
+    }
+    stage('Read trusted files') {
+      steps {
+        readTrusted './contrib/test-suite/run.sh'
+        readTrusted './contrib/test-suite/run-client.sh'
+      }
+      post {
+        failure {
+          script {
+            untrusted = true
+          }
+        }
+      }
+    }
+    stage('Run Tests') {
+      parallel {
+        stage('Test on Fedora 28') {
+          agent {label "sssd-ci"}
+          environment {
+            TEST_SYSTEM = "fedora28"
+            GH_CONTEXT  = "$GH_CONTEXT/fedora28"
+            GH_URL      = "$AWS_BASE/$BRANCH_NAME/$BUILD_ID/$TEST_SYSTEM/index.html"
+            CONFIG      = "$BASE_DIR/configs/${TEST_SYSTEM}.json"
+          }
+          steps {
+            githubNotify status: 'PENDING', context: "$GH_CONTEXT", description: "$GH_PENDING", targetUrl: "$GH_URL"
+            sh '$RUN "$WORKSPACE/sssd" "$SUITE_DIR" "$WORKSPACE/artifacts/$TEST_SYSTEM" "$CONFIG"'
+          }
+          post {
+            always {
+              archiveArtifacts artifacts: "artifacts/**", allowEmptyArchive: true
+              sh '$ARCHIVE $TEST_SYSTEM $WORKSPACE/artifacts/$TEST_SYSTEM $NAME'
+              sh 'rm -fr "$WORKSPACE/artifacts/$TEST_SYSTEM"'
+            }
+            failure {
+              githubNotify status: 'FAILURE', context: "$GH_CONTEXT", description: "$GH_FAILURE", targetUrl: "$GH_URL"
+            }
+            success {
+              githubNotify status: 'SUCCESS', context: "$GH_CONTEXT", description: "$GH_SUCCESS", targetUrl: "$GH_URL"
+            }
+          }
+        }
+      }
+    }
+  }
+  post {
+    failure {
+      script {
+        if (untrusted) {
+          githubNotify status: 'ERROR', context: "$GH_CONTEXT", description: 'Untrusted files were modified.', targetUrl: "$GH_URL"
+        } else {
+          githubNotify status: 'FAILURE', context: "$GH_CONTEXT", description: 'Some tests failed.', targetUrl: "$GH_URL"
+        }
+      }
+    }
+    aborted {
+      githubNotify status: 'ERROR', context: "$GH_CONTEXT", description: 'Aborted.', targetUrl: "$GH_URL"
+    }
+    success {
+      githubNotify status: 'SUCCESS', context: "$GH_CONTEXT", description: 'All tests succeeded', targetUrl: "$GH_URL"
+    }
+  }
+}

--- a/contrib/test-suite/README.md
+++ b/contrib/test-suite/README.md
@@ -1,0 +1,39 @@
+# Run SSSD Test Suite
+
+Script `run.sh` will run all available SSSD test on a set of virtual machines created by vagrant. These virtual machines are part of separate project located at `https://github.com/SSSD/sssd-test-suite`.
+
+## Automated Testing
+
+These test are run automatically when you submit a Pull Request to SSSD project. Status report together with logs will be available in the Pull Request when testing is finished.
+
+## Steps to run the tests manually
+
+1. Checkout `https://github.com/SSSD/sssd-test-suite`
+2. Configure and setup SSSD test suite per instructions located at project readme.
+3. Make sssd-test-suite use already provisioned boxes (either manually created or maintained by SSSD team at https://app.vagrantup.com/sssd-vagrant).
+4. Run `run.sh`, please note that this script will call `vagrant destroy` and it will thus destroy your existing guests.
+
+```
+run.sh SSSD-SOURCE-DIR TEST-SUITE-DIR ARTIFACTS-DIR CONFIG-FILE
+  SSSD-SOURCE-DIR Path to SSSD source directory.
+  TEST-SUITE-DIR  Path to sssd-test-suite_dir directory.
+  ARTIFACTS-DIR   Path to directory where artifacts should be stored.
+  CONFIG-FILE     Path to sssd-test-suite_dir configuration file to use.
+```
+
+At this moment only `client` guest is required. We need to expand our test cases to test agains FreeIPA and Active Directory.
+
+## SSSD CI Architecture
+
+Jenkins master polls github for new branches and pull requests. When it discovers new pull request or branch or changes to existing pull request or branch it will allocate a jenkins agent and executes pipeline defined in `./Jenkinsfile` (in SSSD source) on this agent.
+
+The pipeline executes `./contrib/test-suite/run.sh` and archives logs when testing is finished. Script `./contrib/test-suite/run.sh` prepares sssd-test-suite, starts the vagrant machines and copy SSSD source code to the client machine. Then it calls `./contrib/test-suite/run-client.sh` on the client machine which runs continuous integration tests.
+
+### Extending current tests
+To extend current testing capabilities, modify `./contrib/test-suite/run.sh` and `./contrib/test-suite/run-client.sh` to new requirements. These files can be modified by anyone but are considered untrusted from contributor that is not an administrator of SSSD repository. This means that if a public contributor submits a pull request that changes those files, Jenkins will refuse to run tests.
+
+### Adding additional distribution to test on
+You need to modify `./Jenkinsfile`. Simply copy, paste and amend existing Fedora 28 stage. This file is also considered untrusted so only administrators can modify it within a pull request.
+
+You also need to extend `sssd-test-suite` and prepare vagrant boxes for this distro.
+

--- a/contrib/test-suite/run-client.sh
+++ b/contrib/test-suite/run-client.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# DO NOT RUN THIS MANUALLY
+#
+
+sssd_source="/shared/sssd"
+artifacts_dir="/shared/artifacts"
+
+archive-artifacts() {
+    echo "Archiving Artifact..."
+
+    cp -f $sssd_source/ci-*.log /shared/artifacts
+    cp -f $sssd_source/ci-build-debug/ci-*.log /shared/artifacts
+}
+
+success-or-die() {
+    ret=$1
+    msg=$2
+    if [ $ret -eq 0 ]; then
+        return 0
+    fi
+
+    echo $msg
+    archive-artifacts
+
+    exit $ret
+}
+
+cd $sssd_source
+
+echo "[1/1] Running Continuous Integration Tests"
+./contrib/ci/run
+success-or-die $? "CI Failed!"
+
+archive-artifacts
+exit 0

--- a/contrib/test-suite/run.sh
+++ b/contrib/test-suite/run.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+print-usage() {
+    cat <<EOF
+Run SSSD Continuous Integration Tests
+Make sure to checkout and setup https://github.com/SSSD/sssd-test-suite
+
+run.sh SSSD-SOURCE-DIR TEST-SUITE-DIR ARTIFACTS-DIR CONFIG-FILE
+  SSSD-SOURCE-DIR Path to SSSD source directory.
+  TEST-SUITE-DIR  Path to sssd-test-suite_dir directory.
+  ARTIFACTS-DIR   Path to directory where artifacts should be stored.
+  CONFIG-FILE     Path to sssd-test-suite_dir configuration file to use.
+EOF
+}
+
+print-help-if-asked() {
+    while test $# -gt 0
+    do
+        case "$1" in
+            --help)
+                print-usage ; exit 0
+                ;;
+            -h) print-usage ; exit 0
+                ;;
+            -?) print-usage ; exit 0
+                ;;
+        esac
+        shift
+    done
+}
+
+success-or-die() {
+    if [ $1 -ne 0 ]; then
+        echo $2
+        exit 1
+    fi
+}
+
+print-help-if-asked "$@"
+if [[ $# -ne 4 ]]; then
+    print-usage
+    exit 1
+fi
+
+sssd_source=$1
+suite_dir=$2
+artifacts_dir=$3
+config=$4
+
+guest_source="/shared/sssd"
+guest_artifacts="/shared/artifacts"
+
+# Currently only client machine is needed.
+guests="client"
+
+run-vagrant() {
+    VAGRANT_CWD="$suite_dir" \
+    SSSD_TEST_SUITE_RSYNC="$sssd_source:$guest_source" \
+    SSSD_TEST_SUITE_SSHFS="$artifacts_dir:$guest_artifacts" \
+    SSSD_TEST_SUITE_CONFIG="$config" \
+    vagrant "$@"
+}
+
+start-guest() {
+    # This may fail if guest's box was not yet downloaded. We will ignore it.
+    run-vagrant destroy $1 &> /dev/null
+
+    run-vagrant box update client
+    success-or-die $? "Unable to update guest: $1"
+
+    run-vagrant up client
+    success-or-die $? "Unable to start guest: $1"
+}
+
+stop-guest() {
+    run-vagrant halt $1
+    success-or-die $? "Unable to halt guest: $1"
+}
+
+echo "[1/5] Creating $artifacts_dir"
+mkdir -p "$artifacts_dir"
+success-or-die $? "Unable to create directory: $artifacts_dir"
+
+echo "[2/5] Updating sssd-test-suite"
+git -C "$suite_dir" pull --rebase
+success-or-die $? "Unable to rebase sssd-test-suite at: $suite_dir"
+
+echo "[3/5] Preparing vagrant machines"
+for guest in $guests; do
+    start-guest $guest
+done
+
+echo "[4/5] Running tests"
+run-vagrant ssh client -- "$guest_source/contrib/test-suite/run-client.sh"
+success-or-die $? "SSSD Test Suite Failed: $?"
+
+echo "[5/5] Shutdown machines"
+for guest in $guests; do
+    stop-guest $guest
+done


### PR DESCRIPTION
Jenkins master polls github for new branches and pull requests. When it discovers new pull request or branch or changes to existing pull request or branch it will allocate a jenkins agent and executes pipeline defined in `./Jenkinsfile` (in SSSD source) on this agent.

The pipeline executes `./contrib/test-suite/run.sh` and archives logs when testing is finished. Script `./contrib/test-suite/run.sh` prepares sssd-test-suite, starts the vagrant machines and copy SSSD source code to the client machine. Then it calls `./contrib/test-suite/run-client.sh` on the client machine which runs continuous integration tests.

### Extending current tests
To extend current testing capabilities, modify `./contrib/test-suite/run.sh` and `./contrib/test-suite/run-client.sh` to new requirements. These files can be modified by anyone but are considered untrusted from contributor that is not an administrator of SSSD repository. This means that if a public contributor submits a pull request that changes those files, Jenkins will refuse to run tests.

### Adding additional distribution to test on
You need to modify `./Jenkinsfile`. Simply copy, paste and amend existing Fedora 28 stage. This file is also considered untrusted so only administrators can modify it within a pull request.

You also need to extend `sssd-test-suite` and prepare vagrant boxes for this distro.