### PR TITLE
NSS: Avoid changing the memory cache ownership away from the SSSD user

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -1039,11 +1039,11 @@ done
 %dir %{sssdstatedir}
 %dir %{_localstatedir}/cache/krb5rcache
 %attr(700,sssd,sssd) %dir %{dbpath}
-%attr(755,sssd,sssd) %dir %{mcpath}
+%attr(775,sssd,sssd) %dir %{mcpath}
 %attr(751,sssd,sssd) %dir %{deskprofilepath}
-%ghost %attr(0644,sssd,sssd) %verify(not md5 size mtime) %{mcpath}/passwd
-%ghost %attr(0644,sssd,sssd) %verify(not md5 size mtime) %{mcpath}/group
-%ghost %attr(0644,sssd,sssd) %verify(not md5 size mtime) %{mcpath}/initgroups
+%ghost %attr(0664,sssd,sssd) %verify(not md5 size mtime) %{mcpath}/passwd
+%ghost %attr(0664,sssd,sssd) %verify(not md5 size mtime) %{mcpath}/group
+%ghost %attr(0664,sssd,sssd) %verify(not md5 size mtime) %{mcpath}/initgroups
 %attr(755,sssd,sssd) %dir %{pipepath}
 %attr(750,sssd,root) %dir %{pipepath}/private
 %attr(755,sssd,sssd) %dir %{pubconfpath}

--- a/src/responder/nss/nss_private.h
+++ b/src/responder/nss/nss_private.h
@@ -87,6 +87,8 @@ struct nss_ctx {
     struct sss_mc_ctx *pwd_mc_ctx;
     struct sss_mc_ctx *grp_mc_ctx;
     struct sss_mc_ctx *initgr_mc_ctx;
+    uid_t mc_uid;
+    gid_t mc_gid;
 };
 
 struct sss_cmd_table *get_nss_cmds(void);

--- a/src/responder/nss/nsssrv_mmap_cache.h
+++ b/src/responder/nss/nsssrv_mmap_cache.h
@@ -34,6 +34,7 @@ enum sss_mc_type {
 };
 
 errno_t sss_mmap_cache_init(TALLOC_CTX *mem_ctx, const char *name,
+                            uid_t uid, gid_t gid,
                             enum sss_mc_type type, size_t n_elem,
                             time_t valid_time, struct sss_mc_ctx **mcc);
 
@@ -70,7 +71,9 @@ errno_t sss_mmap_cache_gr_invalidate_gid(struct sss_mc_ctx *mcc, gid_t gid);
 errno_t sss_mmap_cache_initgr_invalidate(struct sss_mc_ctx *mcc,
                                          struct sized_string *name);
 
-errno_t sss_mmap_cache_reinit(TALLOC_CTX *mem_ctx, size_t n_elem,
+errno_t sss_mmap_cache_reinit(TALLOC_CTX *mem_ctx,
+                              uid_t uid, gid_t gid,
+                              size_t n_elem,
                               time_t timeout, struct sss_mc_ctx **mc_ctx);
 
 void sss_mmap_cache_reset(struct sss_mc_ctx *mc_ctx);


### PR DESCRIPTION
Resolves: https://pagure.io/SSSD/sssd/issue/3890

In case SSSD is compiled --with-sssd-user but run as root (which is the 
default on RHEL and derivatives), then the memory cache will be owned by 
the user that sssd_nss runs as, so root.

This conflicts with the packaging which specifies sssd.sssd as the owner.
And in turn, this means that users can't reliably assess the package
integrity using rpm -V.

This patch makes sure that the memory cache files are chowned to sssd.sssd 
even if the nss responder runs as root.

Also, this patch changes the sssd_nss responder so that is becomes a member 
of the supplementary sssd group. Even though in traditional UNIX sense, a
process running as root could write to a file owned by sssd:sssd, with 
SELinux enforcing mode this becomes problematic as SELinux emits an error 
such as:

type=AVC msg=audit(1543524888.125:1495): avc:  denied  { fsetid } for 
pid=7706 comm="sssd_nss" capability=4  scontext=system_u:system_r:sssd_t:s0 
tcontext=system_u:system_r:sssd_t:s0 tclass=capability

To make it possible for the sssd_nss process to write to the files, the 
files are also made group-writable. The 'others' permission is still set to
read only.