### PR TITLE
nss: sssd returns '/' for emtpy home directories

### DIFF
--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -1301,6 +1301,15 @@ static int confdb_get_domain_internal(struct confdb_ctx *cdb,
             ret = ENOMEM;
             goto done;
         }
+    } else {
+        if (strcasecmp(domain->provider, "ad") == 0) {
+            /* ad provider default */
+            domain->fallback_homedir = talloc_strdup(domain, "/home/%d/%u");
+            if (!domain->fallback_homedir) {
+                ret = ENOMEM;
+                goto done;
+            }
+        }
     }
 
     tmp = ldb_msg_find_attr_as_string(res->msgs[0],

--- a/src/man/include/ad_modified_defaults.xml
+++ b/src/man/include/ad_modified_defaults.xml
@@ -76,4 +76,23 @@
             </listitem>
         </itemizedlist>
     </refsect2>
+    <refsect2 id='nss_modifications'>
+        <title>NSS configuration</title>
+        <itemizedlist>
+            <listitem>
+                <para>
+                    fallback_homedir = /home/%d/%u
+                </para>
+                <para>
+                    The AD provider automatically sets
+                    "fallback_homedir = /home/%d/%u" to provide personal
+                    home directories for users without the homeDirectory
+                    attribute. If your AD Domain is properly
+                    populated with Posix attributes, and you want to avoid
+                    this fallback behavior, you can explicitly
+                    set "fallback_homedir = %o".
+                </para>
+            </listitem>
+        </itemizedlist>
+    </refsect2>
 </refsect1>

--- a/src/responder/nss/nss_protocol_pwent.c
+++ b/src/responder/nss/nss_protocol_pwent.c
@@ -118,7 +118,7 @@ nss_get_homedir(TALLOC_CTX *mem_ctx,
 
     homedir = nss_get_homedir_override(mem_ctx, msg, nss_ctx, domain, &hd_ctx);
     if (homedir == NULL) {
-        return "/";
+        return "";
     }
 
     return homedir;

--- a/src/tests/intg/test_files_provider.py
+++ b/src/tests/intg/test_files_provider.py
@@ -656,7 +656,7 @@ def test_user_no_dir(setup_pw_with_canary, files_domain_only):
     Test that resolving a user without a homedir defined works and returns
     a fallback value
     """
-    check_user(incomplete_user_setup(setup_pw_with_canary, 'dir', '/'))
+    check_user(incomplete_user_setup(setup_pw_with_canary, 'dir', ''))
 
 
 def test_user_no_gecos(setup_pw_with_canary, files_domain_only):


### PR DESCRIPTION
For empty home directory in passwd file sssd returns "/". Sssd
should respect system behaviour and return the same as nsswitch
"files" module - return empty string.

Resolves:
https://pagure.io/SSSD/sssd/issue/ To be defined