### PR TITLE
KCM: Add configurable quotas

### DIFF
--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -266,6 +266,9 @@
 #define CONFDB_KCM_CONF_ENTRY "config/kcm"
 #define CONFDB_KCM_SOCKET "socket_path"
 #define CONFDB_KCM_DB "ccache_storage" /* Undocumented on purpose */
+#define CONFDB_KCM_MAX_CCACHES "max_ccaches"
+#define CONFDB_KCM_MAX_UID_CCACHES "max_uid_ccaches"
+#define CONFDB_KCM_MAX_CCACHE_SIZE "max_ccache_size"
 
 /* Certificate mapping rules */
 #define CONFDB_CERTMAP_BASEDN "cn=certmap,cn=config"

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -312,6 +312,9 @@ option = description
 option = socket_path
 option = ccache_storage
 option = responder_idle_timeout
+option = max_ccaches
+option = max_uid_ccaches
+option = max_ccache_size
 
 # Session recording
 [rule/allowed_session_recording_options]

--- a/src/man/sssd-kcm.8.xml
+++ b/src/man/sssd-kcm.8.xml
@@ -201,6 +201,43 @@ systemctl restart sssd-kcm.service
                     </para>
                 </listitem>
             </varlistentry>
+            <varlistentry>
+                <term>max_ccaches (integer)</term>
+                <listitem>
+                    <para>
+                        How many credential caches does the KCM database allow
+                        for all users.
+                    </para>
+                    <para>
+                        Default: 0 (unlimited, only the per-UID quota is enforced)
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term>max_uid_ccaches (integer)</term>
+                <listitem>
+                    <para>
+                        How many credential caches does the KCM database allow
+                        per UID. This is equivalent to <quote>with how many
+                        principals you can kinit</quote>.
+                    </para>
+                    <para>
+                        Default: 64
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term>max_ccache_size (integer)</term>
+                <listitem>
+                    <para>
+                        How big can a credential cache be per ccache. Each
+                        service ticket accounts into this quota.
+                    </para>
+                    <para>
+                        Default: 65536
+                    </para>
+                </listitem>
+            </varlistentry>
         </variablelist>
     </refsect1>
 

--- a/src/man/sssd-kcm.8.xml
+++ b/src/man/sssd-kcm.8.xml
@@ -162,12 +162,17 @@ systemctl restart sssd-kcm.service
         <title>CONFIGURATION OPTIONS</title>
         <para>
             The KCM service is configured in the <quote>kcm</quote>
-            section of the sssd.conf file. Please note that currently,
-            is it not sufficient to restart the sssd-kcm service, because
-            the sssd configuration is only parsed and read to an internal
-            configuration database by the sssd service. Therefore you
-            must restart the sssd service if you change anything in the
-            <quote>kcm</quote> section of sssd.conf.
+            section of the sssd.conf file. Please note that because
+            the KCM service is typically socket-activated, it is
+            enough to just restart the <quote>sssd-kcm</quote> service
+            after changing options in the <quote>kcm</quote> section
+            of sssd.conf:
+            <programlisting>
+systemctl restart sssd-kcm.service
+            </programlisting>
+        </para>
+        <para>
+            The KCM service is configured in the <quote>kcm</quote>
             For a detailed syntax reference, refer to the <quote>FILE FORMAT</quote> section of the
             <citerefentry>
                 <refentrytitle>sssd.conf</refentrytitle>

--- a/src/man/sssd-kcm.8.xml
+++ b/src/man/sssd-kcm.8.xml
@@ -58,11 +58,9 @@
                 </listitem>
                 <listitem>
                     <para>
-                        the SSSD implementation stores the ccaches in the SSSD
-                        <citerefentry>
-                            <refentrytitle>sssd-secrets</refentrytitle><manvolnum>5</manvolnum>
-                        </citerefentry>
-                        secrets store, allowing the ccaches to survive KCM server restarts or machine reboots.
+                        the SSSD implementation stores the ccaches in a database,
+                        typically located at <replaceable>/var/lib/sss/secrets</replaceable>
+                        allowing the ccaches to survive KCM server restarts or machine reboots.
                     </para>
                 </listitem>
             </itemizedlist>

--- a/src/responder/kcm/kcm.c
+++ b/src/responder/kcm/kcm.c
@@ -170,6 +170,8 @@ static int kcm_data_destructor(void *ptr)
 
 static struct kcm_resp_ctx *kcm_data_setup(TALLOC_CTX *mem_ctx,
                                            struct tevent_context *ev,
+                                           struct confdb_ctx *cdb,
+                                           const char *confdb_service_path,
                                            enum kcm_ccdb_be cc_be)
 {
     struct kcm_resp_ctx *kcm_data;
@@ -181,7 +183,11 @@ static struct kcm_resp_ctx *kcm_data_setup(TALLOC_CTX *mem_ctx,
         return NULL;
     }
 
-    kcm_data->db = kcm_ccdb_init(kcm_data, ev, cc_be);
+    kcm_data->db = kcm_ccdb_init(kcm_data,
+                                 ev,
+                                 cdb,
+                                 confdb_service_path,
+                                 cc_be);
     if (kcm_data->db == NULL) {
         talloc_free(kcm_data);
         return NULL;
@@ -235,7 +241,11 @@ static int kcm_process_init(TALLOC_CTX *mem_ctx,
         goto fail;
     }
 
-    kctx->kcm_data = kcm_data_setup(kctx, ev, kctx->cc_be);
+    kctx->kcm_data = kcm_data_setup(kctx,
+                                    ev,
+                                    kctx->rctx->cdb,
+                                    kctx->rctx->confdb_service_path,
+                                    kctx->cc_be);
     if (kctx->kcm_data == NULL) {
         DEBUG(SSSDBG_FATAL_FAILURE,
               "fatal error initializing responder data\n");

--- a/src/responder/kcm/kcmsrv_ccache.c
+++ b/src/responder/kcm/kcmsrv_ccache.c
@@ -229,6 +229,8 @@ struct sss_iobuf *kcm_cred_get_creds(struct kcm_cred *crd)
 
 struct kcm_ccdb *kcm_ccdb_init(TALLOC_CTX *mem_ctx,
                                struct tevent_context *ev,
+                               struct confdb_ctx *cdb,
+                               const char *confdb_service_path,
                                enum kcm_ccdb_be cc_be)
 {
     errno_t ret;
@@ -270,7 +272,7 @@ struct kcm_ccdb *kcm_ccdb_init(TALLOC_CTX *mem_ctx,
         return NULL;
     }
 
-    ret = ccdb->ops->init(ccdb);
+    ret = ccdb->ops->init(ccdb, cdb, confdb_service_path);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Cannot initialize ccache database\n");
         talloc_free(ccdb);

--- a/src/responder/kcm/kcmsrv_ccache.h
+++ b/src/responder/kcm/kcmsrv_ccache.h
@@ -125,6 +125,8 @@ struct kcm_ccdb;
  */
 struct kcm_ccdb *kcm_ccdb_init(TALLOC_CTX *mem_ctx,
                                struct tevent_context *ev,
+                               struct confdb_ctx *cdb,
+                               const char *confdb_service_path,
                                enum kcm_ccdb_be cc_be);
 
 /*

--- a/src/responder/kcm/kcmsrv_ccache_be.h
+++ b/src/responder/kcm/kcmsrv_ccache_be.h
@@ -30,7 +30,9 @@
 #include "responder/kcm/kcmsrv_ccache.h"
 
 typedef errno_t
-(*ccdb_init_fn)(struct kcm_ccdb *db);
+(*ccdb_init_fn)(struct kcm_ccdb *db,
+                struct confdb_ctx *cdb,
+                const char *confdb_service_path);
 
 typedef struct tevent_req *
 (*ccdb_nextid_send_fn)(TALLOC_CTX *mem_ctx,

--- a/src/responder/kcm/kcmsrv_ccache_mem.c
+++ b/src/responder/kcm/kcmsrv_ccache_mem.c
@@ -151,7 +151,9 @@ static int ccwrap_destructor(void *ptr)
     return 0;
 }
 
-static errno_t ccdb_mem_init(struct kcm_ccdb *db)
+static errno_t ccdb_mem_init(struct kcm_ccdb *db,
+                             struct confdb_ctx *cdb,
+                             const char *confdb_service_path)
 {
     struct ccdb_mem *memdb = NULL;
 

--- a/src/responder/kcm/kcmsrv_ccache_secdb.c
+++ b/src/responder/kcm/kcmsrv_ccache_secdb.c
@@ -520,7 +520,9 @@ done:
     return ret;
 }
 
-static errno_t ccdb_secdb_init(struct kcm_ccdb *db)
+static errno_t ccdb_secdb_init(struct kcm_ccdb *db,
+                               struct confdb_ctx *cdb,
+                               const char *confdb_service_path)
 {
     struct ccdb_secdb *secdb = NULL;
     errno_t ret;
@@ -529,8 +531,6 @@ static errno_t ccdb_secdb_init(struct kcm_ccdb *db)
     if (secdb == NULL) {
         return ENOMEM;
     }
-
-    /* TODO: read configuration from the config file, adjust quotas */
 
     ret = sss_sec_init(db, NULL, &secdb->sctx);
     if (ret != EOK) {

--- a/src/responder/kcm/kcmsrv_ccache_secdb.c
+++ b/src/responder/kcm/kcmsrv_ccache_secdb.c
@@ -526,13 +526,72 @@ static errno_t ccdb_secdb_init(struct kcm_ccdb *db,
 {
     struct ccdb_secdb *secdb = NULL;
     errno_t ret;
+    struct sss_sec_hive_config **kcm_section_quota;
+    struct sss_sec_quota_opt dfl_kcm_nest_level = {
+        .opt_name = CONFDB_SEC_CONTAINERS_NEST_LEVEL,
+        .default_value = DEFAULT_SEC_CONTAINERS_NEST_LEVEL,
+    };
+    struct sss_sec_quota_opt dfl_kcm_max_secrets = {
+        .opt_name = CONFDB_KCM_MAX_CCACHES,
+        .default_value = DEFAULT_SEC_KCM_MAX_SECRETS,
+    };
+    struct sss_sec_quota_opt dfl_kcm_max_uid_secrets = {
+        .opt_name = CONFDB_KCM_MAX_UID_CCACHES,
+        .default_value = DEFAULT_SEC_KCM_MAX_UID_SECRETS,
+    };
+    struct sss_sec_quota_opt dfl_kcm_max_payload_size = {
+        .opt_name = CONFDB_KCM_MAX_CCACHE_SIZE,
+        .default_value = DEFAULT_SEC_KCM_MAX_PAYLOAD_SIZE,
+    };
+
 
     secdb = talloc_zero(db, struct ccdb_secdb);
     if (secdb == NULL) {
         return ENOMEM;
     }
 
-    ret = sss_sec_init(db, NULL, &secdb->sctx);
+    kcm_section_quota = talloc_zero_array(secdb,
+                                          struct sss_sec_hive_config *,
+                                          2);
+    if (kcm_section_quota == NULL) {
+        talloc_free(secdb);
+        return ENOMEM;
+    }
+
+    kcm_section_quota[0] = talloc_zero(kcm_section_quota,
+                                       struct sss_sec_hive_config);
+    if (kcm_section_quota == NULL) {
+        talloc_free(secdb);
+        return ENOMEM;
+    }
+    kcm_section_quota[0]->hive_name = "kcm";
+
+    ret = sss_sec_get_quota(cdb,
+                            confdb_service_path,
+                            &dfl_kcm_nest_level,
+                            &dfl_kcm_max_secrets,
+                            &dfl_kcm_max_uid_secrets,
+                            &dfl_kcm_max_payload_size,
+                            &kcm_section_quota[0]->quota);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE,
+              "Failed to get KCM global quotas [%d]: %s\n",
+              ret, sss_strerror(ret));
+        talloc_free(secdb);
+        return ret;
+    }
+
+    if (kcm_section_quota[0]->quota.max_uid_secrets > 0) {
+        /* Even cn=default is considered a secret that adds up to
+         * the quota. To avoid off-by-one-confusion, increase
+         * the quota by two to 1) account for the cn=default object
+         * and 2) always allow writing to cn=defaults even if we
+         * are exactly at the quota limit
+         */
+        kcm_section_quota[0]->quota.max_uid_secrets += 2;
+    }
+
+    ret = sss_sec_init(db, kcm_section_quota, &secdb->sctx);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Cannot initialize the security database\n");

--- a/src/responder/kcm/kcmsrv_ccache_secrets.c
+++ b/src/responder/kcm/kcmsrv_ccache_secrets.c
@@ -659,7 +659,9 @@ static errno_t sec_get_ccache_recv(struct tevent_req *req,
 /*
  * The actual sssd-secrets back end
  */
-static errno_t ccdb_sec_init(struct kcm_ccdb *db)
+static errno_t ccdb_sec_init(struct kcm_ccdb *db,
+                             struct confdb_ctx *cdb,
+                             const char *confdb_service_path)
 {
     struct ccdb_sec *secdb = NULL;
 

--- a/src/tests/multihost/basic/conftest.py
+++ b/src/tests/multihost/basic/conftest.py
@@ -406,6 +406,14 @@ def create_posix_usersgroups(session_multihost):
         assert ret == 'Success'
 
 
+@pytest.fixture(scope='session')
+def create_many_user_principals(session_multihost):
+    krb = krb5srv(session_multihost.master[0], 'EXAMPLE.TEST')
+    for i in range(1, 65):
+        username = "user%04d" % i
+        krb.add_principal(username, 'user', 'Secret123')
+
+
 @pytest.fixture(scope="session", autouse=True)
 def setup_session(request, session_multihost,
                   package_install,

--- a/src/util/secrets/config.c
+++ b/src/util/secrets/config.c
@@ -24,10 +24,10 @@
 
 errno_t sss_sec_get_quota(struct confdb_ctx *cdb,
                           const char *section_config_path,
-                          int default_max_containers_nest_level,
-                          int default_max_num_secrets,
-                          int default_max_num_uid_secrets,
-                          int default_max_payload,
+                          struct sss_sec_quota_opt *dfl_max_containers_nest_level,
+                          struct sss_sec_quota_opt *dfl_max_num_secrets,
+                          struct sss_sec_quota_opt *dfl_max_num_uid_secrets,
+                          struct sss_sec_quota_opt *dfl_max_payload,
                           struct sss_sec_quota *quota)
 {
     int ret;
@@ -38,8 +38,8 @@ errno_t sss_sec_get_quota(struct confdb_ctx *cdb,
 
     ret = confdb_get_int(cdb,
                          section_config_path,
-                         CONFDB_SEC_CONTAINERS_NEST_LEVEL,
-                         default_max_containers_nest_level,
+                         dfl_max_containers_nest_level->opt_name,
+                         dfl_max_containers_nest_level->default_value,
                          &quota->containers_nest_level);
 
     if (ret != EOK) {
@@ -51,8 +51,8 @@ errno_t sss_sec_get_quota(struct confdb_ctx *cdb,
 
     ret = confdb_get_int(cdb,
                          section_config_path,
-                         CONFDB_SEC_MAX_SECRETS,
-                         default_max_num_secrets,
+                         dfl_max_num_secrets->opt_name,
+                         dfl_max_num_secrets->default_value,
                          &quota->max_secrets);
 
     if (ret != EOK) {
@@ -64,8 +64,8 @@ errno_t sss_sec_get_quota(struct confdb_ctx *cdb,
 
     ret = confdb_get_int(cdb,
                          section_config_path,
-                         CONFDB_SEC_MAX_UID_SECRETS,
-                         default_max_num_uid_secrets,
+                         dfl_max_num_uid_secrets->opt_name,
+                         dfl_max_num_uid_secrets->default_value,
                          &quota->max_uid_secrets);
 
     if (ret != EOK) {
@@ -77,8 +77,8 @@ errno_t sss_sec_get_quota(struct confdb_ctx *cdb,
 
     ret = confdb_get_int(cdb,
                          section_config_path,
-                         CONFDB_SEC_MAX_PAYLOAD_SIZE,
-                         default_max_payload,
+                         dfl_max_payload->opt_name,
+                         dfl_max_payload->default_value,
                          &quota->max_payload_size);
 
     if (ret != EOK) {
@@ -93,10 +93,10 @@ errno_t sss_sec_get_quota(struct confdb_ctx *cdb,
 
 errno_t sss_sec_get_hive_config(struct confdb_ctx *cdb,
                                 const char *hive_name,
-                                int default_max_containers_nest_level,
-                                int default_max_num_secrets,
-                                int default_max_num_uid_secrets,
-                                int default_max_payload,
+                                struct sss_sec_quota_opt *dfl_max_containers_nest_level,
+                                struct sss_sec_quota_opt *dfl_max_num_secrets,
+                                struct sss_sec_quota_opt *dfl_max_num_uid_secrets,
+                                struct sss_sec_quota_opt *dfl_max_payload,
                                 struct sss_sec_hive_config *hive_config)
 {
     int ret;
@@ -122,10 +122,10 @@ errno_t sss_sec_get_hive_config(struct confdb_ctx *cdb,
 
     ret = sss_sec_get_quota(cdb,
                             confdb_section,
-                            default_max_containers_nest_level,
-                            default_max_num_secrets,
-                            default_max_num_uid_secrets,
-                            default_max_payload,
+                            dfl_max_containers_nest_level,
+                            dfl_max_num_secrets,
+                            dfl_max_num_uid_secrets,
+                            dfl_max_payload,
                             &hive_config->quota);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,

--- a/src/util/secrets/secrets.h
+++ b/src/util/secrets/secrets.h
@@ -47,6 +47,11 @@ struct sss_sec_ctx;
 
 struct sss_sec_req;
 
+struct sss_sec_quota_opt {
+    const char *opt_name;
+    int default_value;
+};
+
 struct sss_sec_quota {
     int max_secrets;
     int max_uid_secrets;
@@ -98,18 +103,18 @@ bool sss_sec_req_is_list(struct sss_sec_req *req);
 
 errno_t sss_sec_get_quota(struct confdb_ctx *cdb,
                           const char *section_config_path,
-                          int default_max_containers_nest_level,
-                          int default_max_num_secrets,
-                          int default_max_num_uid_secrets,
-                          int default_max_payload,
+                          struct sss_sec_quota_opt *dfl_max_containers_nest_level,
+                          struct sss_sec_quota_opt *dfl_max_num_secrets,
+                          struct sss_sec_quota_opt *dfl_max_num_uid_secrets,
+                          struct sss_sec_quota_opt *dfl_max_payload,
                           struct sss_sec_quota *quota);
 
 errno_t sss_sec_get_hive_config(struct confdb_ctx *cdb,
                                 const char *hive_name,
-                                int default_max_containers_nest_level,
-                                int default_max_num_secrets,
-                                int default_max_num_uid_secrets,
-                                int default_max_payload,
+                                struct sss_sec_quota_opt *dfl_max_containers_nest_level,
+                                struct sss_sec_quota_opt *dfl_max_num_secrets,
+                                struct sss_sec_quota_opt *dfl_max_num_uid_secrets,
+                                struct sss_sec_quota_opt *dfl_max_payload,
                                 struct sss_sec_hive_config *hive_config);
 
 #endif /* __SECRETS_H_ */

--- a/src/util/secrets/secrets.h
+++ b/src/util/secrets/secrets.h
@@ -39,7 +39,7 @@
  * but the secret size must be large because one secret in the /kcm
  * hive holds the whole ccache which consists of several credentials
  */
-#define DEFAULT_SEC_KCM_MAX_SECRETS      256
+#define DEFAULT_SEC_KCM_MAX_SECRETS      0          /* unlimited */
 #define DEFAULT_SEC_KCM_MAX_UID_SECRETS  64
 #define DEFAULT_SEC_KCM_MAX_PAYLOAD_SIZE 65536
 


### PR DESCRIPTION
This PR adds several patches that let the user configure quotas to store
their ccaches.

Please see the commit messages, I hope they are verbose enough. One thing
that should be pointed out is that the global number of ccaches is explicitly
unlimited. Does anyone see an issue with just enforcing the per-UID limits?

An upcoming PR(s) would implement warning when the quota is being exceeded
and a sssctl command to let the administrator display the quota taken.