### PR TITLE
KCM: Fall back to using the first ccache if the default does not exist

### DIFF
--- a/src/responder/kcm/kcmsrv_ops.c
+++ b/src/responder/kcm/kcmsrv_ops.c
@@ -1509,7 +1509,17 @@ static void kcm_op_get_default_ccache_byuuid_done(struct tevent_req *subreq)
         DEBUG(SSSDBG_OP_FAILURE,
               "Cannot get ccahe by UUID [%d]: %s\n",
               ret, sss_strerror(ret));
-        tevent_req_error(req, ret);
+        /* Instead of failing the whole operation, return the first
+         * ccache as a fallback
+         */
+        subreq = kcm_ccdb_list_send(state, state->ev,
+                                    state->op_ctx->kcm_data->db,
+                                    state->op_ctx->client);
+        if (subreq == NULL) {
+            tevent_req_error(req, ENOMEM);
+            return;
+        }
+        tevent_req_set_callback(subreq, kcm_op_get_default_ccache_list_done, req);
         return;
     }
 


### PR DESCRIPTION
Resolves: https://pagure.io/SSSD/sssd/issue/3838

KCM stores the default ccache in a separate DB entry. If the DB entry 
contains a UUID that cannot be found in the DB for whatever reason, we 
should just use the first ccache as the default. (This is what we already
do if there is no default)