### PR TITLE
TESTS: ldb-tools are required for multihost tests

### DIFF
--- a/src/tests/multihost/basic/conftest.py
+++ b/src/tests/multihost/basic/conftest.py
@@ -39,7 +39,7 @@ def package_install(session_multihost):
     pkg_list = 'authselect nss-tools 389-ds-base krb5-server '\
                'openldap-clients krb5-workstation '\
                '389-ds-base-legacy-tools sssd sssd-dbus sssd-kcm ' \
-               'expect'
+               'expect ldb-tools sssd-tools'
     if 'Fedora' in distro:
         cmd = 'dnf install -y %s' % (pkg_list)
     elif '8.' in distro.split()[5]:


### PR DESCRIPTION
Some of the test do use ldbsearch.

Resolves:
https://pagure.io/SSSD/sssd/issue/3894