### PR TITLE
Regex fails if there's a whitespace before option name

### DIFF
--- a/src/config/SSSDConfig/ipachangeconf.py
+++ b/src/config/SSSDConfig/ipachangeconf.py
@@ -475,7 +475,7 @@ class IPAChangeConf(object):
 # An SSSD-specific subclass of IPAChangeConf
 class SSSDChangeConf(IPAChangeConf):
     OPTCRE = re.compile(
-            r'(?P<option>[^:=\s][^:=]*)'          # very permissive!
+            r'\s*(?P<option>[^:=\s][^:=]*)'       # very permissive!
             r'\s*=\s*'                            # any number of space/tab,
                                                   # followed by separator
                                                   # followed by any # space/tab


### PR DESCRIPTION
self.OPTCRE.match(line) fails if there's a whitespace before option name, which is valid for SSSD. This change will ignore any whitespace before the option name.