### PR TITLE
ipa: use only the global catalog service of the forest root

### DIFF
--- a/src/providers/ipa/ipa_subdomains_server.c
+++ b/src/providers/ipa/ipa_subdomains_server.c
@@ -266,7 +266,7 @@ ipa_ad_ctx_new(struct be_ctx *be_ctx,
         DEBUG(SSSDBG_TRACE_ALL, "No extra attrs set.\n");
     }
 
-    gc_service_name = talloc_asprintf(ad_options, "sd_gc_%s", subdom->forest);
+    gc_service_name = talloc_asprintf(ad_options, "sd_gc_%s", subdom->name);
     if (gc_service_name == NULL) {
         talloc_free(ad_options);
         return ENOMEM;


### PR DESCRIPTION
While creating the domains and sub-domains each domain gets a global
catalog services assigned but only one should be used because the global
catalog is by definition responsible for the whole forest so it does not
make sense to use a global catalog service for each domain and in the worst
case connect to the same GC multiple times.

In the AD provider this is simple because the GC service of the configured
domain AD_GC_SERVICE_NAME ("AD_GC") can be used. In the IPA case all
domains from the trusted forest are on the level of sub-domains so we have
to pick one. Since the forest root is linked from all domain of the same
forest it will be the most straight forward choice.

This would also be the proper fix for https://pagure.io/SSSD/sssd/issue/3015 so
the original fix for this ticket is reverted because it would cause other issues.

Related to https://pagure.io/SSSD/sssd/issue/3902