### PR TITLE
Use 120 second default timeout for dbus (#1654537)

### DIFF
--- a/src/sbus/sbus_message.h
+++ b/src/sbus/sbus_message.h
@@ -27,8 +27,10 @@
 #include "util/util.h"
 #include "sbus/sbus_errors.h"
 
-/* Use reasonable default timeout which is computed in libdbus */
-#define SBUS_MESSAGE_TIMEOUT -1
+/* Use longer default timeout than libdbus default due to expensive
+ * selinux operation: see https://bugzilla.redhat.com/show_bug.cgi?id=1654537
+ */
+#define SBUS_MESSAGE_TIMEOUT 120000
 
 /**
  * Bound message with a talloc context.


### PR DESCRIPTION
As discussed in #1654537, first login to a system as a FreeIPA
domain user now usually causes an expensive SELinux operation
to happen; this can take longer than the default dbus message
timeout of 25 seconds. To deal with this for now, let's use a
120 second default timeout; this is a big hammer, but unless we
can refactor things to use a longer timeout just for that one
call, or make the actual operation take less time, there's not
much else we can do.

Resolves:
https://bugzilla.redhat.com/show_bug.cgi?id=1654537

Signed-off-by: Adam Williamson <awilliam@redhat.com>