### PR TITLE
NSS: Avoid changing the memory cache ownership away from the sssd user (sssd-1-16 backport)

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -1025,11 +1025,11 @@ done
 %dir %{sssdstatedir}
 %dir %{_localstatedir}/cache/krb5rcache
 %attr(700,sssd,sssd) %dir %{dbpath}
-%attr(755,sssd,sssd) %dir %{mcpath}
+%attr(775,sssd,sssd) %dir %{mcpath}
 %attr(751,sssd,sssd) %dir %{deskprofilepath}
-%ghost %attr(0644,sssd,sssd) %verify(not md5 size mtime) %{mcpath}/passwd
-%ghost %attr(0644,sssd,sssd) %verify(not md5 size mtime) %{mcpath}/group
-%ghost %attr(0644,sssd,sssd) %verify(not md5 size mtime) %{mcpath}/initgroups
+%ghost %attr(0664,sssd,sssd) %verify(not md5 size mtime) %{mcpath}/passwd
+%ghost %attr(0664,sssd,sssd) %verify(not md5 size mtime) %{mcpath}/group
+%ghost %attr(0664,sssd,sssd) %verify(not md5 size mtime) %{mcpath}/initgroups
 %attr(755,sssd,sssd) %dir %{pipepath}
 %attr(750,sssd,root) %dir %{pipepath}/private
 %attr(755,sssd,sssd) %dir %{pubconfpath}

--- a/src/responder/nss/nss_private.h
+++ b/src/responder/nss/nss_private.h
@@ -87,6 +87,8 @@ struct nss_ctx {
     struct sss_mc_ctx *pwd_mc_ctx;
     struct sss_mc_ctx *grp_mc_ctx;
     struct sss_mc_ctx *initgr_mc_ctx;
+    uid_t mc_uid;
+    gid_t mc_gid;
 };
 
 struct sss_cmd_table *get_nss_cmds(void);

--- a/src/responder/nss/nsssrv.c
+++ b/src/responder/nss/nsssrv.c
@@ -101,7 +101,8 @@ static int nss_clear_memcache(struct sbus_request *dbus_req, void *data)
 
     /* TODO: read cache sizes from configuration */
     DEBUG(SSSDBG_TRACE_FUNC, "Clearing memory caches.\n");
-    ret = sss_mmap_cache_reinit(nctx, SSS_MC_CACHE_ELEMENTS,
+    ret = sss_mmap_cache_reinit(nctx, nctx->mc_uid, nctx->mc_gid,
+                                SSS_MC_CACHE_ELEMENTS,
                                 (time_t) memcache_timeout,
                                 &nctx->pwd_mc_ctx);
     if (ret != EOK) {
@@ -110,7 +111,8 @@ static int nss_clear_memcache(struct sbus_request *dbus_req, void *data)
         return ret;
     }
 
-    ret = sss_mmap_cache_reinit(nctx, SSS_MC_CACHE_ELEMENTS,
+    ret = sss_mmap_cache_reinit(nctx, nctx->mc_uid, nctx->mc_gid,
+                                SSS_MC_CACHE_ELEMENTS,
                                 (time_t) memcache_timeout,
                                 &nctx->grp_mc_ctx);
     if (ret != EOK) {
@@ -119,7 +121,8 @@ static int nss_clear_memcache(struct sbus_request *dbus_req, void *data)
         return ret;
     }
 
-    ret = sss_mmap_cache_reinit(nctx, SSS_MC_CACHE_ELEMENTS,
+    ret = sss_mmap_cache_reinit(nctx, nctx->mc_uid, nctx->mc_gid,
+                                SSS_MC_CACHE_ELEMENTS,
                                 (time_t)memcache_timeout,
                                 &nctx->initgr_mc_ctx);
     if (ret != EOK) {
@@ -284,21 +287,27 @@ static int setup_memcaches(struct nss_ctx *nctx)
     }
 
     /* TODO: read cache sizes from configuration */
-    ret = sss_mmap_cache_init(nctx, "passwd", SSS_MC_PASSWD,
+    ret = sss_mmap_cache_init(nctx, "passwd",
+                              nctx->mc_uid, nctx->mc_gid,
+                              SSS_MC_PASSWD,
                               SSS_MC_CACHE_ELEMENTS, (time_t)memcache_timeout,
                               &nctx->pwd_mc_ctx);
     if (ret) {
         DEBUG(SSSDBG_CRIT_FAILURE, "passwd mmap cache is DISABLED\n");
     }
 
-    ret = sss_mmap_cache_init(nctx, "group", SSS_MC_GROUP,
+    ret = sss_mmap_cache_init(nctx, "group",
+                              nctx->mc_uid, nctx->mc_gid,
+                              SSS_MC_GROUP,
                               SSS_MC_CACHE_ELEMENTS, (time_t)memcache_timeout,
                               &nctx->grp_mc_ctx);
     if (ret) {
         DEBUG(SSSDBG_CRIT_FAILURE, "group mmap cache is DISABLED\n");
     }
 
-    ret = sss_mmap_cache_init(nctx, "initgroups", SSS_MC_INITGROUPS,
+    ret = sss_mmap_cache_init(nctx, "initgroups",
+                              nctx->mc_uid, nctx->mc_gid,
+                              SSS_MC_INITGROUPS,
                               SSS_MC_CACHE_ELEMENTS, (time_t)memcache_timeout,
                               &nctx->initgr_mc_ctx);
     if (ret) {
@@ -306,6 +315,79 @@ static int setup_memcaches(struct nss_ctx *nctx)
     }
 
     return EOK;
+}
+
+static int sssd_supplementary_group(struct nss_ctx *nss_ctx)
+{
+    errno_t ret;
+    int size;
+    gid_t *supp_gids = NULL;
+
+    /*
+     * We explicitly read the IDs of the SSSD user even though the server
+     * receives --uid and --gid by parameters to account for the case where
+     * the SSSD is compiled --with-sssd-user=sssd but the default of the
+     * user option is root (this is what RHEL does)
+     */
+    ret = sss_user_by_name_or_uid(SSSD_USER,
+                                  &nss_ctx->mc_uid,
+                                  &nss_ctx->mc_gid);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_MINOR_FAILURE, "Cannot get info on "SSSD_USER);
+        return ret;
+    }
+
+    if (getgid() == nss_ctx->mc_gid) {
+        DEBUG(SSSDBG_TRACE_FUNC, "Already running as the sssd group\n");
+        return EOK;
+    }
+
+    size = getgroups(0, NULL);
+    if (size == -1) {
+        ret = errno;
+        DEBUG(SSSDBG_CRIT_FAILURE, "Getgroups failed! (%d, %s)\n",
+                                    ret, sss_strerror(ret));
+        return ret;
+    }
+
+    if (size > 0) {
+        supp_gids = talloc_zero_array(NULL, gid_t, size);
+        if (supp_gids == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "Allocation failed!\n");
+            ret = ENOMEM;
+            goto done;
+        }
+    }
+
+    size = getgroups(size, supp_gids);
+    if (size == -1) {
+        ret = errno;
+        DEBUG(SSSDBG_CRIT_FAILURE, "Getgroups failed! (%d, %s)\n",
+                                    ret, sss_strerror(ret));
+        goto done;
+    }
+
+    for (int i = 0; i < size; i++) {
+        if (supp_gids[i] == nss_ctx->mc_gid) {
+            DEBUG(SSSDBG_TRACE_FUNC,
+                  "Already assigned to the SSSD supplementary group\n");
+            ret = EOK;
+            goto done;
+        }
+    }
+
+    ret = setgroups(1, &nss_ctx->mc_gid);
+    if (ret != EOK) {
+        ret = errno;
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Cannot setgroups [%d]: %s\n", ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = EOK;
+done:
+    talloc_free(supp_gids);
+    return ret;
 }
 
 int nss_process_init(TALLOC_CTX *mem_ctx,
@@ -403,6 +485,18 @@ int nss_process_init(TALLOC_CTX *mem_ctx,
     if (nctx->netgrent == NULL) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Unable to initialize netgroups table!\n");
         ret = EFAULT;
+        goto fail;
+    }
+    /*
+     * Adding the NSS process to the SSSD supplementary group avoids
+     * dac_override AVC messages from SELinux in case sssd_nss runs
+     * as root and tries to write to memcache owned by sssd:sssd
+     */
+    ret = sssd_supplementary_group(nctx);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_MINOR_FAILURE,
+              "Cannot add process to the sssd supplementary group [%d]: %s\n",
+              ret, sss_strerror(ret));
         goto fail;
     }
 

--- a/src/responder/nss/nsssrv_mmap_cache.h
+++ b/src/responder/nss/nsssrv_mmap_cache.h
@@ -34,6 +34,7 @@ enum sss_mc_type {
 };
 
 errno_t sss_mmap_cache_init(TALLOC_CTX *mem_ctx, const char *name,
+                            uid_t uid, gid_t gid,
                             enum sss_mc_type type, size_t n_elem,
                             time_t valid_time, struct sss_mc_ctx **mcc);
 
@@ -70,7 +71,9 @@ errno_t sss_mmap_cache_gr_invalidate_gid(struct sss_mc_ctx *mcc, gid_t gid);
 errno_t sss_mmap_cache_initgr_invalidate(struct sss_mc_ctx *mcc,
                                          struct sized_string *name);
 
-errno_t sss_mmap_cache_reinit(TALLOC_CTX *mem_ctx, size_t n_elem,
+errno_t sss_mmap_cache_reinit(TALLOC_CTX *mem_ctx,
+                              uid_t uid, gid_t gid,
+                              size_t n_elem,
                               time_t timeout, struct sss_mc_ctx **mc_ctx);
 
 void sss_mmap_cache_reset(struct sss_mc_ctx *mc_ctx);


### PR DESCRIPTION
Resolves:
https://pagure.io/SSSD/sssd/issue/3890

In case SSSD is compiled --with-sssd-user but run as root (which is the
default on RHEL and derivatives), then the memory cache will be owned by
the user that sssd_nss runs as, so root.

This conflicts with the packaging which specifies sssd.sssd as the owner. And
in turn, this means that users can't reliably assess the package integrity
using rpm -V.

This patch makes sure that the memory cache files are chowned to sssd.sssd
even if the nss responder runs as root.

Also, this patch changes the sssd_nss responder so that is becomes a member
of the supplementary sssd group. Even though in traditional UNIX sense,
a process running as root could write to a file owned by sssd:sssd, with
SELinux enforcing mode this becomes problematic as SELinux emits an error
such as:

type=AVC msg=audit(1543524888.125:1495): avc:  denied  { fsetid } for
pid=7706 comm="sssd_nss" capability=4  scontext=system_u:system_r:sssd_t:s0
tcontext=system_u:system_r:sssd_t:s0 tclass=capability

To make it possible for the sssd_nss process to write to the files, the
files are also made group-writable. The 'others' permission is still set
to read only.

Reviewed-by: Michal Židek <mzidek@redhat.com>
(cherry picked from commit 61e4ba58934b20a950255e05797aca25aadc1242)