### PR TITLE
ifp: extraAttributes is UnknownProperty

### DIFF
--- a/src/responder/ifp/ifp_iface/ifp_iface.c
+++ b/src/responder/ifp/ifp_iface/ifp_iface.c
@@ -173,8 +173,8 @@ ifp_register_sbus_interface(struct sbus_connection *conn,
             SBUS_SYNC(GETTER, org_freedesktop_sssd_infopipe_Users_User, uniqueID, ifp_users_user_get_unique_id, ctx),
             SBUS_SYNC(GETTER, org_freedesktop_sssd_infopipe_Users_User, groups, ifp_users_user_get_groups, ctx),
             SBUS_SYNC(GETTER, org_freedesktop_sssd_infopipe_Users_User, domain, ifp_users_user_get_domain, ctx),
-            SBUS_SYNC(GETTER, org_freedesktop_sssd_infopipe_Users_User, domainname, ifp_users_user_get_domainname, ctx)
-//            SBUS_SYNC(GETTER, org_freedesktop_sssd_infopipe_Users_User, extraAttributes, ifp_users_user_get_extra_attributes, ctx)
+            SBUS_SYNC(GETTER, org_freedesktop_sssd_infopipe_Users_User, domainname, ifp_users_user_get_domainname, ctx),
+            SBUS_SYNC(GETTER, org_freedesktop_sssd_infopipe_Users_User, extraAttributes, ifp_users_user_get_extra_attributes, ctx)
         )
     );
 

--- a/src/responder/ifp/ifpsrv_util.c
+++ b/src/responder/ifp/ifpsrv_util.c
@@ -30,7 +30,7 @@
                                 SYSDB_GIDNUM, SYSDB_GECOS,  \
                                 SYSDB_HOMEDIR, SYSDB_SHELL, \
                                 "groups", "domain", "domainname", \
-                                NULL}
+                                "extraAttributes", NULL}
 
 errno_t ifp_add_value_to_dict(DBusMessageIter *iter_dict,
                               const char *key,

--- a/src/tests/cmocka/test_ifp.c
+++ b/src/tests/cmocka/test_ifp.c
@@ -172,7 +172,8 @@ void test_attr_acl(void **state)
     const char *exp_defaults[] = { SYSDB_NAME, SYSDB_UIDNUM,
                                    SYSDB_GIDNUM, SYSDB_GECOS,
                                    SYSDB_HOMEDIR, SYSDB_SHELL,
-                                   "groups", "domain", "domainname", NULL };
+                                   "groups", "domain", "domainname",
+                                   "extraAttributes", NULL };
     attr_parse_test(exp_defaults, NULL);
 
     /* Test adding some attributes to the defaults */
@@ -180,7 +181,8 @@ void test_attr_acl(void **state)
                               SYSDB_NAME, SYSDB_UIDNUM,
                               SYSDB_GIDNUM, SYSDB_GECOS,
                               SYSDB_HOMEDIR, SYSDB_SHELL,
-                              "groups", "domain", "domainname", NULL };
+                              "groups", "domain", "domainname",
+                              "extraAttributes", NULL };
     attr_parse_test(exp_add, "+telephoneNumber, +streetAddress");
 
     /* Test removing some attributes to the defaults */
@@ -188,7 +190,7 @@ void test_attr_acl(void **state)
                              SYSDB_GIDNUM, SYSDB_GECOS,
                              SYSDB_HOMEDIR, "groups",
                              "domain", "domainname",
-                             NULL };
+                             "extraAttributes", NULL };
     attr_parse_test(exp_rm, "-"SYSDB_SHELL ",-"SYSDB_UIDNUM);
 
     /* Test both add and remove */
@@ -197,7 +199,7 @@ void test_attr_acl(void **state)
                                  SYSDB_GIDNUM, SYSDB_GECOS,
                                  SYSDB_HOMEDIR, "groups",
                                  "domain", "domainname",
-                                 NULL };
+                                 "extraAttributes", NULL };
     attr_parse_test(exp_add_rm, "+telephoneNumber, -"SYSDB_SHELL);
 
     /* Test rm trumps add */
@@ -205,7 +207,8 @@ void test_attr_acl(void **state)
                                           SYSDB_GIDNUM, SYSDB_GECOS,
                                           SYSDB_HOMEDIR, SYSDB_SHELL,
                                           "groups", "domain",
-                                          "domainname", NULL };
+                                          "domainname",
+                                          "extraAttributes", NULL };
     attr_parse_test(exp_add_rm_override,
                     "+telephoneNumber, -telephoneNumber, +telephoneNumber");
 
@@ -214,7 +217,7 @@ void test_attr_acl(void **state)
     attr_parse_test(rm_all,  "-"SYSDB_NAME ", -"SYSDB_UIDNUM
                              ", -"SYSDB_GIDNUM ", -"SYSDB_GECOS
                              ", -"SYSDB_HOMEDIR ", -"SYSDB_SHELL", -groups, "
-                             "-domain, -domainname");
+                             "-domain, -domainname, -extraAttributes");
 
     /* Malformed list */
     attr_parse_test(NULL,  "missing_plus_or_minus");


### PR DESCRIPTION
Attempting to get extraAttributes via SSSD's ifp fails.

Here I uncomment interface function for extraAttributes.
also right for querying this interface is changed to allow
this request.

Resolves:
https://pagure.io/SSSD/sssd/issue/3906