### PR TITLE
contrib/ci/deps.sh: added missing dependency

### DIFF
--- a/contrib/ci/deps.sh
+++ b/contrib/ci/deps.sh
@@ -100,6 +100,7 @@ if [[ "$DISTRO_BRANCH" == -debian-* ]]; then
         libnl-route-3-dev
         libnspr4-dev
         libnss3-dev
+        libnss3-tools
         libpam0g-dev
         libpcre3-dev
         libpopt-dev


### PR DESCRIPTION
Added libnss3-tools to list of debian dependencies:
certutil from this package is required by test_pam_responder.py.