### PR TITLE
AD/IPA: Reset subdomain service name, not domain name

### DIFF
--- a/src/providers/ad/ad_common.c
+++ b/src/providers/ad/ad_common.c
@@ -839,6 +839,19 @@ done:
     return ret;
 }
 
+void
+ad_failover_reset(struct be_ctx *bectx,
+                  struct ad_service *adsvc)
+{
+    if (adsvc == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "NULL service\n");
+        return;
+    }
+
+    sdap_service_reset_fo(bectx, adsvc->sdap);
+    sdap_service_reset_fo(bectx, adsvc->gc);
+}
+
 static void
 ad_resolve_callback(void *private_data, struct fo_server *server)
 {

--- a/src/providers/ad/ad_common.h
+++ b/src/providers/ad/ad_common.h
@@ -148,6 +148,10 @@ ad_failover_init(TALLOC_CTX *mem_ctx, struct be_ctx *ctx,
                  bool use_kdcinfo,
                  struct ad_service **_service);
 
+void
+ad_failover_reset(struct be_ctx *bectx,
+                  struct ad_service *adsvc);
+
 errno_t
 ad_get_id_options(struct ad_options *ad_opts,
                    struct confdb_ctx *cdb,

--- a/src/providers/ipa/ipa_subdomains_id.c
+++ b/src/providers/ipa/ipa_subdomains_id.c
@@ -1770,6 +1770,7 @@ static void ipa_srv_ad_acct_retried(struct tevent_req *subreq)
               "Failed to re-set subdomain [%d]: %s\n", ret, sss_strerror(ret));
         state->dp_error = DP_ERR_FATAL;
         tevent_req_error(req, ret);
+        return;
     }
 
     DEBUG(SSSDBG_TRACE_FUNC, "Subdomain re-set, will retry lookup\n");
@@ -1789,6 +1790,7 @@ static void ipa_srv_ad_acct_retried(struct tevent_req *subreq)
               "Failed to look up AD acct [%d]: %s\n", ret, sss_strerror(ret));
         state->dp_error = DP_ERR_FATAL;
         tevent_req_error(req, ret);
+        return;
     }
 }
 

--- a/src/providers/ldap/ldap_common.c
+++ b/src/providers/ldap/ldap_common.c
@@ -520,6 +520,17 @@ static int ldap_user_data_cmp(void *ud1, void *ud2)
     return strcasecmp((char*) ud1, (char*) ud2);
 }
 
+void sdap_service_reset_fo(struct be_ctx *ctx,
+                           struct sdap_service *service)
+{
+    if (service == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "NULL service\n");
+        return;
+    }
+
+    be_fo_reset_svc(ctx, service->name);
+}
+
 int sdap_service_init(TALLOC_CTX *memctx, struct be_ctx *ctx,
                       const char *service_name, const char *dns_service_name,
                       const char *urls, const char *backup_urls,

--- a/src/providers/ldap/ldap_common.h
+++ b/src/providers/ldap/ldap_common.h
@@ -171,6 +171,9 @@ int sdap_service_init(TALLOC_CTX *memctx, struct be_ctx *ctx,
                       const char *urls, const char *backup_urls,
                       struct sdap_service **_service);
 
+void sdap_service_reset_fo(struct be_ctx *ctx,
+                           struct sdap_service *service);
+
 const char *sdap_gssapi_realm(struct dp_option *opts);
 
 int sdap_gssapi_init(TALLOC_CTX *mem_ctx,


### PR DESCRIPTION
Related: https://pagure.io/SSSD/sssd/issue/3911

Since commit 778f241e78241b0d6b8734148175f8dee804f494 the subdomain fail 
over services use the "sd_" prefix. This was done to make it easier, until
the whole failover design works better with subdomains, to see which
services belong to the main domain from tools.

However, some parts of the code would still just use the domain name for 
the failover service, which meant the service was not found, notably when
trying to reset services:

(Thu Dec 13 05:29:31 2018) [sssd[be[testrelm.test]]]
[ipa_srv_ad_acct_retried] (0x0400): Subdomain re-set, will retry lookup
(Thu Dec 13 05:29:31 2018) [sssd[be[testrelm.test]]] [be_fo_reset_svc]
(0x1000): Resetting all servers in service ipaad2016.test
(Thu Dec 13 05:29:31 2018) [sssd[be[testrelm.test]]] [be_fo_reset_svc]
(0x0080): Cannot retrieve service [ipaad2016.test]

This patch switches to reading the service names from the ad_options and 
the sdap_service structures that are contained within ad_options.