### PR TITLE
KCM: Deleting a non-existent ccache should not yield an error

### DIFF
--- a/src/responder/kcm/kcmsrv_ops.c
+++ b/src/responder/kcm/kcmsrv_ops.c
@@ -698,9 +698,10 @@ static void kcm_op_destroy_getbyname_done(struct tevent_req *subreq)
     ret = kcm_ccdb_uuid_by_name_recv(subreq, state, uuid);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE,
+        DEBUG(SSSDBG_MINOR_FAILURE,
               "Cannot get matching ccache [%d]: %s\n",
               ret, sss_strerror(ret));
+        ret = ERR_NO_MATCHING_CREDS;
         tevent_req_error(req, ret);
         return;
     }

--- a/src/tests/multihost/basic/test_kcm.py
+++ b/src/tests/multihost/basic/test_kcm.py
@@ -122,3 +122,20 @@ class TestSanityKCM(object):
 
         log_lines_debug = self._kcm_log_length(multihost)
         assert log_lines_debug > log_lines_pre + 100
+
+    def test_kdestroy_retval(self, multihost, enable_kcm):
+        """
+        Test that destroying an empty cache does not return a non-zero
+        return code.
+        """
+        ssh = SSHClient(multihost.master[0].sys_hostname,
+                        username='foo3', password='Secret123')
+
+        (_, _, exit_status) = ssh.execute_cmd('kdestroy')
+        assert exit_status == 0
+        # Run the command again in case there was something in the ccache
+        # previously
+        (_, _, exit_status) = ssh.execute_cmd('kdestroy')
+        assert exit_status == 0
+
+        ssh.close()


### PR DESCRIPTION
Resolves: https://pagure.io/SSSD/sssd/issue/3910

When the KCM destroy operation is called, it receives a name as an input.
If the name cannot be found, we would currently return KRB5_CC_NOTFOUND.
But other ccache types return KRB5_FCC_NOFILE in that case and e.g.
utilities like kdestroy special case KRB5_FCC_NOFILE to be non-fatal.