### PR TITLE
confdb: sssd tools don't handle the implicit domain

### DIFF
--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -42,6 +42,9 @@
 #define RETRIEVE_DOMAIN_ERROR_MSG "Error (%d [%s]) retrieving domain [%s], "\
                                   "skipping!\n"
 
+/* SSSD domain name that is used for the auto-configured files domain */
+#define IMPLICIT_FILES_DOMAIN_NAME "implicit_files"
+
 static char *prepend_cn(char *str, int *slen, const char *comp, int clen)
 {
     char *ret;
@@ -1932,8 +1935,8 @@ done:
     return ret;
 }
 
-int confdb_ensure_files_domain(struct confdb_ctx *cdb,
-                               const char *implicit_files_dom_name)
+static int confdb_ensure_files_domain(struct confdb_ctx *cdb,
+                                      const char *implicit_files_dom_name)
 {
 #ifdef ADD_FILES_DOMAIN
     const bool default_enable_files = true;
@@ -2164,6 +2167,14 @@ int confdb_expand_app_domains(struct confdb_ctx *cdb)
     tmp_ctx = talloc_new(NULL);
     if (tmp_ctx == NULL) {
         return ENOMEM;
+    }
+
+    ret = confdb_ensure_files_domain(cdb, IMPLICIT_FILES_DOMAIN_NAME);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_MINOR_FAILURE,
+              "Cannot add the implicit files domain [%d]: %s\n",
+              ret, strerror(ret));
+        /* Not fatal */
     }
 
     ret = confdb_get_string_as_list(cdb, tmp_ctx,

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -437,9 +437,6 @@ int confdb_get_domain(struct confdb_ctx *cdb,
 int confdb_get_domains(struct confdb_ctx *cdb,
                        struct sss_domain_info **domains);
 
-int confdb_ensure_files_domain(struct confdb_ctx *cdb,
-                               const char *implicit_files_dom_name);
-
 int confdb_expand_app_domains(struct confdb_ctx *cdb);
 
 /**

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -90,9 +90,6 @@
                                  "that the file is accessible only by the "\
                                  "owner and owned by root.root.\n"
 
-/* SSSD domain name that is used for the auto-configured files domain */
-#define IMPLICIT_FILES_DOMAIN_NAME "implicit_files"
-
 int cmdline_debug_level;
 int cmdline_debug_timestamps;
 int cmdline_debug_microseconds;
@@ -968,14 +965,6 @@ static int get_monitor_config(struct mt_ctx *ctx)
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Failed to get the unprivileged user\n");
         return ret;
-    }
-
-    ret = confdb_ensure_files_domain(ctx->cdb, IMPLICIT_FILES_DOMAIN_NAME);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_MINOR_FAILURE,
-              "Cannot add the implicit files domain [%d]: %s\n",
-              ret, strerror(ret));
-        /* Not fatal */
     }
 
     ret = confdb_expand_app_domains(ctx->cdb);


### PR DESCRIPTION
When no sssd.conf exists, sssctl can not read objects from the cache
This happend because implicit files domain is not taken into
account when creating list of domains. With implicit files domain
it should expand at least to this one domain.

Resolves:
https://pagure.io/SSSD/sssd/issue/3769