### PR TITLE
sss_client/common.c: fix Coverity issue (issue 3841)

### DIFF
--- a/src/sss_client/common.c
+++ b/src/sss_client/common.c
@@ -539,7 +539,7 @@ static int sss_cli_open_socket(int *errnop, const char *socket_name, int timeout
     int ret;
     int sd;
 
-    if (sizeof(nssaddr.sun_path) <= strlen(socket_name) + 1) {
+    if (sizeof(nssaddr.sun_path) < strlen(socket_name) + 1) {
         *errnop = EINVAL;
         return -1;
     }

--- a/src/sss_client/common.c
+++ b/src/sss_client/common.c
@@ -546,7 +546,7 @@ static int sss_cli_open_socket(int *errnop, const char *socket_name, int timeout
 
     memset(&nssaddr, 0, sizeof(struct sockaddr_un));
     nssaddr.sun_family = AF_UNIX;
-    strncpy(nssaddr.sun_path, socket_name, sizeof(nssaddr.sun_path));
+    strcpy(nssaddr.sun_path, socket_name); /* safe due to above check */
 
     sd = socket(AF_UNIX, SOCK_STREAM, 0);
     if (sd == -1) {


### PR DESCRIPTION
sss_client/common.c: fix Coverity issue

Usage of strncpy(nssaddr.sun_path, socket_name, sizeof(nssaddr.sun_path))
1) confuses Coverity due to 3rd argument being equal to sizeof(1st)
2) again zeroes previously zeroed buffer
So replaced with strcpy()
This should be safe due to existing check of sizes.

Resolves: https://pagure.io/SSSD/sssd/issue/3841