### PR TITLE
providers/ldap: abort unsecure authentication requests

### DIFF
--- a/src/providers/ldap/ldap_auth.c
+++ b/src/providers/ldap/ldap_auth.c
@@ -754,7 +754,7 @@ static bool check_encryption_used(LDAP *ldap)
     int ret;
 
     ret = ldap_get_option(ldap, LDAP_OPT_X_SASL_SSF, &sasl_ssf);
-    if (ret != LDAP_SUCCESS) {
+    if (ret != LDAP_OPT_SUCCESS) {
         DEBUG(SSSDBG_TRACE_LIBS, "ldap_get_option failed to get sasl ssf, "
                                  "assuming SASL is not used.\n");
     }

--- a/src/providers/ldap/ldap_auth.c
+++ b/src/providers/ldap/ldap_auth.c
@@ -757,6 +757,7 @@ static bool check_encryption_used(LDAP *ldap)
     if (ret != LDAP_OPT_SUCCESS) {
         DEBUG(SSSDBG_TRACE_LIBS, "ldap_get_option failed to get sasl ssf, "
                                  "assuming SASL is not used.\n");
+        sasl_ssf = 0;
     }
 
     tls_inplace = ldap_tls_inplace(ldap);


### PR DESCRIPTION
Abort LDAP authentication if the connection is not authenticated and
SDAP_DISABLE_AUTH_TLS is off.

Resolves: https://pagure.io/SSSD/sssd/issue/3889