### PR TITLE
sbus: do not use signature when copying dictionary entry

### DIFF
--- a/src/sbus/interface/sbus_properties.c
+++ b/src/sbus/interface/sbus_properties.c
@@ -181,10 +181,17 @@ sbus_copy_iterator_container(DBusMessageIter *from,
     errno_t ret;
 
     dbus_message_iter_recurse(from, &from_sub);
-    signature = dbus_message_iter_get_signature(&from_sub);
-    if (signature == NULL) {
-        ret = ENOMEM;
-        goto done;
+
+    if (type == DBUS_TYPE_DICT_ENTRY) {
+        /* This is a special case. Dictionary entries do not have any specific
+         * signature when we open their container. */
+        signature = NULL;
+    } else {
+        signature = dbus_message_iter_get_signature(&from_sub);
+        if (signature == NULL) {
+            ret = ENOMEM;
+            goto done;
+        }
     }
 
     dbret = dbus_message_iter_open_container(to, type, signature, &to_sub);


### PR DESCRIPTION
When we open container for DBUS_TYPE_DICT_ENTRY, dbus expects the
signature to be NULL.

Reproducer:

1. Setup custom attributes
```
[ifp]
user_attributes = +test

[domain/ldap.vm]
...
ldap_user_extra_attrs = test:homeDirectory
```

2. Run SSSD and require those attributes for example with
```
sssctl user-checks user-1
```

3. SSSD will crash without the patch