### PR TITLE
KCM: Allow representing ccaches with a NULL principal

### DIFF
--- a/src/responder/kcm/kcmsrv_ccache.c
+++ b/src/responder/kcm/kcmsrv_ccache.c
@@ -68,14 +68,16 @@ errno_t kcm_cc_new(TALLOC_CTX *mem_ctx,
 
     uuid_generate(cc->uuid);
 
-    kret = krb5_copy_principal(k5c, princ, &cc->client);
-    if (kret != 0) {
-        const char *err_msg = sss_krb5_get_error_message(k5c, kret);
-        DEBUG(SSSDBG_OP_FAILURE,
-              "krb5_copy_principal failed: [%d][%s]\n", kret, err_msg);
-        sss_krb5_free_error_message(k5c, err_msg);
-        ret = ERR_INTERNAL;
-        goto done;
+    if (princ) {
+        kret = krb5_copy_principal(k5c, princ, &cc->client);
+        if (kret != 0) {
+            const char *err_msg = sss_krb5_get_error_message(k5c, kret);
+            DEBUG(SSSDBG_OP_FAILURE,
+                "krb5_copy_principal failed: [%d][%s]\n", kret, err_msg);
+            sss_krb5_free_error_message(k5c, err_msg);
+            ret = ERR_INTERNAL;
+            goto done;
+        }
     }
 
     cc->owner.uid = cli_creds_get_uid(owner);

--- a/src/responder/kcm/kcmsrv_ops.c
+++ b/src/responder/kcm/kcmsrv_ops.c
@@ -527,7 +527,7 @@ static void kcm_op_initialize_create_step(struct tevent_req *req)
                                      state->op_ctx->client,
                                      state->new_cc);
     if (subreq == NULL) {
-        tevent_req_error(req, ret);
+        tevent_req_error(req, ENOMEM);
         return;
     }
     tevent_req_set_callback(subreq, kcm_op_initialize_cc_create_done, req);


### PR DESCRIPTION
Related: https://pagure.io/SSSD/sssd/issue/3873

We need to make it possible to create an internal ccache representation 
without passing in a principal. The principal is only assigned to the 
ccache with krb5_cc_initialize(), but some programs like openssh use the 
following sequence of calls:
   krb5_cc_new_unique
   krb5_cc_switch
   krb5_cc_initialize