### PR TITLE
sbus/interface: fixed interface copy helpers

### DIFF
--- a/src/sbus/interface/sbus_interface.c
+++ b/src/sbus/interface/sbus_interface.c
@@ -109,7 +109,7 @@ sbus_method_copy(TALLOC_CTX *mem_ctx,
 
     /* All data is either pointer to a static data or it is not a pointer.
      * We can just copy it. */
-    memcpy(copy, input, sizeof(struct sbus_method) * count + 1);
+    memcpy(copy, input, sizeof(struct sbus_method) * (count + 1));
 
     return copy;
 }
@@ -144,7 +144,7 @@ sbus_signal_copy(TALLOC_CTX *mem_ctx,
 
     /* All data is either pointer to a static data or it is not a pointer.
      * We can just copy it. */
-    memcpy(copy, input, sizeof(struct sbus_signal) * count + 1);
+    memcpy(copy, input, sizeof(struct sbus_signal) * (count + 1));
 
     return copy;
 }
@@ -208,7 +208,7 @@ sbus_property_copy(TALLOC_CTX *mem_ctx,
 
     /* All data is either pointer to a static data or it is not a pointer.
      * We can just copy it. */
-    memcpy(copy, input, sizeof(struct sbus_property) * count + 1);
+    memcpy(copy, input, sizeof(struct sbus_property) * (count + 1));
 
     return copy;
 }


### PR DESCRIPTION
In `sbus_method_copy()` and other copy helpers there was code like:
```
copy = talloc_zero_array(mem_ctx, struct sbus_method, count + 1);
memcpy(copy, input, sizeof(struct sbus_method) * count + 1);
```
Copy of one byte of "sentinel" doesn't make a sense.
We can either rely on the fact that sentinel is zero-initialized struct
*and* `talloc_zero_array()` zero-initializes memory (so copying of
sentinel may be omitted at all) or just copy sentinel in a whole.
Opted for second option as more clear variant.