### PR TITLE
lib/cifs_idmap_sss: fixed unaligned mem access

### DIFF
--- a/src/lib/cifs_idmap_sss/cifs_idmap_sss.c
+++ b/src/lib/cifs_idmap_sss/cifs_idmap_sss.c
@@ -217,12 +217,14 @@ static int sss_sid_to_id(struct sssd_ctx *ctx, const char *sid,
 {
     int err;
     enum sss_id_type id_type;
+    uint32_t uid;
 
-    err = sss_nss_getidbysid(sid, (uint32_t *)&cuxid->id.uid, &id_type);
+    err = sss_nss_getidbysid(sid, &uid, &id_type);
     if (err != 0)  {
         ctx_set_error(ctx, strerror(err));
         return -1;
     }
+    cuxid->id.uid = (uid_t)uid;
 
     switch (id_type) {
     case SSS_ID_TYPE_UID:


### PR DESCRIPTION
Fixed following warning:
```
lib/cifs_idmap_sss/cifs_idmap_sss.c: In function ‘sss_sid_to_id’:
lib/cifs_idmap_sss/cifs_idmap_sss.c:221:47: warning: taking address
of packed member of ‘struct cifs_uxid’ may result in an unaligned
pointer value [-Waddress-of-packed-member]

err = sss_nss_getidbysid(sid, (uint32_t *)&cuxid->id.uid, &id_type);
```

Actually there are two issues:
1) Packed `cifs_uxid::id.uid` may be unaligned thus generating run time
error on some architectures (as compiler complains);
2) In theory size of `uid_t` may be different than size of `uint32_t`
thus resulting in corruption of `cifs_uxid` content.

Proposed patch is not ideal due to `(uid_t)uid` cast but solves most
of issues with minimal effor. Proper solution would require patching of
`sss_nss_getidbysid()` and all underlying functions for no good reason.