### PR TITLE
Added note about default value of ad_gpo_map_batch parameter

### DIFF
--- a/src/man/sssd-ad.5.xml
+++ b/src/man/sssd-ad.5.xml
@@ -668,6 +668,7 @@ ad_gpo_map_network = +my_pam_service, -ftp
 ad_gpo_map_batch = +my_pam_service, -crond
                             </programlisting>
                         </para>
+                        <para>Note: Cron service name may differ depending on Linux distribution used.</para>
                         <para>
                             Default: the default set of PAM service names includes:
                             <itemizedlist>


### PR DESCRIPTION
Various distros uses different names for cron service. Ubuntu uses cron, Suse uses cronie (vixie-cron in the past) and Fedora uses crond. User should be aware that default value might not work as desired on his distro and that default should be updated accordingly. Example of some confusion that default value caused: https://bugs.launchpad.net/ubuntu/+source/sssd/+bug/1572908