### PR TITLE
sbus: terminated active ongoing request when reconnecting

### DIFF
--- a/src/sbus/connection/sbus_dispatcher.c
+++ b/src/sbus/connection/sbus_dispatcher.c
@@ -35,6 +35,10 @@ sbus_dispatch_schedule(struct sbus_connection *conn, uint32_t usecs);
 static void
 sbus_dispatch_reconnect(struct sbus_connection *conn)
 {
+    /* Terminate all outgoing requests associated with this connection. */
+    DEBUG(SSSDBG_TRACE_FUNC, "Connection lost. Terminating active requests.\n");
+    sbus_requests_terminate_all(conn->requests->outgoing, ERR_TERMINATED);
+
     switch (conn->type) {
     case SBUS_CONNECTION_CLIENT:
         /* Remote client closed the connection. We can't reestablish

--- a/src/sbus/request/sbus_request.c
+++ b/src/sbus/request/sbus_request.c
@@ -34,11 +34,6 @@ typedef errno_t
                             DBusMessage **_client_message,
                             DBusMessage ***_reply);
 
-struct sbus_active_requests {
-    hash_table_t *incoming;
-    hash_table_t *outgoing;
-};
-
 struct sbus_active_requests *
 sbus_active_requests_init(TALLOC_CTX *mem_ctx)
 {

--- a/src/sbus/sbus_private.h
+++ b/src/sbus/sbus_private.h
@@ -448,6 +448,11 @@ struct sbus_request_list {
     struct sbus_request_list *next;
 };
 
+struct sbus_active_requests {
+    hash_table_t *incoming;
+    hash_table_t *outgoing;
+};
+
 /* Initialize active requests structure. */
 struct sbus_active_requests *
 sbus_active_requests_init(TALLOC_CTX *mem_ctx);
@@ -478,6 +483,11 @@ sbus_requests_delete(struct sbus_request_list *list);
 void
 sbus_requests_finish(struct sbus_request_list *item,
                      errno_t error);
+
+/* Terminate all requests. */
+void
+sbus_requests_terminate_all(hash_table_t *table,
+                            errno_t error);
 
 /* Create new sbus request. */
 struct sbus_request *


### PR DESCRIPTION
Connection to the remote dbus server was lost. If there are any outgoing
requests they are waiting for a pretty long timeout. During this timeout
we kept chaining even new requests that come after successful reconnection
and these request were waiting for the timeout to ocurr as well because
they were chain to request that started before reconnection.

Now, we terminated all active outgoing request that have a key associated
so we can immediately start sending new requests.

Resolves:
https://pagure.io/SSSD/sssd/issue/3907

This is a trivial solution for now. It would be also possible to resend
existing request after reconnection so their consumers may get correct
answer. This however requires some logic behind in order to detect requests
that actually are causing the crash to avoid endless crash loop of sssd.
I'm thinking on - retry once, if sssd crashes again then kill the request.

Should I create a ticket for this?