### PR TITLE
ad: replace ARRAY_SIZE with N_ELEMENTS

### DIFF
--- a/src/providers/ad/ad_gpo_ndr.c
+++ b/src/providers/ad/ad_gpo_ndr.c
@@ -258,7 +258,7 @@ ndr_pull_dom_sid(struct ndr_pull *ndr,
         NDR_CHECK(ndr_pull_align(ndr, 4));
         NDR_CHECK(ndr_pull_uint8(ndr, NDR_SCALARS, &r->sid_rev_num));
         NDR_CHECK(ndr_pull_int8(ndr, NDR_SCALARS, &r->num_auths));
-        if (r->num_auths < 0 || r->num_auths > ARRAY_SIZE(r->sub_auths)) {
+        if (r->num_auths < 0 || r->num_auths > N_ELEMENTS(r->sub_auths)) {
             return ndr_pull_error(ndr, NDR_ERR_RANGE, "value out of range");
         }
         NDR_CHECK(ndr_pull_array_uint8(ndr, NDR_SCALARS, r->id_auth, 6));

--- a/src/tests/common.h
+++ b/src/tests/common.h
@@ -39,8 +39,6 @@
 #define SSS_ATTRIBUTE_WARN_UNUSED_RESULT
 #endif
 
-#define N_ELEMENTS(arr) (sizeof(arr) / sizeof(arr[0]))
-
 extern TALLOC_CTX *global_talloc_context;
 
 void check_leaks_push(TALLOC_CTX *ctx);

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -726,4 +726,8 @@ errno_t create_preauth_indicator(void);
 #define P11_WAIT_FOR_CARD_TIMEOUT_DEFAULT 60
 #endif  /* SSSD_LIBEXEC_PATH */
 
+#ifndef N_ELEMENTS
+#define N_ELEMENTS(arr) (sizeof(arr) / sizeof(arr[0]))
+#endif
+
 #endif /* __SSSD_UTIL_H__ */


### PR DESCRIPTION
ARRAY_SIZE is taken from the Samba header file memory.h which is not
available as a public header in newer Samba versions anymore. This patch
replaces it with an internal macro.