### PR TITLE
TESTS: Add test case title with @title in docstrings

### DIFF
--- a/src/tests/multihost/basic/test_basic.py
+++ b/src/tests/multihost/basic/test_basic.py
@@ -9,7 +9,9 @@ import pytest
 class TestSanitySSSD(object):
     """ Basic Sanity Test cases """
     def test_ssh_user_login(self, multihost):
-        """Check ssh login as LDAP user with Kerberos credentials """
+        """
+        @Title: Login: Check ssh login as LDAP user with Kerberos credentials
+        """
         try:
             ssh = SSHClient(multihost.master[0].sys_hostname,
                             username='foo1', password='Secret123')
@@ -20,7 +22,9 @@ class TestSanitySSSD(object):
             ssh.close()
 
     def test_kinit(self, multihost):
-        """ Run kinit after user login """
+        """
+        @Title: Login: Verify kinit is successfull after user login
+        """
         try:
             ssh = SSHClient(multihost.master[0].sys_hostname,
                             username='foo2', password='Secret123')
@@ -37,7 +41,7 @@ class TestSanitySSSD(object):
                 ssh.close()
 
     def test_offline_ssh_login(self, multihost):
-        """ Test Offline ssh login """
+        """@Title: Login: Verify offline ssh login"""
         multihost.master[0].transport.get_file('/etc/sssd/sssd.conf',
                                                '/tmp/sssd.conf')
         sssdconfig = ConfigParser.RawConfigParser()

--- a/src/tests/multihost/basic/test_config.py
+++ b/src/tests/multihost/basic/test_config.py
@@ -21,8 +21,8 @@ class TestSSSDConfig(object):
 
     def test_sssd_genconf_sssd_running(self, multihost):
         """
-        Test that sssd --genconf is able to re-generate the configuration
-        even while SSSD is running.
+        @Title: config: sssd --genconf is able to re-generate
+        the configuration even while SSSD is running.
         """
         multihost.master[0].service_sssd('restart')
 
@@ -36,8 +36,8 @@ class TestSSSDConfig(object):
 
     def test_sssd_genconf_section_only(self, multihost):
         """
-        Test that --genconf-section only refreshes those sections given
-        on the command line
+        @Title: config: sssd --genconf-section only
+        refreshes those sections given on the command line
         """
         multihost.master[0].service_sssd('restart')
 
@@ -59,8 +59,8 @@ class TestSSSDConfig(object):
 
     def test_sssd_genconf_add_remove_section(self, multihost):
         """
-        Test that --genconf-section can not only modify existing
-        configuration sections, but also add a new section
+        @Title: config: sssd --genconf-section can not only modify
+        existing configuration sections, but also add a new section
         """
         # Establish a baseline
         multihost.master[0].service_sssd('restart')
@@ -89,8 +89,10 @@ class TestSSSDConfig(object):
 
     def test_sssd_genconf_no_such_section(self, multihost):
         """
-        Referencing a non-existant section must not fail, because
-        we want to call this command from the systemd unit files
+        @Title: config: Referencing a non-existant section must not fail
+
+        @Description: Referencing a non-existant section must not fail,
+        because we want to call this command from the systemd unit files
         and by default the sections don't have to be present
         """
         multihost.master[0].service_sssd('restart')

--- a/src/tests/multihost/basic/test_files.py
+++ b/src/tests/multihost/basic/test_files.py
@@ -23,19 +23,26 @@ class TestImplicitFilesProvider(object):
     together with another domain to stick close to what users use in Fedora
     """
     def test_files_does_not_handle_root(self, multihost):
-        """ The files provider does not handle root """
+        """
+        @Title: files: files provider does not handle root
+        """
         exit_status, _ = get_sss_user(multihost, 'root')
         assert exit_status == 2
 
     def test_files_sanity(self, multihost):
-        """ Test that the files provider can resolve a user """
+        """
+        @Title: files: Test that the files provider can resolve a user
+        """
         exit_status, _ = get_sss_user(multihost, 'lcl1')
         assert exit_status == 0
 
     def test_files_enumeration(self, multihost):
         """
-        Since nss_files enumerates and libc would concatenate the results,
-        the files provider of SSSD should not enumerate
+        @Title: files: Verify files provider do not enumerate
+
+        @Description: Since nss_files enumerates and libc would
+        concatenate the results, the files provider of SSSD should
+        not enumerate
         """
         cmd = multihost.master[0].run_command('getent passwd -s sss')
         assert len(cmd.stdout_text) == 0

--- a/src/tests/multihost/basic/test_ifp.py
+++ b/src/tests/multihost/basic/test_ifp.py
@@ -11,7 +11,7 @@ class TestInfoPipe(object):
     """
     def test_ifp_extra_attributes_property(self, multihost):
         """
-        Test requesting the extraAttributes property works at all,
+        @Title: ifp: requesting the extraAttributes property works
         see e.g.  https://pagure.io/SSSD/sssd/issue/3906
         """
         dbus_send_cmd = \

--- a/src/tests/multihost/basic/test_kcm.py
+++ b/src/tests/multihost/basic/test_kcm.py
@@ -39,7 +39,9 @@ class TestSanityKCM(object):
         return nlines
 
     def test_kinit_kcm(self, multihost, enable_kcm):
-        """ Run kinit with KRB5CCNAME=KCM: """
+        """
+        @Title: kcm: Run kinit with KRB5CCNAME=KCM
+        """
         self._start_kcm(multihost)
         try:
             ssh = SSHClient(multihost.master[0].sys_hostname,
@@ -61,7 +63,9 @@ class TestSanityKCM(object):
             ssh.close()
 
     def test_ssh_login_kcm(self, multihost, enable_kcm):
-        """ Verify ssh logins are successuful with kcm as default """
+        """
+        @Title: kcm: Verify ssh logins are successuful with kcm as default
+        """
         # pylint: disable=unused-argument
         _pytest_fixture = [enable_kcm]
         try:
@@ -77,8 +81,11 @@ class TestSanityKCM(object):
 
     def test_kcm_debug_level_set(self, multihost, enable_kcm):
         """
-        Test that just adding a [kcm] section and restarting the kcm
-        service enables debugging without having to restart the
+        @Title: kcm: After kcm section with debug
+        level set restaring sssd-kcm service enables kcm debugging
+
+        @Description: Test that just adding a [kcm] section and restarting
+        the kcm service enables debugging without having to restart the
         whole sssd
         """
         # Start from a known-good state where the configuration is refreshed
@@ -125,8 +132,8 @@ class TestSanityKCM(object):
 
     def test_kdestroy_retval(self, multihost, enable_kcm):
         """
-        Test that destroying an empty cache does not return a non-zero
-        return code.
+        @Title: kcm: Test that destroying an empty cache does
+        not return a non-zero return code
         """
         ssh = SSHClient(multihost.master[0].sys_hostname,
                         username='foo3', password='Secret123')
@@ -142,7 +149,7 @@ class TestSanityKCM(object):
 
     def test_ssh_forward_creds(self, multihost, enable_kcm):
         """
-        Test that SSH can forward credentials with KCM
+        @Title: kcm: Test that SSH can forward credentials with KCM
 
         A regression test for https://pagure.io/SSSD/sssd/issue/3873
         """

--- a/src/tests/multihost/basic/test_sssctl_config_check.py
+++ b/src/tests/multihost/basic/test_sssctl_config_check.py
@@ -6,7 +6,10 @@ import re
 
 class TestSssctlConfigCheck(object):
     def test_verify_typo_option_name(self, multihost):
-        """ Verify typos in option name (not value) of configuration file """
+        """
+        @Title: sssctl: Verify typos in option name (not value)
+        of configuration file
+        """
         cfgget = '/etc/sssd/sssd.conf'
         cfgput = '/tmp/sssd.conf.backup'
         multihost.master[0].run_command(['/bin/cp',
@@ -32,7 +35,9 @@ class TestSssctlConfigCheck(object):
                                         raiseonerr=False)
 
     def test_verify_typo_domain_name(self, multihost):
-        """ Verify typos in domain name of configuration file """
+        """
+        @Title: sssctl: Verify typos in domain name of configuration file
+        """
         cfgget = '/etc/sssd/sssd.conf'
         cfgput = '/tmp/sssd.conf.backup'
         multihost.master[0].run_command(['/bin/cp',
@@ -58,7 +63,9 @@ class TestSssctlConfigCheck(object):
                                         raiseonerr=False)
 
     def test_misplaced_option(self, multihost):
-        """ Verify misplace options in default configuration file """
+        """
+        @Title: sssctl: Verify misplace options in default configuration file
+        """
         cfgget = '/etc/sssd/sssd.conf'
         cfgput = '/tmp/sssd.conf.backup'
         sssdcfg = multihost.master[0].get_file_contents(cfgget)

--- a/src/tests/multihost/basic/test_sudo.py
+++ b/src/tests/multihost/basic/test_sudo.py
@@ -10,7 +10,9 @@ class TestSanitySudo(object):
     def test_case_senitivity(self, multihost, case_sensitive_sudorule,
                              enable_sss_sudo_nsswitch,
                              set_case_sensitive_false):
-        """ Verify case sensitivity in sudo responder """
+        """
+        @Title: sudo: Verify case sensitivity in sudo responder
+        """
         # pylint: disable=unused-argument
         _pytest_fixtures = [case_sensitive_sudorule, enable_sss_sudo_nsswitch,
                             set_case_sensitive_false]
@@ -35,7 +37,10 @@ class TestSanitySudo(object):
                                   enable_sss_sudo_nsswitch,
                                   generic_sudorule,
                                   set_entry_cache_sudo_timeout):
-        """ Verify refreshing expired sudo rules doesn't crash sssd_sudo """
+        """
+        @Title: sudo: Verify refreshing expired sudo rules
+        do not crash sssd_sudo
+        """
         # pylint: disable=unused-argument
         _pytest_fixtures = [enable_sss_sudo_nsswitch, generic_sudorule,
                             set_entry_cache_sudo_timeout]


### PR DESCRIPTION
Adding test case titles starting with @title.  
When pytest is run with --junit-xml, the resulting junit file contains test function name as test case name. 

With the help of [pytest-modifyjunit](https://pagure.io/pytest-modifyjunit) , this plugin replaces test function name with test case title described with @title. 

sssd qe uses the junit.xml to import the result to Test case management system which tries to match the test case names in junit.xml with the test case title described in tcms. 

https://paste.fedoraproject.org/paste/dHR218kinyECa1yHiLXGxg is the junit.xml which doesn't contain test case title. 

https://paste.fedoraproject.org/paste/kVUlc-2mIibW18ILzbyqcg is the junit.xml which contains test case names with as defined in @title. 
