### PR TITLE
krb5_locator: always use port 88 for master KDC

### DIFF
--- a/src/man/sssd_krb5_locator_plugin.8.xml
+++ b/src/man/sssd_krb5_locator_plugin.8.xml
@@ -20,40 +20,60 @@
         <title>DESCRIPTION</title>
         <para>
             The Kerberos locator plugin
-            <command>sssd_krb5_locator_plugin</command> is used by the Kerberos
-            provider of
-            <citerefentry>
-                <refentrytitle>sssd</refentrytitle>
-                <manvolnum>8</manvolnum>
-            </citerefentry>
-            to tell the Kerberos libraries what Realm and which KDC to use.
-            Typically this is done in
+            <command>sssd_krb5_locator_plugin</command> is used by libkrb5 to
+            find KDCs for a given Kerberos realm. SSSD provides such a plugin to
+            guide all Kerberos clients on a system to a single KDC. In general
+            it should not matter to which KDC a client process is talking to.
+            But there are cases, e.g. after a password change, where not all
+            KDCs are in the same state because the new data has to be replicated
+            first. To avoid unexpected authentication failures and maybe even
+            account lockings it would be good to talk to a single KDC as long as
+            possible.
+        </para>
+        <para>
+            libkrb5 will search the locator plugin in the libkrb5 sub-directory
+            of the Kerberos plugin directory, see plugin_base_dir in
             <citerefentry>
                 <refentrytitle>krb5.conf</refentrytitle>
                 <manvolnum>5</manvolnum>
             </citerefentry>
-            which is always read by the Kerberos libraries. To simplify the
-            configuration the Realm and the KDC can be defined in
-            <citerefentry>
-                <refentrytitle>sssd.conf</refentrytitle>
-                <manvolnum>5</manvolnum>
-            </citerefentry>
-            as described in
-            <citerefentry>
-                <refentrytitle>sssd-krb5</refentrytitle>
-                <manvolnum>5</manvolnum>
-            </citerefentry>
+            for details. The plugin can only be disabled by removing the plugin
+            file. There is no option in the Kerberos configuration to disable
+            it. But the SSSD_KRB5_LOCATOR_DISABLE environment variable can be
+            used to disable the plugin for individual commands. Alternatively
+            the SSSD option krb5_use_kdcinfo=False can be used to not generate
+            the data needed by the plugin. With this the plugin is still
+            called but will provide no data to the caller so that libkrb5 can
+            fall back to other methods defined in krb5.conf.
         </para>
         <para>
-            <citerefentry>
-                <refentrytitle>sssd</refentrytitle>
-                <manvolnum>8</manvolnum>
-            </citerefentry>
-            puts the Realm and the name or IP address of the KDC into the
-            environment variables SSSD_KRB5_REALM and SSSD_KRB5_KDC respectively.
-            When <command>sssd_krb5_locator_plugin</command> is called by the
-            kerberos libraries it reads and evaluates these variables and returns
-            them to the libraries.
+            The plugin reads the information about the KDCs of a given realm
+            from a file called <filename>kdcinfo.REALM</filename>. The file
+            should contain one or more IP addresses either in dotted-decimal
+            IPv4 notation or the hexadecimal IPv6 notation. An optional port
+            number can be added to the end separated with a colon, the IPv6
+            address has to be enclosed in squared brackets in this case as
+            usual. Valid entries are:
+            <itemizedlist>
+                <listitem><para>1.2.3.4</para></listitem>
+                <listitem><para>5.6.7.8:99</para></listitem>
+                <listitem><para>2001:db8:85a3::8a2e:370:7334</para></listitem>
+                <listitem><para>[2001:db8:85a3::8a2e:370:7334]:321</para></listitem>
+            </itemizedlist>
+            SSSD's krb5 auth-provider which is used by the IPA and AD providers
+            as well adds the address of the current KDC or domain controller
+            SSSD is using to this file.
+        </para>
+        <para>
+            In environments with read-only and read-write KDCs where clients are
+            expected to use the read-only instances for the general operations
+            and only the read-write KDC for config changes like password changes
+            a <filename>kpasswdinfo.REALM</filename> is used as well to identify
+            read-write KDCs. If this file exists for the given realm the content
+            will be used by the plugin to reply to requests for a kpasswd or
+            kadmin server or for the MIT Kerberos specific master KDC. If the
+            address contains a port number the default KDC port 88 will be used
+            for the latter.
         </para>
     </refsect1>
 


### PR DESCRIPTION
If the kpasswdinfo file exists and the found IP address includes a port
number as well the master KDC lookup will use this port number which is
most probably wrong. Better use the default port 88 always for master
KDC lookups.

This patch also updates the man page for the locator plugin which was
quite outdated.

Related to https://pagure.io/SSSD/sssd/issue/3958