### PR TITLE
CONFIG: add missing ldap attributes for validation

### DIFF
--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -730,6 +730,14 @@ option = ldap_user_ssh_public_key
 option = ldap_user_uid_number
 option = ldap_user_uuid
 option = ldap_use_tokengroups
+option = ldap_host_object_class
+option = ldap_host_name
+option = ldap_host_fqdn
+option = ldap_host_serverhostname
+option = ldap_host_member_of
+option = ldap_host_search_base
+option = ldap_host_ssh_public_key
+option = ldap_host_uuid
 
 # For application domains
 option = inherit_from


### PR DESCRIPTION
https://pagure.io/SSSD/sssd/issue/3961

This patch adds missing 'ldap_host_*' attributes for config validation.