### PR TITLE
Add use_2fa_combined option to allow pam services to be configured as password+otp entry

### DIFF
--- a/src/man/pam_sss.8.xml
+++ b/src/man/pam_sss.8.xml
@@ -56,6 +56,9 @@
             <arg choice='opt'>
                 <replaceable>require_cert_auth</replaceable>
             </arg>
+            <arg choice='opt'>
+                <replaceable>use_2fa_combined</replaceable>
+            </arg>
         </cmdsynopsis>
     </refsynopsisdiv>
 
@@ -245,6 +248,26 @@ auth sufficient pam_sss.so allow_missing_name
                         If no Smartcard is available after the timeout or
                         certificate based authentication is not allowed for the
                         current service PAM_AUTHINFO_UNAVAIL is returned.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term>
+                    <option>use_2fa_combined</option>
+                </term>
+                <listitem>
+                    <para>
+                        If a client does not provide an answer to the second
+                        prompt (2fa prompt), the password answer is treated
+                        as a "password+otp" entry. However, some clients that
+                        are not 2fa aware respond to all prompts with the same
+                        value. With this option specified, the second answer
+                        will be ignored if it is the same as the first, and the
+                        answer will be treated as a "password+otp" entry.
+                    </para>
+                    <para>
+                        This option is automatically enforced for the sshd
+                        service.
                     </para>
                 </listitem>
             </varlistentry>

--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -1482,6 +1482,8 @@ static int prompt_2fa(pam_handle_t *pamh, struct pam_items *pi,
     }
 
     if (resp[1].resp == NULL || *(resp[1].resp) == '\0'
+            || ((pi->flags & PAM_CLI_FLAGS_USE_2FA_COMBINED)
+                    && strcmp(resp[0].resp, resp[1].resp) == 0)
             || (pi->pam_service != NULL && strcmp(pi->pam_service, "sshd") == 0
                     && strcmp(resp[0].resp, resp[1].resp) == 0)) {
         /* Missing second factor, assume first factor contains combined 2FA
@@ -2005,6 +2007,8 @@ static void eval_argv(pam_handle_t *pamh, int argc, const char **argv,
             *flags |= PAM_CLI_FLAGS_TRY_CERT_AUTH;
         } else if (strcmp(*argv, "require_cert_auth") == 0) {
             *flags |= PAM_CLI_FLAGS_REQUIRE_CERT_AUTH;
+        } else if (strcmp(*argv, "use_2fa_combined") == 0) {
+            *flats |= PAM_CLI_FLAGS_USE_2FA_COMBINED;
         } else {
             logger(pamh, LOG_WARNING, "unknown option: %s", *argv);
         }

--- a/src/sss_client/sss_cli.h
+++ b/src/sss_client/sss_cli.h
@@ -376,6 +376,7 @@ enum pam_item_type {
 #define PAM_CLI_FLAGS_PROMPT_ALWAYS (1 << 7)
 #define PAM_CLI_FLAGS_TRY_CERT_AUTH (1 << 8)
 #define PAM_CLI_FLAGS_REQUIRE_CERT_AUTH (1 << 9)
+#define PAM_CLI_FLAGS_USE_2FA_COMBINED (1 << 10)
 
 #define SSS_NSS_MAX_ENTRIES 256
 #define SSS_NSS_HEADER_SIZE (sizeof(uint32_t) * 4)


### PR DESCRIPTION
Hello,

This is a rough idea and does build successfully but I'm still in the process of getting some testing arranged - I was pulled away from testing unfortunately but wanted to put the idea forward for examination in advance.

I had been trying to get a service to use PAM with 2FA within a FreeIPA environment. However, I was having issues with it refusing to accept a password+otp entry as the single password entered. Having examined the logs it appeared that the 2FA token was being rejected as being incorrect. This confused me as SSHD was working fine and seemed to be configured identically. Looking at the code of the service I could see it was because it was responding to all PAM prompts with the same entered value - the password+otp combination - but was receiving two prompts. Checking SSSD I found the issue in that this behaviour is only allowed for SSHD service, and that the service name was hard-coded in.

This PR adds a new option to pam_sssd, `use_2fa_combined` which allows any service to be configured to behave like `sshd` does, without breaking any compatibility with existing usage.

Does this look like something that would be an acceptable feature to implement, assuming I finish testing and the overall idea works 👍 

Thanks!