### PR TITLE
ldap: prefer LDAP port during initgroups user lookup

### DIFF
--- a/src/providers/ldap/sdap_async.h
+++ b/src/providers/ldap/sdap_async.h
@@ -395,4 +395,6 @@ sdap_handle_id_collision_for_incomplete_groups(struct data_provider *dp,
                                                bool posix,
                                                time_t now);
 
+struct sdap_id_conn_ctx *get_ldap_conn_from_sdom_pvt(struct sdap_options *opts,
+                                                     struct sdap_domain *sdom);
 #endif /* _SDAP_ASYNC_H_ */

--- a/src/providers/ldap/sdap_async_initgroups_ad.c
+++ b/src/providers/ldap/sdap_async_initgroups_ad.c
@@ -1721,3 +1721,21 @@ static errno_t handle_missing_pvt(TALLOC_CTX *mem_ctx,
 done:
     return ret;
 }
+
+struct sdap_id_conn_ctx *get_ldap_conn_from_sdom_pvt(struct sdap_options *opts,
+                                                     struct sdap_domain *sdom)
+{
+    struct ad_id_ctx *ad_id_ctx;
+    struct sdap_id_conn_ctx *user_conn = NULL;
+
+    if (opts->schema_type == SDAP_SCHEMA_AD && sdom->pvt != NULL) {
+        ad_id_ctx = talloc_get_type(sdom->pvt, struct ad_id_ctx);
+        if (ad_id_ctx != NULL &&  ad_id_ctx->ldap_ctx != NULL) {
+            DEBUG(SSSDBG_TRACE_ALL,
+                  "Returning LDAP connection for user lookup.\n");
+            user_conn = ad_id_ctx->ldap_ctx;
+        }
+    }
+
+    return user_conn;
+}


### PR DESCRIPTION
The first step of an initgroups request is to lookup the user. When using
the AD provider the Global Catalog will be the preferred source. But not
all LDAP attributes of the user might be replicated to the Global Catalog
and as a result some of the missing attributes might be removed from the
cached user object.

Related to https://pagure.io/SSSD/sssd/issue/2474