### PR TITLE
sdap: use ldap_pwmodify_mode to change password

### DIFF
--- a/src/config/SSSDConfig/__init__.py.in
+++ b/src/config/SSSDConfig/__init__.py.in
@@ -282,6 +282,7 @@ option_strings = {
     'ldap_backup_uri' : _('ldap_backup_uri, The URI of the LDAP server'),
     'ldap_search_base' : _('The default base DN'),
     'ldap_schema' : _('The Schema Type in use on the LDAP server, rfc2307'),
+    'ldap_pwmodify_mode' : _('Mode used to change user password'),
     'ldap_default_bind_dn' : _('The default bind DN'),
     'ldap_default_authtok_type' : _('The type of the authentication token of the default bind DN'),
     'ldap_default_authtok' : _('The authentication token of the default bind DN'),

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -654,6 +654,7 @@ option = ldap_sasl_canonicalize
 option = ldap_sasl_mech
 option = ldap_sasl_minssf
 option = ldap_schema
+option = ldap_pwmodify_mode
 option = ldap_search_base
 option = ldap_search_timeout
 option = ldap_service_entry_usn

--- a/src/config/etc/sssd.api.d/sssd-ad.conf
+++ b/src/config/etc/sssd.api.d/sssd-ad.conf
@@ -24,6 +24,7 @@ ldap_uri = str, None, false
 ldap_backup_uri = str, None, false
 ldap_search_base = str, None, false
 ldap_schema = str, None, false
+ldap_pwmodify_mode = str, None, false
 ldap_default_bind_dn = str, None, false
 ldap_default_authtok_type = str, None, false
 ldap_default_authtok = str, None, false

--- a/src/config/etc/sssd.api.d/sssd-ipa.conf
+++ b/src/config/etc/sssd.api.d/sssd-ipa.conf
@@ -16,6 +16,7 @@ ldap_uri = str, None, false
 ldap_backup_uri = str, None, false
 ldap_search_base = str, None, false
 ldap_schema = str, None, false
+ldap_pwmodify_mode = str, None, false
 ldap_default_bind_dn = str, None, false
 ldap_default_authtok_type = str, None, false
 ldap_default_authtok = str, None, false

--- a/src/config/etc/sssd.api.d/sssd-ldap.conf
+++ b/src/config/etc/sssd.api.d/sssd-ldap.conf
@@ -3,6 +3,7 @@ ldap_uri = str, None, false
 ldap_backup_uri = str, None, false
 ldap_search_base = str, None, false
 ldap_schema = str, None, false
+ldap_pwmodify_mode = str, None, false
 ldap_default_bind_dn = str, None, false
 ldap_default_authtok_type = str, None, false
 ldap_default_authtok = str, None, false

--- a/src/man/sssd-ldap.5.xml
+++ b/src/man/sssd-ldap.5.xml
@@ -206,6 +206,44 @@
                 </varlistentry>
 
                 <varlistentry>
+                    <term>ldap_pwmodify_mode (string)</term>
+                    <listitem>
+                        <para>
+                            Specify the operation that is used to modify user
+                            password.
+                        </para>
+                        <para>
+                            Two modes are currently supported:
+                            <itemizedlist>
+                                <listitem>
+                                    <para>
+                                        exop - Password Modify Extended
+                                        Operation (RFC 3062)
+                                    </para>
+                                </listitem>
+                                <listitem>
+                                    <para>
+                                        ldap_modify - Direct modification of
+                                        userPassword (not recommended).
+                                    </para>
+                                </listitem>
+                            </itemizedlist>
+                        </para>
+                        <para>
+                            Note: First, a new connection is established to
+                            verify current password by binding as the user
+                            that requested password change. If successful,
+                            this connection is used to change the password
+                            therefore the user must have write access to
+                            userPassword attribute.
+                        </para>
+                        <para>
+                            Default: exop
+                        </para>
+                    </listitem>
+                </varlistentry>
+
+                <varlistentry>
                     <term>ldap_default_bind_dn (string)</term>
                     <listitem>
                         <para>

--- a/src/providers/ad/ad_opts.c
+++ b/src/providers/ad/ad_opts.c
@@ -86,6 +86,7 @@ struct dp_option ad_def_ldap_opts[] = {
     { "ldap_autofs_search_base", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "ldap_autofs_map_master_name", DP_OPT_STRING, { "auto.master" }, NULL_STRING },
     { "ldap_schema", DP_OPT_STRING, { "ad" }, NULL_STRING },
+    { "ldap_pwmodify_mode", DP_OPT_STRING, { "exop" }, NULL_STRING },
     { "ldap_offline_timeout", DP_OPT_NUMBER, { .number = 60 }, NULL_NUMBER },
     { "ldap_force_upper_case_realm", DP_OPT_BOOL, BOOL_TRUE, BOOL_TRUE },
     { "ldap_enumeration_refresh_timeout", DP_OPT_NUMBER, { .number = 300 }, NULL_NUMBER },

--- a/src/providers/ipa/ipa_opts.c
+++ b/src/providers/ipa/ipa_opts.c
@@ -98,6 +98,7 @@ struct dp_option ipa_def_ldap_opts[] = {
     { "ldap_autofs_search_base", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "ldap_autofs_map_master_name", DP_OPT_STRING, { "auto.master" }, NULL_STRING },
     { "ldap_schema", DP_OPT_STRING, { "ipa_v1" }, NULL_STRING },
+    { "ldap_pwmodify_mode", DP_OPT_STRING, { "exop" }, NULL_STRING },
     { "ldap_offline_timeout", DP_OPT_NUMBER, { .number = 60 }, NULL_NUMBER },
     { "ldap_force_upper_case_realm", DP_OPT_BOOL, BOOL_TRUE, BOOL_TRUE },
     { "ldap_enumeration_refresh_timeout", DP_OPT_NUMBER, { .number = 300 }, NULL_NUMBER },

--- a/src/providers/ldap/ldap_options.c
+++ b/src/providers/ldap/ldap_options.c
@@ -38,6 +38,7 @@ int ldap_get_options(TALLOC_CTX *memctx,
     struct sdap_attr_map *default_service_map;
     struct sdap_options *opts;
     char *schema;
+    char *pwmodify;
     const char *search_base;
     const char *pwd_policy;
     int ret;
@@ -255,6 +256,18 @@ int ldap_get_options(TALLOC_CTX *memctx,
         default_service_map = service_map;
     } else {
         DEBUG(SSSDBG_FATAL_FAILURE, "Unrecognized schema type: %s\n", schema);
+        ret = EINVAL;
+        goto done;
+    }
+
+    /* pwmodify mode */
+    pwmodify = dp_opt_get_string(opts->basic, SDAP_PWMODIFY_MODE);
+    if (strcasecmp(pwmodify, "exop") == 0) {
+        opts->pwmodify_mode = SDAP_PWMODIFY_EXOP;
+    } else if (strcasecmp(pwmodify, "ldap_modify") == 0) {
+        opts->pwmodify_mode = SDAP_PWMODIFY_LDAP;
+    } else {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unrecognized pwmodify mode: %s\n", pwmodify);
         ret = EINVAL;
         goto done;
     }

--- a/src/providers/ldap/ldap_opts.c
+++ b/src/providers/ldap/ldap_opts.c
@@ -58,6 +58,7 @@ struct dp_option default_basic_opts[] = {
     { "ldap_autofs_search_base", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "ldap_autofs_map_master_name", DP_OPT_STRING, { "auto.master" }, NULL_STRING },
     { "ldap_schema", DP_OPT_STRING, { "rfc2307" }, NULL_STRING },
+    { "ldap_pwmodify_mode", DP_OPT_STRING, { "exop" }, NULL_STRING },
     { "ldap_offline_timeout", DP_OPT_NUMBER, { .number = 60 }, NULL_NUMBER },
     { "ldap_force_upper_case_realm", DP_OPT_BOOL, BOOL_FALSE, BOOL_FALSE },
     { "ldap_enumeration_refresh_timeout", DP_OPT_NUMBER, { .number = 300 }, NULL_NUMBER },

--- a/src/providers/ldap/sdap.h
+++ b/src/providers/ldap/sdap.h
@@ -176,6 +176,7 @@ enum sdap_basic_opt {
     SDAP_AUTOFS_SEARCH_BASE,
     SDAP_AUTOFS_MAP_MASTER_NAME,
     SDAP_SCHEMA,
+    SDAP_PWMODIFY_MODE,
     SDAP_OFFLINE_TIMEOUT,
     SDAP_FORCE_UPPER_CASE_REALM,
     SDAP_ENUM_REFRESH_TIMEOUT,
@@ -491,6 +492,12 @@ struct sdap_options {
         SDAP_SCHEMA_IPA_V1 = 3,     /* member/memberof */
         SDAP_SCHEMA_AD = 4          /* AD's member/memberof */
     } schema_type;
+
+    /* password modify mode */
+    enum pwmodify_mode {
+        SDAP_PWMODIFY_EXOP = 1,     /* pwmodify extended operation */
+        SDAP_PWMODIFY_LDAP = 2      /* ldap_modify of userPassword */
+    } pwmodify_mode;
 
     /* The search bases for the domain or its subdomain */
     struct sdap_domain *sdom;

--- a/src/providers/ldap/sdap_async.h
+++ b/src/providers/ldap/sdap_async.h
@@ -175,11 +175,22 @@ errno_t sdap_exop_modify_passwd_recv(struct tevent_req *req,
                                      char **user_error_msg);
 
 struct tevent_req *
+sdap_modify_passwd_send(TALLOC_CTX *mem_ctx,
+                        struct tevent_context *ev,
+                        struct sdap_handle *sh,
+                        int timeout,
+                        char *attr,
+                        const char *user_dn,
+                        const char *new_password);
+
+errno_t sdap_modify_passwd_recv(struct tevent_req *req);
+
+struct tevent_req *
 sdap_modify_shadow_lastchange_send(TALLOC_CTX *mem_ctx,
                              struct tevent_context *ev,
                              struct sdap_handle *sh,
                              const char *dn,
-                             char *lastchanged_name);
+                             char *attr);
 
 errno_t sdap_modify_shadow_lastchange_recv(struct tevent_req *req);
 


### PR DESCRIPTION
Resolves:
https://pagure.io/SSSD/sssd/issue/1314

Now you can set `ldap_pwmodify_mode = "exop"` (default) to use
extended operation to change the password (current state) or
set it to `ldap_modify` to modify `userPassword` attribute directly.