### PR TITLE
GPO: Allow customization of GPO_CROND per OS

### DIFF
--- a/src/external/platform.m4
+++ b/src/external/platform.m4
@@ -36,6 +36,14 @@ AM_CONDITIONAL([HAVE_SUSE], [test x"$osname" = xsuse])
 AM_CONDITIONAL([HAVE_DEBIAN], [test x"$osname" = xdebian])
 AM_CONDITIONAL([HAVE_GENTOO], [test x"$osname" = xgentoo])
 
+AS_CASE([$osname],
+        [redhat], [AC_DEFINE_UNQUOTED([HAVE_REDHAT], 1, [Build with redhat config])],
+        [fedora], [AC_DEFINE_UNQUOTED([HAVE_FEDORA], 1, [Build with fedora config])],
+        [suse], [AC_DEFINE_UNQUOTED([HAVE_SUSE], 1, [Build with suse config])],
+        [gentoo], [AC_DEFINE_UNQUOTED([HAVE_GENTOO], 1, [Build with gentoo config])],
+        [debian], [AC_DEFINE_UNQUOTED([HAVE_DEBIAN], 1, [Build with debian config])],
+        [AC_MSG_NOTICE([Build with $osname config])])
+
 AC_CHECK_MEMBERS([struct ucred.pid, struct ucred.uid, struct ucred.gid], , ,
                  [[#include <sys/socket.h>]])
 

--- a/src/providers/ad/ad_gpo.c
+++ b/src/providers/ad/ad_gpo.c
@@ -200,7 +200,11 @@ int ad_gpo_process_cse_recv(struct tevent_req *req);
 #define GPO_SSHD "sshd"
 #define GPO_FTP "ftp"
 #define GPO_SAMBA "samba"
+#ifdef HAVE_DEBIAN
+#define GPO_CROND "cron"
+#else
 #define GPO_CROND "crond"
+#endif
 #define GPO_POLKIT "polkit-1"
 #define GPO_SUDO "sudo"
 #define GPO_SUDO_I "sudo-i"


### PR DESCRIPTION
For both Debian and Ubuntu, the cron PAM service is named "cron" instead
of "crond", denying the use of the service by default.

This patch enables the HAVE_$OS (HAVE_DEBIAN/HAVE_FEDORA...) macros to select
the service name during build, allowing further customization if required.

Resolves:
https://bugs.launchpad.net/ubuntu/+source/sssd/+bug/1572908