### PR TITLE
be: remember last good server's name instead of fo_server structure

### DIFF
--- a/src/providers/backend.h
+++ b/src/providers/backend.h
@@ -58,7 +58,7 @@ struct be_svc_data {
     const char *name;
     struct fo_service *fo_service;
 
-    struct fo_server *last_good_srv;
+    char *last_good_srv;
     time_t last_status_change;
     bool run_callbacks;
 

--- a/src/providers/data_provider/dp_iface_failover.c
+++ b/src/providers/data_provider/dp_iface_failover.c
@@ -274,7 +274,6 @@ dp_failover_active_server(TALLOC_CTX *mem_ctx,
                           const char **_server)
 {
     struct be_svc_data *svc;
-    const char *server;
     bool found = false;
 
     DLIST_FOR_EACH(svc, be_ctx->be_fo->svcs) {
@@ -289,17 +288,7 @@ dp_failover_active_server(TALLOC_CTX *mem_ctx,
         return ENOENT;
     }
 
-    if (svc->last_good_srv == NULL) {
-        server = "";
-    } else {
-        server = fo_get_server_name(svc->last_good_srv);
-        if (server == NULL) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "Unable to get server name\n");
-            return ERR_INTERNAL;
-        }
-    }
-
-    *_server = server;
+    *_server = svc->last_good_srv == NULL ? "" : svc->last_good_srv;
 
     return EOK;
 }


### PR DESCRIPTION
This fo_server may be freed when collapsing servers from SRV lookup
in `collapse_srv_lookup`. This would cause crash when we try to
dereference the pointer.

Resolves:
https://pagure.io/SSSD/sssd/issue/3976