### PR TITLE
providers/ipa: Changed default service search base

### DIFF
--- a/src/providers/ipa/ipa_common.c
+++ b/src/providers/ipa/ipa_common.c
@@ -500,9 +500,9 @@ int ipa_get_id_options(struct ipa_options *ipa_opts,
         }
 
         DEBUG(SSSDBG_TRACE_FUNC, "Option %s set to %s\n",
-                  ipa_opts->id->basic[SDAP_GROUP_SEARCH_BASE].opt_name,
+                  ipa_opts->id->basic[SDAP_SERVICE_SEARCH_BASE].opt_name,
                   dp_opt_get_string(ipa_opts->id->basic,
-                                    SDAP_GROUP_SEARCH_BASE));
+                                    SDAP_SERVICE_SEARCH_BASE));
     }
     ret = sdap_parse_search_base(ipa_opts->id, ipa_opts->id->basic,
                                  SDAP_SERVICE_SEARCH_BASE,

--- a/src/providers/ipa/ipa_common.c
+++ b/src/providers/ipa/ipa_common.c
@@ -492,9 +492,15 @@ int ipa_get_id_options(struct ipa_options *ipa_opts,
 
     if (NULL == dp_opt_get_string(ipa_opts->id->basic,
                                   SDAP_SERVICE_SEARCH_BASE)) {
-        ret = dp_opt_set_string(ipa_opts->id->basic, SDAP_SERVICE_SEARCH_BASE,
+        value = talloc_asprintf(tmpctx, "cn=ipservices,%s",
                                 dp_opt_get_string(ipa_opts->id->basic,
                                                   SDAP_SEARCH_BASE));
+        if (!value) {
+            ret = ENOMEM;
+            goto done;
+        }
+        ret = dp_opt_set_string(ipa_opts->id->basic,
+                                SDAP_SERVICE_SEARCH_BASE, value);
         if (ret != EOK) {
             goto done;
         }


### PR DESCRIPTION
Changed default value of `ldap_service_search_base` config option
to `cn=ipservices,cn=accounts,$BASE` to follow FreeIPA change.

Resolves: https://pagure.io/SSSD/sssd/issue/3899

I do not like the way I have updated man pages but I didn't figure out better option.
Recommendations are welcome.