### PR TITLE
sudo ipa: do not store rules without sudoHost attribute

### DIFF
--- a/src/providers/ipa/ipa_sudo_async.c
+++ b/src/providers/ipa/ipa_sudo_async.c
@@ -88,8 +88,9 @@ ipa_sudo_host_filter(TALLOC_CTX *mem_ctx,
         return NULL;
     }
 
-    filter = talloc_asprintf(tmp_ctx, "(!(%s=*))",
-                             map[IPA_AT_SUDORULE_HOST].name);
+    filter = talloc_asprintf(tmp_ctx, "(&(!(%s=*))(%s=defaults))",
+                             map[IPA_AT_SUDORULE_HOST].name,
+                             map[IPA_AT_SUDORULE_NAME].name);
     if (filter == NULL) {
         goto fail;
     }


### PR DESCRIPTION
Unless it is cn=defaults.

This was already fixed in LDAP provider with:
47ad0778be72994a2294b2e73cc5c670be6811a7

Resolves:
https://pagure.io/SSSD/sssd/issue/3980