### PR TITLE
Monitor: changed provider startup timeout

### DIFF
--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -648,8 +648,11 @@ static int add_services_startup_timeout(struct mt_ctx *ctx)
     struct tevent_timer *to;
     struct timeval tv;
 
-    /* 5 seconds should be plenty */
-    tv = tevent_timeval_current_ofs(5, 0);
+    /* `monitor_service_init()` allows 10 secs for any connected sbus client
+        to proceed with registration.
+        It makes sense to allow overall provider startup timeout
+        to be slightly greater. */
+    tv = tevent_timeval_current_ofs(10, 100000); /* 10.1 sec */
     to = tevent_add_timer(ctx->ev, ctx, tv, services_startup_timeout, ctx);
     if (!to) {
         DEBUG(SSSDBG_FATAL_FAILURE,"Out of memory?!\n");


### PR DESCRIPTION
`monitor_service_init()` allows 10 secs for any connected sbus client
to proceed with registration.
It makes sense to allow overall provider startup timeout to be
slightly greater.

Resolves: https://pagure.io/SSSD/sssd/issue/3969