### PR TITLE
SYSDB: Inherit cached_auth_timeout from the main domain

### DIFF
--- a/src/db/sysdb_subdomains.c
+++ b/src/db/sysdb_subdomains.c
@@ -154,6 +154,7 @@ struct sss_domain_info *new_subdomain(TALLOC_CTX *mem_ctx,
     dom->cache_credentials = parent->cache_credentials;
     dom->cache_credentials_min_ff_length =
                                         parent->cache_credentials_min_ff_length;
+    dom->cached_auth_timeout = parent->cached_auth_timeout;
     dom->case_sensitive = false;
     dom->user_timeout = parent->user_timeout;
     dom->group_timeout = parent->group_timeout;

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -3048,6 +3048,11 @@ subdomain_inherit = ldap_purge_cache_timeout
                             SSSD is in the online mode.
                         </para>
                         <para>
+                            This option's value is inherited by all trusted
+                            domains. At the moment it is not possible to set
+                            a different value per trusted domain.
+                        </para>
+                        <para>
                             Special value 0 implies that this feature is
                             disabled.
                         </para>


### PR DESCRIPTION
cached_auth_timeout is a domain option used by the responder. And because
at the moment the options read from a subdomain section (e.g.
[domain/main/trusted] are only those represented by the back end specific 
dp_option structure instance, the option cached_auth_timeout, which is
directly read from the confdb was not set for the main domain.

This is a minimal patch that just inherits the option from the main domain
until SSSD has a more systematic way of inheriting config attributes
regardless of how they are read and set.

Resolves: https://pagure.io/SSSD/sssd/issue/3960