### PR TITLE
ci/sssd.supp: fixed c-ares-suppress-leak-from-init

### DIFF
--- a/contrib/ci/sssd.supp
+++ b/contrib/ci/sssd.supp
@@ -165,6 +165,7 @@
    fun:recreate_ares_channel
    fun:resolv_init
    fun:be_res_init
+   ...
    fun:be_init_failover
    fun:test_ipa_server_create_trusts_setup
    ...


### PR DESCRIPTION
Valgrind suppression pattern was adjusted to prevent
fails on some target OS.