### PR TITLE
krb5: Write multiple dnsnames into kdc info file

### DIFF
--- a/src/providers/fail_over.c
+++ b/src/providers/fail_over.c
@@ -1637,6 +1637,33 @@ fo_get_server_hostname_last_change(struct fo_server *server)
     return server->common->last_status_change.tv_sec;
 }
 
+struct fo_server *fo_server_first(struct fo_server *server)
+{
+    if (!server) return NULL;
+
+    while (server->prev) { server = server->prev; }
+    return server;
+}
+
+struct fo_server *fo_server_next(struct fo_server *server)
+{
+    if (!server) return NULL;
+
+    return server->next;
+}
+
+size_t fo_server_count(struct fo_server *server)
+{
+    struct fo_server *item = fo_server_first(server);
+    size_t size = 0;
+
+    while (item) {
+        ++size;
+        item = item->next;
+    }
+    return size;
+}
+
 time_t fo_get_service_retry_timeout(struct fo_service *svc)
 {
     if (svc == NULL || svc->ctx == NULL || svc->ctx->opts == NULL) {

--- a/src/providers/fail_over.h
+++ b/src/providers/fail_over.h
@@ -217,6 +217,15 @@ const char **fo_svc_server_list(TALLOC_CTX *mem_ctx,
                                 size_t *_count);
 
 /*
+ * Folowing functions allow to iterate trough list of servers.
+ */
+struct fo_server *fo_server_first(struct fo_server *server);
+
+struct fo_server *fo_server_next(struct fo_server *server);
+
+size_t fo_server_count(struct fo_server *server);
+
+/*
  * pvt will be talloc_stealed to ctx
  */
 bool fo_set_srv_lookup_plugin(struct fo_ctx *ctx,

--- a/src/providers/ipa/ipa_subdomains.c
+++ b/src/providers/ipa/ipa_subdomains.c
@@ -2534,7 +2534,7 @@ static errno_t ipa_subdomains_write_kdcinfo_write_step(struct sss_domain_info *d
     errno_t ret;
     char *address = NULL;
     char *safe_address = NULL;
-    char **safe_addr_list;
+    const char **safe_addr_list;
     int addr_index = 0;
     TALLOC_CTX *tmp_ctx = NULL;
 
@@ -2543,7 +2543,7 @@ static errno_t ipa_subdomains_write_kdcinfo_write_step(struct sss_domain_info *d
         return ENOMEM;
     }
 
-    safe_addr_list = talloc_zero_array(tmp_ctx, char *, rhp_len+1);
+    safe_addr_list = talloc_zero_array(tmp_ctx, const char *, rhp_len+1);
     if (safe_addr_list == NULL) {
         ret = ENOMEM;
         goto done;

--- a/src/providers/krb5/krb5_common.h
+++ b/src/providers/krb5/krb5_common.h
@@ -161,8 +161,13 @@ errno_t sss_krb5_get_options(TALLOC_CTX *memctx, struct confdb_ctx *cdb,
                              const char *conf_path, struct dp_option **_opts);
 
 errno_t write_krb5info_file(struct krb5_service *krb5_service,
-                            char **server_list,
+                            const char **server_list,
                             const char *service);
+
+errno_t write_krb5info_file_from_fo_server(struct krb5_service *krb5_service,
+                                           struct fo_server *server,
+                                           const char *service,
+                                           bool (*filter)(struct fo_server *));
 
 struct krb5_service *krb5_service_new(TALLOC_CTX *mem_ctx,
                                       struct be_ctx *be_ctx,


### PR DESCRIPTION
Multiple servers should be written to kdc info file. In
this PR we iterate trough server list and we write
list of primary servers followed by backup servers.

Resolves:
https://pagure.io/SSSD/sssd/issue/3974