### PR TITLE
NEGCACHE: repopulate negative cache after get_domains and initialize UPN negative cache as well

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -849,7 +849,8 @@
                             from the sss NSS database. This is particularly
                             useful for system accounts. This option can also
                             be set per-domain or include fully-qualified names
-                            to filter only users from the particular domain.
+                            to filter only users from the particular domain or
+                            by a user principal name (UPN).
                         </para>
                         <para>
                             NOTE: The filter_groups option doesn't affect

--- a/src/responder/common/responder_get_domains.c
+++ b/src/responder/common/responder_get_domains.c
@@ -296,7 +296,7 @@ sss_dp_get_domains_process(struct tevent_req *subreq)
     }
 
     if (state->dom == NULL) {
-        /* All domains were local */
+        /* No more domains to check, refreshing the active configuration */
         set_time_of_last_request(state->rctx);
         ret = sss_resp_populate_cr_domains(state->rctx);
         if (ret != EOK) {
@@ -307,6 +307,13 @@ sss_dp_get_domains_process(struct tevent_req *subreq)
         }
 
         sss_resp_update_certmaps(state->rctx);
+
+        ret = sss_ncache_reset_repopulate_permanent(state->rctx,
+                                                    state->rctx->ncache);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "sss_ncache_reset_repopulate_permanent failed, ignored.\n");
+        }
 
         tevent_req_done(req);
         return;

--- a/src/responder/common/responder_get_domains.c
+++ b/src/responder/common/responder_get_domains.c
@@ -442,7 +442,8 @@ static void get_domains_at_startup_done(struct tevent_req *req)
         ret = sss_ncache_reset_repopulate_permanent(state->rctx,
                                                     state->optional_ncache);
         if (ret != EOK) {
-            DEBUG(SSSDBG_MINOR_FAILURE, "sss_dp_get_domains request failed.\n");
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "sss_ncache_reset_repopulate_permanent failed.\n");
         }
     }
 


### PR DESCRIPTION
If SSSD starts offline the responders might only know about the configured
domain because the sub-domains have not been discovered yet. As a result
the permanent negative cache is only populated for the configured domain.

If later the system goes online and the sub-domains are discovered or a new
sub-domain was discovered at runtime the permanent negative cache is
currently not created for those domains.

This patch repopulates the negative cache for all known domains to the end
of the get_domains request.

Related to https://pagure.io/SSSD/sssd/issue/3983

UPNs are handled separately in the negative cache. To properly filter user
names even in the case of the fallback to a UPN lookup the negative cahe
for UPNs has to be initialized with the names from the filter_user option
as well.

If the name from the option is a short name it will be added to the
negative UPN cache for each domain with the respective domain name. If the
name from the option is fully-qualified it will be added as is to the
negative UPN cache for each domain.

Related to https://pagure.io/SSSD/sssd/issue/3978