### PR TITLE
ipa s2n: try to remove objects not found on the server

### DIFF
--- a/src/providers/ipa/ipa_s2n_exop.c
+++ b/src/providers/ipa/ipa_s2n_exop.c
@@ -333,7 +333,7 @@ static errno_t s2n_encode_request(TALLOC_CTX *mem_ctx,
                                                   req_input->inp.id);
             } else {
                 DEBUG(SSSDBG_OP_FAILURE, "Unexpected input type [%d].\n",
-                                          req_input->type == REQ_INP_ID);
+                                          req_input->type);
                 ret = EINVAL;
                 goto done;
             }
@@ -349,7 +349,7 @@ static errno_t s2n_encode_request(TALLOC_CTX *mem_ctx,
                                                   req_input->inp.id);
             } else {
                 DEBUG(SSSDBG_OP_FAILURE, "Unexpected input type [%d].\n",
-                                          req_input->type == REQ_INP_ID);
+                                          req_input->type);
                 ret = EINVAL;
                 goto done;
             }
@@ -360,7 +360,7 @@ static errno_t s2n_encode_request(TALLOC_CTX *mem_ctx,
                                                req_input->inp.secid);
             } else {
                 DEBUG(SSSDBG_OP_FAILURE, "Unexpected input type [%d].\n",
-                                         req_input->type == REQ_INP_ID);
+                                         req_input->type);
                 ret = EINVAL;
                 goto done;
             }

--- a/src/providers/ldap/ldap_common.h
+++ b/src/providers/ldap/ldap_common.h
@@ -378,4 +378,8 @@ errno_t users_get_handle_no_user(TALLOC_CTX *mem_ctx,
                                  struct sss_domain_info *domain,
                                  int filter_type, const char *filter_value,
                                  bool name_is_upn);
+
+errno_t groups_get_handle_no_group(TALLOC_CTX *mem_ctx,
+                                   struct sss_domain_info *domain,
+                                   int filter_type, const char *filter_value);
 #endif /* _LDAP_COMMON_H_ */

--- a/src/providers/ldap/ldap_common.h
+++ b/src/providers/ldap/ldap_common.h
@@ -373,4 +373,9 @@ errno_t sdap_init_certmap(TALLOC_CTX *mem_ctx, struct sdap_id_ctx *id_ctx);
 errno_t sdap_setup_certmap(struct sdap_certmap_ctx *sdap_certmap_ctx,
                            struct certmap_info **certmap_list);
 struct sss_certmap_ctx *sdap_get_sss_certmap(struct sdap_certmap_ctx *ctx);
+
+errno_t users_get_handle_no_user(TALLOC_CTX *mem_ctx,
+                                 struct sss_domain_info *domain,
+                                 int filter_type, const char *filter_value,
+                                 bool name_is_upn);
 #endif /* _LDAP_COMMON_H_ */


### PR DESCRIPTION
If there server returns that the searched object does not exists we should try
to remove it from the cache if it still has an entry.

Related to https://pagure.io/SSSD/sssd/issue/3984