### PR TITLE
knownhostsproxy: friendly error msg for NXDOMAIN

### DIFF
--- a/src/sss_client/ssh/sss_ssh_knownhostsproxy.c
+++ b/src/sss_client/ssh/sss_ssh_knownhostsproxy.c
@@ -339,6 +339,9 @@ int main(int argc, const char **argv)
             }
         }
     } else {
+        fprintf(stderr,
+                "sss_ssh_knownhostsproxy: Could not resolve hostname %s\n",
+                pc_host);
         ret = EFAULT;
     }
     ret = (ret == EOK) ? EXIT_SUCCESS : EXIT_FAILURE;


### PR DESCRIPTION
This patch writes a brief, familiar error message to stderr when no addresses are able to be resolved for the host specified in argv:

```
(with patch)$ ssh the-void
sss_ssh_knownhostsproxy: Could not resolve hostname the-void
ssh_exchange_identification: Connection closed by remote host
```

Users accustomed to using SSH in environments where SSSD is not deployed may expect the usual "Could not resolve hostname" error from SSH when a domain name is misspelled or otherwise invalid:

```
(no sssd)$ ssh the-void
ssh: Could not resolve hostname the-void: Name or service not known
```

When such users begin using SSH in an SSSD-enabled environment, they may be confused when this familiar and straightforward message is replaced by a new one:

```
(sssd)$ ssh the-void
ssh_exchange_identification: Connection closed by remote host
```

If such users aren't aware that the system `ssh_config` is proxying their connection through `sss_ssh_knownhostsproxy`, they may mistakenly conclude that a connection had been made all the way to a remote host and, therefore, that the hostname they specified was valid and able to be resolved.  This patch mitigates this opportunity for confusion.