### PR TITLE
be: remember last good server's name instead of fo_server structure (1.16)

### DIFF
--- a/src/providers/backend.h
+++ b/src/providers/backend.h
@@ -58,7 +58,7 @@ struct be_svc_data {
     const char *name;
     struct fo_service *fo_service;
 
-    struct fo_server *last_good_srv;
+    char *last_good_srv;
     time_t last_status_change;
     bool run_callbacks;
 

--- a/src/providers/data_provider/dp_iface_failover.c
+++ b/src/providers/data_provider/dp_iface_failover.c
@@ -293,18 +293,7 @@ errno_t dp_failover_active_server(struct sbus_request *sbus_req,
         return EOK;
     }
 
-    if (svc->last_good_srv == NULL) {
-        server = "";
-    } else {
-        server = fo_get_server_name(svc->last_good_srv);
-        if (server == NULL) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "Unable to get server name\n");
-            sbus_request_reply_error(sbus_req, SBUS_ERROR_INTERNAL,
-                                     "Unable to get server name");
-            return EOK;
-        }
-    }
-
+    server = svc->last_good_srv == NULL ? "" : svc->last_good_srv;
     iface_dp_failover_ActiveServer_finish(sbus_req, server);
     return EOK;
 }


### PR DESCRIPTION
This fo_server may be freed when collapsing servers from SRV lookup
in `collapse_srv_lookup`. This would cause crash when we try to
dereference the pointer.

Resolves:
https://pagure.io/SSSD/sssd/issue/XXXX