### PR TITLE
AD: Allow configuring auto_private_groups per subdomain or with subdomain_inherit

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -3081,6 +3081,13 @@ subdomain_inherit = ldap_purge_cache_timeout
                                             Create user's private group unconditionally from user's UID number.
                                             The GID number is ignored in this case.
                                         </para>
+                                        <para>
+                                            NOTE: Because the GID number and the user private group
+                                            are inferred from the UID number, it is not supported
+                                            to have multiple entries with the same UID or GID number
+                                            with this option. In other words, enabling this option
+                                            enforces uniqueness across the ID space.
+                                        </para>
                                     </listitem>
                                 </varlistentry>
                                 <varlistentry>
@@ -3127,24 +3134,25 @@ subdomain_inherit = ldap_purge_cache_timeout
                                 </varlistentry>
                             </variablelist>
                         </para>
-			<para>
-			    For POSIX subdomains, setting the option in the main
-			    domain is inherited in the subdomain.
-			</para>
-			<para>
-			    For ID-mapping subdomains, auto_private_groups is
-			    already enabled for the subdomains and setting it to
-			    false will not have any effect for the subdomain.
-			</para>
                         <para>
-                            NOTE: Because the GID number and the user private group
-                            are inferred from the UID number, it is not supported
-                            to have multiple entries with the same UID or GID number
-                            with this option. In other words, enabling this option
-                            enforces uniqueness across the ID space.
+                            For subdomains, the default value is False for
+                            subdomains that use assigned POSIX IDs and True
+                            for subdomains that use automatic ID-mapping.
                         </para>
                         <para>
-                            Default: False
+                            The value of auto_private_groups can either be set per subdomains
+                            in a subsection, for example:
+<programlisting>
+[domain/forest.domain/sub.domain]
+auto_private_groups = false
+</programlisting>
+                            or globally for all subdomains in the main domain section
+                            using the subdomain_inherit option:
+<programlisting>
+[domain/forest.domain]
+subdomain_inherit = auto_private_groups
+auto_private_groups = false
+</programlisting>
                         </para>
                     </listitem>
                 </varlistentry>

--- a/src/providers/ldap/sdap_async_users.c
+++ b/src/providers/ldap/sdap_async_users.c
@@ -389,7 +389,7 @@ int sdap_save_user(TALLOC_CTX *memctx,
             goto done;
         }
 
-        if (IS_SUBDOMAIN(dom) || sss_domain_is_mpg(dom) == true) {
+        if (sss_domain_is_mpg(dom) == true) {
             /* For subdomain users, only create the private group as
              * the subdomain is an MPG domain.
              * But we have to save the GID of the original primary group

--- a/src/util/domain_info_utils.c
+++ b/src/util/domain_info_utils.c
@@ -889,6 +889,14 @@ bool sss_domain_is_forest_root(struct sss_domain_info *dom)
     return (dom->forest_root == dom);
 }
 
+char *subdomain_create_conf_path_from_str(TALLOC_CTX *mem_ctx,
+                                          const char *parent_name,
+                                          const char *subdom_name)
+{
+    return talloc_asprintf(mem_ctx, CONFDB_DOMAIN_PATH_TMPL "/%s",
+                           parent_name, subdom_name);
+}
+
 char *subdomain_create_conf_path(TALLOC_CTX *mem_ctx,
                                  struct sss_domain_info *subdomain)
 {
@@ -899,9 +907,9 @@ char *subdomain_create_conf_path(TALLOC_CTX *mem_ctx,
         return NULL;
     }
 
-    return talloc_asprintf(mem_ctx, CONFDB_DOMAIN_PATH_TMPL "/%s",
-                           subdomain->parent->name,
-                           subdomain->name);
+    return subdomain_create_conf_path_from_str(mem_ctx,
+                                               subdomain->parent->name,
+                                               subdomain->name);
 }
 
 const char *sss_domain_type_str(struct sss_domain_info *dom)

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -559,6 +559,9 @@ find_domain_by_object_name_ex(struct sss_domain_info *domain,
 bool subdomain_enumerates(struct sss_domain_info *parent,
                           const char *sd_name);
 
+char *subdomain_create_conf_path_from_str(TALLOC_CTX *mem_ctx,
+                                          const char *parent_name,
+                                          const char *subdom_name);
 char *subdomain_create_conf_path(TALLOC_CTX *mem_ctx,
                                  struct sss_domain_info *subdomain);
 


### PR DESCRIPTION
Resolves: https://pagure.io/SSSD/sssd/issue/3965

Previously, subdomains that used ID mapping always only used MPGs and POSIX
subdomains always inherited the parent domain settings. This patch is a
small RFE which allows to either set the auto_private_groups option 
directly per subdomain or set it for all subdomains using the 
subdomain_inherit option