### PR TITLE
Speed up check_ccache_files with large cache

### DIFF
--- a/src/db/sysdb_init.c
+++ b/src/db/sysdb_init.c
@@ -559,6 +559,13 @@ static errno_t sysdb_domain_cache_upgrade(TALLOC_CTX *mem_ctx,
         }
     }
 
+    if (strcmp(version, SYSDB_VERSION_0_20) == 0) {
+        ret = sysdb_upgrade_20(sysdb, &version);
+        if (ret != EOK) {
+            goto done;
+        }
+    }
+
 
     ret = EOK;
 done:

--- a/src/db/sysdb_private.h
+++ b/src/db/sysdb_private.h
@@ -23,6 +23,7 @@
 #ifndef __INT_SYS_DB_H__
 #define __INT_SYS_DB_H__
 
+#define SYSDB_VERSION_0_21 "0.21"
 #define SYSDB_VERSION_0_20 "0.20"
 #define SYSDB_VERSION_0_19 "0.19"
 #define SYSDB_VERSION_0_18 "0.18"
@@ -44,7 +45,7 @@
 #define SYSDB_VERSION_0_2 "0.2"
 #define SYSDB_VERSION_0_1 "0.1"
 
-#define SYSDB_VERSION SYSDB_VERSION_0_20
+#define SYSDB_VERSION SYSDB_VERSION_0_21
 
 #define SYSDB_BASE_LDIF \
      "dn: @ATTRIBUTES\n" \
@@ -79,6 +80,7 @@
      "@IDXATTR: uniqueID\n" \
      "@IDXATTR: mail\n" \
      "@IDXATTR: userMappedCertificate\n" \
+     "@IDXATTR: ccacheFile\n" \
      "\n" \
      "dn: @MODULES\n" \
      "@LIST: asq,memberof\n" \
@@ -171,6 +173,7 @@ int sysdb_upgrade_17(struct sysdb_ctx *sysdb,
                      const char **ver);
 int sysdb_upgrade_18(struct sysdb_ctx *sysdb, const char **ver);
 int sysdb_upgrade_19(struct sysdb_ctx *sysdb, const char **ver);
+int sysdb_upgrade_20(struct sysdb_ctx *sysdb, const char **ver);
 
 int sysdb_ts_upgrade_01(struct sysdb_ctx *sysdb, const char **ver);
 

--- a/src/providers/krb5/krb5_renew_tgt.c
+++ b/src/providers/krb5/krb5_renew_tgt.c
@@ -385,7 +385,7 @@ static errno_t check_ccache_files(struct renew_tgt_ctx *renew_tgt_ctx)
 {
     TALLOC_CTX *tmp_ctx;
     int ret;
-    const char *ccache_filter = "(&("SYSDB_CCACHE_FILE"=*)("SYSDB_UC"))";
+    const char *ccache_filter = SYSDB_CCACHE_FILE"=*";
     const char *ccache_attrs[] = { SYSDB_CCACHE_FILE, SYSDB_UPN, SYSDB_NAME,
                                    SYSDB_CANONICAL_UPN, NULL };
     size_t msgs_count = 0;
@@ -403,7 +403,7 @@ static errno_t check_ccache_files(struct renew_tgt_ctx *renew_tgt_ctx)
         return ENOMEM;
     }
 
-    base_dn = sysdb_base_dn(renew_tgt_ctx->be_ctx->domain->sysdb, tmp_ctx);
+    base_dn = sysdb_user_base_dn(tmp_ctx, renew_tgt_ctx->be_ctx->domain);
     if (base_dn == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "sysdb_base_dn failed.\n");
         ret = ENOMEM;

--- a/src/providers/krb5/krb5_renew_tgt.c
+++ b/src/providers/krb5/krb5_renew_tgt.c
@@ -413,7 +413,9 @@ static errno_t check_ccache_files(struct renew_tgt_ctx *renew_tgt_ctx)
     ret = sysdb_search_entry(tmp_ctx, renew_tgt_ctx->be_ctx->domain->sysdb, base_dn,
                              LDB_SCOPE_SUBTREE, ccache_filter, ccache_attrs,
                              &msgs_count, &msgs);
-    if (ret != EOK) {
+    if (ret == ENOENT) {
+        msgs_count = 0; /* Fall through */
+    } else if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "sysdb_search_entry failed.\n");
         goto done;
     }


### PR DESCRIPTION
This PR adds a new index to the database and restricts the search base
to users to avoid check_ccache_files from taking too long and potentially
aborting sssd startup.