### PR TITLE
TESTS: fixed regression in cmocka/test_negcache_2.c

### DIFF
--- a/contrib/ci/sssd.supp
+++ b/contrib/ci/sssd.supp
@@ -221,3 +221,16 @@
    fun:set_default_locale
    fun:main
 }
+
+# glibc nsswitch (getpwuid) leak
+# Seems to be affecting Fedora < F28
+{
+   glibc-nss-getpwuid
+   Memcheck:Leak
+   fun:malloc
+   ...
+   fun:getpwuid_r@@GLIBC_2.2.5
+   fun:getpwuid
+   ...
+   fun:main
+}


### PR DESCRIPTION
Fixed regression in test introduced in 2b564f8 (PR 786)
Test was relying on hardcoded values of non local users and groups.
Test was changed to find those in runtime.

Resolves: https://pagure.io/SSSD/sssd/issue/3964