### PR TITLE
ipa: ipa_getkeytab don't call libnss_sss

### DIFF
--- a/src/providers/ipa/ipa_subdomains_server.c
+++ b/src/providers/ipa/ipa_subdomains_server.c
@@ -474,7 +474,7 @@ static void ipa_getkeytab_exec(const char *ccache,
 {
     errno_t ret;
     int debug_fd;
-    const char *gkt_env[2] = { NULL, NULL };
+    const char *gkt_env[3] = { NULL, "_SSS_LOOPS=NO", NULL };
 
     if (debug_level >= SSSDBG_TRACE_LIBS) {
         debug_fd = get_fd_from_debug_file();


### PR DESCRIPTION
ipa-getkeytab is a help process which might even get called during
the startup of SSSD. Hence it should not try to use any SSSD responder
especially not the NSS responder.

Typically we call helpers with the environment of the calling SSSD
component where then _SSS_LOOPS environment variable is set to 'NO' to
skip calls to SSSD in libnss_sss. Since we have to set the KRB5CCNAME
environment variable to the ccache with the current TGT for the host
principal when calling ipa-getkeytab execle() is used to call
ipa_getkeytab which unfortunately replaces the environment of the caller
with the one provided in the last argument of the call. To make sure
ipa_getkeytab does not call back into SSSD we have to set _SSS_LOOPS=NO
here as well.