### PR TITLE
data_provider_be: got rid of went_offline usage

### DIFF
--- a/src/providers/backend.h
+++ b/src/providers/backend.h
@@ -39,11 +39,6 @@ struct be_ctx;
 
 typedef void (*be_callback_t)(void *);
 
-struct be_offline_status {
-    time_t went_offline;
-    bool offline;
-};
-
 struct be_resolv_ctx {
     struct resolv_ctx *resolv;
     struct dp_option *opts;
@@ -104,7 +99,7 @@ struct be_ctx {
      * reset timers independently of the state of the backend. */
     struct be_cb *unconditional_online_cb_list;
 
-    struct be_offline_status offstat;
+    bool offline;
     /* Periodicly check if we can go online. */
     struct be_ptask *check_if_online_ptask;
 

--- a/src/tests/cmocka/test_be_ptask.c
+++ b/src/tests/cmocka/test_be_ptask.c
@@ -50,13 +50,11 @@ struct test_ctx {
 };
 
 #define mark_online(test_ctx) do { \
-    test_ctx->be_ctx->offstat.went_offline = 0; \
-    test_ctx->be_ctx->offstat.offline = false; \
+    test_ctx->be_ctx->offline = false; \
 } while (0)
 
 #define mark_offline(test_ctx) do { \
-    test_ctx->be_ctx->offstat.went_offline = get_current_time(); \
-    test_ctx->be_ctx->offstat.offline = true; \
+    test_ctx->be_ctx->offline = true; \
 } while (0)
 
 /* Since both test_ctx->done and ptask->req is marked as finished already
@@ -82,7 +80,7 @@ static time_t get_current_time(void)
 
 bool be_is_offline(struct be_ctx *ctx)
 {
-    return ctx->offstat.offline;
+    return ctx->offline;
 }
 
 int be_add_online_cb(TALLOC_CTX *mem_ctx,


### PR DESCRIPTION
Got rid of unused anymore `went_offline` variable

Resolves: https://pagure.io/SSSD/sssd/issue/3991