### PR TITLE
PAM: Also cache SSS_PAM_PREAUTH

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -3046,7 +3046,9 @@ subdomain_inherit = ldap_purge_cache_timeout
                             Specifies time in seconds since last successful
                             online authentication for which user will be
                             authenticated using cached credentials while
-                            SSSD is in the online mode.
+                            SSSD is in the online mode. If the credentials
+                            are incorrect, SSSD falls back to online
+                            authentication.
                         </para>
                         <para>
                             This option's value is inherited by all trusted


### PR DESCRIPTION
Related: https://pagure.io/SSSD/sssd/issue/3960

Even if cached_auth_timeout was set, the pam responder would still forward
the preauthentication requests to the back end. This could trigger unwanted
traffic towards the KDCs.