### PR TITLE
Fix pidpath in systemd unit

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5028,6 +5028,7 @@ edit_cmd = $(SED) \
         -e 's|@environment_file[@]|$(environment_file)|g' \
         -e 's|@localstatedir[@]|$(localstatedir)|g' \
         -e 's|@runstatedir[@]|$(runstatedir)|g' \
+        -e 's|@pidpath[@]|$(pidpath)|g' \
         -e 's|@logpath[@]|$(logpath)|g' \
         -e 's|@libexecdir[@]|$(libexecdir)|g' \
         -e 's|@pipepath[@]|$(pipepath)|g' \

--- a/src/sysv/systemd/sssd.service.in
+++ b/src/sysv/systemd/sssd.service.in
@@ -10,7 +10,7 @@ EnvironmentFile=-@environment_file@
 ExecStart=@sbindir@/sssd -i ${DEBUG_LOGGER}
 Type=notify
 NotifyAccess=main
-PIDFile=@localstatedir@/run/sssd.pid
+PIDFile=@pidpath@/sssd.pid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Most systems with systemd now use /run instead of /var/run,
this fixes setting correct path in systemd service when built with
--with-pid-path=/run

If --with-pid-path is not defined, than pidpath=$localstatedir/run