### PR TITLE
sudo: always use server highest usn for smart refresh

### DIFF
--- a/src/man/sssd-ldap.5.xml
+++ b/src/man/sssd-ldap.5.xml
@@ -2537,12 +2537,23 @@ ldap_access_filter = (employeeType=admin)
                         <para>
                             How many seconds SSSD has to wait before executing
                             a smart refresh of sudo rules (which downloads all
-                            rules that have USN higher than the highest USN of
-                            cached rules).
+                            rules that have USN higher than the highest server
+                            USN value that is currently known by SSSD).
                         </para>
                         <para>
                             If USN attributes are not supported by the server,
                             the modifyTimestamp attribute is used instead.
+                        </para>
+                        <para>
+                            <emphasis>Note:</emphasis> the highest USN value
+                            can be updated by three tasks:
+                            1) By sudo full and smart refresh (if updated rules
+                            are found),
+                            2) by enumeration of users and groups (if enabled
+                            and updated users or groups are found) and
+                            3) by reconnecting to the server
+                            (by default every 15 minutes, see
+                            <emphasis>ldap_connection_expire_timeout</emphasis>).
                         </para>
                         <para>
                             Default: 900 (15 minutes)

--- a/src/providers/ldap/sdap.c
+++ b/src/providers/ldap/sdap.c
@@ -1460,8 +1460,9 @@ void sdap_steal_server_opts(struct sdap_id_ctx *id_ctx,
     }
 
     /* discard if same as previous so we do not reset max usn values
-     * unnecessarily */
+     * unnecessarily, only update last_usn. */
     if (strcmp(id_ctx->srv_opts->server_id, (*srv_opts)->server_id) == 0) {
+        id_ctx->srv_opts->last_usn = (*srv_opts)->last_usn;
         talloc_zfree(*srv_opts);
         return;
     }

--- a/src/providers/ldap/sdap_sudo_shared.c
+++ b/src/providers/ldap/sdap_sudo_shared.c
@@ -174,28 +174,17 @@ sdap_sudo_set_usn(struct sdap_server_opts *srv_opts,
         return;
     }
 
-    if (usn_number == 0) {
-        /* Zero means that there were no rules on the server, so we have
-         * nothing to store. */
-        DEBUG(SSSDBG_TRACE_FUNC, "SUDO USN value is empty.\n");
-        return;
+    if (usn_number > srv_opts->last_usn) {
+        srv_opts->last_usn = usn_number;
     }
 
-    newusn = sdap_sudo_new_usn(srv_opts, usn_number, endptr);
+    newusn = sdap_sudo_new_usn(srv_opts, srv_opts->last_usn, endptr);
     if (newusn == NULL) {
         return;
     }
 
-    if (sysdb_compare_usn(newusn, srv_opts->max_sudo_value) > 0) {
-        talloc_zfree(srv_opts->max_sudo_value);
-        srv_opts->max_sudo_value = newusn;
-    } else {
-        talloc_zfree(newusn);
-    }
-
-    if (usn_number > srv_opts->last_usn) {
-        srv_opts->last_usn = usn_number;
-    }
+    talloc_zfree(srv_opts->max_sudo_value);
+    srv_opts->max_sudo_value = newusn;
 
     DEBUG(SSSDBG_FUNC_DATA, "SUDO higher USN value: [%s]\n",
                              srv_opts->max_sudo_value);


### PR DESCRIPTION
The sudo attributes may not be indexed on the server, therefore if
smart refresh filter is run on the server it may first search using
the indexed entryusn attribute and run the rest of the filter on
non-sudo objects. The number of objects that are filtered may increased
dramatically if sudo rules are not changed for a long time (and thus
keeping smaller and smaller last sudo usn number).

This patch makes sure that highest sudo usn number is always set to
the highest server usn number after each refresh.

Resolves:
https://pagure.io/SSSD/sssd/issue/3997