### PR TITLE
sudo: do not update last usn value on rules refresh

### DIFF
--- a/src/providers/ipa/ipa_sudo.h
+++ b/src/providers/ipa/ipa_sudo.h
@@ -59,7 +59,8 @@ ipa_sudo_refresh_send(TALLOC_CTX *mem_ctx,
                       struct ipa_sudo_ctx *sudo_ctx,
                       const char *cmdgroups_filter,
                       const char *search_filter,
-                      const char *delete_filter);
+                      const char *delete_filter,
+                      bool update_usn);
 
 struct tevent_req *
 ipa_sudo_rules_refresh_send(TALLOC_CTX *mem_ctx,

--- a/src/providers/ipa/ipa_sudo_async.c
+++ b/src/providers/ipa/ipa_sudo_async.c
@@ -847,6 +847,7 @@ struct ipa_sudo_refresh_state {
     const char *cmdgroups_filter;
     const char *search_filter;
     const char *delete_filter;
+    bool update_usn;
 
     struct sdap_id_op *sdap_op;
     struct sdap_handle *sh;
@@ -867,7 +868,8 @@ ipa_sudo_refresh_send(TALLOC_CTX *mem_ctx,
                       struct ipa_sudo_ctx *sudo_ctx,
                       const char *cmdgroups_filter,
                       const char *search_filter,
-                      const char *delete_filter)
+                      const char *delete_filter,
+                      bool update_usn)
 {
     struct ipa_sudo_refresh_state *state;
     struct tevent_req *req;
@@ -886,6 +888,7 @@ ipa_sudo_refresh_send(TALLOC_CTX *mem_ctx,
     state->ipa_opts = sudo_ctx->ipa_opts;
     state->sdap_opts = sudo_ctx->sdap_opts;
     state->dp_error = DP_ERR_FATAL;
+    state->update_usn = update_usn;
 
     state->sdap_op = sdap_id_op_create(state,
                                        sudo_ctx->id_ctx->conn->conn_cache);
@@ -1096,7 +1099,7 @@ ipa_sudo_refresh_done(struct tevent_req *subreq)
     }
     in_transaction = false;
 
-    if (usn != NULL) {
+    if (usn != NULL && state->update_usn) {
         sdap_sudo_set_usn(state->sudo_ctx->id_ctx->srv_opts, usn);
     }
 

--- a/src/providers/ipa/ipa_sudo_refresh.c
+++ b/src/providers/ipa/ipa_sudo_refresh.c
@@ -68,7 +68,7 @@ ipa_sudo_full_refresh_send(TALLOC_CTX *mem_ctx,
     DEBUG(SSSDBG_TRACE_FUNC, "Issuing a full refresh of sudo rules\n");
 
     subreq = ipa_sudo_refresh_send(state, ev, sudo_ctx,
-                                   NULL, NULL, delete_filter);
+                                   NULL, NULL, delete_filter, true);
     if (subreq == NULL) {
         ret = ENOMEM;
         goto immediately;
@@ -191,7 +191,7 @@ ipa_sudo_smart_refresh_send(TALLOC_CTX *mem_ctx,
                              "(USN >= %s)\n", usn);
 
     subreq = ipa_sudo_refresh_send(state, ev, sudo_ctx, cmdgroups_filter,
-                                   search_filter, NULL);
+                                   search_filter, NULL, true);
     if (subreq == NULL) {
         ret = ENOMEM;
         goto immediately;
@@ -341,7 +341,7 @@ ipa_sudo_rules_refresh_send(TALLOC_CTX *mem_ctx,
     }
 
     subreq = ipa_sudo_refresh_send(req, ev, sudo_ctx, NULL, search_filter,
-                                   delete_filter);
+                                   delete_filter, false);
     if (subreq == NULL) {
         ret = ENOMEM;
         goto immediately;

--- a/src/providers/ldap/sdap_sudo.h
+++ b/src/providers/ldap/sdap_sudo.h
@@ -49,7 +49,8 @@ errno_t sdap_sudo_init(TALLOC_CTX *mem_ctx,
 struct tevent_req *sdap_sudo_refresh_send(TALLOC_CTX *mem_ctx,
                                           struct sdap_sudo_ctx *sudo_ctx,
                                           const char *ldap_filter,
-                                          const char *sysdb_filter);
+                                          const char *sysdb_filter,
+                                          bool update_usn);
 
 int sdap_sudo_refresh_recv(TALLOC_CTX *mem_ctx,
                            struct tevent_req *req,

--- a/src/providers/ldap/sdap_sudo_refresh.c
+++ b/src/providers/ldap/sdap_sudo_refresh.c
@@ -79,7 +79,7 @@ struct tevent_req *sdap_sudo_full_refresh_send(TALLOC_CTX *mem_ctx,
     DEBUG(SSSDBG_TRACE_FUNC, "Issuing a full refresh of sudo rules\n");
 
     subreq = sdap_sudo_refresh_send(state, sudo_ctx, search_filter,
-                                    delete_filter);
+                                    delete_filter, true);
     if (subreq == NULL) {
         ret = ENOMEM;
         goto immediately;
@@ -202,7 +202,7 @@ struct tevent_req *sdap_sudo_smart_refresh_send(TALLOC_CTX *mem_ctx,
     DEBUG(SSSDBG_TRACE_FUNC, "Issuing a smart refresh of sudo rules "
                              "(USN >= %s)\n", usn);
 
-    subreq = sdap_sudo_refresh_send(state, sudo_ctx, search_filter, NULL);
+    subreq = sdap_sudo_refresh_send(state, sudo_ctx, search_filter, NULL, true);
     if (subreq == NULL) {
         ret = ENOMEM;
         goto immediately;
@@ -352,7 +352,7 @@ struct tevent_req *sdap_sudo_rules_refresh_send(TALLOC_CTX *mem_ctx,
     }
 
     subreq = sdap_sudo_refresh_send(req, sudo_ctx, search_filter,
-                                    delete_filter);
+                                    delete_filter, false);
     if (subreq == NULL) {
         ret = ENOMEM;
         goto immediately;


### PR DESCRIPTION
Refreshing specific rules may produce a higher usn value that the one
that is already remembered if the rules changed on the server. However,
there may be another rule that is not being refreshed which usn value
is higher then the current value but lower then the value of some of the
refreshed rules. If the highest usn value is updated in this case, the
rule would not be found be smart refresh.

Thus we must not update the usn value during rules refresh.

Resolves:
https://pagure.io/SSSD/sssd/issue/3996