### PR TITLE
sss_cache: Do nothing if SYSTEMD_OFFLINE=1

### DIFF
--- a/src/tools/sss_cache.c
+++ b/src/tools/sss_cache.c
@@ -147,6 +147,21 @@ int main(int argc, const char *argv[])
     bool skipped = true;
     struct sss_domain_info *dinfo;
 
+    /* In offline mode, there's not going to be a sssd instance
+     * running.  This occurs for both e.g. yum --installroot
+     * as well as rpm-ostree offline updates.
+     *
+     * So let's just quickly do nothing.  (Though note today
+     * yum --installroot doesn't set this variable, rpm-ostree
+     * does)
+     *
+     * For more information on the variable, see:
+     * https://github.com/systemd/systemd/pull/7631
+     */
+    const char *systemd_offline = getenv ("SYSTEMD_OFFLINE");
+    if (systemd_offline && strcmp (systemd_offline, "1") == 0)
+      return 0;
+
     ret = init_context(argc, argv, &tctx);
     if (ret == ENOENT) {
         /* nothing to invalidate; no reason to fail */

--- a/src/tools/sss_cache.c
+++ b/src/tools/sss_cache.c
@@ -147,7 +147,8 @@ int main(int argc, const char *argv[])
     bool skipped = true;
     struct sss_domain_info *dinfo;
 
-    /* In offline mode, there's not going to be a sssd instance
+    /* If systemd is in offline mode,
+     * there's not going to be a sssd instance
      * running.  This occurs for both e.g. yum --installroot
      * as well as rpm-ostree offline updates.
      *
@@ -159,8 +160,9 @@ int main(int argc, const char *argv[])
      * https://github.com/systemd/systemd/pull/7631
      */
     const char *systemd_offline = getenv ("SYSTEMD_OFFLINE");
-    if (systemd_offline && strcmp (systemd_offline, "1") == 0)
-      return 0;
+    if (systemd_offline && strcmp (systemd_offline, "1") == 0 && access(DB_PATH, W_OK) != 0) {
+        return 0;
+    }
 
     ret = init_context(argc, argv, &tctx);
     if (ret == ENOENT) {


### PR DESCRIPTION
Running `rpm-ostree compose tree` results in a big spam. This is because rpm-ostree doesn't want scripts writing into `/var`; it's system-administrator managed state.

Let's just silently do nothing if we're running offline, as there won't be a sssd running.

The original suggestion can be found here:
https://pagure.io/SSSD/sssd/pull-request/3959
