### PR TITLE
Implement background refresh for IPA and AD domains and subdomains

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4430,6 +4430,7 @@ libsss_ipa_la_SOURCES = \
     src/providers/ipa/ipa_srv.c \
     src/providers/ipa/ipa_idmap.c \
     src/providers/ipa/ipa_dn.c \
+    src/providers/ipa/ipa_refresh.c \
     src/providers/ad/ad_opts.c \
     src/providers/ad/ad_common.c \
     src/providers/ad/ad_dyndns.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -4502,7 +4502,10 @@ libsss_ad_la_SOURCES = \
     src/providers/ad/ad_gpo_ndr.c \
     src/providers/ad/ad_srv.c \
     src/providers/ad/ad_subdomains.c \
-    src/providers/ad/ad_domain_info.c
+    src/providers/ad/ad_domain_info.c \
+    src/providers/ad/ad_refresh.c \
+    $(NULL)
+
 
 if BUILD_SUDO
 libsss_ad_la_SOURCES += \

--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -1113,6 +1113,17 @@ errno_t sysdb_store_override(struct sss_domain_info *domain,
                              enum sysdb_member_type type,
                              struct sysdb_attrs *attrs, struct ldb_dn *obj_dn);
 
+/*
+ * Cache the time of last initgroups invocation. Typically this is not done when
+ * the provider-specific request itself finishes, because currently the request
+ * might hand over to other requests from a different provider (e.g. an AD user
+ * from a trusted domain might need to also call an IPA request to fetch the
+ * external groups). Instead, the caller of the initgroups request, typically
+ * the DP or the periodical refresh task sets the timestamp.
+ */
+errno_t sysdb_set_initgr_expire_timestamp(struct sss_domain_info *domain,
+                                          const char *name_or_upn_or_sid);
+
 /* Password caching function.
  * If you are in a transaction ignore sysdb and pass in the handle.
  * If you are not in a transaction pass NULL in handle and provide sysdb,

--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -1181,6 +1181,18 @@ int sysdb_search_users(TALLOC_CTX *mem_ctx,
                        size_t *msgs_count,
                        struct ldb_message ***msgs);
 
+#define SYSDB_SEARCH_WITH_TS_ONLY_TS_FILTER     0x0001
+#define SYSDB_SEARCH_WITH_TS_ONLY_SYSDB_FILTER  0x0002
+
+errno_t sysdb_search_with_ts_attr(TALLOC_CTX *mem_ctx,
+                                  struct sss_domain_info *domain,
+                                  struct ldb_dn *base_dn,
+                                  enum ldb_scope scope,
+                                  int optflags,
+                                  const char *filter,
+                                  const char *attrs[],
+                                  struct ldb_result **_result);
+
 int sysdb_search_users_by_timestamp(TALLOC_CTX *mem_ctx,
                                     struct sss_domain_info *domain,
                                     const char *sub_filter,

--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -261,14 +261,14 @@ done:
 
 /* =Search-Entry========================================================== */
 
-static int sysdb_cache_search_entry(TALLOC_CTX *mem_ctx,
-                                    struct ldb_context *ldb,
-                                    struct ldb_dn *base_dn,
-                                    enum ldb_scope scope,
-                                    const char *filter,
-                                    const char **attrs,
-                                    size_t *_msgs_count,
-                                    struct ldb_message ***_msgs)
+int sysdb_cache_search_entry(TALLOC_CTX *mem_ctx,
+                             struct ldb_context *ldb,
+                             struct ldb_dn *base_dn,
+                             enum ldb_scope scope,
+                             const char *filter,
+                             const char **attrs,
+                             size_t *_msgs_count,
+                             struct ldb_message ***_msgs)
 {
     TALLOC_CTX *tmp_ctx;
     struct ldb_result *res;

--- a/src/db/sysdb_private.h
+++ b/src/db/sysdb_private.h
@@ -252,6 +252,16 @@ errno_t sysdb_merge_msg_list_ts_attrs(struct sysdb_ctx *ctx,
 struct ldb_result *sss_merge_ldb_results(struct ldb_result *res,
                                          struct ldb_result *subres);
 
+/* Search Entry in an ldb cache */
+int sysdb_cache_search_entry(TALLOC_CTX *mem_ctx,
+                             struct ldb_context *ldb,
+                             struct ldb_dn *base_dn,
+                             enum ldb_scope scope,
+                             const char *filter,
+                             const char **attrs,
+                             size_t *_msgs_count,
+                             struct ldb_message ***_msgs);
+
 /* Search Entry in the timestamp cache */
 int sysdb_search_ts_entry(TALLOC_CTX *mem_ctx,
                           struct sysdb_ctx *sysdb,

--- a/src/db/sysdb_search.c
+++ b/src/db/sysdb_search.c
@@ -68,6 +68,29 @@ static errno_t merge_ts_attr(struct ldb_message *ts_msg,
     return EOK;
 }
 
+static errno_t merge_all_ts_attrs(struct ldb_message *ts_msg,
+                                  struct ldb_message *sysdb_msg,
+                                  const char *want_attrs[])
+{
+    int ret;
+
+    /* Deliberately start from 2 in order to not merge
+     * objectclass/objectcategory and avoid breaking MPGs where the OC might
+     * be made up
+     */
+    for (size_t c = 2; sysdb_ts_cache_attrs[c]; c++) {
+        ret = merge_ts_attr(ts_msg, sysdb_msg,
+                            sysdb_ts_cache_attrs[c], want_attrs);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "Cannot merge ts attr %s\n", sysdb_ts_cache_attrs[c]);
+            return ret;
+        }
+    }
+
+    return EOK;
+}
+
 static errno_t merge_msg_ts_attrs(struct sysdb_ctx *sysdb,
                                   struct ldb_message *sysdb_msg,
                                   const char *attrs[])
@@ -114,21 +137,46 @@ static errno_t merge_msg_ts_attrs(struct sysdb_ctx *sysdb,
         return EIO;
     }
 
-    /* Deliberately start from 2 in order to not merge
-     * objectclass/objectcategory and avoid breaking MPGs where the OC might
-     * be made up
-     */
-    for (size_t c = 2; sysdb_ts_cache_attrs[c]; c++) {
-        ret = merge_ts_attr(ts_msgs[0], sysdb_msg,
-                            sysdb_ts_cache_attrs[c], attrs);
-        if (ret != EOK) {
-            DEBUG(SSSDBG_MINOR_FAILURE,
-                  "Cannot merge ts attr %s\n", sysdb_ts_cache_attrs[c]);
-            goto done;
-        }
+    ret = merge_all_ts_attrs(ts_msgs[0], sysdb_msg, attrs);
+done:
+    talloc_zfree(tmp_ctx);
+    return ret;
+}
+
+static errno_t merge_msg_sysdb_attrs(TALLOC_CTX *mem_ctx,
+                                     struct sysdb_ctx *sysdb,
+                                     struct ldb_message *ts_msg,
+                                     struct ldb_message **_sysdb_msg,
+                                     const char *attrs[])
+{
+    errno_t ret;
+    TALLOC_CTX *tmp_ctx;
+    size_t msgs_count;
+    struct ldb_message **sysdb_msgs;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
     }
 
-    ret = EOK;
+    ret = sysdb_cache_search_entry(tmp_ctx, sysdb->ldb, ts_msg->dn, LDB_SCOPE_BASE,
+                                   NULL, attrs, &msgs_count, &sysdb_msgs);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    if (msgs_count != 1) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Expected 1 result for base search, got %zu\n", msgs_count);
+        goto done;
+    }
+
+    ret = merge_all_ts_attrs(ts_msg, sysdb_msgs[0], attrs);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    *_sysdb_msg = talloc_steal(mem_ctx, sysdb_msgs[0]);
 done:
     talloc_zfree(tmp_ctx);
     return ret;
@@ -163,6 +211,50 @@ errno_t sysdb_merge_res_ts_attrs(struct sysdb_ctx *ctx,
         }
     }
 
+    return EOK;
+}
+
+static errno_t merge_res_sysdb_attrs(TALLOC_CTX *mem_ctx,
+                                     struct sysdb_ctx *ctx,
+                                     struct ldb_result *ts_res,
+                                     struct ldb_result **_ts_cache_res,
+                                     const char *attrs[])
+{
+    errno_t ret;
+    struct ldb_result *ts_cache_res = NULL;
+
+    if (ts_res == NULL || ctx->ldb_ts == NULL) {
+        return EOK;
+    }
+
+    ts_cache_res = talloc_zero(mem_ctx, struct ldb_result);
+    if (ts_cache_res == NULL) {
+        return ENOMEM;
+    }
+    ts_cache_res->count = ts_res->count;
+    ts_cache_res->msgs = talloc_zero_array(ts_cache_res,
+                                           struct ldb_message *,
+                                           ts_res->count);
+    if (ts_cache_res->msgs == NULL) {
+        talloc_free(ts_cache_res);
+        return ENOMEM;
+    }
+
+    for (size_t c = 0; c < ts_res->count; c++) {
+        ret = merge_msg_sysdb_attrs(ts_cache_res->msgs,
+                                    ctx,
+                                    ts_res->msgs[c],
+                                    &ts_cache_res->msgs[c], attrs);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "Cannot merge sysdb cache values for %s\n",
+                  ldb_dn_get_linearized(ts_res->msgs[c]->dn));
+            /* non-fatal, we just get only the non-timestamp attrs */
+            continue;
+        }
+    }
+
+    *_ts_cache_res = ts_cache_res;
     return EOK;
 }
 
@@ -533,6 +625,119 @@ errno_t sysdb_search_ts_matches(TALLOC_CTX *mem_ctx,
     if (ret) {
         ret = sysdb_error_to_errno(ret);
         goto done;
+    }
+
+    *_res = talloc_steal(mem_ctx, res);
+    ret = EOK;
+
+done:
+    talloc_zfree(tmp_ctx);
+    return ret;
+}
+
+errno_t sysdb_search_with_ts_attr(TALLOC_CTX *mem_ctx,
+                                  struct sss_domain_info *domain,
+                                  struct ldb_dn *base_dn,
+                                  enum ldb_scope scope,
+                                  int optflags,
+                                  const char *filter,
+                                  const char *attrs[],
+                                  struct ldb_result **_res)
+{
+    TALLOC_CTX *tmp_ctx = NULL;
+    struct ldb_result *res;
+    errno_t ret;
+    struct ldb_message **ts_msgs = NULL;
+    struct ldb_result *ts_cache_res = NULL;
+    size_t ts_count;
+
+    if (filter == NULL) {
+        return EINVAL;
+    }
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    res = talloc_zero(tmp_ctx, struct ldb_result);
+    if (res == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    if (optflags & SYSDB_SEARCH_WITH_TS_ONLY_SYSDB_FILTER) {
+        /* We only care about searching the persistent db */
+        ts_cache_res = talloc_zero(tmp_ctx, struct ldb_result);
+        if (ts_cache_res == NULL) {
+            ret = ENOMEM;
+            goto done;
+        }
+        ts_cache_res->count = 0;
+        ts_cache_res->msgs = NULL;
+    } else {
+        /* Because the timestamp database does not contain all the
+         * attributes, we need to search the persistent db for each
+         * of the entries found and merge the results
+         */
+        struct ldb_result ts_res;
+
+        /* We assume that some of the attributes are more up-to-date in
+         * timestamps db and we're supposed to search by them, so let's
+         * first search the timestamp db
+         */
+        ret = sysdb_search_ts_entry(tmp_ctx, domain->sysdb, base_dn,
+                                    scope, filter, attrs,
+                                    &ts_count, &ts_msgs);
+        if (ret == ENOENT) {
+            ts_count = 0;
+        } else if (ret != EOK) {
+            goto done;
+        }
+
+        memset(&ts_res, 0, sizeof(struct ldb_result));
+        ts_res.count = ts_count;
+        ts_res.msgs = ts_msgs;
+
+        /* Overlay the results from the main cache with the ts attrs */
+        ret = merge_res_sysdb_attrs(tmp_ctx,
+                                    domain->sysdb,
+                                    &ts_res,
+                                    &ts_cache_res,
+                                    attrs);
+        if (ret != EOK) {
+            goto done;
+        }
+    }
+
+    if (optflags & SYSDB_SEARCH_WITH_TS_ONLY_TS_FILTER) {
+        /* The filter only contains timestamp attrs, no need to search the
+         * persistent db
+         */
+        if (ts_cache_res) {
+            res->count = ts_cache_res->count;
+            res->msgs = talloc_steal(res, ts_cache_res->msgs);
+        }
+    } else {
+        /* Because some of the attributes being searched might exist in the persistent
+         * database only, we also search the persistent db
+         */
+        size_t count;
+
+        ret = sysdb_search_entry(res, domain->sysdb, base_dn, scope,
+                                 filter, attrs, &count, &res->msgs);
+        if (ret == ENOENT) {
+            res->count = 0;
+        } else if (ret != EOK) {
+            goto done;
+        }
+        res->count = count; /* Just to cleanly assign size_t to unsigned */
+
+        res = sss_merge_ldb_results(res, ts_cache_res);
+        if (res == NULL) {
+            ret = ENOMEM;
+            goto done;
+        }
     }
 
     *_res = talloc_steal(mem_ctx, res);

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2164,7 +2164,15 @@ p11_uri = library-description=OpenSC%20smartcard%20framework;slot-id=2
                         </para>
                         <para>
                             The background refresh will process users,
-                            groups and netgroups in the cache.
+                            groups and netgroups in the cache. For users
+                            who have performed the initgroups (get group
+                            membership for user, typically ran at login)
+                            operation in the past, both the user entry
+                            and the group membership are updated.
+                        </para>
+                        <para>
+                            This option is automatically inherited for all
+                            trusted domains.
                         </para>
                         <para>
                             You can consider setting this value to

--- a/src/providers/ad/ad_common.h
+++ b/src/providers/ad/ad_common.h
@@ -224,4 +224,8 @@ errno_t ad_inherit_opts_if_needed(struct dp_option *parent_opts,
                                   struct confdb_ctx *cdb,
                                   const char *subdom_conf_path,
                                   int opt_id);
+
+errno_t ad_refresh_init(struct be_ctx *be_ctx,
+                        struct ad_id_ctx *id_ctx);
+
 #endif /* AD_COMMON_H_ */

--- a/src/providers/ad/ad_dyndns.c
+++ b/src/providers/ad/ad_dyndns.c
@@ -97,8 +97,9 @@ errno_t ad_dyndns_init(struct be_ctx *be_ctx,
               "dyndns_refresh_interval is 0\n");
         return EINVAL;
     }
+
     ret = be_ptask_create(ad_opts, be_ctx, period, ptask_first_delay, 0, 0, period,
-                          BE_PTASK_OFFLINE_DISABLE, 0,
+                          BE_PTASK_OFFLINE_DISABLE, BE_PTASK_SCHEDULE_FROM_LAST, 0,
                           ad_dyndns_update_send, ad_dyndns_update_recv, ad_opts,
                           "Dyndns update", NULL);
 

--- a/src/providers/ad/ad_id.h
+++ b/src/providers/ad/ad_id.h
@@ -34,6 +34,16 @@ errno_t ad_account_info_handler_recv(TALLOC_CTX *mem_ctx,
                                       struct dp_reply_std *data);
 
 struct tevent_req *
+ad_account_info_send(TALLOC_CTX *mem_ctx,
+                     struct be_ctx *be_ctx,
+                     struct ad_id_ctx *id_ctx,
+                     struct dp_id_data *data);
+
+errno_t ad_account_info_recv(struct tevent_req *req,
+                             int *_dp_error,
+                             const char **_err_msg);
+
+struct tevent_req *
 ad_handle_acct_info_send(TALLOC_CTX *mem_ctx,
                          struct dp_id_data *ar,
                          struct sdap_id_ctx *ctx,

--- a/src/providers/ad/ad_init.c
+++ b/src/providers/ad/ad_init.c
@@ -408,7 +408,7 @@ static errno_t ad_init_misc(struct be_ctx *be_ctx,
         return ret;
     }
 
-    ret = sdap_refresh_init(be_ctx, sdap_id_ctx);
+    ret = ad_refresh_init(be_ctx, ad_id_ctx);
     if (ret != EOK && ret != EEXIST) {
         DEBUG(SSSDBG_MINOR_FAILURE, "Periodical refresh "
               "will not work [%d]: %s\n", ret, sss_strerror(ret));

--- a/src/providers/ad/ad_init.c
+++ b/src/providers/ad/ad_init.c
@@ -408,7 +408,7 @@ static errno_t ad_init_misc(struct be_ctx *be_ctx,
         return ret;
     }
 
-    ret = sdap_refresh_init(be_ctx->refresh_ctx, sdap_id_ctx);
+    ret = sdap_refresh_init(be_ctx, sdap_id_ctx);
     if (ret != EOK && ret != EEXIST) {
         DEBUG(SSSDBG_MINOR_FAILURE, "Periodical refresh "
               "will not work [%d]: %s\n", ret, sss_strerror(ret));

--- a/src/providers/ad/ad_machine_pw_renewal.c
+++ b/src/providers/ad/ad_machine_pw_renewal.c
@@ -382,7 +382,9 @@ errno_t ad_machine_account_password_renewal_init(struct be_ctx *be_ctx,
     }
 
     ret = be_ptask_create(be_ctx, be_ctx, period, initial_delay, 0, 0, 60,
-                          BE_PTASK_OFFLINE_DISABLE, 0,
+                          BE_PTASK_OFFLINE_DISABLE,
+                          BE_PTASK_SCHEDULE_FROM_LAST,
+                          0,
                           ad_machine_account_password_renewal_send,
                           ad_machine_account_password_renewal_recv,
                           renewal_data,

--- a/src/providers/ad/ad_refresh.c
+++ b/src/providers/ad/ad_refresh.c
@@ -188,73 +188,10 @@ static errno_t ad_refresh_recv(struct tevent_req *req)
     return EOK;
 }
 
-static struct tevent_req *
-ad_refresh_initgroups_send(TALLOC_CTX *mem_ctx,
-                           struct tevent_context *ev,
-                           struct be_ctx *be_ctx,
-                           struct sss_domain_info *domain,
-                           char **names,
-                           void *pvt)
-{
-    return ad_refresh_send(mem_ctx, ev, be_ctx, domain,
-                           BE_REQ_INITGROUPS, names, pvt);
-}
-
-static errno_t ad_refresh_initgroups_recv(struct tevent_req *req)
-{
-    return ad_refresh_recv(req);
-}
-
-static struct tevent_req *
-ad_refresh_users_send(TALLOC_CTX *mem_ctx,
-                      struct tevent_context *ev,
-                      struct be_ctx *be_ctx,
-                      struct sss_domain_info *domain,
-                      char **names,
-                      void *pvt)
-{
-    return ad_refresh_send(mem_ctx, ev, be_ctx, domain,
-                           BE_REQ_USER, names, pvt);
-}
-
-static errno_t ad_refresh_users_recv(struct tevent_req *req)
-{
-    return ad_refresh_recv(req);
-}
-
-static struct tevent_req *
-ad_refresh_groups_send(TALLOC_CTX *mem_ctx,
-                       struct tevent_context *ev,
-                       struct be_ctx *be_ctx,
-                       struct sss_domain_info *domain,
-                       char **names,
-                       void *pvt)
-{
-    return ad_refresh_send(mem_ctx, ev, be_ctx, domain,
-                           BE_REQ_GROUP, names, pvt);
-}
-
-static errno_t ad_refresh_groups_recv(struct tevent_req *req)
-{
-    return ad_refresh_recv(req);
-}
-
-static struct tevent_req *
-ad_refresh_netgroups_send(TALLOC_CTX *mem_ctx,
-                          struct tevent_context *ev,
-                          struct be_ctx *be_ctx,
-                          struct sss_domain_info *domain,
-                          char **names,
-                          void *pvt)
-{
-    return ad_refresh_send(mem_ctx, ev, be_ctx, domain,
-                           BE_REQ_NETGROUP, names, pvt);
-}
-
-static errno_t ad_refresh_netgroups_recv(struct tevent_req *req)
-{
-    return ad_refresh_recv(req);
-}
+REFRESH_SEND_RECV_FNS(ad_refresh_initgroups, ad_refresh, BE_REQ_INITGROUPS);
+REFRESH_SEND_RECV_FNS(ad_refresh_users, ad_refresh, BE_REQ_USER);
+REFRESH_SEND_RECV_FNS(ad_refresh_groups, ad_refresh, BE_REQ_GROUP);
+REFRESH_SEND_RECV_FNS(ad_refresh_netgroups, ad_refresh, BE_REQ_NETGROUP);
 
 errno_t ad_refresh_init(struct be_ctx *be_ctx,
                         struct ad_id_ctx *id_ctx)

--- a/src/providers/ad/ad_refresh.c
+++ b/src/providers/ad/ad_refresh.c
@@ -260,51 +260,31 @@ errno_t ad_refresh_init(struct be_ctx *be_ctx,
                         struct ad_id_ctx *id_ctx)
 {
     errno_t ret;
+    struct be_refresh_cb ad_refresh_callbacks[] = {
+        { .send_fn = ad_refresh_initgroups_send,
+          .recv_fn = ad_refresh_initgroups_recv,
+          .pvt = id_ctx,
+        },
+        { .send_fn = ad_refresh_users_send,
+          .recv_fn = ad_refresh_users_recv,
+          .pvt = id_ctx,
+        },
+        { .send_fn = ad_refresh_groups_send,
+          .recv_fn = ad_refresh_groups_recv,
+          .pvt = id_ctx,
+        },
+        { .send_fn = ad_refresh_netgroups_send,
+          .recv_fn = ad_refresh_netgroups_recv,
+          .pvt = id_ctx,
+        },
+    };
 
-    ret = be_refresh_ctx_init(be_ctx, SYSDB_SID_STR);
+    ret = be_refresh_ctx_init_with_callbacks(be_ctx,
+                                             SYSDB_SID_STR,
+                                             ad_refresh_callbacks);
     if (ret != EOK) {
-        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to initialize refresh_ctx\n");
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to initialize background refresh\n");
         return ret;
-    }
-
-    ret = be_refresh_add_cb(be_ctx->refresh_ctx,
-                            BE_REFRESH_TYPE_INITGROUPS,
-                            ad_refresh_initgroups_send,
-                            ad_refresh_initgroups_recv,
-                            id_ctx);
-    if (ret != EOK && ret != EEXIST) {
-        DEBUG(SSSDBG_MINOR_FAILURE, "Periodical refresh of users "
-              "will not work [%d]: %s\n", ret, strerror(ret));
-    }
-
-    ret = be_refresh_add_cb(be_ctx->refresh_ctx,
-                            BE_REFRESH_TYPE_USERS,
-                            ad_refresh_users_send,
-                            ad_refresh_users_recv,
-                            id_ctx);
-    if (ret != EOK && ret != EEXIST) {
-        DEBUG(SSSDBG_MINOR_FAILURE, "Periodical refresh of users "
-              "will not work [%d]: %s\n", ret, strerror(ret));
-    }
-
-    ret = be_refresh_add_cb(be_ctx->refresh_ctx,
-                            BE_REFRESH_TYPE_GROUPS,
-                            ad_refresh_groups_send,
-                            ad_refresh_groups_recv,
-                            id_ctx);
-    if (ret != EOK && ret != EEXIST) {
-        DEBUG(SSSDBG_MINOR_FAILURE, "Periodical refresh of groups "
-              "will not work [%d]: %s\n", ret, strerror(ret));
-    }
-
-    ret = be_refresh_add_cb(be_ctx->refresh_ctx,
-                            BE_REFRESH_TYPE_NETGROUPS,
-                            ad_refresh_netgroups_send,
-                            ad_refresh_netgroups_recv,
-                            id_ctx);
-    if (ret != EOK && ret != EEXIST) {
-        DEBUG(SSSDBG_MINOR_FAILURE, "Periodical refresh of netgroups "
-              "will not work [%d]: %s\n", ret, strerror(ret));
     }
 
     return ret;

--- a/src/providers/ad/ad_refresh.c
+++ b/src/providers/ad/ad_refresh.c
@@ -1,0 +1,283 @@
+/*
+    Copyright (C) 2019 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <talloc.h>
+#include <tevent.h>
+
+#include "providers/ad/ad_common.h"
+#include "providers/ad/ad_id.h"
+
+struct ad_refresh_state {
+    struct tevent_context *ev;
+    struct be_ctx *be_ctx;
+    struct dp_id_data *account_req;
+    struct ad_id_ctx *id_ctx;
+    char **names;
+    size_t index;
+};
+
+static errno_t ad_refresh_step(struct tevent_req *req);
+static void ad_refresh_done(struct tevent_req *subreq);
+
+static struct tevent_req *ad_refresh_send(TALLOC_CTX *mem_ctx,
+                                            struct tevent_context *ev,
+                                            struct be_ctx *be_ctx,
+                                            struct sss_domain_info *domain,
+                                            int entry_type,
+                                            char **names,
+                                            void *pvt)
+{
+    struct ad_refresh_state *state = NULL;
+    struct tevent_req *req = NULL;
+    errno_t ret;
+    uint32_t filter_type;
+
+    req = tevent_req_create(mem_ctx, &state,
+                            struct ad_refresh_state);
+    if (req == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "tevent_req_create() failed\n");
+        return NULL;
+    }
+
+    if (names == NULL) {
+        ret = EOK;
+        goto immediately;
+    }
+
+    state->ev = ev;
+    state->be_ctx = be_ctx;
+    state->id_ctx = talloc_get_type(pvt, struct ad_id_ctx);
+    state->names = names;
+    state->index = 0;
+
+    switch (entry_type) {
+    case BE_REQ_NETGROUP:
+        filter_type = BE_FILTER_NAME;
+        break;
+    case BE_REQ_USER:
+    case BE_REQ_GROUP:
+        filter_type = BE_FILTER_SECID;
+        break;
+    default:
+        ret = EINVAL;
+        goto immediately;
+    }
+
+    state->account_req = be_refresh_acct_req(state, entry_type,
+                                             filter_type, domain);
+    if (state->account_req == NULL) {
+        ret = ENOMEM;
+        goto immediately;
+    }
+
+    ret = ad_refresh_step(req);
+    if (ret == EOK) {
+        DEBUG(SSSDBG_TRACE_FUNC, "Nothing to refresh\n");
+        goto immediately;
+    } else if (ret != EAGAIN) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "ad_refresh_step() failed "
+                                   "[%d]: %s\n", ret, sss_strerror(ret));
+        goto immediately;
+    }
+
+    return req;
+
+immediately:
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else {
+        tevent_req_error(req, ret);
+    }
+    tevent_req_post(req, ev);
+
+    return req;
+}
+
+static errno_t ad_refresh_step(struct tevent_req *req)
+{
+    struct ad_refresh_state *state = NULL;
+    struct tevent_req *subreq = NULL;
+    errno_t ret;
+
+    state = tevent_req_data(req, struct ad_refresh_state);
+
+    if (state->names == NULL) {
+        ret = EOK;
+        goto done;
+    }
+
+    state->account_req->filter_value = state->names[state->index];
+    if (state->account_req->filter_value == NULL) {
+        ret = EOK;
+        goto done;
+    }
+
+    DEBUG(SSSDBG_TRACE_FUNC, "Issuing refresh of %s %s\n",
+          be_req2str(state->account_req->entry_type),
+          state->account_req->filter_value);
+
+    subreq = ad_account_info_send(state, state->be_ctx, state->id_ctx,
+                                  state->account_req);
+    if (subreq == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    tevent_req_set_callback(subreq, ad_refresh_done, req);
+
+    state->index++;
+    ret = EAGAIN;
+
+done:
+    return ret;
+}
+
+static void ad_refresh_done(struct tevent_req *subreq)
+{
+    struct ad_refresh_state *state = NULL;
+    struct tevent_req *req = NULL;
+    const char *err_msg = NULL;
+    errno_t dp_error;
+    errno_t ret;
+
+    req = tevent_req_callback_data(subreq, struct tevent_req);
+    state = tevent_req_data(req, struct ad_refresh_state);
+
+    ret = ad_account_info_recv(subreq, &dp_error, &err_msg);
+    talloc_zfree(subreq);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to refresh %s [dp_error: %d, "
+              "errno: %d]: %s\n", be_req2str(state->account_req->entry_type),
+              dp_error, ret, err_msg);
+        goto done;
+    }
+
+    ret = ad_refresh_step(req);
+    if (ret == EAGAIN) {
+        return;
+    }
+
+done:
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    tevent_req_done(req);
+}
+
+static errno_t ad_refresh_recv(struct tevent_req *req)
+{
+    TEVENT_REQ_RETURN_ON_ERROR(req);
+
+    return EOK;
+}
+
+static struct tevent_req *
+ad_refresh_users_send(TALLOC_CTX *mem_ctx,
+                      struct tevent_context *ev,
+                      struct be_ctx *be_ctx,
+                      struct sss_domain_info *domain,
+                      char **names,
+                      void *pvt)
+{
+    return ad_refresh_send(mem_ctx, ev, be_ctx, domain,
+                           BE_REQ_USER, names, pvt);
+}
+
+static errno_t ad_refresh_users_recv(struct tevent_req *req)
+{
+    return ad_refresh_recv(req);
+}
+
+static struct tevent_req *
+ad_refresh_groups_send(TALLOC_CTX *mem_ctx,
+                       struct tevent_context *ev,
+                       struct be_ctx *be_ctx,
+                       struct sss_domain_info *domain,
+                       char **names,
+                       void *pvt)
+{
+    return ad_refresh_send(mem_ctx, ev, be_ctx, domain,
+                           BE_REQ_GROUP, names, pvt);
+}
+
+static errno_t ad_refresh_groups_recv(struct tevent_req *req)
+{
+    return ad_refresh_recv(req);
+}
+
+static struct tevent_req *
+ad_refresh_netgroups_send(TALLOC_CTX *mem_ctx,
+                          struct tevent_context *ev,
+                          struct be_ctx *be_ctx,
+                          struct sss_domain_info *domain,
+                          char **names,
+                          void *pvt)
+{
+    return ad_refresh_send(mem_ctx, ev, be_ctx, domain,
+                           BE_REQ_NETGROUP, names, pvt);
+}
+
+static errno_t ad_refresh_netgroups_recv(struct tevent_req *req)
+{
+    return ad_refresh_recv(req);
+}
+
+errno_t ad_refresh_init(struct be_ctx *be_ctx,
+                        struct ad_id_ctx *id_ctx)
+{
+    errno_t ret;
+
+    ret = be_refresh_ctx_init(be_ctx, SYSDB_SID_STR);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to initialize refresh_ctx\n");
+        return ret;
+    }
+
+    ret = be_refresh_add_cb(be_ctx->refresh_ctx,
+                            BE_REFRESH_TYPE_USERS,
+                            ad_refresh_users_send,
+                            ad_refresh_users_recv,
+                            id_ctx);
+    if (ret != EOK && ret != EEXIST) {
+        DEBUG(SSSDBG_MINOR_FAILURE, "Periodical refresh of users "
+              "will not work [%d]: %s\n", ret, strerror(ret));
+    }
+
+    ret = be_refresh_add_cb(be_ctx->refresh_ctx,
+                            BE_REFRESH_TYPE_GROUPS,
+                            ad_refresh_groups_send,
+                            ad_refresh_groups_recv,
+                            id_ctx);
+    if (ret != EOK && ret != EEXIST) {
+        DEBUG(SSSDBG_MINOR_FAILURE, "Periodical refresh of groups "
+              "will not work [%d]: %s\n", ret, strerror(ret));
+    }
+
+    ret = be_refresh_add_cb(be_ctx->refresh_ctx,
+                            BE_REFRESH_TYPE_NETGROUPS,
+                            ad_refresh_netgroups_send,
+                            ad_refresh_netgroups_recv,
+                            id_ctx);
+    if (ret != EOK && ret != EEXIST) {
+        DEBUG(SSSDBG_MINOR_FAILURE, "Periodical refresh of netgroups "
+              "will not work [%d]: %s\n", ret, strerror(ret));
+    }
+
+    return ret;
+}

--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -2066,7 +2066,9 @@ errno_t ad_subdomains_init(TALLOC_CTX *mem_ctx,
 
     period = be_ctx->domain->subdomain_refresh_interval;
     ret = be_ptask_create(sd_ctx, be_ctx, period, 0, 0, 0, period,
-                          BE_PTASK_OFFLINE_DISABLE, 0,
+                          BE_PTASK_OFFLINE_DISABLE,
+                          BE_PTASK_SCHEDULE_FROM_LAST,
+                          0,
                           ad_subdomains_ptask_send, ad_subdomains_ptask_recv, sd_ctx,
                           "Subdomains Refresh", NULL);
     if (ret != EOK) {

--- a/src/providers/be_ptask_private.h
+++ b/src/providers/be_ptask_private.h
@@ -32,6 +32,7 @@ struct be_ptask {
     time_t timeout;
     time_t max_backoff;
     enum be_ptask_offline offline;
+    enum be_ptask_schedule success_schedule_type;
     be_ptask_send_t send_fn;
     be_ptask_recv_t recv_fn;
     void *pvt;

--- a/src/providers/be_refresh.c
+++ b/src/providers/be_refresh.c
@@ -365,6 +365,7 @@ errno_t be_refresh_recv(struct tevent_req *req)
 
 struct dp_id_data *be_refresh_acct_req(TALLOC_CTX *mem_ctx,
                                        uint32_t entry_type,
+                                       uint32_t filter_type,
                                        struct sss_domain_info *domain)
 {
     struct dp_id_data *account_req;
@@ -375,7 +376,7 @@ struct dp_id_data *be_refresh_acct_req(TALLOC_CTX *mem_ctx,
     }
 
     account_req->entry_type = entry_type;
-    account_req->filter_type = BE_FILTER_NAME;
+    account_req->filter_type = filter_type;
     account_req->extra_value = NULL;
     account_req->domain = domain->name;
     return account_req;

--- a/src/providers/be_refresh.c
+++ b/src/providers/be_refresh.c
@@ -156,7 +156,9 @@ errno_t be_refresh_ctx_init(struct be_ctx *be_ctx,
     refresh_interval = be_ctx->domain->refresh_expired_interval;
     if (refresh_interval > 0) {
         ret = be_ptask_create(be_ctx, be_ctx, refresh_interval, 30, 5, 0,
-                              refresh_interval, BE_PTASK_OFFLINE_SKIP, 0,
+                              refresh_interval, BE_PTASK_OFFLINE_SKIP,
+                              BE_PTASK_SCHEDULE_FROM_LAST,
+                              0,
                               be_refresh_send, be_refresh_recv,
                               ctx, "Refresh Records", NULL);
         if (ret != EOK) {

--- a/src/providers/be_refresh.c
+++ b/src/providers/be_refresh.c
@@ -157,7 +157,7 @@ errno_t be_refresh_ctx_init(struct be_ctx *be_ctx,
     if (refresh_interval > 0) {
         ret = be_ptask_create(be_ctx, be_ctx, refresh_interval, 30, 5, 0,
                               refresh_interval, BE_PTASK_OFFLINE_SKIP,
-                              BE_PTASK_SCHEDULE_FROM_LAST,
+                              BE_PTASK_SCHEDULE_FROM_NOW,
                               0,
                               be_refresh_send, be_refresh_recv,
                               ctx, "Refresh Records", NULL);

--- a/src/providers/be_refresh.c
+++ b/src/providers/be_refresh.c
@@ -255,7 +255,9 @@ static errno_t be_refresh_step(struct tevent_req *req)
 
         /* if not found than continue with next domain */
         if (state->index == BE_REFRESH_TYPE_SENTINEL) {
-            state->domain = get_next_domain(state->domain, 0);
+            state->domain = get_next_domain(state->domain,
+                                            SSS_GND_DESCEND);
+            state->index = 0;
             continue;
         }
 

--- a/src/providers/be_refresh.c
+++ b/src/providers/be_refresh.c
@@ -362,3 +362,21 @@ errno_t be_refresh_recv(struct tevent_req *req)
 
     return EOK;
 }
+
+struct dp_id_data *be_refresh_acct_req(TALLOC_CTX *mem_ctx,
+                                       uint32_t entry_type,
+                                       struct sss_domain_info *domain)
+{
+    struct dp_id_data *account_req;
+
+    account_req = talloc_zero(mem_ctx, struct dp_id_data);
+    if (account_req == NULL) {
+        return NULL;
+    }
+
+    account_req->entry_type = entry_type;
+    account_req->filter_type = BE_FILTER_NAME;
+    account_req->extra_value = NULL;
+    account_req->domain = domain->name;
+    return account_req;
+}

--- a/src/providers/be_refresh.h
+++ b/src/providers/be_refresh.h
@@ -29,6 +29,26 @@
 /* solve circular dependency */
 struct be_ctx;
 
+#define REFRESH_SEND_RECV_FNS(outer_base, inner_base, req_type) \
+                                                                \
+static struct tevent_req *                                      \
+outer_base ##_send(TALLOC_CTX *mem_ctx,                         \
+                   struct tevent_context *ev,                   \
+                   struct be_ctx *be_ctx,                       \
+                   struct sss_domain_info *domain,              \
+                   char **names,                                \
+                   void *pvt)                                   \
+{                                                               \
+    return inner_base ##_send(mem_ctx, ev,                      \
+                              be_ctx, domain,                   \
+                              req_type, names, pvt);            \
+}                                                               \
+                                                                \
+static errno_t outer_base ##_recv(struct tevent_req *req)       \
+{                                                               \
+    return inner_base ##_recv(req);                             \
+}                                                               \
+
 /**
  * name_list contains SYSDB_NAME of all expired records.
  */

--- a/src/providers/be_refresh.h
+++ b/src/providers/be_refresh.h
@@ -69,4 +69,8 @@ struct tevent_req *be_refresh_send(TALLOC_CTX *mem_ctx,
 
 errno_t be_refresh_recv(struct tevent_req *req);
 
+struct dp_id_data *be_refresh_acct_req(TALLOC_CTX *mem_ctx,
+                                       uint32_t entry_type,
+                                       struct sss_domain_info *domain);
+
 #endif /* _DP_REFRESH_H_ */

--- a/src/providers/be_refresh.h
+++ b/src/providers/be_refresh.h
@@ -44,6 +44,7 @@ typedef errno_t
 (*be_refresh_recv_t)(struct tevent_req *req);
 
 enum be_refresh_type {
+    BE_REFRESH_TYPE_INITGROUPS,
     BE_REFRESH_TYPE_USERS,
     BE_REFRESH_TYPE_GROUPS,
     BE_REFRESH_TYPE_NETGROUPS,

--- a/src/providers/be_refresh.h
+++ b/src/providers/be_refresh.h
@@ -51,16 +51,17 @@ enum be_refresh_type {
     BE_REFRESH_TYPE_SENTINEL
 };
 
+struct be_refresh_cb {
+    be_refresh_send_t send_fn;
+    be_refresh_recv_t recv_fn;
+    void *pvt;
+};
+
 struct be_refresh_ctx;
 
-errno_t be_refresh_ctx_init(struct be_ctx *be_ctx,
-                            const char *attr_name);
-
-errno_t be_refresh_add_cb(struct be_refresh_ctx *ctx,
-                          enum be_refresh_type type,
-                          be_refresh_send_t send_fn,
-                          be_refresh_recv_t recv_fn,
-                          void *pvt);
+errno_t be_refresh_ctx_init_with_callbacks(struct be_ctx *be_ctx,
+                                           const char *attr_name,
+                                           struct be_refresh_cb *callbacks);
 
 struct tevent_req *be_refresh_send(TALLOC_CTX *mem_ctx,
                                    struct tevent_context *ev,

--- a/src/providers/be_refresh.h
+++ b/src/providers/be_refresh.h
@@ -71,6 +71,7 @@ errno_t be_refresh_recv(struct tevent_req *req);
 
 struct dp_id_data *be_refresh_acct_req(TALLOC_CTX *mem_ctx,
                                        uint32_t entry_type,
+                                       uint32_t filter_type,
                                        struct sss_domain_info *domain);
 
 #endif /* _DP_REFRESH_H_ */

--- a/src/providers/be_refresh.h
+++ b/src/providers/be_refresh.h
@@ -52,8 +52,8 @@ enum be_refresh_type {
 
 struct be_refresh_ctx;
 
-struct be_refresh_ctx *be_refresh_ctx_init(struct be_ctx *be_ctx,
-                                           const char *attr_name);
+errno_t be_refresh_ctx_init(struct be_ctx *be_ctx,
+                            const char *attr_name);
 
 errno_t be_refresh_add_cb(struct be_refresh_ctx *ctx,
                           enum be_refresh_type type,

--- a/src/providers/be_refresh.h
+++ b/src/providers/be_refresh.h
@@ -52,7 +52,8 @@ enum be_refresh_type {
 
 struct be_refresh_ctx;
 
-struct be_refresh_ctx *be_refresh_ctx_init(struct be_ctx *be_ctx);
+struct be_refresh_ctx *be_refresh_ctx_init(struct be_ctx *be_ctx,
+                                           const char *attr_name);
 
 errno_t be_refresh_add_cb(struct be_refresh_ctx *ctx,
                           enum be_refresh_type type,

--- a/src/providers/be_refresh.h
+++ b/src/providers/be_refresh.h
@@ -52,7 +52,7 @@ enum be_refresh_type {
 
 struct be_refresh_ctx;
 
-struct be_refresh_ctx *be_refresh_ctx_init(TALLOC_CTX *mem_ctx);
+struct be_refresh_ctx *be_refresh_ctx_init(struct be_ctx *be_ctx);
 
 errno_t be_refresh_add_cb(struct be_refresh_ctx *ctx,
                           enum be_refresh_type type,

--- a/src/providers/data_provider/dp_target_id.c
+++ b/src/providers/data_provider/dp_target_id.c
@@ -390,69 +390,22 @@ done:
     return ret;
 }
 
-static errno_t set_initgroups_expire_attribute(struct sss_domain_info *domain,
-                                               const char *name)
-{
-    errno_t ret;
-    time_t cache_timeout;
-    struct sysdb_attrs *attrs;
-
-    attrs = sysdb_new_attrs(NULL);
-    if (attrs == NULL) {
-        return ENOMEM;
-    }
-
-    cache_timeout = domain->user_timeout
-                        ? time(NULL) + domain->user_timeout
-                        : 0;
-
-    ret = sysdb_attrs_add_time_t(attrs, SYSDB_INITGR_EXPIRE, cache_timeout);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Could not set up attrs\n");
-        goto done;
-    }
-
-    ret = sysdb_set_user_attr(domain, name, attrs, SYSDB_MOD_REP);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Failed to set initgroups expire attribute\n");
-        goto done;
-    }
-
-done:
-    talloc_zfree(attrs);
-    return ret;
-}
-
 static void dp_req_initgr_pp_set_initgr_timestamp(struct dp_initgr_ctx *ctx,
                                                   struct dp_reply_std *reply)
 {
     errno_t ret;
-    const char *cname;
 
     if (reply->dp_error != DP_ERR_OK || reply->error != EOK) {
         /* Only bump the timestamp on successful lookups */
         return;
     }
 
-    ret = sysdb_get_real_name(ctx,
-                              ctx->domain_info,
-                              ctx->filter_value,
-                              &cname);
-    if (ret == ENOENT) {
-        /* No point trying to bump timestamp of an entry that does not exist..*/
-        return;
-    } else if (ret != EOK) {
-        cname = ctx->filter_value;
-        DEBUG(SSSDBG_MINOR_FAILURE,
-              "Failed to canonicalize name, using [%s]\n", cname);
-    }
-
-    ret = set_initgroups_expire_attribute(ctx->domain_info, cname);
+    ret = sysdb_set_initgr_expire_timestamp(ctx->domain_info,
+                                            ctx->filter_value);
     if (ret != EOK) {
         DEBUG(SSSDBG_MINOR_FAILURE,
-              "Cannot set the initgroups expire attribute [%d]: %s\n",
-              ret, sss_strerror(ret));
+              "Failed to set initgroups expiration for [%s]\n",
+              ctx->filter_value);
     }
 }
 

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -454,7 +454,6 @@ errno_t be_process_init(TALLOC_CTX *mem_ctx,
                         struct tevent_context *ev,
                         struct confdb_ctx *cdb)
 {
-    uint32_t refresh_interval;
     struct tevent_req *req;
     struct be_ctx *be_ctx;
     char *str = NULL;
@@ -543,19 +542,6 @@ errno_t be_process_init(TALLOC_CTX *mem_ctx,
         DEBUG(SSSDBG_FATAL_FAILURE, "Unable to initialize refresh_ctx\n");
         ret = ENOMEM;
         goto done;
-    }
-
-    refresh_interval = be_ctx->domain->refresh_expired_interval;
-    if (refresh_interval > 0) {
-        ret = be_ptask_create(be_ctx, be_ctx, refresh_interval, 30, 5, 0,
-                              refresh_interval, BE_PTASK_OFFLINE_SKIP, 0,
-                              be_refresh_send, be_refresh_recv,
-                              be_ctx->refresh_ctx, "Refresh Records", NULL);
-        if (ret != EOK) {
-            DEBUG(SSSDBG_FATAL_FAILURE,
-                  "Unable to initialize refresh periodic task\n");
-            goto done;
-        }
     }
 
     req = dp_init_send(be_ctx, be_ctx->ev, be_ctx, be_ctx->uid, be_ctx->gid);

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -536,14 +536,6 @@ errno_t be_process_init(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    /* Initialize be_refresh periodic task. */
-    be_ctx->refresh_ctx = be_refresh_ctx_init(be_ctx);
-    if (be_ctx->refresh_ctx == NULL) {
-        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to initialize refresh_ctx\n");
-        ret = ENOMEM;
-        goto done;
-    }
-
     req = dp_init_send(be_ctx, be_ctx->ev, be_ctx, be_ctx->uid, be_ctx->gid);
     if (req == NULL) {
         ret = ENOMEM;

--- a/src/providers/ipa/ipa_common.h
+++ b/src/providers/ipa/ipa_common.h
@@ -301,4 +301,7 @@ errno_t ipa_get_host_attrs(struct dp_option *ipa_options,
                            struct sysdb_attrs **hosts,
                            struct sysdb_attrs **_ipa_host);
 
+errno_t ipa_refresh_init(struct be_ctx *be_ctx,
+                         struct ipa_id_ctx *id_ctx);
+
 #endif /* _IPA_COMMON_H_ */

--- a/src/providers/ipa/ipa_dyndns.c
+++ b/src/providers/ipa/ipa_dyndns.c
@@ -72,8 +72,11 @@ errno_t ipa_dyndns_init(struct be_ctx *be_ctx,
               "dyndns_refresh_interval is 0\n");
         return EINVAL;
     }
+
     ret = be_ptask_create(ctx, be_ctx, period, ptask_first_delay, 0, 0, period,
-                          BE_PTASK_OFFLINE_DISABLE, 0,
+                          BE_PTASK_OFFLINE_DISABLE,
+                          BE_PTASK_SCHEDULE_FROM_LAST,
+                          0,
                           ipa_dyndns_update_send, ipa_dyndns_update_recv, ctx,
                           "Dyndns update", NULL);
     if (ret != EOK) {

--- a/src/providers/ipa/ipa_id.h
+++ b/src/providers/ipa/ipa_id.h
@@ -34,6 +34,14 @@
 #define IPA_DEFAULT_VIEW_NAME "Default Trust View"
 
 struct tevent_req *
+ipa_account_info_send(TALLOC_CTX *mem_ctx,
+                      struct be_ctx *be_ctx,
+                      struct ipa_id_ctx *id_ctx,
+                      struct dp_id_data *data);
+errno_t ipa_account_info_recv(struct tevent_req *req,
+                              int *_dp_error);
+
+struct tevent_req *
 ipa_account_info_handler_send(TALLOC_CTX *mem_ctx,
                               struct ipa_id_ctx *id_ctx,
                               struct dp_id_data *data,

--- a/src/providers/ipa/ipa_init.c
+++ b/src/providers/ipa/ipa_init.c
@@ -594,7 +594,7 @@ static errno_t ipa_init_misc(struct be_ctx *be_ctx,
         }
     }
 
-    ret = sdap_refresh_init(be_ctx, sdap_id_ctx);
+    ret = ipa_refresh_init(be_ctx, ipa_id_ctx);
     if (ret != EOK && ret != EEXIST) {
         DEBUG(SSSDBG_MINOR_FAILURE, "Periodical refresh "
               "will not work [%d]: %s\n", ret, sss_strerror(ret));

--- a/src/providers/ipa/ipa_init.c
+++ b/src/providers/ipa/ipa_init.c
@@ -594,7 +594,7 @@ static errno_t ipa_init_misc(struct be_ctx *be_ctx,
         }
     }
 
-    ret = sdap_refresh_init(be_ctx->refresh_ctx, sdap_id_ctx);
+    ret = sdap_refresh_init(be_ctx, sdap_id_ctx);
     if (ret != EOK && ret != EEXIST) {
         DEBUG(SSSDBG_MINOR_FAILURE, "Periodical refresh "
               "will not work [%d]: %s\n", ret, sss_strerror(ret));

--- a/src/providers/ipa/ipa_refresh.c
+++ b/src/providers/ipa/ipa_refresh.c
@@ -1,0 +1,264 @@
+/*
+    Copyright (C) 2019 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <talloc.h>
+#include <tevent.h>
+
+#include "providers/ipa/ipa_common.h"
+#include "providers/ipa/ipa_id.h"
+
+struct ipa_refresh_state {
+    struct tevent_context *ev;
+    struct be_ctx *be_ctx;
+    struct dp_id_data *account_req;
+    struct ipa_id_ctx *id_ctx;
+    char **names;
+    size_t index;
+};
+
+static errno_t ipa_refresh_step(struct tevent_req *req);
+static void ipa_refresh_done(struct tevent_req *subreq);
+
+static struct tevent_req *ipa_refresh_send(TALLOC_CTX *mem_ctx,
+                                            struct tevent_context *ev,
+                                            struct be_ctx *be_ctx,
+                                            struct sss_domain_info *domain,
+                                            int entry_type,
+                                            char **names,
+                                            void *pvt)
+{
+    struct ipa_refresh_state *state = NULL;
+    struct tevent_req *req = NULL;
+    errno_t ret;
+
+    req = tevent_req_create(mem_ctx, &state,
+                            struct ipa_refresh_state);
+    if (req == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "tevent_req_create() failed\n");
+        return NULL;
+    }
+
+    if (names == NULL) {
+        ret = EOK;
+        goto immediately;
+    }
+
+    state->ev = ev;
+    state->be_ctx = be_ctx;
+    state->id_ctx = talloc_get_type(pvt, struct ipa_id_ctx);
+    state->names = names;
+    state->index = 0;
+
+    state->account_req = be_refresh_acct_req(state, entry_type,
+                                             BE_FILTER_NAME, domain);
+    if (state->account_req == NULL) {
+        ret = ENOMEM;
+        goto immediately;
+    }
+
+    ret = ipa_refresh_step(req);
+    if (ret == EOK) {
+        DEBUG(SSSDBG_TRACE_FUNC, "Nothing to refresh\n");
+        goto immediately;
+    } else if (ret != EAGAIN) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "ipa_refresh_step() failed "
+                                   "[%d]: %s\n", ret, sss_strerror(ret));
+        goto immediately;
+    }
+
+    return req;
+
+immediately:
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else {
+        tevent_req_error(req, ret);
+    }
+    tevent_req_post(req, ev);
+
+    return req;
+}
+
+static errno_t ipa_refresh_step(struct tevent_req *req)
+{
+    struct ipa_refresh_state *state = NULL;
+    struct tevent_req *subreq = NULL;
+    errno_t ret;
+
+    state = tevent_req_data(req, struct ipa_refresh_state);
+
+    if (state->names == NULL) {
+        ret = EOK;
+        goto done;
+    }
+
+    state->account_req->filter_value = state->names[state->index];
+    if (state->account_req->filter_value == NULL) {
+        ret = EOK;
+        goto done;
+    }
+
+    subreq = ipa_account_info_send(state, state->be_ctx, state->id_ctx,
+                                  state->account_req);
+    if (subreq == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    tevent_req_set_callback(subreq, ipa_refresh_done, req);
+
+    state->index++;
+    ret = EAGAIN;
+
+done:
+    return ret;
+}
+
+static void ipa_refresh_done(struct tevent_req *subreq)
+{
+    struct ipa_refresh_state *state = NULL;
+    struct tevent_req *req = NULL;
+    errno_t dp_error;
+    errno_t ret;
+
+    req = tevent_req_callback_data(subreq, struct tevent_req);
+    state = tevent_req_data(req, struct ipa_refresh_state);
+
+    ret = ipa_account_info_recv(subreq, &dp_error);
+    talloc_zfree(subreq);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to refresh %s [dp_error: %d, "
+              "errno: %d]\n", be_req2str(state->account_req->entry_type),
+              dp_error, ret);
+        goto done;
+    }
+
+    ret = ipa_refresh_step(req);
+    if (ret == EAGAIN) {
+        return;
+    }
+
+done:
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    tevent_req_done(req);
+}
+
+static errno_t ipa_refresh_recv(struct tevent_req *req)
+{
+    TEVENT_REQ_RETURN_ON_ERROR(req);
+
+    return EOK;
+}
+
+static struct tevent_req *
+ipa_refresh_users_send(TALLOC_CTX *mem_ctx,
+                        struct tevent_context *ev,
+                        struct be_ctx *be_ctx,
+                        struct sss_domain_info *domain,
+                        char **names,
+                        void *pvt)
+{
+    return ipa_refresh_send(mem_ctx, ev, be_ctx, domain,
+                           BE_REQ_USER, names, pvt);
+}
+
+static errno_t ipa_refresh_users_recv(struct tevent_req *req)
+{
+    return ipa_refresh_recv(req);
+}
+
+static struct tevent_req *
+ipa_refresh_groups_send(TALLOC_CTX *mem_ctx,
+                         struct tevent_context *ev,
+                         struct be_ctx *be_ctx,
+                         struct sss_domain_info *domain,
+                         char **names,
+                         void *pvt)
+{
+    return ipa_refresh_send(mem_ctx, ev, be_ctx, domain,
+                           BE_REQ_GROUP, names, pvt);
+}
+
+static errno_t ipa_refresh_groups_recv(struct tevent_req *req)
+{
+    return ipa_refresh_recv(req);
+}
+
+static struct tevent_req *
+ipa_refresh_netgroups_send(TALLOC_CTX *mem_ctx,
+                            struct tevent_context *ev,
+                            struct be_ctx *be_ctx,
+                            struct sss_domain_info *domain,
+                            char **names,
+                            void *pvt)
+{
+    return ipa_refresh_send(mem_ctx, ev, be_ctx, domain,
+                           BE_REQ_NETGROUP, names, pvt);
+}
+
+static errno_t ipa_refresh_netgroups_recv(struct tevent_req *req)
+{
+    return ipa_refresh_recv(req);
+}
+
+errno_t ipa_refresh_init(struct be_ctx *be_ctx,
+                         struct ipa_id_ctx *id_ctx)
+{
+    errno_t ret;
+
+    ret = be_refresh_ctx_init(be_ctx, SYSDB_NAME);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to initialize refresh_ctx\n");
+        return ENOMEM;
+    }
+
+    ret = be_refresh_add_cb(be_ctx->refresh_ctx,
+                            BE_REFRESH_TYPE_USERS,
+                            ipa_refresh_users_send,
+                            ipa_refresh_users_recv,
+                            id_ctx);
+    if (ret != EOK && ret != EEXIST) {
+        DEBUG(SSSDBG_MINOR_FAILURE, "Periodical refresh of users "
+              "will not work [%d]: %s\n", ret, strerror(ret));
+    }
+
+    ret = be_refresh_add_cb(be_ctx->refresh_ctx,
+                            BE_REFRESH_TYPE_GROUPS,
+                            ipa_refresh_groups_send,
+                            ipa_refresh_groups_recv,
+                            id_ctx);
+    if (ret != EOK && ret != EEXIST) {
+        DEBUG(SSSDBG_MINOR_FAILURE, "Periodical refresh of groups "
+              "will not work [%d]: %s\n", ret, strerror(ret));
+    }
+
+    ret = be_refresh_add_cb(be_ctx->refresh_ctx,
+                            BE_REFRESH_TYPE_NETGROUPS,
+                            ipa_refresh_netgroups_send,
+                            ipa_refresh_netgroups_recv,
+                            id_ctx);
+    if (ret != EOK && ret != EEXIST) {
+        DEBUG(SSSDBG_MINOR_FAILURE, "Periodical refresh of netgroups "
+              "will not work [%d]: %s\n", ret, strerror(ret));
+    }
+
+    return ret;
+}

--- a/src/providers/ipa/ipa_refresh.c
+++ b/src/providers/ipa/ipa_refresh.c
@@ -168,73 +168,10 @@ static errno_t ipa_refresh_recv(struct tevent_req *req)
     return EOK;
 }
 
-static struct tevent_req *
-ipa_refresh_initgroups_send(TALLOC_CTX *mem_ctx,
-                            struct tevent_context *ev,
-                            struct be_ctx *be_ctx,
-                            struct sss_domain_info *domain,
-                            char **names,
-                            void *pvt)
-{
-    return ipa_refresh_send(mem_ctx, ev, be_ctx, domain,
-                           BE_REQ_INITGROUPS, names, pvt);
-}
-
-static errno_t ipa_refresh_initgroups_recv(struct tevent_req *req)
-{
-    return ipa_refresh_recv(req);
-}
-
-static struct tevent_req *
-ipa_refresh_users_send(TALLOC_CTX *mem_ctx,
-                        struct tevent_context *ev,
-                        struct be_ctx *be_ctx,
-                        struct sss_domain_info *domain,
-                        char **names,
-                        void *pvt)
-{
-    return ipa_refresh_send(mem_ctx, ev, be_ctx, domain,
-                           BE_REQ_USER, names, pvt);
-}
-
-static errno_t ipa_refresh_users_recv(struct tevent_req *req)
-{
-    return ipa_refresh_recv(req);
-}
-
-static struct tevent_req *
-ipa_refresh_groups_send(TALLOC_CTX *mem_ctx,
-                         struct tevent_context *ev,
-                         struct be_ctx *be_ctx,
-                         struct sss_domain_info *domain,
-                         char **names,
-                         void *pvt)
-{
-    return ipa_refresh_send(mem_ctx, ev, be_ctx, domain,
-                           BE_REQ_GROUP, names, pvt);
-}
-
-static errno_t ipa_refresh_groups_recv(struct tevent_req *req)
-{
-    return ipa_refresh_recv(req);
-}
-
-static struct tevent_req *
-ipa_refresh_netgroups_send(TALLOC_CTX *mem_ctx,
-                            struct tevent_context *ev,
-                            struct be_ctx *be_ctx,
-                            struct sss_domain_info *domain,
-                            char **names,
-                            void *pvt)
-{
-    return ipa_refresh_send(mem_ctx, ev, be_ctx, domain,
-                           BE_REQ_NETGROUP, names, pvt);
-}
-
-static errno_t ipa_refresh_netgroups_recv(struct tevent_req *req)
-{
-    return ipa_refresh_recv(req);
-}
+REFRESH_SEND_RECV_FNS(ipa_refresh_initgroups, ipa_refresh, BE_REQ_INITGROUPS);
+REFRESH_SEND_RECV_FNS(ipa_refresh_users, ipa_refresh, BE_REQ_USER);
+REFRESH_SEND_RECV_FNS(ipa_refresh_groups, ipa_refresh, BE_REQ_GROUP);
+REFRESH_SEND_RECV_FNS(ipa_refresh_netgroups, ipa_refresh, BE_REQ_NETGROUP);
 
 errno_t ipa_refresh_init(struct be_ctx *be_ctx,
                          struct ipa_id_ctx *id_ctx)

--- a/src/providers/ipa/ipa_refresh.c
+++ b/src/providers/ipa/ipa_refresh.c
@@ -240,52 +240,32 @@ errno_t ipa_refresh_init(struct be_ctx *be_ctx,
                          struct ipa_id_ctx *id_ctx)
 {
     errno_t ret;
+    struct be_refresh_cb ipa_refresh_callbacks[] = {
+        { .send_fn = ipa_refresh_initgroups_send,
+          .recv_fn = ipa_refresh_initgroups_recv,
+          .pvt = id_ctx,
+        },
+        { .send_fn = ipa_refresh_users_send,
+          .recv_fn = ipa_refresh_users_recv,
+          .pvt = id_ctx,
+        },
+        { .send_fn = ipa_refresh_groups_send,
+          .recv_fn = ipa_refresh_groups_recv,
+          .pvt = id_ctx,
+        },
+        { .send_fn = ipa_refresh_netgroups_send,
+          .recv_fn = ipa_refresh_netgroups_recv,
+          .pvt = id_ctx,
+        },
+    };
 
-    ret = be_refresh_ctx_init(be_ctx, SYSDB_NAME);
+    ret = be_refresh_ctx_init_with_callbacks(be_ctx,
+                                             SYSDB_NAME,
+                                             ipa_refresh_callbacks);
     if (ret != EOK) {
-        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to initialize refresh_ctx\n");
-        return ENOMEM;
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to initialize background refresh\n");
+        return ret;
     }
 
-    ret = be_refresh_add_cb(be_ctx->refresh_ctx,
-                            BE_REFRESH_TYPE_USERS,
-                            ipa_refresh_initgroups_send,
-                            ipa_refresh_initgroups_recv,
-                            id_ctx);
-    if (ret != EOK && ret != EEXIST) {
-        DEBUG(SSSDBG_MINOR_FAILURE, "Periodical refresh of initgroups "
-              "will not work [%d]: %s\n", ret, strerror(ret));
-    }
-
-    ret = be_refresh_add_cb(be_ctx->refresh_ctx,
-                            BE_REFRESH_TYPE_USERS,
-                            ipa_refresh_users_send,
-                            ipa_refresh_users_recv,
-                            id_ctx);
-    if (ret != EOK && ret != EEXIST) {
-        DEBUG(SSSDBG_MINOR_FAILURE, "Periodical refresh of users "
-              "will not work [%d]: %s\n", ret, strerror(ret));
-    }
-
-    ret = be_refresh_add_cb(be_ctx->refresh_ctx,
-                            BE_REFRESH_TYPE_GROUPS,
-                            ipa_refresh_groups_send,
-                            ipa_refresh_groups_recv,
-                            id_ctx);
-    if (ret != EOK && ret != EEXIST) {
-        DEBUG(SSSDBG_MINOR_FAILURE, "Periodical refresh of groups "
-              "will not work [%d]: %s\n", ret, strerror(ret));
-    }
-
-    ret = be_refresh_add_cb(be_ctx->refresh_ctx,
-                            BE_REFRESH_TYPE_NETGROUPS,
-                            ipa_refresh_netgroups_send,
-                            ipa_refresh_netgroups_recv,
-                            id_ctx);
-    if (ret != EOK && ret != EEXIST) {
-        DEBUG(SSSDBG_MINOR_FAILURE, "Periodical refresh of netgroups "
-              "will not work [%d]: %s\n", ret, strerror(ret));
-    }
-
-    return ret;
+    return EOK;
 }

--- a/src/providers/ipa/ipa_subdomains.c
+++ b/src/providers/ipa/ipa_subdomains.c
@@ -3134,7 +3134,9 @@ errno_t ipa_subdomains_init(TALLOC_CTX *mem_ctx,
 
     period = be_ctx->domain->subdomain_refresh_interval;
     ret = be_ptask_create(sd_ctx, be_ctx, period, ptask_first_delay, 0, 0, period,
-                          BE_PTASK_OFFLINE_DISABLE, 0,
+                          BE_PTASK_OFFLINE_DISABLE,
+                          BE_PTASK_SCHEDULE_FROM_LAST,
+                          0,
                           ipa_subdomains_ptask_send, ipa_subdomains_ptask_recv, sd_ctx,
                           "Subdomains Refresh", NULL);
     if (ret != EOK) {

--- a/src/providers/ldap/ldap_common.h
+++ b/src/providers/ldap/ldap_common.h
@@ -365,7 +365,7 @@ struct sdap_id_ctx *
 sdap_id_ctx_new(TALLOC_CTX *mem_ctx, struct be_ctx *bectx,
                 struct sdap_service *sdap_service);
 
-errno_t sdap_refresh_init(struct be_refresh_ctx *refresh_ctx,
+errno_t sdap_refresh_init(struct be_ctx *be_ctx,
                           struct sdap_id_ctx *id_ctx);
 
 errno_t sdap_init_certmap(TALLOC_CTX *mem_ctx, struct sdap_id_ctx *id_ctx);

--- a/src/providers/ldap/ldap_id_enum.c
+++ b/src/providers/ldap/ldap_id_enum.c
@@ -99,6 +99,7 @@ errno_t ldap_setup_enumeration(struct be_ctx *be_ctx,
                           0,                        /* random offset */
                           period,                   /* timeout */
                           BE_PTASK_OFFLINE_SKIP,
+                          BE_PTASK_SCHEDULE_FROM_LAST,
                           0,                        /* max_backoff */
                           send_fn, recv_fn,
                           ectx, "enumeration", &sdom->enum_task);

--- a/src/providers/ldap/ldap_init.c
+++ b/src/providers/ldap/ldap_init.c
@@ -432,7 +432,7 @@ static errno_t ldap_init_misc(struct be_ctx *be_ctx,
     }
 
     /* Setup periodical refresh of expired records */
-    ret = sdap_refresh_init(be_ctx->refresh_ctx, id_ctx);
+    ret = sdap_refresh_init(be_ctx, id_ctx);
     if (ret != EOK && ret != EEXIST) {
         DEBUG(SSSDBG_MINOR_FAILURE, "Periodical refresh will not work "
               "[%d]: %s\n", ret, sss_strerror(ret));

--- a/src/providers/ldap/sdap_refresh.c
+++ b/src/providers/ldap/sdap_refresh.c
@@ -29,6 +29,7 @@ struct sdap_refresh_state {
     struct be_ctx *be_ctx;
     struct dp_id_data *account_req;
     struct sdap_id_ctx *id_ctx;
+    struct sss_domain_info *domain;
     struct sdap_domain *sdom;
     char **names;
     size_t index;
@@ -63,6 +64,7 @@ static struct tevent_req *sdap_refresh_send(TALLOC_CTX *mem_ctx,
 
     state->ev = ev;
     state->be_ctx = be_ctx;
+    state->domain = domain;
     state->id_ctx = talloc_get_type(pvt, struct sdap_id_ctx);
     state->names = names;
     state->index = 0;
@@ -163,6 +165,16 @@ static void sdap_refresh_done(struct tevent_req *subreq)
                be_req2str(state->account_req->entry_type),
               dp_error, sdap_ret, ret, err_msg);
         goto done;
+    }
+
+    if (state->account_req->entry_type == BE_REQ_INITGROUPS) {
+        ret = sysdb_set_initgr_expire_timestamp(state->domain,
+                                                state->account_req->filter_value);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "Failed to set initgroups expiration for [%s]\n",
+                  state->account_req->filter_value);
+        }
     }
 
     ret = sdap_refresh_step(req);

--- a/src/providers/ldap/sdap_refresh.c
+++ b/src/providers/ldap/sdap_refresh.c
@@ -255,12 +255,19 @@ static errno_t sdap_refresh_netgroups_recv(struct tevent_req *req)
     return sdap_refresh_recv(req);
 }
 
-errno_t sdap_refresh_init(struct be_refresh_ctx *refresh_ctx,
+errno_t sdap_refresh_init(struct be_ctx *be_ctx,
                           struct sdap_id_ctx *id_ctx)
 {
     errno_t ret;
 
-    ret = be_refresh_add_cb(refresh_ctx, BE_REFRESH_TYPE_USERS,
+    be_ctx->refresh_ctx = be_refresh_ctx_init(be_ctx);
+    if (be_ctx->refresh_ctx == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to initialize refresh_ctx\n");
+        return ENOMEM;
+    }
+
+    ret = be_refresh_add_cb(be_ctx->refresh_ctx,
+                            BE_REFRESH_TYPE_USERS,
                             sdap_refresh_users_send,
                             sdap_refresh_users_recv,
                             id_ctx);
@@ -269,7 +276,8 @@ errno_t sdap_refresh_init(struct be_refresh_ctx *refresh_ctx,
               "will not work [%d]: %s\n", ret, strerror(ret));
     }
 
-    ret = be_refresh_add_cb(refresh_ctx, BE_REFRESH_TYPE_GROUPS,
+    ret = be_refresh_add_cb(be_ctx->refresh_ctx,
+                            BE_REFRESH_TYPE_USERS,
                             sdap_refresh_groups_send,
                             sdap_refresh_groups_recv,
                             id_ctx);
@@ -278,7 +286,8 @@ errno_t sdap_refresh_init(struct be_refresh_ctx *refresh_ctx,
               "will not work [%d]: %s\n", ret, strerror(ret));
     }
 
-    ret = be_refresh_add_cb(refresh_ctx, BE_REFRESH_TYPE_NETGROUPS,
+    ret = be_refresh_add_cb(be_ctx->refresh_ctx,
+                            BE_REFRESH_TYPE_USERS,
                             sdap_refresh_netgroups_send,
                             sdap_refresh_netgroups_recv,
                             id_ctx);

--- a/src/providers/ldap/sdap_refresh.c
+++ b/src/providers/ldap/sdap_refresh.c
@@ -186,73 +186,10 @@ static errno_t sdap_refresh_recv(struct tevent_req *req)
     return EOK;
 }
 
-static struct tevent_req *
-sdap_refresh_initgroups_send(TALLOC_CTX *mem_ctx,
-                        struct tevent_context *ev,
-                        struct be_ctx *be_ctx,
-                        struct sss_domain_info *domain,
-                        char **names,
-                        void *pvt)
-{
-    return sdap_refresh_send(mem_ctx, ev, be_ctx, domain,
-                             BE_REQ_INITGROUPS, names, pvt);
-}
-
-static errno_t sdap_refresh_initgroups_recv(struct tevent_req *req)
-{
-    return sdap_refresh_recv(req);
-}
-
-static struct tevent_req *
-sdap_refresh_users_send(TALLOC_CTX *mem_ctx,
-                        struct tevent_context *ev,
-                        struct be_ctx *be_ctx,
-                        struct sss_domain_info *domain,
-                        char **names,
-                        void *pvt)
-{
-    return sdap_refresh_send(mem_ctx, ev, be_ctx, domain,
-                             BE_REQ_USER, names, pvt);
-}
-
-static errno_t sdap_refresh_users_recv(struct tevent_req *req)
-{
-    return sdap_refresh_recv(req);
-}
-
-static struct tevent_req *
-sdap_refresh_groups_send(TALLOC_CTX *mem_ctx,
-                         struct tevent_context *ev,
-                         struct be_ctx *be_ctx,
-                         struct sss_domain_info *domain,
-                         char **names,
-                         void *pvt)
-{
-    return sdap_refresh_send(mem_ctx, ev, be_ctx, domain,
-                             BE_REQ_GROUP, names, pvt);
-}
-
-static errno_t sdap_refresh_groups_recv(struct tevent_req *req)
-{
-    return sdap_refresh_recv(req);
-}
-
-static struct tevent_req *
-sdap_refresh_netgroups_send(TALLOC_CTX *mem_ctx,
-                            struct tevent_context *ev,
-                            struct be_ctx *be_ctx,
-                            struct sss_domain_info *domain,
-                            char **names,
-                            void *pvt)
-{
-    return sdap_refresh_send(mem_ctx, ev, be_ctx, domain,
-                             BE_REQ_NETGROUP, names, pvt);
-}
-
-static errno_t sdap_refresh_netgroups_recv(struct tevent_req *req)
-{
-    return sdap_refresh_recv(req);
-}
+REFRESH_SEND_RECV_FNS(sdap_refresh_initgroups, sdap_refresh, BE_REQ_INITGROUPS);
+REFRESH_SEND_RECV_FNS(sdap_refresh_users, sdap_refresh, BE_REQ_USER);
+REFRESH_SEND_RECV_FNS(sdap_refresh_groups, sdap_refresh, BE_REQ_GROUP);
+REFRESH_SEND_RECV_FNS(sdap_refresh_netgroups, sdap_refresh, BE_REQ_NETGROUP);
 
 errno_t sdap_refresh_init(struct be_ctx *be_ctx,
                           struct sdap_id_ctx *id_ctx)

--- a/src/providers/ldap/sdap_refresh.c
+++ b/src/providers/ldap/sdap_refresh.c
@@ -73,7 +73,8 @@ static struct tevent_req *sdap_refresh_send(TALLOC_CTX *mem_ctx,
         goto immediately;
     }
 
-    state->account_req = be_refresh_acct_req(state, entry_type, domain);
+    state->account_req = be_refresh_acct_req(state, entry_type,
+                                             BE_FILTER_NAME, domain);
     if (state->account_req == NULL) {
         ret = ENOMEM;
         goto immediately;

--- a/src/providers/ldap/sdap_refresh.c
+++ b/src/providers/ldap/sdap_refresh.c
@@ -187,6 +187,23 @@ static errno_t sdap_refresh_recv(struct tevent_req *req)
 }
 
 static struct tevent_req *
+sdap_refresh_initgroups_send(TALLOC_CTX *mem_ctx,
+                        struct tevent_context *ev,
+                        struct be_ctx *be_ctx,
+                        struct sss_domain_info *domain,
+                        char **names,
+                        void *pvt)
+{
+    return sdap_refresh_send(mem_ctx, ev, be_ctx, domain,
+                             BE_REQ_INITGROUPS, names, pvt);
+}
+
+static errno_t sdap_refresh_initgroups_recv(struct tevent_req *req)
+{
+    return sdap_refresh_recv(req);
+}
+
+static struct tevent_req *
 sdap_refresh_users_send(TALLOC_CTX *mem_ctx,
                         struct tevent_context *ev,
                         struct be_ctx *be_ctx,

--- a/src/providers/ldap/sdap_refresh.c
+++ b/src/providers/ldap/sdap_refresh.c
@@ -260,7 +260,7 @@ errno_t sdap_refresh_init(struct be_ctx *be_ctx,
 {
     errno_t ret;
 
-    be_ctx->refresh_ctx = be_refresh_ctx_init(be_ctx);
+    be_ctx->refresh_ctx = be_refresh_ctx_init(be_ctx, SYSDB_NAME);
     if (be_ctx->refresh_ctx == NULL) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Unable to initialize refresh_ctx\n");
         return ENOMEM;

--- a/src/providers/ldap/sdap_refresh.c
+++ b/src/providers/ldap/sdap_refresh.c
@@ -260,8 +260,8 @@ errno_t sdap_refresh_init(struct be_ctx *be_ctx,
 {
     errno_t ret;
 
-    be_ctx->refresh_ctx = be_refresh_ctx_init(be_ctx, SYSDB_NAME);
-    if (be_ctx->refresh_ctx == NULL) {
+    ret = be_refresh_ctx_init(be_ctx, SYSDB_NAME);
+    if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Unable to initialize refresh_ctx\n");
         return ENOMEM;
     }

--- a/src/providers/ldap/sdap_sudo_shared.c
+++ b/src/providers/ldap/sdap_sudo_shared.c
@@ -90,7 +90,9 @@ sdap_sudo_ptask_setup_generic(struct be_ctx *be_ctx,
      * when offline. */
     if (full > 0) {
         ret = be_ptask_create(be_ctx, be_ctx, full, delay, 0, 0, full,
-                              BE_PTASK_OFFLINE_DISABLE, 0,
+                              BE_PTASK_OFFLINE_DISABLE,
+                              BE_PTASK_SCHEDULE_FROM_LAST,
+                              0,
                               full_send_fn, full_recv_fn, pvt,
                               "SUDO Full Refresh", NULL);
         if (ret != EOK) {
@@ -107,7 +109,9 @@ sdap_sudo_ptask_setup_generic(struct be_ctx *be_ctx,
      * when offline. */
     if (smart > 0) {
         ret = be_ptask_create(be_ctx, be_ctx, smart, delay + smart, smart, 0,
-                              smart, BE_PTASK_OFFLINE_DISABLE, 0,
+                              smart, BE_PTASK_OFFLINE_DISABLE,
+                              BE_PTASK_SCHEDULE_FROM_LAST,
+                              0,
                               smart_send_fn, smart_recv_fn, pvt,
                               "SUDO Smart Refresh", NULL);
         if (ret != EOK) {

--- a/src/tests/cmocka/test_be_ptask.c
+++ b/src/tests/cmocka/test_be_ptask.c
@@ -304,7 +304,8 @@ void test_be_ptask_create_einval_be(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, NULL, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, 0, test_be_ptask_send,
+                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
+                          0, test_be_ptask_send,
                           test_be_ptask_recv, NULL, "Test ptask", &ptask);
     assert_int_equal(ret, EINVAL);
     assert_null(ptask);
@@ -317,7 +318,8 @@ void test_be_ptask_create_einval_period(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, 0, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, 0, test_be_ptask_send,
+                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
+                          0, test_be_ptask_send,
                           test_be_ptask_recv, NULL, "Test ptask", &ptask);
     assert_int_equal(ret, EINVAL);
     assert_null(ptask);
@@ -330,7 +332,8 @@ void test_be_ptask_create_einval_send(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, 0, NULL,
+                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
+                          0, NULL,
                           test_be_ptask_recv, NULL, "Test ptask", &ptask);
     assert_int_equal(ret, EINVAL);
     assert_null(ptask);
@@ -343,7 +346,8 @@ void test_be_ptask_create_einval_recv(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, 0, test_be_ptask_send,
+                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
+                          0, test_be_ptask_send,
                           NULL, NULL, "Test ptask", &ptask);
     assert_int_equal(ret, EINVAL);
     assert_null(ptask);
@@ -356,7 +360,8 @@ void test_be_ptask_create_einval_name(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, 0, test_be_ptask_send,
+                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
+                          0, test_be_ptask_send,
                           test_be_ptask_recv, NULL, NULL, &ptask);
     assert_int_equal(ret, EINVAL);
     assert_null(ptask);
@@ -371,7 +376,8 @@ void test_be_ptask_create_no_delay(void **state)
 
     now = get_current_time();
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, 0, test_be_ptask_send,
+                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
+                          0, test_be_ptask_send,
                           test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
@@ -398,7 +404,8 @@ void test_be_ptask_create_first_delay(void **state)
 
     now = get_current_time();
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, DELAY, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, 0, test_be_ptask_send,
+                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
+                          0, test_be_ptask_send,
                           test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
@@ -423,7 +430,8 @@ void test_be_ptask_disable(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, 0, test_be_ptask_send,
+                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
+                          0, test_be_ptask_send,
                           test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
@@ -447,7 +455,8 @@ void test_be_ptask_enable(void **state)
 
     now = get_current_time();
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, 0, test_be_ptask_send,
+                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
+                          0, test_be_ptask_send,
                           test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
@@ -479,7 +488,8 @@ void test_be_ptask_enable_delay(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, DELAY, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, 0, test_be_ptask_send,
+                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
+                          0, test_be_ptask_send,
                           test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
@@ -518,7 +528,8 @@ void test_be_ptask_offline_skip(void **state)
 
     now = get_current_time();
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, 0, test_be_ptask_send,
+                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
+                          0, test_be_ptask_send,
                           test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
@@ -551,7 +562,9 @@ void test_be_ptask_offline_disable(void **state)
     will_return(be_add_offline_cb, test_ctx);
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_DISABLE, 0, test_be_ptask_send,
+                          BE_PTASK_OFFLINE_DISABLE,
+                          BE_PTASK_SCHEDULE_FROM_LAST,
+                          0, test_be_ptask_send,
                           test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
@@ -581,7 +594,9 @@ void test_be_ptask_offline_execute(void **state)
     mark_offline(test_ctx);
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_EXECUTE, 0, test_be_ptask_send,
+                          BE_PTASK_OFFLINE_EXECUTE,
+                          BE_PTASK_SCHEDULE_FROM_LAST,
+                          0, test_be_ptask_send,
                           test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
@@ -608,7 +623,8 @@ void test_be_ptask_reschedule_ok(void **state)
 
     now = get_current_time();
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, 0, test_be_ptask_send,
+                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
+                          0, test_be_ptask_send,
                           test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
@@ -639,7 +655,8 @@ void test_be_ptask_reschedule_null(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, 0, test_be_ptask_null_send,
+                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
+                          0, test_be_ptask_null_send,
                           test_be_ptask_recv, test_ctx, "Test ptask",
                           &ptask);
     assert_int_equal(ret, ERR_OK);
@@ -666,7 +683,8 @@ void test_be_ptask_reschedule_error(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, 0, test_be_ptask_send,
+                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
+                          0, test_be_ptask_send,
                           test_be_ptask_error_recv, test_ctx, "Test ptask",
                           &ptask);
     assert_int_equal(ret, ERR_OK);
@@ -693,7 +711,8 @@ void test_be_ptask_reschedule_timeout(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 1,
-                          BE_PTASK_OFFLINE_SKIP, 0, test_be_ptask_timeout_send,
+                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
+                          0, test_be_ptask_timeout_send,
                           test_be_ptask_error_recv, test_ctx, "Test ptask",
                           &ptask);
     assert_int_equal(ret, ERR_OK);
@@ -730,7 +749,8 @@ void test_be_ptask_reschedule_backoff(void **state)
 
     now_first = get_current_time();
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, PERIOD*2, test_be_ptask_send,
+                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
+                          PERIOD*2, test_be_ptask_send,
                           test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
@@ -784,7 +804,8 @@ void test_be_ptask_get_period(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, 0, test_be_ptask_send,
+                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
+                          0, test_be_ptask_send,
                           test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
@@ -804,7 +825,8 @@ void test_be_ptask_get_timeout(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, TIMEOUT,
-                          BE_PTASK_OFFLINE_SKIP, 0, test_be_ptask_send,
+                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
+                          0, test_be_ptask_send,
                           test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);

--- a/src/tests/cmocka/test_expire_common.c
+++ b/src/tests/cmocka/test_expire_common.c
@@ -32,7 +32,7 @@
 #include "tests/common_check.h"
 #include "tests/cmocka/test_expire_common.h"
 
-#define MAX 100
+#define MAX_VAL 100
 
 static char *now_str(TALLOC_CTX *mem_ctx, const char* format, int s)
 {
@@ -41,10 +41,10 @@ static char *now_str(TALLOC_CTX *mem_ctx, const char* format, int s)
     size_t len;
     char *timestr;
 
-    timestr = talloc_array(mem_ctx, char, MAX);
+    timestr = talloc_array(mem_ctx, char, MAX_VAL);
 
     tm = gmtime(&t);
-    len = strftime(timestr, MAX, format, tm);
+    len = strftime(timestr, MAX_VAL, format, tm);
     if (len == 0) {
         return NULL;
     }

--- a/src/tests/cmocka/test_sysdb_ts_cache.c
+++ b/src/tests/cmocka/test_sysdb_ts_cache.c
@@ -1411,6 +1411,201 @@ static void test_sysdb_zero_now(void **state)
     assert_true(cache_expire_ts > TEST_CACHE_TIMEOUT);
 }
 
+static void test_sysdb_search_with_ts(void **state)
+{
+    int ret;
+    struct sysdb_ts_test_ctx *test_ctx = talloc_get_type_abort(*state,
+                                                     struct sysdb_ts_test_ctx);
+    struct ldb_result *res = NULL;
+    struct ldb_dn *base_dn;
+    const char *attrs[] = { SYSDB_NAME,
+                            SYSDB_OBJECTCATEGORY,
+                            SYSDB_GIDNUM,
+                            SYSDB_CACHE_EXPIRE,
+                            NULL };
+    struct sysdb_attrs *group_attrs = NULL;
+    char *filter;
+    uint64_t cache_expire_sysdb;
+    uint64_t cache_expire_ts;
+    size_t count;
+    struct ldb_message **msgs;
+
+    base_dn = sysdb_base_dn(test_ctx->tctx->dom->sysdb, test_ctx);
+    assert_non_null(base_dn);
+
+    /* Nothing must be stored in either cache at the beginning of the test */
+    ret = sysdb_search_with_ts_attr(test_ctx,
+                                    test_ctx->tctx->dom,
+                                    base_dn,
+                                    LDB_SCOPE_SUBTREE,
+                                    0,
+                                    SYSDB_NAME"=*",
+                                    attrs,
+                                    &res);
+    assert_int_equal(ret, EOK);
+    assert_int_equal(res->count, 0);
+    talloc_free(res);
+
+    group_attrs = create_modstamp_attrs(test_ctx, TEST_MODSTAMP_1);
+    assert_non_null(group_attrs);
+
+    ret = sysdb_store_group(test_ctx->tctx->dom,
+                            TEST_GROUP_NAME,
+                            TEST_GROUP_GID,
+                            group_attrs,
+                            TEST_CACHE_TIMEOUT,
+                            TEST_NOW_1);
+    assert_int_equal(ret, EOK);
+    talloc_zfree(group_attrs);
+
+    group_attrs = create_modstamp_attrs(test_ctx, TEST_MODSTAMP_1);
+    assert_non_null(group_attrs);
+
+    ret = sysdb_store_group(test_ctx->tctx->dom,
+                            TEST_GROUP_NAME_2,
+                            TEST_GROUP_GID_2,
+                            group_attrs,
+                            TEST_CACHE_TIMEOUT,
+                            TEST_NOW_2);
+    assert_int_equal(ret, EOK);
+    talloc_zfree(group_attrs);
+
+    /* Bump the timestamps in the cache so that the ts cache
+     * and sysdb differ
+     */
+
+    group_attrs = create_modstamp_attrs(test_ctx, TEST_MODSTAMP_1);
+    assert_non_null(group_attrs);
+
+    ret = sysdb_store_group(test_ctx->tctx->dom,
+                            TEST_GROUP_NAME,
+                            TEST_GROUP_GID,
+                            group_attrs,
+                            TEST_CACHE_TIMEOUT,
+                            TEST_NOW_3);
+    assert_int_equal(ret, EOK);
+
+    talloc_zfree(group_attrs);
+
+
+    group_attrs = create_modstamp_attrs(test_ctx, TEST_MODSTAMP_1);
+    assert_non_null(group_attrs);
+
+    ret = sysdb_store_group(test_ctx->tctx->dom,
+                            TEST_GROUP_NAME_2,
+                            TEST_GROUP_GID_2,
+                            group_attrs,
+                            TEST_CACHE_TIMEOUT,
+                            TEST_NOW_4);
+    assert_int_equal(ret, EOK);
+
+    talloc_zfree(group_attrs);
+
+    get_gr_timestamp_attrs(test_ctx, TEST_GROUP_NAME,
+                           &cache_expire_sysdb, &cache_expire_ts);
+    assert_int_equal(cache_expire_sysdb, TEST_CACHE_TIMEOUT + TEST_NOW_1);
+    assert_int_equal(cache_expire_ts, TEST_CACHE_TIMEOUT + TEST_NOW_3);
+
+    get_gr_timestamp_attrs(test_ctx, TEST_GROUP_NAME_2,
+                           &cache_expire_sysdb, &cache_expire_ts);
+    assert_int_equal(cache_expire_sysdb, TEST_CACHE_TIMEOUT + TEST_NOW_2);
+    assert_int_equal(cache_expire_ts, TEST_CACHE_TIMEOUT + TEST_NOW_4);
+
+    /* Search for groups that don't expire until TEST_NOW_4 */
+    filter = talloc_asprintf(test_ctx, SYSDB_CACHE_EXPIRE">=%d", TEST_NOW_4);
+    assert_non_null(filter);
+
+    /* This search should yield only one group (so, it needs to search the ts
+     * cache to hit the TEST_NOW_4), but should return attributes merged from
+     * both caches
+     */
+    ret = sysdb_search_with_ts_attr(test_ctx,
+                                    test_ctx->tctx->dom,
+                                    base_dn,
+                                    LDB_SCOPE_SUBTREE,
+                                    0,
+                                    filter,
+                                    attrs,
+                                    &res);
+    assert_int_equal(ret, EOK);
+    assert_int_equal(res->count, 1);
+    assert_int_equal(TEST_GROUP_GID_2, ldb_msg_find_attr_as_uint64(res->msgs[0],
+                                                                   SYSDB_GIDNUM, 0));
+    talloc_free(res);
+
+    /*
+     * In contrast, sysdb_search_entry merges the timestamp attributes, but does
+     * not search the timestamp cache
+     */
+    ret = sysdb_search_entry(test_ctx,
+                             test_ctx->tctx->dom->sysdb,
+                             base_dn,
+                             LDB_SCOPE_SUBTREE,
+                             filter,
+                             attrs,
+                             &count,
+                             &msgs);
+    assert_int_equal(ret, ENOENT);
+
+    /* Should get the same result when searching by ts attrs only */
+    ret = sysdb_search_with_ts_attr(test_ctx,
+                                    test_ctx->tctx->dom,
+                                    base_dn,
+                                    LDB_SCOPE_SUBTREE,
+                                    SYSDB_SEARCH_WITH_TS_ONLY_TS_FILTER,
+                                    filter,
+                                    attrs,
+                                    &res);
+    talloc_zfree(filter);
+    assert_int_equal(ret, EOK);
+    assert_int_equal(res->count, 1);
+    assert_int_equal(TEST_GROUP_GID_2, ldb_msg_find_attr_as_uint64(res->msgs[0],
+                                                                   SYSDB_GIDNUM, 0));
+    talloc_free(res);
+
+    /* We can also search in sysdb only as well, we should get back ts attrs */
+    filter = talloc_asprintf(test_ctx, SYSDB_GIDNUM"=%d", TEST_GROUP_GID);
+    assert_non_null(filter);
+
+    ret = sysdb_search_with_ts_attr(test_ctx,
+                                    test_ctx->tctx->dom,
+                                    base_dn,
+                                    LDB_SCOPE_SUBTREE,
+                                    SYSDB_SEARCH_WITH_TS_ONLY_SYSDB_FILTER,
+                                    filter,
+                                    attrs,
+                                    &res);
+    talloc_zfree(filter);
+    assert_int_equal(ret, EOK);
+    assert_int_equal(res->count, 1);
+    assert_int_equal(TEST_GROUP_GID, ldb_msg_find_attr_as_uint64(res->msgs[0],
+                                                                 SYSDB_GIDNUM, 0));
+    assert_int_equal(TEST_CACHE_TIMEOUT + TEST_NOW_3,
+                     ldb_msg_find_attr_as_uint64(res->msgs[0], SYSDB_CACHE_EXPIRE, 0));
+    talloc_free(res);
+
+    /* We can also search in both using an OR-filter. Note that an AND-filter is not possible
+     * unless we deconstruct the filter..
+     */
+    filter = talloc_asprintf(test_ctx, "(|("SYSDB_GIDNUM"=%d)"
+                                         "("SYSDB_CACHE_EXPIRE">=%d))",
+                                         TEST_GROUP_GID, TEST_NOW_4);
+    assert_non_null(filter);
+
+    ret = sysdb_search_with_ts_attr(test_ctx,
+                                    test_ctx->tctx->dom,
+                                    base_dn,
+                                    LDB_SCOPE_SUBTREE,
+                                    0,
+                                    filter,
+                                    attrs,
+                                    &res);
+    talloc_zfree(filter);
+    assert_int_equal(ret, EOK);
+    assert_int_equal(res->count, 2);
+    talloc_free(res);
+}
+
 int main(int argc, const char *argv[])
 {
     int rv;
@@ -1460,6 +1655,9 @@ int main(int argc, const char *argv[])
                                         test_sysdb_ts_setup,
                                         test_sysdb_ts_teardown),
         cmocka_unit_test_setup_teardown(test_sysdb_zero_now,
+                                        test_sysdb_ts_setup,
+                                        test_sysdb_ts_teardown),
+        cmocka_unit_test_setup_teardown(test_sysdb_search_with_ts,
                                         test_sysdb_ts_setup,
                                         test_sysdb_ts_teardown),
     };

--- a/src/tests/sss_idmap-tests.c
+++ b/src/tests/sss_idmap-tests.c
@@ -140,8 +140,8 @@ void idmap_add_domain_with_sec_slices_setup_cb_fail(void)
 }
 
 
-#define MAX 1000
-char data[MAX];
+#define DATA_MAX 1000
+char data[DATA_MAX];
 
 enum idmap_error_code cb2(const char *dom_name,
                           const char *dom_sid,
@@ -154,10 +154,10 @@ enum idmap_error_code cb2(const char *dom_name,
     char *p = (char*)pvt;
     size_t len;
 
-    len = snprintf(p, MAX, "%s, %s %s, %"PRIu32", %"PRIu32", %" PRIu32,
+    len = snprintf(p, DATA_MAX, "%s, %s %s, %"PRIu32", %"PRIu32", %" PRIu32,
                    dom_name, dom_sid, range_id, min_id, max_id, first_rid);
 
-    if (len >= MAX) {
+    if (len >= DATA_MAX) {
         return IDMAP_OUT_OF_MEMORY;
     }
     return IDMAP_SUCCESS;

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -67,6 +67,14 @@
 #define NULL 0
 #endif
 
+#ifndef MIN
+#define MIN(a, b)  (((a) < (b)) ? (a) : (b))
+#endif
+
+#ifndef MAX
+#define MAX(a, b)  (((a) > (b)) ? (a) : (b))
+#endif
+
 #define SSSD_MAIN_OPTS SSSD_DEBUG_OPTS
 
 #define SSSD_SERVER_OPTS(uid, gid) \


### PR DESCRIPTION
This PR refactors the existing background refresh task to be more extendable,
splits out the account handlers of IPA and AD providers into tevent requests
which are finally reused by new ipa_refresh and ad_refresh modules.

The refreshes are done in batches so that we don't starve out other requests
or even invoke the watchdog.