### PR TITLE
SDAP: allow GSS-SPNEGO for LDAP SASL bind as well

### DIFF
--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -753,6 +753,7 @@ option = ldap_user_search_base
 option = ldap_group_search_base
 option = ldap_netgroup_search_base
 option = ldap_service_search_base
+option = ldap_sasl_mech
 option = ad_server
 option = ad_backup_server
 option = ad_site

--- a/src/man/sssd-ldap.5.xml
+++ b/src/man/sssd-ldap.5.xml
@@ -1750,6 +1750,16 @@
                             GSSAPI and GSS-SPNEGO are tested and supported.
                         </para>
                         <para>
+                            If the backend supports sub-domains the value of
+                            ldap_sasl_mech is automatically inherited to the
+                            sub-domains. If a different value is needed for a
+                            sub-domain it can be overwritten by setting
+                            ldap_sasl_mech for this sub-domain explicitly.
+                            Please see TRUSTED DOMAIN SECTION in
+                            <citerefentry><refentrytitle>sssd.conf</refentrytitle>
+                            <manvolnum>5</manvolnum></citerefentry> for details.
+                        </para>
+                        <para>
                             Default: not set
                         </para>
                     </listitem>

--- a/src/man/sssd-ldap.5.xml
+++ b/src/man/sssd-ldap.5.xml
@@ -1746,8 +1746,8 @@
                     <term>ldap_sasl_mech (string)</term>
                     <listitem>
                         <para>
-                            Specify the SASL mechanism to use.
-                            Currently only GSSAPI is tested and supported.
+                            Specify the SASL mechanism to use.  Currently only
+                            GSSAPI and GSS-SPNEGO are tested and supported.
                         </para>
                         <para>
                             Default: not set
@@ -1759,13 +1759,14 @@
                     <term>ldap_sasl_authid (string)</term>
                     <listitem>
                         <para>
-                            Specify the SASL authorization id to use.
-                            When GSSAPI is used, this represents the Kerberos
-                            principal used for authentication to the directory.
-                            This option can either contain the full principal (for
-                            example host/myhost@EXAMPLE.COM) or just the principal name
-                            (for example host/myhost). By default, the value is not set
-                            and the following principals are used:
+                            Specify the SASL authorization id to use.  When
+                            GSSAPI/GSS-SPNEGO are used, this represents the
+                            Kerberos principal used for authentication to the
+                            directory.  This option can either contain the full
+                            principal (for example host/myhost@EXAMPLE.COM) or
+                            just the principal name (for example host/myhost).
+                            By default, the value is not set and the following
+                            principals are used:
                             <programlisting>
 hostname@REALM
 netbiosname$@REALM
@@ -1816,7 +1817,8 @@ host/*
                     <term>ldap_krb5_keytab (string)</term>
                     <listitem>
                         <para>
-                            Specify the keytab to use when using SASL/GSSAPI.
+                            Specify the keytab to use when using
+                            SASL/GSSAPI/GSS-SPNEGO.
                         </para>
                         <para>
                             Default: System keytab, normally <filename>/etc/krb5.keytab</filename>
@@ -1831,7 +1833,7 @@ host/*
                             Specifies that the id_provider should init
                             Kerberos credentials (TGT).
                             This action is performed only if SASL is used and
-                            the mechanism selected is GSSAPI.
+                            the mechanism selected is GSSAPI or GSS-SPNEGO.
                         </para>
                         <para>
                             Default: true
@@ -1844,7 +1846,7 @@ host/*
                     <listitem>
                         <para>
                             Specifies the lifetime in seconds of the TGT if
-                            GSSAPI is used.
+                            GSSAPI or GSS-SPNEGO is used.
                         </para>
                         <para>
                             Default: 86400 (24 hours)
@@ -1885,7 +1887,8 @@ host/*
                     <term>krb5_realm (string)</term>
                     <listitem>
                         <para>
-                            Specify the Kerberos REALM (for SASL/GSSAPI auth).
+                            Specify the Kerberos REALM (for
+                            SASL/GSSAPI/GSS-SPNEGO auth).
                         </para>
                         <para>
                             Default: System defaults, see <filename>/etc/krb5.conf</filename>

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -3442,6 +3442,7 @@ ldap_user_extra_attrs = phone:telephoneNumber
             <para>ldap_group_search_base,</para>
             <para>ldap_netgroup_search_base,</para>
             <para>ldap_service_search_base,</para>
+            <para>ldap_sasl_mech,</para>
             <para>ad_server,</para>
             <para>ad_backup_server,</para>
             <para>ad_site,</para>

--- a/src/providers/ad/ad_common.c
+++ b/src/providers/ad/ad_common.c
@@ -577,7 +577,7 @@ _ad_servers_init(struct ad_service *service,
         if (resolv_is_address(list[j])) {
             DEBUG(SSSDBG_IMPORTANT_INFO,
                   "ad_server [%s] is detected as IP address, "
-                  "this can cause GSSAPI problems\n", list[j]);
+                  "this can cause GSSAPI/GSS-SPNEGO problems\n", list[j]);
         }
     }
 
@@ -1025,7 +1025,7 @@ ad_set_sdap_options(struct ad_options *ad_opts,
         goto done;
     }
 
-    /* Set the Kerberos Realm for GSSAPI */
+    /* Set the Kerberos Realm for GSSAPI or GSS-SPNEGO */
     krb5_realm = dp_opt_get_string(ad_opts->basic, AD_KRB5_REALM);
     if (!krb5_realm) {
         /* Should be impossible, this is set in ad_get_common_options() */
@@ -1282,7 +1282,7 @@ ad_get_auth_options(TALLOC_CTX *mem_ctx,
            ad_servers);
 
     /* Set krb5 realm */
-    /* Set the Kerberos Realm for GSSAPI */
+    /* Set the Kerberos Realm for GSSAPI/GSS-SPNEGO */
     krb5_realm = dp_opt_get_string(ad_opts->basic, AD_KRB5_REALM);
     if (!krb5_realm) {
         /* Should be impossible, this is set in ad_get_common_options() */

--- a/src/providers/ad/ad_common.h
+++ b/src/providers/ad/ad_common.h
@@ -219,4 +219,9 @@ errno_t netlogon_get_domain_info(TALLOC_CTX *mem_ctx,
                                  char **_site,
                                  char **_forest);
 
+errno_t ad_inherit_opts_if_needed(struct dp_option *parent_opts,
+                                  struct dp_option *suddom_opts,
+                                  struct confdb_ctx *cdb,
+                                  const char *subdom_conf_path,
+                                  int opt_id);
 #endif /* AD_COMMON_H_ */

--- a/src/providers/ad/ad_init.c
+++ b/src/providers/ad/ad_init.c
@@ -56,7 +56,7 @@ static int ad_sasl_getopt(void *context, const char *plugin_name,
     if (!plugin_name || !result) {
         return SASL_FAIL;
     }
-    if (strcmp(plugin_name, "GSSAPI") != 0) {
+    if (!sdap_sasl_mech_needs_kinit(plugin_name)) {
         return SASL_FAIL;
     }
     if (strcmp(option, "ad_compat") != 0) {

--- a/src/providers/ldap/ldap_auth.c
+++ b/src/providers/ldap/ldap_auth.c
@@ -715,9 +715,9 @@ static struct tevent_req *auth_connect_send(struct tevent_req *req)
          * we don't need to authenticate the connection, because we're not
          * looking up any information using the connection. This might be
          * needed e.g. in case both ID and AUTH providers are set to LDAP
-         * and the server is AD, because otherwise the connection would
-         * both do a startTLS and later bind using GSSAPI which doesn't work
-         * well with AD.
+         * and the server is AD, because otherwise the connection would both
+         * do a startTLS and later bind using GSSAPI or GSS-SPNEGO which
+         * doesn't work well with AD.
          */
         skip_conn_auth = true;
     }
@@ -725,8 +725,8 @@ static struct tevent_req *auth_connect_send(struct tevent_req *req)
     if (skip_conn_auth == false) {
         sasl_mech = dp_opt_get_string(state->ctx->opts->basic,
                                       SDAP_SASL_MECH);
-        if (sasl_mech && strcasecmp(sasl_mech, "GSSAPI") == 0) {
-            /* Don't force TLS on if we're told to use GSSAPI */
+        if (sasl_mech && sdap_sasl_mech_needs_kinit(sasl_mech)) {
+            /* Don't force TLS on if we're told to use GSSAPI or GSS-SPNEGO */
             use_tls = false;
         }
     }

--- a/src/providers/ldap/ldap_common.h
+++ b/src/providers/ldap/ldap_common.h
@@ -65,7 +65,7 @@ struct sdap_id_ctx {
     struct be_ctx *be;
     struct sdap_options *opts;
 
-    /* If using GSSAPI */
+    /* If using GSSAPI or GSS-SPNEGO */
     struct krb5_service *krb5_service;
     /* connection to a server */
     struct sdap_id_conn_ctx *conn;

--- a/src/providers/ldap/ldap_init.c
+++ b/src/providers/ldap/ldap_init.c
@@ -365,7 +365,7 @@ static bool should_call_gssapi_init(struct sdap_options *opts)
         return false;
     }
 
-    if (strcasecmp(sasl_mech, "GSSAPI") != 0) {
+    if (!sdap_sasl_mech_needs_kinit(sasl_mech)) {
         return false;
     }
 

--- a/src/providers/ldap/sdap.c
+++ b/src/providers/ldap/sdap.c
@@ -902,6 +902,15 @@ errno_t setup_tls_config(struct dp_option *basic_opts)
     return EOK;
 }
 
+bool sdap_sasl_mech_needs_kinit(const char *sasl_mech)
+{
+    if (strcasecmp(sasl_mech, "GSSAPI") == 0
+            || strcasecmp(sasl_mech, "GSS-SPNEGO") == 0) {
+        return true;
+    }
+
+    return false;
+}
 
 bool sdap_check_sup_list(struct sup_list *l, const char *val)
 {

--- a/src/providers/ldap/sdap.h
+++ b/src/providers/ldap/sdap.h
@@ -617,6 +617,8 @@ bool sdap_check_sup_list(struct sup_list *l, const char *val);
 #define sdap_is_extension_supported(sh, ext_oid) \
     sdap_check_sup_list(&((sh)->supported_extensions), ext_oid)
 
+bool sdap_sasl_mech_needs_kinit(const char *mech);
+
 int build_attrs_from_map(TALLOC_CTX *memctx,
                          struct sdap_attr_map *map,
                          size_t size,

--- a/src/providers/ldap/sdap_async_connection.c
+++ b/src/providers/ldap/sdap_async_connection.c
@@ -1605,14 +1605,14 @@ static void sdap_cli_connect_done(struct tevent_req *subreq)
     sasl_mech = dp_opt_get_string(state->opts->basic, SDAP_SASL_MECH);
 
     if (state->do_auth && sasl_mech && state->use_rootdse) {
-        /* check if server claims to support GSSAPI */
+        /* check if server claims to support the configured SASL MECH */
         if (!sdap_is_sasl_mech_supported(state->sh, sasl_mech)) {
             tevent_req_error(req, ENOTSUP);
             return;
         }
     }
 
-    if (state->do_auth && sasl_mech && (strcasecmp(sasl_mech, "GSSAPI") == 0)) {
+    if (state->do_auth && sasl_mech && sdap_sasl_mech_needs_kinit(sasl_mech)) {
         if (dp_opt_get_bool(state->opts->basic, SDAP_KRB5_KINIT)) {
             sdap_cli_kinit_step(req);
             return;
@@ -1690,14 +1690,14 @@ static void sdap_cli_rootdse_done(struct tevent_req *subreq)
     sasl_mech = dp_opt_get_string(state->opts->basic, SDAP_SASL_MECH);
 
     if (state->do_auth && sasl_mech && state->rootdse) {
-        /* check if server claims to support GSSAPI */
+        /* check if server claims to support the configured SASL MECH */
         if (!sdap_is_sasl_mech_supported(state->sh, sasl_mech)) {
             tevent_req_error(req, ENOTSUP);
             return;
         }
     }
 
-    if (state->do_auth && sasl_mech && (strcasecmp(sasl_mech, "GSSAPI") == 0)) {
+    if (state->do_auth && sasl_mech && sdap_sasl_mech_needs_kinit(sasl_mech)) {
         if (dp_opt_get_bool(state->opts->basic, SDAP_KRB5_KINIT)) {
             sdap_cli_kinit_step(req);
             return;


### PR DESCRIPTION
From the LDAP client perspective GSS-SPNEGO and GSSAPI are quite
similar. To support GSS-SPNEGO SSSD must make sure that a Kerberos
ticket is available before the LDAP SASL bind is started.

Related to https://pagure.io/SSSD/sssd/issue/4006