### PR TITLE
fix to not ignore/drop sudo "defaults" rule

### DIFF
--- a/src/db/sysdb_sudo.c
+++ b/src/db/sysdb_sudo.c
@@ -957,9 +957,12 @@ sysdb_sudo_store_rule(struct sss_domain_info *domain,
 
     DEBUG(SSSDBG_TRACE_FUNC, "Adding sudo rule %s\n", name);
 
-    ret = sysdb_sudo_add_lowered_users(domain, rule);
-    if (ret != EOK) {
-        return ret;
+    /* skip default rules, because they do not have a sudoUser */
+    if (strcasecmp(name,"defaults")) {
+	ret = sysdb_sudo_add_lowered_users(domain, rule);
+    	if (ret != EOK) {
+        	return ret;
+    	}
     }
 
     ret = sysdb_sudo_add_sss_attrs(rule, name, cache_timeout, now);


### PR DESCRIPTION
The "cn=defaults" rule does not require to have a sudoUser attribute, however with latest changes the defaults rule get dropped because of the missing sudoUser attribute. According to sudo ldap schema the attribute sudoUser is only a MAY not a MUST. Also when using the old pam/nss ldap library this is not an issue. I have seen no "cn=defaults" rule until now that does have a sudoUser attribute set, so i count this as a regression.
My proposed patch does skip sysdb_sudo_add_lowered_users() if the rule name matches "defaults", which looks like the best possible approach for now.