### PR TITLE
LDAP: Return the error message from the extdom password change also on failure

### DIFF
--- a/src/providers/ldap/ldap_auth.c
+++ b/src/providers/ldap/ldap_auth.c
@@ -1222,9 +1222,10 @@ sdap_pam_change_password_recv(TALLOC_CTX *mem_ctx,
     struct sdap_pam_change_password_state *state;
     state = tevent_req_data(req, struct sdap_pam_change_password_state);
 
-    TEVENT_REQ_RETURN_ON_ERROR(req);
-
+    /* We want to return the error message even on failure */
     *_user_error_message = talloc_steal(mem_ctx, state->user_error_message);
+
+    TEVENT_REQ_RETURN_ON_ERROR(req);
 
     return EOK;
 }

--- a/src/providers/ldap/sdap_async.c
+++ b/src/providers/ldap/sdap_async.c
@@ -696,6 +696,7 @@ errno_t sdap_exop_modify_passwd_recv(struct tevent_req *req,
     struct sdap_exop_modify_passwd_state *state = tevent_req_data(req,
                                          struct sdap_exop_modify_passwd_state);
 
+    /* We want to return the error message even on failure */
     *user_error_message = talloc_steal(mem_ctx, state->user_error_message);
 
     TEVENT_REQ_RETURN_ON_ERROR(req);


### PR DESCRIPTION
Resolves: https://pagure.io/SSSD/sssd/issue/4015

If password change fails, the tevent request would call 
TEVENT_REQ_RETURN_ON_ERROR before returning the error message that comes 
from the server, so the server message would not be propagated to the
caller.

This regressed in cf1d7ff