### PR TITLE
tests: fix enctypes in test_copy_keytab

### DIFF
--- a/contrib/ci/deps.sh
+++ b/contrib/ci/deps.sh
@@ -52,8 +52,17 @@ if [[ "$DISTRO_BRANCH" == -redhat-* ]]; then
         krb5-server
         krb5-workstation
         dbus-python
-        python-pep8
     )
+
+    if [[ "$DISTRO_BRANCH" == -redhat-fedora-3[1-9]* ]]; then
+        DEPS_LIST+=(
+            python3-pep8
+        )
+    else
+        DEPS_LIST+=(
+            python-pep8
+        )
+    fi
 
     if [[ "$DISTRO_BRANCH" == -redhat-fedora-* ]]; then
         DEPS_LIST+=(


### PR DESCRIPTION
Currently test_copy_keytab uses legacy encryption types to mock up
keytab entries. New versions of libkrb5 might not support them anymore.

With this patch only supported encryption types should be used.