### PR TITLE
CONFDB: Files domain if activated without .conf

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3763,6 +3763,8 @@ intgcheck-prepare:
 	    --enable-intgcheck-reqs \
 	    --without-semanage \
 	    --with-session-recording-shell=/bin/false \
+	    --enable-local-provider \
+	    --enable-files-domain \
 	    $(INTGCHECK_CONFIGURE_FLAGS) \
 	    CFLAGS="-O2 -g $$CFLAGS -DKCM_PEER_UID=$$(id -u)"; \
 	$(MAKE) $(AM_MAKEFLAGS) ; \

--- a/src/confdb/confdb_setup.c
+++ b/src/confdb/confdb_setup.c
@@ -34,7 +34,6 @@
 "version: 2\n\n" \
 "dn: cn=sssd,cn=config\n" \
 "cn: sssd\n" \
-"enable_files_domain: true\n" \
 "services: nss\n\n"
 #endif /* SSSD_FALLBACK_CONFIG_LDIF */
 

--- a/src/tests/intg/test_enumeration.py
+++ b/src/tests/intg/test_enumeration.py
@@ -113,6 +113,7 @@ def format_basic_conf(ldap_conn, schema):
         debug_level         = 0xffff
         domains             = LDAP
         services            = nss, pam
+        enable_files_domain = false
 
         [nss]
         debug_level         = 0xffff

--- a/src/tests/intg/test_ldap.py
+++ b/src/tests/intg/test_ldap.py
@@ -117,6 +117,7 @@ def format_basic_conf(ldap_conn, schema):
         debug_level         = 0xffff
         domains             = LDAP
         services            = nss, pam
+        enable_files_domain = false
 
         [nss]
         debug_level         = 0xffff


### PR DESCRIPTION
Implicit files domain gets activated when no sssd.conf present
and sssd is started. This does not respect --disable-files-domain
configure option

Resolves:
https://bugzilla.redhat.com/show_bug.cgi?id=1713352