### PR TITLE
CONFDB: Files domain if activated without .conf

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4019,6 +4019,7 @@ intgcheck-prepare:
 	    --with-secrets \
 	    --with-session-recording-shell=/bin/false \
 	    --enable-local-provider \
+	    --enable-files-domain \
 	    $(INTGCHECK_CONFIGURE_FLAGS) \
 	    CFLAGS="-O2 -g $$CFLAGS"; \
 	$(MAKE) $(AM_MAKEFLAGS) ; \

--- a/src/confdb/confdb_setup.c
+++ b/src/confdb/confdb_setup.c
@@ -138,7 +138,6 @@ static int confdb_ldif_from_ini_file(TALLOC_CTX *mem_ctx,
     int version;
     char fallback_cfg[] =
         "[sssd]\n"
-        "enable_files_domain = true\n"
         "services = nss\n";
 
     /* Open config file */

--- a/src/tests/intg/test_enumeration.py
+++ b/src/tests/intg/test_enumeration.py
@@ -113,6 +113,7 @@ def format_basic_conf(ldap_conn, schema):
         debug_level         = 0xffff
         domains             = LDAP
         services            = nss, pam
+        enable_files_domain = false
 
         [nss]
         debug_level         = 0xffff

--- a/src/tests/intg/test_ldap.py
+++ b/src/tests/intg/test_ldap.py
@@ -117,6 +117,7 @@ def format_basic_conf(ldap_conn, schema):
         debug_level         = 0xffff
         domains             = LDAP
         services            = nss, pam
+        enable_files_domain = false
 
         [nss]
         debug_level         = 0xffff


### PR DESCRIPTION
Implicit files domain gets activated when no sssd.conf present
and sssd is started. This does not respect --disable-files-domain
configure option

Resolves:
https://bugzilla.redhat.com/show_bug.cgi?id=1713352