### PR TITLE
ldap/sdap_idmap.c: removed unnecessary include

### DIFF
--- a/src/providers/ldap/sdap_idmap.c
+++ b/src/providers/ldap/sdap_idmap.c
@@ -20,7 +20,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "shared/murmurhash3.h"
 #include "util/util.h"
 #include "util/dlinklist.h"
 #include "providers/ldap/sdap_idmap.h"


### PR DESCRIPTION
I know this looks like a nitpick.
But murmurhash3 is a bundled implementation of a hash function. It is safer to make scope it is met in the code as narrow as possible.