### PR TITLE
tests: Add multihost tests to upstream tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5446,7 +5446,19 @@ dist_noinst_DATA += \
     m4 \
     contrib/sssd.spec.in \
     BUILD.txt \
-    COPYING
+    COPYING \
+    src/tests/multihost/basic/conftest.py \
+    src/tests/multihost/basic/mhc.yaml \
+    src/tests/multihost/basic/README \
+    src/tests/multihost/basic/test_basic.py \
+    src/tests/multihost/basic/test_config.py \
+    src/tests/multihost/basic/test_files.py \
+    src/tests/multihost/basic/test_ifp.py \
+    src/tests/multihost/basic/test_kcm.py \
+    src/tests/multihost/basic/test_sssctl_config_check.py \
+    src/tests/multihost/basic/test_sudo.py \
+    src/tests/multihost/basic/utils_config.py \
+    $(NULL)
 
 rpmroot:
 	$(MKDIR_P) $(RPMBUILD)/BUILD


### PR DESCRIPTION
Multihost tests were not part of upstream tarball
for no reason. This complicated packaging a bit.

Resolves:
https://pagure.io/SSSD/sssd/issue/3861