### PR TITLE
ci: disable timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -152,7 +152,6 @@ def CI_Notify(status, message) { CI.Notify(this, status, message) }
 pipeline {
   agent none
   options {
-    timeout(time: 10, unit: 'HOURS')
     checkoutToSubdirectory('sssd')
   }
   stages {


### PR DESCRIPTION
There is a bug in jenkins [1] which causes to include the time a job is
waiting for an available executor is added to the complete execution time.
As a consequence a job may time out without actually started because it
did not get the executor in time.

Therefore we disable the timeout completely. We can abort it manually if
a job hangs for some reason. The job always finished so far but many jobs
were aborted because they were waiting for an executor for a long time.

[1] https://issues.jenkins-ci.org/browse/JENKINS-46569