### PR TITLE
MAN: ldap_user_home_directory default missing

### DIFF
--- a/src/man/sssd-ldap.5.xml
+++ b/src/man/sssd-ldap.5.xml
@@ -373,7 +373,7 @@
                             home directory.
                         </para>
                         <para>
-                            Default: homeDirectory
+                            Default: homeDirectory (LDAP and IPA), unixHomeDirectory (AD)
                         </para>
                     </listitem>
                 </varlistentry>


### PR DESCRIPTION
The default value of "ldap_user_home_directory" is "homeDirectory"
but for AD provider it is "unixHomeDirectory"

Resolves:
https://bugzilla.redhat.com/show_bug.cgi?id=1673443