### PR TITLE
SPECFILE: Add 'make' as build dependency

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -187,6 +187,7 @@ Requires: python2-sssdconfig = %{version}-%{release}
 
 ### Build Dependencies ###
 
+BuildRequires: make
 BuildRequires: autoconf
 BuildRequires: automake
 BuildRequires: libtool


### PR DESCRIPTION
This caused some of my scripts fail when building SSSD
after fetching build dependencies from srpm because
make was not installed.