### PR TITLE
util/find_uid.c: fixed race condition bug

### DIFF
--- a/src/util/find_uid.c
+++ b/src/util/find_uid.c
@@ -338,7 +338,7 @@ errno_t check_if_uid_is_active(uid_t uid, bool *result)
 
     ret = get_active_uid_linux(NULL, uid);
     if (ret != EOK && ret != ENOENT) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "get_uid_table failed.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "get_active_uid_linux() failed.\n");
         return ret;
     }
 


### PR DESCRIPTION
    It was wrong to return EOK from get_uid_from_pid() in case of failed
    open() or fstat() as this leaves `uid` uninitialized and no means
    for caller to detect this situation.
    
    There was no reason to fail get_active_uid_linux() completely in case
    of failed get_uid_from_pid() for one of /proc entries. Function was
    changed to continue with next entry instead.
    
    Resolves: https://pagure.io/SSSD/sssd/issue/2854
