### PR TITLE
DEBUG: Add debug to display ldapsearch requests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1520,6 +1520,7 @@ dist_sssdtapscript_DATA = \
     contrib/systemtap/id_perf.stp \
     contrib/systemtap/nested_group_perf.stp \
     contrib/systemtap/dp_request.stp \
+    contrib/systemtap/ldap_perf.stp \
     $(NULL)
 
 stap_generated_probes.h: $(srcdir)/src/systemtap/sssd_probes.d

--- a/Makefile.am
+++ b/Makefile.am
@@ -2195,6 +2195,9 @@ libsss_test_common_la_LIBADD = \
     $(LDB_LIBS) \
     $(SSSD_INTERNAL_LTLIBS) \
     $(NULL)
+if BUILD_SYSTEMTAP
+libsss_test_common_la_LIBADD += stap_generated_probes.lo
+endif
 
 if HAVE_CHECK
 libsss_test_common_la_SOURCES += \

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -1082,6 +1082,7 @@ done
 %{_datadir}/sssd/systemtap/id_perf.stp
 %{_datadir}/sssd/systemtap/nested_group_perf.stp
 %{_datadir}/sssd/systemtap/dp_request.stp
+%{_datadir}/sssd/systemtap/ldap_perf.stp
 %dir %{_datadir}/systemtap
 %dir %{_datadir}/systemtap/tapset
 %{_datadir}/systemtap/tapset/sssd.stp

--- a/contrib/systemtap/ldap_perf.stp
+++ b/contrib/systemtap/ldap_perf.stp
@@ -1,0 +1,114 @@
+/* Start Run with:
+ *
+ *   stap ldap_perf.stp
+ *
+ * Then reproduce slow operation in another terminal.
+ * Ctrl-C running stap once login completes.
+ *
+ * This script watches all sssd_be processes. This can be limited by
+ * specifying sssd_be process id
+ *
+ *   stap -G sssd_be_pid=1234 ldap_perf.stp
+ *
+ * Probe tapsets are in /usr/share/systemtap/tapset/sssd.stp
+ */
+
+global start_time;
+global sdap_attributes;
+global query_attributes;
+global sssd_be_pid=0;
+
+global slowest_request_time;
+global slowest_request_filter;
+global slowest_request_scope;
+global slowest_request_base;
+global slowest_request_attrs;
+
+probe begin
+{
+    printf("===== ldap queries probe started =====\n");
+    id = pid();
+    start_time[id] = gettimeofday_us();
+    query_attributes[id] = "";
+    slowest_request_time = 0;
+    slowest_request_filter = "";
+    slowest_request_scope = 0;
+    slowest_request_base = "";
+    slowest_request_attrs = "";
+}
+
+probe sdap_parse_entry
+{
+    id = pid();
+    if (sssd_be_pid == 0 || sssd_be_pid == id) {
+        idx = 0;
+        while ([id, attr, idx] in sdap_attributes) {
+            idx++;
+        }
+        sdap_attributes[id, attr, idx] = value;
+    }
+}
+
+probe sdap_parse_entry_done
+{
+    id = pid();
+    if (sssd_be_pid == 0 || sssd_be_pid == id) {
+        dn = sdap_attributes[id, "OriginalDN", 0];
+        printf("[%d] <- dn: %s\n", id, dn);
+        delete sdap_attributes[id, "OriginalDN", *];
+        foreach ([x, attr, idx] in sdap_attributes[id,*,*]) {
+            printf("[%d] <- %s: %s\n", id, attr, sdap_attributes[x, attr, idx]);
+        }
+        delete sdap_attributes[id, *, *];
+    }
+}
+
+probe sdap_search_send
+{
+    id = pid();
+    if (sssd_be_pid == 0 || sssd_be_pid == id) {
+	    printf("[%d] -> ldap request: basedn '%s', scope %d, filter '%s'\n",
+               id, base, scope, filter);
+        printf("[%d] -> attrs: %s\n", id, attrs);
+        query_attributes[id] = attrs;
+        start_time[id] = gettimeofday_ms();
+        delete sdap_attributes[id, *, *];
+	}
+}
+
+
+probe sdap_search_recv
+{
+    id = pid();
+    if (sssd_be_pid == 0 || sssd_be_pid == id) {
+        delta = gettimeofday_ms() - start_time[id];
+	    printf("[%d] ldap response to request: basedn '%s', scope %d, filter '%s'\n",
+               id, base, scope, filter);
+        printf("[%d] took: %d ms\n", id, delta);
+        printf("[%d]--------------------------------------------------\n", id);
+
+        if (slowest_request_time < delta) {
+            slowest_request_time = delta;
+            slowest_request_base = base;
+            slowest_request_scope = scope;
+            slowest_request_filter = filter;
+            slowest_request_attrs = query_attributes[id];
+        }
+    }
+}
+
+probe process("/usr/libexec/sssd/sssd_be").end
+{
+    printf("done\n");
+}
+
+probe end
+{
+    printf("\n===== slowest ldap request =====\n");
+    printf("base: '%s'\nscope: %d\nfilter: '%s'\nattrs: %s\ntook: %d ms\n",
+           slowest_request_base,
+           slowest_request_scope,
+           slowest_request_filter,
+           slowest_request_attrs,
+           slowest_request_time);
+}

--- a/src/man/sssd-systemtap.5.xml
+++ b/src/man/sssd-systemtap.5.xml
@@ -406,7 +406,55 @@ dp_errorstr:string
 
     </refsect1>
 
-	<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="include/seealso.xml" />
+    <refsect1 id='sample-systemtap-scripts'>
+        <title>SAMPLE SYSTEMTAP SCRIPTS</title>
+        <para>
+            Start the SystemTap script
+            (<command>stap /usr/share/sssd/systemtap/&lt;script_name&gt;.stp</command>),
+            then perform an identity operation and the script
+            will collect information from probes.
+        </para>
+        <para>
+            Provided SystemTap scripts are:
+        </para>
+        <variablelist>
+            <varlistentry>
+                <term>dp_request.stp</term>
+                <listitem>
+                    <para>
+                        Monitoring of data provider request performance.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term>id_perf.stp</term>
+                <listitem>
+                    <para>
+                        Monitoring of <command>id</command> command
+                        performance.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+          <term>ldap_perf.stp</term>
+          <listitem>
+              <para>
+                  Monitoring of LDAP queries.
+              </para>
+          </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term>nested_group_perf.stp</term>
+                <listitem>
+                    <para>
+                        Performance of nested groups resolving.
+                    </para>
+                </listitem>
+            </varlistentry>
+        </variablelist>
+    </refsect1>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="include/seealso.xml" />
 
 </refentry>
 </reference>

--- a/src/man/sssd-systemtap.5.xml
+++ b/src/man/sssd-systemtap.5.xml
@@ -152,6 +152,7 @@ probestr:string
 base:string
 scope:integer
 filter:string
+attrs:string
 probestr:string
                         </programlisting>
                     </listitem>

--- a/src/man/sssd-systemtap.5.xml
+++ b/src/man/sssd-systemtap.5.xml
@@ -173,6 +173,31 @@ probestr:string
                     </listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term>probe sdap_parse_entry</term>
+                    <listitem>
+                        <para>
+                            Probes the sdap_parse_entry()
+                            function. It is called repeatedly
+                            with every received attribute.
+                        </para>
+                        <programlisting>
+attr:string
+value:string
+                        </programlisting>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>probe sdap_parse_entry_done</term>
+                    <listitem>
+                        <para>
+                            Probes the sdap_parse_entry()
+                            function. It is called when
+                            parsing of received object is
+                            finished.
+                        </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
                     <term>probe sdap_deref_send</term>
                     <listitem>
                         <para>

--- a/src/providers/ldap/sdap.c
+++ b/src/providers/ldap/sdap.c
@@ -25,6 +25,7 @@
 #include "providers/ldap/ldap_common.h"
 #include "providers/ldap/sdap.h"
 #include "providers/ldap/sdap_range.h"
+#include "util/probes.h"
 
 /* =Retrieve-Options====================================================== */
 
@@ -433,6 +434,7 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
     }
 
     DEBUG(SSSDBG_TRACE_LIBS, "OriginalDN: [%s].\n", str);
+    PROBE(SDAP_PARSE_ENTRY, "OriginalDN", str, strlen(str));
     ret = sysdb_attrs_add_string(attrs, SYSDB_ORIG_DN, str);
     ldap_memfree(str);
     if (ret) goto done;
@@ -570,6 +572,7 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
                         v.data = (uint8_t *)vals[i]->bv_val;
                         v.length = vals[i]->bv_len;
                     }
+                    PROBE(SDAP_PARSE_ENTRY, str, v.data, v.length);
 
                     if (map) {
                         /* The same LDAP attr might be used for more sysdb
@@ -619,6 +622,7 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
         goto done;
     }
 
+    PROBE(SDAP_PARSE_ENTRY_DONE);
     *_attrs = talloc_steal(memctx, attrs);
     ret = EOK;
 

--- a/src/providers/ldap/sdap_async.c
+++ b/src/providers/ldap/sdap_async.c
@@ -1398,7 +1398,7 @@ sdap_get_generic_ext_send(TALLOC_CTX *memctx,
     state->serverctrls[i] = NULL;
 
     PROBE(SDAP_GET_GENERIC_EXT_SEND, state->search_base,
-          state->scope, state->filter);
+          state->scope, state->filter, state->attrs);
 
     ret = sdap_get_generic_ext_step(req);
     if (ret != EOK) {

--- a/src/systemtap/sssd.stp.in
+++ b/src/systemtap/sssd.stp.in
@@ -41,6 +41,7 @@ probe sdap_search_send = process("@libdir@/sssd/libsss_ldap_common.so").mark("sd
     } else {
         filter = user_string($arg3);
     }
+    attrs = __get_argv($arg4, 0);
 
     probestr = sprintf("-> search base [%s] scope [%d] filter [%s]",
                        base, scope, filter);

--- a/src/systemtap/sssd.stp.in
+++ b/src/systemtap/sssd.stp.in
@@ -61,6 +61,17 @@ probe sdap_search_recv = process("@libdir@/sssd/libsss_ldap_common.so").mark("sd
                        base, scope, filter);
 }
 
+probe sdap_parse_entry = process("/usr/lib64/sssd/libsss_ldap_common.so").mark("sdap_parse_entry")
+{
+    attr = user_string($arg1);
+    value = user_string_n($arg2, $arg3);
+}
+
+probe sdap_parse_entry_done = process("/usr/lib64/sssd/libsss_ldap_common.so").mark("sdap_parse_entry_done")
+{
+   # No arguments
+}
+
 probe sdap_deref_send = process("@libdir@/sssd/libsss_ldap_common.so").mark("sdap_deref_search_send")
 {
     base_dn = user_string($arg1);

--- a/src/systemtap/sssd.stp.in
+++ b/src/systemtap/sssd.stp.in
@@ -36,7 +36,11 @@ probe sdap_search_send = process("@libdir@/sssd/libsss_ldap_common.so").mark("sd
 {
     base = user_string($arg1);
     scope = $arg2;
-    filter = user_string($arg3);
+    if ($arg3 == 0) {
+        filter = "<no filter>";
+    } else {
+        filter = user_string($arg3);
+    }
 
     probestr = sprintf("-> search base [%s] scope [%d] filter [%s]",
                        base, scope, filter);
@@ -46,7 +50,11 @@ probe sdap_search_recv = process("@libdir@/sssd/libsss_ldap_common.so").mark("sd
 {
     base = user_string($arg1);
     scope = $arg2;
-    filter = user_string($arg3);
+    if ($arg3 == 0) {
+        filter = "<no filter>";
+    } else {
+        filter = user_string($arg3);
+    }
 
     probestr = sprintf("<- search base [%s] scope [%d] filter [%s]",
                        base, scope, filter);

--- a/src/systemtap/sssd_probes.d
+++ b/src/systemtap/sssd_probes.d
@@ -22,6 +22,9 @@ provider sssd {
                                     const char *filter, const char **attrs);
     probe sdap_get_generic_ext_recv(const char *base, int scope, const char *filter);
 
+    probe sdap_parse_entry(const char *attrname, const char *value, int length);
+    probe sdap_parse_entry_done();
+
     probe sdap_deref_search_send(const char *base_dn, const char *deref_attr);
     probe sdap_deref_search_recv(const char *base_dn, const char *deref_attr);
 

--- a/src/systemtap/sssd_probes.d
+++ b/src/systemtap/sssd_probes.d
@@ -18,7 +18,8 @@ provider sssd {
     probe sdap_search_user_save_end(const char *filter);
     probe sdap_search_user_recv(const char *filter);
 
-    probe sdap_get_generic_ext_send(const char *base, int scope, const char *filter);
+    probe sdap_get_generic_ext_send(const char *base, int scope,
+                                    const char *filter, const char **attrs);
     probe sdap_get_generic_ext_recv(const char *base, int scope, const char *filter);
 
     probe sdap_deref_search_send(const char *base_dn, const char *deref_attr);


### PR DESCRIPTION
The existing debug output from SSSD is quite helpful in this respect,
but it would be better to have systemtap probes that can monitor executed
LDAP search calls and display returned results.

Two new probes are created (SDAP_PARSE_ENTRY, SDAP_PARSE_ENTRY_DONE) in
this PR to expose received attributes. The probe SDAP_GET_GENERIC_EXT_SEND
is extended of requested attributes list.

The systemtap script contrib/systemtap/ldap_perf.stp can be used to monitor
LDAP queries.

Resolves:
https://bugzilla.redhat.com/show_bug.cgi?id=1542137