### PR TITLE
crypto: unconst key in sss_encrypt and sss_decrypt

### DIFF
--- a/src/util/crypto/nss/nss_nite.c
+++ b/src/util/crypto/nss/nss_nite.c
@@ -37,7 +37,7 @@ struct cipher_mech {
 };
 
 int sss_encrypt(TALLOC_CTX *mem_ctx, enum encmethod enctype,
-                const uint8_t *key, size_t keylen,
+                uint8_t *key, size_t keylen,
                 const uint8_t *plaintext, size_t plainlen,
                 uint8_t **ciphertext, size_t *cipherlen)
 {
@@ -171,7 +171,7 @@ done:
 }
 
 int sss_decrypt(TALLOC_CTX *mem_ctx, enum encmethod enctype,
-                const uint8_t *key, size_t keylen,
+                uint8_t *key, size_t keylen,
                 const uint8_t *ciphertext, size_t cipherlen,
                 uint8_t **plaintext, size_t *plainlen)
 {

--- a/src/util/crypto/sss_crypto.h
+++ b/src/util/crypto/sss_crypto.h
@@ -63,11 +63,11 @@ enum encmethod {
 };
 
 int sss_encrypt(TALLOC_CTX *mem_ctx, enum encmethod enctype,
-                const uint8_t *key, size_t keylen,
+                uint8_t *key, size_t keylen,
                 const uint8_t *plaintext, size_t plainlen,
                 uint8_t **ciphertext, size_t *cipherlen);
 int sss_decrypt(TALLOC_CTX *mem_ctx, enum encmethod enctype,
-                const uint8_t *key, size_t keylen,
+                uint8_t *key, size_t keylen,
                 const uint8_t *ciphertext, size_t cipherlen,
                 uint8_t **plaintext, size_t *plainlen);
 


### PR DESCRIPTION
The key parameter was made const in 8aa0dfdf6e36fa90855c0f35a4dfa57139ad6504
but it produces errors:

```
  CC       src/util/crypto/libsss_crypt_la-sss_crypto.lo
/home/pbrezina/workspace/sssd/src/util/crypto/nss/nss_nite.c: In function ‘sss_encrypt’:
/home/pbrezina/workspace/sssd/src/util/crypto/nss/nss_nite.c:96:38: error: passing argument 3 of ‘nss_ctx_init’ discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
     ret = nss_ctx_init(tmp_ctx, enc, key, keylen, out, ivlen, &cctx);
                                      ^~~
In file included from /home/pbrezina/workspace/sssd/src/util/crypto/nss/nss_nite.c:30:
/home/pbrezina/workspace/sssd/src/util/crypto/nss/nss_crypto.h:61:27: note: expected ‘uint8_t *’ {aka ‘unsigned char *’} but argument is of type ‘const uint8_t *’ {aka ‘const unsigned char *’}
                  uint8_t *key, int keylen,
                  ~~~~~~~~~^~~
/home/pbrezina/workspace/sssd/src/util/crypto/nss/nss_nite.c:133:39: error: passing argument 3 of ‘nss_ctx_init’ discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
     ret = nss_ctx_init(tmp_ctx, hmac, key, keylen, NULL, 0, &hctx);
                                       ^~~
In file included from /home/pbrezina/workspace/sssd/src/util/crypto/nss/nss_nite.c:30:
/home/pbrezina/workspace/sssd/src/util/crypto/nss/nss_crypto.h:61:27: note: expected ‘uint8_t *’ {aka ‘unsigned char *’} but argument is of type ‘const uint8_t *’ {aka ‘const unsigned char *’}
                  uint8_t *key, int keylen,
                  ~~~~~~~~~^~~
/home/pbrezina/workspace/sssd/src/util/crypto/nss/nss_nite.c: In function ‘sss_decrypt’:
/home/pbrezina/workspace/sssd/src/util/crypto/nss/nss_nite.c:221:39: error: passing argument 3 of ‘nss_ctx_init’ discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
     ret = nss_ctx_init(tmp_ctx, hmac, key, keylen, NULL, 0, &hctx);
                                       ^~~
In file included from /home/pbrezina/workspace/sssd/src/util/crypto/nss/nss_nite.c:30:
/home/pbrezina/workspace/sssd/src/util/crypto/nss/nss_crypto.h:61:27: note: expected ‘uint8_t *’ {aka ‘unsigned char *’} but argument is of type ‘const uint8_t *’ {aka ‘const unsigned char *’}
                  uint8_t *key, int keylen,
                  ~~~~~~~~~^~~
/home/pbrezina/workspace/sssd/src/util/crypto/nss/nss_nite.c:268:38: error: passing argument 3 of ‘nss_ctx_init’ discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
     ret = nss_ctx_init(tmp_ctx, enc, key, keylen, ivbuf, ivlen, &cctx);
                                      ^~~
In file included from /home/pbrezina/workspace/sssd/src/util/crypto/nss/nss_nite.c:30:
/home/pbrezina/workspace/sssd/src/util/crypto/nss/nss_crypto.h:61:27: note: expected ‘uint8_t *’ {aka ‘unsigned char *’} but argument is of type ‘const uint8_t *’ {aka ‘const unsigned char *’}
                  uint8_t *key, int keylen,
```

Making the parameter const also in `nss_ctx_init` will produce another error which is out of our control thus removing the const.

```
In file included from /home/pbrezina/workspace/sssd/src/util/crypto/nss/nss_util.c:33:
/home/pbrezina/workspace/sssd/src/util/crypto/nss/nss_util.c: In function ‘nss_ctx_init’:
/home/pbrezina/workspace/sssd/src/util/crypto/nss/nss_crypto.h:33:19: error: assignment discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
     (sitem)->data = (sdata);    \
                   ^
/home/pbrezina/workspace/sssd/src/util/crypto/nss/nss_util.c:180:13: note: in expansion of macro ‘MAKE_SECITEM’
             MAKE_SECITEM(key, keylen, cctx->key);
```