### PR TITLE
crypto/nss: some nss_ctx_init() params made const 

### DIFF
--- a/src/util/crypto/nss/nss_crypto.h
+++ b/src/util/crypto/nss/nss_crypto.h
@@ -28,12 +28,6 @@
 #include <base64.h>
 #include <talloc.h>
 
-#define MAKE_SECITEM(sdata, slen, sitem) do { \
-    (sitem)->type = (siBuffer); \
-    (sitem)->data = (sdata);    \
-    (sitem)->len  = (slen);     \
-} while(0)
-
 struct sss_nss_crypto_ctx {
     PK11SlotInfo *slot;
     PK11Context  *ectx;
@@ -58,8 +52,8 @@ enum crypto_mech_op {
 
 int nss_ctx_init(TALLOC_CTX *mem_ctx,
                  struct crypto_mech_data *mech_props,
-                 uint8_t *key, int keylen,
-                 uint8_t *iv, int ivlen,
+                 const uint8_t *key, int keylen,
+                 const uint8_t *iv, int ivlen,
                  struct sss_nss_crypto_ctx **_cctx);
 int nss_crypto_init(struct crypto_mech_data *mech_props,
                     enum crypto_mech_op crypto_op,

--- a/src/util/crypto/nss/nss_nite.c
+++ b/src/util/crypto/nss/nss_nite.c
@@ -90,7 +90,9 @@ int sss_encrypt(TALLOC_CTX *mem_ctx, enum encmethod enctype,
 
     if (ivlen != 0) {
         ret = sss_generate_csprng_buffer(out, ivlen);
-        if (ret) return ret;
+        if (ret != EOK) {
+            goto done;
+        }
     }
 
     ret = nss_ctx_init(tmp_ctx, enc, key, keylen, out, ivlen, &cctx);


### PR DESCRIPTION
This patch fixes compilation issues introduced in 8aa0dfd :
as `key` parameter of sss_encrypt() and sss_decrypt() became const,
changes in signature of nss_ctx_init() were required to follow up.
For more details see SSSD#846