### PR TITLE
Update __init__.py.in

### DIFF
--- a/src/config/SSSDConfig/__init__.py.in
+++ b/src/config/SSSDConfig/__init__.py.in
@@ -1917,6 +1917,35 @@ class SSSDConfig(SSSDChangeConf):
         providers = [ (x['name'],x['value']) for x in self.strip_comments_empty(self.options('domain/%s' % name))
                      if x['name'].rfind('_provider') > 0]
 
+        # Handle the default value for providers if those weren't set in the configuration file
+        default_providers = {
+            'id_provider': None,
+            'sudo_provider': 'id_provider',
+            'auth_provider': 'id_provider',
+            'chpass_provider': 'auth_provider',
+            'autofs_provider': 'id_provider',
+            'selinux_provider': 'id_provider',
+            'subdomains_provider': 'id_provider',
+            'session_provider': 'id_provider',
+            'hostid_provider': 'id_provider',
+        }
+
+        configured_providers = domain.list_providers()
+        providers_list = [x[0] for x in providers]
+
+        if 'access_provider' not in providers_list:
+            providers.append(('access_provider', 'permit'))
+
+        for provider, default_provider in default_providers.items():
+            if provider in providers_list:
+                continue
+
+            if default_provider in providers_list:
+                default_provider_value = providers[providers_list.index(default_provider)]
+                if default_provider_value[1] in configured_providers.keys():
+                    if provider[:provider.rfind('_provider')] in configured_providers[default_provider_value[1]]:
+                        providers.append((provider, default_provider_value[1]))
+
         for (option, value) in providers:
             try:
                 domain.set_option(option, value)

--- a/src/config/SSSDConfigTest.py
+++ b/src/config/SSSDConfigTest.py
@@ -1406,6 +1406,12 @@ class SSSDConfigTestSSSDConfig(unittest.TestCase):
             'id_provider',
             'auth_provider',
             'access_provider',
+            'autofs_provider',
+            'chpass_provider',
+            'sudo_provider',
+            'subdomains_provider',
+            'selinux_provider',
+            'hostid_provider',
             'session_provider',
             'default_shell',
             'fallback_homedir',
@@ -1829,6 +1835,8 @@ class SSSDConfigTestSSSDConfig(unittest.TestCase):
 
         # TODO verify the contents of this domain
         self.assertTrue(domain.get_option('ldap_id_use_start_tls'))
+        self.assertTrue(domain.get_option('ldap_sudo_include_regexp'))
+        self.assertTrue(domain.get_option('ldap_autofs_map_master_name'))
 
         # Negative Test - No such domain
         self.assertRaises(SSSDConfig.NoDomainError, sssdconfig.get_domain, 'nosuchdomain')

--- a/src/config/testconfigs/sssd-valid.conf
+++ b/src/config/testconfigs/sssd-valid.conf
@@ -32,6 +32,8 @@ debug_level = 0
 
 [domain/LDAP]
 ldap_id_use_start_tls = true
+ldap_sudo_include_regexp = true
+ldap_autofs_map_master_name = "auto.master"
 id_provider  =    ldap
 auth_provider=ldap
 debug_level = 0


### PR DESCRIPTION
COMPONENT: SSSDConfig

The default value for sudo_provider, auth_provider, and autofs_provider will be the value of id_provider, if those options weren't set in the configuration file

Resolves:
https://pagure.io/SSSD/sssd/issue/3995