### PR TITLE
 DYNDNS: dyndns_update is not enough 

### DIFF
--- a/src/providers/ad/ad_dyndns.c
+++ b/src/providers/ad/ad_dyndns.c
@@ -101,7 +101,7 @@ errno_t ad_dyndns_init(struct be_ctx *be_ctx,
     ret = be_ptask_create(ad_opts, be_ctx, period, ptask_first_delay, 0, 0, period,
                           BE_PTASK_OFFLINE_DISABLE, BE_PTASK_SCHEDULE_FROM_LAST, 0,
                           ad_dyndns_update_send, ad_dyndns_update_recv, ad_opts,
-                          "Dyndns update", NULL);
+                          "Dyndns update", 0, NULL);
 
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to setup ptask "

--- a/src/providers/ad/ad_dyndns.c
+++ b/src/providers/ad/ad_dyndns.c
@@ -98,10 +98,13 @@ errno_t ad_dyndns_init(struct be_ctx *be_ctx,
         return EINVAL;
     }
 
-    ret = be_ptask_create(ad_opts, be_ctx, period, ptask_first_delay, 0, 0, period,
-                          BE_PTASK_OFFLINE_DISABLE, BE_PTASK_SCHEDULE_FROM_LAST, 0,
+    ret = be_ptask_create(ad_opts, be_ctx, period, ptask_first_delay, 0, 0,
+                          period, 0,
                           ad_dyndns_update_send, ad_dyndns_update_recv, ad_opts,
-                          "Dyndns update", 0, NULL);
+                          "Dyndns update",
+                          BE_PTASK_OFFLINE_DISABLE |
+                          BE_PTASK_SCHEDULE_FROM_LAST,
+                          NULL);
 
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to setup ptask "

--- a/src/providers/ad/ad_dyndns.c
+++ b/src/providers/ad/ad_dyndns.c
@@ -56,6 +56,7 @@ errno_t ad_dyndns_init(struct be_ctx *be_ctx,
     errno_t ret;
     const time_t ptask_first_delay = 10;
     int period;
+    uint32_t extraflags = 0;
 
     /* nsupdate is available. Dynamic updates
      * are supported
@@ -93,15 +94,16 @@ errno_t ad_dyndns_init(struct be_ctx *be_ctx,
 
     period = dp_opt_get_int(ad_opts->dyndns_ctx->opts, DP_OPT_DYNDNS_REFRESH_INTERVAL);
     if (period == 0) {
-        DEBUG(SSSDBG_OP_FAILURE, "Dyndns update task can't be started, "
+        DEBUG(SSSDBG_TRACE_FUNC, "DNS will not be updated periodically, "
               "dyndns_refresh_interval is 0\n");
-        return EINVAL;
+        extraflags |= BE_PTASK_NO_PERIODIC;
     }
 
     ret = be_ptask_create(ad_opts, be_ctx, period, ptask_first_delay, 0, 0,
                           period, 0,
                           ad_dyndns_update_send, ad_dyndns_update_recv, ad_opts,
                           "Dyndns update",
+                          extraflags |
                           BE_PTASK_OFFLINE_DISABLE |
                           BE_PTASK_SCHEDULE_FROM_LAST,
                           NULL);

--- a/src/providers/ad/ad_machine_pw_renewal.c
+++ b/src/providers/ad/ad_machine_pw_renewal.c
@@ -381,14 +381,14 @@ errno_t ad_machine_account_password_renewal_init(struct be_ctx *be_ctx,
         goto done;
     }
 
-    ret = be_ptask_create(be_ctx, be_ctx, period, initial_delay, 0, 0, 60,
-                          BE_PTASK_OFFLINE_DISABLE,
-                          BE_PTASK_SCHEDULE_FROM_LAST,
-                          0,
+    ret = be_ptask_create(be_ctx, be_ctx, period, initial_delay, 0, 0, 60, 0,
                           ad_machine_account_password_renewal_send,
                           ad_machine_account_password_renewal_recv,
                           renewal_data,
-                          "AD machine account password renewal", 0, NULL);
+                          "AD machine account password renewal",
+                          BE_PTASK_OFFLINE_DISABLE |
+                          BE_PTASK_SCHEDULE_FROM_LAST,
+                          NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "be_ptask_create failed.\n");
         goto done;

--- a/src/providers/ad/ad_machine_pw_renewal.c
+++ b/src/providers/ad/ad_machine_pw_renewal.c
@@ -388,7 +388,7 @@ errno_t ad_machine_account_password_renewal_init(struct be_ctx *be_ctx,
                           ad_machine_account_password_renewal_send,
                           ad_machine_account_password_renewal_recv,
                           renewal_data,
-                          "AD machine account password renewal", NULL);
+                          "AD machine account password renewal", 0, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "be_ptask_create failed.\n");
         goto done;

--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -2065,12 +2065,13 @@ errno_t ad_subdomains_init(TALLOC_CTX *mem_ctx,
                   struct ad_subdomains_ctx, struct dp_subdomains_data, struct dp_reply_std);
 
     period = be_ctx->domain->subdomain_refresh_interval;
-    ret = be_ptask_create(sd_ctx, be_ctx, period, 0, 0, 0, period,
-                          BE_PTASK_OFFLINE_DISABLE,
+    ret = be_ptask_create(sd_ctx, be_ctx, period, 0, 0, 0, period, 0,
+                          ad_subdomains_ptask_send, ad_subdomains_ptask_recv,
+                          sd_ctx,
+                          "Subdomains Refresh",
+                          BE_PTASK_OFFLINE_DISABLE |
                           BE_PTASK_SCHEDULE_FROM_LAST,
-                          0,
-                          ad_subdomains_ptask_send, ad_subdomains_ptask_recv, sd_ctx,
-                          "Subdomains Refresh", 0, NULL);
+                          NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to setup ptask "
               "[%d]: %s\n", ret, sss_strerror(ret));

--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -2070,7 +2070,7 @@ errno_t ad_subdomains_init(TALLOC_CTX *mem_ctx,
                           BE_PTASK_SCHEDULE_FROM_LAST,
                           0,
                           ad_subdomains_ptask_send, ad_subdomains_ptask_recv, sd_ctx,
-                          "Subdomains Refresh", NULL);
+                          "Subdomains Refresh", 0, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to setup ptask "
               "[%d]: %s\n", ret, sss_strerror(ret));

--- a/src/providers/be_ptask.h
+++ b/src/providers/be_ptask.h
@@ -39,33 +39,23 @@ struct be_ptask;
 #define BE_PTASK_NO_PERIODIC         0x0001
 
 /**
- * Defines how should task behave when back end is offline.
+ * Flags defining the starting point for scheduling a task
  */
-enum be_ptask_offline {
-    /* current request will be skipped and rescheduled to 'now + period' */
-    BE_PTASK_OFFLINE_SKIP,
-
-    /* An offline and online callback is registered. The task is disabled
-     * immediately when back end goes offline and then enabled again
-     * when back end goes back online */
-    BE_PTASK_OFFLINE_DISABLE,
-
-    /* current request will be executed as planned */
-    BE_PTASK_OFFLINE_EXECUTE
-};
+/* Schedule starting from now, typically this is used when scheduling
+ * relative to the finish time */
+#define BE_PTASK_SCHEDULE_FROM_NOW   0x0002
+/* Schedule relative to the start time of the task */
+#define BE_PTASK_SCHEDULE_FROM_LAST  0x0004
 
 /**
- * Defines the starting point for scheduling a task
+ * Flags defining how should task behave when back end is offline.
  */
-enum be_ptask_schedule {
-    /* Schedule starting from now, typically this is used when scheduling
-     * relative to the finish time
-     */
-    BE_PTASK_SCHEDULE_FROM_NOW,
-    /* Schedule relative to the start time of the task
-     */
-    BE_PTASK_SCHEDULE_FROM_LAST
-};
+/* current request will be skipped and rescheduled to 'now + period' */
+#define BE_PTASK_OFFLINE_SKIP        0x0008
+/* An offline and online callback is registered. The task is disabled */
+#define BE_PTASK_OFFLINE_DISABLE     0x0010
+/* current request will be executed as planned */
+#define BE_PTASK_OFFLINE_EXECUTE     0x0020
 
 typedef struct tevent_req *
 (*be_ptask_send_t)(TALLOC_CTX *mem_ctx,
@@ -128,8 +118,6 @@ errno_t be_ptask_create(TALLOC_CTX *mem_ctx,
                         time_t enabled_delay,
                         time_t random_offset,
                         time_t timeout,
-                        enum be_ptask_offline offline,
-                        enum be_ptask_schedule success_schedule_type,
                         time_t max_backoff,
                         be_ptask_send_t send_fn,
                         be_ptask_recv_t recv_fn,
@@ -145,7 +133,6 @@ errno_t be_ptask_create_sync(TALLOC_CTX *mem_ctx,
                              time_t enabled_delay,
                              time_t random_offset,
                              time_t timeout,
-                             enum be_ptask_offline offline,
                              time_t max_backoff,
                              be_ptask_sync_t fn,
                              void *pvt,

--- a/src/providers/be_ptask.h
+++ b/src/providers/be_ptask.h
@@ -30,6 +30,14 @@ struct be_ctx;
 
 struct be_ptask;
 
+/* be_ptask flags */
+
+/**
+ * Do not schedule periodic task. This flag is useful for tasks that
+ * should be performend only when there is offline/online change.
+ */
+#define BE_PTASK_NO_PERIODIC         0x0001
+
 /**
  * Defines how should task behave when back end is offline.
  */
@@ -127,6 +135,7 @@ errno_t be_ptask_create(TALLOC_CTX *mem_ctx,
                         be_ptask_recv_t recv_fn,
                         void *pvt,
                         const char *name,
+                        uint32_t flags,
                         struct be_ptask **_task);
 
 errno_t be_ptask_create_sync(TALLOC_CTX *mem_ctx,
@@ -141,6 +150,7 @@ errno_t be_ptask_create_sync(TALLOC_CTX *mem_ctx,
                              be_ptask_sync_t fn,
                              void *pvt,
                              const char *name,
+                             uint32_t flags,
                              struct be_ptask **_task);
 
 void be_ptask_enable(struct be_ptask *task);

--- a/src/providers/be_ptask_private.h
+++ b/src/providers/be_ptask_private.h
@@ -30,8 +30,6 @@ struct be_ptask {
     time_t random_offset;
     time_t timeout;
     time_t max_backoff;
-    enum be_ptask_offline offline;
-    enum be_ptask_schedule success_schedule_type;
     be_ptask_send_t send_fn;
     be_ptask_recv_t recv_fn;
     void *pvt;

--- a/src/providers/be_ptask_private.h
+++ b/src/providers/be_ptask_private.h
@@ -42,6 +42,7 @@ struct be_ptask {
     time_t last_execution;  /* last time when send was called */
     struct tevent_req *req; /* active tevent request */
     struct tevent_timer *timer; /* active tevent timer */
+    uint32_t flags;
     bool enabled;
 };
 

--- a/src/providers/be_refresh.c
+++ b/src/providers/be_refresh.c
@@ -173,11 +173,12 @@ static errno_t be_refresh_ctx_init(struct be_ctx *be_ctx,
     refresh_interval = be_ctx->domain->refresh_expired_interval;
     if (refresh_interval > 0) {
         ret = be_ptask_create(be_ctx, be_ctx, refresh_interval, 30, 5, 0,
-                              refresh_interval, BE_PTASK_OFFLINE_SKIP,
-                              BE_PTASK_SCHEDULE_FROM_NOW,
-                              0,
+                              refresh_interval, 0,
                               be_refresh_send, be_refresh_recv,
-                              ctx, "Refresh Records", 0, NULL);
+                              ctx, "Refresh Records",
+                              BE_PTASK_OFFLINE_SKIP |
+                              BE_PTASK_SCHEDULE_FROM_NOW,
+                              NULL);
         if (ret != EOK) {
             DEBUG(SSSDBG_FATAL_FAILURE,
                   "Unable to initialize refresh periodic task [%d]: %s\n",

--- a/src/providers/be_refresh.c
+++ b/src/providers/be_refresh.c
@@ -177,7 +177,7 @@ static errno_t be_refresh_ctx_init(struct be_ctx *be_ctx,
                               BE_PTASK_SCHEDULE_FROM_NOW,
                               0,
                               be_refresh_send, be_refresh_recv,
-                              ctx, "Refresh Records", NULL);
+                              ctx, "Refresh Records", 0, NULL);
         if (ret != EOK) {
             DEBUG(SSSDBG_FATAL_FAILURE,
                   "Unable to initialize refresh periodic task [%d]: %s\n",

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -133,7 +133,7 @@ void be_mark_offline(struct be_ctx *ctx)
                                    BE_PTASK_OFFLINE_EXECUTE,
                                    3600 /* max_backoff */,
                                    try_to_go_online,
-                                   ctx, "Check if online (periodic)",
+                                   ctx, "Check if online (periodic)", 0,
                                    &ctx->check_if_online_ptask);
         if (ret != EOK) {
             DEBUG(SSSDBG_FATAL_FAILURE,

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -130,10 +130,10 @@ void be_mark_offline(struct be_ctx *ctx)
         ret = be_ptask_create_sync(ctx, ctx,
                                    offline_timeout, offline_timeout,
                                    offline_timeout, 30, offline_timeout,
-                                   BE_PTASK_OFFLINE_EXECUTE,
                                    3600 /* max_backoff */,
                                    try_to_go_online,
-                                   ctx, "Check if online (periodic)", 0,
+                                   ctx, "Check if online (periodic)",
+                                   BE_PTASK_OFFLINE_EXECUTE,
                                    &ctx->check_if_online_ptask);
         if (ret != EOK) {
             DEBUG(SSSDBG_FATAL_FAILURE,

--- a/src/providers/ipa/ipa_dyndns.c
+++ b/src/providers/ipa/ipa_dyndns.c
@@ -78,7 +78,7 @@ errno_t ipa_dyndns_init(struct be_ctx *be_ctx,
                           BE_PTASK_SCHEDULE_FROM_LAST,
                           0,
                           ipa_dyndns_update_send, ipa_dyndns_update_recv, ctx,
-                          "Dyndns update", NULL);
+                          "Dyndns update", 0, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to setup ptask "
               "[%d]: %s\n", ret, sss_strerror(ret));

--- a/src/providers/ipa/ipa_dyndns.c
+++ b/src/providers/ipa/ipa_dyndns.c
@@ -58,6 +58,7 @@ errno_t ipa_dyndns_init(struct be_ctx *be_ctx,
     errno_t ret;
     const time_t ptask_first_delay = 10;
     int period;
+    uint32_t extraflags = 0;
 
     ctx->be_res = be_ctx->be_res;
     if (ctx->be_res == NULL) {
@@ -68,15 +69,16 @@ errno_t ipa_dyndns_init(struct be_ctx *be_ctx,
 
     period = dp_opt_get_int(ctx->dyndns_ctx->opts, DP_OPT_DYNDNS_REFRESH_INTERVAL);
     if (period == 0) {
-        DEBUG(SSSDBG_OP_FAILURE, "Dyndns task can't be started, "
+        DEBUG(SSSDBG_TRACE_FUNC, "DNS will not be updated periodically, "
               "dyndns_refresh_interval is 0\n");
-        return EINVAL;
+        extraflags |= BE_PTASK_NO_PERIODIC;
     }
 
     ret = be_ptask_create(ctx, be_ctx, period, ptask_first_delay, 0, 0, period,
                           0,
                           ipa_dyndns_update_send, ipa_dyndns_update_recv, ctx,
                           "Dyndns update",
+                          extraflags |
                           BE_PTASK_OFFLINE_DISABLE |
                           BE_PTASK_SCHEDULE_FROM_LAST,
                           NULL);

--- a/src/providers/ipa/ipa_dyndns.c
+++ b/src/providers/ipa/ipa_dyndns.c
@@ -74,11 +74,12 @@ errno_t ipa_dyndns_init(struct be_ctx *be_ctx,
     }
 
     ret = be_ptask_create(ctx, be_ctx, period, ptask_first_delay, 0, 0, period,
-                          BE_PTASK_OFFLINE_DISABLE,
-                          BE_PTASK_SCHEDULE_FROM_LAST,
                           0,
                           ipa_dyndns_update_send, ipa_dyndns_update_recv, ctx,
-                          "Dyndns update", 0, NULL);
+                          "Dyndns update",
+                          BE_PTASK_OFFLINE_DISABLE |
+                          BE_PTASK_SCHEDULE_FROM_LAST,
+                          NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to setup ptask "
               "[%d]: %s\n", ret, sss_strerror(ret));

--- a/src/providers/ipa/ipa_subdomains.c
+++ b/src/providers/ipa/ipa_subdomains.c
@@ -3138,7 +3138,7 @@ errno_t ipa_subdomains_init(TALLOC_CTX *mem_ctx,
                           BE_PTASK_SCHEDULE_FROM_LAST,
                           0,
                           ipa_subdomains_ptask_send, ipa_subdomains_ptask_recv, sd_ctx,
-                          "Subdomains Refresh", NULL);
+                          "Subdomains Refresh", 0, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to setup ptask "
               "[%d]: %s\n", ret, sss_strerror(ret));

--- a/src/providers/ipa/ipa_subdomains.c
+++ b/src/providers/ipa/ipa_subdomains.c
@@ -3134,11 +3134,12 @@ errno_t ipa_subdomains_init(TALLOC_CTX *mem_ctx,
 
     period = be_ctx->domain->subdomain_refresh_interval;
     ret = be_ptask_create(sd_ctx, be_ctx, period, ptask_first_delay, 0, 0, period,
-                          BE_PTASK_OFFLINE_DISABLE,
-                          BE_PTASK_SCHEDULE_FROM_LAST,
                           0,
                           ipa_subdomains_ptask_send, ipa_subdomains_ptask_recv, sd_ctx,
-                          "Subdomains Refresh", 0, NULL);
+                          "Subdomains Refresh",
+                          BE_PTASK_OFFLINE_DISABLE |
+                          BE_PTASK_SCHEDULE_FROM_LAST,
+                          NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to setup ptask "
               "[%d]: %s\n", ret, sss_strerror(ret));

--- a/src/providers/ldap/ldap_id_cleanup.c
+++ b/src/providers/ldap/ldap_id_cleanup.c
@@ -87,8 +87,9 @@ errno_t ldap_setup_cleanup(struct sdap_id_ctx *id_ctx,
 
     ret = be_ptask_create_sync(sdom, id_ctx->be, period, first_delay,
                                5 /* enabled delay */, 0 /* random offset */,
-                               period /* timeout */, BE_PTASK_OFFLINE_SKIP, 0,
-                               ldap_cleanup_task, cleanup_ctx, name, 0,
+                               period /* timeout */, 0,
+                               ldap_cleanup_task, cleanup_ctx, name,
+                               BE_PTASK_OFFLINE_SKIP,
                                &sdom->cleanup_task);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Unable to initialize cleanup periodic "

--- a/src/providers/ldap/ldap_id_cleanup.c
+++ b/src/providers/ldap/ldap_id_cleanup.c
@@ -88,7 +88,7 @@ errno_t ldap_setup_cleanup(struct sdap_id_ctx *id_ctx,
     ret = be_ptask_create_sync(sdom, id_ctx->be, period, first_delay,
                                5 /* enabled delay */, 0 /* random offset */,
                                period /* timeout */, BE_PTASK_OFFLINE_SKIP, 0,
-                               ldap_cleanup_task, cleanup_ctx, name,
+                               ldap_cleanup_task, cleanup_ctx, name, 0,
                                &sdom->cleanup_task);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Unable to initialize cleanup periodic "

--- a/src/providers/ldap/ldap_id_enum.c
+++ b/src/providers/ldap/ldap_id_enum.c
@@ -98,11 +98,11 @@ errno_t ldap_setup_enumeration(struct be_ctx *be_ctx,
                           5,                        /* enabled delay */
                           0,                        /* random offset */
                           period,                   /* timeout */
-                          BE_PTASK_OFFLINE_SKIP,
-                          BE_PTASK_SCHEDULE_FROM_LAST,
                           0,                        /* max_backoff */
                           send_fn, recv_fn,
-                          ectx, "enumeration", 0, &sdom->enum_task);
+                          ectx, "enumeration",
+                          BE_PTASK_OFFLINE_SKIP | BE_PTASK_SCHEDULE_FROM_LAST,
+                          &sdom->enum_task);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
               "Unable to initialize enumeration periodic task\n");

--- a/src/providers/ldap/ldap_id_enum.c
+++ b/src/providers/ldap/ldap_id_enum.c
@@ -102,7 +102,7 @@ errno_t ldap_setup_enumeration(struct be_ctx *be_ctx,
                           BE_PTASK_SCHEDULE_FROM_LAST,
                           0,                        /* max_backoff */
                           send_fn, recv_fn,
-                          ectx, "enumeration", &sdom->enum_task);
+                          ectx, "enumeration", 0, &sdom->enum_task);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
               "Unable to initialize enumeration periodic task\n");

--- a/src/providers/ldap/sdap_sudo_shared.c
+++ b/src/providers/ldap/sdap_sudo_shared.c
@@ -90,11 +90,12 @@ sdap_sudo_ptask_setup_generic(struct be_ctx *be_ctx,
      * when offline. */
     if (full > 0) {
         ret = be_ptask_create(be_ctx, be_ctx, full, delay, 0, 0, full,
-                              BE_PTASK_OFFLINE_DISABLE,
-                              BE_PTASK_SCHEDULE_FROM_LAST,
                               0,
                               full_send_fn, full_recv_fn, pvt,
-                              "SUDO Full Refresh", 0, NULL);
+                              "SUDO Full Refresh",
+                              BE_PTASK_OFFLINE_DISABLE |
+                              BE_PTASK_SCHEDULE_FROM_LAST,
+                              NULL);
         if (ret != EOK) {
             DEBUG(SSSDBG_CRIT_FAILURE, "Unable to setup full refresh ptask "
                   "[%d]: %s\n", ret, sss_strerror(ret));
@@ -109,11 +110,12 @@ sdap_sudo_ptask_setup_generic(struct be_ctx *be_ctx,
      * when offline. */
     if (smart > 0) {
         ret = be_ptask_create(be_ctx, be_ctx, smart, delay + smart, smart, 0,
-                              smart, BE_PTASK_OFFLINE_DISABLE,
-                              BE_PTASK_SCHEDULE_FROM_LAST,
-                              0,
+                              smart,                              0,
                               smart_send_fn, smart_recv_fn, pvt,
-                              "SUDO Smart Refresh", 0, NULL);
+                              "SUDO Smart Refresh",
+                              BE_PTASK_OFFLINE_DISABLE |
+                              BE_PTASK_SCHEDULE_FROM_LAST,
+                              NULL);
         if (ret != EOK) {
             DEBUG(SSSDBG_CRIT_FAILURE, "Unable to setup smart refresh ptask "
                   "[%d]: %s\n", ret, sss_strerror(ret));

--- a/src/providers/ldap/sdap_sudo_shared.c
+++ b/src/providers/ldap/sdap_sudo_shared.c
@@ -94,7 +94,7 @@ sdap_sudo_ptask_setup_generic(struct be_ctx *be_ctx,
                               BE_PTASK_SCHEDULE_FROM_LAST,
                               0,
                               full_send_fn, full_recv_fn, pvt,
-                              "SUDO Full Refresh", NULL);
+                              "SUDO Full Refresh", 0, NULL);
         if (ret != EOK) {
             DEBUG(SSSDBG_CRIT_FAILURE, "Unable to setup full refresh ptask "
                   "[%d]: %s\n", ret, sss_strerror(ret));
@@ -113,7 +113,7 @@ sdap_sudo_ptask_setup_generic(struct be_ctx *be_ctx,
                               BE_PTASK_SCHEDULE_FROM_LAST,
                               0,
                               smart_send_fn, smart_recv_fn, pvt,
-                              "SUDO Smart Refresh", NULL);
+                              "SUDO Smart Refresh", 0, NULL);
         if (ret != EOK) {
             DEBUG(SSSDBG_CRIT_FAILURE, "Unable to setup smart refresh ptask "
                   "[%d]: %s\n", ret, sss_strerror(ret));

--- a/src/tests/cmocka/test_be_ptask.c
+++ b/src/tests/cmocka/test_be_ptask.c
@@ -304,9 +304,10 @@ void test_be_ptask_create_einval_be(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, NULL, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, NULL, "Test ptask", 0, &ptask);
+                          test_be_ptask_recv, NULL, "Test ptask",
+                          BE_PTASK_OFFLINE_SKIP | BE_PTASK_SCHEDULE_FROM_LAST,
+                          &ptask);
     assert_int_equal(ret, EINVAL);
     assert_null(ptask);
 }
@@ -318,9 +319,10 @@ void test_be_ptask_create_einval_period(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, 0, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, NULL, "Test ptask", 0, &ptask);
+                          test_be_ptask_recv, NULL, "Test ptask",
+                          BE_PTASK_OFFLINE_SKIP | BE_PTASK_SCHEDULE_FROM_LAST,
+                          &ptask);
     assert_int_equal(ret, EINVAL);
     assert_null(ptask);
 }
@@ -332,9 +334,10 @@ void test_be_ptask_create_einval_send(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, NULL,
-                          test_be_ptask_recv, NULL, "Test ptask", 0, &ptask);
+                          test_be_ptask_recv, NULL, "Test ptask",
+                          BE_PTASK_OFFLINE_SKIP | BE_PTASK_SCHEDULE_FROM_LAST,
+                          &ptask);
     assert_int_equal(ret, EINVAL);
     assert_null(ptask);
 }
@@ -346,9 +349,10 @@ void test_be_ptask_create_einval_recv(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          NULL, NULL, "Test ptask", 0, &ptask);
+                          NULL, NULL, "Test ptask",
+                          BE_PTASK_OFFLINE_SKIP | BE_PTASK_SCHEDULE_FROM_LAST,
+                          &ptask);
     assert_int_equal(ret, EINVAL);
     assert_null(ptask);
 }
@@ -360,9 +364,72 @@ void test_be_ptask_create_einval_name(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, NULL, NULL, 0, &ptask);
+                          test_be_ptask_recv, NULL, NULL,
+                          BE_PTASK_OFFLINE_SKIP | BE_PTASK_SCHEDULE_FROM_LAST,
+                          &ptask);
+    assert_int_equal(ret, EINVAL);
+    assert_null(ptask);
+}
+
+void test_be_ptask_mixed_from_flags_einval(void **state)
+{
+    struct test_ctx *test_ctx = (struct test_ctx *)(*state);
+    struct be_ptask *ptask = NULL;
+    errno_t ret;
+
+    ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
+                          0, test_be_ptask_send,
+                          test_be_ptask_recv, NULL, "Test ptask",
+                          BE_PTASK_OFFLINE_SKIP |
+                          BE_PTASK_SCHEDULE_FROM_LAST |
+                          BE_PTASK_SCHEDULE_FROM_NOW,
+                          &ptask);
+    assert_int_equal(ret, EINVAL);
+    assert_null(ptask);
+}
+
+void test_be_ptask_no_from_flags_einval(void **state)
+{
+    struct test_ctx *test_ctx = (struct test_ctx *)(*state);
+    struct be_ptask *ptask = NULL;
+    errno_t ret;
+
+    ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
+                          0, test_be_ptask_send,
+                          test_be_ptask_recv, NULL, "Test ptask",
+                          BE_PTASK_OFFLINE_SKIP,
+                          &ptask);
+    assert_int_equal(ret, EINVAL);
+    assert_null(ptask);
+}
+void test_be_ptask_mixed_offline_flags_einval(void **state)
+{
+    struct test_ctx *test_ctx = (struct test_ctx *)(*state);
+    struct be_ptask *ptask = NULL;
+    errno_t ret;
+
+    ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
+                          0, test_be_ptask_send,
+                          test_be_ptask_recv, NULL, "Test ptask",
+                          BE_PTASK_OFFLINE_SKIP |
+                          BE_PTASK_OFFLINE_DISABLE |
+                          BE_PTASK_SCHEDULE_FROM_NOW,
+                          &ptask);
+    assert_int_equal(ret, EINVAL);
+    assert_null(ptask);
+}
+void test_be_ptask_no_offline_flags_einval(void **state)
+{
+    struct test_ctx *test_ctx = (struct test_ctx *)(*state);
+    struct be_ptask *ptask = NULL;
+    errno_t ret;
+
+    ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
+                          0, test_be_ptask_send,
+                          test_be_ptask_recv, NULL, "Test ptask",
+                          BE_PTASK_SCHEDULE_FROM_NOW,
+                          &ptask);
     assert_int_equal(ret, EINVAL);
     assert_null(ptask);
 }
@@ -376,9 +443,10 @@ void test_be_ptask_create_no_delay(void **state)
 
     now = get_current_time();
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask",
+                          BE_PTASK_OFFLINE_SKIP | BE_PTASK_SCHEDULE_FROM_LAST,
+                          &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -404,9 +472,10 @@ void test_be_ptask_create_first_delay(void **state)
 
     now = get_current_time();
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, DELAY, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask",
+                          BE_PTASK_OFFLINE_SKIP | BE_PTASK_SCHEDULE_FROM_LAST,
+                          &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -430,9 +499,10 @@ void test_be_ptask_disable(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask",
+                          BE_PTASK_OFFLINE_SKIP | BE_PTASK_SCHEDULE_FROM_LAST,
+                          &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -455,9 +525,10 @@ void test_be_ptask_enable(void **state)
 
     now = get_current_time();
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask",
+                          BE_PTASK_OFFLINE_SKIP | BE_PTASK_SCHEDULE_FROM_LAST,
+                          &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -488,9 +559,10 @@ void test_be_ptask_enable_delay(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, DELAY, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask",
+                          BE_PTASK_OFFLINE_SKIP | BE_PTASK_SCHEDULE_FROM_LAST,
+                          &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -528,9 +600,10 @@ void test_be_ptask_offline_skip(void **state)
 
     now = get_current_time();
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask",
+                          BE_PTASK_OFFLINE_SKIP | BE_PTASK_SCHEDULE_FROM_LAST,
+                          &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -562,10 +635,11 @@ void test_be_ptask_offline_disable(void **state)
     will_return(be_add_offline_cb, test_ctx);
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_DISABLE,
-                          BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask",
+                          BE_PTASK_OFFLINE_DISABLE |
+                          BE_PTASK_SCHEDULE_FROM_LAST,
+                          &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -594,10 +668,11 @@ void test_be_ptask_offline_execute(void **state)
     mark_offline(test_ctx);
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_EXECUTE,
-                          BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask",
+                          BE_PTASK_OFFLINE_EXECUTE |
+                          BE_PTASK_SCHEDULE_FROM_LAST,
+                          &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -623,9 +698,10 @@ void test_be_ptask_reschedule_ok(void **state)
 
     now = get_current_time();
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask",
+                          BE_PTASK_OFFLINE_SKIP | BE_PTASK_SCHEDULE_FROM_LAST,
+                          &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -655,9 +731,9 @@ void test_be_ptask_reschedule_null(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_null_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", 0,
+                          test_be_ptask_recv, test_ctx, "Test ptask",
+                          BE_PTASK_OFFLINE_SKIP | BE_PTASK_SCHEDULE_FROM_LAST,
                           &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
@@ -683,9 +759,9 @@ void test_be_ptask_reschedule_error(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_error_recv, test_ctx, "Test ptask", 0,
+                          test_be_ptask_error_recv, test_ctx, "Test ptask",
+                          BE_PTASK_OFFLINE_SKIP | BE_PTASK_SCHEDULE_FROM_LAST,
                           &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
@@ -711,9 +787,9 @@ void test_be_ptask_reschedule_timeout(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 1,
-                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_timeout_send,
-                          test_be_ptask_error_recv, test_ctx, "Test ptask", 0,
+                          test_be_ptask_error_recv, test_ctx, "Test ptask",
+                          BE_PTASK_OFFLINE_SKIP | BE_PTASK_SCHEDULE_FROM_LAST,
                           &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
@@ -749,9 +825,10 @@ void test_be_ptask_reschedule_backoff(void **state)
 
     now_first = get_current_time();
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           PERIOD*2, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask",
+                          BE_PTASK_OFFLINE_SKIP | BE_PTASK_SCHEDULE_FROM_LAST,
+                          &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -804,9 +881,10 @@ void test_be_ptask_get_period(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask",
+                          BE_PTASK_OFFLINE_SKIP | BE_PTASK_SCHEDULE_FROM_LAST,
+                          &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
 
@@ -825,9 +903,10 @@ void test_be_ptask_get_timeout(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, TIMEOUT,
-                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask",
+                          BE_PTASK_OFFLINE_SKIP | BE_PTASK_SCHEDULE_FROM_LAST,
+                          &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
 
@@ -845,10 +924,12 @@ void test_be_ptask_no_periodic(void **state)
     errno_t ret;
 
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, 0, 0, DELAY, 0, 0,
-                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
                           test_be_ptask_recv, test_ctx, "Test ptask",
-                          BE_PTASK_NO_PERIODIC, &ptask);
+                          BE_PTASK_NO_PERIODIC |
+                          BE_PTASK_OFFLINE_SKIP |
+                          BE_PTASK_SCHEDULE_FROM_LAST,
+                          &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
 
@@ -865,8 +946,8 @@ void test_be_ptask_create_sync(void **state)
 
     now = get_current_time();
     ret = be_ptask_create_sync(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                               BE_PTASK_OFFLINE_SKIP, 0, test_be_ptask_sync,
-                               test_ctx, "Test ptask", 0, &ptask);
+                               0, test_be_ptask_sync, test_ctx, "Test ptask",
+                               BE_PTASK_OFFLINE_SKIP, &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -893,8 +974,8 @@ void test_be_ptask_sync_reschedule_ok(void **state)
 
     now = get_current_time();
     ret = be_ptask_create_sync(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                               BE_PTASK_OFFLINE_SKIP, 0, test_be_ptask_sync,
-                               test_ctx, "Test ptask", 0, &ptask);
+                               0, test_be_ptask_sync, test_ctx, "Test ptask",
+                               BE_PTASK_OFFLINE_SKIP, &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -924,9 +1005,9 @@ void test_be_ptask_sync_reschedule_error(void **state)
     errno_t ret;
 
     ret = be_ptask_create_sync(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                               BE_PTASK_OFFLINE_SKIP, 0,
-                               test_be_ptask_sync_error,
-                               test_ctx, "Test ptask", 0, &ptask);
+                               0, test_be_ptask_sync_error,
+                               test_ctx, "Test ptask",
+                               BE_PTASK_OFFLINE_SKIP, &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -953,10 +1034,11 @@ void test_be_ptask_sync_reschedule_backoff(void **state)
     errno_t ret;
 
     now_first = get_current_time();
-    ret = be_ptask_create_sync(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
-                               BE_PTASK_OFFLINE_SKIP, PERIOD*2,
+    ret = be_ptask_create_sync(test_ctx, test_ctx->be_ctx, PERIOD,
+                               0, 0, 0, 0, PERIOD*2,
                                test_be_ptask_sync_error,
-                               test_ctx, "Test ptask", 0, &ptask);
+                               test_ctx, "Test ptask",
+                               BE_PTASK_OFFLINE_SKIP, &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -1017,6 +1099,10 @@ int main(int argc, const char *argv[])
         new_test(be_ptask_create_einval_send),
         new_test(be_ptask_create_einval_recv),
         new_test(be_ptask_create_einval_name),
+        new_test(be_ptask_mixed_from_flags_einval),
+        new_test(be_ptask_no_from_flags_einval),
+        new_test(be_ptask_mixed_offline_flags_einval),
+        new_test(be_ptask_no_offline_flags_einval),
         new_test(be_ptask_create_no_delay),
         new_test(be_ptask_create_first_delay),
         new_test(be_ptask_disable),

--- a/src/tests/cmocka/test_be_ptask.c
+++ b/src/tests/cmocka/test_be_ptask.c
@@ -306,7 +306,7 @@ void test_be_ptask_create_einval_be(void **state)
     ret = be_ptask_create(test_ctx, NULL, PERIOD, 0, 0, 0, 0,
                           BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, NULL, "Test ptask", &ptask);
+                          test_be_ptask_recv, NULL, "Test ptask", 0, &ptask);
     assert_int_equal(ret, EINVAL);
     assert_null(ptask);
 }
@@ -320,7 +320,7 @@ void test_be_ptask_create_einval_period(void **state)
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, 0, 0, 0, 0, 0,
                           BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, NULL, "Test ptask", &ptask);
+                          test_be_ptask_recv, NULL, "Test ptask", 0, &ptask);
     assert_int_equal(ret, EINVAL);
     assert_null(ptask);
 }
@@ -334,7 +334,7 @@ void test_be_ptask_create_einval_send(void **state)
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
                           BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, NULL,
-                          test_be_ptask_recv, NULL, "Test ptask", &ptask);
+                          test_be_ptask_recv, NULL, "Test ptask", 0, &ptask);
     assert_int_equal(ret, EINVAL);
     assert_null(ptask);
 }
@@ -348,7 +348,7 @@ void test_be_ptask_create_einval_recv(void **state)
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
                           BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          NULL, NULL, "Test ptask", &ptask);
+                          NULL, NULL, "Test ptask", 0, &ptask);
     assert_int_equal(ret, EINVAL);
     assert_null(ptask);
 }
@@ -362,7 +362,7 @@ void test_be_ptask_create_einval_name(void **state)
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
                           BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, NULL, NULL, &ptask);
+                          test_be_ptask_recv, NULL, NULL, 0, &ptask);
     assert_int_equal(ret, EINVAL);
     assert_null(ptask);
 }
@@ -378,7 +378,7 @@ void test_be_ptask_create_no_delay(void **state)
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
                           BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -406,7 +406,7 @@ void test_be_ptask_create_first_delay(void **state)
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, DELAY, 0, 0, 0,
                           BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -432,7 +432,7 @@ void test_be_ptask_disable(void **state)
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
                           BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -457,7 +457,7 @@ void test_be_ptask_enable(void **state)
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
                           BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -490,7 +490,7 @@ void test_be_ptask_enable_delay(void **state)
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, DELAY, 0, 0,
                           BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -530,7 +530,7 @@ void test_be_ptask_offline_skip(void **state)
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
                           BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -565,7 +565,7 @@ void test_be_ptask_offline_disable(void **state)
                           BE_PTASK_OFFLINE_DISABLE,
                           BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -597,7 +597,7 @@ void test_be_ptask_offline_execute(void **state)
                           BE_PTASK_OFFLINE_EXECUTE,
                           BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -625,7 +625,7 @@ void test_be_ptask_reschedule_ok(void **state)
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
                           BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -657,7 +657,7 @@ void test_be_ptask_reschedule_null(void **state)
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
                           BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_null_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask",
+                          test_be_ptask_recv, test_ctx, "Test ptask", 0,
                           &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
@@ -685,7 +685,7 @@ void test_be_ptask_reschedule_error(void **state)
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
                           BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_error_recv, test_ctx, "Test ptask",
+                          test_be_ptask_error_recv, test_ctx, "Test ptask", 0,
                           &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
@@ -713,7 +713,7 @@ void test_be_ptask_reschedule_timeout(void **state)
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 1,
                           BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_timeout_send,
-                          test_be_ptask_error_recv, test_ctx, "Test ptask",
+                          test_be_ptask_error_recv, test_ctx, "Test ptask", 0,
                           &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
@@ -751,7 +751,7 @@ void test_be_ptask_reschedule_backoff(void **state)
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
                           BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           PERIOD*2, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -806,7 +806,7 @@ void test_be_ptask_get_period(void **state)
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
                           BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
 
@@ -827,12 +827,30 @@ void test_be_ptask_get_timeout(void **state)
     ret = be_ptask_create(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, TIMEOUT,
                           BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
                           0, test_be_ptask_send,
-                          test_be_ptask_recv, test_ctx, "Test ptask", &ptask);
+                          test_be_ptask_recv, test_ctx, "Test ptask", 0, &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
 
     out_timeout = be_ptask_get_timeout(ptask);
     assert_true(TIMEOUT == out_timeout);
+
+    be_ptask_destroy(&ptask);
+    assert_null(ptask);
+}
+
+void test_be_ptask_no_periodic(void **state)
+{
+    struct test_ctx *test_ctx = (struct test_ctx *)(*state);
+    struct be_ptask *ptask = NULL;
+    errno_t ret;
+
+    ret = be_ptask_create(test_ctx, test_ctx->be_ctx, 0, 0, DELAY, 0, 0,
+                          BE_PTASK_OFFLINE_SKIP, BE_PTASK_SCHEDULE_FROM_LAST,
+                          0, test_be_ptask_send,
+                          test_be_ptask_recv, test_ctx, "Test ptask",
+                          BE_PTASK_NO_PERIODIC, &ptask);
+    assert_int_equal(ret, ERR_OK);
+    assert_non_null(ptask);
 
     be_ptask_destroy(&ptask);
     assert_null(ptask);
@@ -848,7 +866,7 @@ void test_be_ptask_create_sync(void **state)
     now = get_current_time();
     ret = be_ptask_create_sync(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
                                BE_PTASK_OFFLINE_SKIP, 0, test_be_ptask_sync,
-                               test_ctx, "Test ptask", &ptask);
+                               test_ctx, "Test ptask", 0, &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -876,7 +894,7 @@ void test_be_ptask_sync_reschedule_ok(void **state)
     now = get_current_time();
     ret = be_ptask_create_sync(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
                                BE_PTASK_OFFLINE_SKIP, 0, test_be_ptask_sync,
-                               test_ctx, "Test ptask", &ptask);
+                               test_ctx, "Test ptask", 0, &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -908,7 +926,7 @@ void test_be_ptask_sync_reschedule_error(void **state)
     ret = be_ptask_create_sync(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
                                BE_PTASK_OFFLINE_SKIP, 0,
                                test_be_ptask_sync_error,
-                               test_ctx, "Test ptask", &ptask);
+                               test_ctx, "Test ptask", 0, &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -938,7 +956,7 @@ void test_be_ptask_sync_reschedule_backoff(void **state)
     ret = be_ptask_create_sync(test_ctx, test_ctx->be_ctx, PERIOD, 0, 0, 0, 0,
                                BE_PTASK_OFFLINE_SKIP, PERIOD*2,
                                test_be_ptask_sync_error,
-                               test_ctx, "Test ptask", &ptask);
+                               test_ctx, "Test ptask", 0, &ptask);
     assert_int_equal(ret, ERR_OK);
     assert_non_null(ptask);
     assert_non_null(ptask->timer);
@@ -1014,6 +1032,7 @@ int main(int argc, const char *argv[])
         new_test(be_ptask_reschedule_backoff),
         new_test(be_ptask_get_period),
         new_test(be_ptask_get_timeout),
+        new_test(be_ptask_no_periodic),
         new_test(be_ptask_create_sync),
         new_test(be_ptask_sync_reschedule_ok),
         new_test(be_ptask_sync_reschedule_error),


### PR DESCRIPTION
When dyndns_update is set to True and dyndns_refresh_interval is
not set or set to 0, DNS is not updated at all.

With this patch DNS is updated when sssd changes its state to
online.

If dyndns_refresh_interval is set, updates are performed as
before - i. e. when comming online and then every
dyndns_refresh_interval.

Resolves:
https://pagure.io/SSSD/sssd/issue/4047