### PR TITLE
pam_sss: Add missing colon to the PIN prompt

### DIFF
--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -1609,7 +1609,7 @@ static int prompt_2fa_single(pam_handle_t *pamh, struct pam_items *pi,
     return PAM_SUCCESS;
 }
 
-#define SC_PROMPT_FMT "PIN for %s"
+#define SC_PROMPT_FMT "PIN for %s: "
 
 #ifndef discard_const
 #define discard_const(ptr) ((void *)((uintptr_t)(ptr)))


### PR DESCRIPTION
This can be noticed in the sudo prompt, when the system is configured
to authenticate users using smart cards.

Resolves: Pagure#4049 [1]

[1] https://pagure.io/SSSD/sssd/issue/4049