### PR TITLE
Don't qualify users from files domain when default_domain_suffix is set

### DIFF
--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -1049,7 +1049,8 @@ static int confdb_get_domain_internal(struct confdb_ctx *cdb,
 
     /* Determine if user/group names will be Fully Qualified
      * in NSS interfaces */
-    if (default_domain != NULL) {
+    if (default_domain != NULL
+             && is_files_provider(domain) == false) {
         DEBUG(SSSDBG_CONF_SETTINGS,
               "Default domain suffix set. Changing default for "
               "use_fully_qualified_names to True.\n");
@@ -1064,7 +1065,9 @@ static int confdb_get_domain_internal(struct confdb_ctx *cdb,
         goto done;
     }
 
-    if (default_domain != NULL && domain->fqnames == false) {
+    if (default_domain != NULL
+            && domain->fqnames == false
+            && is_files_provider(domain) == false) {
         DEBUG(SSSDBG_FATAL_FAILURE,
               "Invalid configuration detected (default_domain_suffix is used "
               "while use_fully_qualified_names was set to false).\n");

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -412,7 +412,13 @@
                                 to log in. Setting this option changes default
                                 of use_fully_qualified_names to True. It is not
                                 allowed to use this option together with
-                                use_fully_qualified_names set to False.
+                                use_fully_qualified_names set to False. One
+                                exception from this rule are domains with
+                                <quote>id_provider=files</quote> that always try
+                                to match the behaviour of nss_files
+                                and therefore their output is not
+                                qualified even when the default_domain_suffix
+                                option is used.
                             </para>
                             <para>
                                 Default: not set


### PR DESCRIPTION
Resolves: https://pagure.io/SSSD/sssd/issue/4052

The files domain should always be non-qualified. The usual rules like 
qualification of all domains except the one set with default_domain_suffix
should not apply.