### PR TITLE
ldap: do not store empty attribute with ldap_rfc2307_fallback_to_local_users = true

### DIFF
--- a/src/providers/ldap/sdap_async_users.c
+++ b/src/providers/ldap/sdap_async_users.c
@@ -1176,21 +1176,21 @@ errno_t sdap_fallback_local_user(TALLOC_CTX *memctx,
         goto done;
     }
 
-    if (pwd->pw_gecos) {
+    if (pwd->pw_gecos && *pwd->pw_gecos) {
         ret = sysdb_attrs_add_string(user, SYSDB_GECOS, pwd->pw_gecos);
         if (ret != EOK) {
             goto done;
         }
     }
 
-    if (pwd->pw_dir) {
+    if (pwd->pw_dir && *pwd->pw_dir) {
         ret = sysdb_attrs_add_string(user, SYSDB_HOMEDIR, pwd->pw_dir);
         if (ret != EOK) {
             goto done;
         }
     }
 
-    if (pwd->pw_shell) {
+    if (pwd->pw_shell && *pwd->pw_shell) {
         ret = sysdb_attrs_add_string(user, SYSDB_SHELL, pwd->pw_shell);
         if (ret != EOK) {
             goto done;


### PR DESCRIPTION
This caused an error when saving local user as a fallback:

```
[sdap_save_user] (0x0400): Storing info for user testuser@ldap.vm
[sysdb_ldb_msg_difference] (0x2000): Added attr [gecos] to entry [name=testuser@ldap.vm,cn=users,cn=ldap.vm,cn=sysdb]
[sysdb_set_cache_entry_attr] (0x0080): ldb_modify failed: [Invalid attribute syntax](21)[Element gecos has empty attribute in ldb message (name=testuser@ldap.vm,cn=users,cn=ldap.vm,cn=sysdb)!]
[sysdb_set_cache_entry_attr] (0x0040): Error: 22 (Invalid argument)
[sysdb_set_entry_attr] (0x0080): Cannot set attrs for name=testuser@ldap.vm,cn=users,cn=ldap.vm,cn=sysdb, 22 [Invalid argument]
[sysdb_store_user] (0x0040): Cache update failed: 22
[sysdb_store_user] (0x0400): Error: 22 (Invalid argument)
[sdap_save_user] (0x0020): Failed to save user [testuser@ldap.vm]
```

Steps to reproduce:
1. create local user `testuser`
2. add it to LDAP group memberUid
3. set `passwd: sss files`, `group: sss files` (sss must be before files)
4. set enable_files_domain = false and ldap_rfc2307_fallback_to_local_users = true
5. run sssd
6. id testuser
-> it does not contain the LDAP group without the patch

Related to:
https://pagure.io/SSSD/sssd/issue/4013

Note: this fix only the case when the nsswitch order is `sss files` but no files domain is available.