### PR TITLE
Make sure child log files have the right permissions

### DIFF
--- a/src/responder/pam/pamsrv.c
+++ b/src/responder/pam/pamsrv.c
@@ -399,6 +399,15 @@ int main(int argc, const char *argv[])
         }
     }
 
+    /* server_setup() might switch to an unprivileged user, so the permissions
+     * for p11_child.log have to be fixed first. */
+    ret = chown_debug_file("p11_child", uid, gid);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_MINOR_FAILURE,
+              "Cannot chown the p11_child debug file, "
+              "debugging might not work!\n");
+    }
+
     ret = server_setup("sssd[pam]", 0, uid, gid, CONFDB_PAM_CONF_ENTRY, &main_ctx);
     if (ret != EOK) return 2;
 

--- a/src/responder/ssh/sshsrv.c
+++ b/src/responder/ssh/sshsrv.c
@@ -187,6 +187,16 @@ int main(int argc, const char *argv[])
 
     sss_set_logger(opt_logger);
 
+    /* server_setup() might switch to an unprivileged user, so the permissions
+     * for p11_child.log have to be fixed first. We might call p11_child to
+     * validate certificates. */
+    ret = chown_debug_file("p11_child", uid, gid);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_MINOR_FAILURE,
+              "Cannot chown the p11_child debug file, "
+              "debugging might not work!\n");
+    }
+
     ret = server_setup("sssd[ssh]", 0, uid, gid,
                        CONFDB_SSH_CONF_ENTRY, &main_ctx);
     if (ret != EOK) {


### PR DESCRIPTION
If SSSD runs a unprivileged user we should make sure the log files for
child processes have the right permission so that the child process can
write to them.

Related to https://pagure.io/SSSD/sssd/issue/4056