### PR TITLE
Monitor resolv.conf symlink

### DIFF
--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -66,6 +66,7 @@
 #define CONFDB_MONITOR_SBUS_TIMEOUT "sbus_timeout"
 #define CONFDB_MONITOR_ACTIVE_SERVICES "services"
 #define CONFDB_MONITOR_ACTIVE_DOMAINS "domains"
+#define CONFDB_MONITOR_RESOLV_CONF "monitor_resolv_conf"
 #define CONFDB_MONITOR_TRY_INOTIFY "try_inotify"
 #define CONFDB_MONITOR_KRB5_RCACHEDIR "krb5_rcache_dir"
 #define CONFDB_MONITOR_DEFAULT_DOMAIN "default_domain_suffix"

--- a/src/config/SSSDConfigTest.py
+++ b/src/config/SSSDConfigTest.py
@@ -391,6 +391,7 @@ class SSSDConfigTestSSSDService(unittest.TestCase):
             'enable_files_domain',
             'domain_resolution_order',
             'try_inotify',
+            'monitor_resolv_conf',
         ]
 
         self.assertTrue(type(options) == dict,

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -52,6 +52,7 @@ option = disable_netlink
 option = enable_files_domain
 option = domain_resolution_order
 option = try_inotify
+option = monitor_resolv_conf
 
 [rule/allowed_nss_options]
 validator = ini_allowed_options

--- a/src/config/etc/sssd.api.conf
+++ b/src/config/etc/sssd.api.conf
@@ -34,6 +34,7 @@ disable_netlink = bool, None, false
 enable_files_domain = str, None, false
 domain_resolution_order = list, str, false
 try_inotify = bool, None, false
+monitor_resolv_conf = bool, None, false
 
 [nss]
 # Name service

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -319,15 +319,26 @@
                         </listitem>
                     </varlistentry>
                     <varlistentry>
+                        <term>monitor_resolv_conf (boolean)</term>
+                        <listitem>
+                            <para>
+                                Controls if SSSD should monitor the state of
+                                resolv.conf to identify when it needs to
+                                update its internal DNS resolver.
+                            </para>
+                            <para>
+                                Default: true
+                            </para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry>
                         <term>try_inotify (boolean)</term>
                         <listitem>
                             <para>
-                                SSSD monitors the state of resolv.conf to
-                                identify when it needs to update its internal
-                                DNS resolver. By default, we will attempt to
-                                use inotify for this, and will fall back to
-                                polling resolv.conf every five seconds if
-                                inotify cannot be used.
+                                By default, SSSD will attempt to use inotify
+                                to monitor configuration files changes and
+                                will fall back to polling every five seconds
+                                if inotify cannot be used.
                             </para>
                             <para>
                                 There are some limited situations where it is

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -1789,18 +1789,14 @@ static errno_t monitor_config_file_fallback(TALLOC_CTX *parent_ctx,
     if (ret < 0) {
         err = errno;
         if (err == ENOENT) {
-             DEBUG(SSSDBG_MINOR_FAILURE,
-                   "file [%s] is missing. Will not update online status "
-                   "based on watching the file\n", file);
-             return EOK;
-
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "file [%s] is missing. Will try again later.\n", file);
         } else {
             DEBUG(SSSDBG_FATAL_FAILURE,
                   "Could not stat file [%s]. Error [%d:%s]\n",
                   file, err, strerror(err));
-
-            return err;
         }
+        return err;
     }
 
     file_ctx->poll_check.parent_ctx = parent_ctx;


### PR DESCRIPTION
If resolv.conf is a symlink and sssd starts before getting an address from dhcp the data provider will remain forever offline, as the watched parent directory is the directory containing the symlink.