### PR TITLE
ci: use python2 version of pytest

### DIFF
--- a/contrib/ci/deps.sh
+++ b/contrib/ci/deps.sh
@@ -56,7 +56,7 @@ if [[ "$DISTRO_BRANCH" == -redhat-* ]]; then
 
     if [[ "$DISTRO_BRANCH" == -redhat-fedora-3[1-9]* ]]; then
         DEPS_LIST+=(
-            python3-pep8
+            python3-pycodestyle
         )
     else
         DEPS_LIST+=(

--- a/contrib/ci/run
+++ b/contrib/ci/run
@@ -58,6 +58,12 @@ declare BASE_DIR=`pwd`
 declare MODERATE=false
 declare RIGOROUS=false
 
+# pep8 was renamed to pycodestyle
+declare PEP8_BIN="pep8"
+if which pycodestyle &> /dev/null; then
+  PEP8_BIN="pycodestyle"
+fi
+
 # Output program usage information.
 function usage()
 {
@@ -398,7 +404,7 @@ if [[ "$DISTRO_BRANCH" != redhat-* ]]; then
     PEP8_IGNORE+=",E722"
 fi
 stage pep8          find . -path ./src/config -prune -o \
-                           -name \*.py -exec pep8 $PEP8_IGNORE {} +
+                           -name \*.py -exec $PEP8_BIN $PEP8_IGNORE {} +
 stage autoreconf    autoreconf --install --force
 run_build debug     build_debug
 if "$RIGOROUS"; then

--- a/src/external/intgcheck.m4
+++ b/src/external/intgcheck.m4
@@ -1,7 +1,10 @@
 AC_CHECK_PROG([HAVE_FAKEROOT], [fakeroot], [yes], [no])
 
+dnl Check for pytest binary. When available, we will use py.test-2 for python2
+dnl version. If it is not available we will try to use py.test.
 AC_PATH_PROG([PYTEST], [py.test])
-AS_IF([test -n "$PYTEST"], [HAVE_PYTEST=yes], [HAVE_PYTEST=no])
+AC_PATH_PROG([PYTEST2], [py.test-2], [$PYTEST])
+AS_IF([test -n "$PYTEST2"], [HAVE_PYTEST2=yes], [HAVE_PYTEST2=no])
 
 dnl Check for variable and fail unless value is "yes"
 dnl The second argument will be printed in error message in case of error
@@ -27,7 +30,7 @@ AC_DEFUN([SSS_ENABLE_INTGCHECK_REQS], [
         SSS_INTGCHECK_REQ([HAVE_LDAPMODIFY], [ldapmodify])
         SSS_INTGCHECK_REQ([HAVE_FAKEROOT], [fakeroot])
         SSS_INTGCHECK_REQ([HAVE_PYTHON2], [python2])
-        SSS_INTGCHECK_REQ([HAVE_PYTEST], [pytest])
+        SSS_INTGCHECK_REQ([HAVE_PYTEST2], [pytest2])
         SSS_INTGCHECK_REQ([HAVE_PY2MOD_LDAP], [python-ldap])
         SSS_INTGCHECK_REQ([HAVE_PY2MOD_LDAP], [pyldb])
     fi

--- a/src/tests/intg/Makefile.am
+++ b/src/tests/intg/Makefile.am
@@ -184,5 +184,5 @@ intgcheck-installed: config.py passwd group pam_sss_service pam_sss_alt_service 
 	DBUS_SESSION_BUS_ADDRESS="unix:path=$$DBUS_SOCK_DIR/fake_socket" \
 	DBUS_SYSTEM_BUS_ADDRESS="unix:path=$$DBUS_SOCK_DIR/system_bus_socket" \
 	DBUS_SYSTEM_BUS_DEFAULT_ADDRESS="$$DBUS_SYSTEM_BUS_ADDRESS" \
-	    fakeroot $(PYTHON2) $(PYTEST) -v -r a --tb=native $(INTGCHECK_PYTEST_ARGS) .
+	    fakeroot $(PYTHON2) $(PYTEST2) -v -r a --tb=native $(INTGCHECK_PYTEST_ARGS) .
 	rm -f $(DESTDIR)$(logpath)/*


### PR DESCRIPTION
Fedora 31 changed symlink of /usr/bin/py.test from pytest2 to pytest3.
We need to run the python2 version in order to run our tests with python2.

We might want to switch to Python3 in the future, but this is a quick fix
for current situation when we cannot test against rawhide.