### PR TITLE
pam: keep pin on the PAM stack for forward_pass

### DIFF
--- a/src/tests/cmocka/test_authtok.c
+++ b/src/tests/cmocka/test_authtok.c
@@ -473,6 +473,11 @@ void test_sss_authtok_sc_blobs(void **state)
                         needed_size);
 #endif
 
+    pin = sss_auth_get_pin_from_sc_blob(buf, needed_size);
+    assert_non_null(pin);
+    assert_string_equal(pin, "abc");
+    pin = NULL;
+
     ret = sss_authtok_set(ts->authtoken, SSS_AUTHTOK_TYPE_SC_PIN, buf,
                           needed_size);
     assert_int_equal(ret, EOK);

--- a/src/util/authtok-utils.c
+++ b/src/util/authtok-utils.c
@@ -163,3 +163,36 @@ errno_t sss_auth_pack_sc_blob(const char *pin, size_t pin_len,
 
     return 0;
 }
+
+const char *sss_auth_get_pin_from_sc_blob(uint8_t *blob, size_t blob_len)
+{
+    size_t c = 0;
+    uint32_t pin_len;
+    uint32_t token_name_len;
+    uint32_t module_name_len;
+    uint32_t key_id_len;
+
+    if (blob == NULL || blob_len == 0) {
+        return NULL;
+    }
+
+    SAFEALIGN_COPY_UINT32(&pin_len, blob, &c);
+    if (pin_len == 0) {
+        return NULL;
+    }
+
+    SAFEALIGN_COPY_UINT32(&token_name_len, blob + c, &c);
+    SAFEALIGN_COPY_UINT32(&module_name_len, blob + c, &c);
+    SAFEALIGN_COPY_UINT32(&key_id_len, blob + c, &c);
+
+    if (blob_len != 4 * sizeof(uint32_t) + pin_len + token_name_len
+                                         + module_name_len + key_id_len) {
+        return NULL;
+    }
+
+    if (blob[c + pin_len - 1] != '\0') {
+        return NULL;
+    }
+
+    return (const char *) blob + c;
+}

--- a/src/util/authtok-utils.h
+++ b/src/util/authtok-utils.h
@@ -123,4 +123,14 @@ errno_t sss_auth_unpack_sc_blob(TALLOC_CTX *mem_ctx,
                                  char **token_name, size_t *_token_name_len,
                                  char **module_name, size_t *_module_name_len,
                                  char **key_id, size_t *_key_id_len);
+
+/**
+ * @brief Return a pointer to the PIN string in the memory buffer
+ *
+ * @param[in]  blob              Memory buffer containing the 2FA data
+ * @param[in]  blob_len          Size of the memory buffer
+ *
+ * @return     pointer to 0-terminate PIN string in the memory buffer
+ */
+const char *sss_auth_get_pin_from_sc_blob(uint8_t *blob, size_t blob_len);
 #endif /*  __AUTHTOK_UTILS_H__ */


### PR DESCRIPTION
Currently only the password or the long-term part of a two-factor
authentication was kept on the PM stack if pam_sss.so has the option
forward_pass. With this patch the Smartcard PIN can be forwarded to
other PAM modules as well.

Related https://pagure.io/SSSD/sssd/issue/4067