### PR TITLE
pam: do not accept empty PIN

### DIFF
--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -1804,21 +1804,21 @@ static int prompt_sc_pin(pam_handle_t *pamh, struct pam_items *pi)
     struct cert_auth_info *cai = pi->selected_cert;
 
     if (cai == NULL || cai->token_name == NULL || *cai->token_name == '\0') {
-        return EINVAL;
+        return PAM_SYSTEM_ERR;
     }
 
     size = sizeof(SC_PROMPT_FMT) + strlen(cai->token_name);
     prompt = malloc(size);
     if (prompt == NULL) {
         D(("malloc failed."));
-        return ENOMEM;
+        return PAM_BUF_ERR;
     }
 
     ret = snprintf(prompt, size, SC_PROMPT_FMT, cai->token_name);
     if (ret < 0 || ret >= size) {
         D(("snprintf failed."));
         free(prompt);
-        return EFAULT;
+        return PAM_SYSTEM_ERR;
     }
 
     if (pi->user_name_hint) {
@@ -2075,7 +2075,7 @@ static int prompt_by_config(pam_handle_t *pamh, struct pam_items *pi)
     int ret;
 
     if (pi->pc == NULL || *pi->pc == NULL) {
-        return EINVAL;
+        return PAM_SYSTEM_ERR;
     }
 
     for (c = 0; pi->pc[c] != NULL; c++) {
@@ -2096,7 +2096,7 @@ static int prompt_by_config(pam_handle_t *pamh, struct pam_items *pi)
             /* Todo: add extra string option */
             break;
         default:
-            ret = EINVAL;
+            ret = PAM_SYSTEM_ERR;
         }
 
         /* If not credential where given try the next type otherwise we are

--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -1905,10 +1905,10 @@ static int prompt_sc_pin(pam_handle_t *pamh, struct pam_items *pi)
         }
     }
 
-    if (answer == NULL) {
-        pi->pam_authtok = NULL;
-        pi->pam_authtok_type = SSS_AUTHTOK_TYPE_EMPTY;
-        pi->pam_authtok_size=0;
+    if (answer == NULL || *answer == '\0') {
+        D(("Missing PIN."));
+        ret = PAM_CRED_INSUFFICIENT;
+        goto done;
     } else {
 
         ret = sss_auth_pack_sc_blob(answer, 0, cai->token_name, 0,


### PR DESCRIPTION
The current check for an empty PIN was incomplete and if no PIN was
given pam_sss should not send a request to SSSD's pam responder. This
would match the behavior if a user name hint should be requested as
well.

Related to: https://pagure.io/SSSD/sssd/issue/4068