### PR TITLE
pam: set PAM_USER properly with allow_missing_name

### DIFF
--- a/src/tests/intg/Makefile.am
+++ b/src/tests/intg/Makefile.am
@@ -134,6 +134,13 @@ pam_sss_try_sc:
 	echo "password required       $(DESTDIR)$(pammoddir)/pam_sss.so" >> $(PAM_SERVICE_DIR)/$@
 	echo "session  required       $(DESTDIR)$(pammoddir)/pam_sss.so" >> $(PAM_SERVICE_DIR)/$@
 
+pam_sss_allow_missing_name:
+	$(MKDIR_P) $(PAM_SERVICE_DIR)
+	echo "auth     required       $(DESTDIR)$(pammoddir)/pam_sss.so allow_missing_name"  > $(PAM_SERVICE_DIR)/$@
+	echo "account  required       $(DESTDIR)$(pammoddir)/pam_sss.so" >> $(PAM_SERVICE_DIR)/$@
+	echo "password required       $(DESTDIR)$(pammoddir)/pam_sss.so" >> $(PAM_SERVICE_DIR)/$@
+	echo "session  required       $(DESTDIR)$(pammoddir)/pam_sss.so" >> $(PAM_SERVICE_DIR)/$@
+
 CLEANFILES=config.py config.pyc passwd group
 
 clean-local:
@@ -148,7 +155,7 @@ PAM_CERT_DB_PATH="$(abs_builddir)/../test_CA/SSSD_test_CA.pem"
 SOFTHSM2_CONF="$(abs_builddir)/../test_CA/softhsm2_one.conf"
 endif
 
-intgcheck-installed: config.py passwd group pam_sss_service pam_sss_alt_service pam_sss_sc_required pam_sss_try_sc
+intgcheck-installed: config.py passwd group pam_sss_service pam_sss_alt_service pam_sss_sc_required pam_sss_try_sc pam_sss_allow_missing_name
 	pipepath="$(DESTDIR)$(pipepath)"; \
 	if test $${#pipepath} -gt 80; then \
 	    echo "error: Pipe directory path too long," \


### PR DESCRIPTION
Currently if the allow_missing_name pam_sss option is used PAM_USER is
set to the fully-qualified name only for the files provider it is set to
the short name. This might cause issue with other components expecting
that the value of PAM_USER corresponds to the name returned by the nss
calls getpwnam() and getpwuid().

With this patch PAM_USER is set to the same user name as returned by the
NSS responder. For the communication between pam_sss and SSSD's PAM
responder the fully-qualified name is kept.

Related to https://pagure.io/SSSD/sssd/issue/4069