### PR TITLE
pytest: Use idm:DL1 module to install 389-ds

### DIFF
--- a/src/tests/multihost/basic/conftest.py
+++ b/src/tests/multihost/basic/conftest.py
@@ -43,7 +43,9 @@ def package_install(session_multihost):
     if 'Fedora' in distro:
         cmd = 'dnf install -y %s' % (pkg_list)
     elif '8.' in distro.split()[5]:
-        cmd = 'dnf module -y install 389-ds:1.4'
+        enableidm = 'yum -y module enable idm:DL1'
+        session_multihost.master[0].run_command(enableidm)
+        cmd = 'yum install -y %s' % (pkg_list)
     session_multihost.master[0].run_command(cmd)
 
 


### PR DESCRIPTION
the earlier command to install 389-ds is no longer valid and to install 389-ds the module
to be used is idm:DL1


Signed-off-by: Niranjan M.R <mrniranjan@redhat.com>