### PR TITLE
KCM: Fill in pre-created ccache instead of creating a new one in kcm_initialize

### DIFF
--- a/src/responder/kcm/kcmsrv_ccache.h
+++ b/src/responder/kcm/kcmsrv_ccache.h
@@ -257,13 +257,14 @@ errno_t kcm_ccdb_create_cc_recv(struct tevent_req *req);
  */
 struct kcm_mod_ctx {
     int32_t kdc_offset;
+    krb5_principal client;
     /* More settable properties (like name, when we support renames
      * will be added later
      */
 };
 
-void kcm_mod_ctx_clear(struct kcm_mod_ctx *mod_ctx);
-void kcm_mod_cc(struct kcm_ccache *cc, struct kcm_mod_ctx *mod_ctx);
+struct kcm_mod_ctx *kcm_mod_ctx_new(TALLOC_CTX *mem_ctx);
+errno_t kcm_mod_cc(struct kcm_ccache *cc, struct kcm_mod_ctx *mod_ctx);
 
 struct tevent_req *kcm_ccdb_mod_cc_send(TALLOC_CTX *mem_ctx,
                                         struct tevent_context *ev,

--- a/src/responder/kcm/kcmsrv_ccache_mem.c
+++ b/src/responder/kcm/kcmsrv_ccache_mem.c
@@ -676,7 +676,13 @@ static struct tevent_req *ccdb_mem_mod_send(TALLOC_CTX *mem_ctx,
         goto immediate;
     }
 
-    kcm_mod_cc(ccwrap->cc, mod_cc);
+    ret = kcm_mod_cc(ccwrap->cc, mod_cc);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Cannot modify ccache [%d]: %s\n",
+              ret, sss_strerror(ret));
+        goto immediate;
+    }
 
     ret = EOK;
 immediate:

--- a/src/responder/kcm/kcmsrv_ccache_secdb.c
+++ b/src/responder/kcm/kcmsrv_ccache_secdb.c
@@ -1290,7 +1290,13 @@ static struct tevent_req *ccdb_secdb_mod_send(TALLOC_CTX *mem_ctx,
         goto immediate;
     }
 
-    kcm_mod_cc(cc, mod_cc);
+    ret = kcm_mod_cc(cc, mod_cc);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Cannot modify ccache [%d]: %s\n",
+              ret, sss_strerror(ret));
+        goto immediate;
+    }
 
     ret = kcm_ccache_to_sec_input(state, cc, client, &payload);
     if (ret != EOK) {

--- a/src/responder/kcm/kcmsrv_ccache_secrets.c
+++ b/src/responder/kcm/kcmsrv_ccache_secrets.c
@@ -1842,7 +1842,14 @@ static void ccdb_sec_mod_cred_get_done(struct tevent_req *subreq)
         return;
     }
 
-    kcm_mod_cc(cc, state->mod_cc);
+    ret = kcm_mod_cc(cc, state->mod_cc);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Cannot modify ccache [%d]: %s\n",
+              ret, sss_strerror(ret));
+        tevent_req_error(req, ret);
+        return;
+    }
 
     ret = kcm_ccache_to_sec_kv(state, cc, state->client, &url, &payload);
     if (ret != EOK) {

--- a/src/responder/kcm/kcmsrv_ops.c
+++ b/src/responder/kcm/kcmsrv_ops.c
@@ -1990,13 +1990,11 @@ static void kcm_op_set_kdc_offset_getbyname_done(struct tevent_req *subreq)
         return;
     }
 
-    mod_ctx = talloc(state, struct kcm_mod_ctx);
+    mod_ctx = kcm_mod_ctx_new(state);
     if (mod_ctx == NULL) {
         tevent_req_error(req, ENOMEM);
         return;
     }
-
-    kcm_mod_ctx_clear(mod_ctx);
     mod_ctx->kdc_offset = be32toh(offset_be);
 
     subreq = kcm_ccdb_mod_cc_send(state,

--- a/src/responder/kcm/kcmsrv_ops.c
+++ b/src/responder/kcm/kcmsrv_ops.c
@@ -1685,6 +1685,7 @@ static void kcm_op_set_default_ccache_getbyname_done(struct tevent_req *subreq)
         DEBUG(SSSDBG_TRACE_LIBS,
               "The ccache does not exist, creating a new one\n");
         kcm_op_set_default_create_step(req);
+        return;
     } else if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
               "Cannot get ccache by name [%d]: %s\n",


### PR DESCRIPTION
This is a continuation of https://pagure.io/SSSD/sssd/issue/3873

Some programs like openssh use the following sequence of calls:
    cc = krb5_cc_new_unique
    krb5_cc_switch(cc)
    krb5_cc_initialize(cc, principal)

Since switch changes the default ccache, we create a 'dummy' ccache with
krb5_cc_switch() and then the initialize call just fills in the details.

The 'fills in the details' part was not properly implemented with the previous
patchset, the previous patchset worked only for password-based authentication
where nothing is cached initially. For delegation, we watch to make sure
that the credentials that are being delegated are filled in to the new ccache
and the new ccache is used as the default.

What initialize did previously was that if there was a default ccache already
(in this case the dummy one created with krb5_cc_switch()), it would treat
it as obsolete, create a new one and switch to it. Then the client (openssh) would
store the credential in a ccache that wouldn't be the default anymore, leaving
the default ccache empty. Afterwards, klist or similar would see that the default
ccache is empty and just pick the first non-empty one as a fallback, which would
often be one of the previous expired ones.