### PR TITLE
ipa: use LDAP not extdom to lookup IPA users and groups

### DIFF
--- a/src/providers/ipa/ipa_id.c
+++ b/src/providers/ipa/ipa_id.c
@@ -30,13 +30,6 @@
 #include "providers/ldap/sdap_async.h"
 #include "providers/ipa/ipa_id.h"
 
-static struct tevent_req *
-ipa_id_get_account_info_send(TALLOC_CTX *memctx, struct tevent_context *ev,
-                             struct ipa_id_ctx *ipa_ctx,
-                             struct dp_id_data *ar);
-
-static int ipa_id_get_account_info_recv(struct tevent_req *req, int *dp_error);
-
 static bool is_object_overridable(struct dp_id_data *ar)
 {
     bool ret = false;
@@ -515,7 +508,7 @@ static void ipa_id_get_account_info_orig_done(struct tevent_req *subreq);
 static void ipa_id_get_account_info_done(struct tevent_req *subreq);
 static void ipa_id_get_user_list_done(struct tevent_req *subreq);
 
-static struct tevent_req *
+struct tevent_req *
 ipa_id_get_account_info_send(TALLOC_CTX *memctx, struct tevent_context *ev,
                              struct ipa_id_ctx *ipa_ctx,
                              struct dp_id_data *ar)
@@ -1119,7 +1112,7 @@ fail:
     return;
 }
 
-static int ipa_id_get_account_info_recv(struct tevent_req *req, int *dp_error)
+int ipa_id_get_account_info_recv(struct tevent_req *req, int *dp_error)
 {
     struct ipa_id_get_account_info_state *state = tevent_req_data(req,
                                           struct ipa_id_get_account_info_state);

--- a/src/providers/ipa/ipa_id.h
+++ b/src/providers/ipa/ipa_id.h
@@ -151,4 +151,9 @@ ipa_resolve_user_list_send(TALLOC_CTX *memctx, struct tevent_context *ev,
                            struct ldb_message_element *users);
 int ipa_resolve_user_list_recv(struct tevent_req *req, int *dp_error);
 
+struct tevent_req *
+ipa_id_get_account_info_send(TALLOC_CTX *memctx, struct tevent_context *ev,
+                             struct ipa_id_ctx *ipa_ctx,
+                             struct dp_id_data *ar);
+int ipa_id_get_account_info_recv(struct tevent_req *req, int *dp_error);
 #endif


### PR DESCRIPTION
Currently when an IPA client is resolving trusted users and groups with
the help of the extdom plugin it uses the extdom plugin as well to
lookup IPA objects. This might cause issues if e.g. there is a user in
IPA with the same name as a group in AD or the other way round.

To solve this and to lower the load on the extdom plugin on the IPA
server side this patch will lookup IPA object directly from LDAP on the
IPA server.

Related to https://pagure.io/SSSD/sssd/issue/4073