### PR TITLE
ifp: call tevent_req_post in case of error in ifp_user_get_attr_send

### DIFF
--- a/src/responder/ifp/ifpsrv_cmd.c
+++ b/src/responder/ifp/ifpsrv_cmd.c
@@ -96,6 +96,7 @@ ifp_user_get_attr_send(TALLOC_CTX *mem_ctx, struct resp_ctx *rctx,
 done:
     if (ret != EOK) {
         tevent_req_error(req, ret);
+        tevent_req_post(req, rctx->ev);
     }
     return req;
 }


### PR DESCRIPTION
I find this while backporting 18611d70e2916138103a099d45861252d6323366 to 1.16.