### PR TITLE
ipa: support disabled domains

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -554,6 +554,9 @@ errno_t sysdb_master_domain_add_info(struct sss_domain_info *domain,
 
 errno_t sysdb_subdomain_delete(struct sysdb_ctx *sysdb, const char *name);
 
+errno_t sysdb_subdomain_content_delete(struct sysdb_ctx *sysdb,
+                                       const char *name);
+
 errno_t sysdb_get_ranges(TALLOC_CTX *mem_ctx, struct sysdb_ctx *sysdb,
                              size_t *range_count,
                              struct range_info ***range_list);
@@ -893,6 +896,11 @@ int sysdb_delete_entry(struct sysdb_ctx *sysdb,
 int sysdb_delete_recursive(struct sysdb_ctx *sysdb,
                            struct ldb_dn *dn,
                            bool ignore_not_found);
+
+int sysdb_delete_recursive_with_filter(struct sysdb_ctx *sysdb,
+                                       struct ldb_dn *dn,
+                                       bool ignore_not_found,
+                                       const char *filter);
 
 /* Mark entry as expired */
 errno_t sysdb_mark_entry_as_expired_ldb_dn(struct sss_domain_info *dom,

--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -196,9 +196,10 @@ int sysdb_delete_entry(struct sysdb_ctx *sysdb,
 
 /* =Remove-Subentries-From-Sysdb=========================================== */
 
-int sysdb_delete_recursive(struct sysdb_ctx *sysdb,
-                           struct ldb_dn *dn,
-                           bool ignore_not_found)
+int sysdb_delete_recursive_with_filter(struct sysdb_ctx *sysdb,
+                                       struct ldb_dn *dn,
+                                       bool ignore_not_found,
+                                       const char *filter)
 {
     const char *no_attrs[] = { NULL };
     struct ldb_message **msgs;
@@ -219,7 +220,7 @@ int sysdb_delete_recursive(struct sysdb_ctx *sysdb,
     }
 
     ret = sysdb_search_entry(tmp_ctx, sysdb, dn,
-                             LDB_SCOPE_SUBTREE, "(distinguishedName=*)",
+                             LDB_SCOPE_SUBTREE, filter,
                              no_attrs, &msgs_count, &msgs);
     if (ret) {
         if (ignore_not_found && ret == ENOENT) {
@@ -256,6 +257,14 @@ done:
     }
     talloc_free(tmp_ctx);
     return ret;
+}
+
+int sysdb_delete_recursive(struct sysdb_ctx *sysdb,
+                           struct ldb_dn *dn,
+                           bool ignore_not_found)
+{
+    return sysdb_delete_recursive_with_filter(sysdb, dn, ignore_not_found,
+                                              "(distinguishedName=*)");
 }
 
 

--- a/src/db/sysdb_subdomains.c
+++ b/src/db/sysdb_subdomains.c
@@ -1250,7 +1250,9 @@ done:
     return ret;
 }
 
-errno_t sysdb_subdomain_delete(struct sysdb_ctx *sysdb, const char *name)
+static errno_t sysdb_subdomain_delete_with_filter(struct sysdb_ctx *sysdb,
+                                                  const char *name,
+                                                  const char *filter)
 {
     TALLOC_CTX *tmp_ctx = NULL;
     struct ldb_dn *dn;
@@ -1269,7 +1271,7 @@ errno_t sysdb_subdomain_delete(struct sysdb_ctx *sysdb, const char *name)
         goto done;
     }
 
-    ret = sysdb_delete_recursive(sysdb, dn, true);
+    ret = sysdb_delete_recursive_with_filter(sysdb, dn, true, filter);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "sysdb_delete_recursive failed.\n");
         goto done;
@@ -1278,6 +1280,20 @@ errno_t sysdb_subdomain_delete(struct sysdb_ctx *sysdb, const char *name)
 done:
     talloc_free(tmp_ctx);
     return ret;
+}
+
+errno_t sysdb_subdomain_delete(struct sysdb_ctx *sysdb, const char *name)
+{
+    return sysdb_subdomain_delete_with_filter(sysdb, name,
+                                              "(distinguishedName=*)");
+}
+
+errno_t sysdb_subdomain_content_delete(struct sysdb_ctx *sysdb,
+                                       const char *name)
+{
+    const char *filter = "(|("SYSDB_UC")("SYSDB_GC"))";
+
+    return sysdb_subdomain_delete_with_filter(sysdb, name, filter);
 }
 
 errno_t

--- a/src/providers/ipa/ipa_id.c
+++ b/src/providers/ipa/ipa_id.c
@@ -131,7 +131,8 @@ static errno_t ipa_resolve_user_list_get_user_step(struct tevent_req *req)
 
     state->user_domain = find_domain_by_object_name_ex(
                                         state->ipa_ctx->sdap_id_ctx->be->domain,
-                                        ar->filter_value, true);
+                                        ar->filter_value, true,
+                                        SSS_GND_DESCEND);
     /* Use provided domain as fallback because no known domain was found in the
      * user name. */
     if (state->user_domain == NULL) {

--- a/src/providers/ipa/ipa_subdomains.c
+++ b/src/providers/ipa/ipa_subdomains.c
@@ -821,6 +821,13 @@ static errno_t ipa_subdomains_check_domain_state(struct sss_domain_info *dom,
                 DEBUG(SSSDBG_OP_FAILURE, "sysdb_domain_set_enabled failed.\n");
                 return ret;
             }
+
+            ret = sysdb_subdomain_content_delete(dom->sysdb, dom->name);
+            if (ret != EOK) {
+                DEBUG(SSSDBG_OP_FAILURE,
+                      "sysdb_subdomain_content_delete failed.\n");
+                return ret;
+            }
         }
     } else {
         /* enabled domain if it was disabled */

--- a/src/responder/sudo/sudosrv_get_sudorules.c
+++ b/src/responder/sudo/sudosrv_get_sudorules.c
@@ -147,7 +147,8 @@ static errno_t sudosrv_format_runas(struct resp_ctx *rctx,
             continue;
         }
 
-        dom = find_domain_by_object_name_ex(rctx->domains, value, true);
+        dom = find_domain_by_object_name_ex(rctx->domains, value, true,
+                                            SSS_GND_DESCEND);
         if (dom == NULL) {
             continue;
         }

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -534,6 +534,10 @@ struct sss_domain_info *get_next_domain(struct sss_domain_info *domain,
 struct sss_domain_info *find_domain_by_name(struct sss_domain_info *domain,
                                             const char *name,
                                             bool match_any);
+struct sss_domain_info *find_domain_by_name_ex(struct sss_domain_info *domain,
+                                               const char *name,
+                                               bool match_any,
+                                               uint32_t gnd_flags);
 struct sss_domain_info *find_domain_by_sid(struct sss_domain_info *domain,
                                            const char *sid);
 enum sss_domain_state sss_domain_get_state(struct sss_domain_info *dom);
@@ -552,7 +556,8 @@ find_domain_by_object_name(struct sss_domain_info *domain,
 
 struct sss_domain_info *
 find_domain_by_object_name_ex(struct sss_domain_info *domain,
-                              const char *object_name, bool strict);
+                              const char *object_name, bool strict,
+                              uint32_t gnd_flags);
 
 bool subdomain_enumerates(struct sss_domain_info *parent,
                           const char *sd_name);


### PR DESCRIPTION
IPA does not disable domains with the help of a flag in the domain objects but
more general with the help of the SID blacklist. With this patch the blacklist
is read with other data about trusted domains and if the domain SID of a
trusted domain is found the domain is disabled. As a result uses and groups
from this domain cannot be looked up anymore.

Related to https://pagure.io/SSSD/sssd/issue/4078