### PR TITLE
ci: add pam wrapper

### DIFF
--- a/contrib/ci/deps.sh
+++ b/contrib/ci/deps.sh
@@ -46,6 +46,7 @@ if [[ "$DISTRO_BRANCH" == -redhat-* ]]; then
         pyldb
         rpm-build
         uid_wrapper
+        pam_wrapper
         python-requests
         curl-devel
         krb5-server
@@ -127,6 +128,7 @@ if [[ "$DISTRO_BRANCH" == -debian-* ]]; then
         fakeroot
         libnss-wrapper
         libuid-wrapper
+        libpam-wrapper
         python-pytest
         python-ldap
         python-ldb


### PR DESCRIPTION
The integration tests for configurable prompting addded with
558b543270d4bb56336c48040611fbc7c5552451 need pam_wrapper to work as
expected. In newer branches this dependency was already added by other
test.

Related to https://pagure.io/SSSD/sssd/issue/3264