### PR TITLE
util/server: amended close_low_fds()

### DIFF
--- a/src/util/server.c
+++ b/src/util/server.c
@@ -23,6 +23,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <stdio.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/stat.h>
@@ -43,27 +44,16 @@
 static void close_low_fds(void)
 {
 #ifndef VALGRIND
-    int fd;
-    int i;
-
-    close(0);
-    close(1);
-    close(2);
-
     /* try and use up these file descriptors, so silly
        library routines writing to stdout etc. won't cause havoc */
-    for (i = 0; i < 3; i++) {
-        fd = open("/dev/null", O_RDWR, 0);
-        if (fd < 0)
-            fd = open("/dev/null", O_WRONLY, 0);
-        if (fd < 0) {
-            DEBUG(SSSDBG_FATAL_FAILURE, "Can't open /dev/null\n");
-            return;
-        }
-        if (fd != i) {
-            DEBUG(SSSDBG_FATAL_FAILURE, "Didn't get file descriptor %d\n",i);
-            return;
-        }
+    if (freopen ("/dev/null", "r", stdin) == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Can't freopen() stdin to /dev/null\n");
+    }
+    if (freopen ("/dev/null", "w", stdout) == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Can't freopen() stdout to /dev/null\n");
+    }
+    if (freopen ("/dev/null", "w", stderr) == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Can't freopen() stderr to /dev/null\n");
     }
 #endif
 }


### PR DESCRIPTION
Rewrote close_low_fds() to use freopen() as it fits better here
and some flags passed to open() previously didn't make a sense.

Also fixed a number of identical Coverity issues:
```
Error: RESOURCE_LEAK (CWE-772):
sssd-2.2.3/src/util/server.c:58: open_fn: Returning handle opened by "open". [Note: The source code implementation of the function has been overridden by a user model.]
sssd-2.2.3/src/util/server.c:58: var_assign: Assigning: "fd" = handle returned from "open("/dev/null", 1, 0)".
sssd-2.2.3/src/util/server.c:56: overwrite_var: Overwriting handle "fd" in "fd = open("/dev/null", 2, 0)" leaks the handle.
   54|          library routines writing to stdout etc. won't cause havoc */
   55|       for (i = 0; i < 3; i++) {
   56|->         fd = open("/dev/null", O_RDWR, 0);
   57|           if (fd < 0)
   58|               fd = open("/dev/null", O_WRONLY, 0);
```