### PR TITLE
sss_ptr_hash: pass new hash_entry_t to custom delete callback

### DIFF
--- a/src/util/sss_ptr_hash.c
+++ b/src/util/sss_ptr_hash.c
@@ -136,7 +136,7 @@ sss_ptr_hash_delete_cb(hash_entry_t *item,
 {
     struct sss_ptr_hash_delete_data *data;
     struct sss_ptr_hash_value *value;
-    void *ptr;
+    struct hash_entry_t callback_entry;
 
     data = talloc_get_type(pvt, struct sss_ptr_hash_delete_data);
     if (data == NULL) {
@@ -150,16 +150,17 @@ sss_ptr_hash_delete_cb(hash_entry_t *item,
         return;
     }
 
-    ptr = value->ptr;
-
-    /* Free value. */
-    talloc_free(value);
+    callback_entry.key = item->key;
+    callback_entry.value.type = HASH_VALUE_PTR;
+    callback_entry.value.ptr = value->ptr;
 
     /* Switch to the input value and call custom callback. */
     if (data->callback != NULL) {
-        item->value.ptr = ptr;
-        data->callback(item, deltype, data->pvt);
+        data->callback(&callback_entry, deltype, data->pvt);
     }
+
+    /* Free value. */
+    talloc_free(value);
 }
 
 hash_table_t *sss_ptr_hash_create(TALLOC_CTX *mem_ctx,


### PR DESCRIPTION
Setting `item->ptr = ptr` actually overwrote the original hash entry
stored in the hash. If this entry is looked up in the delete callback
it contains the overwritten value instead of the original.

Steps to reproduce:
```
1. Run sssd
2. Call e.g. `id user-1`
3. Terminate SSSD
```

You will see these `Invalid data type` messages.

(Snippet from domain log)
```
[dp_client_destructor] (0x0400): Removed IFP client
[sbus_signal_handler] (0x2000): Received D-Bus signal org.freedesktop.DBus.NameOwnerChanged on /org/freedesktop/DBus
[sbus_signal_handler] (0x2000): Received D-Bus signal org.freedesktop.DBus.NameOwnerChanged on /org/freedesktop/DBus
[sbus_senders_delete] (0x2000): Removing identity of sender [sssd.ifp]
[sbus_issue_request_done] (0x0400): org.freedesktop.DBus.NameOwnerChanged: Success
[sbus_senders_delete] (0x2000): Removing identity of sender [:1.5]
[sbus_issue_request_done] (0x0400): org.freedesktop.DBus.NameOwnerChanged: Success
[sbus_dispatch_reconnect] (0x0400): Connection lost. Terminating active requests.
[sss_ptr_hash_check_type] (0x0020): Invalid data type detected. Expected [struct sss_ptr_hash_value], got [struct sbus_connection].
[sss_ptr_hash_check_type] (0x0020): Invalid data type detected. Expected [struct sss_ptr_hash_value], got [struct sbus_connection].
```