### PR TITLE
SSS_CLIENT: got rid of using PRNG

### DIFF
--- a/src/sss_client/common.c
+++ b/src/sss_client/common.c
@@ -566,11 +566,6 @@ static int sss_cli_open_socket(int *errnop, const char *socket_name, int timeout
     /* this piece is adapted from winbind client code */
     wait_time = 0;
     sleep_time = 0;
-    /* This is not security relevant functionality and
-     * it is undesirable to pull unnecessary dependency (util/crypto)
-     * so plain srand() & rand() are used here.
-     */
-    srand(time(NULL) * getpid());
     while (inprogress) {
         int connect_errno = 0;
         socklen_t errnosize;
@@ -605,7 +600,7 @@ static int sss_cli_open_socket(int *errnop, const char *socket_name, int timeout
             break;
         case EAGAIN:
             if (wait_time < timeout) {
-                sleep_time = rand() % 2 + 1;
+                sleep_time = 1;
                 sleep(sleep_time);
             }
             break;


### PR DESCRIPTION
1) no reason to expect "thundering herd issue"
2) randomization as it was done (strictly 1 or 2 secs)
   would not help much anyway
3) usage of PRNG might break app that depends on deterministic
   PRNG behaviour

Resolves: https://pagure.io/SSSD/sssd/issue/4094