### PR TITLE
Update sss_ssh.c

### DIFF
--- a/src/util/sss_ssh.c
+++ b/src/util/sss_ssh.c
@@ -232,6 +232,7 @@ sss_ssh_print_pubkey(struct sss_ssh_pubkey *pubkey)
         DEBUG(SSSDBG_OP_FAILURE,
               "sss_ssh_format_pubkey() failed (%d): %s\n",
               ret, strerror(ret));
+        sss_log(SSS_LOG_ERR, "SSH key is malformed: %s\n", strerror(ret));
         goto end;
     }
 


### PR DESCRIPTION
SSH: Adds a message to the syslog if an SSH key is malformed

If an SSH key contains trailing whitespace (or newlines), it will be considered as malformed by sss_ssh_format_pubkey() function. With the current version the only way to detect that problem is to enable --debug option for /usr/bin/sss_ssh_authorizedkeys utility. I'm adding an additional message to the syslog which will help to determine such problems without enabling debug.

Resolves: https://pagure.io/SSSD/sssd/issue/3864