### PR TITLE
KCM: Set kdc_offset to zero initially

### DIFF
--- a/src/responder/kcm/kcmsrv_ccache.c
+++ b/src/responder/kcm/kcmsrv_ccache.c
@@ -82,7 +82,7 @@ errno_t kcm_cc_new(TALLOC_CTX *mem_ctx,
 
     cc->owner.uid = cli_creds_get_uid(owner);
     cc->owner.gid = cli_creds_get_gid(owner);
-    cc->kdc_offset = INT32_MAX;
+    cc->kdc_offset = 0;
 
     talloc_set_destructor(cc, kcm_cc_destructor);
     *_cc = cc;


### PR DESCRIPTION
Resolves: https://pagure.io/SSSD/sssd/issue/4100

KCM assumed that the client library would always set the KDC offset, but 
that's not always the case, especially when using multiple krb contexts 
from the client application:
   https://bugzilla.redhat.com/show_bug.cgi?id=1757224#c64

Heimdal also creates ccaches with zero kdc_offset:
  
https://github.com/heimdal/heimdal/commit/9f58896af958ae5e6e3ebde8c48dad4eda841986 
so we should do the same..