### PR TITLE
Don't ignore host entries in Group Policy security filters

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -781,6 +781,7 @@ dist_noinst_HEADERS = \
     src/db/sysdb_services.h \
     src/db/sysdb_ssh.h \
     src/db/sysdb_domain_resolution_order.h \
+    src/db/sysdb_computer.h \
     src/confdb/confdb.h \
     src/confdb/confdb_private.h \
     src/confdb/confdb_setup.h \
@@ -1245,6 +1246,7 @@ libsss_util_la_SOURCES = \
     src/db/sysdb_certmap.c \
     src/db/sysdb_domain_resolution_order.c \
     src/util/sss_pam_data.c \
+    src/db/sysdb_computer.c \
     src/util/util.c \
     src/util/util_ext.c \
     src/util/util_preauth.c \

--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -1228,6 +1228,17 @@ static int confdb_get_domain_internal(struct confdb_ctx *cdb,
         goto done;
     }
 
+    /* Override the computer timeout, if specified */
+    ret = get_entry_as_uint32(res->msgs[0], &domain->computer_timeout,
+                              CONFDB_DOMAIN_COMPUTER_CACHE_TIMEOUT,
+                              entry_cache_timeout);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE,
+              "Invalid value for [%s]\n",
+              CONFDB_DOMAIN_COMPUTER_CACHE_TIMEOUT);
+        goto done;
+    }
+
     /* Set refresh_expired_interval, if specified */
     ret = get_entry_as_uint32(res->msgs[0], &domain->refresh_expired_interval,
                               CONFDB_DOMAIN_REFRESH_EXPIRED_INTERVAL,

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -226,6 +226,7 @@
 #define CONFDB_DOMAIN_AUTOFS_CACHE_TIMEOUT "entry_cache_autofs_timeout"
 #define CONFDB_DOMAIN_SUDO_CACHE_TIMEOUT "entry_cache_sudo_timeout"
 #define CONFDB_DOMAIN_SSH_HOST_CACHE_TIMEOUT "entry_cache_ssh_host_timeout"
+#define CONFDB_DOMAIN_COMPUTER_CACHE_TIMEOUT "entry_cache_computer_timeout"
 #define CONFDB_DOMAIN_PWD_EXPIRATION_WARNING "pwd_expiration_warning"
 #define CONFDB_DOMAIN_REFRESH_EXPIRED_INTERVAL "refresh_expired_interval"
 #define CONFDB_DOMAIN_OFFLINE_TIMEOUT "offline_timeout"
@@ -369,6 +370,7 @@ struct sss_domain_info {
     uint32_t autofsmap_timeout;
     uint32_t sudo_timeout;
     uint32_t ssh_host_timeout;
+    uint32_t computer_timeout;
 
     uint32_t refresh_expired_interval;
     uint32_t subdomain_refresh_interval;

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -401,6 +401,7 @@ option = entry_cache_service_timeout
 option = entry_cache_autofs_timeout
 option = entry_cache_sudo_timeout
 option = entry_cache_ssh_host_timeout
+option = entry_cache_computer_timeout
 option = refresh_expired_interval
 
 # Dynamic DNS updates

--- a/src/db/sysdb_computer.c
+++ b/src/db/sysdb_computer.c
@@ -1,0 +1,164 @@
+/*
+    SSSD
+
+    Authors:
+        Samuel Cabrero <scabrero@suse.com>
+        David Mulder <dmulder@suse.com>
+
+    Copyright (C) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <arpa/inet.h>
+
+#include "db/sysdb.h"
+#include "db/sysdb_private.h"
+#include "db/sysdb_computer.h"
+
+static errno_t
+sysdb_search_computer(TALLOC_CTX *mem_ctx,
+                      struct sss_domain_info *domain,
+                      const char *filter,
+                      const char **attrs,
+                      size_t *_num_hosts,
+                      struct ldb_message ***_hosts)
+{
+    errno_t ret;
+    TALLOC_CTX *tmp_ctx;
+    struct ldb_message **results;
+    size_t num_results;
+
+    tmp_ctx = talloc_new(NULL);
+    if (!tmp_ctx) {
+        return ENOMEM;
+    }
+
+    ret = sysdb_search_custom(tmp_ctx, domain, filter,
+                              COMPUTERS_SUBDIR, attrs,
+                              &num_results, &results);
+    if (ret != EOK && ret != ENOENT) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Error looking up host [%d]: %s\n",
+               ret, strerror(ret));
+        goto done;
+    } else if (ret == ENOENT) {
+        DEBUG(SSSDBG_TRACE_FUNC, "No such host\n");
+        *_hosts = NULL;
+        *_num_hosts = 0;
+        goto done;
+    }
+
+    *_hosts = talloc_steal(mem_ctx, results);
+    *_num_hosts = num_results;
+    ret = EOK;
+
+done:
+    talloc_free(tmp_ctx);
+
+    return ret;
+}
+
+int
+sysdb_get_computer(TALLOC_CTX *mem_ctx,
+                   struct sss_domain_info *domain,
+                   const char *computer_name,
+                   const char **attrs,
+                   struct ldb_message **_computer)
+{
+    TALLOC_CTX *tmp_ctx;
+    errno_t ret;
+    const char *filter;
+    struct ldb_message **hosts;
+    size_t num_hosts;
+
+    tmp_ctx = talloc_new(NULL);
+    if (!tmp_ctx) {
+        return ENOMEM;
+    }
+
+    filter = talloc_asprintf(tmp_ctx, SYSDB_COMP_FILTER, computer_name);
+    if (!filter) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = sysdb_search_computer(tmp_ctx, domain, filter, attrs,
+                                &num_hosts, &hosts);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    if (num_hosts != 1) {
+        ret = EINVAL;
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Did not find a single host with name %s\n", computer_name);
+        goto done;
+    }
+
+    *_computer = talloc_steal(mem_ctx, hosts[0]);
+    ret = EOK;
+
+done:
+    talloc_free(tmp_ctx);
+
+    return ret;
+}
+
+int
+sysdb_set_computer(TALLOC_CTX *mem_ctx,
+                   struct sss_domain_info *domain,
+                   const char *computer_name,
+                   const char *sid_str)
+{
+    TALLOC_CTX *tmp_ctx;
+    int ret;
+    struct sysdb_attrs *attrs;
+
+    tmp_ctx = talloc_new(NULL);
+    if (!tmp_ctx) {
+        return ENOMEM;
+    }
+
+    attrs = sysdb_new_attrs(tmp_ctx);
+    if (!attrs) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = sysdb_attrs_add_string(attrs, SYSDB_SID_STR, sid_str);
+    if (ret) goto done;
+
+    ret = sysdb_attrs_add_string(attrs, SYSDB_OBJECTCLASS, SYSDB_COMPUTER_CLASS);
+    if (ret) goto done;
+
+    ret = sysdb_attrs_add_string(attrs, SYSDB_NAME, computer_name);
+    if (ret) goto done;
+
+    /* creation time */
+    ret = sysdb_attrs_add_time_t(attrs, SYSDB_CREATE_TIME, time(NULL));
+    if (ret) goto done;
+
+    ret = sysdb_store_custom(domain, computer_name, COMPUTERS_SUBDIR, attrs);
+    if (ret) goto done;
+
+
+done:
+    if (ret) {
+        DEBUG(SSSDBG_TRACE_FUNC, "Error: %d (%s)\n", ret, strerror(ret));
+    }
+    talloc_zfree(tmp_ctx);
+
+    return ret;
+}

--- a/src/db/sysdb_computer.h
+++ b/src/db/sysdb_computer.h
@@ -44,6 +44,8 @@ int
 sysdb_set_computer(TALLOC_CTX *mem_ctx,
                    struct sss_domain_info *domain,
                    const char *computer_name,
-                   const char *sid_str);
+                   const char *sid_str,
+                   int cache_timeout,
+                   time_t now);
 
 #endif /* SYSDB_COMPUTERS_H_ */

--- a/src/db/sysdb_computer.h
+++ b/src/db/sysdb_computer.h
@@ -1,0 +1,49 @@
+/*
+    SSSD
+
+    Authors:
+        Samuel Cabrero <scabrero@suse.com>
+        David Mulder <dmulder@suse.com>
+
+    Copyright (C) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SYSDB_COMPUTERS_H_
+#define SYSDB_COMPUTERS_H_
+
+#include "db/sysdb.h"
+
+#define COMPUTERS_SUBDIR            "computers"
+#define SYSDB_COMPUTER_CLASS        "computer"
+#define SYSDB_COMPUTERS_CONTAINER   "cn="COMPUTERS_SUBDIR
+#define SYSDB_TMPL_COMPUTER_BASE    SYSDB_COMPUTERS_CONTAINER","SYSDB_DOM_BASE
+#define SYSDB_TMPL_COMPUTER         SYSDB_NAME"=%s,"SYSDB_TMPL_COMPUTER_BASE
+#define SYSDB_COMP_FILTER           "(&("SYSDB_NAME"=%s)("SYSDB_OBJECTCLASS"="SYSDB_COMPUTER_CLASS"))"
+
+int
+sysdb_get_computer(TALLOC_CTX *mem_ctx,
+                   struct sss_domain_info *domain,
+                   const char *computer_name,
+                   const char **attrs,
+                   struct ldb_message **computer);
+
+int
+sysdb_set_computer(TALLOC_CTX *mem_ctx,
+                   struct sss_domain_info *domain,
+                   const char *computer_name,
+                   const char *sid_str);
+
+#endif /* SYSDB_COMPUTERS_H_ */

--- a/src/man/sssd-ad.5.xml
+++ b/src/man/sssd-ad.5.xml
@@ -407,13 +407,6 @@ DOM:dom1:(memberOf:1.2.840.113556.1.4.1941:=cn=nestedgroup,ou=groups,dc=example,
                             always apply also to the user.
                         </para>
                         <para>
-                            NOTE: The current version of SSSD does not support
-                            host (computer) entries in the GPO 'Security
-                            Filtering' list. Only user and group entries are
-                            supported. Host entries in the list have no
-                            effect.
-                        </para>
-                        <para>
                             NOTE: If the operation mode is set to enforcing, it
                             is possible that users that were previously allowed
                             logon access will now be denied logon access (as

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2192,6 +2192,19 @@ p11_uri = library-description=OpenSC%20smartcard%20framework;slot-id=2
                 </varlistentry>
 
                 <varlistentry>
+                    <term>entry_cache_computer_timeout (integer)</term>
+                    <listitem>
+                        <para>
+                            How many seconds to keep the local computer
+                            entry before asking the backend again
+                        </para>
+                        <para>
+                            Default: entry_cache_timeout
+                        </para>
+                    </listitem>
+                </varlistentry>
+
+                <varlistentry>
                     <term>refresh_expired_interval (integer)</term>
                     <listitem>
                         <para>

--- a/src/providers/ad/ad_gpo.c
+++ b/src/providers/ad/ad_gpo.c
@@ -1947,7 +1947,6 @@ ad_gpo_target_dn_retrieval_done(struct tevent_req *subreq)
     struct sysdb_attrs **reply;
     const char *target_dn = NULL;
     uint32_t uac;
-    char *filter = NULL;
     char *domain_dn;
     const char *attrs[] = {AD_AT_SID, NULL};
     struct ldb_message *msg;
@@ -2050,16 +2049,10 @@ ad_gpo_target_dn_retrieval_done(struct tevent_req *subreq)
             goto done;
         }
 
-        filter = talloc_asprintf(subreq, SYSDB_COMP_FILTER, state->ad_hostname);
-        if (!filter) {
-            ret = ENOMEM;
-            goto done;
-        }
-
         subreq = sdap_get_generic_send(state, state->ev, state->opts,
                                        sdap_id_op_handle(state->sdap_op),
-                                       domain_dn, LDAP_SCOPE_SUBTREE,
-                                       filter, attrs, NULL, 0,
+                                       state->target_dn, LDAP_SCOPE_BASE,
+                                       "(&)", attrs, NULL, 0,
                                        state->timeout,
                                        false);
 

--- a/src/providers/ad/ad_gpo.c
+++ b/src/providers/ad/ad_gpo.c
@@ -2192,12 +2192,9 @@ static void ad_gpo_get_host_sid_retrieval_done(struct tevent_req *subreq)
     state->host_sid = talloc_steal(state, sid_str);
 
     /* Put the sid string in the sysdb */
-    /* FIXME Using the same timeout as user cache objects. We should create
-     * a specific setting, check autofsmap_timeout or ssh_host_timeout for
-     * example */
     ret = sysdb_set_computer(subreq, state->user_domain,
                              state->ad_hostname, state->host_sid,
-                             state->user_domain->user_timeout,
+                             state->user_domain->computer_timeout,
                              time(NULL));
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,

--- a/src/providers/ad/ad_gpo_ndr.c
+++ b/src/providers/ad/ad_gpo_ndr.c
@@ -248,7 +248,7 @@ ndr_pull_security_ace_object_ctr(struct ndr_pull *ndr,
     return NDR_ERR_SUCCESS;
 }
 
-static enum ndr_err_code
+enum ndr_err_code
 ndr_pull_dom_sid(struct ndr_pull *ndr,
                  int ndr_flags,
                  struct dom_sid *r)

--- a/src/tests/cmocka/test_ad_gpo.c
+++ b/src/tests/cmocka/test_ad_gpo.c
@@ -267,6 +267,7 @@ void test_populate_gplink_list_malformed(void **state)
  * Test SID-matching logic
  */
 static void test_ad_gpo_ace_includes_client_sid(const char *user_sid,
+                                                const char *host_sid,
                                                 const char **group_sids,
                                                 int group_size,
                                                 struct dom_sid ace_dom_sid,
@@ -286,8 +287,8 @@ static void test_ad_gpo_ace_includes_client_sid(const char *user_sid,
                          &idmap_ctx);
     assert_int_equal(err, IDMAP_SUCCESS);
 
-    ret = ad_gpo_ace_includes_client_sid(user_sid, group_sids, group_size,
-                                         ace_dom_sid, idmap_ctx,
+    ret = ad_gpo_ace_includes_client_sid(user_sid, host_sid, group_sids,
+                                         group_size, ace_dom_sid, idmap_ctx,
                                          &includes_client_sid);
     talloc_free(idmap_ctx);
 
@@ -305,13 +306,14 @@ void test_ad_gpo_ace_includes_client_sid_true(void **state)
     struct dom_sid ace_dom_sid = {1, 4, {0, 0, 0, 0, 0, 5}, {21, 2, 3, 4}};
 
     const char *user_sid = "S-1-5-21-1175337206-4250576914-2321192831-1103";
+    const char *host_sid = "S-1-5-21-1898687337-2196588786-2775055786-2102";
 
     int group_size = 2;
     const char *group_sids[] = {"S-1-5-21-2-3-4",
                                 "S-1-5-21-2-3-5"};
 
-    test_ad_gpo_ace_includes_client_sid(user_sid, group_sids, group_size,
-                                        ace_dom_sid, true);
+    test_ad_gpo_ace_includes_client_sid(user_sid, host_sid, group_sids,
+                                        group_size, ace_dom_sid, true);
 }
 
 void test_ad_gpo_ace_includes_client_sid_false(void **state)
@@ -320,13 +322,29 @@ void test_ad_gpo_ace_includes_client_sid_false(void **state)
     struct dom_sid ace_dom_sid = {1, 4, {0, 0, 0, 0, 0, 5}, {21, 2, 3, 4}};
 
     const char *user_sid = "S-1-5-21-1175337206-4250576914-2321192831-1103";
+    const char *host_sid = "S-1-5-21-1898687337-2196588786-2775055786-2102";
 
     int group_size = 2;
     const char *group_sids[] = {"S-1-5-21-2-3-5",
                                 "S-1-5-21-2-3-6"};
 
-    test_ad_gpo_ace_includes_client_sid(user_sid, group_sids, group_size,
-                                        ace_dom_sid, false);
+    test_ad_gpo_ace_includes_client_sid(user_sid, host_sid, group_sids,
+                                        group_size, ace_dom_sid, false);
+}
+
+void test_ad_gpo_ace_includes_host_sid_true(void **state)
+{
+    /* ace_dom_sid represents "S-1-5-21-1898687337-2196588786-2775055786-2102" */
+    struct dom_sid ace_dom_sid = {1, 5, {0, 0, 0, 0, 0, 5}, {21, 1898687337, 2196588786, 2775055786, 2102}};
+
+    const char *user_sid = "S-1-5-21-1175337206-4250576914-2321192831-1103";
+    const char *host_sid = "S-1-5-21-1898687337-2196588786-2775055786-2102";
+
+    int group_size = 0;
+    const char *group_sids[] = {};
+
+    test_ad_gpo_ace_includes_client_sid(user_sid, host_sid, group_sids,
+                                        group_size, ace_dom_sid, true);
 }
 
 int main(int argc, const char *argv[])
@@ -362,6 +380,9 @@ int main(int argc, const char *argv[])
                                         ad_gpo_test_setup,
                                         ad_gpo_test_teardown),
         cmocka_unit_test_setup_teardown(test_ad_gpo_ace_includes_client_sid_false,
+                                        ad_gpo_test_setup,
+                                        ad_gpo_test_teardown),
+        cmocka_unit_test_setup_teardown(test_ad_gpo_ace_includes_host_sid_true,
                                         ad_gpo_test_setup,
                                         ad_gpo_test_teardown),
     };


### PR DESCRIPTION
I'm posting my code here to hopefully receive some feedback while I work on host entries in gpo security filters. Any feedback/criticism is welcome!

Finished:
Validate against host sid in ad_gpo_evaluate_dacl(), also test.
Host sid retrieval via sdap.
Caching host sid in sysdb.