### PR TITLE
memcache: Stop using the word fastcache for memcache

### DIFF
--- a/src/man/sssd.8.xml
+++ b/src/man/sssd.8.xml
@@ -257,7 +257,7 @@
         <title>NOTES</title>
         <para>
             If the environment variable SSS_NSS_USE_MEMCACHE is set to "NO",
-            client applications will not use the fast in memory cache.
+            client applications will not use the fast in-memory cache.
         </para>
     </refsect1>
 

--- a/src/responder/nss/nsssrv_mmap_cache.c
+++ b/src/responder/nss/nsssrv_mmap_cache.c
@@ -539,7 +539,7 @@ static struct sss_mc_rec *sss_mc_find_record(struct sss_mc_ctx *mcc,
     while (slot != MC_INVALID_VAL) {
         if (!MC_SLOT_WITHIN_BOUNDS(slot, mcc->dt_size)) {
             DEBUG(SSSDBG_FATAL_FAILURE,
-                  "Corrupted fastcache. Slot number too big.\n");
+                  "Corrupted memcache. Slot number too big.\n");
             sss_mc_save_corrupted(mcc);
             sss_mmap_cache_reset(mcc);
             return NULL;
@@ -570,7 +570,7 @@ static struct sss_mc_rec *sss_mc_find_record(struct sss_mc_ctx *mcc,
                 || strs_offset > max_addr - (uint8_t *)rec->data
                 || strs_len > max_addr - (uint8_t *)rec->data - strs_offset) {
             DEBUG(SSSDBG_FATAL_FAILURE,
-                  "Corrupted fastcache entry at slot %u. "
+                  "Corrupted memcache entry at slot %u. "
                   "name_ptr value is %u.\n", slot, name_ptr);
             sss_mc_save_corrupted(mcc);
             sss_mmap_cache_reset(mcc);
@@ -813,7 +813,7 @@ errno_t sss_mmap_cache_pw_invalidate_uid(struct sss_mc_ctx *mcc, uid_t uid)
 
     while (slot != MC_INVALID_VAL) {
         if (!MC_SLOT_WITHIN_BOUNDS(slot, mcc->dt_size)) {
-            DEBUG(SSSDBG_FATAL_FAILURE, "Corrupted fastcache.\n");
+            DEBUG(SSSDBG_FATAL_FAILURE, "Corrupted memcache.\n");
             sss_mc_save_corrupted(mcc);
             sss_mmap_cache_reset(mcc);
             ret = ENOENT;
@@ -952,7 +952,7 @@ errno_t sss_mmap_cache_gr_invalidate_gid(struct sss_mc_ctx *mcc, gid_t gid)
 
     while (slot != MC_INVALID_VAL) {
         if (!MC_SLOT_WITHIN_BOUNDS(slot, mcc->dt_size)) {
-            DEBUG(SSSDBG_FATAL_FAILURE, "Corrupted fastcache.\n");
+            DEBUG(SSSDBG_FATAL_FAILURE, "Corrupted memcache.\n");
             sss_mc_save_corrupted(mcc);
             sss_mmap_cache_reset(mcc);
             ret = ENOENT;

--- a/src/tools/tools_mc_util.c
+++ b/src/tools/tools_mc_util.c
@@ -129,7 +129,7 @@ done:
     return ret;
 }
 
-static int clear_fastcache(bool *sssd_nss_is_off)
+static int clear_memcache(bool *sssd_nss_is_off)
 {
     int ret;
     ret = sss_memcache_invalidate(SSS_NSS_MCACHE_DIR"/passwd");
@@ -199,13 +199,13 @@ errno_t sss_memcache_clear_all(void)
     bool sssd_nss_is_off = false;
     FILE *clear_mc_flag;
 
-    ret = clear_fastcache(&sssd_nss_is_off);
+    ret = clear_memcache(&sssd_nss_is_off);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Failed to clear caches.\n");
         return EIO;
     }
     if (!sssd_nss_is_off) {
-        /* sssd_nss is running -> signal monitor to invalidate fastcache */
+        /* sssd_nss is running -> signal monitor to invalidate memcache */
         clear_mc_flag = fopen(SSS_NSS_MCACHE_DIR"/"CLEAR_MC_FLAG, "w");
         if (clear_mc_flag == NULL) {
             DEBUG(SSSDBG_CRIT_FAILURE,
@@ -231,8 +231,7 @@ errno_t sss_memcache_clear_all(void)
 
         ret = wait_till_nss_responder_invalidate_cache();
         if (ret != EOK) {
-            ERROR("The fast memory caches was not invalidated by NSS "
-                  "responder.\n");
+            ERROR("The memcache was not invalidated by NSS responder.\n");
         }
     }
 


### PR DESCRIPTION
This patch removes the word fastche from our codebase.

We do not reffer to the fast in-memory mmaped cache consistently.
Sometimes we call it fastcache, sometimes memcache and sometimes
mmap cache.

While we can not get rid of memcache, because it is rooted
in some config option names and in the documentation and
mmap cache is used a lot internally in our code, so getting
rid of that would require a lot of code changes, we can
easily get rid of the 'fastcache' word because it is
only in a handful of places.

I think we should really stick to calling it memcache in
the documentation and debug messages and ideally also in
code comments to avoid confusion.