### PR TITLE
ifp: implement connection-wide access check

### DIFF
--- a/src/responder/ifp/ifp_private.h
+++ b/src/responder/ifp/ifp_private.h
@@ -61,6 +61,9 @@ struct ifp_req {
     struct ifp_ctx *ifp_ctx;
 };
 
+errno_t ifp_check_access(struct sbus_request *dbus_req,
+                         struct ifp_ctx *ifp_ctx);
+
 errno_t ifp_req_create(struct sbus_request *dbus_req,
                        struct ifp_ctx *ifp_ctx,
                        struct ifp_req **_ifp_req);

--- a/src/responder/ifp/ifpsrv.c
+++ b/src/responder/ifp/ifpsrv.c
@@ -145,6 +145,9 @@ sysbus_init(TALLOC_CTX *mem_ctx,
         goto fail;
     }
 
+    sbus_connection_set_access_check(system_bus->conn,
+         (sbus_connection_access_check_fn)ifp_check_access, pvt);
+
     ret = ifp_register_sbus_interface(system_bus->conn, pvt);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Could not register interfaces\n");

--- a/src/sbus/sssd_dbus.h
+++ b/src/sbus/sssd_dbus.h
@@ -451,4 +451,14 @@ sbus_signal_listen(struct sbus_connection *conn,
  * down, unregistering them in the monitor. */
 void *sbus_connection_get_destructor_data(struct sbus_connection *conn);
 
+/* Access check callback. */
+typedef void * sbus_connection_access_check_data;
+typedef errno_t
+(*sbus_connection_access_check_fn)(struct sbus_request *,
+                                   sbus_connection_access_check_data);
+
+void sbus_connection_set_access_check(struct sbus_connection *conn,
+                                      sbus_connection_access_check_fn check_fn,
+                                      sbus_connection_access_check_data data);
+
 #endif /* _SSSD_DBUS_H_*/

--- a/src/sbus/sssd_dbus_connection.c
+++ b/src/sbus/sssd_dbus_connection.c
@@ -613,3 +613,29 @@ void *sbus_connection_get_destructor_data(struct sbus_connection *conn)
 
     return conn->client_destructor_data;
 }
+
+void sbus_connection_set_access_check(struct sbus_connection *conn,
+                                      sbus_connection_access_check_fn check_fn,
+                                      sbus_connection_access_check_data data)
+{
+    if (conn == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Bug: connection is NULL\n");
+        return;
+    }
+
+    if (check_fn == NULL) {
+        DEBUG(SSSDBG_TRACE_FUNC, "Unsetting access check function\n");
+        conn->access_data = NULL;
+        conn->access_fn = NULL;
+        return;
+    }
+
+    if (conn->access_fn != NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Bug: access check function is "
+              "already set\n");
+        return;
+    }
+
+    conn->access_fn = check_fn;
+    conn->access_data = data;
+}

--- a/src/sbus/sssd_dbus_private.h
+++ b/src/sbus/sssd_dbus_private.h
@@ -72,6 +72,9 @@ struct sbus_connection {
 
     /* client related stuff */
     void *client_destructor_data;
+
+    sbus_connection_access_check_fn access_fn;
+    sbus_connection_access_check_data access_data;
 };
 
 /* =Standard=interfaces=================================================== */

--- a/src/tests/cmocka/test_ifp.c
+++ b/src/tests/cmocka/test_ifp.c
@@ -110,7 +110,6 @@ void ifp_test_req_create(void **state)
 
 void ifp_test_req_wrong_uid(void **state)
 {
-    struct ifp_req *ireq;
     struct sbus_request *sr;
     struct ifp_ctx *ifp_ctx;
     errno_t ret;
@@ -124,7 +123,7 @@ void ifp_test_req_wrong_uid(void **state)
     sr = mock_sbus_request(ifp_ctx, geteuid()+1);
     assert_non_null(sr);
 
-    ret = ifp_req_create(sr, ifp_ctx, &ireq);
+    ret = ifp_check_access(sr, ifp_ctx);
     assert_int_equal(ret, EACCES);
     talloc_free(sr);
 


### PR DESCRIPTION
Currently only a small subset of infopipe methods performed access check.
This change makes sure that we do this check global for everything.

Steps to reproduce:
1. Call an infopipe method as a user not-listed in [ifp] allowed_uids
2. Without the patch the access is granted

E.g.
```
$ dbus-send --print-reply --system --dest=org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe/Users org.freedesktop.sssd.infopipe.Users.FindByName string:user-1
```

Resolves:
https://pagure.io/SSSD/sssd/issue/4105