### PR TITLE
Added PRINT macro in the sssctl tool

### DIFF
--- a/src/tools/sssctl/sssctl_cert.c
+++ b/src/tools/sssctl/sssctl_cert.c
@@ -168,7 +168,7 @@ errno_t sssctl_cert_map(struct sss_cmdline *cmdline,
             puts(name);
         }
     } else {
-        puts(" - no mapped users found -");
+        PRINT(" - no mapped users found -");
     }
 
     ret = EOK;

--- a/src/tools/sssctl/sssctl_domains.c
+++ b/src/tools/sssctl/sssctl_domains.c
@@ -269,7 +269,7 @@ sssctl_domain_status_server_list(struct sbus_sync_connection *conn,
         }
 
         if (servers == NULL || servers[0] == NULL) {
-            puts(_("None so far.\n"));
+            PRINT("None so far.\n");
             continue;
         }
 


### PR DESCRIPTION
sssctl: Added PRINT macro in the sssctl tool

As a continuation of PR #902 I've added a few more PRINT macros to the sssctl tool.

Resolves: https://pagure.io/SSSD/sssd/issue/3078