### PR TITLE
Updated test_pam_responder.py

### DIFF
--- a/contrib/ci/deps.sh
+++ b/contrib/ci/deps.sh
@@ -116,8 +116,6 @@ if [[ "$DISTRO_BRANCH" == -debian-* ]]; then
         libnfsidmap-dev
         libnl-3-dev
         libnl-route-3-dev
-        libnspr4-dev
-        libnss3-dev
         libpam0g-dev
         libpcre3-dev
         libpopt-dev

--- a/src/tests/intg/Makefile.am
+++ b/src/tests/intg/Makefile.am
@@ -150,9 +150,11 @@ clean-local:
 if HAVE_NSS
 PAM_CERT_DB_PATH="sql:$(DESTDIR)$(sysconfdir)/pki/nssdb"
 SOFTHSM2_CONF=""
+USE_NSS=1
 else
 PAM_CERT_DB_PATH="$(abs_builddir)/../test_CA/SSSD_test_CA.pem"
 SOFTHSM2_CONF="$(abs_builddir)/../test_CA/softhsm2_one.conf"
+USE_NSS=0
 endif
 
 intgcheck-installed: config.py passwd group pam_sss_service pam_sss_alt_service pam_sss_sc_required pam_sss_try_sc pam_sss_allow_missing_name
@@ -187,6 +189,7 @@ intgcheck-installed: config.py passwd group pam_sss_service pam_sss_alt_service 
 	PAM_WRAPPER_PATH=$$(pkg-config --libs pam_wrapper) \
 	PAM_CERT_DB_PATH=$(PAM_CERT_DB_PATH) \
 	SOFTHSM2_CONF=$(SOFTHSM2_CONF) \
+	USE_NSS=$(USE_NSS) \
 	DBUS_SOCK_DIR="$(DESTDIR)$(runstatedir)/dbus/" \
 	DBUS_SESSION_BUS_ADDRESS="unix:path=$$DBUS_SOCK_DIR/fake_socket" \
 	DBUS_SYSTEM_BUS_ADDRESS="unix:path=$$DBUS_SOCK_DIR/system_bus_socket" \

--- a/src/tests/intg/test_pam_responder.py
+++ b/src/tests/intg/test_pam_responder.py
@@ -272,13 +272,15 @@ def cleanup_nssdb():
 
 
 def create_nssdb_fixture(request):
-    create_nssdb()
-    request.addfinalizer(cleanup_nssdb)
+    if 'USE_NSS' in os.environ and os.environ['USE_NSS'] == '1':
+        create_nssdb()
+        request.addfinalizer(cleanup_nssdb)
 
 
 def create_nssdb_no_cert_fixture(request):
-    create_nssdb_no_cert()
-    request.addfinalizer(cleanup_nssdb)
+    if 'USE_NSS' in os.environ and os.environ['USE_NSS'] == '1':
+        create_nssdb_no_cert()
+        request.addfinalizer(cleanup_nssdb)
 
 
 @pytest.fixture


### PR DESCRIPTION
Integration tests/CI: Updated test_pam_responder.py and removed libnss3-dev and libnspr4-dev from Debian dependency list

 - Modified functions create_nssdb_fixture and create_nssdb_no_cert_fixture inside test_pam_responder.py file. These functions will produce the output only if environment variable USE_NSS is defined and set
 - Since CI build for Debian is using OpenSSL this improvement allowed to drop libnss3-dev and libnspr4-dev from Debian dependency list in contrib/ci/deps.sh

Resolves: https://pagure.io/SSSD/sssd/issue/3914