### PR TITLE
bash_rc: Build with systemtap

### DIFF
--- a/contrib/fedora/bashrc_sssd
+++ b/contrib/fedora/bashrc_sssd
@@ -44,6 +44,7 @@ fedconfig()
         --infodir=/usr/share/info \
         --enable-nsslibdir=/$SSS_LIB \
         --enable-pammoddir=/$SSS_LIB/security \
+        --enable-systemtap \
         --with-krb5-rcache-dir=/var/cache/krb5rcache \
         --with-initscript=systemd \
         --with-syslog=journald \


### PR DESCRIPTION
We build with --enable-systemtap in Fedora and RHEL by default. We
should do the same in the helper script in contrib/fedora/bashrc_sssd.