### PR TITLE
Fix krb5-related debug

### DIFF
--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -2631,7 +2631,7 @@ static krb5_error_code check_fast_ccache(TALLOC_CTX *mem_ctx,
         const char *__err_msg = sss_krb5_get_error_message(ctx, kerr);
         DEBUG(SSSDBG_FATAL_FAILURE,
               "Failed to read keytab file [%s]: %s\n",
-               KEYTAB_CLEAN_NAME,
+               sss_printable_keytab_name(ctx, keytab_name),
                __err_msg);
         sss_krb5_free_error_message(ctx, __err_msg);
         goto done;

--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -2628,10 +2628,12 @@ static krb5_error_code check_fast_ccache(TALLOC_CTX *mem_ctx,
         kerr = krb5_kt_default(ctx, &keytab);
     }
     if (kerr) {
+        const char *__err_msg = sss_krb5_get_error_message(ctx, kerr);
         DEBUG(SSSDBG_FATAL_FAILURE,
               "Failed to read keytab file [%s]: %s\n",
                KEYTAB_CLEAN_NAME,
-               sss_krb5_get_error_message(ctx, kerr));
+               __err_msg);
+        sss_krb5_free_error_message(ctx, __err_msg);
         goto done;
     }
 

--- a/src/providers/ldap/ldap_child.c
+++ b/src/providers/ldap/ldap_child.c
@@ -187,15 +187,18 @@ static int lc_verify_keytab_ex(const char *principal,
 
     krberr = krb5_kt_start_seq_get(context, keytab, &cursor);
     if (krberr) {
+        const char *__err_msg = sss_krb5_get_error_message(context, krberr);
+
         DEBUG(SSSDBG_FATAL_FAILURE,
-              "Cannot read keytab [%s].\n", KEYTAB_CLEAN_NAME);
+              "Cannot read keytab [%s]: [%d][%s].\n", KEYTAB_CLEAN_NAME,
+              krberr, __err_msg);
 
         sss_log(SSS_LOG_ERR, "Error reading keytab file [%s]: [%d][%s]. "
                              "Unable to create GSSAPI-encrypted LDAP "
                              "connection.",
-                             KEYTAB_CLEAN_NAME, krberr,
-                             sss_krb5_get_error_message(context, krberr));
+                             KEYTAB_CLEAN_NAME, krberr, __err_msg);
 
+        sss_krb5_free_error_message(context, __err_msg);
         return EIO;
     }
 

--- a/src/providers/ldap/ldap_child.c
+++ b/src/providers/ldap/ldap_child.c
@@ -190,13 +190,15 @@ static int lc_verify_keytab_ex(const char *principal,
         const char *__err_msg = sss_krb5_get_error_message(context, krberr);
 
         DEBUG(SSSDBG_FATAL_FAILURE,
-              "Cannot read keytab [%s]: [%d][%s].\n", KEYTAB_CLEAN_NAME,
+              "Cannot read keytab [%s]: [%d][%s].\n",
+              sss_printable_keytab_name(context, keytab_name),
               krberr, __err_msg);
 
         sss_log(SSS_LOG_ERR, "Error reading keytab file [%s]: [%d][%s]. "
                              "Unable to create GSSAPI-encrypted LDAP "
                              "connection.",
-                             KEYTAB_CLEAN_NAME, krberr, __err_msg);
+                             sss_printable_keytab_name(context, keytab_name),
+                             krberr, __err_msg);
 
         sss_krb5_free_error_message(context, __err_msg);
         return EIO;
@@ -234,7 +236,7 @@ static int lc_verify_keytab_ex(const char *principal,
     if (krberr) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Could not close keytab.\n");
         sss_log(SSS_LOG_ERR, "Could not close keytab file [%s].",
-                             KEYTAB_CLEAN_NAME);
+                             sss_printable_keytab_name(context, keytab_name));
         return EIO;
     }
 
@@ -242,11 +244,12 @@ static int lc_verify_keytab_ex(const char *principal,
         DEBUG(SSSDBG_FATAL_FAILURE,
               "Principal [%s] not found in keytab [%s]\n",
                principal,
-               KEYTAB_CLEAN_NAME);
+               sss_printable_keytab_name(context, keytab_name));
         sss_log(SSS_LOG_ERR, "Error processing keytab file [%s]: "
                              "Principal [%s] was not found. "
                              "Unable to create GSSAPI-encrypted LDAP connection.",
-                             KEYTAB_CLEAN_NAME, principal);
+                             sss_printable_keytab_name(context, keytab_name),
+                             principal);
 
         return EFAULT;
     }
@@ -373,7 +376,8 @@ static krb5_error_code ldap_child_get_tgt_sync(TALLOC_CTX *memctx,
     } else {
         krberr = krb5_kt_default(context, &keytab);
     }
-    DEBUG(SSSDBG_CONF_SETTINGS, "Using keytab [%s]\n", KEYTAB_CLEAN_NAME);
+    DEBUG(SSSDBG_CONF_SETTINGS, "Using keytab [%s]\n",
+          sss_printable_keytab_name(context, keytab_name));
     if (krberr != 0) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to read keytab file: %d\n", krberr);
         goto done;
@@ -520,12 +524,12 @@ done:
         sss_log(SSS_LOG_ERR,
                 "Failed to initialize credentials using keytab [%s]: %s. "
                 "Unable to create GSSAPI-encrypted LDAP connection.",
-                KEYTAB_CLEAN_NAME, *_krb5_msg);
+                sss_printable_keytab_name(context, keytab_name), *_krb5_msg);
 
         DEBUG(SSSDBG_FATAL_FAILURE,
               "Failed to initialize credentials using keytab [%s]: %s. "
               "Unable to create GSSAPI-encrypted LDAP connection.\n",
-              KEYTAB_CLEAN_NAME, *_krb5_msg);
+              sss_printable_keytab_name(context, keytab_name), *_krb5_msg);
     }
     if (keytab) krb5_kt_close(context, keytab);
     if (context) krb5_free_context(context);

--- a/src/providers/ldap/ldap_common.c
+++ b/src/providers/ldap/ldap_common.c
@@ -253,8 +253,10 @@ sdap_gssapi_get_default_realm(TALLOC_CTX *mem_ctx)
 
     krberr = krb5_get_default_realm(context, &krb5_realm);
     if (krberr) {
+        const char *__err_msg = sss_krb5_get_error_message(context, krberr);
         DEBUG(SSSDBG_OP_FAILURE, "Failed to get default realm name: %s\n",
-                  sss_krb5_get_error_message(context, krberr));
+              __err_msg);
+        sss_krb5_free_error_message(context, __err_msg);
         goto done;
     }
 

--- a/src/util/sss_krb5.c
+++ b/src/util/sss_krb5.c
@@ -67,8 +67,7 @@ sss_krb5_get_primary(TALLOC_CTX *mem_ctx,
     return talloc_asprintf(mem_ctx, pattern, hostname);
 }
 
-static const char *sss_printable_keytab_name(krb5_context ctx,
-                                             const char *keytab_name)
+const char *sss_printable_keytab_name(krb5_context ctx, const char *keytab_name)
 {
     /* sss_printable_keytab_name() output is expected to be used
        for logging purposes only. Thus it is non-critical to provide

--- a/src/util/sss_krb5.h
+++ b/src/util/sss_krb5.h
@@ -43,7 +43,8 @@
  * authentication is presumably a rare case a separate config option is not
  * necessary. */
 #define KERBEROS_PWEXPIRE_WARNING_TIME (7 * 24 * 60 * 60)
-#define KEYTAB_CLEAN_NAME keytab_name ? keytab_name : "default"
+
+const char *sss_printable_keytab_name(krb5_context ctx, const char *keytab_name);
 
 #if defined HAVE_KRB5_CC_CACHE_MATCH && defined HAVE_KRB5_CC_GET_FULL_NAME
 #define HAVE_KRB5_CC_COLLECTION 1


### PR DESCRIPTION
This PR is continuation of cleanup work done in #883.

`KEYTAB_CLEAN_NAME` macro was replaced with `sss_printable_keytab_name()` function and a number of issues related with usage of `krb5_get_error_message()` were fixed.