### PR TITLE
ci: improvements for on-demand builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -264,6 +264,12 @@ def notification = new Notification(
   on_demand
 )
 
+if (params.SYSTEMS) {
+  if (params.SYSTEMS != 'all') {
+    systems = params.SYSTEMS.split()
+  }
+}
+
 try {
   /* Setup nice build description so pull request are easy to find. */
   stage('Setup description') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@ def systems = [
   'fedora28',
   'fedora29',
   'fedora30',
+  'fedora31',
   'fedora-rawhide',
   'debian10',
 ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,6 +104,9 @@ class Test {
     this.artifactsdir = "${this.pipeline.env.WORKSPACE}/artifacts/${this.system}"
     this.codedir = "${this.pipeline.env.WORKSPACE}/sssd"
 
+    /* Clean-up previous artifacts just to be sure there are no leftovers. */
+    this.pipeline.sh "rm -fr ${this.artifactsdir} || :"
+
     try {
       this.pipeline.echo "Running on ${this.pipeline.env.NODE_NAME}"
       this.notify('PENDING', 'Build is in progress.')
@@ -244,6 +247,12 @@ class OnDemandTest extends Test {
 
   def archive() {
     this.pipeline.echo 'On demand run. Artifacts are not stored in the cloud.'
+    this.pipeline.echo 'They are accessible only from Jenkins.'
+    this.pipeline.echo "${this.pipeline.env.BUILD_URL}/artifact/artifacts/${this.system}"
+    this.pipeline.archiveArtifacts artifacts: "artifacts/**",
+      allowEmptyArchive: true
+
+    this.pipeline.sh "rm -fr ${this.artifactsdir}"
   }
 }
 

--- a/contrib/ci/configure.sh
+++ b/contrib/ci/configure.sh
@@ -75,6 +75,12 @@ if [[ "$DISTRO_BRANCH" == -redhat-fedora-29* ||
     )
 fi
 
+if [[ "$DISTRO_BRANCH" == -redhat-fedora-3[2-9]* ]]; then
+    CONFIGURE_ARG_LIST+=(
+        "--without-python2-bindings"
+    )
+fi
+
 declare -r -a CONFIGURE_ARG_LIST
 
 fi # _CONFIGURE_SH

--- a/contrib/ci/deps.sh
+++ b/contrib/ci/deps.sh
@@ -49,6 +49,15 @@ if [[ "$DISTRO_BRANCH" == -redhat-* ]]; then
         krb5-workstation
     )
 
+    if [[ "$DISTRO_BRANCH" == -redhat-fedora-31* ||
+          "$DISTRO_BRANCH" == -redhat-redhatenterprise*-8.*- ||
+          "$DISTRO_BRANCH" == -redhat-centos-8.*- ]]; then
+        DEPS_LIST+=(
+            python2
+            python2-devel
+        )
+    fi
+
     if [[ "$DISTRO_BRANCH" == -redhat-fedora-3[1-9]* ||
           "$DISTRO_BRANCH" == -redhat-redhatenterprise*-8.*- ||
           "$DISTRO_BRANCH" == -redhat-centos-8.*- ]]; then


### PR DESCRIPTION
1. Logs are now correctly archived in Jenkins.
2. Internal `sssd-ci` tool now allows to issue build only for specific systems (`sssd-ci build -s debian10 -s fedora-rawhide`)