### PR TITLE
util/server.c: fix handling when error occurs in waitpid()

### DIFF
--- a/src/util/server.c
+++ b/src/util/server.c
@@ -86,7 +86,7 @@ void become_daemon(bool Fork)
             do {
                 errno = 0;
                 cpid = waitpid(pid, &status, 0);
-                if (cpid == 1) {
+                if (cpid == -1) {
                     /* An error occurred while waiting */
                     error = errno;
                     if (error != EINTR) {


### PR DESCRIPTION
-1 is returned if an error occurs in waitpid().
Fixed inappropriate error handling.