### PR TITLE
Fix timing to save errno

### DIFF
--- a/src/confdb/confdb_setup.c
+++ b/src/confdb/confdb_setup.c
@@ -172,9 +172,9 @@ static int confdb_ldif_from_ini_file(TALLOC_CTX *mem_ctx,
         errno = 0;
         ret = sss_ini_get_mtime(init_data, sizeof(timestr), timestr);
         if (ret <= 0 || ret >= (int)sizeof(timestr)) {
+            ret = errno ? errno : EFAULT;
             DEBUG(SSSDBG_FATAL_FAILURE,
                   "Failed to convert time_t to string??\n");
-            ret = errno ? errno : EFAULT;
             return ret;
         }
     } else {

--- a/src/krb5_plugin/sssd_krb5_locator_plugin.c
+++ b/src/krb5_plugin/sssd_krb5_locator_plugin.c
@@ -343,9 +343,9 @@ static int get_krb5info(const char *realm, struct sssd_ctx *ctx,
 
     fd = open(krb5info_name, O_RDONLY);
     if (fd == -1) {
-        PLUGIN_DEBUG("open failed [%s][%d][%s].\n",
-                     krb5info_name, errno, strerror(errno));
         ret = errno;
+        PLUGIN_DEBUG("open failed [%s][%d][%s].\n",
+                     krb5info_name, ret, strerror(ret));
         goto done;
     }
 

--- a/src/providers/ipa/ipa_common.c
+++ b/src/providers/ipa/ipa_common.c
@@ -81,9 +81,9 @@ int ipa_get_options(TALLOC_CTX *memctx,
     if (ipa_hostname == NULL) {
         ret = gethostname(hostname, sizeof(hostname));
         if (ret != EOK) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "gethostname failed [%d][%s].\n", errno,
-                      strerror(errno));
             ret = errno;
+            DEBUG(SSSDBG_CRIT_FAILURE, "gethostname failed [%d][%s].\n", ret,
+                      strerror(ret));
             goto done;
         }
         hostname[HOST_NAME_MAX] = '\0';

--- a/src/tools/tools_util.c
+++ b/src/tools/tools_util.c
@@ -578,8 +578,8 @@ int run_userdel_cmd(struct tools_ctx *tctx)
             }
         }
         if (child_pid == -1) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "waitpid failed\n");
             ret = errno;
+            DEBUG(SSSDBG_CRIT_FAILURE, "waitpid failed\n");
             goto done;
         }
     }

--- a/src/util/child_common.c
+++ b/src/util/child_common.c
@@ -822,9 +822,9 @@ errno_t child_debug_init(const char *logfile, int *debug_fd)
 
         *debug_fd = fileno(debug_filep);
         if (*debug_fd == -1) {
-            DEBUG(SSSDBG_FATAL_FAILURE,
-                  "fileno failed [%d][%s]\n", errno, strerror(errno));
             ret = errno;
+            DEBUG(SSSDBG_FATAL_FAILURE,
+                  "fileno failed [%d][%s]\n", ret, strerror(ret));
             return ret;
         }
     }


### PR DESCRIPTION
The timing to save some errnos is after DEBUG output, not immediately after the system call.
Fix to save errno before DEBUG output so that errno is not overwritten by DEBUG output processing.