### PR TITLE
PRNG usage amended

### DIFF
--- a/src/responder/nss/nsssrv_mmap_cache.c
+++ b/src/responder/nss/nsssrv_mmap_cache.c
@@ -1353,7 +1353,10 @@ errno_t sss_mmap_cache_init(TALLOC_CTX *mem_ctx, const char *name,
 
     /* generate a pseudo-random seed.
      * Needed to fend off dictionary based collision attacks */
-    mc_ctx->seed = sss_rand();
+    ret = sss_generate_csprng_buffer((uint8_t *)&mc_ctx->seed, sizeof(mc_ctx->seed));
+    if (ret != EOK) {
+        goto done;
+    }
 
     sss_mc_header_update(mc_ctx, SSS_MC_HEADER_ALIVE);
 

--- a/src/util/crypto/libcrypto/crypto_prng.c
+++ b/src/util/crypto/libcrypto/crypto_prng.c
@@ -28,27 +28,6 @@
 #include "util/util_errors.h"
 #include "util/crypto/sss_crypto.h"
 
-int sss_rand(void)
-{
-    static bool srand_done = false;
-    int result;
-
-    if (RAND_bytes((unsigned char*)&result, (int)sizeof(int)) == 1) {
-        return result;
-    }
-
-    /* Fallback to libc `rand()`
-     * Coverity might complain here: "DC.WEAK_CRYPTO (CWE-327)"
-     * But if `RAND_bytes()` failed then there is no entropy available
-     * so it doesn't make any sense to try reading "/dev/[u]random"
-     */
-    if (!srand_done) {
-        srand(time(NULL) * getpid());
-        srand_done = true;
-    }
-    return rand();
-}
-
 int sss_generate_csprng_buffer(uint8_t *buf, size_t size)
 {
     if ((buf == NULL) || (size > INT_MAX)) {

--- a/src/util/crypto/nss/nss_prng.c
+++ b/src/util/crypto/nss/nss_prng.c
@@ -27,21 +27,6 @@
 #include "util/util.h"
 #include "util/crypto/sss_crypto.h"
 
-int sss_rand(void)
-{
-    static bool srand_done = false;
-
-    if (!srand_done) {
-        srand(time(NULL) * getpid());
-        srand_done = true;
-    }
-
-    /* Coverity will complain here: "DC.WEAK_CRYPTO (CWE-327)"
-     * We do not care as libnss is being deprecated as crypto backend.
-     */
-    return rand();
-}
-
 int sss_generate_csprng_buffer(uint8_t *buf, size_t size)
 {
     ssize_t rsize;

--- a/src/util/crypto/sss_crypto.h
+++ b/src/util/crypto/sss_crypto.h
@@ -21,12 +21,6 @@
 #include <talloc.h>
 #include <stdint.h>
 
-/* Does its best to generate crypto strong random int but fallbacks to
- * plain `rand()` in case of failure.
- * Thus *not* suitable to be used in security relevant context.
- */
-int sss_rand(void);
-
 /* Guaranteed either to fill given buffer with crypto strong random data
  * or to fail with error code (for example in the case of the lack of
  * proper entropy)

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -1067,3 +1067,18 @@ bool local_provider_is_built(void)
     return false;
 #endif
 }
+
+int sss_rand(void)
+{
+    static bool srand_done = false;
+
+    /* Coverity might complain here: "DC.WEAK_CRYPTO (CWE-327)"
+     * It is safe to ignore as this helper function is *NOT* intended
+     * to be used in security relevant context.
+     */
+    if (!srand_done) {
+        srand(time(NULL) * getpid());
+        srand_done = true;
+    }
+    return rand();
+}

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -498,6 +498,13 @@ int domain_to_basedn(TALLOC_CTX *memctx, const char *domain, char **basedn);
 
 bool is_host_in_domain(const char *host, const char *domain);
 
+/* This is simple wrapper around libc rand() intended to avoid calling srand()
+ * explicitly, thus *not* suitable to be used in security relevant context.
+ * If CS properties are desired (security relevant functionality/FIPS/etc) then
+ * use sss_crypto.h:sss_generate_csprng_buffer() instead!
+ */
+int sss_rand(void);
+
 /* from nscd.c */
 enum nscd_db {
     NSCD_DB_PASSWD,


### PR DESCRIPTION
This PR is intended to address https://pagure.io/SSSD/sssd/issue/4024#comment-603526

    sss_rand() was:
     - moved out of crypto lib,
     - non security relevant purpose was emphasized
     - attempt to "use RAND_bytes() if available" was removed to simplify
       things and make return value compatible with rand()

    MMAP_CACHE: use CSPRNG to init hash table seed
