### PR TITLE
Amend util/server.c:become_daemon()

### DIFF
--- a/src/util/server.c
+++ b/src/util/server.c
@@ -124,7 +124,6 @@ static void become_daemon(void)
         ret = errno;
         DEBUG(SSSDBG_FATAL_FAILURE, "Cannot change directory (%d [%s])\n",
                                      ret, strerror(ret));
-        return;
     }
 
     /* Close FDs 0,1,2. Needed if started by rsh */

--- a/src/util/server.c
+++ b/src/util/server.c
@@ -115,8 +115,14 @@ static void become_daemon(void)
         _exit(ret);
     }
 
-    /* detach from the terminal */
-    setsid();
+    /* create new session, process group and detach from the terminal */
+    if (setsid() == (pid_t) -1) {
+        ret = errno;
+        DEBUG(SSSDBG_FATAL_FAILURE, "setsid() failed: %d [%s]\n",
+                                     ret, strerror(ret));
+        sss_log(SSS_LOG_ERR, "can't start: setsid() failed");
+        _exit(1);
+    }
 
     /* chdir to / to be sure we're not on a remote filesystem */
     errno = 0;

--- a/src/util/server.c
+++ b/src/util/server.c
@@ -67,7 +67,7 @@ static void daemon_parent_sigterm(int sig)
  Become a daemon, discarding the controlling terminal.
 **/
 
-void become_daemon(bool Fork)
+static void become_daemon(bool Fork)
 {
     pid_t pid, cpid;
     int status;

--- a/src/util/server.c
+++ b/src/util/server.c
@@ -74,6 +74,13 @@ static void become_daemon(void)
     int ret, error;
 
     pid = fork();
+    if (pid == -1) {
+        ret = errno;
+        DEBUG(SSSDBG_FATAL_FAILURE, "fork() failed: %d [%s]\n",
+                                     ret, strerror(ret));
+        sss_log(SSS_LOG_ERR, "can't start: fork() failed");
+        _exit(1);
+    }
     if (pid != 0) {
         /* Terminate parent process on demand so we can hold systemd
          * or initd from starting next service until SSSD is initialized.

--- a/src/util/server.c
+++ b/src/util/server.c
@@ -88,9 +88,9 @@ static void become_daemon(void)
          * context yet. */
         CatchSignal(SIGTERM, daemon_parent_sigterm);
 
-        /* or exit when sssd monitor is terminated */
+        /* or exit when child process (i.e. sssd monitor) is terminated */
         do {
-            errno = 0;
+            error = 0;
             cpid = waitpid(pid, &status, 0);
             if (cpid == -1) {
                 /* An error occurred while waiting */
@@ -105,7 +105,6 @@ static void become_daemon(void)
                 }
             }
 
-            error = 0;
             /* return error if we didn't exited normally */
             ret = 1;
 


### PR DESCRIPTION
Fixed a number of issues in/with `become_daemon()` function.

Among others fixed this covscan issue:
```
Error: CLANG_WARNING:
sssd-2.2.3/src/util/server.c:98:25: warning: Value stored to 'ret' is never read
#                        ret = 1;
#                        ^     ~
sssd-2.2.3/src/util/server.c:98:25: note: Value stored to 'ret' is never read
#                        ret = 1;
#                        ^     ~
#   96|                           /* Forcibly kill this child */
#   97|                           kill(pid, SIGKILL);
#   98|->                         ret = 1;
#   99|                       }
#  100|                   }
```

This PR is marked as [WiP] as it has to be rebased on the top of PR #921.