### PR TITLE
ipa: use the right context for autofs

### DIFF
--- a/src/providers/ipa/ipa_autofs.c
+++ b/src/providers/ipa/ipa_autofs.c
@@ -52,11 +52,11 @@ errno_t ipa_autofs_init(TALLOC_CTX *mem_ctx,
                   struct sdap_id_ctx, struct dp_autofs_data, dp_no_output);
 
     dp_set_method(dp_methods, DPM_AUTOFS_GET_MAP,
-                  sdap_autofs_get_map_handler_send, sdap_autofs_get_map_handler_recv, id_ctx,
+                  sdap_autofs_get_map_handler_send, sdap_autofs_get_map_handler_recv, id_ctx->sdap_id_ctx,
                   struct sdap_id_ctx, struct dp_autofs_data, dp_no_output);
 
     dp_set_method(dp_methods, DPM_AUTOFS_GET_ENTRY,
-                  sdap_autofs_get_entry_handler_send, sdap_autofs_get_entry_handler_recv, id_ctx,
+                  sdap_autofs_get_entry_handler_send, sdap_autofs_get_entry_handler_recv, id_ctx->sdap_id_ctx,
                   struct sdap_id_ctx, struct dp_autofs_data, dp_no_output);
 
     return ret;


### PR DESCRIPTION
Related to https://pagure.io/SSSD/sssd/issue/4111