### PR TITLE
Add processing to save errno before outputting DEBUG

### DIFF
--- a/src/providers/ldap/ldap_common.c
+++ b/src/providers/ldap/ldap_common.c
@@ -568,6 +568,7 @@ errno_t string_to_shadowpw_days(const char *s, long *d)
 {
     long l;
     char *endptr;
+    int ret;
 
     if (s == NULL || *s == '\0') {
         *d = -1;
@@ -577,9 +578,10 @@ errno_t string_to_shadowpw_days(const char *s, long *d)
     errno = 0;
     l = strtol(s, &endptr, 10);
     if (errno != 0) {
+        ret = errno;
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "strtol failed [%d][%s].\n", errno, strerror(errno));
-        return errno;
+              "strtol failed [%d][%s].\n", ret, strerror(ret));
+        return ret;
     }
 
     if (*endptr != '\0') {

--- a/src/tools/sss_userdel.c
+++ b/src/tools/sss_userdel.c
@@ -109,8 +109,10 @@ static int kick_user(struct tools_ctx *tctx)
             }
         }
         if (child_pid == -1) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "waitpid failed\n");
-            return errno;
+            ret = errno;
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "waitpid failed [%d]: %s\n", ret, strerror(ret));
+            return ret;
         }
     }
 

--- a/src/util/check_and_open.c
+++ b/src/util/check_and_open.c
@@ -53,9 +53,10 @@ errno_t check_file(const char *filename,
         ret = lstat(filename, stat_buf);
     }
     if (ret == -1) {
+        ret = errno;
         DEBUG(SSSDBG_TRACE_FUNC, "lstat for [%s] failed: [%d][%s].\n",
-                                 filename, errno, strerror(errno));
-        return errno;
+                                 filename, ret, strerror(ret));
+        return ret;
     }
 
     return perform_checks(stat_buf, uid, gid, mode, mask);
@@ -77,10 +78,11 @@ errno_t check_fd(int fd, uid_t uid, gid_t gid,
 
     ret = fstat(fd, stat_buf);
     if (ret == -1) {
+        ret = errno;
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "fstat for [%d] failed: [%d][%s].\n", fd, errno,
-                                                        strerror(errno));
-        return errno;
+              "fstat for [%d] failed: [%d][%s].\n", fd, ret,
+                                                        strerror(ret));
+        return ret;
     }
 
     return perform_checks(stat_buf, uid, gid, mode, mask);
@@ -133,10 +135,11 @@ errno_t check_and_open_readonly(const char *filename, int *fd,
 
     *fd = open(filename, O_RDONLY);
     if (*fd == -1) {
+        ret = errno;
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "open [%s] failed: [%d][%s].\n", filename, errno,
-                  strerror(errno));
-        return errno;
+              "open [%s] failed: [%d][%s].\n", filename, ret,
+                  strerror(ret));
+        return ret;
     }
 
     ret = check_fd(*fd, uid, gid, mode, mask, &stat_buf);


### PR DESCRIPTION
In some processes, DEBUG is output after a system call error, and errno is returned.
errno should be saved before DEBUG is output.
Add a process to save errno before outputting DEBUG so that errno is not overwritten in DEBUG output process.