### PR TITLE
pam_sss: treat whitespace name as missing name if allow_missing_name is set

### DIFF
--- a/src/tests/intg/test_pam_responder.py
+++ b/src/tests/intg/test_pam_responder.py
@@ -621,6 +621,33 @@ def test_sc_auth_missing_name(simple_pam_cert_auth, env_for_sssctl):
     assert err.find("pam_authenticate for user [user1]: Success") != -1
 
 
+def test_sc_auth_missing_name_whitespace(simple_pam_cert_auth, env_for_sssctl):
+    """
+    Test pam_sss allow_missing_name feature.
+    """
+
+    sssctl = subprocess.Popen(["sssctl", "user-checks", " ",
+                               "--action=auth",
+                               "--service=pam_sss_allow_missing_name"],
+                              universal_newlines=True,
+                              env=env_for_sssctl, stdin=subprocess.PIPE,
+                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    try:
+        out, err = sssctl.communicate(input="123456")
+    except:
+        sssctl.kill()
+        out, err = sssctl.communicate()
+
+    sssctl.stdin.close()
+    sssctl.stdout.close()
+
+    if sssctl.wait() != 0:
+        raise Exception("sssctl failed")
+
+    assert err.find("pam_authenticate for user [user1]: Success") != -1
+
+
 def test_sc_auth_name_format(simple_pam_cert_auth_name_format, env_for_sssctl):
     """
     Test that full_name_format is respected with pam_sss allow_missing_name


### PR DESCRIPTION
Resolves:
https://pagure.io/SSSD/sssd/issue/4101