### PR TITLE
failover: make sure we switch to anoter server if only port differs

### DIFF
--- a/src/providers/backend.h
+++ b/src/providers/backend.h
@@ -54,6 +54,7 @@ struct be_svc_data {
     struct fo_service *fo_service;
 
     char *last_good_srv;
+    int last_good_port;
     time_t last_status_change;
     bool run_callbacks;
 

--- a/src/providers/data_provider_fo.c
+++ b/src/providers/data_provider_fo.c
@@ -670,6 +670,7 @@ errno_t be_resolve_server_process(struct tevent_req *subreq,
      * requested or if the server is the same but changed status since last time*/
     if (state->svc->last_good_srv == NULL ||
         strcmp(fo_get_server_name(state->srv), state->svc->last_good_srv) != 0 ||
+        fo_get_server_port(state->srv) != state->svc->last_good_port ||
         state->svc->run_callbacks ||
         srv_status_change > state->svc->last_status_change) {
         state->svc->last_status_change = srv_status_change;
@@ -683,6 +684,7 @@ errno_t be_resolve_server_process(struct tevent_req *subreq,
 
         talloc_free(state->svc->last_good_srv);
         state->svc->last_good_srv = srvname;
+        state->svc->last_good_port = fo_get_server_port(state->srv);
 
         DLIST_FOR_EACH(callback, state->svc->callbacks) {
             callback->fn(callback->private_data, state->srv);


### PR DESCRIPTION
This is a regression introduced in 735af71a8e169f17fa5462db610a1567c9618e29.
After this commit we checked only server name instead of name and port combo.

Steps to reproduce:
1. Configure SSSD to use two servers with same name but different ports
```
[domain/LDAP]
debug_level=0xFFF0
id_provider = ldap
ldap_uri = ldap://$SERVER1:12345,ldap://$SERVER1:389
ldap_tls_cacertdir = /etc/openldap/certs
ldap_search_base = dc=example,dc=com
```

2. The first server port is unreachable, the second is working.
3. Run sssd and try to resolve user.
4. Without the patch SSSD tries to connect to the first server twice
   because new URI is not constructed and goes offline.

Resolves:
https://pagure.io/SSSD/sssd/issue/4112