### PR TITLE
[WiP] SBUS: remove dbus fd from tevent loop when watch is removed

### DIFF
--- a/src/sbus/sssd_dbus_common.c
+++ b/src/sbus/sssd_dbus_common.c
@@ -53,6 +53,7 @@ static int watch_destructor(void *mem)
 
     watch = talloc_get_type(mem, struct sbus_watch_ctx);
     DLIST_REMOVE(watch->conn->watch_list, watch);
+    talloc_free(watch->fde);
 
     return 0;
 }


### PR DESCRIPTION
According to the tevent API:
"To cancel the monitoring of a file descriptor, call talloc_free()
on the object returned by this (tevent_add_fd()) function."

Resolves: https://pagure.io/SSSD/sssd/issue/2660