### PR TITLE
SBUS: defer deallocation of sbus_watch_ctx

### DIFF
--- a/src/sbus/sssd_dbus_private.h
+++ b/src/sbus/sssd_dbus_private.h
@@ -88,6 +88,7 @@ struct sbus_watch_ctx {
 
     struct tevent_fd *fde;
     int fd;
+    struct tevent_immediate *im_event;
 
     DBusWatch *dbus_read_watch;
     DBusWatch *dbus_write_watch;


### PR DESCRIPTION
The following flow was causing use-after-free error:
  tevent_common_invoke_fd_handler(RW) -> sbus_watch_handler(RW) ->
  dbus_watch_handle(R) -> ...libdbus detects connection is closed... ->
  sbus_remove_watch() -> talloc_free(watch) ->
  ... get back to libdbus and back to sbus_watch_handler() ->
  "if (watch->dbus_write_watch) dbus_watch_handle(W)" => use-after-free

To resolve an issue schedule deallocation of watch as immediate event.

Resolves: https://pagure.io/SSSD/sssd/issue/2660