### PR TITLE
autofs: delete possible duplicate of an autofs entry

### DIFF
--- a/src/providers/ldap/sdap_async_autofs.c
+++ b/src/providers/ldap/sdap_async_autofs.c
@@ -30,11 +30,6 @@
 #include "providers/ldap/sdap_autofs.h"
 #include "providers/ldap/sdap_ops.h"
 
-enum autofs_map_op {
-    AUTOFS_MAP_OP_ADD,
-    AUTOFS_MAP_OP_DEL
-};
-
 /* ====== Utility functions ====== */
 static const char *
 get_autofs_map_name(struct sysdb_attrs *map, struct sdap_options *opts)


### PR DESCRIPTION
Steps to reproduce:

1. Create the following autofs objects
```ldif
 dn: ou=auto.master,ou=autofs,dc=ldap,dc=vm objectClass:
automountMap objectClass: top ou: auto.master

dn: automountKey=/home,ou=auto.master,ou=autofs,dc=ldap,dc=vm objectClass:
automount objectClass: top automountInformation: auto.home automountKey:
/home

dn: ou=auto.home,ou=autofs,dc=ldap,dc=vm objectClass: automountMap
objectClass: top ou: auto.home

dn: automountKey=/home1,ou=auto.home,ou=autofs,dc=ldap,dc=vm objectClass:
automount objectClass: top automountInformation: home1 automountKey: /home1
```

2. Use e.g. the test tool to fetch the maps:
```
 ./autofs_test_client auto.master
 ./autofs_test_client auto.home -n /home1
```

3. Change automountInformation of /home1
``` dn: automountKey=/home1,ou=auto.home,ou=autofs,dc=ldap,dc=vm
objectClass: automount objectClass: top automountInformation: home1_1
automountKey: /home1
```

4. Run the test tool again:
```
./autofs_test_client auto.master
./autofs_test_client auto.home -n /home1
> error happens
```

It is important the `get entry by name is called` thus the `-n` parameter.

Resolves: https://pagure.io/SSSD/sssd/issue/4116