### PR TITLE
sudo: use objectCategory instead of objectClass in ad sudo provider

### DIFF
--- a/src/config/SSSDConfig/__init__.py.in
+++ b/src/config/SSSDConfig/__init__.py.in
@@ -440,6 +440,7 @@ option_strings = {
     'ldap_sudo_include_netgroups' : _('Whether to include rules that contains netgroup in host attribute'),
     'ldap_sudo_include_regexp' : _('Whether to include rules that contains regular expression in host attribute'),
     'ldap_sudorule_object_class' : _('Object class for sudo rules'),
+    'ldap_sudorule_object_class_attr' : _('Name of attribute that is used as object class for sudo rules'),
     'ldap_sudorule_name' : _('Sudo rule name'),
     'ldap_sudorule_command' : _('Sudo rule command attribute'),
     'ldap_sudorule_host' : _('Sudo rule host attribute'),

--- a/src/config/etc/sssd.api.d/sssd-ad.conf
+++ b/src/config/etc/sssd.api.d/sssd-ad.conf
@@ -167,6 +167,7 @@ ldap_sudo_ip = str, None, false
 ldap_sudo_include_netgroups = bool, None, false
 ldap_sudo_include_regexp = bool, None, false
 ldap_sudorule_object_class = str, None, false
+ldap_sudorule_object_class_attr = str, None, false
 ldap_sudorule_name = str, None, false
 ldap_sudorule_command = str, None, false
 ldap_sudorule_host = str, None, false

--- a/src/config/etc/sssd.api.d/sssd-ipa.conf
+++ b/src/config/etc/sssd.api.d/sssd-ipa.conf
@@ -228,6 +228,7 @@ ldap_sudo_ip = str, None, false
 ldap_sudo_include_netgroups = bool, None, false
 ldap_sudo_include_regexp = bool, None, false
 ldap_sudorule_object_class = str, None, false
+ldap_sudorule_object_class_attr = str, None, false
 ldap_sudorule_name = str, None, false
 ldap_sudorule_command = str, None, false
 ldap_sudorule_host = str, None, false

--- a/src/config/etc/sssd.api.d/sssd-ldap.conf
+++ b/src/config/etc/sssd.api.d/sssd-ldap.conf
@@ -153,6 +153,7 @@ ldap_sudo_ip = str, None, false
 ldap_sudo_include_netgroups = bool, None, false
 ldap_sudo_include_regexp = bool, None, false
 ldap_sudorule_object_class = str, None, false
+ldap_sudorule_object_class_attr = str, None, false
 ldap_sudorule_name = str, None, false
 ldap_sudorule_command = str, None, false
 ldap_sudorule_host = str, None, false

--- a/src/providers/ad/ad_opts.c
+++ b/src/providers/ad/ad_opts.c
@@ -23,6 +23,7 @@
 #include "src/providers/data_provider.h"
 #include "db/sysdb_services.h"
 #include "db/sysdb_autofs.h"
+#include "db/sysdb_sudo.h"
 #include "providers/ldap/ldap_common.h"
 #include "config.h"
 
@@ -286,4 +287,22 @@ struct dp_option ad_dyndns_opts[] = {
     { "dyndns_auth", DP_OPT_STRING, { "gss-tsig" }, NULL_STRING },
     { "dyndns_server", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     DP_OPTION_TERMINATOR
+};
+
+struct sdap_attr_map ad_sudorule_map[] = {
+    { "ldap_sudorule_object_class", "sudoRole", SYSDB_SUDO_CACHE_OC, NULL },
+    { "ldap_sudorule_object_class_attr", "objectCategory", SYSDB_OBJECTCATEGORY, NULL },
+    { "ldap_sudorule_name", "cn", SYSDB_SUDO_CACHE_AT_CN, NULL },
+    { "ldap_sudorule_command", "sudoCommand", SYSDB_SUDO_CACHE_AT_COMMAND, NULL },
+    { "ldap_sudorule_host", "sudoHost", SYSDB_SUDO_CACHE_AT_HOST, NULL },
+    { "ldap_sudorule_user", "sudoUser", SYSDB_SUDO_CACHE_AT_USER, NULL },
+    { "ldap_sudorule_option", "sudoOption", SYSDB_SUDO_CACHE_AT_OPTION, NULL },
+    { "ldap_sudorule_runas", "sudoRunAs", SYSDB_SUDO_CACHE_AT_RUNAS, NULL },
+    { "ldap_sudorule_runasuser", "sudoRunAsUser", SYSDB_SUDO_CACHE_AT_RUNASUSER, NULL },
+    { "ldap_sudorule_runasgroup", "sudoRunAsGroup", SYSDB_SUDO_CACHE_AT_RUNASGROUP, NULL },
+    { "ldap_sudorule_notbefore", "sudoNotBefore", SYSDB_SUDO_CACHE_AT_NOTBEFORE, NULL },
+    { "ldap_sudorule_notafter", "sudoNotAfter", SYSDB_SUDO_CACHE_AT_NOTAFTER, NULL },
+    { "ldap_sudorule_order", "sudoOrder", SYSDB_SUDO_CACHE_AT_ORDER, NULL },
+    { "ldap_sudorule_entry_usn", NULL, SYSDB_USN, NULL },
+    SDAP_ATTR_MAP_TERMINATOR
 };

--- a/src/providers/ad/ad_opts.h
+++ b/src/providers/ad/ad_opts.h
@@ -48,4 +48,6 @@ extern struct sdap_attr_map ad_autofs_entry_map[];
 
 extern struct dp_option ad_dyndns_opts[];
 
+extern struct sdap_attr_map ad_sudorule_map[];
+
 #endif /* AD_OPTS_H_ */

--- a/src/providers/ad/ad_sudo.c
+++ b/src/providers/ad/ad_sudo.c
@@ -36,7 +36,11 @@ errno_t ad_sudo_init(TALLOC_CTX *mem_ctx,
 
     DEBUG(SSSDBG_TRACE_INTERNAL, "Initializing sudo AD back end\n");
 
-    ret = sdap_sudo_init(mem_ctx, be_ctx, id_ctx->sdap_id_ctx, dp_methods);
+    ret = sdap_sudo_init(mem_ctx,
+                         be_ctx,
+                         id_ctx->sdap_id_ctx,
+                         "objectCategory",
+                         dp_methods);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "Cannot initialize LDAP SUDO [%d]: %s\n",
                                  ret, sss_strerror(ret));

--- a/src/providers/ad/ad_sudo.c
+++ b/src/providers/ad/ad_sudo.c
@@ -23,6 +23,7 @@
 */
 
 #include "providers/ad/ad_common.h"
+#include "providers/ad/ad_opts.h"
 #include "providers/ldap/sdap_sudo.h"
 
 errno_t ad_sudo_init(TALLOC_CTX *mem_ctx,
@@ -39,7 +40,7 @@ errno_t ad_sudo_init(TALLOC_CTX *mem_ctx,
     ret = sdap_sudo_init(mem_ctx,
                          be_ctx,
                          id_ctx->sdap_id_ctx,
-                         "objectCategory",
+                         ad_sudorule_map,
                          dp_methods);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "Cannot initialize LDAP SUDO [%d]: %s\n",

--- a/src/providers/ipa/ipa_sudo.c
+++ b/src/providers/ipa/ipa_sudo.c
@@ -21,6 +21,7 @@
 #include "providers/ipa/ipa_opts.h"
 #include "providers/ipa/ipa_common.h"
 #include "providers/ldap/sdap_sudo.h"
+#include "providers/ldap/ldap_opts.h"
 #include "providers/ipa/ipa_sudo.h"
 #include "db/sysdb_sudo.h"
 
@@ -311,7 +312,7 @@ int ipa_sudo_init(TALLOC_CTX *mem_ctx,
         ret = sdap_sudo_init(mem_ctx,
                              be_ctx,
                              id_ctx->sdap_id_ctx,
-                             "objectClass",
+                             native_sudorule_map,
                              dp_methods);
         break;
     }

--- a/src/providers/ipa/ipa_sudo.c
+++ b/src/providers/ipa/ipa_sudo.c
@@ -308,7 +308,11 @@ int ipa_sudo_init(TALLOC_CTX *mem_ctx,
         break;
     case SUDO_SCHEMA_LDAP:
         DEBUG(SSSDBG_TRACE_FUNC, "Using LDAP schema for sudo\n");
-        ret = sdap_sudo_init(mem_ctx, be_ctx, id_ctx->sdap_id_ctx, dp_methods);
+        ret = sdap_sudo_init(mem_ctx,
+                             be_ctx,
+                             id_ctx->sdap_id_ctx,
+                             "objectClass",
+                             dp_methods);
         break;
     }
 

--- a/src/providers/ldap/ldap_common.h
+++ b/src/providers/ldap/ldap_common.h
@@ -232,6 +232,7 @@ int ldap_get_options(TALLOC_CTX *memctx,
 int ldap_get_sudo_options(struct confdb_ctx *cdb,
                           const char *conf_path,
                           struct sdap_options *opts,
+                          struct sdap_attr_map *native_map,
                           bool *use_host_filter,
                           bool *include_regexp,
                           bool *include_netgroups);

--- a/src/providers/ldap/ldap_init.c
+++ b/src/providers/ldap/ldap_init.c
@@ -24,6 +24,7 @@
 
 #include "util/child_common.h"
 #include "providers/ldap/ldap_common.h"
+#include "providers/ldap/ldap_opts.h"
 #include "providers/ldap/sdap_async_private.h"
 #include "providers/ldap/sdap_access.h"
 #include "providers/ldap/sdap_hostid.h"
@@ -695,7 +696,7 @@ errno_t sssm_ldap_sudo_init(TALLOC_CTX *mem_ctx,
     return sdap_sudo_init(mem_ctx,
                           be_ctx,
                           init_ctx->id_ctx,
-                          "objectClass",
+                          native_sudorule_map,
                           dp_methods);
 #else
     DEBUG(SSSDBG_MINOR_FAILURE, "Sudo init handler called but SSSD is "

--- a/src/providers/ldap/ldap_init.c
+++ b/src/providers/ldap/ldap_init.c
@@ -692,7 +692,11 @@ errno_t sssm_ldap_sudo_init(TALLOC_CTX *mem_ctx,
     DEBUG(SSSDBG_TRACE_INTERNAL, "Initializing LDAP sudo handler\n");
     init_ctx = talloc_get_type(module_data, struct ldap_init_ctx);
 
-    return sdap_sudo_init(mem_ctx, be_ctx, init_ctx->id_ctx, dp_methods);
+    return sdap_sudo_init(mem_ctx,
+                          be_ctx,
+                          init_ctx->id_ctx,
+                          "objectClass",
+                          dp_methods);
 #else
     DEBUG(SSSDBG_MINOR_FAILURE, "Sudo init handler called but SSSD is "
                                  "built without sudo support, ignoring\n");

--- a/src/providers/ldap/ldap_options.c
+++ b/src/providers/ldap/ldap_options.c
@@ -386,6 +386,7 @@ done:
 int ldap_get_sudo_options(struct confdb_ctx *cdb,
                           const char *conf_path,
                           struct sdap_options *opts,
+                          struct sdap_attr_map *native_map,
                           bool *use_host_filter,
                           bool *include_regexp,
                           bool *include_netgroups)
@@ -425,7 +426,7 @@ int ldap_get_sudo_options(struct confdb_ctx *cdb,
 
     /* attrs map */
     ret = sdap_get_map(opts, cdb, conf_path,
-                       native_sudorule_map,
+                       native_map,
                        SDAP_OPTS_SUDO,
                        &opts->sudorule_map);
     if (ret != EOK) {

--- a/src/providers/ldap/ldap_opts.c
+++ b/src/providers/ldap/ldap_opts.c
@@ -342,6 +342,7 @@ struct sdap_attr_map host_map[] = {
 
 struct sdap_attr_map native_sudorule_map[] = {
     { "ldap_sudorule_object_class", "sudoRole", SYSDB_SUDO_CACHE_OC, NULL },
+    { "ldap_sudorule_object_class_attr", "objectClass", SYSDB_OBJECTCATEGORY, NULL },
     { "ldap_sudorule_name", "cn", SYSDB_SUDO_CACHE_AT_CN, NULL },
     { "ldap_sudorule_command", "sudoCommand", SYSDB_SUDO_CACHE_AT_COMMAND, NULL },
     { "ldap_sudorule_host", "sudoHost", SYSDB_SUDO_CACHE_AT_HOST, NULL },

--- a/src/providers/ldap/sdap.h
+++ b/src/providers/ldap/sdap.h
@@ -326,6 +326,7 @@ enum sdap_netgroup_attrs {
 
 enum sdap_sudorule_attrs {
     SDAP_OC_SUDORULE = 0,
+    SDAP_AT_SUDO_OC,
     SDAP_AT_SUDO_NAME,
     SDAP_AT_SUDO_COMMAND,
     SDAP_AT_SUDO_HOST,

--- a/src/providers/ldap/sdap_sudo.c
+++ b/src/providers/ldap/sdap_sudo.c
@@ -159,7 +159,7 @@ static void sdap_sudo_online_cb(void *pvt)
 errno_t sdap_sudo_init(TALLOC_CTX *mem_ctx,
                        struct be_ctx *be_ctx,
                        struct sdap_id_ctx *id_ctx,
-                       const char *objectclass_attr,
+                       struct sdap_attr_map *native_map,
                        struct dp_method *dp_methods)
 {
     struct sdap_sudo_ctx *sudo_ctx;
@@ -174,13 +174,9 @@ errno_t sdap_sudo_init(TALLOC_CTX *mem_ctx,
     }
 
     sudo_ctx->id_ctx = id_ctx;
-    sudo_ctx->objectclass_attr = talloc_strdup(sudo_ctx, objectclass_attr);
-    if (sudo_ctx->objectclass_attr == NULL) {
-        ret = ENOMEM;
-        goto done;
-    }
 
     ret = ldap_get_sudo_options(be_ctx->cdb, be_ctx->conf_path, id_ctx->opts,
+                                native_map,
                                 &sudo_ctx->use_host_filter,
                                 &sudo_ctx->include_regexp,
                                 &sudo_ctx->include_netgroups);

--- a/src/providers/ldap/sdap_sudo.c
+++ b/src/providers/ldap/sdap_sudo.c
@@ -159,6 +159,7 @@ static void sdap_sudo_online_cb(void *pvt)
 errno_t sdap_sudo_init(TALLOC_CTX *mem_ctx,
                        struct be_ctx *be_ctx,
                        struct sdap_id_ctx *id_ctx,
+                       const char *objectclass_attr,
                        struct dp_method *dp_methods)
 {
     struct sdap_sudo_ctx *sudo_ctx;
@@ -173,6 +174,11 @@ errno_t sdap_sudo_init(TALLOC_CTX *mem_ctx,
     }
 
     sudo_ctx->id_ctx = id_ctx;
+    sudo_ctx->objectclass_attr = talloc_strdup(sudo_ctx, objectclass_attr);
+    if (sudo_ctx->objectclass_attr == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
 
     ret = ldap_get_sudo_options(be_ctx->cdb, be_ctx->conf_path, id_ctx->opts,
                                 &sudo_ctx->use_host_filter,

--- a/src/providers/ldap/sdap_sudo.h
+++ b/src/providers/ldap/sdap_sudo.h
@@ -29,7 +29,6 @@ struct sdap_sudo_ctx {
 
     char **hostnames;
     char **ip_addr;
-    const char *objectclass_attr;
     bool include_netgroups;
     bool include_regexp;
     bool use_host_filter;
@@ -44,7 +43,7 @@ struct sdap_sudo_ctx {
 errno_t sdap_sudo_init(TALLOC_CTX *mem_ctx,
                        struct be_ctx *be_ctx,
                        struct sdap_id_ctx *id_ctx,
-                       const char *objectclass_attr,
+                       struct sdap_attr_map *native_map,
                        struct dp_method *dp_methods);
 
 /* sdap async interface */

--- a/src/providers/ldap/sdap_sudo.h
+++ b/src/providers/ldap/sdap_sudo.h
@@ -29,6 +29,7 @@ struct sdap_sudo_ctx {
 
     char **hostnames;
     char **ip_addr;
+    const char *objectclass_attr;
     bool include_netgroups;
     bool include_regexp;
     bool use_host_filter;
@@ -43,6 +44,7 @@ struct sdap_sudo_ctx {
 errno_t sdap_sudo_init(TALLOC_CTX *mem_ctx,
                        struct be_ctx *be_ctx,
                        struct sdap_id_ctx *id_ctx,
+                       const char *objectclass_attr,
                        struct dp_method *dp_methods);
 
 /* sdap async interface */
@@ -91,7 +93,7 @@ int sdap_sudo_get_hostinfo_recv(TALLOC_CTX *mem_ctx,
 
 /* (&(objectClass=sudoRole)(|(cn=defaults)(sudoUser=ALL)%s)) */
 #define SDAP_SUDO_FILTER_USER "(&(objectClass=%s)(|(%s=%s)(%s=ALL)%s))"
-#define SDAP_SUDO_FILTER_CLASS "(objectClass=%s)"
+#define SDAP_SUDO_FILTER_CLASS "(%s=%s)"
 #define SDAP_SUDO_FILTER_DEFAULTS  "(&(objectClass=%s)(%s=%s))"
 #define SDAP_SUDO_DEFAULTS    "defaults"
 

--- a/src/providers/ldap/sdap_sudo_refresh.c
+++ b/src/providers/ldap/sdap_sudo_refresh.c
@@ -62,6 +62,7 @@ struct tevent_req *sdap_sudo_full_refresh_send(TALLOC_CTX *mem_ctx,
 
     /* Download all rules from LDAP */
     search_filter = talloc_asprintf(state, SDAP_SUDO_FILTER_CLASS,
+                            sudo_ctx->objectclass_attr,
                             id_ctx->opts->sudorule_map[SDAP_OC_SUDORULE].name);
     if (search_filter == NULL) {
         ret = ENOMEM;
@@ -183,11 +184,13 @@ struct tevent_req *sdap_sudo_smart_refresh_send(TALLOC_CTX *mem_ctx,
     if (srv_opts == NULL || srv_opts->max_sudo_value == 0) {
         DEBUG(SSSDBG_TRACE_FUNC, "USN value is unknown, assuming zero.\n");
         usn = "0";
-        search_filter = talloc_asprintf(state, "(objectclass=%s)",
+        search_filter = talloc_asprintf(state, "(%s=%s)",
+                                        sudo_ctx->objectclass_attr,
                                         map[SDAP_OC_SUDORULE].name);
     } else {
         usn = srv_opts->max_sudo_value;
-        search_filter = talloc_asprintf(state, "(&(objectclass=%s)(%s>=%s))",
+        search_filter = talloc_asprintf(state, "(&(%s=%s)(%s>=%s))",
+                                        sudo_ctx->objectclass_attr,
                                         map[SDAP_OC_SUDORULE].name,
                                         map[SDAP_AT_SUDO_USN].name, usn);
     }
@@ -336,6 +339,7 @@ struct tevent_req *sdap_sudo_rules_refresh_send(TALLOC_CTX *mem_ctx,
     state->num_rules = i;
 
     search_filter = talloc_asprintf(tmp_ctx, "(&"SDAP_SUDO_FILTER_CLASS"(|%s))",
+                                    sudo_ctx->objectclass_attr,
                                     opts->sudorule_map[SDAP_OC_SUDORULE].name,
                                     search_filter);
     if (search_filter == NULL) {

--- a/src/providers/ldap/sdap_sudo_refresh.c
+++ b/src/providers/ldap/sdap_sudo_refresh.c
@@ -62,7 +62,7 @@ struct tevent_req *sdap_sudo_full_refresh_send(TALLOC_CTX *mem_ctx,
 
     /* Download all rules from LDAP */
     search_filter = talloc_asprintf(state, SDAP_SUDO_FILTER_CLASS,
-                            sudo_ctx->objectclass_attr,
+                            id_ctx->opts->sudorule_map[SDAP_AT_SUDO_OC].name,
                             id_ctx->opts->sudorule_map[SDAP_OC_SUDORULE].name);
     if (search_filter == NULL) {
         ret = ENOMEM;
@@ -185,12 +185,12 @@ struct tevent_req *sdap_sudo_smart_refresh_send(TALLOC_CTX *mem_ctx,
         DEBUG(SSSDBG_TRACE_FUNC, "USN value is unknown, assuming zero.\n");
         usn = "0";
         search_filter = talloc_asprintf(state, "(%s=%s)",
-                                        sudo_ctx->objectclass_attr,
+                                        map[SDAP_AT_SUDO_OC].name,
                                         map[SDAP_OC_SUDORULE].name);
     } else {
         usn = srv_opts->max_sudo_value;
         search_filter = talloc_asprintf(state, "(&(%s=%s)(%s>=%s))",
-                                        sudo_ctx->objectclass_attr,
+                                        map[SDAP_AT_SUDO_OC].name,
                                         map[SDAP_OC_SUDORULE].name,
                                         map[SDAP_AT_SUDO_USN].name, usn);
     }
@@ -339,7 +339,7 @@ struct tevent_req *sdap_sudo_rules_refresh_send(TALLOC_CTX *mem_ctx,
     state->num_rules = i;
 
     search_filter = talloc_asprintf(tmp_ctx, "(&"SDAP_SUDO_FILTER_CLASS"(|%s))",
-                                    sudo_ctx->objectclass_attr,
+                                    opts->sudorule_map[SDAP_AT_SUDO_OC].name,
                                     opts->sudorule_map[SDAP_OC_SUDORULE].name,
                                     search_filter);
     if (search_filter == NULL) {


### PR DESCRIPTION
This improves performance because objectCategory attribute is indexed
as opposed to objectClass which may not be indexed.

See: https://docs.microsoft.com/en-us/previous-versions/ms808539(v=msdn.10)