### PR TITLE
[wip] files_ops: Fix cached password remove

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -920,6 +920,11 @@ int sysdb_delete_recursive(struct sysdb_ctx *sysdb,
                            struct ldb_dn *dn,
                            bool ignore_not_found);
 
+int sysdb_delete_recursive_with_whitelist(struct sysdb_ctx *sysdb,
+                                          struct ldb_dn *dn,
+                                          bool ignore_not_found,
+                                          const char **whitelist);
+
 int sysdb_delete_recursive_with_filter(struct sysdb_ctx *sysdb,
                                        struct ldb_dn *dn,
                                        bool ignore_not_found,


### PR DESCRIPTION
When SSSD daemon will detect refresh of password (group) file
it will delete all cached users (groups) data.
With this change cached data will be deleted only for non
existing users (groups).

Resolves:
https://pagure.io/SSSD/sssd/issue/3591