### PR TITLE
ssh: apply certificate matching rules

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1668,6 +1668,7 @@ sssd_ssh_LDADD = \
     $(SSSD_INTERNAL_LTLIBS) \
     $(SYSTEMD_DAEMON_LIBS) \
     libsss_cert.la \
+    libsss_certmap.la \
     libsss_iface.la \
     libsss_sbus.la \
     $(NULL)

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -165,6 +165,7 @@
 #endif
 #define CONFDB_SSH_USE_CERT_KEYS "ssh_use_certificate_keys"
 #define CONFDB_DEFAULT_SSH_USE_CERT_KEYS true
+#define CONFDB_SSH_USE_CERT_RULES "ssh_use_certificate_matching_rules"
 
 /* PAC */
 #define CONFDB_PAC_CONF_ENTRY "config/pac"

--- a/src/config/SSSDConfig/__init__.py.in
+++ b/src/config/SSSDConfig/__init__.py.in
@@ -119,6 +119,7 @@ option_strings = {
     'ssh_hash_known_hosts': _('Whether to hash host names and addresses in the known_hosts file'),
     'ssh_known_hosts_timeout': _('How many seconds to keep a host in the known_hosts file after its host keys were requested'),
     'ca_db': _('Path to storage of trusted CA certificates'),
+    'ssh_use_certificate_keys': _('Allow to generate ssh-keys from certificates'),
 
     # [pac]
     'allowed_uids': _('List of UIDs or user names allowed to access the PAC responder'),

--- a/src/config/SSSDConfig/__init__.py.in
+++ b/src/config/SSSDConfig/__init__.py.in
@@ -120,6 +120,7 @@ option_strings = {
     'ssh_known_hosts_timeout': _('How many seconds to keep a host in the known_hosts file after its host keys were requested'),
     'ca_db': _('Path to storage of trusted CA certificates'),
     'ssh_use_certificate_keys': _('Allow to generate ssh-keys from certificates'),
+    'ssh_use_certificate_matching_rules': _('Use the following matching rules to filter the certificates for ssh-key generation'),
 
     # [pac]
     'allowed_uids': _('List of UIDs or user names allowed to access the PAC responder'),

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -199,6 +199,7 @@ option = ssh_hash_known_hosts
 option = ssh_known_hosts_timeout
 option = ca_db
 option = ssh_use_certificate_keys
+option = ssh_use_certificate_matching_rules
 
 [rule/allowed_pac_options]
 validator = ini_allowed_options

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -198,6 +198,7 @@ option = cache_first
 option = ssh_hash_known_hosts
 option = ssh_known_hosts_timeout
 option = ca_db
+option = ssh_use_certificate_keys
 
 [rule/allowed_pac_options]
 validator = ini_allowed_options

--- a/src/config/etc/sssd.api.conf
+++ b/src/config/etc/sssd.api.conf
@@ -95,6 +95,7 @@ autofs_negative_timeout = int, None, false
 ssh_hash_known_hosts = bool, None, false
 ssh_known_hosts_timeout = int, None, false
 ca_db = str, None, false
+ssh_use_certificate_keys = bool, None, false
 
 [pac]
 # PAC responder

--- a/src/config/etc/sssd.api.conf
+++ b/src/config/etc/sssd.api.conf
@@ -96,6 +96,7 @@ ssh_hash_known_hosts = bool, None, false
 ssh_known_hosts_timeout = int, None, false
 ca_db = str, None, false
 ssh_use_certificate_keys = bool, None, false
+ssh_use_certificate_matching_rules = str, None, false
 
 [pac]
 # PAC responder

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -1718,6 +1718,28 @@ p11_uri = library-description=OpenSC%20smartcard%20framework;slot-id=2
                     </listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term>ssh_use_certificate_matching_rules (string)</term>
+                    <listitem>
+                        <para>
+                            By default the ssh responder will use all available
+                            certificate matching rules to filter the
+                            certificates so that ssh keys are only derived from
+                            the matching ones. With this option the used rules
+                            can be restricted with a comma separated list of
+                            mapping and matching rule names. All other rules
+                            will be ignored.
+                        </para>
+                        <para>
+                            If a non-existing rule name is given all rules will
+                            be ignored and all available certificates will be
+                            used to derive ssh keys.
+                        </para>
+                        <para>
+                            Default: not set, all found rules are used
+                        </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
                     <term>ca_db (string)</term>
                     <listitem>
                         <para>

--- a/src/p11_child/p11_child_common.c
+++ b/src/p11_child/p11_child_common.c
@@ -81,7 +81,8 @@ static int do_work(TALLOC_CTX *mem_ctx, enum op_mode mode, const char *ca_db,
 
 
     if (mode == OP_VERIFIY) {
-        if (do_verification_b64(p11_ctx, cert_b64)) {
+        if (!cert_verify_opts->do_verification
+                    || do_verification_b64(p11_ctx, cert_b64)) {
             DEBUG(SSSDBG_TRACE_FUNC, "Certificate is valid.\n");
             ret = 0;
         } else {
@@ -356,9 +357,8 @@ int main(int argc, const char *argv[])
 
     if (mode == OP_VERIFIY && !cert_verify_opts->do_verification) {
         fprintf(stderr,
-                "Cannot run verification with option 'no_verification'.\n");
-        ret = EINVAL;
-        goto fail;
+                "Called verification with option 'no_verification', "
+                "it this intended?\n");
     }
 
     if (mode == OP_AUTH && pin_mode == PIN_STDIN) {

--- a/src/responder/ssh/ssh_private.h
+++ b/src/responder/ssh/ssh_private.h
@@ -38,6 +38,7 @@ struct ssh_ctx {
 
     time_t certmap_last_read;
     struct sss_certmap_ctx *sss_certmap_ctx;
+    char **cert_rules;
 };
 
 struct sss_cmd_table *get_ssh_cmds(void);

--- a/src/responder/ssh/ssh_private.h
+++ b/src/responder/ssh/ssh_private.h
@@ -36,6 +36,7 @@ struct ssh_ctx {
     char *ca_db;
     bool use_cert_keys;
 
+    int p11_child_debug_fd;
     time_t certmap_last_read;
     struct sss_certmap_ctx *sss_certmap_ctx;
     char **cert_rules;

--- a/src/responder/ssh/ssh_private.h
+++ b/src/responder/ssh/ssh_private.h
@@ -35,6 +35,9 @@ struct ssh_ctx {
     int known_hosts_timeout;
     char *ca_db;
     bool use_cert_keys;
+
+    time_t certmap_last_read;
+    struct sss_certmap_ctx *sss_certmap_ctx;
 };
 
 struct sss_cmd_table *get_ssh_cmds(void);

--- a/src/responder/ssh/ssh_reply.c
+++ b/src/responder/ssh/ssh_reply.c
@@ -243,6 +243,7 @@ struct tevent_req *ssh_get_output_keys_send(TALLOC_CTX *mem_ctx,
     subreq = cert_to_ssh_key_send(state, state->ev, -1,
                                   state->p11_child_timeout,
                                   state->ssh_ctx->ca_db,
+                                  state->ssh_ctx->sss_certmap_ctx,
                                   state->current_cert->num_values,
                                   state->current_cert->values,
                                   state->cert_verification_opts);
@@ -328,6 +329,7 @@ void ssh_get_output_keys_done(struct tevent_req *subreq)
     subreq = cert_to_ssh_key_send(state, state->ev, -1,
                                   state->p11_child_timeout,
                                   state->ssh_ctx->ca_db,
+                                  state->ssh_ctx->sss_certmap_ctx,
                                   state->current_cert->num_values,
                                   state->current_cert->values,
                                   state->cert_verification_opts);

--- a/src/responder/ssh/ssh_reply.c
+++ b/src/responder/ssh/ssh_reply.c
@@ -240,7 +240,8 @@ struct tevent_req *ssh_get_output_keys_send(TALLOC_CTX *mem_ctx,
     state->current_cert = state->user_cert != NULL ? state->user_cert
                                                    : state->user_cert_override;
 
-    subreq = cert_to_ssh_key_send(state, state->ev, -1,
+    subreq = cert_to_ssh_key_send(state, state->ev,
+                                  state->ssh_ctx->p11_child_debug_fd,
                                   state->p11_child_timeout,
                                   state->ssh_ctx->ca_db,
                                   state->ssh_ctx->sss_certmap_ctx,

--- a/src/responder/ssh/sshsrv.c
+++ b/src/responder/ssh/sshsrv.c
@@ -21,6 +21,7 @@
 #include <popt.h>
 
 #include "util/util.h"
+#include "util/child_common.h"
 #include "confdb/confdb.h"
 #include "responder/common/responder.h"
 #include "responder/ssh/ssh_private.h"
@@ -123,6 +124,16 @@ int ssh_process_init(TALLOC_CTX *mem_ctx,
                                     " from confdb (%d) [%s].\n", ret,
                                     sss_strerror(ret));
         goto fail;
+    }
+
+    ssh_ctx->p11_child_debug_fd = -1;
+    if (ssh_ctx->use_cert_keys) {
+        ret = child_debug_init(P11_CHILD_LOG_FILE,
+                               &ssh_ctx->p11_child_debug_fd);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_FATAL_FAILURE,
+                  "Failed to setup p11_child logging, ignored.\n");
+        }
     }
 
     ret = schedule_get_domains_task(rctx, rctx->ev, rctx, NULL);

--- a/src/responder/ssh/sshsrv.c
+++ b/src/responder/ssh/sshsrv.c
@@ -112,6 +112,19 @@ int ssh_process_init(TALLOC_CTX *mem_ctx,
         goto fail;
     }
 
+    ret = confdb_get_string_as_list(ssh_ctx->rctx->cdb, ssh_ctx,
+                                    CONFDB_SSH_CONF_ENTRY,
+                                    CONFDB_SSH_USE_CERT_RULES,
+                                    &ssh_ctx->cert_rules);
+    if (ret == ENOENT) {
+        ssh_ctx->cert_rules = NULL;
+    } else if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Error reading " CONFDB_SSH_USE_CERT_RULES
+                                    " from confdb (%d) [%s].\n", ret,
+                                    sss_strerror(ret));
+        goto fail;
+    }
+
     ret = schedule_get_domains_task(rctx, rctx->ev, rctx, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "schedule_get_domains_tasks failed.\n");

--- a/src/tests/cmocka/test_ssh_srv.c
+++ b/src/tests/cmocka/test_ssh_srv.c
@@ -544,6 +544,60 @@ static int test_ssh_user_pubkey_cert_check(uint32_t status,
     return EOK;
 }
 
+static int test_ssh_user_pubkey_cert_1_check(uint32_t status,
+                                             uint8_t *body, size_t blen)
+{
+    uint32_t val;
+    size_t exp_len;
+    size_t name_len;
+    size_t key_len[2];
+    uint8_t *key[2];
+    size_t rp = 0;
+    size_t c;
+
+    key[0] = sss_base64_decode(ssh_test_ctx, TEST_SSH_PUBKEY, &key_len[0]);
+    assert_non_null(key[0]);
+
+    key[1] = sss_base64_decode(ssh_test_ctx, SSSD_TEST_CERT_SSH_KEY_0001,
+                               &key_len[1]);
+    assert_non_null(key[1]);
+
+    name_len = strlen(ssh_test_ctx->ssh_user_fqdn) + 1;
+
+    exp_len = 2 * sizeof(uint32_t) + 2* 3* sizeof(uint32_t) + 2 * name_len
+                                   + key_len[0] + key_len[1];
+
+    assert_int_equal(status, EOK);
+    assert_int_equal(blen, exp_len);
+
+    SAFEALIGN_COPY_UINT32(&val, &body[rp], &rp);
+    assert_int_equal(val, 2);
+
+    SAFEALIGN_COPY_UINT32(&val, &body[rp], &rp);
+    assert_int_equal(val, 0);
+
+    for (c = 0; c < 2; c++) {
+        SAFEALIGN_COPY_UINT32(&val, &body[rp], &rp);
+        assert_int_equal(val, 0);
+
+        SAFEALIGN_COPY_UINT32(&val, &body[rp], &rp);
+        assert_int_equal(val, name_len);
+
+        assert_memory_equal(body + rp, ssh_test_ctx->ssh_user_fqdn, name_len);
+        rp += name_len;
+
+        SAFEALIGN_COPY_UINT32(&val, &body[rp], &rp);
+        assert_int_equal(val, key_len[c]);
+
+        assert_memory_equal(body + rp, key[c], key_len[c]);
+        rp += key_len[c];
+    }
+
+    assert_int_equal(rp, blen);
+
+    return EOK;
+}
+
 void test_ssh_user_pubkey_cert(void **state)
 {
     int ret;
@@ -594,6 +648,184 @@ void test_ssh_user_pubkey_cert(void **state)
     assert_int_equal(ret, EOK);
 }
 
+struct certmap_info rule_1 = {
+                            discard_const("rule1"), -1,
+                            discard_const("<SUBJECT>CN=SSSD test cert 0001,.*"),
+                            NULL, NULL };
+struct certmap_info rule_2 = {
+                            discard_const("rule2"), -1,
+                            discard_const("<SUBJECT>CN=SSSD test cert 0002,.*"),
+                            NULL, NULL };
+
+void test_ssh_user_pubkey_cert_with_rule(void **state)
+{
+    int ret;
+    struct sysdb_attrs *attrs;
+    /* Both rules are enabled, both certificates should be handled. */
+    struct certmap_info *certmap_list[] = { &rule_1, &rule_2, NULL};
+
+    attrs = sysdb_new_attrs(ssh_test_ctx);
+    assert_non_null(attrs);
+    ret = sysdb_attrs_add_string(attrs, SYSDB_SSH_PUBKEY, TEST_SSH_PUBKEY);
+    assert_int_equal(ret, EOK);
+    ret = sysdb_attrs_add_base64_blob(attrs, SYSDB_USER_CERT,
+                                      SSSD_TEST_CERT_0001);
+    assert_int_equal(ret, EOK);
+    ret = sysdb_attrs_add_base64_blob(attrs, SYSDB_USER_CERT,
+                                      SSSD_TEST_CERT_0002);
+    assert_int_equal(ret, EOK);
+
+    ret = sysdb_set_user_attr(ssh_test_ctx->tctx->dom,
+                              ssh_test_ctx->ssh_user_fqdn,
+                              attrs,
+                              LDB_FLAG_MOD_ADD);
+    talloc_free(attrs);
+    assert_int_equal(ret, EOK);
+
+    mock_input_user(ssh_test_ctx, ssh_test_ctx->ssh_user_fqdn);
+    will_return(__wrap_sss_packet_get_cmd, SSS_SSH_GET_USER_PUBKEYS);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+
+    /* Enable certificate support */
+    ssh_test_ctx->ssh_ctx->use_cert_keys = true;
+    ssh_test_ctx->ssh_ctx->rctx->domains->certmaps = certmap_list;
+    ssh_test_ctx->ssh_ctx->certmap_last_read = 0;
+    ssh_test_ctx->ssh_ctx->rctx->get_domains_last_call.tv_sec = 1;
+#ifdef HAVE_NSS
+    ssh_test_ctx->ssh_ctx->ca_db = discard_const("sql:" ABS_BUILD_DIR
+                                                "/src/tests/test_CA/p11_nssdb");
+#else
+    ssh_test_ctx->ssh_ctx->ca_db = discard_const(ABS_BUILD_DIR
+                                                "/src/tests/test_CA/SSSD_test_CA.pem");
+#endif
+
+    set_cmd_cb(test_ssh_user_pubkey_cert_check);
+    ret = sss_cmd_execute(ssh_test_ctx->cctx, SSS_SSH_GET_USER_PUBKEYS,
+                          ssh_test_ctx->ssh_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(ssh_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+}
+
+void test_ssh_user_pubkey_cert_with_unknow_rule_name(void **state)
+{
+    int ret;
+    struct sysdb_attrs *attrs;
+    /* No rule is enabled because the unknown rule name "none" is used, both
+     * certificates should be handled. */
+    const char *rule_list[] = { "none", NULL };
+    struct certmap_info *certmap_list[] = { &rule_1, &rule_2, NULL};
+
+    attrs = sysdb_new_attrs(ssh_test_ctx);
+    assert_non_null(attrs);
+    ret = sysdb_attrs_add_string(attrs, SYSDB_SSH_PUBKEY, TEST_SSH_PUBKEY);
+    assert_int_equal(ret, EOK);
+    ret = sysdb_attrs_add_base64_blob(attrs, SYSDB_USER_CERT,
+                                      SSSD_TEST_CERT_0001);
+    assert_int_equal(ret, EOK);
+    ret = sysdb_attrs_add_base64_blob(attrs, SYSDB_USER_CERT,
+                                      SSSD_TEST_CERT_0002);
+    assert_int_equal(ret, EOK);
+
+    ret = sysdb_set_user_attr(ssh_test_ctx->tctx->dom,
+                              ssh_test_ctx->ssh_user_fqdn,
+                              attrs,
+                              LDB_FLAG_MOD_ADD);
+    talloc_free(attrs);
+    assert_int_equal(ret, EOK);
+
+    mock_input_user(ssh_test_ctx, ssh_test_ctx->ssh_user_fqdn);
+    will_return(__wrap_sss_packet_get_cmd, SSS_SSH_GET_USER_PUBKEYS);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+
+    /* Enable certificate support */
+    ssh_test_ctx->ssh_ctx->use_cert_keys = true;
+    ssh_test_ctx->ssh_ctx->rctx->domains->certmaps = certmap_list;
+    ssh_test_ctx->ssh_ctx->certmap_last_read = 0;
+    ssh_test_ctx->ssh_ctx->rctx->get_domains_last_call.tv_sec = 1;
+    ssh_test_ctx->ssh_ctx->cert_rules = discard_const(rule_list);
+#ifdef HAVE_NSS
+    ssh_test_ctx->ssh_ctx->ca_db = discard_const("sql:" ABS_BUILD_DIR
+                                                "/src/tests/test_CA/p11_nssdb");
+#else
+    ssh_test_ctx->ssh_ctx->ca_db = discard_const(ABS_BUILD_DIR
+                                                "/src/tests/test_CA/SSSD_test_CA.pem");
+#endif
+
+    set_cmd_cb(test_ssh_user_pubkey_cert_check);
+    ret = sss_cmd_execute(ssh_test_ctx->cctx, SSS_SSH_GET_USER_PUBKEYS,
+                          ssh_test_ctx->ssh_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(ssh_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+}
+
+void test_ssh_user_pubkey_cert_with_rule_1(void **state)
+{
+    int ret;
+    struct sysdb_attrs *attrs;
+    /* Only "rule1" is selected, only certificate 1 should be handled. */
+    const char *rule_list[] = { "rule1", NULL };
+    struct certmap_info *certmap_list[] = { &rule_1, &rule_2, NULL};
+
+    attrs = sysdb_new_attrs(ssh_test_ctx);
+    assert_non_null(attrs);
+    ret = sysdb_attrs_add_string(attrs, SYSDB_SSH_PUBKEY, TEST_SSH_PUBKEY);
+    assert_int_equal(ret, EOK);
+    ret = sysdb_attrs_add_base64_blob(attrs, SYSDB_USER_CERT,
+                                      SSSD_TEST_CERT_0001);
+    assert_int_equal(ret, EOK);
+    ret = sysdb_attrs_add_base64_blob(attrs, SYSDB_USER_CERT,
+                                      SSSD_TEST_CERT_0002);
+    assert_int_equal(ret, EOK);
+
+    ret = sysdb_set_user_attr(ssh_test_ctx->tctx->dom,
+                              ssh_test_ctx->ssh_user_fqdn,
+                              attrs,
+                              LDB_FLAG_MOD_ADD);
+    talloc_free(attrs);
+    assert_int_equal(ret, EOK);
+
+    mock_input_user(ssh_test_ctx, ssh_test_ctx->ssh_user_fqdn);
+    will_return(__wrap_sss_packet_get_cmd, SSS_SSH_GET_USER_PUBKEYS);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
+
+    /* Enable certificate support */
+    ssh_test_ctx->ssh_ctx->use_cert_keys = true;
+    ssh_test_ctx->ssh_ctx->rctx->domains->certmaps = certmap_list;
+    ssh_test_ctx->ssh_ctx->certmap_last_read = 0;
+    ssh_test_ctx->ssh_ctx->rctx->get_domains_last_call.tv_sec = 1;
+    ssh_test_ctx->ssh_ctx->cert_rules = discard_const(rule_list);
+#ifdef HAVE_NSS
+    ssh_test_ctx->ssh_ctx->ca_db = discard_const("sql:" ABS_BUILD_DIR
+                                                "/src/tests/test_CA/p11_nssdb");
+#else
+    ssh_test_ctx->ssh_ctx->ca_db = discard_const(ABS_BUILD_DIR
+                                                "/src/tests/test_CA/SSSD_test_CA.pem");
+#endif
+
+    set_cmd_cb(test_ssh_user_pubkey_cert_1_check);
+    ret = sss_cmd_execute(ssh_test_ctx->cctx, SSS_SSH_GET_USER_PUBKEYS,
+                          ssh_test_ctx->ssh_cmds);
+    assert_int_equal(ret, EOK);
+
+    /* Wait until the test finishes with EOK */
+    ret = test_ev_loop(ssh_test_ctx->tctx);
+    assert_int_equal(ret, EOK);
+}
+
 int main(int argc, const char *argv[])
 {
     int rv;
@@ -617,6 +849,12 @@ int main(int argc, const char *argv[])
         cmocka_unit_test_setup_teardown(test_ssh_user_pubkey_cert_disabled,
                                         ssh_test_setup, ssh_test_teardown),
         cmocka_unit_test_setup_teardown(test_ssh_user_pubkey_cert,
+                                        ssh_test_setup, ssh_test_teardown),
+        cmocka_unit_test_setup_teardown(test_ssh_user_pubkey_cert_with_rule,
+                                        ssh_test_setup, ssh_test_teardown),
+        cmocka_unit_test_setup_teardown(test_ssh_user_pubkey_cert_with_unknow_rule_name,
+                                        ssh_test_setup, ssh_test_teardown),
+        cmocka_unit_test_setup_teardown(test_ssh_user_pubkey_cert_with_rule_1,
                                         ssh_test_setup, ssh_test_teardown),
 #endif
     };

--- a/src/util/cert.h
+++ b/src/util/cert.h
@@ -56,6 +56,7 @@ struct tevent_req *cert_to_ssh_key_send(TALLOC_CTX *mem_ctx,
                                         struct tevent_context *ev,
                                         int child_debug_fd, time_t timeout,
                                         const char *ca_db,
+                                        struct sss_certmap_ctx *sss_certmap_ctx,
                                         size_t cert_count,
                                         struct ldb_val *bin_certs,
                                         const char *verify_opts);


### PR DESCRIPTION
Use available certificate matching rules to select certificates to derive
ssh-keys.

Related to https://pagure.io/SSSD/sssd/issue/4121