### PR TITLE
sysdb_sudo: Enable LDAP time format compatibility

### DIFF
--- a/src/db/sysdb_sudo.c
+++ b/src/db/sysdb_sudo.c
@@ -55,6 +55,22 @@ static errno_t sysdb_sudo_convert_time(const char *str, time_t *unix_time)
                              "%Y%m%d%H%M%S.0%z",
                              "%Y%m%d%H%M%S,0Z",
                              "%Y%m%d%H%M%S,0%z",
+                             /* LDAP specification says that minutes and seconds
+                                might be omitted and in that case these are meant
+                                to be treated as zeros [1].
+                             */
+                             "%Y%m%d%H%MZ",    /* Discard seconds */
+                             "%Y%m%d%H%M%z",
+                             "%Y%m%d%H%M.0Z",
+                             "%Y%m%d%H%M.0%z",
+                             "%Y%m%d%H%M,0Z",
+                             "%Y%m%d%H%M,0%z",
+                             "%Y%m%d%HZ",    /* Discard minutes and seconds*/
+                             "%Y%m%d%H%z",
+                             "%Y%m%d%H.0Z",
+                             "%Y%m%d%H.0%z",
+                             "%Y%m%d%H,0Z",
+                             "%Y%m%d%H,0%z",
                              NULL};
 
     for (format = formats; *format != NULL; format++) {


### PR DESCRIPTION
LDAP specification allows to ommit seconds and minutes
in time border definition. In that case they defaults to zeros.
Current sssd.sudo implementation requires precision up to
seconds in time definition. This commit allows to lower
the precision up to hours.

Resolves:
https://pagure.io/SSSD/sssd/issue/4118