### PR TITLE
INI: sssctl config-check command error messages

### DIFF
--- a/src/util/sss_ini.c
+++ b/src/util/sss_ini.c
@@ -865,6 +865,7 @@ int sss_ini_read_sssd_conf(struct sss_ini *self,
 
     ret = sss_ini_parse(self);
     if (ret != EOK) {
+        sss_ini_config_print_errors(self->error_list);
         DEBUG(SSSDBG_FATAL_FAILURE, "Failed to parse configuration.\n");
         return ERR_INI_PARSE_FAILED;
     }


### PR DESCRIPTION
In case of parsing error sssctl config-check command does not give
proper error messages with line number. With this patch the error
message is printed again.

Resolves:
https://pagure.io/SSSD/sssd/issue/4129