### PR TITLE
nss: use real primary gid if the value is overriden (sssd-1-16)

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -208,6 +208,7 @@
 
 #define SYSDB_GRNAM_FILTER "(&("SYSDB_GC")(|("SYSDB_NAME_ALIAS"=%s)("SYSDB_NAME_ALIAS"=%s)("SYSDB_NAME"=%s)))"
 #define SYSDB_GRGID_FILTER "(&("SYSDB_GC")("SYSDB_GIDNUM"=%lu))"
+#define SYSDB_GRORIGGID_FILTER "(&("SYSDB_GC")("ORIGINALAD_PREFIX SYSDB_GIDNUM"=%lu))"
 #define SYSDB_GRSID_FILTER "(&("SYSDB_GC")("SYSDB_SID_STR"=%s))"
 #define SYSDB_GRENT_FILTER "("SYSDB_GC")"
 #define SYSDB_GRNAM_MPG_FILTER "(&("SYSDB_MPGC")(|("SYSDB_NAME_ALIAS"=%s)("SYSDB_NAME_ALIAS"=%s)("SYSDB_NAME"=%s)))"
@@ -973,6 +974,12 @@ int sysdb_search_group_by_gid(TALLOC_CTX *mem_ctx,
                               gid_t gid,
                               const char **attrs,
                               struct ldb_message **msg);
+
+int sysdb_search_group_by_origgid(TALLOC_CTX *mem_ctx,
+                                  struct sss_domain_info *domain,
+                                  gid_t gid,
+                                  const char **attrs,
+                                  struct ldb_message **msg);
 
 int sysdb_search_group_by_sid_str(TALLOC_CTX *mem_ctx,
                                   struct sss_domain_info *domain,

--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -763,14 +763,13 @@ int sysdb_search_group_by_name(TALLOC_CTX *mem_ctx,
     return sysdb_search_by_name(mem_ctx, domain, name, SYSDB_GROUP, attrs, msg);
 }
 
-/* Please note that sysdb_search_group_by_gid() is not aware of MPGs. If MPG
- * support is needed either the caller must handle it or sysdb_getgrgid() or
- * sysdb_getgrgid_attrs() should be used. */
-int sysdb_search_group_by_gid(TALLOC_CTX *mem_ctx,
-                              struct sss_domain_info *domain,
-                              gid_t gid,
-                              const char **attrs,
-                              struct ldb_message **msg)
+static int
+sysdb_search_group_by_id(TALLOC_CTX *mem_ctx,
+                         struct sss_domain_info *domain,
+                         const char *filterfmt,
+                         gid_t gid,
+                         const char **attrs,
+                         struct ldb_message **msg)
 {
     TALLOC_CTX *tmp_ctx;
     const char *def_attrs[] = { SYSDB_NAME, SYSDB_GIDNUM, NULL };
@@ -791,7 +790,7 @@ int sysdb_search_group_by_gid(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    filter = talloc_asprintf(tmp_ctx, SYSDB_GRGID_FILTER, (unsigned long)gid);
+    filter = talloc_asprintf(tmp_ctx, filterfmt, (unsigned long)gid);
     if (!filter) {
         ret = ENOMEM;
         goto done;
@@ -820,6 +819,29 @@ done:
 
     talloc_zfree(tmp_ctx);
     return ret;
+}
+
+/* Please note that sysdb_search_group_by_gid() is not aware of MPGs. If MPG
+ * support is needed either the caller must handle it or sysdb_getgrgid() or
+ * sysdb_getgrgid_attrs() should be used. */
+int sysdb_search_group_by_gid(TALLOC_CTX *mem_ctx,
+                              struct sss_domain_info *domain,
+                              gid_t gid,
+                              const char **attrs,
+                              struct ldb_message **msg)
+{
+    return sysdb_search_group_by_id(mem_ctx, domain, SYSDB_GRGID_FILTER,
+                                    gid, attrs, msg);
+}
+
+int sysdb_search_group_by_origgid(TALLOC_CTX *mem_ctx,
+                                  struct sss_domain_info *domain,
+                                  gid_t gid,
+                                  const char **attrs,
+                                  struct ldb_message **msg)
+{
+    return sysdb_search_group_by_id(mem_ctx, domain, SYSDB_GRORIGGID_FILTER,
+                                    gid, attrs, msg);
 }
 
 int sysdb_search_group_by_sid_str(TALLOC_CTX *mem_ctx,


### PR DESCRIPTION
SYSDB_PRIMARY_GROUP_GIDNUM contains original primary group id from AD
because any possible override may not be known at the time of storing
the user.

Now we try to lookup group by its originalADgidNumber and if it is found
we will replace the original id with real primary group id.

Steps to reproduce:
1. Enroll SSSD to IPA domain with AD trust
2. Add ID override to Domain Users `ipa idoverridegroup-add 'Default Trust View' "Domain Users@ad.vm" --gid=40000000`
3. On IPA server: Remove cache for the overrides to apply immediately and restart SSSD `sssctl cache-remove --stop --start`
4. On IPA server: Resolve user `id Administrator@ad.vm`

There will be visible both new and old gids without the patch.

Resolves:
https://pagure.io/SSSD/sssd/issue/4124

Reviewed-by: Sumit Bose <sbose@redhat.com>
(cherry picked from commit 03bc96247cbd567ad11a4c693c1d90580f903bb7)