### PR TITLE
util/watchdog: fixed watchdog implementation

### DIFF
--- a/src/util/util_watchdog.c
+++ b/src/util/util_watchdog.c
@@ -54,9 +54,8 @@ static void watchdog_detect_timeshift(void)
         if (write(watchdog_ctx.pipefd[1], "1", 1) != 1) {
             if (getpid() == getpgrp()) {
                 kill(-getpgrp(), SIGTERM);
-            } else {
-                _exit(1);
             }
+            _exit(1);
         }
     }
 }
@@ -75,9 +74,8 @@ static void watchdog_handler(int sig)
     if (__sync_add_and_fetch(&watchdog_ctx.ticks, 1) > WATCHDOG_MAX_TICKS) {
         if (getpid() == getpgrp()) {
             kill(-getpgrp(), SIGTERM);
-        } else {
-            _exit(1);
         }
+        _exit(1);
     }
 }
 


### PR DESCRIPTION
In case watchdog detected locked process and this process was parent
process it just sent SIGTERM to the whole group of processes, including
itself.
This handling was wrong: generic `server_setup()` installs custom
libtevent handler for SIGTERM signal so this signal is only processed
in the context of tevent mainloop. But if tevent mainloop is stuck
(exactly the case that triggers WD) then event is not processed
and this made watchdog useless.
`watchdog_handler()` and `watchdog_detect_timeshift()` were amended to do
unconditional `_exit()` after optionally sending a signal to the group.

Resolves: https://pagure.io/SSSD/sssd/issue/4089