### PR TITLE
certmap: mention special regex characters in man page

### DIFF
--- a/src/man/sss-certmap.5.xml
+++ b/src/man/sss-certmap.5.xml
@@ -92,6 +92,15 @@
                     <para>
                         Example: &lt;SUBJECT&gt;.*,DC=MY,DC=DOMAIN
                     </para>
+                    <para>
+                        Please note that the characters "^.[$()|*+?{\" have a
+                        special meaning in regular expressions and must be
+                        escaped with the help of the '\' character so that they
+                        are matched as ordinary characters.
+                    </para>
+                    <para>
+                        Example: &lt;SUBJECT&gt;^CN=.* \(Admin\),DC=MY,DC=DOMAIN$
+                    </para>
                     </listitem>
                 </varlistentry>
                 <varlistentry>


### PR DESCRIPTION
Since some of the matching rules use regular expressions some characters
must be escaped so that they can be used a ordinary characters in the
rules.

Related to https://pagure.io/SSSD/sssd/issue/4127