### PR TITLE
[wip] ad gpo: use ndr_pull_steal_switch_value

### DIFF
--- a/src/external/samba.m4
+++ b/src/external/samba.m4
@@ -143,3 +143,14 @@ AC_CHECK_MEMBERS([struct PAC_LOGON_INFO.resource_groups], , ,
                     #include <gen_ndr/krb5pac.h>
                     #include <gen_ndr/krb5pac.h>]])
 CFLAGS=$SAVE_CFLAGS
+
+PKG_CHECK_MODULES([NDR],[ndr])
+if test x$has_ndr != xno; then
+    SAFE_LIBS="$LIBS"
+    LIBS="$NDR_LIBS"
+
+    AC_CHECK_FUNC([ndr_pull_get_switch_value],
+                  AC_DEFINE([HAVE_NDR_PULL_GET_SWITCH_VALUE], [1],
+                            [Define if ndr_pull_get_switch_value exists]))
+    LIBS="$SAFE_LIBS"
+fi

--- a/src/providers/ad/ad_gpo_ndr.c
+++ b/src/providers/ad/ad_gpo_ndr.c
@@ -105,7 +105,11 @@ ndr_pull_security_ace_object_type(struct ndr_pull *ndr,
                                   union security_ace_object_type *r)
 {
     uint32_t level;
+#ifdef HAVE_NDR_PULL_GET_SWITCH_VALUE
     level = ndr_pull_get_switch_value(ndr, r);
+#else
+    NDR_CHECK(ndr_pull_steal_switch_value(ndr, r, &level));
+#endif
     NDR_PULL_CHECK_FLAGS(ndr, ndr_flags);
     if (ndr_flags & NDR_SCALARS) {
         NDR_CHECK(ndr_pull_union_align(ndr, 4));
@@ -135,7 +139,11 @@ ndr_pull_security_ace_object_inherited_type(struct ndr_pull *ndr,
                                             union security_ace_object_inherited_type *r)
 {
     uint32_t level;
+#ifdef HAVE_NDR_PULL_GET_SWITCH_VALUE
     level = ndr_pull_get_switch_value(ndr, r);
+#else
+    NDR_CHECK(ndr_pull_steal_switch_value(ndr, r, &level));
+#endif
     NDR_PULL_CHECK_FLAGS(ndr, ndr_flags);
     if (ndr_flags & NDR_SCALARS) {
         NDR_CHECK(ndr_pull_union_align(ndr, 4));
@@ -198,7 +206,11 @@ ndr_pull_security_ace_object_ctr(struct ndr_pull *ndr,
                                  union security_ace_object_ctr *r)
 {
     uint32_t level;
+#ifdef HAVE_NDR_PULL_GET_SWITCH_VALUE
     level = ndr_pull_get_switch_value(ndr, r);
+#else
+    NDR_CHECK(ndr_pull_steal_switch_value(ndr, r, &level));
+#endif
     NDR_PULL_CHECK_FLAGS(ndr, ndr_flags);
     if (ndr_flags & NDR_SCALARS) {
         NDR_CHECK(ndr_pull_union_align(ndr, 4));


### PR DESCRIPTION
Newest samba (samba-devel-4.12.0-0.0.rc1) removed `ndr_pull_get_switch_value` [1].
This function is replaced with `ndr_pull_steal_switch_value` in samba code [2].
Because it also changed the signature of `ndr_pull_steal_switch_value` we need
to keep using `ndr_pull_get_switch_value` in older systems [3].

[1] https://gitlab.com/samba-team/samba/commit/9018c7f112c105fb37fb18109b7fe93b4b7666fe
[2] https://gitlab.com/samba-team/samba/commit/e5162a4d1cff265ac1425e71f4833a7fff093b2a
[3] https://gitlab.com/samba-team/samba/commit/263269ba6f75a36676546823b0be1bddd6958307