### PR TITLE
Remove redundant header file inclusion

### DIFF
--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -31,7 +31,6 @@
 #ifdef HAVE_SYS_INOTIFY_H
 #include <sys/inotify.h>
 #endif
-#include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <fcntl.h>

--- a/src/providers/ipa/ipa_netgroups.c
+++ b/src/providers/ipa/ipa_netgroups.c
@@ -26,7 +26,6 @@
 #include "db/sysdb.h"
 #include "providers/ldap/sdap_async_private.h"
 #include "providers/ipa/ipa_id.h"
-#include "db/sysdb.h"
 #include <ctype.h>
 
 #define ENTITY_NG 1

--- a/src/responder/common/cache_req/cache_req.c
+++ b/src/responder/common/cache_req/cache_req.c
@@ -26,7 +26,6 @@
 #include "util/util.h"
 #include "responder/common/responder.h"
 #include "responder/common/cache_req/cache_req_private.h"
-#include "responder/common/cache_req/cache_req_private.h"
 #include "responder/common/cache_req/cache_req_plugin.h"
 
 static const struct cache_req_plugin *

--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -32,7 +32,6 @@
 #include "responder/pam/pamsrv.h"
 #include "responder/pam/pam_helpers.h"
 #include "responder/common/cache_req/cache_req.h"
-#include "db/sysdb.h"
 
 enum pam_verbosity {
     PAM_VERBOSITY_NO_MESSAGES = 0,

--- a/src/sss_client/sss_pac_responder_client.c
+++ b/src/sss_client/sss_pac_responder_client.c
@@ -24,7 +24,6 @@
 #include <sys/types.h>
 #include <errno.h>
 
-#include <unistd.h>
 #include <sys/syscall.h>
 
 #include "sss_client/sss_cli.h"

--- a/src/tests/cmocka/test_negcache.c
+++ b/src/tests/cmocka/test_negcache.c
@@ -38,7 +38,6 @@
 #include "util/util_sss_idmap.h"
 #include "lib/idmap/sss_idmap.h"
 #include "util/util.h"
-#include "util/util_sss_idmap.h"
 #include "db/sysdb_private.h"
 #include "responder/common/responder.h"
 #include "responder/common/negcache.h"

--- a/src/tools/sssctl/sssctl_logs.c
+++ b/src/tools/sssctl/sssctl_logs.c
@@ -31,7 +31,6 @@
 #include <ldb.h>
 #include <popt.h>
 #include <stdio.h>
-#include <signal.h>
 
 #include "util/util.h"
 #include "tools/common/sss_process.h"

--- a/src/util/usertools.c
+++ b/src/util/usertools.c
@@ -22,7 +22,6 @@
 #include <pwd.h>
 #include <errno.h>
 #include <talloc.h>
-#include <pwd.h>
 #include <grp.h>
 
 #include "db/sysdb.h"


### PR DESCRIPTION
There are some source code including the same header file redundantly.
We remove these redundant header file inclusion.