### PR TITLE
monitor: Fix check process about multiple starts of sssd when pidfile…

### DIFF
--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -2509,10 +2509,13 @@ int main(int argc, const char *argv[])
     if (opt_genconf == 0) {
         ret = check_file(SSSD_PIDFILE, 0, 0, S_IFREG|0600, 0, NULL, false);
         if (ret == EOK) {
-            DEBUG(SSSDBG_FATAL_FAILURE,
-                "pidfile exists at %s\n", SSSD_PIDFILE);
-            ERROR("SSSD is already running\n");
-            return 2;
+            ret = check_pidfile(SSSD_PIDFILE);
+            if (ret != EOK) {
+                DEBUG(SSSDBG_FATAL_FAILURE,
+                    "pidfile exists at %s\n", SSSD_PIDFILE);
+                ERROR("SSSD is already running\n");
+                return 2;
+            }
         }
 
         /* Warn if nscd seems to be running */

--- a/src/util/server.c
+++ b/src/util/server.c
@@ -136,15 +136,13 @@ static void become_daemon(void)
     close_low_fds();
 }
 
-int pidfile(const char *file)
+int check_pidfile(const char *file)
 {
     char pid_str[32];
     pid_t pid;
     int fd;
     int ret, err;
     ssize_t len;
-    size_t size;
-    ssize_t written;
     ssize_t pidlen = sizeof(pid_str) - 1;
 
     fd = open(file, O_RDONLY, 0644);
@@ -191,6 +189,22 @@ int pidfile(const char *file)
         if (err != ENOENT) {
             return err;
         }
+    }
+
+    return 0;
+}
+
+int pidfile(const char *file)
+{
+    char pid_str[32];
+    int fd;
+    int ret, err;
+    size_t size;
+    ssize_t written;
+
+    ret = check_pidfile(file);
+    if (ret != EOK) {
+        return ret;
     }
 
     fd = open(file, O_CREAT | O_WRONLY | O_EXCL, 0644);

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -183,6 +183,7 @@ struct main_context {
 errno_t server_common_rotate_logs(struct confdb_ctx *confdb,
                                   const char *conf_entry);
 int die_if_parent_died(void);
+int check_pidfile(const char *file);
 int pidfile(const char *file);
 int server_setup(const char *name, int flags,
                  uid_t uid, gid_t gid,


### PR DESCRIPTION
… remains

If PIDFile is invalid in sssd.service, pidfile remains if sssd terminates abnormally.
Also, if /var/run is not tmpfs, the pidfile will remain when the OS is forcibly stopped.

In check process about multiple starts of sssd, only the existence of pidfile is checked.
Fix not only to check if pidfile exists, but also to check if PID exists.