### PR TITLE
sss_sockets: pass pointer instead of integer

### DIFF
--- a/src/util/sss_sockets.c
+++ b/src/util/sss_sockets.c
@@ -120,7 +120,7 @@ static errno_t set_fd_common_opts(int fd, int timeout)
         }
 
         milli = timeout * 1000; /* timeout in milliseconds */
-        ret = setsockopt(fd, IPPROTO_TCP, TCP_USER_TIMEOUT, milli,
+        ret = setsockopt(fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &milli,
                          sizeof(milli));
         if (ret != 0) {
             ret = errno;


### PR DESCRIPTION
```
/home/pbrezina/workspace/sssd/src/util/sss_sockets.c: In function ‘set_fd_common_opts’:
/home/pbrezina/workspace/sssd/src/util/sss_sockets.c:123:61: error: passing argument 4 of ‘setsockopt’ makes pointer from integer without a cast [-Werror=int-conversion]
  123 |         ret = setsockopt(fd, IPPROTO_TCP, TCP_USER_TIMEOUT, milli,
      |                                                             ^~~~~
      |                                                             |
      |                                                             unsigned int
In file included from /home/pbrezina/workspace/sssd/src/util/sss_sockets.c:28:
/usr/include/sys/socket.h:216:22: note: expected ‘const void *’ but argument is of type ‘unsigned int’
  216 |          const void *__optval, socklen_t __optlen) __THROW;
      |          ~~~~~~~~~~~~^~~~~~~~
  CC       src/util/sssd_kcm-sss_iobuf.o
cc1: all warnings being treated as errors
```

Introduced by 7aa96458f3bec4ef6ff7385107458e6b2b0b06ac