### PR TITLE
man: fix typos

### DIFF
--- a/src/man/sssd-krb5.5.xml
+++ b/src/man/sssd-krb5.5.xml
@@ -46,7 +46,7 @@
         <para>
             This backend also provides access control based on the .k5login
             file in the home directory of the user. See <citerefentry>
-            <refentrytitle>.k5login</refentrytitle><manvolnum>5</manvolnum>
+            <refentrytitle>k5login</refentrytitle><manvolnum>5</manvolnum>
             </citerefentry> for more details. Please note that an empty .k5login
             file will deny all access to this user. To activate this feature,
             use 'access_provider = krb5' in your SSSD configuration.

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -314,7 +314,7 @@
                             </para>
                             <para>
                                 Each domain can have an individual format string configured.
-                                see DOMAIN SECTIONS for more info on this option.
+                                See DOMAIN SECTIONS for more info on this option.
                             </para>
                         </listitem>
                     </varlistentry>
@@ -1599,7 +1599,7 @@ pam_p11_allowed_services = +my_pam_service, -login
                         <para>
                             Example:
                             <programlisting>
-p11_uri = slot-description=My%20Smartcar%20Reader
+p11_uri = slot-description=My%20Smartcard%20Reader
                             </programlisting>
                             or
                             <programlisting>


### PR DESCRIPTION
 - add whitespace between words
 - correct manpage reference
 - correct wrong word
 - capitalize the first letter