### PR TITLE
config: allowed auto_private_groups in child domains

### DIFF
--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -771,6 +771,7 @@ option = ad_server
 option = ad_backup_server
 option = ad_site
 option = use_fully_qualified_names
+option = auto_private_groups
 
 [rule/sssd_checks]
 validator = sssd_checks


### PR DESCRIPTION
sssctl config-check failed if auto_private_groups was enabled/disabled in child domains

Resolves:
https://pagure.io/SSSD/sssd/issue/4161