### PR TITLE
ci: keep system list outside repository

### DIFF
--- a/contrib/ci/run
+++ b/contrib/ci/run
@@ -172,7 +172,6 @@ function mock_privileged_conf()
     trap 'trap - RETURN; rm -R "$conf_dir";' RETURN
     # Preserve timestamps to avoid unnecessary cache rebuilds
     cp -r --preserve=timestamps /etc/mock/* "$conf_dir"/
-    cat >> "${conf_dir}/${chroot}.cfg"
     touch --reference="/etc/mock/${chroot}.cfg" "${conf_dir}/${chroot}.cfg"
     mock_privileged --configdir="$conf_dir" --root="$chroot" "$@"
 }
@@ -195,16 +194,7 @@ function mock_privileged_deps()
         exit 1
     fi
 
-    mock_privileged_conf "$chroot" "$@" <<<"
-config_opts['yum.conf'] += '''
-[sssd-deps]
-name=Extra SSSD dependencies
-baseurl=http://copr-be.cloud.fedoraproject.org/results/lslebodn/sssd-deps/$repo/
-skip_if_unavailable=true
-gpgcheck=0
-enabled=1
-'''
-"
+    mock_privileged_conf "$chroot" "$@"
 }
 
 # Run debug build checks.


### PR DESCRIPTION
This way we do not need to push new commit to repository every time
when we change the list of distribution we test on and changes
will be immediately picked up by opened pull request without the
need to rebase them.

It will also help us to temporarily disable particular distribution
when there are errors that we can not fix (e.g. current rawhide issue)
so we can still have all green results.