### PR TITLE
Two fixes for wait-for-card feature

### DIFF
--- a/src/p11_child/p11_child_openssl.c
+++ b/src/p11_child/p11_child_openssl.c
@@ -1546,35 +1546,38 @@ static errno_t wait_for_card(CK_FUNCTION_LIST *module, CK_SLOT_ID *slot_id)
     CK_RV rv;
     CK_SLOT_INFO info;
 
-    rv = module->C_WaitForSlotEvent(wait_flags, slot_id, NULL);
-    if (rv != CKR_OK) {
-        if (rv != CKR_FUNCTION_NOT_SUPPORTED) {
+    do {
+        rv = module->C_WaitForSlotEvent(wait_flags, slot_id, NULL);
+        if (rv != CKR_OK && rv != CKR_FUNCTION_NOT_SUPPORTED) {
             DEBUG(SSSDBG_OP_FAILURE,
                   "C_WaitForSlotEvent failed [%lu][%s].\n",
                   rv, p11_kit_strerror(rv));
             return EIO;
         }
 
-        /* Poor man's wait */
-        do {
+        if (rv == CKR_FUNCTION_NOT_SUPPORTED) {
+            /* Poor man's wait */
             sleep(10);
-            rv = module->C_GetSlotInfo(*slot_id, &info);
-            if (rv != CKR_OK) {
-                DEBUG(SSSDBG_OP_FAILURE, "C_GetSlotInfo failed\n");
-                return EIO;
-            }
-            DEBUG(SSSDBG_TRACE_ALL,
-                  "Description [%s] Manufacturer [%s] flags [%lu] "
-                  "removable [%s] token present [%s].\n",
-                  info.slotDescription, info.manufacturerID, info.flags,
-                  (info.flags & CKF_REMOVABLE_DEVICE) ? "true": "false",
-                  (info.flags & CKF_TOKEN_PRESENT) ? "true": "false");
-            if ((info.flags & CKF_REMOVABLE_DEVICE)
-                    && (info.flags & CKF_TOKEN_PRESENT)) {
-                break;
-            }
-        } while (true);
-    }
+        }
+
+        rv = module->C_GetSlotInfo(*slot_id, &info);
+        if (rv != CKR_OK) {
+            DEBUG(SSSDBG_OP_FAILURE, "C_GetSlotInfo failed\n");
+            return EIO;
+        }
+        DEBUG(SSSDBG_TRACE_ALL,
+              "Description [%s] Manufacturer [%s] flags [%lu] "
+              "removable [%s] token present [%s].\n",
+              info.slotDescription, info.manufacturerID, info.flags,
+              (info.flags & CKF_REMOVABLE_DEVICE) ? "true": "false",
+              (info.flags & CKF_TOKEN_PRESENT) ? "true": "false");
+
+        /* Check if really a token is present */
+        if ((info.flags & CKF_REMOVABLE_DEVICE)
+                && (info.flags & CKF_TOKEN_PRESENT)) {
+            break;
+        }
+    } while (true);
 
     return EOK;
 }

--- a/src/sss_client/common.c
+++ b/src/sss_client/common.c
@@ -910,8 +910,8 @@ int sss_pam_make_request(enum sss_cli_command cmd,
         goto out;
     }
 
-    /* only root shall use the privileged pipe */
-    if (getuid() == 0 && getgid() == 0) {
+    /* only UID 0 shall use the privileged pipe */
+    if (getuid() == 0) {
         socket_name = SSS_PAM_PRIV_SOCKET_NAME;
         errno = 0;
         statret = stat(socket_name, &stat_buf);


### PR DESCRIPTION
Some privileged services like e.g. might only call with UID 0 but with a
different GID. This patch removes the GID 0 requirement to access to
private PAM socket so that e.g. gdm can use the wait-for-card option.

Some implementations of C_WaitForSlotEvent() might return even if no card
was inserted. So it has to be checked if a card is really present.

Resolves: https://pagure.io/SSSD/sssd/issue/4159