### PR TITLE
configure: prefer python3 if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -376,7 +376,7 @@ them please use argument --without-python3-bindings when running configure.])])
     SSS_CLEAN_PYTHON_VARIABLES
 fi
 
-if test x$HAVE_PYTHON3_BINDINGS = xyes; then
+if test x$HAVE_PYTHON3 = xyes; then
     PYTHON_EXEC=$PYTHON3
 else
     PYTHON_EXEC=$PYTHON2


### PR DESCRIPTION
We should prefer python3 every time when it is available regardless of
whether python3 binding are generated, otherwise `sbus_generate.sh` fails
in python3 only systems, where sssd is configured with
`--without-python3-bindings` parameter.