### PR TITLE
sssd.spec: Add recommended packages

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -173,6 +173,9 @@ Requires: python3-sssdconfig = %{version}-%{release}
 %else
 Requires: python2-sssdconfig = %{version}-%{release}
 %endif
+%if (0%{?fedora} >= 30 || 0%{?rhel} >= 8)
+Recommends: logrotate
+%endif
 
 %global servicename sssd
 %global sssdstatedir %{_localstatedir}/lib/sss
@@ -375,6 +378,9 @@ Requires: python2-sssdconfig = %{version}-%{release}
 %endif
 %if (0%{?use_systemd} == 0)
 Requires: /sbin/service
+%endif
+%if (0%{?fedora} >= 30 || 0%{?rhel} >= 8)
+Recommends: sssd-dbus
 %endif
 
 %description tools


### PR DESCRIPTION
sssd-dbus is recommended for tools and SSSD's logrotate
support can only be useful with the logrotate package
in place. It makes sense to recommend them.