### PR TITLE
Fix sssd-ldap man page

### DIFF
--- a/src/man/sssd-ldap.5.xml
+++ b/src/man/sssd-ldap.5.xml
@@ -278,6 +278,14 @@
                         <para>
                             Default: password
                         </para>
+                        <para>
+                            See the
+                            <citerefentry>
+                                <refentrytitle>sss_obfuscate</refentrytitle>
+                                <manvolnum>8</manvolnum>
+                            </citerefentry>
+                            manual page for more information.
+                        </para>
                     </listitem>
                 </varlistentry>
 

--- a/src/man/sssd-ldap.5.xml
+++ b/src/man/sssd-ldap.5.xml
@@ -286,7 +286,6 @@
                     <listitem>
                         <para>
                             The authentication token of the default bind DN.
-                            Only clear text passwords are currently supported.
                         </para>
                     </listitem>
                 </varlistentry>


### PR DESCRIPTION
The option 'ldap_default_authtok_type' also accepts non clear text passwords
in the meantime.

Signed-off-by: Thorsten Scherf <tscherf@redhat.com>