### PR TITLE
spec: Do not overwrite /etc/pam.d/sssd-shadowutils on update

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -1067,7 +1067,7 @@ done
 %dir %{_sysconfdir}/rwtab.d
 %config(noreplace) %{_sysconfdir}/rwtab.d/sssd
 %dir %{_datadir}/sssd
-%{_sysconfdir}/pam.d/sssd-shadowutils
+%config(noreplace) %{_sysconfdir}/pam.d/sssd-shadowutils
 %dir %{_libdir}/%{name}/conf
 %{_libdir}/%{name}/conf/sssd.conf
 


### PR DESCRIPTION
We should not overwrite this file when sssd-common is
updated.