### PR TITLE
Mem-cache fixes/improvements

### DIFF
--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -115,6 +115,9 @@
 #define CONFDB_NSS_SHELL_FALLBACK "shell_fallback"
 #define CONFDB_NSS_DEFAULT_SHELL "default_shell"
 #define CONFDB_MEMCACHE_TIMEOUT "memcache_timeout"
+#define CONFDB_NSS_MEMCACHE_SIZE_PASSWD "memcache_size_passwd"
+#define CONFDB_NSS_MEMCACHE_SIZE_GROUP "memcache_size_group"
+#define CONFDB_NSS_MEMCACHE_SIZE_INITGROUPS "memcache_size_initgroups"
 #define CONFDB_NSS_HOMEDIR_SUBSTRING "homedir_substring"
 #define CONFDB_DEFAULT_HOMEDIR_SUBSTRING "/home"
 

--- a/src/config/SSSDConfig/sssdoptions.py
+++ b/src/config/SSSDConfig/sssdoptions.py
@@ -72,6 +72,9 @@ class SSSDOptions(object):
         'shell_fallback': _('If a shell stored in central directory is allowed but not available, use this fallback'),
         'default_shell': _('Shell to use if the provider does not list one'),
         'memcache_timeout': _('How long will be in-memory cache records valid'),
+        'memcache_size_passwd': _('Number of slots in fast in-memory cache for passwd requests'),
+        'memcache_size_group': _('Number of slots in fast in-memory cache for group requests'),
+        'memcache_size_initgroups': _('Number of slots in fast in-memory cache for initgroups requests'),
         'homedir_substring': _('The value of this option will be used in the expansion of the override_homedir option '
                                'if the template contains the format string %H.'),
         'get_domains_timeout': _('Specifies time in seconds for which the list of subdomains will be considered '

--- a/src/config/SSSDConfig/sssdoptions.py
+++ b/src/config/SSSDConfig/sssdoptions.py
@@ -72,9 +72,9 @@ class SSSDOptions(object):
         'shell_fallback': _('If a shell stored in central directory is allowed but not available, use this fallback'),
         'default_shell': _('Shell to use if the provider does not list one'),
         'memcache_timeout': _('How long will be in-memory cache records valid'),
-        'memcache_size_passwd': _('Number of slots in fast in-memory cache for passwd requests'),
-        'memcache_size_group': _('Number of slots in fast in-memory cache for group requests'),
-        'memcache_size_initgroups': _('Number of slots in fast in-memory cache for initgroups requests'),
+        'memcache_size_passwd': _('Size (in megabytes) of the data table allocated inside fast in-memory cache for passwd requests'),
+        'memcache_size_group': _('Size (in megabytes) of the data table allocated inside fast in-memory cache for group requests'),
+        'memcache_size_initgroups': _('Size (in megabytes) of the data table allocated inside fast in-memory cache for initgroups requests'),
         'homedir_substring': _('The value of this option will be used in the expansion of the override_homedir option '
                                'if the template contains the format string %H.'),
         'get_domains_timeout': _('Specifies time in seconds for which the list of subdomains will be considered '

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -92,6 +92,9 @@ option = shell_fallback
 option = default_shell
 option = get_domains_timeout
 option = memcache_timeout
+option = memcache_size_passwd
+option = memcache_size_group
+option = memcache_size_initgroups
 
 [rule/allowed_pam_options]
 validator = ini_allowed_options

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -1101,6 +1101,84 @@ fallback_homedir = /home/%u
                     </listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term>memcache_size_passwd (integer)</term>
+                    <listitem>
+                        <para>
+                            Number of slots allocated inside fast in-memory
+                            cache for passwd requests. Note that one entry
+                            in fast in-memory cache can occupy more than one slot.
+                            Setting the size to 0 will disable the passwd in-memory
+                            cache.
+                        </para>
+                        <para>
+                            Default: 200000
+                        </para>
+                        <para>
+                            WARNING: Disabled or too small in-memory cache can
+                            have significant negative impact on SSSD's
+                            performance.
+                        </para>
+                        <para>
+                            NOTE: If the environment variable
+                            SSS_NSS_USE_MEMCACHE is set to "NO", client
+                            applications will not use the fast in-memory
+                            cache.
+                        </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>memcache_size_group (integer)</term>
+                    <listitem>
+                        <para>
+                            Number of slots allocated inside fast in-memory
+                            cache for group requests. Note that one entry
+                            in fast in-memory cache can occupy more than one
+                            slot. Setting the size to 0 will disable the group
+                            in-memory cache.
+                        </para>
+                        <para>
+                            Default: 150000
+                        </para>
+                        <para>
+                            WARNING: Disabled or too small in-memory cache can
+                            have significant negative impact on SSSD's
+                            performance.
+                        </para>
+                        <para>
+                            NOTE: If the environment variable
+                            SSS_NSS_USE_MEMCACHE is set to "NO", client
+                            applications will not use the fast in-memory
+                            cache.
+                        </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>memcache_size_initgroups (integer)</term>
+                    <listitem>
+                        <para>
+                            Number of slots allocated inside fast in-memory
+                            cache for initgroups requests. Note that one entry
+                            in fast in-memory cache can occupy more than one
+                            slot. Setting the size to 0 will disable the
+                            initgroups in-memory cache.
+                        </para>
+                        <para>
+                            Default: 250000
+                        </para>
+                        <para>
+                            WARNING: Disabled or too small in-memory cache can
+                            have significant negative impact on SSSD's
+                            performance.
+                        </para>
+                        <para>
+                            NOTE: If the environment variable
+                            SSS_NSS_USE_MEMCACHE is set to "NO", client
+                            applications will not use the fast in-memory
+                            cache.
+                        </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
                     <term>user_attributes (string)</term>
                     <listitem>
                         <para>

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -1076,7 +1076,7 @@ fallback_homedir = /home/%u
                     </listitem>
                 </varlistentry>
                 <varlistentry>
-                    <term>memcache_timeout (int)</term>
+                    <term>memcache_timeout (integer)</term>
                     <listitem>
                         <para>
                             Specifies time in seconds for which records
@@ -1104,14 +1104,13 @@ fallback_homedir = /home/%u
                     <term>memcache_size_passwd (integer)</term>
                     <listitem>
                         <para>
-                            Number of slots allocated inside fast in-memory
-                            cache for passwd requests. Note that one entry
-                            in fast in-memory cache can occupy more than one slot.
-                            Setting the size to 0 will disable the passwd in-memory
-                            cache.
+                            Size (in megabytes) of the data table allocated inside
+                            fast in-memory cache for passwd requests.
+                            Setting the size to 0 will disable the passwd
+                            in-memory cache.
                         </para>
                         <para>
-                            Default: 200000
+                            Default: 8
                         </para>
                         <para>
                             WARNING: Disabled or too small in-memory cache can
@@ -1130,14 +1129,13 @@ fallback_homedir = /home/%u
                     <term>memcache_size_group (integer)</term>
                     <listitem>
                         <para>
-                            Number of slots allocated inside fast in-memory
-                            cache for group requests. Note that one entry
-                            in fast in-memory cache can occupy more than one
-                            slot. Setting the size to 0 will disable the group
+                            Size (in megabytes) of the data table allocated inside
+                            fast in-memory cache for group requests.
+                            Setting the size to 0 will disable the group
                             in-memory cache.
                         </para>
                         <para>
-                            Default: 150000
+                            Default: 6
                         </para>
                         <para>
                             WARNING: Disabled or too small in-memory cache can
@@ -1156,14 +1154,13 @@ fallback_homedir = /home/%u
                     <term>memcache_size_initgroups (integer)</term>
                     <listitem>
                         <para>
-                            Number of slots allocated inside fast in-memory
-                            cache for initgroups requests. Note that one entry
-                            in fast in-memory cache can occupy more than one
-                            slot. Setting the size to 0 will disable the
-                            initgroups in-memory cache.
+                            Size (in megabytes) of the data table allocated inside
+                            fast in-memory cache for initgroups requests.
+                            Setting the size to 0 will disable the initgroups
+                            in-memory cache.
                         </para>
                         <para>
-                            Default: 250000
+                            Default: 10
                         </para>
                         <para>
                             WARNING: Disabled or too small in-memory cache can

--- a/src/responder/nss/nss_protocol_grent.c
+++ b/src/responder/nss/nss_protocol_grent.c
@@ -292,16 +292,17 @@ nss_protocol_fill_grent(struct nss_ctx *nss_ctx,
         num_results++;
 
         /* Do not store entry in memory cache during enumeration or when
-         * requested. */
+         * requested or if cache explicitly disabled. */
         if (!cmd_ctx->enumeration
-                && (cmd_ctx->flags & SSS_NSS_EX_FLAG_INVALIDATE_CACHE) == 0) {
+                && ((cmd_ctx->flags & SSS_NSS_EX_FLAG_INVALIDATE_CACHE) == 0)
+                && (nss_ctx->grp_mc_ctx != NULL)) {
             members = (char *)&body[rp_members];
             members_size = body_len - rp_members;
             ret = sss_mmap_cache_gr_store(&nss_ctx->grp_mc_ctx, name, &pwfield,
                                           gid, num_members, members,
                                           members_size);
             if (ret != EOK) {
-                DEBUG(SSSDBG_MINOR_FAILURE,
+                DEBUG(SSSDBG_OP_FAILURE,
                       "Failed to store group %s (%s) in mem-cache [%d]: %s!\n",
                       name->str, result->domain->name, ret, sss_strerror(ret));
             }
@@ -423,7 +424,8 @@ nss_protocol_fill_initgr(struct nss_ctx *nss_ctx,
     }
 
     if (nss_ctx->initgr_mc_ctx
-                && (cmd_ctx->flags & SSS_NSS_EX_FLAG_INVALIDATE_CACHE) == 0) {
+                && ((cmd_ctx->flags & SSS_NSS_EX_FLAG_INVALIDATE_CACHE) == 0)
+                && (nss_ctx->initgr_mc_ctx != NULL)) {
         to_sized_string(&rawname, cmd_ctx->rawname);
         to_sized_string(&unique_name, result->lookup_name);
 
@@ -431,7 +433,7 @@ nss_protocol_fill_initgr(struct nss_ctx *nss_ctx,
                                           &unique_name, num_results,
                                           body + 2 * sizeof(uint32_t));
         if (ret != EOK) {
-            DEBUG(SSSDBG_MINOR_FAILURE,
+            DEBUG(SSSDBG_OP_FAILURE,
                   "Failed to store initgroups %s (%s) in mem-cache [%d]: %s!\n",
                   rawname.str, domain->name, ret, sss_strerror(ret));
             sss_packet_set_size(packet, 0);

--- a/src/responder/nss/nss_protocol_pwent.c
+++ b/src/responder/nss/nss_protocol_pwent.c
@@ -301,13 +301,14 @@ nss_protocol_fill_pwent(struct nss_ctx *nss_ctx,
         num_results++;
 
         /* Do not store entry in memory cache during enumeration or when
-         * requested. */
+         * requested or if cache explicitly disabled. */
         if (!cmd_ctx->enumeration
-                && (cmd_ctx->flags & SSS_NSS_EX_FLAG_INVALIDATE_CACHE) == 0) {
+                && ((cmd_ctx->flags & SSS_NSS_EX_FLAG_INVALIDATE_CACHE) == 0)
+                && (nss_ctx->pwd_mc_ctx != NULL)) {
             ret = sss_mmap_cache_pw_store(&nss_ctx->pwd_mc_ctx, name, &pwfield,
                                           uid, gid, &gecos, &homedir, &shell);
             if (ret != EOK) {
-                DEBUG(SSSDBG_MINOR_FAILURE,
+                DEBUG(SSSDBG_OP_FAILURE,
                       "Failed to store user %s (%s) in mmap cache [%d]: %s!\n",
                       name->str, result->domain->name, ret, sss_strerror(ret));
             }

--- a/src/responder/nss/nsssrv.c
+++ b/src/responder/nss/nsssrv.c
@@ -209,13 +209,16 @@ done:
 
 static int setup_memcaches(struct nss_ctx *nctx)
 {
-    /* TODO: read cache sizes from configuration */
+    /* Default memcache sizes */
     static const size_t SSS_MC_CACHE_PASSWD_SLOTS    = 200000;  /*  8mb */
     static const size_t SSS_MC_CACHE_GROUP_SLOTS     = 150000;  /*  6mb */
     static const size_t SSS_MC_CACHE_INITGROUP_SLOTS = 250000;  /* 10mb */
 
     int ret;
     int memcache_timeout;
+    int mc_size_passwd;
+    int mc_size_group;
+    int mc_size_initgroups;
 
     /* Remove the CLEAR_MC_FLAG file if exists. */
     ret = unlink(SSS_NSS_MCACHE_DIR"/"CLEAR_MC_FLAG);
@@ -243,34 +246,77 @@ static int setup_memcaches(struct nss_ctx *nctx)
         return EOK;
     }
 
-    ret = sss_mmap_cache_init(nctx, "passwd",
-                              nctx->mc_uid, nctx->mc_gid,
-                              SSS_MC_PASSWD,
-                              SSS_MC_CACHE_PASSWD_SLOTS,
-                              (time_t)memcache_timeout,
-                              &nctx->pwd_mc_ctx);
-    if (ret) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "passwd mmap cache is DISABLED\n");
+    /* Get all memcache sizes from confdb (pwd, grp, initgr) */
+
+    ret = confdb_get_int(nctx->rctx->cdb,
+                         CONFDB_NSS_CONF_ENTRY,
+                         CONFDB_NSS_MEMCACHE_SIZE_PASSWD,
+                         SSS_MC_CACHE_PASSWD_SLOTS,
+                         &mc_size_passwd);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE,
+              "Failed to get 'memcache_size_passwd' option from confdb.\n");
+        return ret;
     }
 
-    ret = sss_mmap_cache_init(nctx, "group",
-                              nctx->mc_uid, nctx->mc_gid,
-                              SSS_MC_GROUP,
-                              SSS_MC_CACHE_GROUP_SLOTS,
-                              (time_t)memcache_timeout,
-                              &nctx->grp_mc_ctx);
-    if (ret) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "group mmap cache is DISABLED\n");
+    ret = confdb_get_int(nctx->rctx->cdb,
+                         CONFDB_NSS_CONF_ENTRY,
+                         CONFDB_NSS_MEMCACHE_SIZE_GROUP,
+                         SSS_MC_CACHE_GROUP_SLOTS,
+                         &mc_size_group);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE,
+              "Failed to get 'memcache_size_group' option from confdb.\n");
+        return ret;
     }
 
-    ret = sss_mmap_cache_init(nctx, "initgroups",
-                              nctx->mc_uid, nctx->mc_gid,
-                              SSS_MC_INITGROUPS,
-                              SSS_MC_CACHE_INITGROUP_SLOTS,
-                              (time_t)memcache_timeout,
-                              &nctx->initgr_mc_ctx);
-    if (ret) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "initgroups mmap cache is DISABLED\n");
+    ret = confdb_get_int(nctx->rctx->cdb,
+                         CONFDB_NSS_CONF_ENTRY,
+                         CONFDB_NSS_MEMCACHE_SIZE_INITGROUPS,
+                         SSS_MC_CACHE_INITGROUP_SLOTS,
+                         &mc_size_initgroups);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE,
+              "Failed to get 'memcache_size_nitgroups' option from confdb.\n");
+        return ret;
+    }
+
+    /* Initialize the fast in-memory caches if they were not disabled */
+
+    if (mc_size_passwd != 0) {
+        ret = sss_mmap_cache_init(nctx, "passwd",
+                                  nctx->mc_uid, nctx->mc_gid,
+                                  SSS_MC_PASSWD,
+                                  mc_size_passwd,
+                                  (time_t)memcache_timeout,
+                                  &nctx->pwd_mc_ctx);
+        if (ret) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "passwd mmap cache is DISABLED\n");
+        }
+    }
+
+    if (mc_size_group != 0) {
+        ret = sss_mmap_cache_init(nctx, "group",
+                                  nctx->mc_uid, nctx->mc_gid,
+                                  SSS_MC_GROUP,
+                                  mc_size_group,
+                                  (time_t)memcache_timeout,
+                                  &nctx->grp_mc_ctx);
+        if (ret) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "group mmap cache is DISABLED\n");
+        }
+    }
+
+    if (mc_size_initgroups != 0) {
+        ret = sss_mmap_cache_init(nctx, "initgroups",
+                                  nctx->mc_uid, nctx->mc_gid,
+                                  SSS_MC_INITGROUPS,
+                                  mc_size_initgroups,
+                                  (time_t)memcache_timeout,
+                                  &nctx->initgr_mc_ctx);
+        if (ret) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "initgroups mmap cache is DISABLED\n");
+        }
     }
 
     return EOK;

--- a/src/responder/nss/nsssrv.c
+++ b/src/responder/nss/nsssrv.c
@@ -242,12 +242,6 @@ static int setup_memcaches(struct nss_ctx *nctx)
         return ret;
     }
 
-    if (memcache_timeout == 0) {
-        DEBUG(SSSDBG_CONF_SETTINGS,
-              "Fast in-memory cache will not be initialized.");
-        return EOK;
-    }
-
     /* Get all memcache sizes from confdb (pwd, grp, initgr) */
 
     ret = confdb_get_int(nctx->rctx->cdb,
@@ -288,64 +282,40 @@ static int setup_memcaches(struct nss_ctx *nctx)
 
     /* Initialize the fast in-memory caches if they were not disabled */
 
-    if (mc_size_passwd != 0) {
-        ret = sss_mmap_cache_init(nctx, "passwd",
-                                  nctx->mc_uid, nctx->mc_gid,
-                                  SSS_MC_PASSWD,
-                                  mc_size_passwd * SSS_MC_CACHE_SLOTS_PER_MB,
-                                  (time_t)memcache_timeout,
-                                  &nctx->pwd_mc_ctx);
-        if (ret) {
-            DEBUG(SSSDBG_CRIT_FAILURE,
-                  "Failed to initialize passwd mmap cache: '%s'\n",
-                  sss_strerror(ret));
-        } else {
-            DEBUG(SSSDBG_CONF_SETTINGS, "Passwd mmap cache size is %d\n",
-                  mc_size_passwd);
-        }
-    } else {
-        DEBUG(SSSDBG_IMPORTANT_INFO,
-              "Passwd mmap cache is explicitly DISABLED\n");
+    ret = sss_mmap_cache_init(nctx, "passwd",
+                              nctx->mc_uid, nctx->mc_gid,
+                              SSS_MC_PASSWD,
+                              mc_size_passwd * SSS_MC_CACHE_SLOTS_PER_MB,
+                              (time_t)memcache_timeout,
+                              &nctx->pwd_mc_ctx);
+    if (ret) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Failed to initialize passwd mmap cache: '%s'\n",
+              sss_strerror(ret));
     }
 
-    if (mc_size_group != 0) {
-        ret = sss_mmap_cache_init(nctx, "group",
-                                  nctx->mc_uid, nctx->mc_gid,
-                                  SSS_MC_GROUP,
-                                  mc_size_group * SSS_MC_CACHE_SLOTS_PER_MB,
-                                  (time_t)memcache_timeout,
-                                  &nctx->grp_mc_ctx);
-        if (ret) {
-            DEBUG(SSSDBG_CRIT_FAILURE,
-                  "Failed to initialize group mmap cache: '%s'\n",
-                  sss_strerror(ret));
-        } else {
-            DEBUG(SSSDBG_CONF_SETTINGS, "Group mmap cache size is %d\n",
-                  mc_size_group);
-        }
-    } else {
-        DEBUG(SSSDBG_IMPORTANT_INFO,
-              "Group mmap cache is explicitly DISABLED\n");
+    ret = sss_mmap_cache_init(nctx, "group",
+                              nctx->mc_uid, nctx->mc_gid,
+                              SSS_MC_GROUP,
+                              mc_size_group * SSS_MC_CACHE_SLOTS_PER_MB,
+                              (time_t)memcache_timeout,
+                              &nctx->grp_mc_ctx);
+    if (ret) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Failed to initialize group mmap cache: '%s'\n",
+              sss_strerror(ret));
     }
 
-    if (mc_size_initgroups != 0) {
-        ret = sss_mmap_cache_init(nctx, "initgroups",
-                                  nctx->mc_uid, nctx->mc_gid,
-                                  SSS_MC_INITGROUPS,
-                                  mc_size_initgroups * SSS_MC_CACHE_SLOTS_PER_MB,
-                                  (time_t)memcache_timeout,
-                                  &nctx->initgr_mc_ctx);
-        if (ret) {
-            DEBUG(SSSDBG_CRIT_FAILURE,
-                  "Failed to initialize initgroups mmap cache: '%s'\n",
-                  sss_strerror(ret));
-        } else {
-            DEBUG(SSSDBG_CONF_SETTINGS, "Initgroups mmap cache size is %d\n",
-                  mc_size_initgroups);
-        }
-    } else {
-        DEBUG(SSSDBG_IMPORTANT_INFO,
-              "Initgroups mmap cache is explicitly DISABLED\n");
+    ret = sss_mmap_cache_init(nctx, "initgroups",
+                              nctx->mc_uid, nctx->mc_gid,
+                              SSS_MC_INITGROUPS,
+                              mc_size_initgroups * SSS_MC_CACHE_SLOTS_PER_MB,
+                              (time_t)memcache_timeout,
+                              &nctx->initgr_mc_ctx);
+    if (ret) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Failed to initialize initgroups mmap cache: '%s'\n",
+              sss_strerror(ret));
     }
 
     return EOK;

--- a/src/responder/nss/nsssrv.c
+++ b/src/responder/nss/nsssrv.c
@@ -255,7 +255,8 @@ static int setup_memcaches(struct nss_ctx *nctx)
                          &mc_size_passwd);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
-              "Failed to get 'memcache_size_passwd' option from confdb.\n");
+              "Failed to get '"CONFDB_NSS_MEMCACHE_SIZE_PASSWD
+              "' option from confdb.\n");
         return ret;
     }
 
@@ -266,7 +267,8 @@ static int setup_memcaches(struct nss_ctx *nctx)
                          &mc_size_group);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
-              "Failed to get 'memcache_size_group' option from confdb.\n");
+              "Failed to get '"CONFDB_NSS_MEMCACHE_SIZE_GROUP
+              "' option from confdb.\n");
         return ret;
     }
 
@@ -277,7 +279,8 @@ static int setup_memcaches(struct nss_ctx *nctx)
                          &mc_size_initgroups);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
-              "Failed to get 'memcache_size_nitgroups' option from confdb.\n");
+              "Failed to get '"CONFDB_NSS_MEMCACHE_SIZE_INITGROUPS
+              "' option from confdb.\n");
         return ret;
     }
 
@@ -291,8 +294,16 @@ static int setup_memcaches(struct nss_ctx *nctx)
                                   (time_t)memcache_timeout,
                                   &nctx->pwd_mc_ctx);
         if (ret) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "passwd mmap cache is DISABLED\n");
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Failed to initialize passwd mmap cache: '%s'\n",
+                  sss_strerror(ret));
+        } else {
+            DEBUG(SSSDBG_CONF_SETTINGS, "Passwd mmap cache size is %d\n",
+                  mc_size_passwd);
         }
+    } else {
+        DEBUG(SSSDBG_IMPORTANT_INFO,
+              "Passwd mmap cache is explicitly DISABLED\n");
     }
 
     if (mc_size_group != 0) {
@@ -303,8 +314,16 @@ static int setup_memcaches(struct nss_ctx *nctx)
                                   (time_t)memcache_timeout,
                                   &nctx->grp_mc_ctx);
         if (ret) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "group mmap cache is DISABLED\n");
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Failed to initialize group mmap cache: '%s'\n",
+                  sss_strerror(ret));
+        } else {
+            DEBUG(SSSDBG_CONF_SETTINGS, "Group mmap cache size is %d\n",
+                  mc_size_group);
         }
+    } else {
+        DEBUG(SSSDBG_IMPORTANT_INFO,
+              "Group mmap cache is explicitly DISABLED\n");
     }
 
     if (mc_size_initgroups != 0) {
@@ -315,8 +334,16 @@ static int setup_memcaches(struct nss_ctx *nctx)
                                   (time_t)memcache_timeout,
                                   &nctx->initgr_mc_ctx);
         if (ret) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "initgroups mmap cache is DISABLED\n");
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Failed to initialize initgroups mmap cache: '%s'\n",
+                  sss_strerror(ret));
+        } else {
+            DEBUG(SSSDBG_CONF_SETTINGS, "Initgroups mmap cache size is %d\n",
+                  mc_size_initgroups);
         }
+    } else {
+        DEBUG(SSSDBG_IMPORTANT_INFO,
+              "Initgroups mmap cache is explicitly DISABLED\n");
     }
 
     return EOK;

--- a/src/responder/nss/nsssrv_mmap_cache.c
+++ b/src/responder/nss/nsssrv_mmap_cache.c
@@ -65,7 +65,7 @@ struct sss_mc_ctx {
 
     uint8_t *free_table;    /* free list bitmaps */
     uint32_t ft_size;       /* size of free table */
-    uint32_t next_slot;     /* the next slot after last allocation */
+    uint32_t next_slot;     /* the next slot after last allocation done via erasure */
 
     uint8_t *data_table;    /* data table address (in mmap) */
     uint32_t dt_size;       /* size of data table */
@@ -442,6 +442,9 @@ static errno_t sss_mc_find_free_slots(struct sss_mc_ctx *mcc,
         if (cur == t) {
             /* ok found num_slots consecutive free bits */
             *free_slot = cur - num_slots;
+            /* `mcc->next_slot` is not updated here intentionally.
+             * For details see discussion in https://github.com/SSSD/sssd/pull/999
+             */
             return EOK;
         }
     }

--- a/src/responder/nss/nsssrv_mmap_cache.h
+++ b/src/responder/nss/nsssrv_mmap_cache.h
@@ -22,8 +22,6 @@
 #ifndef _NSSSRV_MMAP_CACHE_H_
 #define _NSSSRV_MMAP_CACHE_H_
 
-#define SSS_MC_CACHE_ELEMENTS 50000
-
 struct sss_mc_ctx;
 
 enum sss_mc_type {

--- a/src/util/mmap_cache.h
+++ b/src/util/mmap_cache.h
@@ -40,9 +40,6 @@ typedef uint32_t rel_ptr_t;
 
 #define MC_HT_SIZE(elems) ( (elems) * MC_32 )
 #define MC_HT_ELEMS(size) ( (size) / MC_32 )
-#define MC_DT_SIZE(elems, payload) ( (elems) * (payload) )
-#define MC_FT_SIZE(elems) ( (elems) / 8 )
-/* ^^ 8 bits per byte so we need just elems/8 bytes to represent all blocks */
 
 #define MC_PTR_ADD(ptr, bytes) (void *)((uint8_t *)(ptr) + (bytes))
 #define MC_PTR_DIFF(ptr, base) ((uint8_t *)(ptr) - (uint8_t *)(base))


### PR DESCRIPTION
This is set of patches consisting of the following:

(1) fix of https://pagure.io/SSSD/sssd/issue/4160
(2) revival of @mzidek-gh's patch to make size of mem-caches configurable (#390)
(3 & 4) slight improvements of (2)
(5) additional debug&syslog message to signal user that cache is full and may require change of size
This is to address https://github.com/SSSD/sssd/pull/390#issuecomment-371428333 (at least to some extent)

I keep those patches separate to make review easier. But if PR will be accepted then it makes sense to squash (2, 3 & 4) into single patch before merging.