### PR TITLE
ssh: fix matching rules default

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -1767,13 +1767,20 @@ p11_uri = library-description=OpenSC%20smartcard%20framework;slot-id=2
                             from all valid certificates.
                         </para>
                         <para>
+                            If no rules are configured using 'all_rules' will
+                            enable a default rule which enables all
+                            certificates suitable for client authentication.
+                            This is the same behavior as for the PAM responder
+                            if certificate authentication is enabled.
+                        </para>
+                        <para>
                             A non-existing rule name is considered an error.
                             If as a result no rule is selected all certificates
                             will be ignored.
                         </para>
                         <para>
                             Default: not set, equivalent to 'all_rules,
-                            all found rules are used
+                            all found rules or the default rule are used
                         </para>
                     </listitem>
                 </varlistentry>

--- a/src/responder/pam/pam_helpers.h
+++ b/src/responder/pam/pam_helpers.h
@@ -25,6 +25,8 @@
 
 #include "util/util.h"
 
+#define CERT_AUTH_DEFAULT_MATCHING_RULE "KRB5:<EKU>clientAuth"
+
 errno_t pam_initgr_cache_set(struct tevent_context *ev,
                              hash_table_t *id_table,
                              char *name,

--- a/src/responder/pam/pamsrv_p11.c
+++ b/src/responder/pam/pamsrv_p11.c
@@ -26,12 +26,11 @@
 #include "util/child_common.h"
 #include "util/strtonum.h"
 #include "responder/pam/pamsrv.h"
+#include "responder/pam/pam_helpers.h"
 #include "lib/certmap/sss_certmap.h"
 #include "util/crypto/sss_crypto.h"
 #include "db/sysdb.h"
 
-
-#define CERT_AUTH_DEFAULT_MATCHING_RULE "KRB5:<EKU>clientAuth"
 
 struct cert_auth_info {
     char *cert;


### PR DESCRIPTION
Before the ssh_use_certificate_matching_rules option was added the ssh
responder returned ssh keys derived from all valid certificates. Since
the default of the ssh_use_certificate_matching_rules option is
'all_rules' in a case where no matching rules are defined all
certificated will be filtered out and no ssh keys are returned.

The intention of the default was to allow the same same certificates
which are allowed in the PAM responder for authentication. The missing
default matching rule which is currently use by the PAM responder if no
other rules are available is added by this patch.

There might still be a small regression in case certificates without the
extended key usage (EKU) clientAuth were used for ssh. In this case
'ssh_use_certificate_matching_rules = no_rules' or a suitable matching
rule must be added to the configuration.

Related to https://pagure.io/SSSD/sssd/issue/4121