### PR TITLE
SBUS: fixed off-by-one error" in sbus_auto_reconnect()

### DIFF
--- a/src/sbus/sssd_dbus_connection.c
+++ b/src/sbus/sssd_dbus_connection.c
@@ -467,7 +467,7 @@ static int sbus_auto_reconnect(struct sbus_connection *conn)
     struct timeval tv;
 
     conn->retries++;
-    if (conn->retries >= conn->max_retries) {
+    if (conn->retries > conn->max_retries) {
         /* Return EIO (to tell the calling process it
          * needs to create a new connection from scratch
          */


### PR DESCRIPTION
Fixed "off-by-one error" in `reconnection_retries` interpretation.

Resolves: https://pagure.io/SSSD/sssd/issue/4168