### PR TITLE
Watchdog: fixes "off-by-one" error

### DIFF
--- a/src/util/util_watchdog.c
+++ b/src/util/util_watchdog.c
@@ -71,7 +71,7 @@ static void watchdog_handler(int sig)
     watchdog_detect_timeshift();
 
     /* if a pre-defined number of ticks passed by kills itself */
-    if (__sync_add_and_fetch(&watchdog_ctx.ticks, 1) > WATCHDOG_MAX_TICKS) {
+    if (__sync_add_and_fetch(&watchdog_ctx.ticks, 1) >= WATCHDOG_MAX_TICKS) {
         if (getpid() == getpgrp()) {
             kill(-getpgrp(), SIGTERM);
         }


### PR DESCRIPTION
'man sssd.conf': timeout: "Note that after three missed heartbeats
the process will terminate itself."

But implementation was:
```
\#define WATCHDOG_MAX_TICKS 3
...
    if (__sync_add_and_fetch(&watchdog_ctx.ticks, 1) > WATCHDOG_MAX_TICKS) {
        ...
        _exit(1);
```
  -- since after reset ticks start from 0 effectively this was 4 heartbeats.

Fixed to match man page.

Resolves: https://pagure.io/SSSD/sssd/issue/4169