### PR TITLE
sbus: commit complete generated code

### DIFF
--- a/src/sss_iface/sbus_sss_arguments.c
+++ b/src/sss_iface/sbus_sss_arguments.c
@@ -709,3 +709,4 @@ errno_t _sbus_sss_invoker_write_uuus
 
     return EOK;
 }
+

--- a/src/sss_iface/sbus_sss_invokers.c
+++ b/src/sss_iface/sbus_sss_invokers.c
@@ -3408,3 +3408,4 @@ static void _sbus_sss_invoke_in_uuus_out_qus_done(struct tevent_req *subreq)
     tevent_req_done(req);
     return;
 }
+

--- a/src/sss_iface/sbus_sss_keygens.c
+++ b/src/sss_iface/sbus_sss_keygens.c
@@ -156,3 +156,4 @@ _sbus_sss_key_uuus_0_1_2_3
         sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
         sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3);
 }
+


### PR DESCRIPTION
99ce117106b9c0d0e0167f1c10f5840a7912fa7f incorrectly commited generated code.