### PR TITLE
pam: Use cache for users with existing session

### DIFF
--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -138,6 +138,7 @@
 #define CONFDB_PAM_APP_SERVICES "pam_app_services"
 #define CONFDB_PAM_P11_ALLOWED_SERVICES "pam_p11_allowed_services"
 #define CONFDB_PAM_P11_URI "p11_uri"
+#define CONFDB_PAM_INITGROUPS_SCHEME "pam_initgroups_scheme"
 
 /* SUDO */
 #define CONFDB_SUDO_CONF_ENTRY "config/sudo"

--- a/src/config/SSSDConfig/sssdoptions.py
+++ b/src/config/SSSDConfig/sssdoptions.py
@@ -100,6 +100,7 @@ class SSSDOptions(object):
         'pam_p11_allowed_services': _('Allowed services for using smartcards'),
         'p11_wait_for_card_timeout': _('Additional timeout to wait for a card if requested'),
         'p11_uri': _('PKCS#11 URI to restrict the selection of devices for Smartcard authentication'),
+        'pam_initgroups_scheme' : _('When shall the PAM responder force an initgroups request'),
 
         # [sudo]
         'sudo_timed': _('Whether to evaluate the time-based attributes in sudo rules'),

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -131,6 +131,7 @@ option = pam_app_services
 option = pam_p11_allowed_services
 option = p11_wait_for_card_timeout
 option = p11_uri
+option = pam_initgroups_scheme
 
 [rule/allowed_sudo_options]
 validator = ini_allowed_options

--- a/src/config/etc/sssd.api.conf
+++ b/src/config/etc/sssd.api.conf
@@ -79,6 +79,7 @@ pam_app_services = str, None, false
 pam_p11_allowed_services = str, None, false
 p11_wait_for_card_timeout = int, None, false
 p11_uri = str, None, false
+pam_initgroups_scheme = str, None, false
 
 [sudo]
 # sudo service

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -1617,6 +1617,38 @@ p11_uri = library-description=OpenSC%20smartcard%20framework;slot-id=2
                         </para>
                     </listitem>
                 </varlistentry>
+                <varlistentry>
+                    <term>pam_initgroups_scheme</term>
+                    <listitem>
+                        <para>
+                            The PAM responder can force an online lookup to get
+                            the current group memberships of the user trying to
+                            log in. This option controls when this should be
+                            done and the following values are allowed:
+                            <variablelist>
+                            <varlistentry><term>always</term>
+                                <listitem><para>Always do an online lookup,
+                                please note that pam_id_timeout still
+                                applies</para></listitem>
+                            </varlistentry>
+                            <varlistentry><term>no_session</term>
+                                <listitem><para>Only do an online
+                                lookup if there is no active session of the
+                                user, i.e. if the user is currently not logged
+                                in</para></listitem>
+                            </varlistentry>
+                            <varlistentry><term>never</term>
+                                <listitem><para>Never force an online lookup,
+                                use the data from the cache as long as they are
+                                not expired</para></listitem>
+                            </varlistentry>
+                            </variablelist>
+                        </para>
+                        <para>
+                            Default: no_session
+                        </para>
+                    </listitem>
+                </varlistentry>
             </variablelist>
         </refsect2>
 

--- a/src/responder/common/cache_req/cache_req.h
+++ b/src/responder/common/cache_req/cache_req.h
@@ -80,6 +80,17 @@ enum cache_req_dom_type {
     CACHE_REQ_ANY_DOM
 };
 
+/* Controls behavior about how to use cached information during
+ * a lookup, this is to fine tune some behaviors for specific
+ * situations
+ */
+enum cache_req_behavior {
+    CACHE_REQ_NORMAL,
+    CACHE_REQ_CACHE_FIRST,
+    CACHE_REQ_BYPASS_CACHE,
+    CACHE_REQ_BYPASS_PROVIDER,
+};
+
 /* Input data. */
 
 struct cache_req_data;

--- a/src/responder/common/cache_req/cache_req_private.h
+++ b/src/responder/common/cache_req/cache_req_private.h
@@ -40,9 +40,10 @@ struct cache_req {
 
     /* Domain related information. */
     struct sss_domain_info *domain;
-    bool cache_first;
-    bool bypass_cache;
-    bool bypass_dp;
+
+    /* wanted cache behavior */
+    enum cache_req_behavior cache_behavior;
+
     /* Only contact domains with this type */
     enum cache_req_dom_type req_dom_type;
 
@@ -105,8 +106,8 @@ struct tevent_req *
 cache_req_search_send(TALLOC_CTX *mem_ctx,
                       struct tevent_context *ev,
                       struct cache_req *cr,
-                      bool bypass_cache,
-                      bool bypass_dp);
+                      bool first_iteration,
+                      bool cache_only_override);
 
 errno_t cache_req_search_recv(TALLOC_CTX *mem_ctx,
                               struct tevent_req *req,

--- a/src/responder/pam/pam_helpers.c
+++ b/src/responder/pam/pam_helpers.c
@@ -46,6 +46,12 @@ errno_t pam_initgr_cache_set(struct tevent_context *ev,
     struct timeval tv;
     struct pam_initgr_table_ctx *table_ctx;
 
+    ret = pam_initgr_check_timeout(id_table, name);
+    if (ret == EOK) {
+        /* user is already in the cache */
+        goto done;
+    }
+
     table_ctx = talloc_zero(id_table, struct pam_initgr_table_ctx);
     if (!table_ctx) return ENOMEM;
 

--- a/src/responder/pam/pamsrv.c
+++ b/src/responder/pam/pamsrv.c
@@ -54,6 +54,7 @@
 #else
 #define DEFAULT_PAM_CERT_DB_PATH SYSCONFDIR"/sssd/pki/sssd_auth_ca_db.pem"
 #endif
+#define DEFAULT_PAM_INITGROUPS_SCHEME "no_session"
 
 static errno_t get_trusted_uids(struct pam_ctx *pctx)
 {
@@ -168,6 +169,7 @@ static int pam_process_init(TALLOC_CTX *mem_ctx,
     int ret;
     int id_timeout;
     int fd_limit;
+    char *tmpstr = NULL;
 
     pam_cmds = get_pam_cmds();
     ret = sss_process_init(mem_ctx, ev, cdb,
@@ -304,6 +306,29 @@ static int pam_process_init(TALLOC_CTX *mem_ctx,
                   "Failed to create pre-authentication indicator file, "
                   "Smartcard authentication or configured prompting might "
                   "not work as expected.\n");
+        }
+    }
+
+    ret = confdb_get_string(pctx->rctx->cdb, pctx, CONFDB_PAM_CONF_ENTRY,
+                            CONFDB_PAM_INITGROUPS_SCHEME,
+                            DEFAULT_PAM_INITGROUPS_SCHEME, &tmpstr);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE,
+              "Failed to determine initgroups scheme.\n");
+        goto done;
+    }
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Found value [%s] for option [%s].\n", tmpstr,
+                                 CONFDB_PAM_INITGROUPS_SCHEME);
+
+    if (tmpstr == NULL) {
+        pctx->initgroups_scheme = PAM_INITGR_NO_SESSION;
+    } else {
+        pctx->initgroups_scheme = pam_initgroups_string_to_enum(tmpstr);
+        if (pctx->initgroups_scheme == PAM_INITGR_INVALID) {
+            DEBUG(SSSDBG_FATAL_FAILURE, "Unknown value [%s] for option %s.\n",
+                                        tmpstr, CONFDB_PAM_INITGROUPS_SCHEME);
+            ret = EINVAL;
+            goto done;
         }
     }
 

--- a/src/responder/pam/pamsrv.h
+++ b/src/responder/pam/pamsrv.h
@@ -32,6 +32,13 @@ struct pam_auth_req;
 
 typedef void (pam_dp_callback_t)(struct pam_auth_req *preq);
 
+enum pam_initgroups_scheme {
+    PAM_INITGR_NEVER,
+    PAM_INITGR_NO_SESSION,
+    PAM_INITGR_ALWAYS,
+    PAM_INITGR_INVALID
+};
+
 struct pam_ctx {
     struct resp_ctx *rctx;
     time_t id_timeout;
@@ -54,6 +61,8 @@ struct pam_ctx {
 
     char **prompting_config_sections;
     int num_prompting_config_sections;
+
+    enum pam_initgroups_scheme initgroups_scheme;
 };
 
 struct pam_auth_req {
@@ -132,4 +141,6 @@ errno_t filter_responses(struct confdb_ctx *cdb,
 
 errno_t pam_eval_prompting_config(struct pam_ctx *pctx, struct pam_data *pd);
 
+enum pam_initgroups_scheme pam_initgroups_string_to_enum(const char *str);
+const char *pam_initgroup_enum_to_string(enum pam_initgroups_scheme scheme);
 #endif /* __PAMSRV_H__ */

--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -23,6 +23,7 @@
 #include <time.h>
 #include "util/util.h"
 #include "util/auth_utils.h"
+#include "util/find_uid.h"
 #include "db/sysdb.h"
 #include "confdb/confdb.h"
 #include "responder/common/responder_packet.h"
@@ -1845,12 +1846,16 @@ done:
     pam_check_user_done(preq, ret);
 }
 
-static void pam_dp_send_acct_req_done(struct tevent_req *req);
+static void pam_check_user_search_next(struct tevent_req *req);
+static void pam_check_user_search_lookup(struct tevent_req *req);
+static void pam_check_user_search_done(struct pam_auth_req *preq, int ret,
+                                       struct cache_req_result *result);
+
+/* lookup the user uid from the cache first,
+ * then we'll refresh initgroups if needed */
 static int pam_check_user_search(struct pam_auth_req *preq)
 {
-    int ret;
     struct tevent_req *dpreq;
-    struct pam_ctx *pctx;
     struct cache_req_data *data;
 
     data = cache_req_data_name(preq,
@@ -1860,23 +1865,8 @@ static int pam_check_user_search(struct pam_auth_req *preq)
         return ENOMEM;
     }
 
-    pctx = talloc_get_type(preq->cctx->rctx->pvt_ctx, struct pam_ctx);
-
-    /* The initgr cache is used to make sure that during a single PAM session
-     * (auth, acct_mgtm, ....) the backend is contacted only once. logon_name
-     * is the name provided by the PAM client and will not be modified during
-     * the request, so it makes sense to use it here instead od the pd->user. */
-    ret = pam_initgr_check_timeout(pctx->id_table, preq->pd->logon_name);
-    if (ret == EOK) {
-        /* Entry is still valid, force to lookup in the cache first */
-        cache_req_data_set_bypass_cache(data, false);
-    } else if (ret == ENOENT) {
-        /* Call the data provider first */
-        cache_req_data_set_bypass_cache(data, true);
-    } else {
-        DEBUG(SSSDBG_OP_FAILURE, "Could not look up initgroup timeout\n");
-        return EIO;
-    }
+    cache_req_data_set_bypass_cache(data, false);
+    cache_req_data_set_bypass_dp(data, true);
 
     dpreq = cache_req_send(preq,
                            preq->cctx->rctx->ev,
@@ -1892,17 +1882,19 @@ static int pam_check_user_search(struct pam_auth_req *preq)
         return ENOMEM;
     }
 
-    tevent_req_set_callback(dpreq, pam_dp_send_acct_req_done, preq);
+    tevent_req_set_callback(dpreq, pam_check_user_search_next, preq);
 
     /* tell caller we are in an async call */
     return EAGAIN;
 }
 
-static void pam_dp_send_acct_req_done(struct tevent_req *req)
+static void pam_check_user_search_next(struct tevent_req *req)
 {
-    struct cache_req_result *result;
     struct pam_auth_req *preq;
     struct pam_ctx *pctx;
+    struct cache_req_result *result;
+    struct cache_req_data *data;
+    struct tevent_req *dpreq;
     int ret;
 
     preq = tevent_req_callback_data(req, struct pam_auth_req);
@@ -1916,6 +1908,100 @@ static void pam_dp_send_acct_req_done(struct tevent_req *req)
         talloc_zfree(preq->cctx);
         return;
     }
+
+    if (ret == EOK) {
+        bool user_has_session = false;
+        uid_t uid = ldb_msg_find_attr_as_uint64(result->msgs[0], SYSDB_UIDNUM, 0);
+        if (!uid) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "A user with no UID?\n");
+            talloc_zfree(preq->cctx);
+            return;
+        }
+
+        /* If a user already has a session on the system, we take the
+         * cache for granted and do not force an online lookup. This is
+         * because in most cases the user is just trying to authenticate
+         * but not create a new session (sudo, lockscreen, polkit, etc.)
+         * An online refresh in this situation would just delay operations
+         * without providing any useful additional information.
+         */
+        (void)check_if_uid_is_active(uid, &user_has_session);
+
+        /* The initgr cache is used to make sure that during a single PAM
+         * session (auth, acct_mgtm, ....) the backend is contacted only
+         * once. logon_name is the name provided by the PAM client and
+         * will not be modified during the request, so it makes sense to
+         * use it here instead od the pd->user.
+         */
+        ret = pam_initgr_check_timeout(pctx->id_table, preq->pd->logon_name);
+        if (ret != EOK && ret != ENOENT) {
+            DEBUG(SSSDBG_OP_FAILURE, "Could not look up initgroup timeout\n");
+        }
+
+        if ((ret == EOK) || user_has_session) {
+            pam_check_user_search_done(preq, EOK, result);
+            return;
+        }
+    }
+
+    /* If we get here it means the user was not found or does not have a
+     * session, or initgr has not been cached before, so we force a new
+     * online lookup */
+    data = cache_req_data_name(preq,
+                               CACHE_REQ_INITGROUPS,
+                               preq->pd->logon_name);
+    if (data == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory\n");
+        talloc_zfree(preq->cctx);
+        return;
+    }
+    cache_req_data_set_bypass_cache(data, true);
+    cache_req_data_set_bypass_dp(data, false);
+
+    dpreq = cache_req_send(preq,
+                           preq->cctx->rctx->ev,
+                           preq->cctx->rctx,
+                           preq->cctx->rctx->ncache,
+                           0,
+                           preq->req_dom_type,
+                           NULL,
+                           data);
+    if (!dpreq) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Out of memory sending data provider request\n");
+        talloc_zfree(preq->cctx);
+        return;
+    }
+
+    tevent_req_set_callback(dpreq, pam_check_user_search_lookup, preq);
+}
+
+static void pam_check_user_search_lookup(struct tevent_req *req)
+{
+    struct cache_req_result *result;
+    struct pam_auth_req *preq;
+    int ret;
+
+    preq = tevent_req_callback_data(req, struct pam_auth_req);
+
+    ret = cache_req_single_domain_recv(preq, req, &result);
+    talloc_zfree(req);
+    if (ret != EOK && ret != ENOENT) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Fatal error, killing connection!\n");
+        talloc_zfree(preq->cctx);
+        return;
+    }
+
+    pam_check_user_search_done(preq, ret, result);
+}
+
+static void pam_check_user_search_done(struct pam_auth_req *preq, int ret,
+                                       struct cache_req_result *result)
+{
+    struct pam_ctx *pctx;
+
+    pctx = talloc_get_type(preq->cctx->rctx->pvt_ctx, struct pam_ctx);
 
     if (ret == EOK) {
         preq->user_obj = result->msgs[0];

--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -43,6 +43,44 @@ enum pam_verbosity {
 
 #define DEFAULT_PAM_VERBOSITY PAM_VERBOSITY_IMPORTANT
 
+struct pam_initgroup_enum_str {
+    enum pam_initgroups_scheme scheme;
+    const char *option;
+};
+
+struct pam_initgroup_enum_str pam_initgroup_enum_str[] = {
+    { PAM_INITGR_NEVER, "never" },
+    { PAM_INITGR_NO_SESSION, "no_session" },
+    { PAM_INITGR_ALWAYS, "always" },
+    { PAM_INITGR_INVALID, NULL }
+};
+
+enum pam_initgroups_scheme pam_initgroups_string_to_enum(const char *str)
+{
+    size_t c;
+
+    for (c = 0 ; pam_initgroup_enum_str[c].option != NULL; c++) {
+        if (strcasecmp(pam_initgroup_enum_str[c].option, str) == 0) {
+            return pam_initgroup_enum_str[c].scheme;
+        }
+    }
+
+    return PAM_INITGR_INVALID;
+}
+
+const char *pam_initgroup_enum_to_string(enum pam_initgroups_scheme scheme) {
+    size_t c;
+
+    for (c = 0 ; pam_initgroup_enum_str[c].option != NULL; c++) {
+        if (pam_initgroup_enum_str[c].scheme == scheme) {
+            return pam_initgroup_enum_str[c].option;
+        }
+    }
+
+    return NULL;
+}
+
+
 static errno_t
 pam_null_last_online_auth_with_curr_token(struct sss_domain_info *domain,
                                           const char *username);

--- a/src/tests/cmocka/test_nss_srv.c
+++ b/src/tests/cmocka/test_nss_srv.c
@@ -4828,7 +4828,6 @@ void test_nss_getgrgid_ex_no_members(void **state)
     will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
     will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
     mock_account_recv_simple();
-    mock_account_recv_simple();
 
     set_cmd_cb(test_nss_getgrnam_no_members_check);
     ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETGRGID_EX,
@@ -4843,11 +4842,6 @@ void test_nss_getgrgid_ex_no_members(void **state)
     /* Use flag SSS_NSS_EX_FLAG_INVALIDATE_CACHE */
     mock_input_id_ex(nss_test_ctx, getgrnam_no_members.gr_gid,
                      SSS_NSS_EX_FLAG_INVALIDATE_CACHE);
-    will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETGRGID_EX);
-    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
-    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
-    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
-    will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
 
     set_cmd_cb(test_nss_getgrnam_no_members_check);
     ret = sss_cmd_execute(nss_test_ctx->cctx, SSS_NSS_GETGRGID_EX,

--- a/src/tests/cmocka/test_pam_srv.c
+++ b/src/tests/cmocka/test_pam_srv.c
@@ -415,6 +415,8 @@ struct pam_ctx *mock_pctx(TALLOC_CTX *mem_ctx)
     ret = p11_refresh_certmap_ctx(pctx, NULL);
     assert_int_equal(ret, 0);
 
+    pctx->initgroups_scheme = PAM_INITGR_NO_SESSION;
+
     return pctx;
 }
 

--- a/src/tests/cmocka/test_pam_srv.c
+++ b/src/tests/cmocka/test_pam_srv.c
@@ -2084,8 +2084,9 @@ void test_pam_auth_no_upn_logon_name(void **state)
     assert_int_equal(ret, EOK);
 
     mock_input_pam_ex(pam_test_ctx, "upn@"TEST_DOM_NAME, "12345", NULL, NULL,
-                      true);
+                      false);
     mock_account_recv_simple();
+    mock_parse_inp("upn@"TEST_DOM_NAME, NULL, EOK);
 
     will_return(__wrap_sss_packet_get_cmd, SSS_PAM_AUTHENTICATE);
     will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
@@ -2124,6 +2125,8 @@ void test_pam_auth_upn_logon_name(void **state)
     mock_input_pam_ex(pam_test_ctx, "upn@"TEST_DOM_NAME, "12345", NULL, NULL,
                       true);
     mock_account_recv_simple();
+
+    mock_parse_inp("pamuser", NULL, EOK);
 
     will_return(__wrap_sss_packet_get_cmd, SSS_PAM_AUTHENTICATE);
     will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
@@ -2404,6 +2407,8 @@ void test_pam_preauth_cert_no_logon_name(void **state)
                         test_lookup_by_cert_cb, SSSD_TEST_CERT_0001, false);
     mock_account_recv_simple();
     mock_parse_inp("pamuser", NULL, EOK);
+    mock_account_recv_simple();
+    mock_parse_inp("pamuser", NULL, EOK);
 
     will_return(__wrap_sss_packet_get_cmd, SSS_PAM_PREAUTH);
     will_return(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
@@ -2628,6 +2633,8 @@ void test_pam_cert_auth_no_logon_name(void **state)
                         "C554C9F82C2A9D58B70921C143304153A8A42F17", NULL,
                         test_lookup_by_cert_cb, SSSD_TEST_CERT_0001, true);
 
+    mock_account_recv_simple();
+    mock_parse_inp("pamuser", NULL, EOK);
     mock_account_recv_simple();
     mock_parse_inp("pamuser", NULL, EOK);
 
@@ -3255,6 +3262,7 @@ void test_appsvc_posix_dom(void **state)
 
     /* The domain is POSIX, the request will skip over it */
     mock_input_pam_ex(pam_test_ctx, "pamuser", NULL, NULL, "app_svc", false);
+    mock_parse_inp("pamuser", NULL, EOK);
     pam_test_ctx->exp_pam_status = PAM_USER_UNKNOWN;
 
     will_return(__wrap_sss_packet_get_cmd, SSS_PAM_AUTHENTICATE);
@@ -3339,6 +3347,7 @@ void test_not_appsvc_app_dom(void **state)
 
     /* A different service than the app one can authenticate against a POSIX domain */
     mock_input_pam_ex(pam_test_ctx, "pamuser", NULL, NULL, "not_app_svc", false);
+    mock_parse_inp("pamuser", NULL, EOK);
 
     pam_test_ctx->exp_pam_status = PAM_USER_UNKNOWN;
 


### PR DESCRIPTION
Users that have an existing session do the bulk of their authentication to
unlock services that do not make use of initgroups (used only to create a
new login session). Forcing online initgroups calls for these users leads
mostly to delays in providing those services and do not provide any useful
data.

Resolves: https://pagure.io/SSSD/sssd/issue/4098