### PR TITLE
LDAP: Netgroups refresh in background task

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -1222,14 +1222,17 @@ int sysdb_search_users(TALLOC_CTX *mem_ctx,
                        size_t *msgs_count,
                        struct ldb_message ***msgs);
 
-#define SYSDB_SEARCH_WITH_TS_ONLY_TS_FILTER     0x0001
-#define SYSDB_SEARCH_WITH_TS_ONLY_SYSDB_FILTER  0x0002
+enum sysdb_cache_type {
+    SYSDB_CACHE_TYPE_NONE,
+    SYSDB_CACHE_TYPE_TIMESTAMP,
+    SYSDB_CACHE_TYPE_PERSISTENT
+};
 
 errno_t sysdb_search_with_ts_attr(TALLOC_CTX *mem_ctx,
                                   struct sss_domain_info *domain,
                                   struct ldb_dn *base_dn,
                                   enum ldb_scope scope,
-                                  int optflags,
+                                  enum sysdb_cache_type search_cache,
                                   const char *filter,
                                   const char *attrs[],
                                   struct ldb_result **_result);

--- a/src/providers/be_refresh.c
+++ b/src/providers/be_refresh.c
@@ -35,7 +35,7 @@ static errno_t be_refresh_get_values_ex(TALLOC_CTX *mem_ctx,
                                         struct ldb_dn *base_dn,
                                         const char *key_attr,
                                         const char *value_attr,
-                                        int optflags,
+                                        enum sysdb_cache_type search_cache,
                                         char ***_values)
 {
     TALLOC_CTX *tmp_ctx = NULL;
@@ -65,7 +65,7 @@ static errno_t be_refresh_get_values_ex(TALLOC_CTX *mem_ctx,
 
     ret = sysdb_search_with_ts_attr(tmp_ctx, domain, base_dn,
                                     LDB_SCOPE_SUBTREE,
-                                    optflags,
+                                    search_cache,
                                     filter, attrs,
                                     &res);
     if (ret != EOK) {
@@ -103,7 +103,7 @@ static errno_t be_refresh_get_values(TALLOC_CTX *mem_ctx,
     struct ldb_dn *base_dn = NULL;
     errno_t ret;
     const char *key_attr;
-    int optflags = SYSDB_SEARCH_WITH_TS_ONLY_TS_FILTER;
+    enum sysdb_cache_type search_cache = SYSDB_CACHE_TYPE_TIMESTAMP;
 
     switch (type) {
     case BE_REFRESH_TYPE_INITGROUPS:
@@ -121,7 +121,7 @@ static errno_t be_refresh_get_values(TALLOC_CTX *mem_ctx,
     case BE_REFRESH_TYPE_NETGROUPS:
         key_attr = SYSDB_CACHE_EXPIRE;
         // Netgroup will reside in persistent cache rather than timestamp one
-        optflags = SYSDB_SEARCH_WITH_TS_ONLY_SYSDB_FILTER;
+        search_cache = SYSDB_CACHE_TYPE_PERSISTENT;
         base_dn = sysdb_netgroup_base_dn(mem_ctx, domain);
         break;
     default:
@@ -136,7 +136,7 @@ static errno_t be_refresh_get_values(TALLOC_CTX *mem_ctx,
 
     ret = be_refresh_get_values_ex(mem_ctx, domain, period,
                                    base_dn, key_attr,
-                                   attr_name, optflags, _values);
+                                   attr_name, search_cache, _values);
 
     talloc_free(base_dn);
     return ret;

--- a/src/tests/cmocka/test_sysdb_ts_cache.c
+++ b/src/tests/cmocka/test_sysdb_ts_cache.c
@@ -1438,7 +1438,7 @@ static void test_sysdb_search_with_ts(void **state)
                                     test_ctx->tctx->dom,
                                     base_dn,
                                     LDB_SCOPE_SUBTREE,
-                                    0,
+                                    SYSDB_CACHE_TYPE_NONE,
                                     SYSDB_NAME"=*",
                                     attrs,
                                     &res);
@@ -1523,7 +1523,7 @@ static void test_sysdb_search_with_ts(void **state)
                                     test_ctx->tctx->dom,
                                     base_dn,
                                     LDB_SCOPE_SUBTREE,
-                                    0,
+                                    SYSDB_CACHE_TYPE_NONE,
                                     filter,
                                     attrs,
                                     &res);
@@ -1552,7 +1552,7 @@ static void test_sysdb_search_with_ts(void **state)
                                     test_ctx->tctx->dom,
                                     base_dn,
                                     LDB_SCOPE_SUBTREE,
-                                    SYSDB_SEARCH_WITH_TS_ONLY_TS_FILTER,
+                                    SYSDB_CACHE_TYPE_TIMESTAMP,
                                     filter,
                                     attrs,
                                     &res);
@@ -1571,7 +1571,7 @@ static void test_sysdb_search_with_ts(void **state)
                                     test_ctx->tctx->dom,
                                     base_dn,
                                     LDB_SCOPE_SUBTREE,
-                                    SYSDB_SEARCH_WITH_TS_ONLY_SYSDB_FILTER,
+                                    SYSDB_CACHE_TYPE_PERSISTENT,
                                     filter,
                                     attrs,
                                     &res);
@@ -1596,7 +1596,7 @@ static void test_sysdb_search_with_ts(void **state)
                                     test_ctx->tctx->dom,
                                     base_dn,
                                     LDB_SCOPE_SUBTREE,
-                                    0,
+                                    SYSDB_CACHE_TYPE_NONE,
                                     filter,
                                     attrs,
                                     &res);


### PR DESCRIPTION
refresh_expired_interval config value spawns be_task
responsible for refreshing expired cache entries
in background.

Netgroup related entries are stored in persistent
cache rather than timestamp cache. After sdap_refresh_step()
has been replaced by generic be_refresh_step()
lookup routine was searching for entries only in
timestamp cache. This result in LDAP netgroup entries
not refreshing in background.

Resolves:
https://bugzilla.redhat.com/show_bug.cgi?id=1779486