### PR TITLE
sysdb: sanitize certmap rule name before using it in DN

### DIFF
--- a/src/providers/ipa/ipa_subdomains.c
+++ b/src/providers/ipa/ipa_subdomains.c
@@ -450,7 +450,7 @@ static errno_t ipa_certmap_parse_results(TALLOC_CTX *mem_ctx,
 
     ret = sysdb_update_certmap(domain->sysdb, certmap_list, user_name_hint);
     if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "sysdb_update_certmap failed");
+        DEBUG(SSSDBG_OP_FAILURE, "sysdb_update_certmap failed.\n");
         goto done;
     }
 


### PR DESCRIPTION
The name of a certificate mapping and matching rule might contain
characters which are not allowed in RDNs an must be escaped before if can
be used in the DN of the cached certmap object.

Resolves: https://pagure.io/SSSD/sssd/issue/3721