### PR TITLE
proxy: allow proxy provider to start without having proxy_resolver_lib_name set

### DIFF
--- a/src/providers/data_provider/dp_targets.c
+++ b/src/providers/data_provider/dp_targets.c
@@ -290,6 +290,12 @@ static errno_t dp_target_init(struct be_ctx *be_ctx,
          * configured so we shall just continue. */
         DEBUG(SSSDBG_CONF_SETTINGS, "Target [%s] is not supported by "
               "module [%s].\n", target->name, target->module_name);
+
+        /* Target is not initialized in this case so we can free
+         * its resources. However this is not an error so we return EOK. */
+        talloc_zfree(target->methods);
+        target->initialized = false;
+
         ret = EOK;
         goto done;
     } else if (ret != EOK) {
@@ -300,7 +306,7 @@ static errno_t dp_target_init(struct be_ctx *be_ctx,
 
 done:
     if (ret != EOK) {
-        talloc_free(target->methods);
+        talloc_zfree(target->methods);
     }
 
     return ret;

--- a/src/providers/data_provider_req.c
+++ b/src/providers/data_provider_req.c
@@ -40,6 +40,8 @@ const char *be_req2str(dbus_uint32_t req_type)
         return be_req_to_str(BE_REQ_SUDO_FULL);
     case BE_REQ_SUDO_RULES:
         return be_req_to_str(BE_REQ_SUDO_RULES);
+    case BE_REQ_HOST:
+        return be_req_to_str(BE_REQ_HOST);
     case BE_REQ_BY_SECID:
         return be_req_to_str(BE_REQ_BY_SECID);
     case BE_REQ_USER_AND_GROUP:

--- a/src/providers/proxy/proxy_init.c
+++ b/src/providers/proxy/proxy_init.c
@@ -396,8 +396,6 @@ errno_t sssm_proxy_resolver_init(TALLOC_CTX *mem_ctx,
     char *libname;
     errno_t ret;
 
-    /* New config option proxy_resolver_target = files | dns | mdns4 ... */
-
     module_ctx = talloc_get_type(module_data, struct proxy_module_ctx);
 
     module_ctx->resolver_ctx = talloc_zero(mem_ctx, struct proxy_resolver_ctx);
@@ -406,7 +404,10 @@ errno_t sssm_proxy_resolver_init(TALLOC_CTX *mem_ctx,
     }
 
     ret = proxy_resolver_conf(module_ctx->resolver_ctx, be_ctx, &libname);
-    if (ret != EOK) {
+    if (ret == ENOENT) {
+        ret = ENOTSUP;
+        goto done;
+    } else if (ret != EOK) {
         goto done;
     }
 


### PR DESCRIPTION
Proxy provider fails to start unless `proxy_resolver_lib_name` is set
since recent hosts resolver addition. This would impact all existing
proxy provider configurations.

This patch makes sure that proxy resolver is disabled if the option
is not set but other functions are not affected.