### PR TITLE
confdb: use proper timestamp if sssd.conf is missing

### DIFF
--- a/src/confdb/confdb_setup.c
+++ b/src/confdb/confdb_setup.c
@@ -134,7 +134,7 @@ static int confdb_ldif_from_ini_file(TALLOC_CTX *mem_ctx,
                                      const char **_ldif)
 {
     errno_t ret;
-    char timestr[21];
+    char timestr[21] = "1";
     int version;
 
     ret = sss_ini_read_sssd_conf(init_data,


### PR DESCRIPTION
If sssd.conf is missing the timestamp is uninitialized and as a result
the lastUpdate attribute in config.ldb will contain some random binary
value.

This patch initializes the timestamp to "1".

Resolves: https://pagure.io/SSSD/sssd/issue/4178