### PR TITLE
mem-cache: sizes of free and data tables were made consistent

### DIFF
--- a/src/responder/nss/nsssrv_mmap_cache.c
+++ b/src/responder/nss/nsssrv_mmap_cache.c
@@ -27,13 +27,6 @@
 #include "responder/nss/nss_private.h"
 #include "responder/nss/nsssrv_mmap_cache.h"
 
-/* arbitrary (avg of my /etc/passwd) */
-#define SSS_AVG_PASSWD_PAYLOAD (MC_SLOT_SIZE * 4)
-/* short group name and no gids (private user group */
-#define SSS_AVG_GROUP_PAYLOAD (MC_SLOT_SIZE * 3)
-/* average place for 40 supplementary groups + 2 names */
-#define SSS_AVG_INITGROUP_PAYLOAD (MC_SLOT_SIZE * 5)
-
 #define MC_NEXT_BARRIER(val) ((((val) + 1) & 0x00ffffff) | 0xf0000000)
 
 #define MC_RAISE_BARRIER(m) do { \
@@ -1253,24 +1246,14 @@ errno_t sss_mmap_cache_init(TALLOC_CTX *mem_ctx, const char *name,
                             enum sss_mc_type type, size_t n_elem,
                             time_t timeout, struct sss_mc_ctx **mcc)
 {
+    /* sss_mc_header alone occupies whole slot,
+     * so each entry takes 2 slots at the very least
+     */
+    static const int PAYLOAD_FACTOR = 2;
+
     struct sss_mc_ctx *mc_ctx = NULL;
     unsigned int rseed;
-    int payload;
     int ret, dret;
-
-    switch (type) {
-    case SSS_MC_PASSWD:
-        payload = SSS_AVG_PASSWD_PAYLOAD;
-        break;
-    case SSS_MC_GROUP:
-        payload = SSS_AVG_GROUP_PAYLOAD;
-        break;
-    case SSS_MC_INITGROUPS:
-        payload = SSS_AVG_INITGROUP_PAYLOAD;
-        break;
-    default:
-        return EINVAL;
-    }
 
     mc_ctx = talloc_zero(mem_ctx, struct sss_mc_ctx);
     if (!mc_ctx) {
@@ -1306,9 +1289,9 @@ errno_t sss_mmap_cache_init(TALLOC_CTX *mem_ctx, const char *name,
 
     /* hash table is double the size because it will store both forward and
      * reverse keys (name/uid, name/gid, ..) */
-    mc_ctx->ht_size = MC_HT_SIZE(n_elem * 2);
-    mc_ctx->dt_size = MC_DT_SIZE(n_elem, payload);
-    mc_ctx->ft_size = MC_FT_SIZE(n_elem);
+    mc_ctx->ht_size = MC_HT_SIZE(2 * n_elem / PAYLOAD_FACTOR);
+    mc_ctx->dt_size = n_elem * MC_SLOT_SIZE;
+    mc_ctx->ft_size = n_elem / 8; /* 1 bit per slot */
     mc_ctx->mmap_size = MC_HEADER_SIZE +
                         MC_ALIGN64(mc_ctx->dt_size) +
                         MC_ALIGN64(mc_ctx->ft_size) +

--- a/src/responder/nss/nsssrv_mmap_cache.h
+++ b/src/responder/nss/nsssrv_mmap_cache.h
@@ -22,8 +22,6 @@
 #ifndef _NSSSRV_MMAP_CACHE_H_
 #define _NSSSRV_MMAP_CACHE_H_
 
-#define SSS_MC_CACHE_ELEMENTS 50000
-
 struct sss_mc_ctx;
 
 enum sss_mc_type {

--- a/src/util/mmap_cache.h
+++ b/src/util/mmap_cache.h
@@ -40,9 +40,6 @@ typedef uint32_t rel_ptr_t;
 
 #define MC_HT_SIZE(elems) ( (elems) * MC_32 )
 #define MC_HT_ELEMS(size) ( (size) / MC_32 )
-#define MC_DT_SIZE(elems, payload) ( (elems) * (payload) )
-#define MC_FT_SIZE(elems) ( (elems) / 8 )
-/* ^^ 8 bits per byte so we need just elems/8 bytes to represent all blocks */
 
 #define MC_PTR_ADD(ptr, bytes) (void *)((uint8_t *)(ptr) + (bytes))
 #define MC_PTR_DIFF(ptr, base) ((uint8_t *)(ptr) - (uint8_t *)(base))


### PR DESCRIPTION
This is partial backport of #999

Since size of "free table" didn't account for SSS_AVG_*_PAYLOAD factor
only small fraction of "data table" was actually used.
SSS_AVG_*_PAYLOAD differentiation for different payload types only
affected size of hash table and was removed as unjustified.

Resolves: https://pagure.io/SSSD/sssd/issue/4160