### PR TITLE
Backport of crashbug fix #737 to 1-16

### DIFF
--- a/src/providers/proxy/proxy_id.c
+++ b/src/providers/proxy/proxy_id.c
@@ -602,9 +602,9 @@ static errno_t remove_duplicate_group_members(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    for (i=0; orig_grp->gr_mem[i] != NULL; i++) {
-        orig_member_count++;
-    }
+    for (i=0; orig_grp->gr_mem[i] != NULL; ++i) /* no-op: just counting */;
+
+    orig_member_count = i;
 
     if (orig_member_count == 0) {
         ret = ENOENT;
@@ -618,7 +618,7 @@ static errno_t remove_duplicate_group_members(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    for (i=0; orig_grp->gr_mem[i] != NULL; i++) {
+    for (i=0; i < orig_member_count; ++i) {
         key.type = HASH_KEY_STRING;
         key.str = talloc_strdup(member_tbl, orig_grp->gr_mem[i]);
         if (key.str == NULL) {

--- a/src/providers/proxy/proxy_id.c
+++ b/src/providers/proxy/proxy_id.c
@@ -629,7 +629,7 @@ static errno_t remove_duplicate_group_members(TALLOC_CTX *mem_ctx,
 
         value.type = HASH_VALUE_PTR;
         value.ptr = talloc_strdup(member_tbl, orig_grp->gr_mem[i]);
-        if (key.str == NULL) {
+        if (value.ptr == NULL) {
             DEBUG(SSSDBG_OP_FAILURE, "talloc_strdup failed.\n");
             ret = ENOMEM;
             goto done;

--- a/src/providers/proxy/proxy_id.c
+++ b/src/providers/proxy/proxy_id.c
@@ -649,7 +649,7 @@ static errno_t remove_duplicate_group_members(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    grp = talloc(mem_ctx, struct group);
+    grp = talloc(tmp_ctx, struct group);
     if (grp == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "talloc failed.\n");
         ret = ENOMEM;

--- a/src/providers/proxy/proxy_id.c
+++ b/src/providers/proxy/proxy_id.c
@@ -620,24 +620,15 @@ static errno_t remove_duplicate_group_members(TALLOC_CTX *mem_ctx,
 
     for (i=0; i < orig_member_count; ++i) {
         key.type = HASH_KEY_STRING;
-        key.str = talloc_strdup(member_tbl, orig_grp->gr_mem[i]);
-        if (key.str == NULL) {
-            DEBUG(SSSDBG_OP_FAILURE, "talloc_strdup failed.\n");
-            ret = ENOMEM;
-            goto done;
-        }
+        key.str = orig_grp->gr_mem[i]; /* hash_enter() makes copy itself */
 
         value.type = HASH_VALUE_PTR;
-        value.ptr = talloc_strdup(member_tbl, orig_grp->gr_mem[i]);
-        if (value.ptr == NULL) {
-            DEBUG(SSSDBG_OP_FAILURE, "talloc_strdup failed.\n");
-            ret = ENOMEM;
-            goto done;
-        }
+        /* no need to put copy in hash_table since
+           copy will be created during construction of new grp */
+        value.ptr = orig_grp->gr_mem[i];
 
         ret = hash_enter(member_tbl, &key, &value);
         if (ret != HASH_SUCCESS) {
-            talloc_free(key.str);
             ret = ENOMEM;
             goto done;
         }

--- a/src/providers/proxy/proxy_id.c
+++ b/src/providers/proxy/proxy_id.c
@@ -597,8 +597,32 @@ static errno_t remove_duplicate_group_members(TALLOC_CTX *mem_ctx,
         return ENOMEM;
     }
 
+    grp = talloc(tmp_ctx, struct group);
+    if (grp == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "talloc failed.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    grp->gr_gid = orig_grp->gr_gid;
+
+    grp->gr_name = talloc_strdup(grp, orig_grp->gr_name);
+    if (grp->gr_name == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "talloc_strdup failed.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    grp->gr_passwd = talloc_strdup(grp, orig_grp->gr_passwd);
+    if (grp->gr_passwd == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "talloc_strdup failed.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
     if (orig_grp->gr_mem == NULL) {
-        ret = ENOENT;
+        grp->gr_mem = NULL;
+        ret = EOK;
         goto done;
     }
 
@@ -607,7 +631,14 @@ static errno_t remove_duplicate_group_members(TALLOC_CTX *mem_ctx,
     orig_member_count = i;
 
     if (orig_member_count == 0) {
-        ret = ENOENT;
+        grp->gr_mem = talloc_zero_array(grp, char *, 1);
+        if (grp->gr_mem == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE, "talloc_zero_array failed.\n");
+            ret = ENOMEM;
+            goto done;
+        }
+        grp->gr_mem[0] = NULL;
+        ret = EOK;
         goto done;
     }
 
@@ -636,14 +667,8 @@ static errno_t remove_duplicate_group_members(TALLOC_CTX *mem_ctx,
 
     member_count = hash_count(member_tbl);
     if (member_count == 0) {
-        ret = ENOENT;
-        goto done;
-    }
-
-    grp = talloc(tmp_ctx, struct group);
-    if (grp == NULL) {
-        DEBUG(SSSDBG_OP_FAILURE, "talloc failed.\n");
-        ret = ENOMEM;
+        DEBUG(SSSDBG_CRIT_FAILURE, "Empty resulting hash table - must be internal bug.\n");
+        ret = EINVAL;
         goto done;
     }
 
@@ -673,32 +698,13 @@ static errno_t remove_duplicate_group_members(TALLOC_CTX *mem_ctx,
     }
     grp->gr_mem[i] = NULL;
 
-    grp->gr_gid = orig_grp->gr_gid;
-
-    grp->gr_name = talloc_strdup(grp, orig_grp->gr_name);
-    if (grp->gr_name == NULL) {
-        DEBUG(SSSDBG_OP_FAILURE, "talloc_strdup failed.\n");
-        ret = ENOMEM;
-        goto done;
-    }
-
-    grp->gr_passwd = talloc_strdup(grp, orig_grp->gr_passwd);
-    if (grp->gr_passwd == NULL) {
-        DEBUG(SSSDBG_OP_FAILURE, "talloc_strdup failed.\n");
-        ret = ENOMEM;
-        goto done;
-    }
-
-    *_grp = talloc_steal(mem_ctx, grp);
     ret = EOK;
 
 done:
-    talloc_zfree(tmp_ctx);
-
-    if (ret == ENOENT) {
-        *_grp = talloc_steal(mem_ctx, orig_grp);
-        ret = EOK;
+    if (ret == EOK) {
+        *_grp = talloc_steal(mem_ctx, grp);
     }
+    talloc_zfree(tmp_ctx);
 
     return ret;
 }


### PR DESCRIPTION
This is backport of patches from #737 (excluding one not strictly required patch) where one of the patches (namely "providers/proxy: fixed erroneous free of orig_grp" ) was amended with fix from PR https://pagure.io/SSSD/sssd/pull-request/4036