### PR TITLE
DOMAIN: Downgrade log message type

### DIFF
--- a/src/util/usertools.c
+++ b/src/util/usertools.c
@@ -532,8 +532,8 @@ calc_flat_name(struct sss_domain_info *domain)
 
     s = domain->flat_name;
     if (s == NULL) {
-        DEBUG(SSSDBG_MINOR_FAILURE, "Flat name requested but domain has no"
-              "flat name set, falling back to domain name\n");
+        DEBUG(SSSDBG_FUNC_DATA, "Domain has no flat name set,"
+              "using domain name instead\n");
         s = domain->name;
     }
 


### PR DESCRIPTION
Not all domains contains flat name.
This is specific and in most cases needed for AD domain.
In case of AD domain flat name checking and failure log already exists:
src/providers/ad/ad_domain_info.c +104

src/util/usertools.c contains more generic domain related
functions. In those cases missing of flat_name should not be
considered as failure.

Resolves:
https://github.com/SSSD/sssd/issues/1032