### PR TITLE
config: switch to OpenSSL as default crypto backend

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -815,6 +815,8 @@ autoreconf -ivf
     --disable-static \
 %if (0%{?use_openssl} == 1)
     --with-crypto=libcrypto \
+%else
+    --with-crypto=nss \
 %endif
     --disable-rpath \
 %if %{with sssd_user}

--- a/src/conf_macros.m4
+++ b/src/conf_macros.m4
@@ -558,11 +558,11 @@ AC_DEFUN([WITH_LIBNL],
 AC_DEFUN([WITH_CRYPTO],
     [ AC_ARG_WITH([crypto],
                   [AC_HELP_STRING([--with-crypto=CRYPTO_LIB],
-                                  [The cryptographic library to use (nss|libcrypto). The default is nss.]
+                                  [The cryptographic library to use (libcrypto|nss). The default is libcrypto (OpenSSL). NSS is deprecated.]
                                  )
                   ],
                   [],
-                  with_crypto=nss
+                  with_crypto=libcrypto
                  )
 
       cryptolib=""
@@ -570,9 +570,14 @@ AC_DEFUN([WITH_CRYPTO],
           if test x"$with_crypto" = xnss || \
           test x"$with_crypto" = xlibcrypto; then
               cryptolib="$with_crypto";
+              if test x"$with_crypto" = xnss; then
+                  AC_MSG_WARN([NSS is deprecated crypto backend and it support will be dropped in upcoming releases.])
+              fi
           else
               AC_MSG_ERROR([Illegal value -$with_crypto- for option --with-crypto])
           fi
+      else
+          cryptolib=libcrypto
       fi
       AM_CONDITIONAL([HAVE_NSS], [test x"$cryptolib" = xnss])
       AM_CONDITIONAL([HAVE_LIBCRYPTO], [test x"$cryptolib" = xlibcrypto])


### PR DESCRIPTION
 - switch default to OpenSSL
 - warn about deprecation in the case NSS is selected
   during configuration

Partially resolves: https://github.com/SSSD/sssd/issues/1041 - parts I.1 and I.2