### PR TITLE
krb5_auth: when providing wrong password return PAM_AUTH_ERR

### DIFF
--- a/src/providers/ipa/ipa_auth.c
+++ b/src/providers/ipa/ipa_auth.c
@@ -271,6 +271,14 @@ static void ipa_pam_auth_handler_krb5_done(struct tevent_req *subreq)
         return;
     }
 
+    /* PAM_CRED_ERR is used to indicate to the IPA provider that trying
+     * password migration would make sense. From this point on it isn't
+     * necessary to keep this status, so it can be translated to PAM_AUTH_ERR.
+     */
+    if (state->pd->pam_status == PAM_CRED_ERR) {
+        state->pd->pam_status = PAM_AUTH_ERR;
+    }
+
 done:
     /* TODO For backward compatibility we always return EOK to DP now. */
     tevent_req_done(req);
@@ -310,6 +318,14 @@ static void ipa_pam_auth_handler_flag_done(struct tevent_req *subreq)
 
         tevent_req_set_callback(subreq, ipa_pam_auth_handler_connect_done, req);
         return;
+    }
+
+    /* PAM_CRED_ERR is used to indicate to the IPA provider that trying
+     * password migration would make sense. From this point on it isn't
+     * necessary to keep this status, so it can be translated to PAM_AUTH_ERR.
+     */
+    if (state->pd->pam_status == PAM_CRED_ERR) {
+        state->pd->pam_status = PAM_AUTH_ERR;
     }
 
 done:

--- a/src/providers/krb5/krb5_auth.c
+++ b/src/providers/krb5/krb5_auth.c
@@ -1291,6 +1291,14 @@ static void krb5_pam_handler_auth_done(struct tevent_req *subreq)
         state->pd->pam_status = PAM_SYSTEM_ERR;
     }
 
+    /* PAM_CRED_ERR is used to indicate to the IPA provider that trying
+     * password migration would make sense. From this point on it isn't
+     * necessary to keep this status, so it can be translated to PAM_AUTH_ERR.
+     */
+    if (state->pd->pam_status == PAM_CRED_ERR) {
+        state->pd->pam_status = PAM_AUTH_ERR;
+    }
+
     /* TODO For backward compatibility we always return EOK to DP now. */
     tevent_req_done(req);
 }


### PR DESCRIPTION
When providing a wrong password for an existing IPA user, return PAM_AUTH_ERR (authentication failure) instead of PAM_CRED_ERR (failure setting user credentials)

Resolves:
https://github.com/SSSD/sssd/issues/5139