### PR TITLE
p11_child: fix initializer error

### DIFF
--- a/src/p11_child/p11_child_openssl.c
+++ b/src/p11_child/p11_child_openssl.c
@@ -1293,7 +1293,7 @@ static CK_RV get_preferred_rsa_mechanism(TALLOC_CTX *mem_ctx,
         { CKM_SHA256_RSA_PKCS, "CKM_SHA256_RSA_PKCS", EVP_sha256(), "sha256" },
         { CKM_SHA224_RSA_PKCS, "CKM_SHA224_RSA_PKCS", EVP_sha224(), "sha224" },
         { CKM_SHA1_RSA_PKCS,   "CKM_SHA1_RSA_PKCS",   EVP_sha1(),   "sha1" },
-        { 0, NULL }
+        { 0, NULL, NULL, NULL }
     };
 
     *preferred_mechanism = CKM_SHA1_RSA_PKCS;


### PR DESCRIPTION
Building with:
```
$ echo $CFLAGS
-m64 -mtune=generic -fstack-protector-all -Wall -Wextra -Wno-sign-compare -Wshadow -Wunused-variable -Wno-unused-parameter -Wno-error=cpp -O0 -ggdb3 -Werror -Wp,-U_FORTIFY_SOURCE
```

Produces:
```
/home/pbrezina/workspace/sssd/src/p11_child/p11_child_openssl.c: In function ‘get_preferred_rsa_mechanism’:
/home/pbrezina/workspace/sssd/src/p11_child/p11_child_openssl.c:1296:9: error: missing initializer for field ‘evp_md’ of ‘struct prefs’ [-Werror=missing-field-initializers]
 1296 |         { 0, NULL }
      |         ^
/home/pbrezina/workspace/sssd/src/p11_child/p11_child_openssl.c:1288:23: note: ‘evp_md’ declared here
 1288 |         const EVP_MD *evp_md;
      |                       ^~~~~~
```