### PR TITLE
SBUS: do not return invalid connection pointer

### DIFF
--- a/src/sbus/connection/sbus_dbus.c
+++ b/src/sbus/connection/sbus_dbus.c
@@ -175,6 +175,7 @@ done:
     dbus_error_free(&dbus_error);
     if (ret != EOK && dbus_conn != NULL) {
         dbus_connection_unref(dbus_conn);
+        dbus_conn = NULL;
     }
 
     return dbus_conn;


### PR DESCRIPTION
Relates: https://github.com/SSSD/sssd/issues/5126