### PR TITLE
ad: check forest root directly in not present on local DC

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -562,6 +562,24 @@ errno_t sysdb_subdomain_delete(struct sysdb_ctx *sysdb, const char *name);
 errno_t sysdb_subdomain_content_delete(struct sysdb_ctx *sysdb,
                                        const char *name);
 
+/* The utility function to create a subdomain sss_domain_info object is handy
+ * for unit tests, so it should be available in a headerr.
+ */
+struct sss_domain_info *new_subdomain(TALLOC_CTX *mem_ctx,
+                                      struct sss_domain_info *parent,
+                                      const char *name,
+                                      const char *realm,
+                                      const char *flat_name,
+                                      const char *id,
+                                      enum sss_domain_mpg_mode mpg_mode,
+                                      bool enumerate,
+                                      const char *forest,
+                                      const char **upn_suffixes,
+                                      uint32_t trust_direction,
+                                      struct confdb_ctx *confdb,
+                                      bool enabled);
+
+
 errno_t sysdb_get_ranges(TALLOC_CTX *mem_ctx, struct sysdb_ctx *sysdb,
                              size_t *range_count,
                              struct range_info ***range_list);

--- a/src/db/sysdb_private.h
+++ b/src/db/sysdb_private.h
@@ -196,25 +196,6 @@ int sysdb_replace_ulong(struct ldb_message *msg,
 int sysdb_delete_ulong(struct ldb_message *msg,
                        const char *attr, unsigned long value);
 
-/* The utility function to create a subdomain sss_domain_info object is handy
- * for unit tests, so it should be available in a header, but not a public util
- * one, because the only interface for the daemon itself should be adding
- * the sysdb domain object and calling sysdb_update_subdomains()
- */
-struct sss_domain_info *new_subdomain(TALLOC_CTX *mem_ctx,
-                                      struct sss_domain_info *parent,
-                                      const char *name,
-                                      const char *realm,
-                                      const char *flat_name,
-                                      const char *id,
-                                      enum sss_domain_mpg_mode mpg_mode,
-                                      bool enumerate,
-                                      const char *forest,
-                                      const char **upn_suffixes,
-                                      uint32_t trust_direction,
-                                      struct confdb_ctx *confdb,
-                                      bool enabled);
-
 /* Helper functions to deal with the timestamp cache should not be used
  * outside the sysdb itself. The timestamp cache should be completely
  * opaque to the sysdb consumers

--- a/src/db/sysdb_subdomains.c
+++ b/src/db/sysdb_subdomains.c
@@ -421,7 +421,9 @@ errno_t sysdb_update_subdomains(struct sss_domain_info *domain,
                 }
 
                 /* in theory these may change, but it should never happen */
-                if (strcasecmp(dom->realm, realm) != 0) {
+                if ((dom->realm == NULL && realm != NULL)
+                        || (dom->realm != NULL && realm != NULL
+                            && strcasecmp(dom->realm, realm) != 0)) {
                     DEBUG(SSSDBG_TRACE_INTERNAL,
                           "Realm name changed from [%s] to [%s]!\n",
                            dom->realm, realm);
@@ -432,7 +434,9 @@ errno_t sysdb_update_subdomains(struct sss_domain_info *domain,
                         goto done;
                     }
                 }
-                if (strcasecmp(dom->flat_name, flat) != 0) {
+                if ((dom->flat_name == NULL && flat != NULL)
+                        || (dom->flat_name != NULL && flat != NULL
+                            && strcasecmp(dom->flat_name, flat) != 0)) {
                     DEBUG(SSSDBG_TRACE_INTERNAL,
                           "Flat name changed from [%s] to [%s]!\n",
                            dom->flat_name, flat);
@@ -443,7 +447,9 @@ errno_t sysdb_update_subdomains(struct sss_domain_info *domain,
                         goto done;
                     }
                 }
-                if (strcasecmp(dom->domain_id, id) != 0) {
+                if ((dom->domain_id == NULL && id != NULL)
+                        || (dom->domain_id != NULL && id != NULL
+                            && strcasecmp(dom->domain_id, id) != 0)) {
                     DEBUG(SSSDBG_TRACE_INTERNAL,
                           "Domain changed from [%s] to [%s]!\n",
                            dom->domain_id, id);

--- a/src/providers/ad/ad_domain_info.c
+++ b/src/providers/ad/ad_domain_info.c
@@ -175,7 +175,7 @@ done:
     return ret;
 }
 
-struct ad_master_domain_state {
+struct ad_domain_info_state {
     struct tevent_context *ev;
     struct sdap_id_conn_ctx *conn;
     struct sdap_id_op *id_op;
@@ -191,22 +191,22 @@ struct ad_master_domain_state {
     char *sid;
 };
 
-static errno_t ad_master_domain_next(struct tevent_req *req);
-static void ad_master_domain_next_done(struct tevent_req *subreq);
-static void ad_master_domain_netlogon_done(struct tevent_req *req);
+static errno_t ad_domain_info_next(struct tevent_req *req);
+static void ad_domain_info_next_done(struct tevent_req *subreq);
+static void ad_domain_info_netlogon_done(struct tevent_req *req);
 
 struct tevent_req *
-ad_master_domain_send(TALLOC_CTX *mem_ctx,
-                      struct tevent_context *ev,
-                      struct sdap_id_conn_ctx *conn,
-                      struct sdap_id_op *op,
-                      const char *dom_name)
+ad_domain_info_send(TALLOC_CTX *mem_ctx,
+                    struct tevent_context *ev,
+                    struct sdap_id_conn_ctx *conn,
+                    struct sdap_id_op *op,
+                    const char *dom_name)
 {
     errno_t ret;
     struct tevent_req *req;
-    struct ad_master_domain_state *state;
+    struct ad_domain_info_state *state;
 
-    req = tevent_req_create(mem_ctx, &state, struct ad_master_domain_state);
+    req = tevent_req_create(mem_ctx, &state, struct ad_domain_info_state);
     if (!req) return NULL;
 
     state->ev = ev;
@@ -216,7 +216,7 @@ ad_master_domain_send(TALLOC_CTX *mem_ctx,
     state->opts = conn->id_ctx->opts;
     state->dom_name = dom_name;
 
-    ret = ad_master_domain_next(req);
+    ret = ad_domain_info_next(req);
     if (ret != EOK && ret != EAGAIN) {
         goto immediate;
     }
@@ -234,14 +234,14 @@ immediate:
 }
 
 static errno_t
-ad_master_domain_next(struct tevent_req *req)
+ad_domain_info_next(struct tevent_req *req)
 {
     struct tevent_req *subreq;
     struct sdap_search_base *base;
     const char *master_sid_attrs[] = {AD_AT_OBJECT_SID, NULL};
 
-    struct ad_master_domain_state *state =
-        tevent_req_data(req, struct ad_master_domain_state);
+    struct ad_domain_info_state *state =
+        tevent_req_data(req, struct ad_domain_info_state);
 
     base = state->opts->sdom->search_bases[state->base_iter];
     if (base == NULL) {
@@ -261,13 +261,13 @@ ad_master_domain_next(struct tevent_req *req)
         DEBUG(SSSDBG_OP_FAILURE, "sdap_get_generic_send failed.\n");
         return ENOMEM;
     }
-    tevent_req_set_callback(subreq, ad_master_domain_next_done, req);
+    tevent_req_set_callback(subreq, ad_domain_info_next_done, req);
 
     return EAGAIN;
 }
 
 static void
-ad_master_domain_next_done(struct tevent_req *subreq)
+ad_domain_info_next_done(struct tevent_req *subreq)
 {
     errno_t ret;
     size_t reply_count;
@@ -281,8 +281,8 @@ ad_master_domain_next_done(struct tevent_req *subreq)
 
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                       struct tevent_req);
-    struct ad_master_domain_state *state =
-        tevent_req_data(req, struct ad_master_domain_state);
+    struct ad_domain_info_state *state =
+        tevent_req_data(req, struct ad_domain_info_state);
 
     ret = sdap_get_generic_recv(subreq, state, &reply_count, &reply);
     talloc_zfree(subreq);
@@ -293,7 +293,7 @@ ad_master_domain_next_done(struct tevent_req *subreq)
 
     if (reply_count == 0) {
         state->base_iter++;
-        ret = ad_master_domain_next(req);
+        ret = ad_domain_info_next(req);
         if (ret == EAGAIN) {
             /* Async request will get us back here again */
             return;
@@ -362,7 +362,7 @@ ad_master_domain_next_done(struct tevent_req *subreq)
         goto done;
     }
 
-    tevent_req_set_callback(subreq, ad_master_domain_netlogon_done, req);
+    tevent_req_set_callback(subreq, ad_domain_info_netlogon_done, req);
     return;
 
 done:
@@ -370,7 +370,7 @@ done:
 }
 
 static void
-ad_master_domain_netlogon_done(struct tevent_req *subreq)
+ad_domain_info_netlogon_done(struct tevent_req *subreq)
 {
     int ret;
     size_t reply_count;
@@ -378,8 +378,8 @@ ad_master_domain_netlogon_done(struct tevent_req *subreq)
 
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                       struct tevent_req);
-    struct ad_master_domain_state *state =
-        tevent_req_data(req, struct ad_master_domain_state);
+    struct ad_domain_info_state *state =
+        tevent_req_data(req, struct ad_domain_info_state);
 
     ret = sdap_get_generic_recv(subreq, state, &reply_count, &reply);
     talloc_zfree(subreq);
@@ -422,15 +422,15 @@ done:
 }
 
 errno_t
-ad_master_domain_recv(struct tevent_req *req,
-                      TALLOC_CTX *mem_ctx,
-                      char **_flat,
-                      char **_id,
-                      char **_site,
-                      char **_forest)
+ad_domain_info_recv(struct tevent_req *req,
+                    TALLOC_CTX *mem_ctx,
+                    char **_flat,
+                    char **_id,
+                    char **_site,
+                    char **_forest)
 {
-    struct ad_master_domain_state *state = tevent_req_data(req,
-                                              struct ad_master_domain_state);
+    struct ad_domain_info_state *state = tevent_req_data(req,
+                                              struct ad_domain_info_state);
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
 

--- a/src/providers/ad/ad_domain_info.h
+++ b/src/providers/ad/ad_domain_info.h
@@ -22,22 +22,22 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef _AD_MASTER_DOMAIN_H_
-#define _AD_MASTER_DOMAIN_H_
+#ifndef _AD_DOMAIN_INFO_H_
+#define _AD_DOMAIN_INFO_H_
 
 struct tevent_req *
-ad_master_domain_send(TALLOC_CTX *mem_ctx,
+ad_domain_info_send(TALLOC_CTX *mem_ctx,
                       struct tevent_context *ev,
                       struct sdap_id_conn_ctx *conn,
                       struct sdap_id_op *op,
                       const char *dom_name);
 
 errno_t
-ad_master_domain_recv(struct tevent_req *req,
+ad_domain_info_recv(struct tevent_req *req,
                       TALLOC_CTX *mem_ctx,
                       char **_flat,
                       char **_id,
                       char **_site,
                       char **_forest);
 
-#endif /* _AD_MASTER_DOMAIN_H_ */
+#endif /* _AD_DOMAIN_INFO_H_ */

--- a/src/providers/ad/ad_gpo.c
+++ b/src/providers/ad/ad_gpo.c
@@ -3162,11 +3162,11 @@ ad_gpo_process_som_send(TALLOC_CTX *mem_ctx,
         goto immediately;
     }
 
-    subreq = ad_master_domain_send(state, state->ev, conn,
-                                   state->sdap_op, domain_name);
+    subreq = ad_domain_info_send(state, state->ev, conn,
+                                 state->sdap_op, domain_name);
 
     if (subreq == NULL) {
-        DEBUG(SSSDBG_OP_FAILURE, "ad_master_domain_send failed.\n");
+        DEBUG(SSSDBG_OP_FAILURE, "ad_domain_info_send failed.\n");
         ret = ENOMEM;
         goto immediately;
     }
@@ -3199,7 +3199,7 @@ ad_gpo_site_name_retrieval_done(struct tevent_req *subreq)
     state = tevent_req_data(req, struct ad_gpo_process_som_state);
 
     /* gpo code only cares about the site name */
-    ret = ad_master_domain_recv(subreq, state, NULL, NULL, &site, NULL);
+    ret = ad_domain_info_recv(subreq, state, NULL, NULL, &site, NULL);
     talloc_zfree(subreq);
 
     if (ret != EOK || site == NULL) {

--- a/src/providers/ad/ad_id.c
+++ b/src/providers/ad/ad_id.c
@@ -663,12 +663,12 @@ ad_enumeration_conn_done(struct tevent_req *subreq)
         return;
     }
 
-    subreq = ad_master_domain_send(state, state->ev,
-                                   state->id_ctx->ldap_ctx,
-                                   state->sdap_op,
-                                   state->sdom->dom->name);
+    subreq = ad_domain_info_send(state, state->ev,
+                                  state->id_ctx->ldap_ctx,
+                                  state->sdap_op,
+                                  state->sdom->dom->name);
     if (subreq == NULL) {
-        DEBUG(SSSDBG_OP_FAILURE, "ad_master_domain_send failed.\n");
+        DEBUG(SSSDBG_OP_FAILURE, "ad_domain_info_send failed.\n");
         tevent_req_error(req, ret);
         return;
     }
@@ -687,8 +687,8 @@ ad_enumeration_master_done(struct tevent_req *subreq)
     char *master_sid;
     char *forest;
 
-    ret = ad_master_domain_recv(subreq, state,
-                                &flat_name, &master_sid, NULL, &forest);
+    ret = ad_domain_info_recv(subreq, state,
+                              &flat_name, &master_sid, NULL, &forest);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "Cannot retrieve master domain info\n");

--- a/src/providers/ad/ad_resolver.c
+++ b/src/providers/ad/ad_resolver.c
@@ -317,10 +317,10 @@ ad_resolver_enumeration_conn_done(struct tevent_req *subreq)
         return;
     }
 
-    subreq = ad_master_domain_send(state, state->ev, id_ctx->conn,
-                                   state->sdap_op, state->sdom->dom->name);
+    subreq = ad_domain_info_send(state, state->ev, id_ctx->conn,
+                                 state->sdap_op, state->sdom->dom->name);
     if (subreq == NULL) {
-        DEBUG(SSSDBG_OP_FAILURE, "ad_master_domain_send failed.\n");
+        DEBUG(SSSDBG_OP_FAILURE, "ad_domain_info_send failed.\n");
         tevent_req_error(req, ret);
         return;
     }
@@ -346,7 +346,7 @@ ad_resolver_enumeration_master_done(struct tevent_req *subreq)
     char *forest;
     struct ad_id_ctx *ad_id_ctx;
 
-    ret = ad_master_domain_recv(subreq, state,
+    ret = ad_domain_info_recv(subreq, state,
                                 &flat_name, &master_sid, NULL, &forest);
     talloc_zfree(subreq);
     if (ret != EOK) {

--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -2143,3 +2143,254 @@ errno_t ad_subdomains_init(TALLOC_CTX *mem_ctx,
 
     return EOK;
 }
+
+struct ad_check_domain_state {
+    struct tevent_context *ev;
+    struct be_ctx *be_ctx;
+    struct sdap_id_op *sdap_op;
+    struct ad_id_ctx *dom_id_ctx;
+    struct sdap_options *opts;
+
+    const char *dom_name;
+    struct sss_domain_info *dom;
+    struct sss_domain_info *parent;
+    struct sdap_domain *sdom;
+
+    char *flat;
+    char *site;
+    char *forest;
+    char *sid;
+};
+
+static void ad_check_domain_connect_done(struct tevent_req *subreq);
+static void ad_check_domain_done(struct tevent_req *subreq);
+
+static int ad_check_domain_destructor(void *mem)
+{
+    struct ad_check_domain_state *state = talloc_get_type(mem,
+                                                  struct ad_check_domain_state);
+
+    if (state->sdom != NULL) {
+        DEBUG(SSSDBG_TRACE_ALL, "Removing sdap domain [%s].\n",
+                                state->dom->name);
+        sdap_domain_remove(state->opts, state->dom);
+        /* terminate all requests for this subdomain so we can free it */
+        dp_terminate_domain_requests(state->be_ctx->provider, state->dom->name);
+        talloc_zfree(state->sdom);
+    }
+
+    if (state->dom != NULL) {
+        DEBUG(SSSDBG_TRACE_ALL, "Removing domain [%s].\n", state->dom->name);
+        sss_domain_set_state(state->dom, DOM_DISABLED);
+        DLIST_REMOVE(state->be_ctx->domain->subdomains, state->dom);
+        talloc_zfree(state->dom);
+    }
+
+    return 0;
+}
+
+struct tevent_req *
+ad_check_domain_send(TALLOC_CTX *mem_ctx,
+                     struct tevent_context *ev,
+                     struct be_ctx *be_ctx,
+                     struct ad_id_ctx *ad_id_ctx,
+                     const char *dom_name,
+                     const char *parent_dom_name)
+{
+    errno_t ret;
+    struct tevent_req *req;
+    struct tevent_req *subreq;
+    struct ad_check_domain_state *state;
+
+    req = tevent_req_create(mem_ctx, &state, struct ad_check_domain_state);
+    if (req == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "tevent_req_create failed.\n");
+        return NULL;
+    }
+
+    state->ev = ev;
+    state->be_ctx = be_ctx;
+    state->opts = ad_id_ctx->sdap_id_ctx->opts;
+    state->dom_name = dom_name;
+    state->parent = NULL;
+    state->sdom = NULL;
+
+    state->dom = find_domain_by_name(be_ctx->domain, dom_name, true);
+    if (state->dom == NULL) {
+        state->parent = find_domain_by_name(be_ctx->domain, parent_dom_name,
+                                            true);
+        if (state->parent == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "Failed to find domain object for domain [%s].\n",
+                  parent_dom_name);
+            ret = ENOENT;
+            goto immediately;
+        }
+
+        state->dom = new_subdomain(state->parent, state->parent, dom_name,
+                                   dom_name, NULL, NULL, MPG_DISABLED, false,
+                                   state->parent->forest,
+                                   NULL, 0, be_ctx->cdb, true);
+        if (state->dom == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE, "new_subdomain() failed.\n");
+            ret = EINVAL;
+            goto immediately;
+        }
+
+        talloc_set_destructor((TALLOC_CTX *) state, ad_check_domain_destructor);
+
+        DLIST_ADD_END(state->parent->subdomains, state->dom,
+                      struct sss_domain_info *);
+
+        ret = sdap_domain_add(state->opts, state->dom, &state->sdom);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_OP_FAILURE, "sdap_domain_subdom_add failed.\n");
+            goto immediately;
+        }
+
+        ret = ad_set_search_bases(ad_id_ctx->ad_options->id, state->sdom);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE, "failed to set ldap search bases for "
+                  "domain '%s'. Will try to use automatically detected search "
+                  "bases.", state->sdom->dom->name);
+        }
+
+    }
+
+    state->dom_id_ctx = ads_get_dom_id_ctx(be_ctx, ad_id_ctx, state->dom,
+                                           state->opts);
+    if (state->dom_id_ctx == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "ads_get_dom_id_ctx() failed.\n");
+        ret = EINVAL;
+        goto immediately;
+    }
+
+    state->sdap_op = sdap_id_op_create(state,
+                             state->dom_id_ctx->sdap_id_ctx->conn->conn_cache);
+    if (state->sdap_op == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "sdap_id_op_create() failed\n");
+         ret = ENOMEM;
+         goto immediately;
+    }
+
+    subreq = sdap_id_op_connect_send(state->sdap_op, state, &ret);
+    if (subreq == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "sdap_id_op_connect_send() failed "
+              "[%d]: %s\n", ret, sss_strerror(ret));
+         goto immediately;
+    }
+
+    tevent_req_set_callback(subreq, ad_check_domain_connect_done, req);
+
+    return req;
+
+immediately:
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else {
+        tevent_req_error(req, ret);
+    }
+    tevent_req_post(req, ev);
+
+    return req;
+}
+
+static void ad_check_domain_connect_done(struct tevent_req *subreq)
+{
+    struct tevent_req *req;
+    struct ad_check_domain_state *state;
+    int ret;
+    int dp_error;
+
+    req = tevent_req_callback_data(subreq, struct tevent_req);
+    state = tevent_req_data(req, struct ad_check_domain_state);
+
+    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    talloc_zfree(subreq);
+
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to connect to LDAP "
+              "[%d]: %s\n", ret, sss_strerror(ret));
+        if (dp_error == DP_ERR_OFFLINE) {
+            DEBUG(SSSDBG_MINOR_FAILURE, "No AD server is available, "
+                  "cannot get the subdomain list while offline\n");
+            ret = ERR_OFFLINE;
+        }
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    subreq = ad_domain_info_send(state, state->ev,
+                                 state->dom_id_ctx->sdap_id_ctx->conn,
+                                 state->sdap_op, state->dom_name);
+
+    tevent_req_set_callback(subreq, ad_check_domain_done, req);
+
+    return;
+}
+
+static void ad_check_domain_done(struct tevent_req *subreq)
+{
+    struct tevent_req *req;
+    struct ad_check_domain_state *state;
+    errno_t ret;
+
+
+    req = tevent_req_callback_data(subreq, struct tevent_req);
+    state = tevent_req_data(req, struct ad_check_domain_state);
+
+    ret = ad_domain_info_recv(subreq, state, &state->flat, &state->sid,
+                              &state->site, &state->forest);
+    talloc_zfree(subreq);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "Unable to lookup domain information "
+              "[%d]: %s\n", ret, sss_strerror(ret));
+        goto done;
+    }
+    DEBUG(SSSDBG_TRACE_ALL, "%s %s %s %s.\n", state->flat, state->sid,
+                                              state->site, state->forest);
+
+    /* New domain was successfully checked, remove destructor. */
+    talloc_set_destructor(state, NULL);
+
+    ret = EOK;
+
+done:
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    tevent_req_done(req);
+}
+
+errno_t ad_check_domain_recv(TALLOC_CTX *mem_ctx,
+                             struct tevent_req *req,
+                             char **_flat,
+                             char **_id,
+                             char **_site,
+                             char **_forest)
+{
+    struct ad_check_domain_state *state = tevent_req_data(req,
+                                                  struct ad_check_domain_state);
+
+    TEVENT_REQ_RETURN_ON_ERROR(req);
+
+    if (_flat) {
+        *_flat = talloc_steal(mem_ctx, state->flat);
+    }
+
+    if (_site) {
+        *_site = talloc_steal(mem_ctx, state->site);
+    }
+
+    if (_forest) {
+        *_forest = talloc_steal(mem_ctx, state->forest);
+    }
+
+    if (_id) {
+        *_id = talloc_steal(mem_ctx, state->sid);
+    }
+
+    return EOK;
+}

--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -35,6 +35,10 @@
 #include <ndr.h>
 #include <ndr/ndr_nbt.h>
 
+/* Avoid that ldb_val is overwritten by data_blob.h */
+#undef ldb_val
+#include <ldb.h>
+
 /* Attributes of AD trusted domains */
 #define AD_AT_FLATNAME      "flatName"
 #define AD_AT_SID           "securityIdentifier"
@@ -1258,15 +1262,37 @@ ads_get_dom_id_ctx(struct be_ctx *be_ctx,
 
 struct ad_get_root_domain_state {
     struct ad_subdomains_ctx *sd_ctx;
+    struct tevent_context *ev;
     struct be_ctx *be_ctx;
     struct sdap_idmap_ctx *idmap_ctx;
     struct sdap_options *opts;
+    const char *domain;
+    const char *forest;
 
+    struct sysdb_attrs **reply;
+    size_t reply_count;
     struct ad_id_ctx *root_id_ctx;
     struct sysdb_attrs *root_domain_attrs;
 };
 
 static void ad_get_root_domain_done(struct tevent_req *subreq);
+static void ad_check_root_domain_done(struct tevent_req *subreq);
+static errno_t
+ad_get_root_domain_refresh(struct ad_get_root_domain_state *state);
+
+struct tevent_req *
+ad_check_domain_send(TALLOC_CTX *mem_ctx,
+                     struct tevent_context *ev,
+                     struct be_ctx *be_ctx,
+                     struct ad_id_ctx *ad_id_ctx,
+                     const char *dom_name,
+                     const char *parent_dom_name);
+errno_t ad_check_domain_recv(TALLOC_CTX *mem_ctx,
+                             struct tevent_req *req,
+                             char **_flat,
+                             char **_id,
+                             char **_site,
+                             char **_forest);
 
 static struct tevent_req *
 ad_get_root_domain_send(TALLOC_CTX *mem_ctx,
@@ -1305,6 +1331,9 @@ ad_get_root_domain_send(TALLOC_CTX *mem_ctx,
     state->opts = opts = sd_ctx->sdap_id_ctx->opts;
     state->be_ctx = sd_ctx->be_ctx;
     state->idmap_ctx = opts->idmap_ctx;
+    state->ev = ev;
+    state->domain = domain;
+    state->forest = forest;
 
     filter = talloc_asprintf(state, FOREST_ROOT_FILTER_FMT, forest);
     if (filter == NULL) {
@@ -1340,17 +1369,14 @@ static void ad_get_root_domain_done(struct tevent_req *subreq)
 {
     struct tevent_req *req;
     struct ad_get_root_domain_state *state;
-    struct sysdb_attrs **reply;
-    struct sss_domain_info *root_domain;
-    size_t reply_count;
-    bool has_changes;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct ad_get_root_domain_state);
 
-    ret = sdap_search_bases_return_first_recv(subreq, state, &reply_count,
-                                              &reply);
+    ret = sdap_search_bases_return_first_recv(subreq, state,
+                                              &state->reply_count,
+                                              &state->reply);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "Unable to lookup forest root information "
@@ -1358,19 +1384,142 @@ static void ad_get_root_domain_done(struct tevent_req *subreq)
         goto done;
     }
 
-    if (reply_count == 0) {
-        DEBUG(SSSDBG_OP_FAILURE, "No information provided for root domain\n");
-        ret = ENOENT;
-        goto done;
-    } else if (reply_count > 1) {
+    if (state->reply_count == 0) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "No information provided for root domain, trying directly.\n");
+        subreq = ad_check_domain_send(state, state->ev, state->be_ctx,
+                                      state->sd_ctx->ad_id_ctx, state->forest,
+                                      state->domain);
+        if (subreq == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE, "ad_check_domain_send() failed.\n");
+            ret = ENOMEM;
+            goto done;
+        }
+        tevent_req_set_callback(subreq, ad_check_root_domain_done, req);
+        return;
+    } else if (state->reply_count > 1) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Multiple results for root domain search, "
               "domain list might be incomplete!\n");
         ret = ERR_MALFORMED_ENTRY;
         goto done;
     }
 
+    ret = ad_get_root_domain_refresh(state);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "ad_get_root_domain_refresh() failed.\n");
+    }
+
+done:
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    tevent_req_done(req);
+}
+
+static void ad_check_root_domain_done(struct tevent_req *subreq)
+{
+    struct tevent_req *req;
+    struct ad_get_root_domain_state *state;
+    errno_t ret;
+    char *flat = NULL;
+    char *id = NULL;
+    enum idmap_error_code err;
+    struct ldb_val id_val;
+
+    req = tevent_req_callback_data(subreq, struct tevent_req);
+    state = tevent_req_data(req, struct ad_get_root_domain_state);
+
+    ret = ad_check_domain_recv(state, subreq, &flat, &id, NULL, NULL);
+    talloc_zfree(subreq);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "Unable to check forest root information "
+              "[%d]: %s\n", ret, sss_strerror(ret));
+        goto done;
+    }
+
+    if (flat == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "NetBIOS name of forest root not available.\n");
+        ret = EINVAL;
+        goto done;
+    }
+
+    if (id == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Domain SID of forest root not available.\n");
+        ret = EINVAL;
+        goto done;
+    }
+
+    state->reply = talloc_array(state, struct sysdb_attrs *, 1);
+    if (state->reply == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "talloc_array() failed.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    state->reply[0] = sysdb_new_attrs(state->reply);
+    if (state->reply[0] == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "sysdb_new_attrs() failed.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = sysdb_attrs_add_string(state->reply[0], AD_AT_FLATNAME, flat);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sysdb_attrs_add_string() failed.\n");
+        goto done;
+    }
+
+    ret = sysdb_attrs_add_string(state->reply[0], AD_AT_TRUST_PARTNER,
+                                 state->forest);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sysdb_attrs_add_string() failed.\n");
+        goto done;
+    }
+
+    err = sss_idmap_sid_to_bin_sid(state->idmap_ctx->map, id,
+                                   &id_val.data, &id_val.length);
+    if (err != IDMAP_SUCCESS) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Could not convert SID: [%s].\n", idmap_error_string(err));
+        ret = EFAULT;
+        goto done;
+    }
+
+    ret = sysdb_attrs_add_val(state->reply[0], AD_AT_SID, &id_val);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sysdb_attrs_add_string() failed.\n");
+        goto done;
+    }
+
+    state->reply_count = 1;
+
+    ret = ad_get_root_domain_refresh(state);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "ad_get_root_domain_refresh() failed.\n");
+    }
+
+done:
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    tevent_req_done(req);
+}
+
+static errno_t
+ad_get_root_domain_refresh(struct ad_get_root_domain_state *state)
+{
+    struct sss_domain_info *root_domain;
+    bool has_changes;
+    errno_t ret;
+
     ret = ad_subdomains_refresh(state->be_ctx, state->idmap_ctx, state->opts,
-                                reply, reply_count, true,
+                                state->reply, state->reply_count, true,
                                 &state->sd_ctx->last_refreshed,
                                 &has_changes);
     if (ret != EOK) {
@@ -1387,8 +1536,8 @@ static void ad_get_root_domain_done(struct tevent_req *subreq)
         }
     }
 
-    state->root_domain_attrs = reply[0];
-    root_domain = ads_get_root_domain(state->be_ctx, reply[0]);
+    state->root_domain_attrs = state->reply[0];
+    root_domain = ads_get_root_domain(state->be_ctx, state->reply[0]);
     if (root_domain == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Could not find the root domain\n");
         ret = EFAULT;
@@ -1407,12 +1556,7 @@ static void ad_get_root_domain_done(struct tevent_req *subreq)
     ret = EOK;
 
 done:
-    if (ret != EOK) {
-        tevent_req_error(req, ret);
-        return;
-    }
-
-    tevent_req_done(req);
+    return ret;
 }
 
 static errno_t ad_get_root_domain_recv(TALLOC_CTX *mem_ctx,

--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -1756,8 +1756,8 @@ static void ad_subdomains_refresh_connect_done(struct tevent_req *subreq)
     }
 
     /* connect to the DC we are a member of */
-    subreq = ad_master_domain_send(state, state->ev, state->id_ctx->conn,
-                                   state->sdap_op, state->sd_ctx->domain_name);
+    subreq = ad_domain_info_send(state, state->ev, state->id_ctx->conn,
+                                 state->sdap_op, state->sd_ctx->domain_name);
     if (subreq == NULL) {
         tevent_req_error(req, ENOMEM);
         return;
@@ -1779,8 +1779,8 @@ static void ad_subdomains_refresh_master_done(struct tevent_req *subreq)
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct ad_subdomains_refresh_state);
 
-    ret = ad_master_domain_recv(subreq, state, &flat_name, &master_sid,
-                                NULL, &state->forest);
+    ret = ad_domain_info_recv(subreq, state, &flat_name, &master_sid,
+                              NULL, &state->forest);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to get master domain information "

--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -576,20 +576,12 @@ ad_subdom_store(struct confdb_ctx *cdb,
     enum idmap_error_code err;
     struct ldb_message_element *el;
     char *sid_str = NULL;
-    uint32_t trust_type;
     enum sss_domain_mpg_mode mpg_mode;
     enum sss_domain_mpg_mode default_mpg_mode;
 
     tmp_ctx = talloc_new(NULL);
     if (tmp_ctx == NULL) {
         ret = ENOMEM;
-        goto done;
-    }
-
-    ret = sysdb_attrs_get_uint32_t(subdom_attrs, AD_AT_TRUST_TYPE,
-                                   &trust_type);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "sysdb_attrs_get_uint32_t failed.\n");
         goto done;
     }
 

--- a/src/tests/cmocka/test_negcache.c
+++ b/src/tests/cmocka/test_negcache.c
@@ -38,7 +38,6 @@
 #include "util/util_sss_idmap.h"
 #include "lib/idmap/sss_idmap.h"
 #include "util/util.h"
-#include "db/sysdb_private.h"
 #include "responder/common/responder.h"
 #include "responder/common/negcache.h"
 

--- a/src/tests/cmocka/test_nss_srv.c
+++ b/src/tests/cmocka/test_nss_srv.c
@@ -36,7 +36,6 @@
 #include "util/crypto/sss_crypto.h"
 #include "util/crypto/nss/nss_util.h"
 #include "util/sss_endian.h"
-#include "db/sysdb_private.h"   /* new_subdomain() */
 #include "db/sysdb_iphosts.h"
 #include "db/sysdb_ipnetworks.h"
 

--- a/src/tests/cmocka/test_responder_cache_req.c
+++ b/src/tests/cmocka/test_responder_cache_req.c
@@ -27,7 +27,6 @@
 #include "tests/cmocka/common_mock_resp.h"
 #include "db/sysdb.h"
 #include "responder/common/cache_req/cache_req.h"
-#include "db/sysdb_private.h"   /* new_subdomain() */
 
 #define TESTS_PATH "tp_" BASE_FILE_STEM
 #define TEST_CONF_DB "test_responder_cache_req_conf.ldb"


### PR DESCRIPTION
If the information about the forest root domain cannot be read from the
local domain-controller it is tried to read it from a DC of the forest root
directly.

Resolves: https://github.com/SSSD/sssd/issues/5151