### PR TITLE
MAN: use_fully_qualified_names description updated

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2468,8 +2468,9 @@ p11_uri = library-description=OpenSC%20smartcard%20framework;slot-id=2
                             name is requested.
                         </para>
                         <para>
-                            Default: FALSE (TRUE if default_domain_suffix is
-                            used)
+                            Default: FALSE (TRUE for trusted
+                            domain/sub-domains or if default_domain_suffix
+                            is used)
                         </para>
                     </listitem>
                 </varlistentry>


### PR DESCRIPTION
Has updated the information about when the option defaults to TRUE

Resolves: https://github.com/SSSD/sssd/issues/1025