### PR TITLE
man: Document invalid selinux context for homedirs

### DIFF
--- a/src/man/include/ad_modified_defaults.xml
+++ b/src/man/include/ad_modified_defaults.xml
@@ -92,6 +92,18 @@
                     this fallback behavior, you can explicitly
                     set "fallback_homedir = %o".
                 </para>
+                <para>
+                    Note that the system typically expects a home directory
+                    in /home/%u folder. If you decide to use a different
+                    directory structure, some other parts of your system may
+                    need adjustments.
+                </para>
+                <para>
+                    For example automated creation of home directories in
+                    combination with selinux requires selinux adjustment,
+                    otherwise the home directory will be created with wrong
+                    selinux context.
+                </para>
             </listitem>
         </itemizedlist>
     </refsect2>


### PR DESCRIPTION
The default value of fallback_homedir expands into path, that is not
expected by selinux. Generally not only selinux might be affected by
this default value. This PR documents the issue and recommends
further steps.

Resolves:
https://github.com/SSSD/sssd/issues/5155