### PR TITLE
NSS client: preserve errno during _nss_sss_end* calls

### DIFF
--- a/src/sss_client/nss_group.c
+++ b/src/sss_client/nss_group.c
@@ -735,6 +735,7 @@ enum nss_status _nss_sss_endgrent(void)
 {
     enum nss_status nret;
     int errnop;
+    int saved_errno = errno;
 
     sss_nss_lock();
 
@@ -745,6 +746,8 @@ enum nss_status _nss_sss_endgrent(void)
                                 NULL, NULL, NULL, &errnop);
     if (nret != NSS_STATUS_SUCCESS) {
         errno = errnop;
+    } else {
+        errno = saved_errno;
     }
 
     sss_nss_unlock();

--- a/src/sss_client/nss_hosts.c
+++ b/src/sss_client/nss_hosts.c
@@ -565,6 +565,7 @@ _nss_sss_endhostent(void)
 {
     enum nss_status nret;
     int errnop;
+    int saved_errno = errno;
 
     sss_nss_lock();
 
@@ -575,9 +576,10 @@ _nss_sss_endhostent(void)
                                 NULL, NULL, NULL, &errnop);
     if (nret != NSS_STATUS_SUCCESS) {
         errno = errnop;
+    } else {
+        errno = saved_errno;
     }
 
     sss_nss_unlock();
-
     return nret;
 }

--- a/src/sss_client/nss_ipnetworks.c
+++ b/src/sss_client/nss_ipnetworks.c
@@ -510,6 +510,7 @@ _nss_sss_endnetent(void)
 {
     enum nss_status nret;
     int errnop;
+    int saved_errno = errno;
 
     sss_nss_lock();
 
@@ -520,10 +521,11 @@ _nss_sss_endnetent(void)
                                 NULL, NULL, NULL, &errnop);
     if (nret != NSS_STATUS_SUCCESS) {
         errno = errnop;
+    } else {
+        errno = saved_errno;
     }
 
     sss_nss_unlock();
-
     return nret;
 }
 

--- a/src/sss_client/nss_netgroup.c
+++ b/src/sss_client/nss_netgroup.c
@@ -309,6 +309,7 @@ enum nss_status _nss_sss_endnetgrent(struct __netgrent *result)
 {
     enum nss_status nret;
     int errnop;
+    int saved_errno = errno;
 
     sss_nss_lock();
 
@@ -319,6 +320,8 @@ enum nss_status _nss_sss_endnetgrent(struct __netgrent *result)
                                 NULL, NULL, NULL, &errnop);
     if (nret != NSS_STATUS_SUCCESS) {
         errno = errnop;
+    } else {
+        errno = saved_errno;
     }
 
     sss_nss_unlock();

--- a/src/sss_client/nss_passwd.c
+++ b/src/sss_client/nss_passwd.c
@@ -455,6 +455,7 @@ enum nss_status _nss_sss_endpwent(void)
 {
     enum nss_status nret;
     int errnop;
+    int saved_errno = errno;
 
     sss_nss_lock();
 
@@ -465,6 +466,8 @@ enum nss_status _nss_sss_endpwent(void)
                                 NULL, NULL, NULL, &errnop);
     if (nret != NSS_STATUS_SUCCESS) {
         errno = errnop;
+    } else {
+        errno = saved_errno;
     }
 
     sss_nss_unlock();

--- a/src/sss_client/nss_services.c
+++ b/src/sss_client/nss_services.c
@@ -484,6 +484,7 @@ _nss_sss_endservent(void)
 {
     enum nss_status nret;
     int errnop;
+    int saved_errno = errno;
 
     sss_nss_lock();
 
@@ -494,6 +495,8 @@ _nss_sss_endservent(void)
                                 NULL, NULL, NULL, &errnop);
     if (nret != NSS_STATUS_SUCCESS) {
         errno = errnop;
+    } else {
+        errno = saved_errno;
     }
 
     sss_nss_unlock();


### PR DESCRIPTION
glibc does not expect that errno is changed by some of the calls
provided by nss modules. This caused at least issues when
_nss_sss_endpwent() is called in compat mode. To be on the safe side
errno is preserved for the other _nss_sss_end* calls as well.

Resolves: https://github.com/SSSD/sssd/issues/5153