### PR TITLE
Fixed unsafe usage of strncpy()

### DIFF
--- a/src/monitor/monitor_netlink.c
+++ b/src/monitor/monitor_netlink.c
@@ -297,7 +297,8 @@ static void nladdr_to_string(struct nl_addr *nl, char *buf, size_t bufsize)
 
     addr_family = nl_addr_get_family(nl);
     if (addr_family != AF_INET && addr_family != AF_INET6) {
-        strncpy(buf, "unknown", bufsize);
+        strncpy(buf, "unknown", bufsize-1);
+        buf[bufsize-1] = '\0';
         return;
     }
 

--- a/src/providers/ad/ad_common.c
+++ b/src/providers/ad/ad_common.c
@@ -465,7 +465,8 @@ ad_try_to_get_fqdn(const char *hostname,
         return ret;
     }
 
-    strncpy(buf, res->ai_canonname, buflen);
+    strncpy(buf, res->ai_canonname, buflen-1);
+    buf[buflen-1] = '\0';
 
     freeaddrinfo(res);
 
@@ -543,7 +544,7 @@ ad_get_common_options(TALLOC_CTX *mem_ctx,
                       "The hostname [%s] has been expanded to FQDN [%s]. "
                       "If sssd should really use the short hostname, please "
                       "set ad_hostname explicitly.\n", hostname, fqdn);
-                strncpy(hostname, fqdn, sizeof(hostname));
+                strncpy(hostname, fqdn, HOST_NAME_MAX);
                 hostname[HOST_NAME_MAX] = '\0';
             }
         }

--- a/src/sss_client/idmap/sss_nss_idmap.c
+++ b/src/sss_client/idmap/sss_nss_idmap.c
@@ -310,7 +310,8 @@ static int sss_nss_getyyybyxxx(union input inp, enum sss_cli_command cmd,
             goto done;
         }
 
-        strncpy(str, (char *) repbuf + DATA_START, data_len);
+        strncpy(str, (char *) repbuf + DATA_START, data_len-1);
+        str[data_len-1] = '\0';
 
         out->d.str = str;
 


### PR DESCRIPTION
This patch fixes unsafe usage of strncpy() that renders warnings like:
```
In function ‘ad_try_to_get_fqdn’,
    inlined from ‘ad_get_common_options’ at ../src/providers/ad/ad_common.c:540:19:
../src/providers/ad/ad_common.c:468:5: warning: ‘strncpy’ specified bound 65 equals destination size [-Wstringop-truncation]
  468 |     strncpy(buf, res->ai_canonname, buflen);
```