### PR TITLE
ad: make GSS-SPNEGO maxssf=0 workaround configurable

### DIFF
--- a/src/conf_macros.m4
+++ b/src/conf_macros.m4
@@ -958,3 +958,16 @@ AS_IF([test x$enable_local_provider = xyes],
       AC_DEFINE_UNQUOTED([BUILD_LOCAL_PROVIDER], [1],
           [whether to build unconditionally enable local provider]))
 AM_CONDITIONAL([BUILD_LOCAL_PROVIDER], [test x$enable_local_provider = xyes])
+
+AC_ARG_ENABLE([gss-spnego-for-zero-maxssf],
+              [AS_HELP_STRING([--enable-gss-spnego-for-zero-maxssf],
+                              [If this feature is enabled, GSS-SPNEGO will be
+                               used even if maxssf is set to 0. Only recent
+                               version of cyrus-sasl handle this correctly.
+                               Please only enable this if the installed
+                               cyrus-sasl can handle it.  [default=no]])],
+              [enable_gss_spnego_for_zero_maxssf=$enableval],
+              [enable_gss_spnego_for_zero_maxssf=no])
+AS_IF([test x$enable_gss_spnego_for_zero_maxssf = xyes],
+      AC_DEFINE_UNQUOTED([ALLOW_GSS_SPNEGO_FOR_ZERO_MAXSSF], [1],
+                         [whether to use GSS-SPNEGO if maxssf is 0 (zero)]))

--- a/src/providers/ad/ad_common.c
+++ b/src/providers/ad/ad_common.c
@@ -1117,6 +1117,7 @@ void ad_set_ssf_and_mech_for_ldaps(struct sdap_options *id_opts)
               "Failed to set SASL maxssf for ldaps usage, ignored.\n");
     }
 
+#ifndef ALLOW_GSS_SPNEGO_FOR_ZERO_MAXSSF
     /* There is an issue in cyrus-sasl with respect to GSS-SPNEGO and
      * maxssf==0. Until the fix
      * https://github.com/cyrusimap/cyrus-sasl/pull/603 is widely used we
@@ -1127,6 +1128,7 @@ void ad_set_ssf_and_mech_for_ldaps(struct sdap_options *id_opts)
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Failed to set SASL mech for ldaps usage, ignored.\n");
     }
+#endif
 }
 
 static errno_t


### PR DESCRIPTION
To allow tp by-pass the workaround if the installed cyrus-sasl can
handle maxsssf=0 with GSS-SPNEGO a new configure option
--enable-gss-spnego-for-zero-maxssf is added. By default this option is
set to 'no' and the workaround is enabled.

Resolves: https://github.com/SSSD/sssd/issues/4978
          https://pagure.io/SSSD/sssd/issue/4007