### PR TITLE
ldap: add new option ldap_library_debug_level

### DIFF
--- a/src/config/SSSDConfig/sssdoptions.py
+++ b/src/config/SSSDConfig/sssdoptions.py
@@ -480,6 +480,7 @@ class SSSDOptions(object):
         'ldap_max_id': _('Set upper boundary for allowed IDs from the LDAP server'),
         'ldap_pwdlockout_dn': _('DN for ppolicy queries'),
         'wildcard_limit': _('How many maximum entries to fetch during a wildcard request'),
+        'ldap_library_debug_level': _('Set libldap debug level'),
 
         # [provider/ldap/auth]
         'ldap_pwd_policy': _('Policy to evaluate the password expiration'),

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -646,6 +646,7 @@ option = ldap_id_use_start_tls
 option = ldap_krb5_init_creds
 option = ldap_krb5_keytab
 option = ldap_krb5_ticket_lifetime
+option = ldap_library_debug_level
 option = ldap_max_id
 option = ldap_min_id
 option = ldap_netgroup_member

--- a/src/config/etc/sssd.api.d/sssd-ldap.conf
+++ b/src/config/etc/sssd.api.d/sssd-ldap.conf
@@ -130,6 +130,7 @@ ldap_rfc2307_fallback_to_local_users = bool, None, false
 ldap_min_id = int, None, false
 ldap_max_id = int, None, false
 ldap_pwdlockout_dn = str, None, false
+ldap_library_debug_level = int, None, false
 
 [provider/ldap/auth]
 ldap_pwd_policy = str, None, false

--- a/src/man/sssd-ldap.5.xml
+++ b/src/man/sssd-ldap.5.xml
@@ -1477,6 +1477,25 @@ ldap_access_filter = (employeeType=admin)
                     </listitem>
                 </varlistentry>
 
+                <varlistentry>
+                    <term>ldap_library_debug_level (integer)</term>
+                    <listitem>
+                        <para>
+                            Switches on libldap debugging with the given level.
+                            The libldap debug messages will be written
+                            independent of the general debug_level.
+                        </para>
+                        <para>
+                            OpenLDAP uses a bitmap to enable debugging for
+                            specific components, -1 will enable full debug
+                            output.
+                        </para>
+                        <para>
+                            Default: 0 (libldap debugging disabled)
+                        </para>
+                    </listitem>
+                </varlistentry>
+
             </variablelist>
         </para>
     </refsect1>

--- a/src/providers/ad/ad_init.c
+++ b/src/providers/ad/ad_init.c
@@ -375,6 +375,8 @@ static errno_t ad_init_misc(struct be_ctx *be_ctx,
         /* Continue without DNS updates */
     }
 
+    setup_ldap_debug(sdap_id_ctx->opts->basic);
+
     ret = setup_tls_config(sdap_id_ctx->opts->basic);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to get TLS options [%d]: %s\n",

--- a/src/providers/ad/ad_opts.c
+++ b/src/providers/ad/ad_opts.c
@@ -160,6 +160,7 @@ struct dp_option ad_def_ldap_opts[] = {
     { "ldap_max_id", DP_OPT_NUMBER, NULL_NUMBER, NULL_NUMBER},
     { "ldap_pwdlockout_dn", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "wildcard_limit", DP_OPT_NUMBER, { .number = 1000 }, NULL_NUMBER},
+    { "ldap_library_debug_level", DP_OPT_NUMBER, NULL_NUMBER, NULL_NUMBER},
     DP_OPTION_TERMINATOR
 };
 

--- a/src/providers/ipa/ipa_init.c
+++ b/src/providers/ipa/ipa_init.c
@@ -491,6 +491,8 @@ static errno_t ipa_init_auth_ctx(TALLOC_CTX *mem_ctx,
     }
     ipa_options->auth_ctx->sdap_auth_ctx = sdap_auth_ctx;
 
+    setup_ldap_debug(sdap_auth_ctx->opts->basic);
+
     ret = setup_tls_config(sdap_auth_ctx->opts->basic);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "setup_tls_config failed [%d]: %s\n",
@@ -547,6 +549,8 @@ static errno_t ipa_init_misc(struct be_ctx *be_ctx,
               ret, sss_strerror(ret));
         return ret;
     }
+
+    setup_ldap_debug(sdap_id_ctx->opts->basic);
 
     ret = setup_tls_config(sdap_id_ctx->opts->basic);
     if (ret != EOK) {

--- a/src/providers/ipa/ipa_opts.c
+++ b/src/providers/ipa/ipa_opts.c
@@ -166,6 +166,7 @@ struct dp_option ipa_def_ldap_opts[] = {
     { "ldap_max_id", DP_OPT_NUMBER, NULL_NUMBER, NULL_NUMBER},
     { "ldap_pwdlockout_dn", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "wildcard_limit", DP_OPT_NUMBER, { .number = 1000 }, NULL_NUMBER},
+    { "ldap_library_debug_level", DP_OPT_NUMBER, NULL_NUMBER, NULL_NUMBER},
     DP_OPTION_TERMINATOR
 };
 

--- a/src/providers/ldap/ldap_init.c
+++ b/src/providers/ldap/ldap_init.c
@@ -396,6 +396,8 @@ static errno_t ldap_init_misc(struct be_ctx *be_ctx,
         }
     }
 
+    setup_ldap_debug(options->basic);
+
     ret = setup_tls_config(options->basic);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to get TLS options [%d]: %s\n",

--- a/src/providers/ldap/ldap_opts.c
+++ b/src/providers/ldap/ldap_opts.c
@@ -128,6 +128,7 @@ struct dp_option default_basic_opts[] = {
     { "ldap_max_id", DP_OPT_NUMBER, NULL_NUMBER, NULL_NUMBER},
     { "ldap_pwdlockout_dn", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "wildcard_limit", DP_OPT_NUMBER, { .number = 1000 }, NULL_NUMBER},
+    { "ldap_library_debug_level", DP_OPT_NUMBER, NULL_NUMBER, NULL_NUMBER},
     DP_OPTION_TERMINATOR
 };
 

--- a/src/providers/ldap/sdap.c
+++ b/src/providers/ldap/sdap.c
@@ -816,6 +816,44 @@ done:
     return ret;
 }
 
+static void sss_ldap_debug(const char *buf)
+{
+    sss_debug_fn(__FILE__, __LINE__, __FUNCTION__, SSSDBG_TRACE_ALL,
+                "libldap: %s", buf);
+}
+
+void setup_ldap_debug(struct dp_option *basic_opts)
+{
+    int ret;
+    int ldap_debug_level;
+
+    ldap_debug_level = dp_opt_get_int(basic_opts, SDAP_LIBRARY_DEBUG_LEVEL);
+    if (ldap_debug_level == 0) {
+        return;
+    }
+
+    DEBUG(SSSDBG_CONF_SETTINGS, "Setting LDAP library debug level [%d].\n",
+                                ldap_debug_level);
+
+    ret = ber_set_option(NULL, LBER_OPT_DEBUG_LEVEL, &ldap_debug_level);
+    if (ret != LBER_OPT_SUCCESS) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Failed to set LBER_OPT_DEBUG_LEVEL, ignored .\n");
+    }
+
+    ret = ber_set_option(NULL,  LBER_OPT_LOG_PRINT_FN, sss_ldap_debug);
+    if (ret != LBER_OPT_SUCCESS) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Failed to set LBER_OPT_LOG_PRINT_FN, ignored .\n");
+    }
+
+    ret = ldap_set_option(NULL, LDAP_OPT_DEBUG_LEVEL, &ldap_debug_level);
+    if (ret != LDAP_OPT_SUCCESS) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Failed to set LDAP_OPT_DEBUG_LEVEL, ignored .\n");
+    }
+}
+
 errno_t setup_tls_config(struct dp_option *basic_opts)
 {
     int ret;

--- a/src/providers/ldap/sdap.h
+++ b/src/providers/ldap/sdap.h
@@ -240,6 +240,7 @@ enum sdap_basic_opt {
     SDAP_MAX_ID,
     SDAP_PWDLOCKOUT_DN,
     SDAP_WILDCARD_LIMIT,
+    SDAP_LIBRARY_DEBUG_LEVEL,
 
     SDAP_OPTS_BASIC /* opts counter */
 };
@@ -621,6 +622,8 @@ errno_t sdap_parse_deref(TALLOC_CTX *mem_ctx,
                          size_t num_maps,
                          LDAPDerefRes *dref,
                          struct sdap_deref_attrs ***_deref_res);
+
+void setup_ldap_debug(struct dp_option *basic_opts);
 
 errno_t setup_tls_config(struct dp_option *basic_opts);
 


### PR DESCRIPTION
With the new option ldap_library_debug_level the debug level for
OpenLDAP's internal debugging can be set. If set the OpenLDAP debug
messages will be written to the logs independent of the general
debug_level.