### PR TITLE
DEBUG: only open child process log files when required

### DIFF
--- a/src/providers/ad/ad_init.c
+++ b/src/providers/ad/ad_init.c
@@ -402,13 +402,6 @@ static errno_t ad_init_misc(struct be_ctx *be_ctx,
 
     sdap_id_ctx->opts->sdom->pvt = ad_id_ctx;
 
-    ret = sdap_setup_child();
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "sdap_setup_child() failed [%d]: %s\n",
-              ret, sss_strerror(ret));
-        return ret;
-    }
-
     ret = ad_init_srv_plugin(be_ctx, ad_options);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to setup SRV plugin [%d]: %s\n",

--- a/src/providers/ad/ad_machine_pw_renewal.c
+++ b/src/providers/ad/ad_machine_pw_renewal.c
@@ -185,7 +185,7 @@ ad_machine_account_password_renewal_send(TALLOC_CTX *mem_ctx,
     child_pid = fork();
     if (child_pid == 0) { /* child */
         exec_child_ex(state, pipefd_to_child, pipefd_from_child,
-                      renewal_data->prog_path, -1,
+                      renewal_data->prog_path, NULL,
                       extra_args, true,
                       STDIN_FILENO, STDERR_FILENO);
 

--- a/src/providers/ipa/ipa_init.c
+++ b/src/providers/ipa/ipa_init.c
@@ -571,13 +571,6 @@ static errno_t ipa_init_misc(struct be_ctx *be_ctx,
         return ret;
     }
 
-    ret = sdap_setup_child();
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to setup sdap child [%d]: %s\n",
-              ret, sss_strerror(ret));
-        return ret;
-    }
-
     if (dp_opt_get_bool(ipa_options->basic, IPA_SERVER_MODE)) {
         ret = ipa_init_server_mode(be_ctx, ipa_options, ipa_id_ctx);
         if (ret != EOK) {

--- a/src/providers/krb5/krb5_child_handler.c
+++ b/src/providers/krb5/krb5_child_handler.c
@@ -465,7 +465,7 @@ static errno_t fork_child(struct tevent_req *req)
     if (pid == 0) { /* child */
         exec_child_ex(state,
                       pipefd_to_child, pipefd_from_child,
-                      KRB5_CHILD, state->kr->krb5_ctx->child_debug_fd,
+                      KRB5_CHILD, KRB5_CHILD_LOG_FILE,
                       krb5_child_extra_args, false,
                       STDIN_FILENO, STDOUT_FILENO);
 

--- a/src/providers/krb5/krb5_common.h
+++ b/src/providers/krb5/krb5_common.h
@@ -124,7 +124,6 @@ struct krb5_ctx {
     struct dp_option *opts;
     struct krb5_service *service;
     struct krb5_service *kpasswd_service;
-    int child_debug_fd;
 
     sss_regexp_t *illegal_path_re;
 

--- a/src/providers/krb5/krb5_init_shared.c
+++ b/src/providers/krb5/krb5_init_shared.c
@@ -71,14 +71,6 @@ errno_t krb5_child_init(struct krb5_ctx *krb5_auth_ctx,
         goto done;
     }
 
-    krb5_auth_ctx->child_debug_fd = -1; /* -1 means not initialized */
-    ret = child_debug_init(KRB5_CHILD_LOG_FILE,
-                           &krb5_auth_ctx->child_debug_fd);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "Could not set krb5_child debugging!\n");
-        goto done;
-    }
-
     ret = parse_krb5_map_user(krb5_auth_ctx,
                               dp_opt_get_cstring(krb5_auth_ctx->opts,
                                                  KRB5_MAP_USER),

--- a/src/providers/ldap/ldap_common.c
+++ b/src/providers/ldap/ldap_common.c
@@ -35,9 +35,6 @@
 
 #include "providers/ldap/sdap_idmap.h"
 
-/* a fd the child process would log into */
-int ldap_child_debug_fd = -1;
-
 errno_t ldap_id_setup_tasks(struct sdap_id_ctx *ctx)
 {
     return sdap_id_setup_tasks(ctx->be, ctx, ctx->opts->sdom,

--- a/src/providers/ldap/ldap_common.h
+++ b/src/providers/ldap/ldap_common.h
@@ -44,9 +44,6 @@
 
 #define LDAP_ENUM_PURGE_TIMEOUT 10800
 
-/* a fd the child process would log into */
-extern int ldap_child_debug_fd;
-
 struct sdap_id_ctx;
 
 struct sdap_id_conn_ctx {
@@ -341,9 +338,6 @@ errno_t
 sdap_ipnetwork_handler_recv(TALLOC_CTX *mem_ctx,
                             struct tevent_req *req,
                             struct dp_reply_std *data);
-
-/* setup child logging */
-int sdap_setup_child(void);
 
 
 errno_t string_to_shadowpw_days(const char *s, long *d);

--- a/src/providers/ldap/ldap_init.c
+++ b/src/providers/ldap/ldap_init.c
@@ -419,13 +419,6 @@ static errno_t ldap_init_misc(struct be_ctx *be_ctx,
         return ret;
     }
 
-    ret = sdap_setup_child();
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to setup sdap child [%d]: %s\n",
-              ret, sss_strerror(ret));
-        return ret;
-    }
-
     /* Setup SRV lookup plugin */
     ret = be_fo_set_dns_srv_lookup_plugin(be_ctx, NULL);
     if (ret != EOK) {

--- a/src/providers/ldap/sdap_child_helpers.c
+++ b/src/providers/ldap/sdap_child_helpers.c
@@ -111,7 +111,7 @@ static errno_t sdap_fork_child(struct tevent_context *ev,
     if (pid == 0) { /* child */
         exec_child(child,
                    pipefd_to_child, pipefd_from_child,
-                   LDAP_CHILD, ldap_child_debug_fd);
+                   LDAP_CHILD, LDAP_CHILD_LOG_FILE);
 
         /* We should never get here */
         DEBUG(SSSDBG_CRIT_FAILURE, "BUG: Could not exec LDAP child\n");
@@ -511,12 +511,4 @@ static errno_t set_tgt_child_timeout(struct tevent_req *req,
     }
 
     return EOK;
-}
-
-
-
-/* Setup child logging */
-int sdap_setup_child(void)
-{
-    return child_debug_init(LDAP_CHILD_LOG_FILE, &ldap_child_debug_fd);
 }

--- a/src/responder/pam/pamsrv.c
+++ b/src/responder/pam/pamsrv.c
@@ -277,7 +277,6 @@ static int pam_process_init(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    pctx->p11_child_debug_fd = -1;
     if (pctx->cert_auth) {
         ret = p11_child_init(pctx);
         if (ret != EOK) {

--- a/src/responder/pam/pamsrv.h
+++ b/src/responder/pam/pamsrv.h
@@ -54,7 +54,6 @@ struct pam_ctx {
     char **app_services;
 
     bool cert_auth;
-    int p11_child_debug_fd;
     char *nss_db;
     struct sss_certmap_ctx *sss_certmap_ctx;
     char **smartcard_services;
@@ -110,7 +109,6 @@ void sss_cai_check_users(struct cert_auth_info **list, size_t *_cert_count,
 
 struct tevent_req *pam_check_cert_send(TALLOC_CTX *mem_ctx,
                                        struct tevent_context *ev,
-                                       int child_debug_fd,
                                        const char *nss_db,
                                        time_t timeout,
                                        const char *verify_opts,

--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -1404,7 +1404,7 @@ static errno_t check_cert(TALLOC_CTX *mctx,
         return ret;
     }
 
-    req = pam_check_cert_send(mctx, ev, pctx->p11_child_debug_fd,
+    req = pam_check_cert_send(mctx, ev,
                               pctx->nss_db, p11_child_timeout,
                               cert_verification_opts, pctx->sss_certmap_ctx,
                               uri, pd);

--- a/src/responder/pam/pamsrv_p11.c
+++ b/src/responder/pam/pamsrv_p11.c
@@ -242,7 +242,7 @@ errno_t p11_child_init(struct pam_ctx *pctx)
         return ret;
     }
 
-    return child_debug_init(P11_CHILD_LOG_FILE, &pctx->p11_child_debug_fd);
+    return EOK;
 }
 
 static inline bool
@@ -705,7 +705,6 @@ static void p11_child_timeout(struct tevent_context *ev,
 
 struct tevent_req *pam_check_cert_send(TALLOC_CTX *mem_ctx,
                                        struct tevent_context *ev,
-                                       int child_debug_fd,
                                        const char *nss_db,
                                        time_t timeout,
                                        const char *verify_opts,
@@ -838,14 +837,10 @@ struct tevent_req *pam_check_cert_send(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    if (child_debug_fd == -1) {
-        child_debug_fd = STDERR_FILENO;
-    }
-
     child_pid = fork();
     if (child_pid == 0) { /* child */
         exec_child_ex(state, pipefd_to_child, pipefd_from_child,
-                      P11_CHILD_PATH, child_debug_fd, extra_args, false,
+                      P11_CHILD_PATH, P11_CHILD_LOG_FILE, extra_args, false,
                       STDIN_FILENO, STDOUT_FILENO);
 
         /* We should never get here */

--- a/src/responder/ssh/ssh_private.h
+++ b/src/responder/ssh/ssh_private.h
@@ -36,7 +36,6 @@ struct ssh_ctx {
     char *ca_db;
     bool use_cert_keys;
 
-    int p11_child_debug_fd;
     time_t certmap_last_read;
     struct sss_certmap_ctx *sss_certmap_ctx;
     char **cert_rules;

--- a/src/responder/ssh/ssh_reply.c
+++ b/src/responder/ssh/ssh_reply.c
@@ -249,7 +249,7 @@ struct tevent_req *ssh_get_output_keys_send(TALLOC_CTX *mem_ctx,
                                                    : state->user_cert_override;
 
     subreq = cert_to_ssh_key_send(state, state->ev,
-                                  state->ssh_ctx->p11_child_debug_fd,
+                                  P11_CHILD_LOG_FILE,
                                   state->p11_child_timeout,
                                   state->ssh_ctx->ca_db,
                                   state->ssh_ctx->sss_certmap_ctx,
@@ -335,7 +335,7 @@ void ssh_get_output_keys_done(struct tevent_req *subreq)
         goto done;
     }
 
-    subreq = cert_to_ssh_key_send(state, state->ev, -1,
+    subreq = cert_to_ssh_key_send(state, state->ev, NULL,
                                   state->p11_child_timeout,
                                   state->ssh_ctx->ca_db,
                                   state->ssh_ctx->sss_certmap_ctx,

--- a/src/responder/ssh/sshsrv.c
+++ b/src/responder/ssh/sshsrv.c
@@ -126,16 +126,6 @@ int ssh_process_init(TALLOC_CTX *mem_ctx,
         goto fail;
     }
 
-    ssh_ctx->p11_child_debug_fd = -1;
-    if (ssh_ctx->use_cert_keys) {
-        ret = child_debug_init(P11_CHILD_LOG_FILE,
-                               &ssh_ctx->p11_child_debug_fd);
-        if (ret != EOK) {
-            DEBUG(SSSDBG_FATAL_FAILURE,
-                  "Failed to setup p11_child logging, ignored.\n");
-        }
-    }
-
     ret = schedule_get_domains_task(rctx, rctx->ev, rctx, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "schedule_get_domains_tasks failed.\n");

--- a/src/tests/cmocka/test_cert_utils.c
+++ b/src/tests/cmocka/test_cert_utils.c
@@ -391,7 +391,7 @@ void test_cert_to_ssh_key_send(void **state)
     ev = tevent_context_init(ts);
     assert_non_null(ev);
 
-    req = cert_to_ssh_key_send(ts, ev, -1, P11_CHILD_TIMEOUT,
+    req = cert_to_ssh_key_send(ts, ev, NULL, P11_CHILD_TIMEOUT,
 #ifdef HAVE_NSS
                             "sql:" ABS_BUILD_DIR "/src/tests/test_CA/p11_nssdb",
 #else
@@ -465,7 +465,7 @@ void test_cert_to_ssh_2keys_send(void **state)
     ev = tevent_context_init(ts);
     assert_non_null(ev);
 
-    req = cert_to_ssh_key_send(ts, ev, -1, P11_CHILD_TIMEOUT,
+    req = cert_to_ssh_key_send(ts, ev, NULL, P11_CHILD_TIMEOUT,
 #ifdef HAVE_NSS
                             "sql:" ABS_BUILD_DIR "/src/tests/test_CA/p11_nssdb",
 #else
@@ -548,7 +548,7 @@ void test_cert_to_ssh_2keys_invalid_send(void **state)
     ev = tevent_context_init(ts);
     assert_non_null(ev);
 
-    req = cert_to_ssh_key_send(ts, ev, -1, P11_CHILD_TIMEOUT,
+    req = cert_to_ssh_key_send(ts, ev, NULL, P11_CHILD_TIMEOUT,
 #ifdef HAVE_NSS
                             "sql:" ABS_BUILD_DIR "/src/tests/test_CA/p11_nssdb",
 #else
@@ -614,7 +614,7 @@ void test_ec_cert_to_ssh_key_send(void **state)
     ev = tevent_context_init(ts);
     assert_non_null(ev);
 
-    req = cert_to_ssh_key_send(ts, ev, -1, P11_CHILD_TIMEOUT,
+    req = cert_to_ssh_key_send(ts, ev, NULL, P11_CHILD_TIMEOUT,
 #ifdef HAVE_NSS
                     "sql:" ABS_BUILD_DIR "/src/tests/test_ECC_CA/p11_ecc_nssdb",
 #else
@@ -691,7 +691,7 @@ void test_cert_to_ssh_2keys_with_certmap_send(void **state)
     ev = tevent_context_init(ts);
     assert_non_null(ev);
 
-    req = cert_to_ssh_key_send(ts, ev, -1, P11_CHILD_TIMEOUT,
+    req = cert_to_ssh_key_send(ts, ev, NULL, P11_CHILD_TIMEOUT,
 #ifdef HAVE_NSS
                             "sql:" ABS_BUILD_DIR "/src/tests/test_CA/p11_nssdb",
 #else
@@ -769,7 +769,7 @@ void test_cert_to_ssh_2keys_with_certmap_2_send(void **state)
     ev = tevent_context_init(ts);
     assert_non_null(ev);
 
-    req = cert_to_ssh_key_send(ts, ev, -1, P11_CHILD_TIMEOUT,
+    req = cert_to_ssh_key_send(ts, ev, NULL, P11_CHILD_TIMEOUT,
 #ifdef HAVE_NSS
                             "sql:" ABS_BUILD_DIR "/src/tests/test_CA/p11_nssdb",
 #else

--- a/src/util/cert.h
+++ b/src/util/cert.h
@@ -57,7 +57,7 @@ errno_t get_ssh_key_from_derb64(TALLOC_CTX *mem_ctx, const char *derb64,
 
 struct tevent_req *cert_to_ssh_key_send(TALLOC_CTX *mem_ctx,
                                         struct tevent_context *ev,
-                                        int child_debug_fd, time_t timeout,
+                                        const char *logfile, time_t timeout,
                                         const char *ca_db,
                                         struct sss_certmap_ctx *sss_certmap_ctx,
                                         size_t cert_count,

--- a/src/util/child_common.h
+++ b/src/util/child_common.h
@@ -106,7 +106,7 @@ void fd_nonblocking(int fd);
 /* Never returns EOK, ether returns an error, or doesn't return on success */
 void exec_child_ex(TALLOC_CTX *mem_ctx,
                    int *pipefd_to_child, int *pipefd_from_child,
-                   const char *binary, int debug_fd,
+                   const char *binary, const char *logfile,
                    const char *extra_argv[], bool extra_args_only,
                    int child_in_fd, int child_out_fd);
 
@@ -115,10 +115,8 @@ void exec_child_ex(TALLOC_CTX *mem_ctx,
  */
 void exec_child(TALLOC_CTX *mem_ctx,
                 int *pipefd_to_child, int *pipefd_from_child,
-                const char *binary, int debug_fd);
+                const char *binary, const char *logfile);
 
 int child_io_destructor(void *ptr);
-
-errno_t child_debug_init(const char *logfile, int *debug_fd);
 
 #endif /* __CHILD_COMMON_H__ */


### PR DESCRIPTION
There was no reason to keep child process log files open permanently.

This patch:
 - helps to avoid issue when SIGHUP was ignored for child process logs;
 - somewhat reduces code duplication.

Resolves: https://github.com/SSSD/sssd/issues/4667