### PR TITLE
AD: Enforcing GPO rule restriction on user

### DIFF
--- a/src/providers/ad/ad_gpo.c
+++ b/src/providers/ad/ad_gpo.c
@@ -2552,7 +2552,16 @@ ad_gpo_process_gpo_done(struct tevent_req *subreq)
         /* no gpos contain "SecuritySettings" cse_guid, nothing to enforce */
         DEBUG(SSSDBG_TRACE_FUNC,
               "no applicable gpos found after cse_guid filtering\n");
-        ret = EOK;
+
+        if (state->gpo_implicit_deny == true) {
+            DEBUG(SSSDBG_TRACE_FUNC,
+                  "No applicable GPOs have been found and ad_gpo_implicit_deny"
+                  " is set to 'true'. The user will be denied access.\n");
+            ret = ERR_ACCESS_DENIED;
+        } else {
+            ret = EOK;
+        }
+
         goto done;
     }
 


### PR DESCRIPTION
This fixes bug related to ad_gpo_implicit_deny option set to True.
gpo_implict_denay was checked only for dacl_filtered_gpos,
but not for cse_filtered_gpos.

Resolves:
https://github.com/SSSD/sssd/issues/5181
https://bugzilla.redhat.com/show_bug.cgi?id=1837020