### PR TITLE
pam_sss: special handling for gdm-smartcard

### DIFF
--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -1835,8 +1835,13 @@ static int prompt_sc_pin(pam_handle_t *pamh, struct pam_items *pi)
     struct pam_message m[2] = { { 0 }, { 0 } };
     struct pam_response *resp = NULL;
     struct cert_auth_info *cai = pi->selected_cert;
+    struct cert_auth_info empty_cai = { NULL, NULL, discard_const("Smartcard"),
+                                        NULL, NULL, NULL, NULL, NULL };
 
-    if (cai == NULL || cai->token_name == NULL || *cai->token_name == '\0') {
+    if (cai == NULL && SERVICE_IS_GDM_SMARTCARD(pi)) {
+        cai = &empty_cai;
+    } else if (cai == NULL || cai->token_name == NULL
+                    || *cai->token_name == '\0') {
         return PAM_SYSTEM_ERR;
     }
 
@@ -2188,6 +2193,9 @@ static int get_authtok_for_authentication(pam_handle_t *pamh,
                     }
                 }
                 ret = prompt_sc_pin(pamh, pi);
+            } else if (SERVICE_IS_GDM_SMARTCARD(pi)) {
+               /* Use pin prompt as fallback for gdm-smartcard */
+                ret = prompt_sc_pin(pamh, pi);
             } else {
                 ret = prompt_password(pamh, pi, _("Password: "));
             }
@@ -2496,7 +2504,7 @@ static int pam_sss(enum sss_cli_command task, pam_handle_t *pamh,
 {
     int ret;
     int pam_status;
-    struct pam_items pi;
+    struct pam_items pi = { 0 };
     uint32_t flags = 0;
     const int *exp_data;
     int *pw_exp_data;
@@ -2570,7 +2578,8 @@ static int pam_sss(enum sss_cli_command task, pam_handle_t *pamh,
                         /*
                          * Since we are only interested in the result message
                          * and will always use password authentication
-                         * as a fallback, errors can be ignored here.
+                         * as a fallback (except for gdm-smartcard),
+                         * errors can be ignored here.
                          */
                     }
                 }
@@ -2588,7 +2597,6 @@ static int pam_sss(enum sss_cli_command task, pam_handle_t *pamh,
                                                  quiet_mode);
                     if (ret != PAM_SUCCESS) {
                         D(("check_login_token_name failed.\n"));
-                        return ret;
                     }
                 }
 

--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -71,6 +71,8 @@
 #define DEBUG_MGS_LEN 1024
 #define MAX_AUTHTOK_SIZE (1024*1024)
 #define CHECK_AND_RETURN_PI_STRING(s) ((s != NULL && *s != '\0')? s : "(not available)")
+#define SERVICE_IS_GDM_SMARTCARD(pitem) (strcmp((pitem)->pam_service, \
+                                                "gdm-smartcard") == 0)
 
 static void logger(pam_handle_t *pamh, int level, const char *fmt, ...) {
     va_list ap;
@@ -2580,7 +2582,7 @@ static int pam_sss(enum sss_cli_command task, pam_handle_t *pamh,
                     return PAM_AUTHINFO_UNAVAIL;
                 }
 
-                if (strcmp(pi.pam_service, "gdm-smartcard") == 0
+                if (SERVICE_IS_GDM_SMARTCARD(&pi)
                         || (flags & PAM_CLI_FLAGS_REQUIRE_CERT_AUTH)) {
                     ret = check_login_token_name(pamh, &pi, retries,
                                                  quiet_mode);


### PR DESCRIPTION
The gdm-smartcard service is special since it is triggered by the presence
of a Smartcard and even in the case of an error it will immediately try
again. To break this loop we should ask for an user input and asking for a
PIN is most straight forward and would show the same behavior as
pam_pkcs11.

Additionally it does not make sense to fall back the a password prompt for
gdm-smartcard so also here a PIN prompt should be shown.

Resolves: https://github.com/SSSD/sssd/issues/5190