### PR TITLE
pam_sss: special handling for gdm-smartcard (sssd-1-16)

### DIFF
--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -79,6 +79,8 @@
 #define DEBUG_MGS_LEN 1024
 #define MAX_AUTHTOK_SIZE (1024*1024)
 #define CHECK_AND_RETURN_PI_STRING(s) ((s != NULL && *s != '\0')? s : "(not available)")
+#define SERVICE_IS_GDM_SMARTCARD(pitem) (strcmp((pitem)->pam_service, \
+                                                "gdm-smartcard") == 0)
 
 static void logger(pam_handle_t *pamh, int level, const char *fmt, ...) {
     va_list ap;
@@ -2506,7 +2508,7 @@ static int pam_sss(enum sss_cli_command task, pam_handle_t *pamh,
                     }
                 }
 
-                if (strcmp(pi.pam_service, "gdm-smartcard") == 0) {
+                if (SERVICE_IS_GDM_SMARTCARD(&pi)) {
                     ret = check_login_token_name(pamh, &pi, quiet_mode);
                     if (ret != PAM_SUCCESS) {
                         D(("check_login_token_name failed.\n"));


### PR DESCRIPTION
The gdm-smartcard service is special since it is triggered by the presence
of a Smartcard and even in the case of an error it will immediately try
again. To break this loop we should ask for an user input and asking for a
PIN is most straight forward and would show the same behavior as
pam_pkcs11.

Additionally it does not make sense to fall back the a password prompt for
gdm-smartcard so also here a PIN prompt should be shown.

Resolves: https://github.com/SSSD/sssd/issues/5190

(cherry picked with changes from commit
f1cebb7401a62034385a804557157c56f22bd2cf)