### PR TITLE
sss_cache: Do nothing if SYSTEMD_OFFLINE=1

### DIFF
--- a/src/tools/sss_cache.c
+++ b/src/tools/sss_cache.c
@@ -160,7 +160,7 @@ int main(int argc, const char *argv[])
      * https://github.com/systemd/systemd/pull/7631
      */
     const char *systemd_offline = getenv ("SYSTEMD_OFFLINE");
-    if (systemd_offline && strcmp (systemd_offline, "1") == 0 && access(DB_PATH, W_OK) != 0) {
+    if (systemd_offline && strcmp (systemd_offline, "1") == 0) {
         return 0;
     }
 


### PR DESCRIPTION
Do not check for `/var` being RO as this will break cases where we explicitely request sssd not to update the cache by setting `SYSTEMD_OFFLINE=1`.

This will still complain if `/var` is RO and `SYSTEMD_OFFLINE` is not set.

See initial discussion at: https://pagure.io/SSSD/sssd/pull-request/3959

This mostly reverts: sss_cache: Do nothing if /var is read-only https://github.com/SSSD/sssd/commit/073b03a096a763170165fe3814fa987881713e75