### PR TITLE
failover: fix documentation of default timeouts

### DIFF
--- a/src/man/include/failover.xml
+++ b/src/man/include/failover.xml
@@ -97,7 +97,7 @@
                             hostname or discovery domain.
                         </para>
                         <para>
-                            Default: 2
+                            Default: 3
                         </para>
                     </listitem>
                 </varlistentry>
@@ -113,7 +113,7 @@
                             queries or locating the site.
                         </para>
                         <para>
-                            Default: 4
+                            Default: 6
                         </para>
                     </listitem>
                 </varlistentry>


### PR DESCRIPTION
Commit e97ff0adb62c89cfc7e75858b7e592e0303720b0 for #4250 changed the default timeouts for the DNS resolver. While it also updated the man pages, this update did not correctly reflect the new defaults. @pbrezina @jhrozek 