### PR TITLE
1.16: ldap_child: do not try PKINIT

### DIFF
--- a/src/providers/ldap/ldap_child.c
+++ b/src/providers/ldap/ldap_child.c
@@ -271,7 +271,7 @@ static krb5_error_code ldap_child_get_tgt_sync(TALLOC_CTX *memctx,
     krb5_ccache ccache = NULL;
     krb5_principal kprinc;
     krb5_creds my_creds;
-    krb5_get_init_creds_opt options;
+    krb5_get_init_creds_opt *options = NULL;
     krb5_error_code krberr;
     krb5_timestamp kdc_time_offset;
     int canonicalize = 0;
@@ -379,19 +379,32 @@ static krb5_error_code ldap_child_get_tgt_sync(TALLOC_CTX *memctx,
     }
 
     memset(&my_creds, 0, sizeof(my_creds));
-    memset(&options, 0, sizeof(options));
 
-    krb5_get_init_creds_opt_set_address_list(&options, NULL);
-    krb5_get_init_creds_opt_set_forwardable(&options, 0);
-    krb5_get_init_creds_opt_set_proxiable(&options, 0);
-    krb5_get_init_creds_opt_set_tkt_life(&options, lifetime);
+    krberr = krb5_get_init_creds_opt_alloc(context, &options);
+    if (krberr != 0) {
+        DEBUG(SSSDBG_OP_FAILURE, "krb5_get_init_creds_opt_alloc failed.\n");
+        goto done;
+    }
+
+    krb5_get_init_creds_opt_set_address_list(options, NULL);
+    krb5_get_init_creds_opt_set_forwardable(options, 0);
+    krb5_get_init_creds_opt_set_proxiable(options, 0);
+    krb5_get_init_creds_opt_set_tkt_life(options, lifetime);
+    krberr = krb5_get_init_creds_opt_set_pa(context, options,
+                                            "X509_user_identity", "");
+    if (krberr != 0) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "krb5_get_init_creds_opt_set_pa failed [%d], ignored.\n",
+              krberr);
+    }
+
 
     tmp_str = getenv("KRB5_CANONICALIZE");
     if (tmp_str != NULL && strcasecmp(tmp_str, "true") == 0) {
         DEBUG(SSSDBG_CONF_SETTINGS, "Will canonicalize principals\n");
         canonicalize = 1;
     }
-    sss_krb5_get_init_creds_opt_set_canonicalize(&options, canonicalize);
+    sss_krb5_get_init_creds_opt_set_canonicalize(options, canonicalize);
 
     ccname_file = talloc_asprintf(tmp_ctx, "%s/ccache_%s",
                                   DB_PATH, realm_name);
@@ -424,7 +437,7 @@ static krb5_error_code ldap_child_get_tgt_sync(TALLOC_CTX *memctx,
     }
 
     krberr = krb5_get_init_creds_keytab(context, &my_creds, kprinc,
-                                        keytab, 0, NULL, &options);
+                                        keytab, 0, NULL, options);
     krb5_kt_close(context, keytab);
     keytab = NULL;
     if (krberr) {
@@ -500,6 +513,7 @@ static krb5_error_code ldap_child_get_tgt_sync(TALLOC_CTX *memctx,
     *expire_time_out = my_creds.times.endtime - kdc_time_offset;
 
 done:
+    krb5_get_init_creds_opt_free(context, options);
     if (krberr != 0) {
         const char *krb5_msg;
 


### PR DESCRIPTION
Backport the fix for #5087 onto sssd-1-16.

This branch is affected by the same bug, which can cause delays when attempting smart card login using the AD provider.