### PR TITLE
NEGCACHE: skip permanent entries in [users/groups] reset

### DIFF
--- a/src/responder/common/negcache.c
+++ b/src/responder/common/negcache.c
@@ -900,9 +900,18 @@ static int delete_prefix(struct tdb_context *tdb,
                          TDB_DATA key, TDB_DATA data, void *state)
 {
     const char *prefix = (const char *) state;
+    unsigned long long int timestamp;
+    char *ep = NULL;
 
     if (strncmp((char *)key.dptr, prefix, strlen(prefix) - 1) != 0) {
         /* not interested in this key */
+        return 0;
+    }
+
+    errno = 0;
+    timestamp = strtoull((const char *)data.dptr, &ep, 10);
+    if ((errno == 0) && (*ep == '\0') && (timestamp == 0)) {
+        /* skip permanent entries */
         return 0;
     }
 

--- a/src/responder/common/negcache.h
+++ b/src/responder/common/negcache.h
@@ -146,6 +146,7 @@ int sss_ncache_set_locate_uid(struct sss_nc_ctx *ctx,
                               uid_t uid);
 
 int sss_ncache_reset_permanent(struct sss_nc_ctx *ctx);
+/* sss_ncache_reset_[users/groups] skips permanent entries */
 int sss_ncache_reset_users(struct sss_nc_ctx *ctx);
 int sss_ncache_reset_groups(struct sss_nc_ctx *ctx);
 


### PR DESCRIPTION
Files provider calling `sss_ncache_reset_[users/groups]()`
during cache rebuilding was breaking neg-cache prepopulation.

Resolves: https://github.com/SSSD/sssd/issues/1024