### PR TITLE
pam_sss: fix missing initializer

### DIFF
--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -1836,7 +1836,7 @@ static int prompt_sc_pin(pam_handle_t *pamh, struct pam_items *pi)
     struct pam_response *resp = NULL;
     struct cert_auth_info *cai = pi->selected_cert;
     struct cert_auth_info empty_cai = { NULL, NULL, discard_const("Smartcard"),
-                                        NULL, NULL, NULL, NULL, NULL };
+                                        NULL, NULL, NULL, NULL, NULL, NULL };
 
     if (cai == NULL && SERVICE_IS_GDM_SMARTCARD(pi)) {
         cai = &empty_cai;


### PR DESCRIPTION
Fix the following error introduced by:
3ed254765fc92e9cc9e4c35335818eaf1256e0d6

```
/home/pbrezina/workspace/sssd/src/sss_client/pam_sss.c: In function ‘prompt_sc_pin’:
/home/pbrezina/workspace/sssd/src/sss_client/pam_sss.c:1839:41: error: missing initializer for field ‘next’ of ‘struct cert_auth_info’ [-Werror=missing-field-initializers]
                                         NULL, NULL, NULL, NULL, NULL };
                                         ^~~~
/home/pbrezina/workspace/sssd/src/sss_client/pam_sss.c:132:28: note: ‘next’ declared here
     struct cert_auth_info *next;

```