### PR TITLE
pam_sss: make sure old certificate data is removed before retry

### DIFF
--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -2467,6 +2467,8 @@ static int check_login_token_name(pam_handle_t *pamh, struct pam_items *pi,
                         && strcmp(login_token_name,
                                   pi->cert_list->token_name) != 0)) {
 
+        free_cert_list(pi->cert_list);
+        pi->cert_list = NULL;
         if (retries < 0) {
             ret = PAM_AUTHINFO_UNAVAIL;
             goto done;


### PR DESCRIPTION
To avoid that certificates will be shown in the certificate selection
which are not available anymore they must be remove before a new request
to look up the certificates is send to SSSD's PAM responder.

Resolves: https://github.com/SSSD/sssd/issues/5190