### PR TITLE
config: [RFE] Add "enabled" option to domain section

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -291,6 +291,7 @@ if HAVE_CMOCKA
         test_iobuf \
         sss_certmap_test \
         test_sssd_krb5_locator_plugin \
+        test_confdb \
         $(NULL)
 
 
@@ -480,6 +481,7 @@ dist_noinst_DATA = \
     src/config/testconfigs/sssd-invalid-badbool.conf \
     src/config/testconfigs/sssd-nonexisting-services-domains.conf \
     src/config/testconfigs/sssd-test-parse.conf \
+    src/config/testconfigs/sssd-enabled-option.conf \
     src/config/etc/sssd.api.d/crash_test_dummy \
     contrib/ci/README.md \
     contrib/ci/configure.sh \
@@ -3858,6 +3860,21 @@ test_iobuf_CFLAGS = \
 test_iobuf_LDADD = \
     $(CMOCKA_LIBS) \
     $(SSSD_LIBS) \
+    $(NULL)
+
+test_confdb_SOURCES = \
+    src/tests/cmocka/confdb/test_confdb.c \
+    $(NULL)
+test_confdb_CFLAGS = \
+    $(AM_CFLAGS) \
+    $(NULL)
+test_confdb_LDADD = \
+    $(CMOCKA_LIBS) \
+    $(LDB_LIBS) \
+    $(POPT_LIBS) \
+    $(TALLOC_LIBS) \
+    $(SSSD_INTERNAL_LTLIBS) \
+    libsss_test_common.la \
     $(NULL)
 
 EXTRA_simple_access_tests_DEPENDENCIES = \

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -189,6 +189,7 @@
 #define CONFDB_SESSION_RECORDING_GROUPS "groups"
 
 /* Domains */
+#define CONFDB_DOMAIN_ENABLED "enabled"
 #define CONFDB_DOMAIN_PATH_TMPL "config/domain/%s"
 #define CONFDB_DOMAIN_BASEDN "cn=domain,cn=config"
 #define CONFDB_APP_DOMAIN_BASEDN "cn=application,cn=config"

--- a/src/config/SSSDConfig/__init__.py.in
+++ b/src/config/SSSDConfig/__init__.py.in
@@ -1373,23 +1373,27 @@ class SSSDConfig(SSSDChangeConf):
             raise NotInitializedError
 
         if (self.has_option('sssd', 'domains')):
-            active_domains = striplist(self.get('sssd', 'domains').split(','))
-            domain_dict = dict.fromkeys(active_domains)
+            sssd_domains = striplist(self.get('sssd', 'domains').split(','))
+            domain_dict = dict.fromkeys(sssd_domains)
             if '' in domain_dict:
                 del domain_dict['']
-
-            # Remove any entries in this list that don't
-            # correspond to an active domain, for integrity
-            configured_domains = self.list_domains()
-            for dom in list(domain_dict):
-                if dom not in configured_domains:
-                    del domain_dict[dom]
-
-            active_domains = list(domain_dict)
+            sssd_domains = list(domain_dict)
         else:
-            active_domains = []
+            sssd_domains = []
 
-        return active_domains
+        domains = self.list_domains()
+        for dom in self.list_domains():
+            # Remove explicitly enabled from the list
+            if self.has_option('domain/%s' % dom, 'enabled'):
+                if self.get('domain/%s' % dom, 'enabled') == 'false':
+                    domains.remove(dom)
+                    if dom in sssd_domains:
+                        sssd_domains.remove(dom)
+            else:
+                if dom not in sssd_domains:
+                    domains.remove(dom)
+
+        return domains
 
     def list_inactive_domains(self):
         """
@@ -1407,12 +1411,24 @@ class SSSDConfig(SSSDChangeConf):
             raise NotInitializedError
 
         if (self.has_option('sssd', 'domains')):
-            active_domains = striplist(self.get('sssd', 'domains').split(','))
+            sssd_domains = striplist(self.get('sssd', 'domains').split(','))
+            domain_dict = dict.fromkeys(sssd_domains)
+            if '' in domain_dict:
+                del domain_dict['']
+            sssd_domains = list(domain_dict)
         else:
-            active_domains = []
+            sssd_domains = []
 
-        domains = [x for x in self.list_domains()
-                   if x not in active_domains]
+        domains = self.list_domains()
+        for dom in self.list_domains():
+            # Remove explicitly enabled from the list
+            if self.has_option('domain/%s' % dom, 'enabled'):
+                if self.get('domain/%s' % dom, 'enabled') == 'true':
+                    domains.remove(dom)
+            else:
+                if dom in sssd_domains:
+                    domains.remove(dom)
+
         return domains
 
     def list_domains(self):

--- a/src/config/SSSDConfig/sssdoptions.py
+++ b/src/config/SSSDConfig/sssdoptions.py
@@ -174,6 +174,7 @@ class SSSDOptions(object):
 
         # [domain]
         'domain_type': _('Whether the domain is usable by the OS or by applications'),
+        'enabled': _('Enable or disable the domain'),
         'min_id': _('Minimum user ID'),
         'max_id': _('Maximum user ID'),
         'enumerate': _('Enable enumerating all users/groups'),

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -358,6 +358,7 @@ option = session_provider
 option = resolver_provider
 
 # Options available to all domains
+option = enabled
 option = domain_type
 option = min_id
 option = max_id

--- a/src/config/etc/sssd.api.conf
+++ b/src/config/etc/sssd.api.conf
@@ -153,6 +153,7 @@ resolver_provider = str, None, false
 
 [domain]
 # Options available to all domains
+enabled = bool, None, false
 description = str, None, false
 domain_type = str, None, false
 debug = int, None, false

--- a/src/config/testconfigs/sssd-enabled-option.conf
+++ b/src/config/testconfigs/sssd-enabled-option.conf
@@ -1,0 +1,34 @@
+[nss]
+debug_level = 0
+
+[sssd]
+services = nss, pam
+reconnection_retries = 3
+domains = enabled_1, enabled_3, disabled_3
+config_file_version = 2
+debug_timestamps = False
+
+[domain/enabled_1]
+id_provider = local
+
+[domain/enabled_2]
+enabled = true
+id_provider = local
+
+[domain/enabled_3]
+enabled = true
+id_provider = local
+
+[domain/disabled_1]
+id_provider = local
+
+[domain/disabled_2]
+enabled = false
+id_provider = local
+
+[domain/disabled_3]
+enabled = false
+id_provider = local
+
+[pam]
+debug_level = 2

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2031,6 +2031,21 @@ p11_uri = library-description=OpenSC%20smartcard%20framework;slot-id=2
             <quote>[domain/<replaceable>NAME</replaceable>]</quote>
             <variablelist>
                 <varlistentry>
+                    <term>enabled</term>
+                    <listitem>
+                        <para>
+                            Explicitly enable or disable the domain. If
+                            <quote>true</quote>, the domain is always
+                            <quote>enabled</quote>. If <quote>false</quote>,
+                            the domain is always <quote>disabled</quote>. If
+                            this option is not set, the domain is enabled only
+                            if it is listed in the domains option in the
+                            <quote>[sssd]</quote> section.
+                        </para>
+                    </listitem>
+                </varlistentry>
+
+                <varlistentry>
                     <term>domain_type (string)</term>
                     <listitem>
                         <para>

--- a/src/tests/cmocka/confdb/test_confdb.c
+++ b/src/tests/cmocka/confdb/test_confdb.c
@@ -1,0 +1,306 @@
+/*
+    Copyright (C) 2020 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#define _GNU_SOURCE
+
+#include <talloc.h>
+#include <tevent.h>
+#include <errno.h>
+#include <popt.h>
+
+#include <string.h>
+
+#include "confdb/confdb.h"
+#include "tests/cmocka/common_mock.h"
+#include "tests/common.h"
+#include "tests/cmocka/common_mock_be.h"
+
+
+#include "confdb/confdb.c"
+
+#define TESTS_PATH "confdb_" BASE_FILE_STEM
+#define TEST_CONF_DB "test_confdb.ldb"
+
+#define TEST_DOMAIN_ENABLED_1 "enabled_1"
+#define TEST_DOMAIN_ENABLED_2 "enabled_2"
+#define TEST_DOMAIN_ENABLED_3 "enabled_3"
+
+#define TEST_DOMAIN_DISABLED_1 "disabled_1"
+#define TEST_DOMAIN_DISABLED_2 "disabled_2"
+#define TEST_DOMAIN_DISABLED_3 "disabled_3"
+
+
+struct test_ctx {
+    struct confdb_ctx *confdb;
+};
+
+
+static int confdb_test_setup(void **state)
+{
+    struct test_ctx *test_ctx;
+    char *conf_db = NULL;
+    int ret;
+    const char *val[2];
+    val[1] = NULL;
+
+    assert_true(leak_check_setup());
+
+    test_ctx = talloc_zero(global_talloc_context, struct test_ctx);
+    assert_non_null(test_ctx);
+
+    conf_db = talloc_asprintf(test_ctx, "%s/%s", TESTS_PATH, TEST_CONF_DB);
+    assert_non_null(conf_db);
+
+    ret = confdb_init(test_ctx, &test_ctx->confdb, conf_db);
+    assert_int_equal(ret, EOK);
+
+    talloc_free(conf_db);
+
+    /* [sssd] */
+    val[0] = "2";
+    ret = confdb_add_param(test_ctx->confdb, true,
+                           "config/sssd", "config_file_version", val);
+    assert_int_equal(ret, EOK);
+
+    val[0] = TEST_DOMAIN_ENABLED_1 ", " TEST_DOMAIN_ENABLED_3 ", " TEST_DOMAIN_DISABLED_3;
+    ret = confdb_add_param(test_ctx->confdb, true,
+                           "config/sssd", "domains", val);
+    assert_int_equal(ret, EOK);
+
+    /* [domain/enabled_1] */
+    val[0] = "local";
+    ret = confdb_add_param(test_ctx->confdb, true,
+                           "config/domain/" TEST_DOMAIN_ENABLED_1, "id_provider", val);
+    assert_int_equal(ret, EOK);
+
+    /* [domain/enabled_2] */
+    val[0] = "local";
+    ret = confdb_add_param(test_ctx->confdb, true,
+                           "config/domain/" TEST_DOMAIN_ENABLED_2, "id_provider", val);
+    assert_int_equal(ret, EOK);
+
+    val[0] = "true";
+    ret = confdb_add_param(test_ctx->confdb, true,
+                           "config/domain/" TEST_DOMAIN_ENABLED_2, "enabled", val);
+    assert_int_equal(ret, EOK);
+
+    /* [domain/enabled_3] */
+    val[0] = "local";
+    ret = confdb_add_param(test_ctx->confdb, true,
+                           "config/domain/" TEST_DOMAIN_ENABLED_3, "id_provider", val);
+    assert_int_equal(ret, EOK);
+
+    val[0] = "true";
+    ret = confdb_add_param(test_ctx->confdb, true,
+                           "config/domain/" TEST_DOMAIN_ENABLED_3, "enabled", val);
+    assert_int_equal(ret, EOK);
+
+    /* [domain/disabled_1] */
+    val[0] = "local";
+    ret = confdb_add_param(test_ctx->confdb, true,
+                           "config/domain/" TEST_DOMAIN_DISABLED_1, "id_provider", val);
+    assert_int_equal(ret, EOK);
+
+    /* [domain/disabled_2] */
+    val[0] = "local";
+    ret = confdb_add_param(test_ctx->confdb, true,
+                           "config/domain/" TEST_DOMAIN_DISABLED_2, "id_provider", val);
+    assert_int_equal(ret, EOK);
+
+    val[0] = "false";
+    ret = confdb_add_param(test_ctx->confdb, true,
+                           "config/domain/" TEST_DOMAIN_DISABLED_2, "enabled", val);
+    assert_int_equal(ret, EOK);
+
+    /* [domain/disabled_3] */
+    val[0] = "local";
+    ret = confdb_add_param(test_ctx->confdb, true,
+                           "config/domain/" TEST_DOMAIN_DISABLED_3, "id_provider", val);
+    assert_int_equal(ret, EOK);
+
+    val[0] = "false";
+    ret = confdb_add_param(test_ctx->confdb, true,
+                           "config/domain/" TEST_DOMAIN_DISABLED_3, "enabled", val);
+    assert_int_equal(ret, EOK);
+
+    check_leaks_push(test_ctx);
+
+    *state = test_ctx;
+    return 0;
+}
+
+
+static int confdb_test_teardown(void **state)
+{
+    struct test_ctx *test_ctx;
+
+    test_ctx = talloc_get_type(*state, struct test_ctx);
+
+    assert_true(check_leaks_pop(test_ctx) == true);
+    talloc_free(test_ctx);
+    assert_true(leak_check_teardown());
+    return 0;
+}
+
+
+static void test_confdb_get_domain_enabled(void **state)
+{
+    struct test_ctx *test_ctx = talloc_get_type(*state, struct test_ctx);
+    int ret;
+    bool enabled;
+    struct {
+        const char* domain;
+        int ret;
+        bool enabled;
+    } expected[] = {
+        {
+            TEST_DOMAIN_ENABLED_1,
+            ENOENT,
+            false
+        },
+        {
+            TEST_DOMAIN_ENABLED_2,
+            EOK,
+            true
+        },
+        {
+            TEST_DOMAIN_ENABLED_3,
+            EOK,
+            true
+        },
+        {
+            TEST_DOMAIN_DISABLED_1,
+            ENOENT,
+            true
+        },
+        {
+            TEST_DOMAIN_DISABLED_2,
+            EOK,
+            false
+        },
+        {
+            TEST_DOMAIN_DISABLED_3,
+            EOK,
+            false
+        },
+        {
+            "unexistingdomain",
+            ENOENT,
+            false
+        },
+        {
+            NULL,
+            ENOENT,
+            false
+        },
+    };
+
+    for (int index = 0; expected[index].domain; index++) {
+        ret = confdb_get_domain_enabled(test_ctx->confdb, expected[index].domain, &enabled);
+        assert_int_equal(ret, expected[index].ret);
+        ret = confdb_get_domain_enabled(test_ctx->confdb, expected[index].domain, &enabled);
+        if (ret == EOK) {
+            if (expected[index].enabled) {
+                assert_true(enabled);
+            } else {
+                assert_false(enabled);
+            }
+        }
+    }
+}
+
+
+static void test_confdb_get_enabled_domain_list(void **state)
+{
+    struct test_ctx *test_ctx = talloc_get_type(*state, struct test_ctx);
+    TALLOC_CTX* tmp_ctx = talloc_new(NULL);
+    char** result = NULL;
+    int ret = EOK;
+
+    const char* expected_enabled_domain_list[] = {
+        TEST_DOMAIN_ENABLED_1,
+        TEST_DOMAIN_ENABLED_2,
+        TEST_DOMAIN_ENABLED_3,
+        NULL
+    };
+
+    ret = confdb_get_enabled_domain_list(test_ctx->confdb, tmp_ctx, &result);
+    assert_int_equal(EOK, ret);
+    assert_non_null(result);
+    for (int index = 0; expected_enabled_domain_list[index]; index++) {
+        assert_true(string_in_list(expected_enabled_domain_list[index], result, false));
+    }
+    for (int index = 0; result[index]; index++) {
+        assert_true(string_in_list(result[index], expected_enabled_domain_list, false));
+    }
+
+    TALLOC_FREE(tmp_ctx);
+}
+
+
+int main(int argc, const char *argv[])
+{
+    poptContext pc;
+    int opt;
+    int rv;
+    int no_cleanup = 0;
+    struct poptOption long_options[] = {
+        POPT_AUTOHELP
+        SSSD_DEBUG_OPTS
+        {"no-cleanup", 'n', POPT_ARG_NONE, &no_cleanup, 0,
+         _("Do not delete the test database after a test run"), NULL },
+        POPT_TABLEEND
+    };
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_confdb_get_domain_enabled,
+                                        confdb_test_setup,
+                                        confdb_test_teardown),
+        cmocka_unit_test_setup_teardown(test_confdb_get_enabled_domain_list,
+                                        confdb_test_setup,
+                                        confdb_test_teardown),
+    };
+
+    /* Set debug level to invalid value so we can decide if -d 0 was used. */
+    debug_level = SSSDBG_INVALID;
+
+    pc = poptGetContext(argv[0], argc, argv, long_options, 0);
+    while((opt = poptGetNextOpt(pc)) != -1) {
+        switch(opt) {
+        default:
+            fprintf(stderr, "\nInvalid option %s: %s\n\n",
+                    poptBadOption(pc, 0), poptStrerror(opt));
+            poptPrintUsage(pc, stderr, 0);
+            return 1;
+        }
+    }
+    poptFreeContext(pc);
+
+    DEBUG_CLI_INIT(debug_level);
+
+    /* Even though normally the tests should clean up after themselves
+     * they might not after a failed run. Remove the old DB to be sure */
+    tests_set_cwd();
+    test_dom_suite_cleanup(TESTS_PATH, TEST_CONF_DB, NULL);
+    test_dom_suite_setup(TESTS_PATH);
+
+    rv = cmocka_run_group_tests(tests, NULL, NULL);
+    if (rv == 0 && !no_cleanup) {
+        test_dom_suite_cleanup(TESTS_PATH, TEST_CONF_DB, NULL);
+    }
+
+    return rv;
+}

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -494,6 +494,9 @@ remove_ipv6_brackets(char *ipv6addr);
 errno_t add_string_to_list(TALLOC_CTX *mem_ctx, const char *string,
                            char ***list_p);
 
+errno_t del_string_from_list(const char *string,
+                             char ***list_p, bool case_sensitive);
+
 bool string_in_list(const char *string, char **list, bool case_sensitive);
 
 int domain_to_basedn(TALLOC_CTX *memctx, const char *domain, char **basedn);


### PR DESCRIPTION
A new attribute is appended to [domain/*] sections so that
a domain ca be enabled/disabled by domain section and for
extension by configuration file if each domain is divided
in separate files.

This attribute override the list of domains at [sssd]
section, however the new **enabled** attribute override
the values of the list. If no **enabled** attribute is
found for a domain section, the domain list criteria is
used to enable/disable a domain.

Resolves: #4743