### PR TITLE
ipa: Do not qualify already qualified users in sudo rules

### DIFF
--- a/src/providers/ipa/ipa_sudo_conversion.c
+++ b/src/providers/ipa/ipa_sudo_conversion.c
@@ -879,6 +879,10 @@ convert_ext_user(TALLOC_CTX *mem_ctx,
                  const char *value,
                  bool *skip_entry)
 {
+    /* If value is already fully qualified, return it as it is */
+    if (strrchr(value, '@') != NULL) {
+        return talloc_strdup(mem_ctx, value);
+    }
     return sss_create_internal_fqname(mem_ctx, value, conv->dom->name);
 }
 


### PR DESCRIPTION
SSSD normalizes externalUser attribute value the same way as a normal
sudoUser attribute which supposed to be non-fully qualified. This,
however, breaks for trusted AD users/groups because they are already
qualified.

Note that FreeIPA currently doesn't allow to specify AD users and groups
in externalUser attribute but the work to add this is under way and is
pending this fix.

Fixes: https://github.com/SSSD/sssd/issues/5199