### PR TITLE
PAM: do not treat error for cache-only lookups as fatal

### DIFF
--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -1941,10 +1941,8 @@ static void pam_check_user_search_next(struct tevent_req *req)
     ret = cache_req_single_domain_recv(preq, req, &result);
     talloc_zfree(req);
     if (ret != EOK && ret != ENOENT) {
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Fatal error, killing connection!\n");
-        talloc_zfree(preq->cctx);
-        return;
+        DEBUG(SSSDBG_OP_FAILURE, "Cache lookup failed, trying to get fresh "
+                                 "data from the backened.\n");
     }
 
     DEBUG(SSSDBG_TRACE_ALL, "PAM initgroups scheme [%s].\n",


### PR DESCRIPTION
The original fatal error came from a time where at this place in the
code the response form the backend was checked and an error was clearly
fatal.

Now we only check if the entry is in the cache and valid. An error would
mean that the backend is called to lookup or refresh the entry. So the
backend can change the state of the cache and make upcoming cache
lookups successful. So it makes sense to not only call the backend if
ENOENT is returned but for all kind of errors.

Resolves https://pagure.io/SSSD/sssd/issue/4098