### PR TITLE
python/pysss_nss_idmap: check return from functions

### DIFF
--- a/src/python/pyhbac.c
+++ b/src/python/pyhbac.c
@@ -1940,7 +1940,9 @@ initpyhbac(void)
     m = Py_InitModule(sss_py_const_p(char, PYTHON_MODULE_NAME),
                       pyhbac_module_methods);
 #endif
-    if (m == NULL) MODINITERROR;
+    if (m == NULL) {
+        MODINITERROR(NULL);
+    }
 
     /* The HBAC module exception */
     PyExc_HbacError = sss_exception_with_doc(
@@ -1948,43 +1950,73 @@ initpyhbac(void)
                         PyExc_EnvironmentError, NULL);
     Py_INCREF(PyExc_HbacError);
     ret = PyModule_AddObject(m, sss_py_const_p(char, "HbacError"), PyExc_HbacError);
-    if (ret == -1) MODINITERROR;
+    if (ret == -1) {
+        MODINITERROR(m);
+    }
 
     /* HBAC rule categories */
     ret = PyModule_AddIntMacro(m, HBAC_CATEGORY_NULL);
-    if (ret == -1) MODINITERROR;
+    if (ret == -1) {
+        MODINITERROR(m);
+    }
     ret = PyModule_AddIntMacro(m, HBAC_CATEGORY_ALL);
-    if (ret == -1) MODINITERROR;
+    if (ret == -1) {
+        MODINITERROR(m);
+    }
 
     /* HBAC rule elements */
     ret = PyModule_AddIntMacro(m, HBAC_RULE_ELEMENT_USERS);
-    if (ret == -1) MODINITERROR;
+    if (ret == -1) {
+        MODINITERROR(m);
+    }
     ret = PyModule_AddIntMacro(m, HBAC_RULE_ELEMENT_SERVICES);
-    if (ret == -1) MODINITERROR;
+    if (ret == -1) {
+        MODINITERROR(m);
+    }
     ret = PyModule_AddIntMacro(m, HBAC_RULE_ELEMENT_TARGETHOSTS);
-    if (ret == -1) MODINITERROR;
+    if (ret == -1) {
+        MODINITERROR(m);
+    }
     ret = PyModule_AddIntMacro(m, HBAC_RULE_ELEMENT_SOURCEHOSTS);
-    if (ret == -1) MODINITERROR;
+    if (ret == -1) {
+        MODINITERROR(m);
+    }
 
     /* enum hbac_eval_result */
     ret = PyModule_AddIntMacro(m, HBAC_EVAL_ALLOW);
-    if (ret == -1) MODINITERROR;
+    if (ret == -1) {
+        MODINITERROR(m);
+    }
     ret = PyModule_AddIntMacro(m, HBAC_EVAL_DENY);
-    if (ret == -1) MODINITERROR;
+    if (ret == -1) {
+        MODINITERROR(m);
+    }
     ret = PyModule_AddIntMacro(m, HBAC_EVAL_ERROR);
-    if (ret == -1) MODINITERROR;
+    if (ret == -1) {
+        MODINITERROR(m);
+    }
 
     /* enum hbac_error_code */
     ret = PyModule_AddIntMacro(m, HBAC_ERROR_UNKNOWN);
-    if (ret == -1) MODINITERROR;
+    if (ret == -1) {
+        MODINITERROR(m);
+    }
     ret = PyModule_AddIntMacro(m, HBAC_SUCCESS);
-    if (ret == -1) MODINITERROR;
+    if (ret == -1) {
+        MODINITERROR(m);
+    }
     ret = PyModule_AddIntMacro(m, HBAC_ERROR_NOT_IMPLEMENTED);
-    if (ret == -1) MODINITERROR;
+    if (ret == -1) {
+        MODINITERROR(m);
+    }
     ret = PyModule_AddIntMacro(m, HBAC_ERROR_OUT_OF_MEMORY);
-    if (ret == -1) MODINITERROR;
+    if (ret == -1) {
+        MODINITERROR(m);
+    }
     ret = PyModule_AddIntMacro(m, HBAC_ERROR_UNPARSEABLE_RULE);
-    if (ret == -1) MODINITERROR;
+    if (ret == -1) {
+        MODINITERROR(m);
+    }
 
     TYPE_READY(m, pyhbac_hbacrule_type, "HbacRule");
     TYPE_READY(m, pyhbac_hbacrule_element_type, "HbacRuleElement");

--- a/src/python/pyhbac.c
+++ b/src/python/pyhbac.c
@@ -1951,6 +1951,7 @@ initpyhbac(void)
     Py_INCREF(PyExc_HbacError);
     ret = PyModule_AddObject(m, sss_py_const_p(char, "HbacError"), PyExc_HbacError);
     if (ret == -1) {
+        Py_XDECREF(PyExc_HbacError);
         MODINITERROR(m);
     }
 

--- a/src/python/pysss.c
+++ b/src/python/pysss.c
@@ -333,16 +333,18 @@ initpysss(void)
 {
     PyObject *m;
 
-    if (PyType_Ready(&pysss_password_type) < 0)
-        MODINITERROR;
+    if (PyType_Ready(&pysss_password_type) < 0) {
+        MODINITERROR(NULL);
+    }
 
 #ifdef IS_PY3K
     m = PyModule_Create(&pysssdef);
 #else
     m = Py_InitModule(discard_const_p(char, "pysss"), module_methods);
 #endif
-    if (m == NULL)
-        MODINITERROR;
+    if (m == NULL){
+        MODINITERROR(NULL);
+    }
 
     Py_INCREF(&pysss_password_type);
     PyModule_AddObject(m, discard_const_p(char, "password"), (PyObject *)&pysss_password_type);

--- a/src/python/pysss.c
+++ b/src/python/pysss.c
@@ -347,7 +347,11 @@ initpysss(void)
     }
 
     Py_INCREF(&pysss_password_type);
-    PyModule_AddObject(m, discard_const_p(char, "password"), (PyObject *)&pysss_password_type);
+    if (PyModule_AddObject(m, discard_const_p(char, "password"),
+                           (PyObject *)&pysss_password_type) == -1) {
+        Py_XDECREF(&pysss_password_type);
+        MODINITERROR(m);
+    }
 
 #ifdef IS_PY3K
     return m;

--- a/src/python/pysss_murmur.c
+++ b/src/python/pysss_murmur.c
@@ -91,8 +91,9 @@ initpysss_murmur(void)
     m = Py_InitModule3(sss_py_const_p(char, "pysss_murmur"),
                    methods, sss_py_const_p(char, "murmur hash functions"));
 #endif
-    if (m == NULL)
-        MODINITERROR;
+    if (m == NULL) {
+        MODINITERROR(NULL);
+    }
 #ifdef IS_PY3K
     return m;
 #endif

--- a/src/python/pysss_nss_idmap.c
+++ b/src/python/pysss_nss_idmap.c
@@ -579,8 +579,9 @@ initpysss_nss_idmap(void)
                             methods,
                             sss_py_const_p(char, "SSSD ID-mapping functions"));
 #endif
-    if (module == NULL)
-        MODINITERROR;
+    if (module == NULL) {
+        MODINITERROR(NULL);
+    }
 
     PyModule_AddIntConstant(module, "ID_NOT_SPECIFIED",
                             SSS_ID_TYPE_NOT_SPECIFIED);

--- a/src/python/pysss_nss_idmap.c
+++ b/src/python/pysss_nss_idmap.c
@@ -583,16 +583,32 @@ initpysss_nss_idmap(void)
         MODINITERROR(NULL);
     }
 
-    PyModule_AddIntConstant(module, "ID_NOT_SPECIFIED",
-                            SSS_ID_TYPE_NOT_SPECIFIED);
-    PyModule_AddIntConstant(module, "ID_USER", SSS_ID_TYPE_UID);
-    PyModule_AddIntConstant(module, "ID_GROUP", SSS_ID_TYPE_GID);
-    PyModule_AddIntConstant(module, "ID_BOTH", SSS_ID_TYPE_BOTH);
+    if (PyModule_AddIntConstant(module, "ID_NOT_SPECIFIED",
+                                SSS_ID_TYPE_NOT_SPECIFIED) == -1) {
+        MODINITERROR(module);
+    }
+    if (PyModule_AddIntConstant(module, "ID_USER", SSS_ID_TYPE_UID) == -1) {
+        MODINITERROR(module);
+    }
+    if (PyModule_AddIntConstant(module, "ID_GROUP", SSS_ID_TYPE_GID) == -1) {
+        MODINITERROR(module);
+    }
+    if (PyModule_AddIntConstant(module, "ID_BOTH", SSS_ID_TYPE_BOTH) == -1) {
+        MODINITERROR(module);
+    }
 
-    PyModule_AddStringConstant(module, "SID_KEY", SSS_SID_KEY);
-    PyModule_AddStringConstant(module, "NAME_KEY", SSS_NAME_KEY);
-    PyModule_AddStringConstant(module, "ID_KEY", SSS_ID_KEY);
-    PyModule_AddStringConstant(module, "TYPE_KEY", SSS_TYPE_KEY);
+    if (PyModule_AddStringConstant(module, "SID_KEY", SSS_SID_KEY) == -1) {
+        MODINITERROR(module);
+    }
+    if (PyModule_AddStringConstant(module, "NAME_KEY", SSS_NAME_KEY) == -1) {
+        MODINITERROR(module);
+    }
+    if (PyModule_AddStringConstant(module, "ID_KEY", SSS_ID_KEY) == -1) {
+        MODINITERROR(module);
+    }
+    if (PyModule_AddStringConstant(module, "TYPE_KEY", SSS_TYPE_KEY) == -1) {
+        MODINITERROR(module);
+    }
 
 #ifdef IS_PY3K
     return module;


### PR DESCRIPTION
Coverity warns that PyModule_AddIntConstant() returns operation success
or failure but this value is never checked.

```
Error: CHECKED_RETURN (CWE-252):
sssd-2.3.0/src/python/pysss_nss_idmap.c:587: check_return: Calling
"PyModule_AddIntConstant" without checking return value (as is done
elsewhere 4 out of 5 times).
sssd-2.3.0/src/python/pyhbac.c:1956: example_assign: Example 1:
Assigning: "ret" = return value from "PyModule_AddIntConstant(m,
"HBAC_CATEGORY_ALL", 1L)".
sssd-2.3.0/src/python/pyhbac.c:1957: example_checked: Example 1 (cont.):
"ret" has its value checked in "ret == -1".
sssd-2.3.0/src/python/pyhbac.c:1960: example_assign: Example 2:
Assigning: "ret" = return value from "PyModule_AddIntConstant(m,
"HBAC_RULE_ELEMENT_USERS", 1L)".
sssd-2.3.0/src/python/pyhbac.c:1961: example_checked: Example 2 (cont.):
"ret" has its value checked in "ret == -1".
sssd-2.3.0/src/python/pyhbac.c:1972: example_assign: Example 3:
Assigning: "ret" = return value from "PyModule_AddIntConstant(m,
"HBAC_EVAL_DENY", HBAC_EVAL_DENY)".
sssd-2.3.0/src/python/pyhbac.c:1973: example_checked: Example 3 (cont.):
"ret" has its value checked in "ret == -1".
sssd-2.3.0/src/python/pyhbac.c:1982: example_assign: Example 4:
Assigning: "ret" = return value from "PyModule_AddIntConstant(m,
"HBAC_ERROR_NOT_IMPLEMENTED", HBAC_ERROR_NOT_IMPLEMENTED)".
sssd-2.3.0/src/python/pyhbac.c:1983: example_checked: Example 4 (cont.):
"ret" has its value checked in "ret == -1".
 #  585|       PyModule_AddIntConstant(module, "ID_NOT_SPECIFIED",
 #  586|                               SSS_ID_TYPE_NOT_SPECIFIED);
 #  587|->     PyModule_AddIntConstant(module, "ID_USER", SSS_ID_TYPE_UID);
 #  588|       PyModule_AddIntConstant(module, "ID_GROUP", SSS_ID_TYPE_GID);
 #  589|       PyModule_AddIntConstant(module, "ID_BOTH", SSS_ID_TYPE_BOTH);
```

Moreover, even though coverity doesn't indicate it the same happens with
PyModule_AddStringConstant().