### PR TITLE
Removed store statements from unread variables

### DIFF
--- a/src/p11_child/p11_child_common.c
+++ b/src/p11_child/p11_child_common.c
@@ -345,7 +345,6 @@ int main(int argc, const char *argv[])
         DEBUG(SSSDBG_FATAL_FAILURE,
               "--module_name, --token_name and --key_id must be given for "
               "authentication");
-        ret = EINVAL;
         goto fail;
     }
 

--- a/src/providers/data_provider/dp_target_id.c
+++ b/src/providers/data_provider/dp_target_id.c
@@ -194,7 +194,6 @@ static void dp_req_initgr_pp_sr_overlay(struct data_provider *provider,
     if (tmp_ctx == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Failed creating temporary talloc context\n");
-        ret = ENOMEM;
         goto done;
     }
 
@@ -305,7 +304,6 @@ static void dp_req_initgr_pp_sr_overlay(struct data_provider *provider,
     if (add_attrs == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Failed creating attributes\n");
-        ret = ENOMEM;
         goto done;
     }
     ret = sysdb_attrs_add_bool(add_attrs, SYSDB_SESSION_RECORDING, enabled);

--- a/src/sss_client/autofs/autofs_test_client.c
+++ b/src/sss_client/autofs/autofs_test_client.c
@@ -56,7 +56,7 @@ int main(int argc, const char *argv[])
     pc = poptGetContext(NULL, argc, argv, long_options, 0);
     poptSetOtherOptionHelp(pc, "MAPNAME");
 
-    while ((ret = poptGetNextOpt(pc)) > 0)
+    while (poptGetNextOpt(pc) > 0)
         ;
 
     mapname = poptGetArg(pc);

--- a/src/tools/common/sss_tools.c
+++ b/src/tools/common/sss_tools.c
@@ -59,7 +59,6 @@ static void sss_tool_common_opts(struct sss_tool_ctx *tool_ctx,
     int debug = SSSDBG_DEFAULT;
     int orig_argc = *argc;
     int help = 0;
-    int opt;
 
     struct poptOption options[] = {
         {"debug", '\0', POPT_ARG_INT | POPT_ARGFLAG_STRIP, &debug,
@@ -70,7 +69,7 @@ static void sss_tool_common_opts(struct sss_tool_ctx *tool_ctx,
     };
 
     pc = poptGetContext(argv[0], orig_argc, argv, options, 0);
-    while ((opt = poptGetNextOpt(pc)) != -1) {
+    while (poptGetNextOpt(pc) != -1) {
         /* do nothing */
     }
 


### PR DESCRIPTION
As indicated by coverity removed store statements from unread variables. Moreover, in one of the cases the code has been refactored to reduce several function calls to only one.

Errors:
```
Error: CLANG_WARNING:
sssd-2.3.0/src/providers/data_provider/dp_target_id.c:197:9: warning:
Value stored to 'ret' is never read
 #        ret = ENOMEM;
 #        ^     ~~~~~~
sssd-2.3.0/src/providers/data_provider/dp_target_id.c:197:9: note:
Value stored to 'ret' is never read
 #        ret = ENOMEM;
 #        ^     ~~~~~~
 #  195|           DEBUG(SSSDBG_CRIT_FAILURE,
 #  196|                 "Failed creating temporary talloc context\n");
 #  197|->         ret = ENOMEM;
 #  198|           goto done;
 #  199|       }

Error: CLANG_WARNING:
sssd-2.3.0/src/providers/data_provider/dp_target_id.c:308:9: warning:
Value stored to 'ret' is never read
 #        ret = ENOMEM;
 #        ^     ~~~~~~
sssd-2.3.0/src/providers/data_provider/dp_target_id.c:308:9: note:
Value stored to 'ret' is never read
 #        ret = ENOMEM;
 #        ^     ~~~~~~
 #  306|           DEBUG(SSSDBG_CRIT_FAILURE,
 #  307|                 "Failed creating attributes\n");
 #  308|->         ret = ENOMEM;
 #  309|           goto done;
 #  310|       }

Error: CLANG_WARNING:
sssd-2.3.0/src/p11_child/p11_child_common.c:348:9: warning: Value stored
to 'ret' is never read
 #        ret = EINVAL;
 #        ^     ~~~~~~
sssd-2.3.0/src/p11_child/p11_child_common.c:348:9: note: Value stored to
'ret' is never read
 #        ret = EINVAL;
 #        ^     ~~~~~~
 #  346|                 "--module_name, --token_name and --key_id must be given for "
 #  347|                 "authentication");
 #  348|->         ret = EINVAL;
 #  349|           goto fail;
 #  350|       }

Error: CLANG_WARNING:
sssd-2.3.0/src/responder/common/responder_packet.c:217:21: warning:
Although the value stored to 'new_len' is used in the enclosing
expression, the value is never actually read from 'new_len'
 #                && (new_len = sss_packet_get_len(packet))
 #                    ^         ~~~~~~~~~~~~~~~~~~~~~~~~~~
sssd-2.3.0/src/responder/common/responder_packet.c:217:21: note:
Although the value stored to 'new_len' is used in the enclosing
expression, the value is never actually read from 'new_len'
 #                && (new_len = sss_packet_get_len(packet))
 #                    ^         ~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  215|                       || sss_packet_get_cmd(packet) == SSS_NSS_GETLISTBYCERT)
 #  216|                   && packet->memsize < SSS_CERT_PACKET_MAX_RECV_SIZE
 #  217|->                 && (new_len = sss_packet_get_len(packet))
 #  218|                                      < SSS_CERT_PACKET_MAX_RECV_SIZE) {
 #  219|               new_len = sss_packet_get_len(packet);

Error: CLANG_WARNING:
sssd-2.3.0/src/sss_client/autofs/autofs_test_client.c:59:13: warning:
Although the value stored to 'ret' is used in the enclosing expression,
the value is never actually read from 'ret'
 #    while ((ret = poptGetNextOpt(pc)) > 0)
 #            ^     ~~~~~~~~~~~~~~~~~~
sssd-2.3.0/src/sss_client/autofs/autofs_test_client.c:59:13: note:
Although the value stored to 'ret' is used in the enclosing expression,
the value is never actually read from 'ret'
 #    while ((ret = poptGetNextOpt(pc)) > 0)
 #            ^     ~~~~~~~~~~~~~~~~~~
 #   57|       poptSetOtherOptionHelp(pc, "MAPNAME");
 #   58|
 #   59|->     while ((ret = poptGetNextOpt(pc)) > 0)
 #   60|           ;
 #   61|

Error: CLANG_WARNING:
sssd-2.3.0/src/tools/common/sss_tools.c:73:13: warning: Although the
value stored to 'opt' is used in the enclosing expression, the value is
never actually read from 'opt'
 #    while ((opt = poptGetNextOpt(pc)) != -1) {
 #            ^     ~~~~~~~~~~~~~~~~~~
sssd-2.3.0/src/tools/common/sss_tools.c:73:13: note: Although the value
stored to 'opt' is used in the enclosing expression, the value is never
actually read from 'opt'
 #    while ((opt = poptGetNextOpt(pc)) != -1) {
 #            ^     ~~~~~~~~~~~~~~~~~~
 #   71|
 #   72|       pc = poptGetContext(argv[0], orig_argc, argv, options, 0);
 #   73|->     while ((opt = poptGetNextOpt(pc)) != -1) {
 #   74|           /* do nothing */
 #   75|       }
```