### PR TITLE
libwbclient-sssd: deprecate libwbclient-sssd

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -728,23 +728,6 @@ Requires: libsss_simpleifp = %{version}-%{release}
 %description -n libsss_simpleifp-devel
 Provides library that simplifies D-Bus API for the SSSD InfoPipe responder.
 
-%package libwbclient
-Summary: The SSSD libwbclient implementation
-Group: Applications/System
-License: GPLv3+ and LGPLv3+
-Requires: libsss_nss_idmap = %{version}-%{release}
-
-%description libwbclient
-The SSSD libwbclient implementation.
-
-%package libwbclient-devel
-Summary: Development libraries for the SSSD libwbclient implementation
-Group:  Development/Libraries
-License: GPLv3+ and LGPLv3+
-
-%description libwbclient-devel
-Development libraries for the SSSD libwbclient implementation.
-
 %package winbind-idmap
 Summary: SSSD's idmap_sss Backend for Winbind
 Group:  Applications/System
@@ -1352,18 +1335,6 @@ done
 %defattr(-,root,root,-)
 %{python3_sitearch}/pyhbac.so
 %endif
-
-%files libwbclient
-%defattr(-,root,root,-)
-%dir %{_libdir}/%{name}
-%dir %{_libdir}/%{name}/modules
-%{_libdir}/%{name}/modules/libwbclient.so.*
-
-%files libwbclient-devel
-%defattr(-,root,root,-)
-%{_includedir}/wbclient_sssd.h
-%{_libdir}/%{name}/modules/libwbclient.so
-%{_libdir}/pkgconfig/wbclient_sssd.pc
 
 %files winbind-idmap -f sssd_winbind_idmap.lang
 %dir %{_libdir}/samba/idmap

--- a/src/conf_macros.m4
+++ b/src/conf_macros.m4
@@ -738,11 +738,13 @@ AC_DEFUN([WITH_IFP],
 AC_DEFUN([WITH_LIBWBCLIENT],
   [ AC_ARG_WITH([libwbclient],
                 [AC_HELP_STRING([--with-libwbclient],
-                                [Whether to build SSSD implementation of libwbclient [yes]]
+                                [Whether to build SSSD implementation of libwbclient [no].
+                                 Please note SSSD's libwbclient is deprecated and will be
+                                 removed in one of the next versions of SSSD.]
                                )
                 ],
                 [with_libwbclient=$withval],
-                with_libwbclient=yes
+                with_libwbclient=no
                )
 
     if test x"$with_libwbclient" = xyes; then


### PR DESCRIPTION
Recent version of Samba require that winbindd is running to handle the
communication with AD. SSSD's implementation of libwbclient cannot be
used anymore in this case and should be deprecated so that the related
code can be removed in a later version.

With this patch libwbclient will not be build by default anymore and the
configure help messages indicates that libwbclient is deprecated.

Resolves: https://github.com/SSSD/sssd/issues/5230