### PR TITLE
NSS: fixed UNINIT (CWE-457)

### DIFF
--- a/src/responder/nss/nss_protocol_grent.c
+++ b/src/responder/nss/nss_protocol_grent.c
@@ -127,7 +127,7 @@ nss_protocol_fill_members(struct sss_packet *packet,
     struct ldb_message_element *el;
     struct sized_string *name;
     const char *member_name;
-    uint32_t num_members;
+    uint32_t num_members = 0;
     size_t body_len;
     uint8_t *body;
     errno_t ret;
@@ -161,7 +161,6 @@ nss_protocol_fill_members(struct sss_packet *packet,
 
     sss_packet_get_body(packet, &body, &body_len);
 
-    num_members = 0;
     for (i = 0; i < sizeof(members) / sizeof(members[0]); i++) {
         el = members[i];
         if (el == NULL) {


### PR DESCRIPTION
This is an addition to #5171

Fixed following warning:
```
Error: UNINIT (CWE-457):
sssd-2.3.1/src/responder/nss/nss_protocol_grent.c:130: var_decl: Declaring variable "num_members" without initializer.
sssd-2.3.1/src/responder/nss/nss_protocol_grent.c:206: uninit_use: Using uninitialized value "num_members".
 #  204|
 #  205|   done:
 #  206|->     *_num_members = num_members;
 #  207|       talloc_free(tmp_ctx);
 #  208|
```