### PR TITLE
pam: use requested_domains to restrict cache_req searches

### DIFF
--- a/src/man/pam_sss.8.xml
+++ b/src/man/pam_sss.8.xml
@@ -155,8 +155,9 @@
                         SSSD domain names, as specified in the sssd.conf file.
                     </para>
                     <para>
-                        NOTE: Must be used in conjunction with the
-                        <quote>pam_trusted_users</quote> and
+                        NOTE: If this is used for a service not running as root
+                        user, e.g. a web-server, it must be used in conjunction
+                        with the <quote>pam_trusted_users</quote> and
                         <quote>pam_public_domains</quote> options.
                         Please see the
                         <citerefentry>

--- a/src/responder/common/cache_req/cache_req.h
+++ b/src/responder/common/cache_req/cache_req.h
@@ -167,6 +167,9 @@ void
 cache_req_data_set_bypass_dp(struct cache_req_data *data,
                              bool bypass_dp);
 
+void
+cache_req_data_set_requested_domains(struct cache_req_data *data,
+                                     char **requested_domains);
 
 enum cache_req_type
 cache_req_data_get_type(struct cache_req_data *data);

--- a/src/responder/common/cache_req/cache_req_data.c
+++ b/src/responder/common/cache_req/cache_req_data.c
@@ -443,6 +443,18 @@ cache_req_data_set_bypass_dp(struct cache_req_data *data,
     data->bypass_dp = bypass_dp;
 }
 
+void
+cache_req_data_set_requested_domains(struct cache_req_data *data,
+                                     char **requested_domains)
+{
+    if (data == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "cache_req_data should never be NULL\n");
+        return;
+    }
+
+    data->requested_domains = requested_domains;
+}
+
 enum cache_req_type
 cache_req_data_get_type(struct cache_req_data *data)
 {

--- a/src/responder/common/cache_req/cache_req_domain.h
+++ b/src/responder/common/cache_req/cache_req_domain.h
@@ -54,6 +54,7 @@ cache_req_domain_new_list_from_domain_resolution_order(
 errno_t
 cache_req_domain_copy_cr_domains(TALLOC_CTX *mem_ctx,
                                  struct cache_req_domain *src,
+                                 char **requested_domains,
                                  struct cache_req_domain **_dest);
 
 void cache_req_domain_list_zfree(struct cache_req_domain **cr_domains);

--- a/src/responder/common/cache_req/cache_req_private.h
+++ b/src/responder/common/cache_req/cache_req_private.h
@@ -100,6 +100,9 @@ struct cache_req_data {
 
     bool bypass_cache;
     bool bypass_dp;
+
+    /* if set, only search in the listed domains */
+    char **requested_domains;
 };
 
 struct tevent_req *

--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -1902,6 +1902,7 @@ static int pam_check_user_search(struct pam_auth_req *preq)
 
     cache_req_data_set_bypass_cache(data, false);
     cache_req_data_set_bypass_dp(data, true);
+    cache_req_data_set_requested_domains(data, preq->pd->requested_domains);
 
     dpreq = cache_req_send(preq,
                            preq->cctx->rctx->ev,
@@ -2010,6 +2011,7 @@ static void pam_check_user_search_next(struct tevent_req *req)
     }
     cache_req_data_set_bypass_cache(data, true);
     cache_req_data_set_bypass_dp(data, false);
+    cache_req_data_set_requested_domains(data, preq->pd->requested_domains);
 
     dpreq = cache_req_send(preq,
                            preq->cctx->rctx->ev,

--- a/src/tests/intg/Makefile.am
+++ b/src/tests/intg/Makefile.am
@@ -142,6 +142,17 @@ pam_sss_allow_missing_name:
 	echo "password required       $(DESTDIR)$(pammoddir)/pam_sss.so" >> $(PAM_SERVICE_DIR)/$@
 	echo "session  required       $(DESTDIR)$(pammoddir)/pam_sss.so" >> $(PAM_SERVICE_DIR)/$@
 
+pam_sss_domains:
+	$(MKDIR_P) $(PAM_SERVICE_DIR)
+	echo "auth     sufficient       $(DESTDIR)$(pammoddir)/pam_sss.so forward_pass domains=wrong.dom1"  > $(PAM_SERVICE_DIR)/$@
+	echo "auth     sufficient       $(DESTDIR)$(pammoddir)/pam_sss.so forward_pass domains=wrong.dom2"  >> $(PAM_SERVICE_DIR)/$@
+	echo "auth     sufficient       $(DESTDIR)$(pammoddir)/pam_sss.so forward_pass domains=wrong.dom3"  >> $(PAM_SERVICE_DIR)/$@
+	echo "auth     sufficient       $(DESTDIR)$(pammoddir)/pam_sss.so forward_pass domains=krb5_auth"  >> $(PAM_SERVICE_DIR)/$@
+	echo "auth     required         pam_deny.so" >> $(PAM_SERVICE_DIR)/$@
+	echo "account  required       $(DESTDIR)$(pammoddir)/pam_sss.so" >> $(PAM_SERVICE_DIR)/$@
+	echo "password required       $(DESTDIR)$(pammoddir)/pam_sss.so" >> $(PAM_SERVICE_DIR)/$@
+	echo "session  required       $(DESTDIR)$(pammoddir)/pam_sss.so" >> $(PAM_SERVICE_DIR)/$@
+
 CLEANFILES=config.py config.pyc passwd group
 
 clean-local:
@@ -151,7 +162,7 @@ clean-local:
 PAM_CERT_DB_PATH="$(abs_builddir)/../test_CA/SSSD_test_CA.pem"
 SOFTHSM2_CONF="$(abs_builddir)/../test_CA/softhsm2_one.conf"
 
-intgcheck-installed: config.py passwd group pam_sss_service pam_sss_alt_service pam_sss_sc_required pam_sss_try_sc pam_sss_allow_missing_name
+intgcheck-installed: config.py passwd group pam_sss_service pam_sss_alt_service pam_sss_sc_required pam_sss_try_sc pam_sss_allow_missing_name pam_sss_domains
 	pipepath="$(DESTDIR)$(pipepath)"; \
 	if test $${#pipepath} -gt 80; then \
 	    echo "error: Pipe directory path too long," \


### PR DESCRIPTION
If the 'domains' is used with pam_sss.so it is expected that only users
from the given domains are allowed. Currently it is checked after the user
is searched if the result is from one of those domains.

To speed things up and to allow more flexible setups this patch restricts
the list of domains already in the cache_req. The check after the search is
kept as an additional safe-guard although the cache_req should now only
return users from the given domains or an error.