### PR TITLE
sss_ssh_knownhostsproxy: print error when unable to connect

### DIFF
--- a/src/sss_client/ssh/sss_ssh_knownhostsproxy.c
+++ b/src/sss_client/ssh/sss_ssh_knownhostsproxy.c
@@ -322,6 +322,10 @@ int main(int argc, const char **argv)
 
         if (ret == EOK) {
             ret = proxy_data(socket_descriptor);
+            if (ret != EOK) {
+                ERROR("sss_ssh_knownhostsproxy: unable to proxy data: "
+                      "%s\n", strerror(ret));
+            }
         } else {
             ERROR("sss_ssh_knownhostsproxy: connect to host %s port %d: "
                   "%s\n", pc_host, pc_port, strerror(ret));


### PR DESCRIPTION
This was partial fixed by:
9a7b04690e30fc57dce45c82b918b8d95b978df1

Now we print error also when we are unable to open the socket.

How to test:
```
$ ssh -oProxyCommand="/usr/bin/sss_ssh_knownhostsproxy -p 22 nonexistenthost" -oGlobalKnownHostsFile=/var/lib/sss/pubconf/known_hosts nonexistenthost
$ ssh -oProxyCommand="/usr/bin/sss_ssh_knownhostsproxy -p 22 localhost" -oGlobalKnownHostsFile=/var/lib/sss/pubconf/known_hosts localhost
```

(assuming `localhost` does not run ssh server)

Resolves:
https://github.com/SSSD/sssd/issues/5236`