### PR TITLE
GPO: respect ad_gpo_implicit_deny when evaluation rules

### DIFF
--- a/src/man/sssd-ad.5.xml
+++ b/src/man/sssd-ad.5.xml
@@ -477,9 +477,68 @@ DOM:dom1:(memberOf:1.2.840.113556.1.4.1941:=cn=nestedgroup,ou=groups,dc=example,
                             built-in Administrators group if no GPO rules
                             apply to them.
                         </para>
+
                         <para>
                             Default: False
                         </para>
+
+                        <para>
+                            The following 2 tables should illustrate when a user
+                            is allowed or rejected based on the allow and deny
+                            login rights defined on the server-side and the
+                            setting of ad_gpo_implicit_deny.
+                        </para>
+                        <informaltable frame='all'>
+                        <tgroup cols='3'>
+                        <colspec colname='c1' align='center'/>
+                        <colspec colname='c2' align='center'/>
+                        <colspec colname='c3' align='center'/>
+                        <thead>
+                        <row><entry namest='c1' nameend='c3' align='center'>
+                            ad_gpo_implicit_deny = False (default)</entry></row>
+                        <row><entry>allow-rules</entry><entry>deny-rules</entry>
+                            <entry>results</entry></row>
+                        </thead>
+                        <tbody>
+                        <row><entry>missing</entry><entry>missing</entry>
+                            <entry><para>all users are allowed</para>
+                            </entry></row>
+                        <row><entry>missing</entry><entry>present</entry>
+                            <entry><para>only users not in deny-rules are
+                            allowed</para></entry></row>
+                        <row><entry>present</entry><entry>missing</entry>
+                            <entry><para>only users in allow-rules are
+                            allowed</para></entry></row>
+                        <row><entry>present</entry><entry>present</entry>
+                            <entry><para>only users in allow-rules and not in
+                            deny-rules are allowed</para></entry></row>
+                        </tbody></tgroup></informaltable>
+
+                        <informaltable frame='all'>
+                        <tgroup cols='3'>
+                        <colspec colname='c1' align='center'/>
+                        <colspec colname='c2' align='center'/>
+                        <colspec colname='c3' align='center'/>
+                        <thead>
+                        <row><entry namest='c1' nameend='c3' align='center'>
+                            ad_gpo_implicit_deny = True</entry></row>
+                        <row><entry>allow-rules</entry><entry>deny-rules</entry>
+                            <entry>results</entry></row>
+                        </thead>
+                        <tbody>
+                        <row><entry>missing</entry><entry>missing</entry>
+                            <entry><para>no users are allowed</para>
+                            </entry></row>
+                        <row><entry>missing</entry><entry>present</entry>
+                            <entry><para>no users are allowed</para>
+                            </entry></row>
+                        <row><entry>present</entry><entry>missing</entry>
+                            <entry><para>only users in allow-rules are
+                            allowed</para></entry></row>
+                        <row><entry>present</entry><entry>present</entry>
+                            <entry><para>only users in allow-rules and not in
+                            deny-rules are allowed</para></entry></row>
+                        </tbody></tgroup></informaltable>
                     </listitem>
                 </varlistentry>
 


### PR DESCRIPTION
Currently if setting ad_gpo_implicit_deny to 'True' is rejected access
if no GPOs applied to the host since in this case there are obvious not
allow rules available.

But according to the man page we have to be more strict "When this
option is set to True users will be allowed access only when explicitly
allowed by a GPO rule". So if GPOs apply and no allow rules are present
we have to reject access as well.

Resolves: https://github.com/SSSD/sssd/issues/5061