### PR TITLE
subdomains: allow to inherit case_sensitive=Preserving

### DIFF
--- a/src/db/sysdb_subdomains.c
+++ b/src/db/sysdb_subdomains.c
@@ -157,6 +157,14 @@ struct sss_domain_info *new_subdomain(TALLOC_CTX *mem_ctx,
         dom->ignore_group_members = parent->ignore_group_members;
     }
 
+    /* Inherit case_sensitive. All subdomains are always case insensitive,
+     * but we want to inherit case preserving which is set with
+     * case_sensitive=Preserving. */
+    inherit_option = string_in_list(CONFDB_DOMAIN_CASE_SENSITIVE,
+                                    parent->sd_inherit, false);
+    dom->case_sensitive = false;
+    dom->case_preserve = inherit_option ? parent->case_preserve : false;
+
     dom->trust_direction = trust_direction;
     /* If the parent domain explicitly limits ID ranges, the subdomain
      * should honour the limits as well.
@@ -168,14 +176,12 @@ struct sss_domain_info *new_subdomain(TALLOC_CTX *mem_ctx,
     dom->cache_credentials_min_ff_length =
                                         parent->cache_credentials_min_ff_length;
     dom->cached_auth_timeout = parent->cached_auth_timeout;
-    dom->case_sensitive = false;
     dom->user_timeout = parent->user_timeout;
     dom->group_timeout = parent->group_timeout;
     dom->netgroup_timeout = parent->netgroup_timeout;
     dom->service_timeout = parent->service_timeout;
     dom->resolver_timeout = parent->resolver_timeout;
     dom->names = parent->names;
-
     dom->override_homedir = parent->override_homedir;
     dom->fallback_homedir = parent->fallback_homedir;
     dom->subdomain_homedir = parent->subdomain_homedir;

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -3375,6 +3375,9 @@ pam_gssapi_services = sudo, sudo-i
                             auto_private_groups
                         </para>
                         <para>
+                            case_sensitive
+                        </para>
+                        <para>
                             Example:
                             <programlisting>
 subdomain_inherit = ldap_purge_cache_timeout

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -3372,6 +3372,9 @@ pam_gssapi_services = sudo, sudo-i
                             used if ldap_krb5_keytab is not set explicitly)
                         </para>
                         <para>
+                            auto_private_groups
+                        </para>
+                        <para>
                             Example:
                             <programlisting>
 subdomain_inherit = ldap_purge_cache_timeout

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -3336,9 +3336,20 @@ pam_gssapi_services = sudo, sudo-i
                                         protocol names) are still lowercased in
                                         the output.
                                     </para>
+                                    <para>
+                                        If you want to set this value for
+                                        trusted domain with IPA provider, you
+                                        need to set it on both the client and
+                                        SSSD on the server.
+                                    </para>
                                 </listitem>
                             </varlistentry>
                         </variablelist>
+                        </para>
+                        <para>
+                            This option can be also set per subdomain or
+                            inherited via
+                            <emphasis>subdomain_inherit</emphasis>.
                         </para>
                         <para>
                             Default: True (False for AD provider)


### PR DESCRIPTION
The first patch is just man page update to reflect current state.

I think it makes sense to be able to show subdomain names in
their original casing. Patches 2-3 make it work for AD provider.

Patch 4 makes it work for IPA provider. There is apparantely a bug
in winbind, but there is no link the any bugzilla so I do not know
if it was already fixed. The commit is four years old. This patch
requires case_sensitive=Preserving to be set also on the server,
otherwise it does not work. It can be enabled without the server setting
but we need to make nss_cmd_getpwnam_ex (and other _ex commands) to
always return case preserving name. So before I continue the work
I'd like to ask @sumit-bose if we can do it like this.

Resolves:
https://github.com/SSSD/sssd/issues/5250