### PR TITLE
config: allow prompting options in configuration

### DIFF
--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -14,6 +14,10 @@ section = session_recording
 section_re = ^secrets/users/[0-9]\+$
 section_re = ^secrets/secrets$
 section_re = ^secrets/kcm$
+section_re = ^prompting/password$
+section_re = ^prompting/password/[^/\@]\+$
+section_re = ^prompting/2fa$
+section_re = ^prompting/2fa/[^/\@]\+$
 section_re = ^domain/[^/\@]\+$
 section_re = ^domain/[^/\@]\+/[^/\@]\+$
 section_re = ^application/[^/\@]\+$
@@ -331,6 +335,36 @@ section_re = ^session_recording$
 option = scope
 option = users
 option = groups
+
+# Prompting during authentication
+[rule/allowed_prompting_password_options]
+validator = ini_allowed_options
+section_re = ^prompting/password$
+
+option = password_prompt
+
+[rule/allowed_prompting_2fa_options]
+validator = ini_allowed_options
+section_re = ^prompting/2fa$
+
+option = single_prompt
+option = first_prompt
+option = second_prompt
+
+[rule/allowed_prompting_password_subsec_options]
+validator = ini_allowed_options
+section_re = ^prompting/password/[^/\@]\+$
+
+option = password_prompt
+
+[rule/allowed_prompting_2fa_subsec_options]
+validator = ini_allowed_options
+section_re = ^prompting/2fa/[^/\@]\+$
+
+option = single_prompt
+option = first_prompt
+option = second_prompt
+
 
 [rule/allowed_domain_options]
 validator = ini_allowed_options


### PR DESCRIPTION
False warnings were logged after enabling prompting options in
configuration file. This change modifies the configuration rules to
allow prompting options.

Resolves:
https://github.com/SSSD/sssd/issues/5259