### PR TITLE
Utils: White space replace with another character

### DIFF
--- a/src/util/string_utils.c
+++ b/src/util/string_utils.c
@@ -53,10 +53,10 @@ char * sss_replace_space(TALLOC_CTX *mem_ctx,
     }
 
     if (strchr(orig_name, subst) != NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE,
+        DEBUG(SSSDBG_FUNC_DATA,
               "Input [%s] already contains replacement character [%c].\n",
               orig_name, subst);
-        sss_log(SSS_LOG_CRIT,
+        sss_log(SSS_LOG_DEBUG,
                 "Name [%s] already contains replacement character [%c]. " \
                 "No replacement will be done.\n",
                 orig_name, subst);


### PR DESCRIPTION
Function responsible for replacing white space
has wrong log levels set. It can create false positive
critical error messages broadcasted across the system
without any real reason.

This patch adjusts those log levels to be on the debug
level rather than criticar error level.

Resolves:
https://bugzilla.redhat.com/show_bug.cgi?id=1818671