### PR TITLE
BE_REFRESH: Do not try to refresh domains from other backends (1-16)

### DIFF
--- a/src/providers/be_refresh.c
+++ b/src/providers/be_refresh.c
@@ -388,6 +388,10 @@ static errno_t be_refresh_step(struct tevent_req *req)
         if (state->index == BE_REFRESH_TYPE_SENTINEL) {
             state->domain = get_next_domain(state->domain,
                                             SSS_GND_DESCEND);
+            /* we can update just subdomains */
+            if (state->domain != NULL && !IS_SUBDOMAIN(state->domain)) {
+                break;
+            }
             state->index = 0;
             continue;
         }


### PR DESCRIPTION
We cannot refresh domains from different sssd_be processes.
We can refresh just subdomains

Resolves:
https://pagure.io/SSSD/sssd/issue/4142

Merges: https://pagure.io/SSSD/sssd/pull-request/4139

Reviewed-by: Sumit Bose <sbose@redhat.com>
(cherry picked from commit 007d5b79b7aef67dd843ed9a3b65095faaeb580f)