### PR TITLE
man: clarify AD certificate rule

### DIFF
--- a/src/man/sss-certmap.5.xml
+++ b/src/man/sss-certmap.5.xml
@@ -487,7 +487,7 @@
                         sign.
                     </para>
                     <para>
-                        Example: (|(userPrincipal={subject_principal})(samAccountName={subject_principal.short_name}))
+                        Example: (|(userPrincipalName={subject_nt_principal})(samAccountName={subject_nt_principal.short_name}))
                     </para>
                     </listitem>
                 </varlistentry>


### PR DESCRIPTION
Clarify AD specific certificate rule example by changing userPrincipal to
userPrincipalName. Moreover, match the subject principal name in the
example with the rule name.

Resolves:
https://github.com/SSSD/sssd/issues/5278