### PR TITLE
KCM: Increase client idle timeout to 5 minutes

### DIFF
--- a/src/man/sssd-kcm.8.xml
+++ b/src/man/sssd-kcm.8.xml
@@ -68,6 +68,10 @@
             cache, yet share the credential cache between some or no
             containers by bind-mounting the socket.
         </para>
+        <para>
+            The KCM default client idle timeout is 5 minutes, this allows
+            more time for user interaction with command line tools such as kinit.
+        </para>
     </refsect1>
 
     <refsect1 id='usage'>

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -756,7 +756,7 @@
                             will be adjusted to 10 seconds.
                         </para>
                         <para>
-                            Default: 60
+                            Default: 60, KCM: 300
                         </para>
                     </listitem>
                 </varlistentry>

--- a/src/responder/kcm/kcm.c
+++ b/src/responder/kcm/kcm.c
@@ -31,6 +31,7 @@
 #include "util/sss_krb5.h"
 
 #define DEFAULT_KCM_FD_LIMIT 2048
+#define DEFAULT_KCM_CLI_IDLE_TIMEOUT 300
 
 #ifndef SSS_KCM_SOCKET_NAME
 #define SSS_KCM_SOCKET_NAME DEFAULT_KCM_SOCKET_PATH
@@ -101,7 +102,7 @@ static int kcm_get_config(struct kcm_ctx *kctx)
     ret = confdb_get_int(kctx->rctx->cdb,
                          kctx->rctx->confdb_service_path,
                          CONFDB_RESPONDER_CLI_IDLE_TIMEOUT,
-                         CONFDB_RESPONDER_CLI_IDLE_DEFAULT_TIMEOUT,
+                         DEFAULT_KCM_CLI_IDLE_TIMEOUT,
                          &kctx->rctx->client_idle_timeout);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,


### PR DESCRIPTION
Increase the default timeout to allow time for user interaction on the command-line with kinit.