### PR TITLE
build: Don't use AC_CHECK_FILE when building manpages

### DIFF
--- a/src/external/docbook.m4
+++ b/src/external/docbook.m4
@@ -18,7 +18,7 @@ dnl Checks if the XML catalog given by FILE exists and
 dnl if a particular URI appears in the XML catalog
 AC_DEFUN([CHECK_STYLESHEET],
 [
-  AC_CHECK_FILE($1, [], [AC_MSG_ERROR([could not find XML catalog])])
+  AS_IF([test -f "$1"], [], [AC_MSG_ERROR([could not find XML catalog])])
 
   AC_MSG_CHECKING([for ifelse([$3],,[$2],[$3]) in XML catalog])
   if AC_RUN_LOG([$XSLTPROC --catalogs --nonet --noout "$2" >&2]); then


### PR DESCRIPTION
AC_CHECK_FILE does not support cross-compilation, and will only check
the host rootfs. Replace AC_CHECK_FILE with a 'test -f <FILE>' instead,
to allow building manpages when cross-compiling.

Signed-off-by: Jonatan Pålsson <jonatan.p@gmail.com>