### PR TITLE
krb5: only try pkinit with Smartcard credentials

### DIFF
--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -804,7 +804,11 @@ static krb5_error_code sss_krb5_responder(krb5_context ctx,
                     return kerr;
                 }
             } else if (strcmp(question_list[c],
-                       KRB5_RESPONDER_QUESTION_PKINIT) == 0) {
+                              KRB5_RESPONDER_QUESTION_PKINIT) == 0
+                        && (sss_authtok_get_type(kr->pd->authtok)
+                                               == SSS_AUTHTOK_TYPE_SC_PIN
+                            || sss_authtok_get_type(kr->pd->authtok)
+                                               == SSS_AUTHTOK_TYPE_SC_KEYPAD)) {
                 return answer_pkinit(ctx, kr, rctx);
             }
         }


### PR DESCRIPTION
Currently pkinit is tried if a Smartcard is present. But depending on
the used PAM service and other configurations it might happen that the
user didn't provide the Smartcard PIN but e.g. the password. Hence,
before trying pkinit we should check if the right credentials are
available.

Resolves:
https://github.com/SSSD/sssd/issues/5290