### PR TITLE
AD: "getAccountDomain" tweaks

### DIFF
--- a/src/providers/ad/ad_id.c
+++ b/src/providers/ad/ad_id.c
@@ -1287,6 +1287,12 @@ static errno_t ad_get_account_domain_prepare_search(struct tevent_req *req)
         return EINVAL;
     }
 
+    if (state->search_bases == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Failed to prepare search: missing search_bases\n");
+        return EINVAL;
+    }
+
     switch (state->filter_type) {
     case BE_FILTER_IDNUM:
         break;

--- a/src/providers/data_provider/dp_iface.h
+++ b/src/providers/data_provider/dp_iface.h
@@ -179,6 +179,7 @@ dp_get_account_domain_send(TALLOC_CTX *mem_ctx,
                            struct tevent_context *ev,
                            struct sbus_request *sbus_req,
                            struct data_provider *provider,
+                           uint32_t dp_flags,
                            uint32_t entry_type,
                            const char *filter);
 

--- a/src/providers/data_provider/dp_target_id.c
+++ b/src/providers/data_provider/dp_target_id.c
@@ -691,6 +691,7 @@ dp_get_account_domain_send(TALLOC_CTX *mem_ctx,
                            struct tevent_context *ev,
                            struct sbus_request *sbus_req,
                            struct data_provider *provider,
+                           uint32_t dp_flags,
                            uint32_t entry_type,
                            const char *filter)
 {
@@ -718,7 +719,7 @@ dp_get_account_domain_send(TALLOC_CTX *mem_ctx,
     }
 
     subreq = dp_req_send(state, provider, NULL, "AccountDomain", DPT_ID,
-                         DPM_ACCT_DOMAIN_HANDLER, 0, state->data,
+                         DPM_ACCT_DOMAIN_HANDLER, dp_flags, state->data,
                          &state->request_name);
     if (subreq == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");

--- a/src/responder/common/cache_req/plugins/cache_req_group_by_id.c
+++ b/src/responder/common/cache_req/plugins/cache_req_group_by_id.c
@@ -188,6 +188,7 @@ cache_req_group_by_id_get_domain_send(TALLOC_CTX *mem_ctx,
     return sss_dp_get_account_domain_send(mem_ctx,
                                           rctx,
                                           domain,
+                                          true, /* fast_reply */
                                           SSS_DP_GROUP,
                                           data->id);
 }

--- a/src/responder/common/cache_req/plugins/cache_req_object_by_id.c
+++ b/src/responder/common/cache_req/plugins/cache_req_object_by_id.c
@@ -177,6 +177,7 @@ cache_req_object_by_id_get_domain_send(TALLOC_CTX *mem_ctx,
     return sss_dp_get_account_domain_send(mem_ctx,
                                           rctx,
                                           domain,
+                                          true, /* fast_reply */
                                           SSS_DP_USER_AND_GROUP,
                                           data->id);
 }

--- a/src/responder/common/cache_req/plugins/cache_req_user_by_id.c
+++ b/src/responder/common/cache_req/plugins/cache_req_user_by_id.c
@@ -188,6 +188,7 @@ cache_req_user_by_id_get_domain_send(TALLOC_CTX *mem_ctx,
     return sss_dp_get_account_domain_send(mem_ctx,
                                           rctx,
                                           domain,
+                                          true, /* fast_reply */
                                           SSS_DP_USER,
                                           data->id);
 }

--- a/src/responder/common/responder.h
+++ b/src/responder/common/responder.h
@@ -348,6 +348,7 @@ errno_t sss_dp_get_domains_recv(struct tevent_req *req);
 struct tevent_req *sss_dp_get_account_domain_send(TALLOC_CTX *mem_ctx,
                                                   struct resp_ctx *rctx,
                                                   struct sss_domain_info *domain,
+                                                  bool fast_reply,
                                                   enum sss_dp_acct_type type,
                                                   uint32_t opt_id);
 

--- a/src/responder/common/responder_get_domains.c
+++ b/src/responder/common/responder_get_domains.c
@@ -684,6 +684,7 @@ struct tevent_req *
 sss_dp_get_account_domain_send(TALLOC_CTX *mem_ctx,
                                struct resp_ctx *rctx,
                                struct sss_domain_info *dom,
+                               bool fast_reply,
                                enum sss_dp_acct_type type,
                                uint32_t opt_id)
 {
@@ -693,6 +694,7 @@ sss_dp_get_account_domain_send(TALLOC_CTX *mem_ctx,
     struct be_conn *be_conn;
     uint32_t entry_type;
     char *filter;
+    uint32_t dp_flags;
     errno_t ret;
 
     req = tevent_req_create(mem_ctx, &state, struct sss_dp_get_account_domain_state);
@@ -733,10 +735,12 @@ sss_dp_get_account_domain_send(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
+    dp_flags = fast_reply ? DP_FAST_REPLY : 0;
+
     subreq = sbus_call_dp_dp_getAccountDomain_send(state, be_conn->conn,
                                                    be_conn->bus_name,
-                                                   SSS_BUS_PATH, entry_type,
-                                                   filter);
+                                                   SSS_BUS_PATH, dp_flags,
+                                                   entry_type, filter);
     if (subreq == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
         ret = ENOMEM;

--- a/src/sss_iface/sbus_sss_arguments.c
+++ b/src/sss_iface/sbus_sss_arguments.c
@@ -582,6 +582,55 @@ errno_t _sbus_sss_invoker_write_uss
     return EOK;
 }
 
+errno_t _sbus_sss_invoker_read_uus
+   (TALLOC_CTX *mem_ctx,
+    DBusMessageIter *iter,
+    struct _sbus_sss_invoker_args_uus *args)
+{
+    errno_t ret;
+
+    ret = sbus_iterator_read_u(iter, &args->arg0);
+    if (ret != EOK) {
+        return ret;
+    }
+
+    ret = sbus_iterator_read_u(iter, &args->arg1);
+    if (ret != EOK) {
+        return ret;
+    }
+
+    ret = sbus_iterator_read_s(mem_ctx, iter, &args->arg2);
+    if (ret != EOK) {
+        return ret;
+    }
+
+    return EOK;
+}
+
+errno_t _sbus_sss_invoker_write_uus
+   (DBusMessageIter *iter,
+    struct _sbus_sss_invoker_args_uus *args)
+{
+    errno_t ret;
+
+    ret = sbus_iterator_write_u(iter, args->arg0);
+    if (ret != EOK) {
+        return ret;
+    }
+
+    ret = sbus_iterator_write_u(iter, args->arg1);
+    if (ret != EOK) {
+        return ret;
+    }
+
+    ret = sbus_iterator_write_s(iter, args->arg2);
+    if (ret != EOK) {
+        return ret;
+    }
+
+    return EOK;
+}
+
 errno_t _sbus_sss_invoker_read_uusss
    (TALLOC_CTX *mem_ctx,
     DBusMessageIter *iter,

--- a/src/sss_iface/sbus_sss_arguments.h
+++ b/src/sss_iface/sbus_sss_arguments.h
@@ -265,6 +265,23 @@ _sbus_sss_invoker_write_uss
    (DBusMessageIter *iter,
     struct _sbus_sss_invoker_args_uss *args);
 
+struct _sbus_sss_invoker_args_uus {
+    uint32_t arg0;
+    uint32_t arg1;
+    const char * arg2;
+};
+
+errno_t
+_sbus_sss_invoker_read_uus
+   (TALLOC_CTX *mem_ctx,
+    DBusMessageIter *iter,
+    struct _sbus_sss_invoker_args_uus *args);
+
+errno_t
+_sbus_sss_invoker_write_uus
+   (DBusMessageIter *iter,
+    struct _sbus_sss_invoker_args_uus *args);
+
 struct _sbus_sss_invoker_args_uusss {
     uint32_t arg0;
     uint32_t arg1;

--- a/src/sss_iface/sbus_sss_client_async.c
+++ b/src/sss_iface/sbus_sss_client_async.c
@@ -1174,116 +1174,6 @@ sbus_method_in_us_out__recv
     return EOK;
 }
 
-struct sbus_method_in_us_out_qus_state {
-    struct _sbus_sss_invoker_args_us in;
-    struct _sbus_sss_invoker_args_qus *out;
-};
-
-static void sbus_method_in_us_out_qus_done(struct tevent_req *subreq);
-
-static struct tevent_req *
-sbus_method_in_us_out_qus_send
-    (TALLOC_CTX *mem_ctx,
-     struct sbus_connection *conn,
-     sbus_invoker_keygen keygen,
-     const char *bus,
-     const char *path,
-     const char *iface,
-     const char *method,
-     uint32_t arg0,
-     const char * arg1)
-{
-    struct sbus_method_in_us_out_qus_state *state;
-    struct tevent_req *subreq;
-    struct tevent_req *req;
-    errno_t ret;
-
-    req = tevent_req_create(mem_ctx, &state, struct sbus_method_in_us_out_qus_state);
-    if (req == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
-        return NULL;
-    }
-
-    state->out = talloc_zero(state, struct _sbus_sss_invoker_args_qus);
-    if (state->out == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Unable to allocate space for output parameters!\n");
-        ret = ENOMEM;
-        goto done;
-    }
-
-    state->in.arg0 = arg0;
-    state->in.arg1 = arg1;
-
-    subreq = sbus_call_method_send(state, conn, NULL, keygen,
-                                   (sbus_invoker_writer_fn)_sbus_sss_invoker_write_us,
-                                   bus, path, iface, method, &state->in);
-    if (subreq == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
-        ret = ENOMEM;
-        goto done;
-    }
-
-    tevent_req_set_callback(subreq, sbus_method_in_us_out_qus_done, req);
-
-    ret = EAGAIN;
-
-done:
-    if (ret != EAGAIN) {
-        tevent_req_error(req, ret);
-        tevent_req_post(req, conn->ev);
-    }
-
-    return req;
-}
-
-static void sbus_method_in_us_out_qus_done(struct tevent_req *subreq)
-{
-    struct sbus_method_in_us_out_qus_state *state;
-    struct tevent_req *req;
-    DBusMessage *reply;
-    errno_t ret;
-
-    req = tevent_req_callback_data(subreq, struct tevent_req);
-    state = tevent_req_data(req, struct sbus_method_in_us_out_qus_state);
-
-    ret = sbus_call_method_recv(state, subreq, &reply);
-    talloc_zfree(subreq);
-    if (ret != EOK) {
-        tevent_req_error(req, ret);
-        return;
-    }
-
-    ret = sbus_read_output(state->out, reply, (sbus_invoker_reader_fn)_sbus_sss_invoker_read_qus, state->out);
-    if (ret != EOK) {
-        tevent_req_error(req, ret);
-        return;
-    }
-
-    tevent_req_done(req);
-    return;
-}
-
-static errno_t
-sbus_method_in_us_out_qus_recv
-    (TALLOC_CTX *mem_ctx,
-     struct tevent_req *req,
-     uint16_t* _arg0,
-     uint32_t* _arg1,
-     const char ** _arg2)
-{
-    struct sbus_method_in_us_out_qus_state *state;
-    state = tevent_req_data(req, struct sbus_method_in_us_out_qus_state);
-
-    TEVENT_REQ_RETURN_ON_ERROR(req);
-
-    *_arg0 = state->out->arg0;
-    *_arg1 = state->out->arg1;
-    *_arg2 = talloc_steal(mem_ctx, state->out->arg2);
-
-    return EOK;
-}
-
 struct sbus_method_in_usq_out__state {
     struct _sbus_sss_invoker_args_usq in;
 };
@@ -1558,6 +1448,118 @@ sbus_method_in_uss_out_qus_recv
 {
     struct sbus_method_in_uss_out_qus_state *state;
     state = tevent_req_data(req, struct sbus_method_in_uss_out_qus_state);
+
+    TEVENT_REQ_RETURN_ON_ERROR(req);
+
+    *_arg0 = state->out->arg0;
+    *_arg1 = state->out->arg1;
+    *_arg2 = talloc_steal(mem_ctx, state->out->arg2);
+
+    return EOK;
+}
+
+struct sbus_method_in_uus_out_qus_state {
+    struct _sbus_sss_invoker_args_uus in;
+    struct _sbus_sss_invoker_args_qus *out;
+};
+
+static void sbus_method_in_uus_out_qus_done(struct tevent_req *subreq);
+
+static struct tevent_req *
+sbus_method_in_uus_out_qus_send
+    (TALLOC_CTX *mem_ctx,
+     struct sbus_connection *conn,
+     sbus_invoker_keygen keygen,
+     const char *bus,
+     const char *path,
+     const char *iface,
+     const char *method,
+     uint32_t arg0,
+     uint32_t arg1,
+     const char * arg2)
+{
+    struct sbus_method_in_uus_out_qus_state *state;
+    struct tevent_req *subreq;
+    struct tevent_req *req;
+    errno_t ret;
+
+    req = tevent_req_create(mem_ctx, &state, struct sbus_method_in_uus_out_qus_state);
+    if (req == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
+        return NULL;
+    }
+
+    state->out = talloc_zero(state, struct _sbus_sss_invoker_args_qus);
+    if (state->out == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Unable to allocate space for output parameters!\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    state->in.arg0 = arg0;
+    state->in.arg1 = arg1;
+    state->in.arg2 = arg2;
+
+    subreq = sbus_call_method_send(state, conn, NULL, keygen,
+                                   (sbus_invoker_writer_fn)_sbus_sss_invoker_write_uus,
+                                   bus, path, iface, method, &state->in);
+    if (subreq == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    tevent_req_set_callback(subreq, sbus_method_in_uus_out_qus_done, req);
+
+    ret = EAGAIN;
+
+done:
+    if (ret != EAGAIN) {
+        tevent_req_error(req, ret);
+        tevent_req_post(req, conn->ev);
+    }
+
+    return req;
+}
+
+static void sbus_method_in_uus_out_qus_done(struct tevent_req *subreq)
+{
+    struct sbus_method_in_uus_out_qus_state *state;
+    struct tevent_req *req;
+    DBusMessage *reply;
+    errno_t ret;
+
+    req = tevent_req_callback_data(subreq, struct tevent_req);
+    state = tevent_req_data(req, struct sbus_method_in_uus_out_qus_state);
+
+    ret = sbus_call_method_recv(state, subreq, &reply);
+    talloc_zfree(subreq);
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    ret = sbus_read_output(state->out, reply, (sbus_invoker_reader_fn)_sbus_sss_invoker_read_qus, state->out);
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    tevent_req_done(req);
+    return;
+}
+
+static errno_t
+sbus_method_in_uus_out_qus_recv
+    (TALLOC_CTX *mem_ctx,
+     struct tevent_req *req,
+     uint16_t* _arg0,
+     uint32_t* _arg1,
+     const char ** _arg2)
+{
+    struct sbus_method_in_uus_out_qus_state *state;
+    state = tevent_req_data(req, struct sbus_method_in_uus_out_qus_state);
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
@@ -2120,11 +2122,12 @@ sbus_call_dp_dp_getAccountDomain_send
      struct sbus_connection *conn,
      const char *busname,
      const char *object_path,
+     uint32_t arg_dp_flags,
      uint32_t arg_entry_type,
      const char * arg_filter)
 {
-    return sbus_method_in_us_out_qus_send(mem_ctx, conn, _sbus_sss_key_us_0_1,
-        busname, object_path, "sssd.dataprovider", "getAccountDomain", arg_entry_type, arg_filter);
+    return sbus_method_in_uus_out_qus_send(mem_ctx, conn, _sbus_sss_key_uus_0_1_2,
+        busname, object_path, "sssd.dataprovider", "getAccountDomain", arg_dp_flags, arg_entry_type, arg_filter);
 }
 
 errno_t
@@ -2135,7 +2138,7 @@ sbus_call_dp_dp_getAccountDomain_recv
      uint32_t* _error,
      const char ** _domain_name)
 {
-    return sbus_method_in_us_out_qus_recv(mem_ctx, req, _dp_error, _error, _domain_name);
+    return sbus_method_in_uus_out_qus_recv(mem_ctx, req, _dp_error, _error, _domain_name);
 }
 
 struct tevent_req *

--- a/src/sss_iface/sbus_sss_client_async.h
+++ b/src/sss_iface/sbus_sss_client_async.h
@@ -238,6 +238,7 @@ sbus_call_dp_dp_getAccountDomain_send
      struct sbus_connection *conn,
      const char *busname,
      const char *object_path,
+     uint32_t arg_dp_flags,
      uint32_t arg_entry_type,
      const char * arg_filter);
 

--- a/src/sss_iface/sbus_sss_interface.h
+++ b/src/sss_iface/sbus_sss_interface.h
@@ -517,23 +517,23 @@
 
 /* Method: sssd.dataprovider.getAccountDomain */
 #define SBUS_METHOD_SYNC_sssd_dataprovider_getAccountDomain(handler, data) ({ \
-    SBUS_CHECK_SYNC((handler), (data), uint32_t, const char *, uint16_t*, uint32_t*, const char **); \
+    SBUS_CHECK_SYNC((handler), (data), uint32_t, uint32_t, const char *, uint16_t*, uint32_t*, const char **); \
     sbus_method_sync("getAccountDomain", \
         &_sbus_sss_args_sssd_dataprovider_getAccountDomain, \
         NULL, \
-        _sbus_sss_invoke_in_us_out_qus_send, \
-        _sbus_sss_key_us_0_1, \
+        _sbus_sss_invoke_in_uus_out_qus_send, \
+        _sbus_sss_key_uus_0_1_2, \
         (handler), (data)); \
 })
 
 #define SBUS_METHOD_ASYNC_sssd_dataprovider_getAccountDomain(handler_send, handler_recv, data) ({ \
-    SBUS_CHECK_SEND((handler_send), (data), uint32_t, const char *); \
+    SBUS_CHECK_SEND((handler_send), (data), uint32_t, uint32_t, const char *); \
     SBUS_CHECK_RECV((handler_recv), uint16_t*, uint32_t*, const char **); \
     sbus_method_async("getAccountDomain", \
         &_sbus_sss_args_sssd_dataprovider_getAccountDomain, \
         NULL, \
-        _sbus_sss_invoke_in_us_out_qus_send, \
-        _sbus_sss_key_us_0_1, \
+        _sbus_sss_invoke_in_uus_out_qus_send, \
+        _sbus_sss_key_uus_0_1_2, \
         (handler_send), (handler_recv), (data)); \
 })
 

--- a/src/sss_iface/sbus_sss_invokers.c
+++ b/src/sss_iface/sbus_sss_invokers.c
@@ -2339,187 +2339,6 @@ static void _sbus_sss_invoke_in_us_out__done(struct tevent_req *subreq)
     return;
 }
 
-struct _sbus_sss_invoke_in_us_out_qus_state {
-    struct _sbus_sss_invoker_args_us *in;
-    struct _sbus_sss_invoker_args_qus out;
-    struct {
-        enum sbus_handler_type type;
-        void *data;
-        errno_t (*sync)(TALLOC_CTX *, struct sbus_request *, void *, uint32_t, const char *, uint16_t*, uint32_t*, const char **);
-        struct tevent_req * (*send)(TALLOC_CTX *, struct tevent_context *, struct sbus_request *, void *, uint32_t, const char *);
-        errno_t (*recv)(TALLOC_CTX *, struct tevent_req *, uint16_t*, uint32_t*, const char **);
-    } handler;
-
-    struct sbus_request *sbus_req;
-    DBusMessageIter *read_iterator;
-    DBusMessageIter *write_iterator;
-};
-
-static void
-_sbus_sss_invoke_in_us_out_qus_step
-    (struct tevent_context *ev,
-     struct tevent_timer *te,
-     struct timeval tv,
-     void *private_data);
-
-static void
-_sbus_sss_invoke_in_us_out_qus_done
-   (struct tevent_req *subreq);
-
-struct tevent_req *
-_sbus_sss_invoke_in_us_out_qus_send
-   (TALLOC_CTX *mem_ctx,
-    struct tevent_context *ev,
-    struct sbus_request *sbus_req,
-    sbus_invoker_keygen keygen,
-    const struct sbus_handler *handler,
-    DBusMessageIter *read_iterator,
-    DBusMessageIter *write_iterator,
-    const char **_key)
-{
-    struct _sbus_sss_invoke_in_us_out_qus_state *state;
-    struct tevent_req *req;
-    const char *key;
-    errno_t ret;
-
-    req = tevent_req_create(mem_ctx, &state, struct _sbus_sss_invoke_in_us_out_qus_state);
-    if (req == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
-        return NULL;
-    }
-
-    state->handler.type = handler->type;
-    state->handler.data = handler->data;
-    state->handler.sync = handler->sync;
-    state->handler.send = handler->async_send;
-    state->handler.recv = handler->async_recv;
-
-    state->sbus_req = sbus_req;
-    state->read_iterator = read_iterator;
-    state->write_iterator = write_iterator;
-
-    state->in = talloc_zero(state, struct _sbus_sss_invoker_args_us);
-    if (state->in == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Unable to allocate space for input parameters!\n");
-        ret = ENOMEM;
-        goto done;
-    }
-
-    ret = _sbus_sss_invoker_read_us(state, read_iterator, state->in);
-    if (ret != EOK) {
-        goto done;
-    }
-
-    ret = sbus_invoker_schedule(state, ev, _sbus_sss_invoke_in_us_out_qus_step, req);
-    if (ret != EOK) {
-        goto done;
-    }
-
-    ret = sbus_request_key(state, keygen, sbus_req, state->in, &key);
-    if (ret != EOK) {
-        goto done;
-    }
-
-    if (_key != NULL) {
-        *_key = talloc_steal(mem_ctx, key);
-    }
-
-    ret = EAGAIN;
-
-done:
-    if (ret != EAGAIN) {
-        tevent_req_error(req, ret);
-        tevent_req_post(req, ev);
-    }
-
-    return req;
-}
-
-static void _sbus_sss_invoke_in_us_out_qus_step
-   (struct tevent_context *ev,
-    struct tevent_timer *te,
-    struct timeval tv,
-    void *private_data)
-{
-    struct _sbus_sss_invoke_in_us_out_qus_state *state;
-    struct tevent_req *subreq;
-    struct tevent_req *req;
-    errno_t ret;
-
-    req = talloc_get_type(private_data, struct tevent_req);
-    state = tevent_req_data(req, struct _sbus_sss_invoke_in_us_out_qus_state);
-
-    switch (state->handler.type) {
-    case SBUS_HANDLER_SYNC:
-        if (state->handler.sync == NULL) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "Bug: sync handler is not specified!\n");
-            ret = ERR_INTERNAL;
-            goto done;
-        }
-
-        ret = state->handler.sync(state, state->sbus_req, state->handler.data, state->in->arg0, state->in->arg1, &state->out.arg0, &state->out.arg1, &state->out.arg2);
-        if (ret != EOK) {
-            goto done;
-        }
-
-        ret = _sbus_sss_invoker_write_qus(state->write_iterator, &state->out);
-        goto done;
-    case SBUS_HANDLER_ASYNC:
-        if (state->handler.send == NULL || state->handler.recv == NULL) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "Bug: async handler is not specified!\n");
-            ret = ERR_INTERNAL;
-            goto done;
-        }
-
-        subreq = state->handler.send(state, ev, state->sbus_req, state->handler.data, state->in->arg0, state->in->arg1);
-        if (subreq == NULL) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
-            ret = ENOMEM;
-            goto done;
-        }
-
-        tevent_req_set_callback(subreq, _sbus_sss_invoke_in_us_out_qus_done, req);
-        ret = EAGAIN;
-        goto done;
-    }
-
-    ret = ERR_INTERNAL;
-
-done:
-    if (ret == EOK) {
-        tevent_req_done(req);
-    } else if (ret != EAGAIN) {
-        tevent_req_error(req, ret);
-    }
-}
-
-static void _sbus_sss_invoke_in_us_out_qus_done(struct tevent_req *subreq)
-{
-    struct _sbus_sss_invoke_in_us_out_qus_state *state;
-    struct tevent_req *req;
-    errno_t ret;
-
-    req = tevent_req_callback_data(subreq, struct tevent_req);
-    state = tevent_req_data(req, struct _sbus_sss_invoke_in_us_out_qus_state);
-
-    ret = state->handler.recv(state, subreq, &state->out.arg0, &state->out.arg1, &state->out.arg2);
-    talloc_zfree(subreq);
-    if (ret != EOK) {
-        tevent_req_error(req, ret);
-        return;
-    }
-
-    ret = _sbus_sss_invoker_write_qus(state->write_iterator, &state->out);
-    if (ret != EOK) {
-        tevent_req_error(req, ret);
-        return;
-    }
-
-    tevent_req_done(req);
-    return;
-}
-
 struct _sbus_sss_invoke_in_usq_out__state {
     struct _sbus_sss_invoker_args_usq *in;
     struct {
@@ -3029,6 +2848,187 @@ static void _sbus_sss_invoke_in_uss_out_qus_done(struct tevent_req *subreq)
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct _sbus_sss_invoke_in_uss_out_qus_state);
+
+    ret = state->handler.recv(state, subreq, &state->out.arg0, &state->out.arg1, &state->out.arg2);
+    talloc_zfree(subreq);
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    ret = _sbus_sss_invoker_write_qus(state->write_iterator, &state->out);
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    tevent_req_done(req);
+    return;
+}
+
+struct _sbus_sss_invoke_in_uus_out_qus_state {
+    struct _sbus_sss_invoker_args_uus *in;
+    struct _sbus_sss_invoker_args_qus out;
+    struct {
+        enum sbus_handler_type type;
+        void *data;
+        errno_t (*sync)(TALLOC_CTX *, struct sbus_request *, void *, uint32_t, uint32_t, const char *, uint16_t*, uint32_t*, const char **);
+        struct tevent_req * (*send)(TALLOC_CTX *, struct tevent_context *, struct sbus_request *, void *, uint32_t, uint32_t, const char *);
+        errno_t (*recv)(TALLOC_CTX *, struct tevent_req *, uint16_t*, uint32_t*, const char **);
+    } handler;
+
+    struct sbus_request *sbus_req;
+    DBusMessageIter *read_iterator;
+    DBusMessageIter *write_iterator;
+};
+
+static void
+_sbus_sss_invoke_in_uus_out_qus_step
+    (struct tevent_context *ev,
+     struct tevent_timer *te,
+     struct timeval tv,
+     void *private_data);
+
+static void
+_sbus_sss_invoke_in_uus_out_qus_done
+   (struct tevent_req *subreq);
+
+struct tevent_req *
+_sbus_sss_invoke_in_uus_out_qus_send
+   (TALLOC_CTX *mem_ctx,
+    struct tevent_context *ev,
+    struct sbus_request *sbus_req,
+    sbus_invoker_keygen keygen,
+    const struct sbus_handler *handler,
+    DBusMessageIter *read_iterator,
+    DBusMessageIter *write_iterator,
+    const char **_key)
+{
+    struct _sbus_sss_invoke_in_uus_out_qus_state *state;
+    struct tevent_req *req;
+    const char *key;
+    errno_t ret;
+
+    req = tevent_req_create(mem_ctx, &state, struct _sbus_sss_invoke_in_uus_out_qus_state);
+    if (req == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
+        return NULL;
+    }
+
+    state->handler.type = handler->type;
+    state->handler.data = handler->data;
+    state->handler.sync = handler->sync;
+    state->handler.send = handler->async_send;
+    state->handler.recv = handler->async_recv;
+
+    state->sbus_req = sbus_req;
+    state->read_iterator = read_iterator;
+    state->write_iterator = write_iterator;
+
+    state->in = talloc_zero(state, struct _sbus_sss_invoker_args_uus);
+    if (state->in == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Unable to allocate space for input parameters!\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = _sbus_sss_invoker_read_uus(state, read_iterator, state->in);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    ret = sbus_invoker_schedule(state, ev, _sbus_sss_invoke_in_uus_out_qus_step, req);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    ret = sbus_request_key(state, keygen, sbus_req, state->in, &key);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    if (_key != NULL) {
+        *_key = talloc_steal(mem_ctx, key);
+    }
+
+    ret = EAGAIN;
+
+done:
+    if (ret != EAGAIN) {
+        tevent_req_error(req, ret);
+        tevent_req_post(req, ev);
+    }
+
+    return req;
+}
+
+static void _sbus_sss_invoke_in_uus_out_qus_step
+   (struct tevent_context *ev,
+    struct tevent_timer *te,
+    struct timeval tv,
+    void *private_data)
+{
+    struct _sbus_sss_invoke_in_uus_out_qus_state *state;
+    struct tevent_req *subreq;
+    struct tevent_req *req;
+    errno_t ret;
+
+    req = talloc_get_type(private_data, struct tevent_req);
+    state = tevent_req_data(req, struct _sbus_sss_invoke_in_uus_out_qus_state);
+
+    switch (state->handler.type) {
+    case SBUS_HANDLER_SYNC:
+        if (state->handler.sync == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "Bug: sync handler is not specified!\n");
+            ret = ERR_INTERNAL;
+            goto done;
+        }
+
+        ret = state->handler.sync(state, state->sbus_req, state->handler.data, state->in->arg0, state->in->arg1, state->in->arg2, &state->out.arg0, &state->out.arg1, &state->out.arg2);
+        if (ret != EOK) {
+            goto done;
+        }
+
+        ret = _sbus_sss_invoker_write_qus(state->write_iterator, &state->out);
+        goto done;
+    case SBUS_HANDLER_ASYNC:
+        if (state->handler.send == NULL || state->handler.recv == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "Bug: async handler is not specified!\n");
+            ret = ERR_INTERNAL;
+            goto done;
+        }
+
+        subreq = state->handler.send(state, ev, state->sbus_req, state->handler.data, state->in->arg0, state->in->arg1, state->in->arg2);
+        if (subreq == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
+            ret = ENOMEM;
+            goto done;
+        }
+
+        tevent_req_set_callback(subreq, _sbus_sss_invoke_in_uus_out_qus_done, req);
+        ret = EAGAIN;
+        goto done;
+    }
+
+    ret = ERR_INTERNAL;
+
+done:
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else if (ret != EAGAIN) {
+        tevent_req_error(req, ret);
+    }
+}
+
+static void _sbus_sss_invoke_in_uus_out_qus_done(struct tevent_req *subreq)
+{
+    struct _sbus_sss_invoke_in_uus_out_qus_state *state;
+    struct tevent_req *req;
+    errno_t ret;
+
+    req = tevent_req_callback_data(subreq, struct tevent_req);
+    state = tevent_req_data(req, struct _sbus_sss_invoke_in_uus_out_qus_state);
 
     ret = state->handler.recv(state, subreq, &state->out.arg0, &state->out.arg1, &state->out.arg2);
     talloc_zfree(subreq);

--- a/src/sss_iface/sbus_sss_invokers.h
+++ b/src/sss_iface/sbus_sss_invokers.h
@@ -52,10 +52,10 @@ _sbus_sss_declare_invoker(ss, o);
 _sbus_sss_declare_invoker(ssau, );
 _sbus_sss_declare_invoker(u, );
 _sbus_sss_declare_invoker(us, );
-_sbus_sss_declare_invoker(us, qus);
 _sbus_sss_declare_invoker(usq, );
 _sbus_sss_declare_invoker(uss, );
 _sbus_sss_declare_invoker(uss, qus);
+_sbus_sss_declare_invoker(uus, qus);
 _sbus_sss_declare_invoker(uusss, qus);
 _sbus_sss_declare_invoker(uuus, qus);
 

--- a/src/sss_iface/sbus_sss_keygens.c
+++ b/src/sss_iface/sbus_sss_keygens.c
@@ -124,6 +124,23 @@ _sbus_sss_key_uss_0_1_2
 }
 
 const char *
+_sbus_sss_key_uus_0_1_2
+   (TALLOC_CTX *mem_ctx,
+    struct sbus_request *sbus_req,
+    struct _sbus_sss_invoker_args_uus *args)
+{
+    if (sbus_req->sender == NULL) {
+        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%s",
+            sbus_req->type, sbus_req->interface, sbus_req->member,
+            sbus_req->path, args->arg0, args->arg1, args->arg2);
+    }
+
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%s",
+        sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
+        sbus_req->path, args->arg0, args->arg1, args->arg2);
+}
+
+const char *
 _sbus_sss_key_uusss_0_1_2_3_4
    (TALLOC_CTX *mem_ctx,
     struct sbus_request *sbus_req,

--- a/src/sss_iface/sbus_sss_keygens.h
+++ b/src/sss_iface/sbus_sss_keygens.h
@@ -61,6 +61,12 @@ _sbus_sss_key_uss_0_1_2
     struct _sbus_sss_invoker_args_uss *args);
 
 const char *
+_sbus_sss_key_uus_0_1_2
+   (TALLOC_CTX *mem_ctx,
+    struct sbus_request *sbus_req,
+    struct _sbus_sss_invoker_args_uus *args);
+
+const char *
 _sbus_sss_key_uusss_0_1_2_3_4
    (TALLOC_CTX *mem_ctx,
     struct sbus_request *sbus_req,

--- a/src/sss_iface/sbus_sss_symbols.c
+++ b/src/sss_iface/sbus_sss_symbols.c
@@ -246,6 +246,7 @@ _sbus_sss_args_sssd_Responder_NegativeCache_ResetUsers = {
 const struct sbus_method_arguments
 _sbus_sss_args_sssd_dataprovider_getAccountDomain = {
     .input = (const struct sbus_argument[]){
+        {.type = "u", .name = "dp_flags"},
         {.type = "u", .name = "entry_type"},
         {.type = "s", .name = "filter"},
         {NULL}

--- a/src/sss_iface/sss_iface.xml
+++ b/src/sss_iface/sss_iface.xml
@@ -146,8 +146,9 @@
             <arg name="error_message" type="s" direction="out" />
         </method>
         <method name="getAccountDomain">
-            <arg name="entry_type" type="u" direction="in" key="1" />
-            <arg name="filter" type="s" direction="in" key="2" />
+            <arg name="dp_flags" type="u" direction="in" key="1" />
+            <arg name="entry_type" type="u" direction="in" key="2" />
+            <arg name="filter" type="s" direction="in" key="3" />
             <arg name="dp_error" type="q" direction="out" />
             <arg name="error" type="u" direction="out" />
             <arg name="domain_name" type="s" direction="out" />

--- a/src/tests/cmocka/common_mock_resp_dp.c
+++ b/src/tests/cmocka/common_mock_resp_dp.c
@@ -235,6 +235,7 @@ struct tevent_req *
 sss_dp_get_account_domain_send(TALLOC_CTX *mem_ctx,
                                struct resp_ctx *rctx,
                                struct sss_domain_info *domain,
+                               bool fast_reply,
                                enum sss_dp_acct_type type,
                                uint32_t opt_id)
 {


### PR DESCRIPTION
In specific circumstances "sdom->*_search_bases" might be unset yet
when "ad_get_account_domain_send() -> ad_get_account_domain_prepare_search()"
is executed.

Resolves:
https://github.com/SSSD/sssd/issues/5295

Note: 
Actually I'm not entirely sure if it makes much sense to extend "getAccountDomain" sbus interface with a new parameter "dp_flags" since we always going to use "fast_reply == true".
It's possible to simply pass `DP_FAST_REPLY` at https://github.com/SSSD/sssd/blob/eb276b5f081207c399579235646d92e4f3ba9687/src/providers/data_provider/dp_target_id.c#L722 instead.

So iface is changed mostly to be consistent with "getAccountInfo" interface.

On the other hand, `sss_dp_get_account_send()` is always called with "fast_reply == true" as well.
Perhaps it makes more sense to get rid of "dp_flags"  in "getAccountInfo" instead of addition it to "getAccountDomain"...