### PR TITLE
Fix IP network by address lookup

### DIFF
--- a/src/providers/proxy/proxy_hosts.c
+++ b/src/providers/proxy/proxy_hosts.c
@@ -265,26 +265,26 @@ get_host_by_name_internal(struct proxy_resolver_ctx *ctx,
     }
 
     ret = nss_status_to_errno(status);
-    if (ret != EOK && ret != ENOENT) {
-        DEBUG(SSSDBG_MINOR_FAILURE,
-            "gethostbyname2_r (%s) failed for host [%s]: %d, %s, %s.\n",
-            af == AF_INET ? "AF_INET" : "AF_INET6",
-            search_name, status, strerror(err), hstrerror(h_err));
+    if (ret != EOK) {
+        if (ret != ENOENT) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                "gethostbyname2_r (%s) failed for host [%s]: %d, %s, %s.\n",
+                af == AF_INET ? "AF_INET" : "AF_INET6",
+                search_name, status, strerror(err), hstrerror(h_err));
+        }
+
         goto done;
     }
 
-    if (ret == EOK) {
-        ret = parse_hostent(mem_ctx, result, domain->case_sensitive,
-                            out_name, out_aliases, out_addresses);
-        if (ret != EOK) {
-            DEBUG(SSSDBG_MINOR_FAILURE,
-                  "Failed to parse hostent [%d]: %s\n",
-                  ret, sss_strerror(ret));
-            goto done;
-        }
+    ret = parse_hostent(mem_ctx, result, domain->case_sensitive,
+                        out_name, out_aliases, out_addresses);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Failed to parse hostent [%d]: %s\n",
+              ret, sss_strerror(ret));
+        goto done;
     }
 
-    ret = EOK;
 done:
     talloc_free(tmp_ctx);
 

--- a/src/providers/proxy/proxy_ipnetworks.c
+++ b/src/providers/proxy/proxy_ipnetworks.c
@@ -304,6 +304,9 @@ get_net_byaddr(struct proxy_resolver_ctx *ctx,
         goto done;
     }
 
+    /* getnetbyaddr_r expects address in host byte order */
+    addrbuf = ntohl(addrbuf);
+
     for (status = NSS_STATUS_TRYAGAIN,
          err = ERANGE, h_err = 0;
          status == NSS_STATUS_TRYAGAIN && err == ERANGE;

--- a/src/sss_client/nss_ipnetworks.c
+++ b/src/sss_client/nss_ipnetworks.c
@@ -287,6 +287,15 @@ _nss_sss_getnetbyaddr_r(uint32_t addr, int type,
     size_t ctr = 0;
     socklen_t addrlen;
 
+    if (type == AF_UNSPEC) {
+        char addrbuf[INET_ADDRSTRLEN];
+
+        /* Try to parse to IPv4 */
+        if (inet_ntop(AF_INET, &addr, addrbuf, INET_ADDRSTRLEN)) {
+            type = AF_INET;
+        }
+    }
+
     if (type != AF_INET) {
         *errnop = EAFNOSUPPORT;
         *h_errnop = NETDB_INTERNAL;

--- a/src/sss_client/nss_ipnetworks.c
+++ b/src/sss_client/nss_ipnetworks.c
@@ -287,6 +287,10 @@ _nss_sss_getnetbyaddr_r(uint32_t addr, int type,
     size_t ctr = 0;
     socklen_t addrlen;
 
+    /* addr is in host byte order, but nss_protocol_parse_addr and inet_ntop
+     * expects the buffer in network byte order */
+    addr = htonl(addr);
+
     if (type == AF_UNSPEC) {
         char addrbuf[INET_ADDRSTRLEN];
 

--- a/src/tests/intg/sssd_nets.py
+++ b/src/tests/intg/sssd_nets.py
@@ -120,7 +120,7 @@ def call_sssd_getnetbyname(name):
     return (res, h_errno, netent_dict)
 
 
-def call_sssd_getnetbyaddr(addrstr):
+def call_sssd_getnetbyaddr(addrstr, af):
     """
     A Python wrapper to retrieve an IP network by address. Returns:
         (res, netent_dict)
@@ -138,7 +138,7 @@ def call_sssd_getnetbyaddr(addrstr):
     binaddr = unpack('<I', addr.packed)[0]
     binaddr = socket.ntohl(binaddr)
 
-    (res, errno, h_errno, result_p) = getnetbyaddr_r(binaddr, socket.AF_INET,
+    (res, errno, h_errno, result_p) = getnetbyaddr_r(binaddr, af,
                                                      result_p, buff,
                                                      IP_NETWORK_BUFLEN)
     if errno != 0:

--- a/src/tests/intg/sssd_nets.py
+++ b/src/tests/intg/sssd_nets.py
@@ -136,6 +136,7 @@ def call_sssd_getnetbyaddr(addrstr):
         addrstr = addrstr.decode('utf-8')
     addr = IPv4Address(addrstr)
     binaddr = unpack('<I', addr.packed)[0]
+    binaddr = socket.ntohl(binaddr)
 
     (res, errno, h_errno, result_p) = getnetbyaddr_r(binaddr, socket.AF_INET,
                                                      result_p, buff,

--- a/src/tests/intg/test_resolver.py
+++ b/src/tests/intg/test_resolver.py
@@ -310,7 +310,7 @@ def test_netbyname(add_nets):
 
 
 def test_netbyaddr(add_nets):
-    (res, hres, _) = call_sssd_getnetbyname("10.2.2.1")
+    (res, hres, _) = call_sssd_getnetbyaddr("10.2.2.1")
     assert res == NssReturnCode.NOTFOUND
     assert hres == HostError.HOST_NOT_FOUND
 

--- a/src/tests/intg/test_resolver.py
+++ b/src/tests/intg/test_resolver.py
@@ -27,7 +27,7 @@ import time
 import ldap
 import pytest
 import ent
-
+import socket
 import config
 import ds_openldap
 import ldap_ent
@@ -310,10 +310,18 @@ def test_netbyname(add_nets):
 
 
 def test_netbyaddr(add_nets):
-    (res, hres, _) = call_sssd_getnetbyaddr("10.2.2.1")
+    (res, hres, _) = call_sssd_getnetbyaddr("10.2.2.1", socket.AF_INET)
     assert res == NssReturnCode.NOTFOUND
     assert hres == HostError.HOST_NOT_FOUND
 
-    (res, hres, _) = call_sssd_getnetbyaddr("10.2.2.2")
+    (res, hres, _) = call_sssd_getnetbyaddr("10.2.2.1", socket.AF_UNSPEC)
+    assert res == NssReturnCode.NOTFOUND
+    assert hres == HostError.HOST_NOT_FOUND
+
+    (res, hres, _) = call_sssd_getnetbyaddr("10.2.2.2", socket.AF_INET)
+    assert res == NssReturnCode.SUCCESS
+    assert hres == 0
+
+    (res, hres, _) = call_sssd_getnetbyaddr("10.2.2.2", socket.AF_UNSPEC)
     assert res == NssReturnCode.SUCCESS
     assert hres == 0


### PR DESCRIPTION
Resolves https://github.com/SSSD/sssd/issues/5256.

The first commit fixes the error path when an IP host is not found in the proxy provider. A memory allocation error was logged because we didn't jump to done label after receiving ENOENT.

```
[be[test]] [proxy_save_host] (0x0040): Cannot get cased name.
[be[test]] [get_host_byname] (0x0040): Failed to store host [(null)] [12]: Cannot allocate memory
```