### PR TITLE
dp: fix potential race condition in provider's sbus server

### DIFF
--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -2008,7 +2008,8 @@ static int monitor_process_init(struct mt_ctx *ctx,
 
     req = sbus_server_create_and_connect_send(ctx, ctx->ev, SSS_BUS_MONITOR,
                                               NULL, SSS_MONITOR_ADDRESS,
-                                              false, 100, ctx->uid, ctx->gid);
+                                              false, 100, ctx->uid, ctx->gid,
+                                              NULL, NULL);
     if (req == NULL) {
         ret = ENOMEM;
         goto done;

--- a/src/providers/data_provider/dp.c
+++ b/src/providers/data_provider/dp.c
@@ -192,9 +192,9 @@ dp_init_send(TALLOC_CTX *mem_ctx,
     talloc_set_destructor(state->provider, dp_destructor);
 
     subreq = sbus_server_create_and_connect_send(state->provider, ev,
-                                                 state->sbus_name,
-                                                 NULL, sbus_address, true, 1000,
-                                                 uid, gid);
+        state->sbus_name, NULL, sbus_address, true, 1000, uid, gid,
+        (sbus_server_on_connection_cb)dp_client_init,
+        (sbus_server_on_connection_data)state->provider);
     if (subreq == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
         ret = ENOMEM;
@@ -234,9 +234,6 @@ static void dp_init_done(struct tevent_req *subreq)
         tevent_req_error(req, ret);
         return;
     }
-
-    sbus_server_set_on_connection(state->provider->sbus_server,
-                                  dp_client_init, state->provider);
 
     /* be_ctx->provider must be accessible from modules and targets */
     state->be_ctx->provider = talloc_steal(state->be_ctx, state->provider);

--- a/src/sbus/connection/sbus_connection_connect.c
+++ b/src/sbus/connection/sbus_connection_connect.c
@@ -344,7 +344,9 @@ sbus_server_create_and_connect_send(TALLOC_CTX *mem_ctx,
                                     bool use_symlink,
                                     uint32_t max_connections,
                                     uid_t uid,
-                                    gid_t gid)
+                                    gid_t gid,
+                                    sbus_server_on_connection_cb on_conn_cb,
+                                    sbus_server_on_connection_data on_conn_data)
 {
     struct sbus_server_create_and_connect_state *state;
     struct tevent_req *subreq;
@@ -358,7 +360,8 @@ sbus_server_create_and_connect_send(TALLOC_CTX *mem_ctx,
     }
 
     state->server = sbus_server_create(state, ev, address, use_symlink,
-                                       max_connections, uid, gid);
+                                       max_connections, uid, gid,
+                                       on_conn_cb, on_conn_data);
     if (state->server == NULL) {
         ret = ENOMEM;
         goto done;

--- a/src/sbus/sbus.h
+++ b/src/sbus/sbus.h
@@ -138,6 +138,8 @@ errno_t sbus_connect_private_recv(TALLOC_CTX *mem_ctx,
  * @param use_symlink            If a symlink to @address should be created.
  * @param uid                    Socket owner uid.
  * @param gid                    Socket owner gid.
+ * @param on_conn_cb             On new connection callback function.
+ * @param on_conn_data           Private data passed to the callback.
  *
  * @return New sbus server or NULL on error.
  */
@@ -148,7 +150,9 @@ sbus_server_create(TALLOC_CTX *mem_ctx,
                    bool use_symlink,
                    uint32_t max_connections,
                    uid_t uid,
-                   gid_t gid);
+                   gid_t gid,
+                   sbus_server_on_connection_cb on_conn_cb,
+                   sbus_server_on_connection_data on_conn_data);
 
 /**
  * Create a new sbus server at socket address @address and connect to it.
@@ -162,6 +166,8 @@ sbus_server_create(TALLOC_CTX *mem_ctx,
  * @param use_symlink            If a symlink to @address should be created.
  * @param uid                    Socket owner uid.
  * @param gid                    Socket owner gid.
+ * @param on_conn_cb             On new connection callback function.
+ * @param on_conn_data           Private data passed to the callback.
  *
  * @return Tevent request or NULL on error.
  */
@@ -174,7 +180,9 @@ sbus_server_create_and_connect_send(TALLOC_CTX *mem_ctx,
                                     bool use_symlink,
                                     uint32_t max_connections,
                                     uid_t uid,
-                                    gid_t gid);
+                                    gid_t gid,
+                                    sbus_server_on_connection_cb on_conn_cb,
+                                    sbus_server_on_connection_data on_conn_data);
 
 /**
  * Receive reply from @sbus_server_create_and_connect_send.
@@ -445,5 +453,8 @@ sbus_router_add_node(struct sbus_connection *conn,
 errno_t
 sbus_router_add_node_map(struct sbus_connection *conn,
                          struct sbus_node *map);
+
+/* Get connection name, well known name is preferred. */
+const char * sbus_connection_get_name(struct sbus_connection *conn);
 
 #endif /* _SBUS_H_ */

--- a/src/sbus/sbus_private.h
+++ b/src/sbus/sbus_private.h
@@ -190,9 +190,6 @@ void sbus_connection_tevent_disable(struct sbus_connection *conn);
 /* Mark that this connection is currently active (new method call arrived). */
 void sbus_connection_mark_active(struct sbus_connection *conn);
 
-/* Get connection name, well known name is preferred. */
-const char * sbus_connection_get_name(struct sbus_connection *conn);
-
 /* Set connection well known name. */
 errno_t sbus_connection_set_name(struct sbus_connection *conn,
                                  const char *name);

--- a/src/sbus/server/sbus_server.c
+++ b/src/sbus/server/sbus_server.c
@@ -635,7 +635,9 @@ sbus_server_create(TALLOC_CTX *mem_ctx,
                    bool use_symlink,
                    uint32_t max_connections,
                    uid_t uid,
-                   gid_t gid)
+                   gid_t gid,
+                   sbus_server_on_connection_cb on_conn_cb,
+                   sbus_server_on_connection_data on_conn_data)
 {
     DBusServer *dbus_server;
     struct sbus_server *sbus_server;
@@ -673,6 +675,11 @@ sbus_server_create(TALLOC_CTX *mem_ctx,
     if (sbus_server->on_connection == NULL) {
         ret = ENOMEM;
         goto done;
+    }
+
+    if (on_conn_cb != NULL) {
+        _sbus_server_set_on_connection(sbus_server, "on-connection", on_conn_cb,
+                                       on_conn_data);
     }
 
     sbus_server->names = sss_ptr_hash_create(sbus_server,


### PR DESCRIPTION
We can hit a segfault if provider start is somehow delayed.

- dp_init_send
  - sbus_server_create_and_connect_send
    - sbus_server_create (*)
- dp_init_done (callback for sbus_server_create_and_connect_send)
  - sbus_server_create_and_connect_recv
  - sbus_server_set_on_connection (sets clients data and creates dp_cli)

At (*) sbus server is already created and accepts new connections once
we get into tevent loop. So it is possible that the client connects to
server before sbus_server_set_on_connection is called and thus the client
is not properly initialized. However it should not happen in normal start
because providers are started before responders and it can happen only if
data provider startup is somehow delay.

You can use this diff to reproduce the crash:
```diff
--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -702,6 +702,8 @@ int main(int argc, const char *argv[])
     uid_t uid;
     gid_t gid;

+    sleep(5);
+
     struct poptOption long_options[] = {
         POPT_AUTOHELP
         SSSD_MAIN_OPTS
```

Resolves:
https://github.com/SSSD/sssd/issues/5298