### PR TITLE
use prerealease option in make srpm script

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,3 +1,3 @@
 srpm:
 	dnf -y install git rpm-build dnf-plugins-core libldb-devel
-	./contrib/fedora/make_srpm.sh --output $(outdir)
+	./contrib/fedora/make_srpm.sh --prerelease --output $(outdir)


### PR DESCRIPTION
With --prereleasae option enabled, make_srpm.sh script can set different
version each time copr build is created. It adds date time and git
commit hash in the build version.
eg.
2.3.2-0.20200826.1356.gitdb1049057.fc31