### PR TITLE
conf: disable python2 bindings by default

### DIFF
--- a/contrib/ci/configure.sh
+++ b/contrib/ci/configure.sh
@@ -29,6 +29,7 @@ declare -a CONFIGURE_ARG_LIST=(
     "--enable-ldb-version-check"
     "--with-syslog=journald"
     "--enable-systemtap"
+    "--with-python2-bindings"
 )
 
 

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -113,6 +113,7 @@
     %global with_python2_option --without-python2-bindings
 %else
     %global with_python2 1
+    %global with_python2_option --with-python2-bindings
 %endif
 
 %global enable_systemtap 1

--- a/src/conf_macros.m4
+++ b/src/conf_macros.m4
@@ -377,10 +377,10 @@ AC_DEFUN([WITH_KRB5_CONF],
 AC_DEFUN([WITH_PYTHON2_BINDINGS],
   [ AC_ARG_WITH([python2-bindings],
                 [AC_HELP_STRING([--with-python2-bindings],
-                                [Whether to build python2 bindings [yes]])
+                                [Whether to build python2 bindings [no]])
                 ],
                 [],
-                [with_python2_bindings=yes]
+                [with_python2_bindings=no]
                )
     if test x"$with_python2_bindings" = xyes; then
         AC_SUBST([HAVE_PYTHON2_BINDINGS], [yes])


### PR DESCRIPTION
Python2 is being fully replaced by Python3 on modern distros so
there is no need to build the bindings by default. We even don't
ship python2 packages in Fedora for quite some time now.

Keeping this on by default requires using --without-python2-bindings
on modern distributions where python2 is not installed by default.