### PR TITLE
Add seconds in copr build version

### DIFF
--- a/contrib/fedora/make_srpm.sh
+++ b/contrib/fedora/make_srpm.sh
@@ -141,7 +141,7 @@ fi
 
 PRERELEASE_VERSION=""
 if [ -n "$PRERELEASE" ]; then
-    PRERELEASE_VERSION=.$(date +%Y%m%d.%H%M).git$(git log -1 --pretty=format:%h)
+    PRERELEASE_VERSION=.$(date +%y%m%d.%H%M%S).git$(git log -1 --pretty=format:%h)
 fi
 
 mkdir -p $RPMBUILD/BUILD


### PR DESCRIPTION
Add seconds to distiguish builds that are triigerred in the same minute.
Shorten the year by using only the last 2 digits.

Signed-off-by: Steeve Goveas <sgoveas@redhat.com>