### PR TITLE
sss_cache: sss_cache exits immediately if SSSD is not running.

### DIFF
--- a/src/tools/sss_cache.c
+++ b/src/tools/sss_cache.c
@@ -32,6 +32,7 @@
 #include "db/sysdb_autofs.h"
 #include "db/sysdb_ssh.h"
 #include "db/sysdb_sudo.h"
+#include "tools/common/sss_process.h"
 
 #define INVALIDATE_NONE 0
 #define INVALIDATE_USERS 1
@@ -161,6 +162,10 @@ int main(int argc, const char *argv[])
      */
     const char *systemd_offline = getenv ("SYSTEMD_OFFLINE");
     if (systemd_offline && strcmp (systemd_offline, "1") == 0 && access(DB_PATH, W_OK) != 0) {
+        return 0;
+    }
+
+    if (!sss_daemon_running()) {
         return 0;
     }
 


### PR DESCRIPTION
When running sss_cache if /var is mounted as NFS,
the fcntl access time to /var/lib/sss/db/timestamps_implicit_files.ldb is accumulated
and the sss_ cache command took a long time to complete.

Not only executing sss_cache directly, but also sss_cache may be executed
by other commands (for example, useradd and groupadd in shadow utility).
In this case, I encountered this problem when running useradd.

It is hard for all callers of sss_cache to fix,
so fix sss_cache to exit immediately while SSSD is not running.