### PR TITLE
UTIL:utf8: code cleanup 

### DIFF
--- a/src/tests/util-tests.c
+++ b/src/tests/util-tests.c
@@ -475,54 +475,17 @@ START_TEST(test_size_t_overflow)
 }
 END_TEST
 
-START_TEST(test_utf8_lowercase)
-{
-    const uint8_t munchen_utf8_upcase[] = { 'M', 0xC3, 0x9C, 'N', 'C', 'H', 'E', 'N', 0x0 };
-    const uint8_t munchen_utf8_lowcase[] = { 'm', 0xC3, 0xBC, 'n', 'c', 'h', 'e', 'n', 0x0 };
-    uint8_t *lcase;
-    size_t nlen;
-
-    lcase = sss_utf8_tolower(munchen_utf8_upcase,
-                             strlen((const char *)munchen_utf8_upcase),
-                             &nlen);
-    ck_assert_int_eq(strlen((const char *) munchen_utf8_upcase), nlen); /* This is not true for utf8 strings in general */
-    fail_if(memcmp(lcase, munchen_utf8_lowcase, nlen),
-            "Unexpected binary values");
-    sss_utf8_free(lcase);
-}
-END_TEST
-
-START_TEST(test_utf8_talloc_lowercase)
-{
-    const uint8_t munchen_utf8_upcase[] = { 'M', 0xC3, 0x9C, 'N', 'C', 'H', 'E', 'N', 0x0 };
-    const uint8_t munchen_utf8_lowcase[] = { 'm', 0xC3, 0xBC, 'n', 'c', 'h', 'e', 'n', 0x0 };
-    uint8_t *lcase;
-    size_t nsize;
-
-    TALLOC_CTX *test_ctx;
-    test_ctx = talloc_new(NULL);
-    fail_if(test_ctx == NULL, "Failed to allocate memory");
-
-    lcase = sss_tc_utf8_tolower(test_ctx, munchen_utf8_upcase,
-                                strlen((const char *) munchen_utf8_upcase),
-                                &nsize);
-    fail_if(memcmp(lcase, munchen_utf8_lowcase, nsize),
-            "Unexpected binary values");
-    talloc_free(test_ctx);
-}
-END_TEST
-
 START_TEST(test_utf8_talloc_str_lowercase)
 {
-    const uint8_t munchen_utf8_upcase[] = { 'M', 0xC3, 0x9C, 'N', 'C', 'H', 'E', 'N', 0x0 };
-    const uint8_t munchen_utf8_lowcase[] = { 'm', 0xC3, 0xBC, 'n', 'c', 'h', 'e', 'n', 0x0 };
+    const char munchen_utf8_upcase[] = { 'M', 0xC3, 0x9C, 'N', 'C', 'H', 'E', 'N', 0x0 };
+    const char munchen_utf8_lowcase[] = { 'm', 0xC3, 0xBC, 'n', 'c', 'h', 'e', 'n', 0x0 };
     char *lcase;
 
     TALLOC_CTX *test_ctx;
     test_ctx = talloc_new(NULL);
     fail_if(test_ctx == NULL, "Failed to allocate memory");
 
-    lcase = sss_tc_utf8_str_tolower(test_ctx, (const char *) munchen_utf8_upcase);
+    lcase = sss_tc_utf8_str_tolower(test_ctx, munchen_utf8_upcase);
     fail_if(memcmp(lcase, munchen_utf8_lowcase, strlen(lcase)),
             "Unexpected binary values");
     talloc_free(test_ctx);
@@ -1167,8 +1130,6 @@ Suite *util_suite(void)
     tcase_set_timeout(tc_util, 60);
 
     TCase *tc_utf8 = tcase_create("utf8");
-    tcase_add_test (tc_utf8, test_utf8_lowercase);
-    tcase_add_test (tc_utf8, test_utf8_talloc_lowercase);
     tcase_add_test (tc_utf8, test_utf8_talloc_str_lowercase);
     tcase_add_test (tc_utf8, test_utf8_caseeq);
     tcase_add_test (tc_utf8, test_utf8_check);

--- a/src/util/sss_tc_utf8.c
+++ b/src/util/sss_tc_utf8.c
@@ -18,13 +18,49 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "config.h"
+
+#ifdef HAVE_LIBUNISTRING
+#include <stdlib.h>
+#include <unistr.h>
+#elif defined(HAVE_GLIB2)
+#include <glib.h>
+#endif
+
 #include <talloc.h>
 #include "util/util.h"
-#include "util/sss_utf8.h"
 
-/* from sss_utf8.c */
-void sss_utf8_free(char *ptr);
-char *sss_utf8_tolower(const char *s);
+#ifdef HAVE_LIBUNISTRING
+static void sss_utf8_free(char *ptr)
+{
+    free(ptr);
+}
+#elif defined(HAVE_GLIB2)
+static void sss_utf8_free(char *ptr)
+{
+    g_free(ptr);
+}
+#else
+#error No unicode library
+#endif
+
+/* Expects and returns NULL-terminated string;
+ * result must be freed with sss_utf8_free()
+ */
+#ifdef HAVE_LIBUNISTRING
+static char *sss_utf8_tolower(const char *s)
+{
+    size_t llen;
+    return u8_tolower((const uint8_t *)s, strlen(s) + 1, NULL, NULL, NULL, &llen);
+}
+#elif defined(HAVE_GLIB2)
+static char *sss_utf8_tolower(const char *s)
+{
+    return g_utf8_strdown((const gchar *)s, -1);
+}
+#else
+#error No unicode library
+#endif
 
 char *sss_tc_utf8_str_tolower(TALLOC_CTX *mem_ctx, const char *s)
 {

--- a/src/util/sss_tc_utf8.c
+++ b/src/util/sss_tc_utf8.c
@@ -22,37 +22,21 @@
 #include "util/util.h"
 #include "util/sss_utf8.h"
 
-char *
-sss_tc_utf8_str_tolower(TALLOC_CTX *mem_ctx, const char *s)
+/* from sss_utf8.c */
+void sss_utf8_free(char *ptr);
+char *sss_utf8_tolower(const char *s);
+
+char *sss_tc_utf8_str_tolower(TALLOC_CTX *mem_ctx, const char *s)
 {
-    size_t nlen;
-    uint8_t *ret;
+    char *lower;
+    char *ret = NULL;
 
-    ret = sss_tc_utf8_tolower(mem_ctx, (const uint8_t *) s, strlen(s), &nlen);
-    if (!ret) return NULL;
+    lower = sss_utf8_tolower(s);
+    if (lower) {
+        ret = talloc_strdup(mem_ctx, lower);
+        sss_utf8_free(lower);
+    }
 
-    ret = talloc_realloc(mem_ctx, ret, uint8_t, nlen+1);
-    if (!ret) return NULL;
-
-    ret[nlen] = '\0';
-    return (char *) ret;
-}
-
-uint8_t *
-sss_tc_utf8_tolower(TALLOC_CTX *mem_ctx, const uint8_t *s, size_t len, size_t *_nlen)
-{
-    uint8_t *lower;
-    uint8_t *ret;
-    size_t nlen;
-
-    lower = sss_utf8_tolower(s, len, &nlen);
-    if (!lower) return NULL;
-
-    ret = talloc_memdup(mem_ctx, lower, nlen);
-    sss_utf8_free(lower);
-    if (!ret) return NULL;
-
-    *_nlen = nlen;
     return ret;
 }
 

--- a/src/util/sss_utf8.c
+++ b/src/util/sss_utf8.c
@@ -36,38 +36,6 @@
 #include "sss_utf8.h"
 
 #ifdef HAVE_LIBUNISTRING
-void sss_utf8_free(char *ptr)
-{
-    free(ptr);
-}
-#elif defined(HAVE_GLIB2)
-void sss_utf8_free(char *ptr)
-{
-    g_free(ptr);
-}
-#else
-#error No unicode library
-#endif
-
-/* Expects and returns NULL-terminated string;
- * result must be freed with sss_utf8_free()
- */
-#ifdef HAVE_LIBUNISTRING
-char *sss_utf8_tolower(const char *s)
-{
-    size_t llen;
-    return u8_tolower((const uint8_t *)s, strlen(s) + 1, NULL, NULL, NULL, &llen);
-}
-#elif defined(HAVE_GLIB2)
-char *sss_utf8_tolower(const char *s)
-{
-    return g_utf8_strdown((const gchar *)s, -1);
-}
-#else
-#error No unicode library
-#endif
-
-#ifdef HAVE_LIBUNISTRING
 bool sss_utf8_check(const uint8_t *s, size_t n)
 {
     if (u8_check(s, n) == NULL) {

--- a/src/util/sss_utf8.c
+++ b/src/util/sss_utf8.c
@@ -36,54 +36,32 @@
 #include "sss_utf8.h"
 
 #ifdef HAVE_LIBUNISTRING
-void sss_utf8_free(void *ptr)
+void sss_utf8_free(char *ptr)
 {
-    return free(ptr);
+    free(ptr);
 }
 #elif defined(HAVE_GLIB2)
-void sss_utf8_free(void *ptr)
+void sss_utf8_free(char *ptr)
 {
-    return g_free(ptr);
+    g_free(ptr);
 }
 #else
 #error No unicode library
 #endif
 
+/* Expects and returns NULL-terminated string;
+ * result must be freed with sss_utf8_free()
+ */
 #ifdef HAVE_LIBUNISTRING
-uint8_t *sss_utf8_tolower(const uint8_t *s, size_t len, size_t *_nlen)
+char *sss_utf8_tolower(const char *s)
 {
     size_t llen;
-    uint8_t *lower;
-
-    lower = u8_tolower(s, len, NULL, NULL, NULL, &llen);
-    if (!lower) return NULL;
-
-    if (_nlen) *_nlen = llen;
-    return lower;
+    return u8_tolower((const uint8_t *)s, strlen(s) + 1, NULL, NULL, NULL, &llen);
 }
 #elif defined(HAVE_GLIB2)
-uint8_t *sss_utf8_tolower(const uint8_t *s, size_t len, size_t *_nlen)
+char *sss_utf8_tolower(const char *s)
 {
-    gchar *glower;
-    size_t nlen;
-    uint8_t *lower;
-
-    glower = g_utf8_strdown((const gchar *) s, len);
-    if (!glower) return NULL;
-
-    /* strlen() is safe here because g_utf8_strdown() always null-terminates */
-    nlen = strlen(glower);
-
-    lower = g_malloc(nlen);
-    if (!lower) {
-        g_free(glower);
-        return NULL;
-    }
-
-    memcpy(lower, glower, nlen);
-    g_free(glower);
-    if (_nlen) *_nlen = nlen;
-    return (uint8_t *) lower;
+    return g_utf8_strdown((const gchar *)s, -1);
 }
 #else
 #error No unicode library
@@ -108,10 +86,6 @@ bool sss_utf8_check(const uint8_t *s, size_t n)
 #error No unicode library
 #endif
 
-/* Returns EOK on match, ENOTUNIQ if comparison succeeds but
- * does not match.
- * May return other errno error codes on failure
- */
 #ifdef HAVE_LIBUNISTRING
 errno_t sss_utf8_case_eq(const uint8_t *s1, const uint8_t *s2)
 {

--- a/src/util/sss_utf8.h
+++ b/src/util/sss_utf8.h
@@ -32,13 +32,12 @@
 
 #include "util/util_errors.h"
 
-void sss_utf8_free(void *ptr);
-
-/* The result must be freed with sss_utf8_free() */
-uint8_t *sss_utf8_tolower(const uint8_t *s, size_t len, size_t *nlen);
-
 bool sss_utf8_check(const uint8_t *s, size_t n);
 
+/* Returns EOK on match, ENOTUNIQ if comparison succeeds but
+ * does not match.
+ * May return other errno error codes on failure
+ */
 errno_t sss_utf8_case_eq(const uint8_t *s1, const uint8_t *s2);
 
 

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -525,6 +525,7 @@ char *
 sss_tc_utf8_str_tolower(TALLOC_CTX *mem_ctx, const char *s);
 uint8_t *
 sss_tc_utf8_tolower(TALLOC_CTX *mem_ctx, const uint8_t *s, size_t len, size_t *_nlen);
+/* from sss_utf8.c */
 bool sss_string_equal(bool cs, const char *s1, const char *s2);
 
 /* len includes terminating '\0' */


### PR DESCRIPTION
This patch touches `sss_*_utf8_*_tolower()` helpers:
 - gets rid of some of them
 - simplifies / optimizes code (avoiding excessive realloc's / memcpy's)
 - limits visibility of "internal" helper

It also fixes following covscan error:
```
Error: OVERRUN (CWE-119):
sssd-2.3.2/src/util/sss_utf8.c:75: strlen_assign: Setting variable "nlen" to the return value of strlen called with argument "glower".
sssd-2.3.2/src/util/sss_utf8.c:77: alloc_strlen: Allocating insufficient memory for the terminating null of the string.
 #   75|       nlen = strlen(glower);
 #   76|
 #   77|->     lower = g_malloc(nlen);
 #   78|       if (!lower) {
 #   79|           g_free(glower);
```