### PR TITLE
KCM: Fix SSH GSSAPI delegation for the memory back end

### DIFF
--- a/src/responder/kcm/kcmsrv_ccache_mem.c
+++ b/src/responder/kcm/kcmsrv_ccache_mem.c
@@ -578,7 +578,7 @@ struct tevent_req *ccdb_mem_uuid_by_name_send(TALLOC_CTX *mem_ctx,
 
     ccwrap = memdb_get_by_name(memdb, client, name);
     if (ccwrap == NULL) {
-        ret = ERR_KCM_CC_END;
+        ret = ERR_NO_CREDS;
         goto immediate;
     }
 


### PR DESCRIPTION
When GSSAPI credentials are delegated over SSH, the KCM set default ccache operation looks for a ERR_NO_CREDS return code to continue handling the SSH-created ccache correctly. 

https://github.com/SSSD/sssd/blob/fbc7082149ccc6ee4fe077480a5d692a86e75c79/src/responder/kcm/kcmsrv_ops.c#L1762

The memory back end will now return this error code in this situation, matching the default secdb back end. Note we already have a multihost for GSSAPI delegation with the default KCM back end.

The memory back end is only returning ERR_KCM_CC_END, so i'm not sure if we should be returning ERR_KCM_CC_END elsewhere.