### PR TITLE
SSSCTL: fix logs-remove when log directory is empty

### DIFF
--- a/src/tools/sssctl/sssctl_logs.c
+++ b/src/tools/sssctl/sssctl_logs.c
@@ -254,7 +254,7 @@ errno_t sssctl_logs_remove(struct sss_cmdline *cmdline,
         sss_signal(SIGHUP);
     } else {
         PRINT("Truncating log files...\n");
-        ret = sssctl_run_command("truncate --size 0 " LOG_FILES);
+        ret = sssctl_run_command("truncate --no-create --size 0 " LOG_FILES);
         if (ret != EOK) {
             ERROR("Unable to truncate log files\n");
             return ret;


### PR DESCRIPTION
"sssctl logs-remove" calls "truncate --size 0 *.log" and "*.log"
will expand to literal '*.log' when directory is empty. The result
is a new empty '*.log' file.

Add '--no-create' to truncate call.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>