### PR TITLE
CLIENT:PAM: fixed missed return check

### DIFF
--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -2357,10 +2357,10 @@ static int get_authtok_for_password_change(pam_handle_t *pamh,
                 }
             } else {
                 ret = prompt_password(pamh, pi, _("Current Password: "));
-                if (ret != PAM_SUCCESS) {
-                    D(("failed to get password from user"));
-                    return ret;
-                }
+            }
+            if (ret != PAM_SUCCESS) {
+                D(("failed to get credentials from user"));
+                return ret;
             }
 
             ret = pam_set_item(pamh, PAM_OLDAUTHTOK, pi->pam_authtok);


### PR DESCRIPTION
Return code of `prompt_2fa()` wasn't checked and
thus its fail wasn't properly processed.

Spotted with a help of following warning:
```
Error: CLANG_WARNING:
sssd-2.3.2/src/sss_client/pam_sss.c:2355:21: warning: Value stored to 'ret' is never read
 #                    ret = prompt_2fa(pamh, pi, _("First Factor (Current Password): "),
 #                    ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```