### PR TITLE
spec: disable lto to make mock build work

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -770,6 +770,11 @@ use the KCM: Kerberos credentials cache.
 %setup -q -n %{name}-%{version}
 
 %build
+# make check uses -Wl,-wrap to wrap calls at link time. This is incompatible
+# with LTO. Disable LTO.
+# TODO: disable it only for check if possible
+%define _lto_cflags %{nil}
+
 autoreconf -ivf
 
 %configure \


### PR DESCRIPTION
Mock build on Fedora 33+ does not work in PRCI because LTO
is incompatible with out tests.

This is just a quick fix to make PRCI green again. If anyone
has an idea how to disable it for make check only, bring it.