### PR TITLE
MAN: update 'ldap_referrals' config entry

### DIFF
--- a/src/man/sssd-ldap.5.xml
+++ b/src/man/sssd-ldap.5.xml
@@ -1116,7 +1116,12 @@ host/*
                             example is Microsoft Active Directory. If
                             your setup does not in fact require the use
                             of referrals, setting this option to false
-                            might bring a noticeable performance improvement.
+                            might bring a noticeable performance improvement. 
+                            Setting this option to false is therefore recommended 
+                            in case the SSSD LDAP provider is used together with 
+                            Microsoft Active Directory as a backend. Even if SSSD 
+                            would be able to follow the referral to a different AD 
+                            DC no additional data would be available.
                         </para>
                         <para>
                             Default: true


### PR DESCRIPTION
Add explicit statement that 'ldap_referrals' should be turned off when Active Directory is used as a backend with the SSSD LDAP provider.

Resolves: https://github.com/SSSD/sssd/issues/5338