### PR TITLE
KCM: Fix access after free on shutdown

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3947,6 +3947,7 @@ test_kcm_json_LDADD = \
     $(NULL)
 
 test_kcm_queue_SOURCES = \
+    $(TEST_MOCK_RESP_OBJ) \
     src/tests/cmocka/test_kcm_queue.c \
     src/responder/kcm/kcmsrv_op_queue.c \
     $(NULL)
@@ -3954,10 +3955,13 @@ test_kcm_queue_CFLAGS = \
     $(AM_CFLAGS) \
     $(NULL)
 test_kcm_queue_LDADD = \
+    $(LIBADD_DL) \
     $(CMOCKA_LIBS) \
     $(SSSD_LIBS) \
     $(SSSD_INTERNAL_LTLIBS) \
     libsss_test_common.la \
+    libsss_iface.la \
+    libsss_sbus.la \
     $(NULL)
 
 endif # BUILD_KCM

--- a/src/responder/kcm/kcm.c
+++ b/src/responder/kcm/kcm.c
@@ -147,7 +147,7 @@ static int kcm_get_config(struct kcm_ctx *kctx)
         }
     }
 
-    kctx->qctx = kcm_ops_queue_create(kctx);
+    kctx->qctx = kcm_ops_queue_create(kctx, kctx);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
               "Cannot create KCM request queue [%d]: %s\n",

--- a/src/responder/kcm/kcmsrv_pvt.h
+++ b/src/responder/kcm/kcmsrv_pvt.h
@@ -88,7 +88,8 @@ krb5_error_code sss2krb5_error(errno_t err);
  */
 struct kcm_ops_queue_entry;
 
-struct kcm_ops_queue_ctx *kcm_ops_queue_create(TALLOC_CTX *mem_ctx);
+struct kcm_ops_queue_ctx *kcm_ops_queue_create(TALLOC_CTX *mem_ctx,
+                                               struct kcm_ctx *kctx);
 
 struct tevent_req *kcm_op_queue_send(TALLOC_CTX *mem_ctx,
                                      struct tevent_context *ev,


### PR DESCRIPTION
Skip triggering the queue entry destructor on KCM shutdown to prevent a crash when multiple requests are queued.

Resolves: https://github.com/SSSD/sssd/issues/4733