### PR TITLE
autofs: distinguish between empty cache and offline state

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES])
 AM_CONDITIONAL([HAVE_GCC], [test "$ac_cv_prog_gcc" = yes])
 
 AC_CHECK_HEADERS(stdint.h dlfcn.h)
+AC_CHECK_HEADERS([stdatomic.h],,AC_MSG_ERROR([C11 atomic types are not supported]))
 AC_CONFIG_HEADER(config.h)
 
 AC_CHECK_TYPES([errno_t], [], [], [[#include <errno.h>]])

--- a/src/responder/common/cache_req/cache_req.c
+++ b/src/responder/common/cache_req/cache_req.c
@@ -974,6 +974,13 @@ static void cache_req_search_domains_done(struct tevent_req *subreq)
     case ERR_ID_OUTSIDE_RANGE:
     case ENOENT:
         if (state->check_next == false) {
+            if (state->cr->data->propogate_offline_status && !state->dp_success) {
+                /* Not found and data provider request failed so we were
+                 * unable to fetch the data. */
+                ret = ERR_OFFLINE;
+                goto done;
+            }
+
             /* Not found. */
             ret = ENOENT;
             goto done;
@@ -1002,6 +1009,12 @@ done:
     case EAGAIN:
         break;
     default:
+        if (ret == ENOENT && state->cr->data->propogate_offline_status
+                && !state->dp_success) {
+            /* Not found and data provider request failed so we were
+             * unable to fetch the data. */
+            ret = ERR_OFFLINE;
+        }
         tevent_req_error(req, ret);
         break;
     }

--- a/src/responder/common/cache_req/cache_req.h
+++ b/src/responder/common/cache_req/cache_req.h
@@ -171,6 +171,10 @@ void
 cache_req_data_set_requested_domains(struct cache_req_data *data,
                                      char **requested_domains);
 
+void
+cache_req_data_set_propogate_offline_status(struct cache_req_data *data,
+                                            bool propogate_offline_status);
+
 enum cache_req_type
 cache_req_data_get_type(struct cache_req_data *data);
 

--- a/src/responder/common/cache_req/cache_req_data.c
+++ b/src/responder/common/cache_req/cache_req_data.c
@@ -455,6 +455,18 @@ cache_req_data_set_requested_domains(struct cache_req_data *data,
     data->requested_domains = requested_domains;
 }
 
+void
+cache_req_data_set_propogate_offline_status(struct cache_req_data *data,
+                                            bool propogate_offline_status)
+{
+    if (data == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "cache_req_data should never be NULL\n");
+        return;
+    }
+
+    data->propogate_offline_status = propogate_offline_status;
+}
+
 enum cache_req_type
 cache_req_data_get_type(struct cache_req_data *data)
 {

--- a/src/responder/common/cache_req/cache_req_private.h
+++ b/src/responder/common/cache_req/cache_req_private.h
@@ -103,6 +103,9 @@ struct cache_req_data {
 
     /* if set, only search in the listed domains */
     char **requested_domains;
+
+    /* if set, ERR_OFFLINE is returned if data provider is offline */
+    bool propogate_offline_status;
 };
 
 struct tevent_req *

--- a/src/responder/common/cache_req/plugins/cache_req_autofs_entry_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_autofs_entry_by_name.c
@@ -84,7 +84,7 @@ cache_req_autofs_entry_by_name_dp_send(TALLOC_CTX *mem_ctx,
 
     return sbus_call_dp_autofs_GetEntry_send(mem_ctx, be_conn->conn,
                                              be_conn->bus_name, SSS_BUS_PATH,
-                                             DP_FAST_REPLY, data->name.name,
+                                             0, data->name.name,
                                              data->autofs_entry_name);
 }
 

--- a/src/responder/common/cache_req/plugins/cache_req_autofs_entry_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_autofs_entry_by_name.c
@@ -142,6 +142,8 @@ cache_req_autofs_entry_by_name_send(TALLOC_CTX *mem_ctx,
         return NULL;
     }
 
+    cache_req_data_set_propogate_offline_status(data, true);
+
     return cache_req_steal_data_and_send(mem_ctx, ev, rctx, ncache,
                                          cache_refresh_percent,
                                          CACHE_REQ_POSIX_DOM, domain,

--- a/src/responder/common/cache_req/plugins/cache_req_autofs_map_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_autofs_map_by_name.c
@@ -81,7 +81,7 @@ cache_req_autofs_map_by_name_dp_send(TALLOC_CTX *mem_ctx,
 
     return sbus_call_dp_autofs_GetMap_send(mem_ctx, be_conn->conn,
                                            be_conn->bus_name, SSS_BUS_PATH,
-                                           DP_FAST_REPLY, data->name.name);
+                                           0, data->name.name);
 }
 
 bool

--- a/src/responder/common/cache_req/plugins/cache_req_autofs_map_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_autofs_map_by_name.c
@@ -136,6 +136,8 @@ cache_req_autofs_map_by_name_send(TALLOC_CTX *mem_ctx,
         return NULL;
     }
 
+    cache_req_data_set_propogate_offline_status(data, true);
+
     return cache_req_steal_data_and_send(mem_ctx, ev, rctx, ncache,
                                          cache_refresh_percent,
                                          CACHE_REQ_POSIX_DOM, domain,

--- a/src/responder/common/cache_req/plugins/cache_req_autofs_map_entries.c
+++ b/src/responder/common/cache_req/plugins/cache_req_autofs_map_entries.c
@@ -168,6 +168,8 @@ cache_req_autofs_map_entries_send(TALLOC_CTX *mem_ctx,
         return NULL;
     }
 
+    cache_req_data_set_propogate_offline_status(data, true);
+
     return cache_req_steal_data_and_send(mem_ctx, ev, rctx, ncache,
                                          cache_refresh_percent,
                                          CACHE_REQ_POSIX_DOM, domain,

--- a/src/responder/common/cache_req/plugins/cache_req_autofs_map_entries.c
+++ b/src/responder/common/cache_req/plugins/cache_req_autofs_map_entries.c
@@ -113,7 +113,7 @@ cache_req_autofs_map_entries_dp_send(TALLOC_CTX *mem_ctx,
 
     return sbus_call_dp_autofs_Enumerate_send(mem_ctx, be_conn->conn,
                                               be_conn->bus_name, SSS_BUS_PATH,
-                                              DP_FAST_REPLY, data->name.name);
+                                              0, data->name.name);
 }
 
 bool

--- a/src/sss_client/autofs/autofs_test_client.c
+++ b/src/sss_client/autofs/autofs_test_client.c
@@ -45,10 +45,14 @@ int main(int argc, const char *argv[])
     char *value = NULL;
     char *pc_key = NULL;
     int pc_setent = 0;
+    int pc_protocol = 1;
+    unsigned int protocol;
+    unsigned int requested_protocol = 1;
     struct poptOption long_options[] = {
         POPT_AUTOHELP
         { "by-name",  'n', POPT_ARG_STRING, &pc_key, 0, "Request map by name", NULL },
         { "only-setent",  's', POPT_ARG_VAL, &pc_setent, 1, "Run only setent, do not enumerate", NULL },
+        { "protocol",  'p', POPT_ARG_INT, &pc_protocol, 0, "Protocol version", NULL },
         POPT_TABLEEND
     };
     poptContext pc = NULL;
@@ -68,6 +72,14 @@ int main(int argc, const char *argv[])
     }
 
     poptFreeContext(pc);
+
+    requested_protocol = pc_protocol;
+    protocol = _sss_auto_protocol_version(requested_protocol);
+    if (protocol != requested_protocol) {
+        fprintf(stderr, "Unsupported protocol version: %d -> %d\n",
+                requested_protocol, protocol);
+        exit(EXIT_FAILURE);
+    }
 
     ret = _sss_setautomntent(mapname, &ctx);
     if (ret) {

--- a/src/sss_client/autofs/sss_autofs.exports
+++ b/src/sss_client/autofs/sss_autofs.exports
@@ -2,10 +2,11 @@ EXPORTED {
 
     # public functions
     global:
-                _sss_setautomntent;
-                _sss_getautomntent_r;
-                _sss_getautomntbyname_r;
-                _sss_endautomntent;
+        _sss_auto_protocol_version;
+        _sss_setautomntent;
+        _sss_getautomntent_r;
+        _sss_getautomntbyname_r;
+        _sss_endautomntent;
 
     # everything else is local
     local:

--- a/src/sss_client/autofs/sss_autofs_private.h
+++ b/src/sss_client/autofs/sss_autofs_private.h
@@ -22,6 +22,11 @@
 #include "util/util.h"
 
 /**
+ * Choose an autofs protocol version to be used between autofs and sss_autofs.
+ */
+unsigned int _sss_auto_protocol_version(unsigned int requested);
+
+/**
  * Selects a map for processing.
  */
 errno_t _sss_setautomntent(const char *mapname, void **context);

--- a/src/sss_client/common.c
+++ b/src/sss_client/common.c
@@ -44,6 +44,7 @@
 #define _(STRING) dgettext (PACKAGE, STRING)
 #include "sss_cli.h"
 #include "common_private.h"
+#include "util/util_errors.h"
 
 #if HAVE_PTHREAD
 #include <pthread.h>
@@ -1054,9 +1055,17 @@ int sss_autofs_make_request(enum sss_cli_command cmd,
                             uint8_t **repbuf, size_t *replen,
                             int *errnop)
 {
-    return sss_cli_make_request_with_checks(cmd, rd, SSS_CLI_SOCKET_TIMEOUT,
-                                            repbuf, replen, errnop,
-                                            SSS_AUTOFS_SOCKET_NAME);
+    enum sss_status status;
+
+    status = sss_cli_make_request_with_checks(cmd, rd, SSS_CLI_SOCKET_TIMEOUT,
+                                              repbuf, replen, errnop,
+                                              SSS_AUTOFS_SOCKET_NAME);
+
+    if (*errnop == ERR_OFFLINE) {
+        *errnop = EHOSTDOWN;
+    }
+
+    return status;
 }
 
 int sss_ssh_make_request(enum sss_cli_command cmd,


### PR DESCRIPTION
If the cache is empty and SSSD is offline we now return a proper
error code to autofs so it can iplement a proper retry logic to
fetch the maps when SSSD comes back offline.

This also requires changes in autofs which are not yet available
so the best way to test it with SSSD is to use the autofs test
tool (autofs_test_client) to see that it returns correct error
codes.

Resolves:
https://github.com/SSSD/sssd/issues/3413