### PR TITLE
be: remove accidental sleep

### DIFF
--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -690,8 +690,6 @@ int main(int argc, const char *argv[])
     uid_t uid;
     gid_t gid;
 
-    sleep(5);
-
     struct poptOption long_options[] = {
         POPT_AUTOHELP
         SSSD_MAIN_OPTS


### PR DESCRIPTION
This sleep was used to test a crash in data provider and quite unfortunately
it was left in the patch.

dp: fix potential race condition in provider's sbus server
4a84f8e18ea5604ac7e69849dee492718fd96296.

Perhaps this is the cause of recent failures in session recording tests.