### PR TITLE
krb5_child: Harden credentials validation code

### DIFF
--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -1406,6 +1406,7 @@ static krb5_error_code validate_tgt(struct krb5_req *kr)
 
 
     krb5_verify_init_creds_opt_init(&opt);
+    krb5_verify_init_creds_opt_set_ap_req_nofail(&opt, TRUE);
     kerr = krb5_verify_init_creds(kr->ctx, kr->creds, validation_princ, keytab,
                                   &validation_ccache, &opt);
 


### PR DESCRIPTION
The krb5_verify_init_creds() call is used to validate the credentials
just obtained by trying to acquire a ticket from the KDC that we can
decrypti. This insures the KDC is indeed legitimate as it proves
possesion of the shared key.

However this function will *enforce* this behavior only if the
KRB5_VERIFY_INIT_CREDS_OPT_AP_REQ_NOFAIL options is set to the value
TRUE.

If this option is unset it defaults to FALSE which means verify will
silently return success if no key is available.

SSSD *does* ensure that a key is always available for validation, so
this is not a security bug with the current code. However we add belt
and suspenders here to futureproof this code in case of future
inadvertent changes that may lead to a code path where a key may be
missing.