### PR TITLE
krb5_child: reduce log severity in sss_krb5_prompter

### DIFF
--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -853,7 +853,7 @@ static krb5_error_code sss_krb5_prompter(krb5_context context, void *data,
             }
         }
 
-        DEBUG(SSSDBG_CRIT_FAILURE, "Cannot handle password prompts.\n");
+        DEBUG(SSSDBG_FUNC_DATA, "Prompter interface isn't used for password prompts by SSSD.\n");
         return KRB5_LIBOS_CANTREADPWD;
     }
 


### PR DESCRIPTION
krb5_child primarily uses krb5_get_init_creds_opt_set_responder() /
sss_krb5_responder() to do a work, old scheme sss_krb5_prompter()
is mostly used for debug purposes and password prompt request isn't
a real error here.