### PR TITLE
SDAP: set common options for sockets open by libldap

### DIFF
--- a/src/util/sss_sockets.c
+++ b/src/util/sss_sockets.c
@@ -74,7 +74,7 @@ static errno_t set_fcntl_flags(int fd, int fd_flags, int fl_flags)
     return EOK;
 }
 
-static errno_t set_fd_common_opts(int fd, int timeout)
+errno_t set_fd_common_opts(int fd, int timeout)
 {
     int dummy = 1;
     int ret;

--- a/src/util/sss_sockets.h
+++ b/src/util/sss_sockets.h
@@ -22,6 +22,8 @@
 #ifndef __SSS_SOCKETS_H__
 #define __SSS_SOCKETS_H__
 
+errno_t set_fd_common_opts(int fd, int timeout);
+
 struct tevent_req *sssd_async_connect_send(TALLOC_CTX *mem_ctx,
                                            struct tevent_context *ev,
                                            int fd,


### PR DESCRIPTION
In case of referral chasing libldap can open a new socket on its own.
This socket requires the same setup as socket created by SSSD itself.
Otherwise process can hang on blocked TCP operation.

Resolves: https://github.com/SSSD/sssd/issues/5359