### PR TITLE
DEBUG: fixes program identifier as seen in syslog

### DIFF
--- a/src/util/debug.c
+++ b/src/util/debug.c
@@ -250,7 +250,7 @@ static errno_t journal_send(const char *file,
             "MESSAGE=%s", message,
             "PRIORITY=%i", LOG_DEBUG,
             "SSSD_DOMAIN=%s", domain,
-            "SSSD_PRG_NAME=%s", debug_prg_name,
+            "SSSD_PRG_NAME=sssd[%s]", debug_prg_name,
             "SSSD_DEBUG_LEVEL=%x", level,
             NULL);
     ret = -res;

--- a/src/util/debug.c
+++ b/src/util/debug.c
@@ -201,7 +201,7 @@ static void debug_printf(const char *format, ...)
 }
 
 #ifdef WITH_JOURNALD
-errno_t journal_send(const char *file,
+static errno_t journal_send(const char *file,
         long line,
         const char *function,
         int level,

--- a/src/util/sss_log.c
+++ b/src/util/sss_log.c
@@ -107,7 +107,7 @@ static void sss_log_internal(int priority, int facility, const char *format,
                     "SSSD_DOMAIN=%s", domain,
                     "PRIORITY=%i", syslog_priority,
                     "SYSLOG_FACILITY=%i", LOG_FAC(facility),
-                    "SYSLOG_IDENTIFIER=%s", debug_prg_name,
+                    "SYSLOG_IDENTIFIER=sssd[%s]", debug_prg_name,
                     NULL);
 
     free(message);
@@ -118,15 +118,9 @@ static void sss_log_internal(int priority, int facility, const char *format,
 static void sss_log_internal(int priority, int facility, const char *format,
                             va_list ap)
 {
-    int syslog_priority;
+    int syslog_priority = sss_to_syslog(priority);
 
-    syslog_priority = sss_to_syslog(priority);
-
-    openlog(debug_prg_name, 0, facility);
-
-    vsyslog(syslog_priority, format, ap);
-
-    closelog();
+    vsyslog(facility|syslog_priority, format, ap);
 }
 
 #endif /* WITH_JOURNALD */


### PR DESCRIPTION
Commit 225fe9950f2807d5fb226f6b3be1ff4cefd731f0 changed `debug_prg_name` to accomodate needs of own SSSD logs, but this affected journal/syslog as well.
    
This patch amends situation:
 - journal messages gets "umbrella" identifier "sssd[]"
 - syslog uses default which is program name

Issue was reported at https://bugzilla.redhat.com/show_bug.cgi?id=1888409
