### PR TITLE
ifp: fix use-after-free

### DIFF
--- a/src/responder/ifp/ifpsrv_cmd.c
+++ b/src/responder/ifp/ifpsrv_cmd.c
@@ -128,6 +128,7 @@ static void ifp_user_get_attr_done(struct tevent_req *subreq)
         tevent_req_error(req, ERR_INTERNAL);
         return;
     }
+    fqdn = talloc_steal(state, fqdn);
 
     if (state->search_type == SSS_DP_USER) {
         /* throw away the result and perform attr search */


### PR DESCRIPTION
The variable fqdn is pointing to some data from state->res->msgs[0]. But
before fqdn is used in the next search state->res and the memory
hierarchy below is freed. As a result the location where fqdn is pointing
to might hold the expected data or other data and the search will fail
intermittently.

Resolves: https://github.com/SSSD/sssd/issues/5382