### PR TITLE
krb5: Remove secrets text from drop-in KCM file

### DIFF
--- a/contrib/kcm_default_ccache
+++ b/contrib/kcm_default_ccache
@@ -3,7 +3,7 @@
 # On Fedora/RHEL/CentOS, this is /etc/krb5.conf.d/
 #
 # To enable the KCM credential cache enable the KCM socket and the service:
-#   systemctl enable sssd-secrets.socket sssd-kcm.socket
+#   systemctl enable sssd-kcm.socket
 #   systemctl start sssd-kcm.socket
 #
 # To disable the KCM credential cache, comment out the following lines.


### PR DESCRIPTION
On my Fedora system I get `Failed to enable unit: Unit file sssd-secrets.socket does not exist.`

I believe this secrets socket is no longer needed after KCM was decoupled from secrets.