### PR TITLE
winbind idmap plugin: Fix struct idmap_domain definition

### DIFF
--- a/src/external/samba.m4
+++ b/src/external/samba.m4
@@ -130,15 +130,16 @@ int main(void)
         AC_DEFINE_UNQUOTED(SMB_IDMAP_DOMAIN_HAS_DOM_SID, 1,
                            [Samba's struct idmap_domain has dom_sid member])
         AC_MSG_NOTICE([Samba's struct idmap_domain has dom_sid member])
-        if test $samba_minor_version -ge 12 ; then
-            AC_DEFINE_UNQUOTED(SMB_HAS_NEW_NDR_PULL_STEAL_SWITCH, 1,
-                               [Samba's new push/pull switch functions])
-            AC_MSG_NOTICE([Samba has support for new ndr_push_steal_switch_value and ndr_pull_steal_switch_value functions])
-        else
-            AC_MSG_NOTICE([Samba supports old ndr_pull_steal_switch_value and ndr_pull_steal_switch_value functions])
-        fi
     else
         AC_MSG_NOTICE([Samba's struct idmap_domain does not have dom_sid member])
+    fi
+
+    if ([[ $samba_major_version -gt 4 ]]) ||
+       ([[ $samba_major_version -eq 4 ]] && [[ $samba_minor_version -ge 12 ]]); then
+        AC_DEFINE_UNQUOTED(SMB_HAS_NEW_NDR_PULL_STEAL_SWITCH, 1,
+                           [Samba's new push/pull switch functions])
+        AC_MSG_NOTICE([Samba has support for new ndr_push_steal_switch_value and ndr_pull_steal_switch_value functions])
+    else
         AC_MSG_NOTICE([Samba supports old ndr_pull_steal_switch_value and ndr_pull_steal_switch_value functions])
     fi
 fi

--- a/src/external/samba.m4
+++ b/src/external/samba.m4
@@ -126,7 +126,9 @@ int main(void)
     samba_minor_version=`printf '#include <samba/version.h>\nSAMBA_VERSION_MINOR' | $CPP $SMBCLIENT_CFLAGS -P -`
     samba_release_version=`printf '#include <samba/version.h>\nSAMBA_VERSION_RELEASE' | $CPP $SMBCLIENT_CFLAGS -P -`
     AC_MSG_NOTICE([Samba version: $samba_major_version $samba_minor_version $samba_release_version])
-    if test $samba_major_version -ge 4 -a $samba_minor_version -ge 8 ; then
+    if ([[ $samba_major_version -gt 4 ]]) ||
+       ([[ $samba_major_version -eq 4 ]] && [[ $samba_minor_version -ge 8 ]]) ||
+       ([[ $samba_major_version -eq 4 ]] && [[ $samba_minor_version -eq 7 ]] && [[ $samba_release_version -ge 4 ]]); then
         AC_DEFINE_UNQUOTED(SMB_IDMAP_DOMAIN_HAS_DOM_SID, 1,
                            [Samba's struct idmap_domain has dom_sid member])
         AC_MSG_NOTICE([Samba's struct idmap_domain has dom_sid member])


### PR DESCRIPTION
The patch for samba bug 13052 was backported to samba >= 4.7.4 adding
the dom_sid field to the idmap_domain struct.

This missmatch in the struct definition causes the plugin to fail
all unixids_to_sids and sids_to_unixids calls with
NT_STATUS_INVALID_PARAMETER for samba versions between 4.7.4 and 4.8.

Signed-off-by: Samuel Cabrero <scabrero@suse.de>