### PR TITLE
authtok: add label to Smartcard token

### DIFF
--- a/src/p11_child/p11_child.h
+++ b/src/p11_child/p11_child.h
@@ -68,7 +68,8 @@ bool do_verification_b64(struct p11_ctx *p11_ctx, const char *cert_b64);
 errno_t do_card(TALLOC_CTX *mem_ctx, struct p11_ctx *p11_ctx,
                 enum op_mode mode, const char *pin,
                 const char *module_name_in, const char *token_name_in,
-                const char *key_id_in, const char *uri, char **_multi);
+                const char *key_id_in, const char *label,
+                const char *uri, char **_multi);
 
 errno_t parse_cert_verify_opts(TALLOC_CTX *mem_ctx, const char *verify_opts,
                                struct cert_verify_opts **cert_verify_opts);

--- a/src/p11_child/p11_child_common.c
+++ b/src/p11_child/p11_child_common.c
@@ -60,7 +60,8 @@ static int do_work(TALLOC_CTX *mem_ctx, enum op_mode mode, const char *ca_db,
                    bool wait_for_card,
                    const char *cert_b64, const char *pin,
                    const char *module_name, const char *token_name,
-                   const char *key_id, const char *uri, char **multi)
+                   const char *key_id, const char *label, const char *uri,
+                   char **multi)
 {
     int ret;
     struct p11_ctx *p11_ctx;
@@ -91,7 +92,7 @@ static int do_work(TALLOC_CTX *mem_ctx, enum op_mode mode, const char *ca_db,
         }
     } else {
         ret = do_card(mem_ctx, p11_ctx, mode, pin,
-                      module_name, token_name, key_id, uri, multi);
+                      module_name, token_name, key_id, label, uri, multi);
     }
 
 done:
@@ -158,6 +159,7 @@ int main(int argc, const char *argv[])
     char *module_name = NULL;
     char *token_name = NULL;
     char *key_id = NULL;
+    char *label = NULL;
     char *cert_b64 = NULL;
     bool wait_for_card = false;
     char *uri = NULL;
@@ -194,6 +196,8 @@ int main(int argc, const char *argv[])
          _("Token name for authentication"), NULL},
         {"key_id", 0, POPT_ARG_STRING, &key_id, 0,
          _("Key ID for authentication"), NULL},
+        {"label", 0, POPT_ARG_STRING, &label, 0,
+         _("Label for authentication"), NULL},
         {"certificate", 0, POPT_ARG_STRING, &cert_b64, 0,
          _("certificate to verify, base64 encoded"), NULL},
         {"uri", 0, POPT_ARG_STRING, &uri, 0,
@@ -340,6 +344,7 @@ int main(int argc, const char *argv[])
     }
     talloc_steal(main_ctx, debug_prg_name);
 
+    /* We do not require the label, but it is recommended */
     if (mode == OP_AUTH && (module_name == NULL || token_name == NULL
                                 || key_id == NULL)) {
         DEBUG(SSSDBG_FATAL_FAILURE,
@@ -369,7 +374,8 @@ int main(int argc, const char *argv[])
     }
 
     ret = do_work(main_ctx, mode, ca_db, cert_verify_opts, wait_for_card,
-                  cert_b64, pin, module_name, token_name, key_id, uri, &multi);
+                  cert_b64, pin, module_name, token_name, key_id, label, uri,
+                  &multi);
     if (ret != 0) {
         DEBUG(SSSDBG_OP_FAILURE, "do_work failed.\n");
         goto fail;

--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -714,7 +714,7 @@ static krb5_error_code answer_pkinit(krb5_context ctx,
         kerr = sss_authtok_get_sc(kr->pd->authtok, &pin, NULL,
                                  &token_name, NULL,
                                  &module_name, NULL,
-                                 NULL, NULL);
+                                 NULL, NULL, NULL, NULL);
         if (kerr != EOK) {
             DEBUG(SSSDBG_OP_FAILURE,
                   "sss_authtok_get_sc failed.\n");
@@ -1226,11 +1226,12 @@ static errno_t get_pkinit_identity(TALLOC_CTX *mem_ctx,
     const char *token_name;
     const char *module_name;
     const char *key_id;
+    const char *label;
 
     ret = sss_authtok_get_sc(authtok, NULL, NULL,
                              &token_name, NULL,
                              &module_name, NULL,
-                             &key_id, NULL);
+                             &key_id, NULL, &label, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "sss_authtok_get_sc failed.\n");
         return ret;
@@ -1260,6 +1261,15 @@ static errno_t get_pkinit_identity(TALLOC_CTX *mem_ctx,
 
     if (key_id != NULL && *key_id != '\0') {
         identity = talloc_asprintf_append(identity, ":certid=%s", key_id);
+        if (identity == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "talloc_asprintf_append failed.\n");
+            return ENOMEM;
+        }
+    }
+
+    if (label != NULL && *label != '\0') {
+        identity = talloc_asprintf_append(identity, ":certlabel=%s", label);
         if (identity == NULL) {
             DEBUG(SSSDBG_OP_FAILURE,
                   "talloc_asprintf_append failed.\n");

--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -1258,7 +1258,7 @@ static errno_t pam_forwarder_parse_data(struct cli_ctx *cctx, struct pam_data *p
                     || sss_authtok_get_type(pd->authtok)
                                                == SSS_AUTHTOK_TYPE_SC_KEYPAD)) {
             ret = sss_authtok_get_sc(pd->authtok, NULL, NULL, NULL, NULL, NULL,
-                                     NULL, &key_id, NULL);
+                                     NULL, &key_id, NULL, NULL, NULL);
             if (ret != EOK) {
                 DEBUG(SSSDBG_OP_FAILURE, "sss_authtok_get_sc failed.\n");
                 goto done;
@@ -2274,7 +2274,8 @@ static void pam_dom_forwarder(struct pam_auth_req *preq)
                                  SSS_AUTHTOK_TYPE_SC_PIN, NULL, 0,
                                  sss_cai_get_token_name(preq->current_cert), 0,
                                  sss_cai_get_module_name(preq->current_cert), 0,
-                                 sss_cai_get_key_id(preq->current_cert), 0);
+                                 sss_cai_get_key_id(preq->current_cert), 0,
+                                 sss_cai_get_label(preq->current_cert), 0);
                         if (ret != EOK) {
                             DEBUG(SSSDBG_OP_FAILURE,
                                   "sss_authtok_set_sc failed, Smartcard "

--- a/src/responder/pam/pamsrv_p11.c
+++ b/src/responder/pam/pamsrv_p11.c
@@ -1086,11 +1086,13 @@ static errno_t pack_cert_data(TALLOC_CTX *mem_ctx, const char *sysdb_username,
     const char *token_name;
     const char *module_name;
     const char *key_id;
+    const char *label;
     char *prompt;
     size_t user_len;
     size_t token_len;
     size_t module_len;
     size_t key_id_len;
+    size_t label_len;
     size_t prompt_len;
     size_t nss_name_len;
     const char *username = "";
@@ -1113,16 +1115,18 @@ static errno_t pack_cert_data(TALLOC_CTX *mem_ctx, const char *sysdb_username,
     token_name = sss_cai_get_token_name(cert_info);
     module_name = sss_cai_get_module_name(cert_info);
     key_id = sss_cai_get_key_id(cert_info);
+    label = sss_cai_get_label(cert_info);
 
     user_len = strlen(username) + 1;
     token_len = strlen(token_name) + 1;
     module_len = strlen(module_name) + 1;
     key_id_len = strlen(key_id) + 1;
+    label_len = strlen(label) + 1;
     prompt_len = strlen(prompt) + 1;
     nss_name_len = strlen(nss_username) +1;
 
-    msg_len = user_len + token_len + module_len + key_id_len + prompt_len
-                       + nss_name_len;
+    msg_len = user_len + token_len + module_len + key_id_len + label_len
+                       + prompt_len + nss_name_len;
 
     msg = talloc_zero_size(mem_ctx, msg_len);
     if (msg == NULL) {
@@ -1136,8 +1140,11 @@ static errno_t pack_cert_data(TALLOC_CTX *mem_ctx, const char *sysdb_username,
     memcpy(msg + user_len + token_len, module_name, module_len);
     memcpy(msg + user_len + token_len + module_len, key_id, key_id_len);
     memcpy(msg + user_len + token_len + module_len + key_id_len,
+           label, label_len);
+    memcpy(msg + user_len + token_len + module_len + key_id_len + label_len,
            prompt, prompt_len);
-    memcpy(msg + user_len + token_len + module_len + key_id_len + prompt_len,
+    memcpy(msg + user_len + token_len + module_len + key_id_len + label_len
+               + prompt_len,
            nss_username, nss_name_len);
     talloc_free(prompt);
 

--- a/src/responder/pam/pamsrv_p11.c
+++ b/src/responder/pam/pamsrv_p11.c
@@ -727,6 +727,7 @@ struct tevent_req *pam_check_cert_send(TALLOC_CTX *mem_ctx,
     const char *module_name = NULL;
     const char *token_name = NULL;
     const char *key_id = NULL;
+    const char *label = NULL;
 
     req = tevent_req_create(mem_ctx, &state, struct pam_check_cert_state);
     if (req == NULL) {
@@ -766,7 +767,8 @@ struct tevent_req *pam_check_cert_send(TALLOC_CTX *mem_ctx,
     if (sss_authtok_get_type(pd->authtok) == SSS_AUTHTOK_TYPE_SC_PIN
             || sss_authtok_get_type(pd->authtok) == SSS_AUTHTOK_TYPE_SC_KEYPAD) {
         ret = sss_authtok_get_sc(pd->authtok, NULL, NULL, &token_name, NULL,
-                                 &module_name, NULL, &key_id, NULL);
+                                 &module_name, NULL, &key_id, NULL,
+                                 &label, NULL);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "sss_authtok_get_sc failed.\n");
             goto done;
@@ -783,6 +785,10 @@ struct tevent_req *pam_check_cert_send(TALLOC_CTX *mem_ctx,
         if (key_id != NULL && *key_id != '\0') {
             extra_args[arg_c++] = key_id;
             extra_args[arg_c++] = "--key_id";
+        }
+        if (label != NULL && *label != '\0') {
+            extra_args[arg_c++] = label;
+            extra_args[arg_c++] = "--label";
         }
     }
 

--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -142,6 +142,7 @@ static void free_cai(struct cert_auth_info *cai)
         free(cai->token_name);
         free(cai->module_name);
         free(cai->key_id);
+        free(cai->label);
         free(cai->prompt_str);
         free(cai->choice_list_id);
         free(cai);
@@ -930,6 +931,20 @@ static int parse_cert_info(struct pam_items *pi, uint8_t *buf, size_t len,
     }
 
     offset += strlen(cai->key_id) + 1;
+    if (offset >= len) {
+        D(("Cert message size mismatch"));
+        ret = EINVAL;
+        goto done;
+    }
+
+    cai->label = strdup((char *) &buf[*p + offset]);
+    if (cai->label == NULL) {
+        D(("strdup failed"));
+        ret = ENOMEM;
+        goto done;
+    }
+
+    offset += strlen(cai->label) + 1;
     if (offset >= len) {
         D(("Cert message size mismatch"));
         ret = EINVAL;

--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -128,6 +128,7 @@ struct cert_auth_info {
     char *key_id;
     char *prompt_str;
     char *pam_cert_user;
+    char *choice_list_id;
     struct cert_auth_info *prev;
     struct cert_auth_info *next;
 };
@@ -141,6 +142,7 @@ static void free_cai(struct cert_auth_info *cai)
         free(cai->module_name);
         free(cai->key_id);
         free(cai->prompt_str);
+        free(cai->choice_list_id);
         free(cai);
     }
 }
@@ -1698,7 +1700,15 @@ static int prompt_multi_cert_gdm(pam_handle_t *pamh, struct pam_items *pi)
             ret = ENOMEM;
             goto done;
         }
-        request->list.items[c].key = cai->key_id;
+        free(cai->choice_list_id);
+        ret = asprintf(&cai->choice_list_id, "%zu", c);
+        if (ret == -1) {
+            cai->choice_list_id = NULL;
+            ret = ENOMEM;
+            goto done;
+        }
+
+        request->list.items[c].key = cai->choice_list_id;
         request->list.items[c++].text = prompt;
     }
 
@@ -1719,7 +1729,7 @@ static int prompt_multi_cert_gdm(pam_handle_t *pamh, struct pam_items *pi)
     }
 
     DLIST_FOR_EACH(cai, pi->cert_list) {
-        if (strcmp(response->key, cai->key_id) == 0) {
+        if (strcmp(response->key, cai->choice_list_id) == 0) {
             pam_info(pamh, "Certificate ‘%s’ selected", cai->key_id);
             pi->selected_cert = cai;
             ret = 0;

--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -126,6 +126,7 @@ struct cert_auth_info {
     char *token_name;
     char *module_name;
     char *key_id;
+    char *label;
     char *prompt_str;
     char *pam_cert_user;
     char *choice_list_id;
@@ -1962,6 +1963,7 @@ static int prompt_sc_pin(pam_handle_t *pamh, struct pam_items *pi)
         ret = sss_auth_pack_sc_blob(answer, 0, cai->token_name, 0,
                                     cai->module_name, 0,
                                     cai->key_id, 0,
+                                    cai->label, 0,
                                     NULL, 0, &needed_size);
         if (ret != EAGAIN) {
             D(("sss_auth_pack_sc_blob failed."));
@@ -1979,6 +1981,7 @@ static int prompt_sc_pin(pam_handle_t *pamh, struct pam_items *pi)
         ret = sss_auth_pack_sc_blob(answer, 0, cai->token_name, 0,
                                     cai->module_name, 0,
                                     cai->key_id, 0,
+                                    cai->label, 0,
                                     (uint8_t *) pi->pam_authtok, needed_size,
                                     &needed_size);
         if (ret != EOK) {

--- a/src/tests/cmocka/test_authtok.c
+++ b/src/tests/cmocka/test_authtok.c
@@ -451,25 +451,27 @@ void test_sss_authtok_sc_blobs(void **state)
     size_t module_name_len;
     const char *key_id;
     size_t key_id_len;
+    const char *label;
+    size_t label_len;
 
     ts = talloc_get_type_abort(*state, struct test_state);
 
     ret = sss_auth_pack_sc_blob("abc", 0, "defg", 0, "hijkl", 0, "mnopqr", 0,
-                                NULL, 0, &needed_size);
+                                "stuvw", 0, NULL, 0, &needed_size);
     assert_int_equal(ret, EAGAIN);
 
     buf = talloc_size(ts, needed_size);
     assert_non_null(buf);
 
     ret = sss_auth_pack_sc_blob("abc", 0, "defg", 0, "hijkl", 0, "mnopqr", 0,
-                                buf, needed_size, &needed_size);
+                                "stuvw", 0, buf, needed_size, &needed_size);
     assert_int_equal(ret, EOK);
 
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-    assert_memory_equal(buf, "\4\0\0\0\5\0\0\0\6\0\0\0\7\0\0\0abc\0defg\0hijkl\0mnopqr\0",
+    assert_memory_equal(buf, "\4\0\0\0\5\0\0\0\6\0\0\0\7\0\0\0\6\0\0\0abc\0defg\0hijkl\0mnopqr\0stuvw\0",
                         needed_size);
 #else
-    assert_memory_equal(buf, "\0\0\0\4\0\0\0\5\0\0\0\6\0\0\0\7abc\0defg\0hijkl\0mnopqr\0",
+    assert_memory_equal(buf, "\0\0\0\4\0\0\0\5\0\0\0\6\0\0\0\7\0\0\0\6abc\0defg\0hijkl\0mnopqr\0stuvw\0",
                         needed_size);
 #endif
 
@@ -485,7 +487,8 @@ void test_sss_authtok_sc_blobs(void **state)
     ret = sss_authtok_get_sc(ts->authtoken, &pin, &pin_len,
                              &token_name, &token_name_len,
                              &module_name, &module_name_len,
-                             &key_id, &key_id_len);
+                             &key_id, &key_id_len,
+                             &label, &label_len);
     assert_int_equal(ret, EOK);
     assert_int_equal(pin_len, 3);
     assert_string_equal(pin, "abc");
@@ -495,11 +498,14 @@ void test_sss_authtok_sc_blobs(void **state)
     assert_string_equal(module_name, "hijkl");
     assert_int_equal(key_id_len, 6);
     assert_string_equal(key_id, "mnopqr");
+    assert_int_equal(label_len, 5);
+    assert_string_equal(label, "stuvw");
 
     ret = sss_authtok_get_sc(ts->authtoken, NULL, NULL,
                              &token_name, &token_name_len,
                              &module_name, &module_name_len,
-                             &key_id, &key_id_len);
+                             &key_id, &key_id_len,
+                             &label, &label_len);
     assert_int_equal(ret, EOK);
     assert_int_equal(token_name_len, 4);
     assert_string_equal(token_name, "defg");
@@ -507,15 +513,19 @@ void test_sss_authtok_sc_blobs(void **state)
     assert_string_equal(module_name, "hijkl");
     assert_int_equal(key_id_len, 6);
     assert_string_equal(key_id, "mnopqr");
+    assert_int_equal(label_len, 5);
+    assert_string_equal(label, "stuvw");
 
     ret = sss_authtok_get_sc(ts->authtoken, NULL, NULL,
                              &token_name, NULL,
                              &module_name, NULL,
-                             &key_id, NULL);
+                             &key_id, NULL,
+                             &label, NULL);
     assert_int_equal(ret, EOK);
     assert_string_equal(token_name, "defg");
     assert_string_equal(module_name, "hijkl");
     assert_string_equal(key_id, "mnopqr");
+    assert_string_equal(label, "stuvw");
 
     sss_authtok_set_empty(ts->authtoken);
     talloc_free(buf);
@@ -608,14 +618,14 @@ void test_sss_authtok_sc_pin(void **state)
     assert_int_equal(sss_authtok_get_type(ts->authtoken),
                      SSS_AUTHTOK_TYPE_SC_PIN);
     size = sss_authtok_get_size(ts->authtoken);
-    assert_int_equal(size, 28);
+    assert_int_equal(size, 33);
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     assert_memory_equal(sss_authtok_get_data(ts->authtoken),
-                        "\11\0\0\0\1\0\0\0\1\0\0\0\1\0\0\0" "12345678\0\0\0\0",
+                        "\11\0\0\0\1\0\0\0\1\0\0\0\1\0\0\0\1\0\0\0" "12345678\0\0\0\0\0",
                         size);
 #else
     assert_memory_equal(sss_authtok_get_data(ts->authtoken),
-                        "\0\0\0\11\0\0\0\1\0\0\0\1\0\0\0\1" "12345678\0\0\0\0",
+                        "\0\0\0\11\0\0\0\1\0\0\0\1\0\0\0\1\0\0\0\1" "12345678\0\0\0\0\0",
                         size);
 #endif
 
@@ -624,14 +634,14 @@ void test_sss_authtok_sc_pin(void **state)
     assert_int_equal(sss_authtok_get_type(ts->authtoken),
                      SSS_AUTHTOK_TYPE_SC_PIN);
     size = sss_authtok_get_size(ts->authtoken);
-    assert_int_equal(size, 25);
+    assert_int_equal(size, 30);
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     assert_memory_equal(sss_authtok_get_data(ts->authtoken),
-                        "\6\0\0\0\1\0\0\0\1\0\0\0\1\0\0\0" "12345\0\0\0\0",
+                        "\6\0\0\0\1\0\0\0\1\0\0\0\1\0\0\0\1\0\0\0" "12345\0\0\0\0\0",
                         size);
 #else
     assert_memory_equal(sss_authtok_get_data(ts->authtoken),
-                        "\0\0\0\6\0\0\0\1\0\0\0\1\0\0\0\1" "12345\0\0\0\0",
+                        "\0\0\0\6\0\0\0\1\0\0\0\1\0\0\0\1\0\0\0\1" "12345\0\0\0\0\0",
                         size);
 #endif
 

--- a/src/tests/cmocka/test_pam_srv.c
+++ b/src/tests/cmocka/test_pam_srv.c
@@ -62,13 +62,16 @@
 #define TEST_TOKEN_NAME "SSSD Test Token"
 #define TEST_TOKEN2_NAME "SSSD Test Token Number 2"
 #define TEST_KEY_ID "C554C9F82C2A9D58B70921C143304153A8A42F17"
+#define TEST_LABEL "SSSD test cert 0001"
 #define TEST_MODULE_NAME SOFTHSM2_PATH
 #define TEST_PROMPT "SSSD test cert 0001\nCN=SSSD test cert 0001,OU=SSSD test,O=SSSD"
 #define TEST2_PROMPT "SSSD test cert 0002\nCN=SSSD test cert 0002,OU=SSSD test,O=SSSD"
 #define TEST5_PROMPT "SSSD test cert 0005\nCN=SSSD test cert 0005,OU=SSSD test,O=SSSD"
 
 #define TEST2_KEY_ID "5405842D56CF31F0BB025A695C5F3E907051C5B9"
+#define TEST2_LABEL "SSSD test cert 0002"
 #define TEST5_KEY_ID "1195833C424AB00297F582FC43FFFFAB47A64CC9"
+#define TEST5_LABEL "SSSD test cert 0005"
 
 static char CACHED_AUTH_TIMEOUT_STR[] = "4";
 static const int CACHED_AUTH_TIMEOUT = 4;
@@ -673,6 +676,7 @@ static int test_pam_cert_check_gdm_smartcard(uint32_t status, uint8_t *body,
                                 + sizeof(TEST_TOKEN_NAME)
                                 + sizeof(TEST_MODULE_NAME)
                                 + sizeof(TEST_KEY_ID)
+                                + sizeof(TEST_LABEL)
                                 + sizeof(TEST_PROMPT)
                                 + sizeof("pamuser")));
 
@@ -691,6 +695,10 @@ static int test_pam_cert_check_gdm_smartcard(uint32_t status, uint8_t *body,
     assert_int_equal(*(body + rp + sizeof(TEST_KEY_ID) - 1), 0);
     assert_string_equal(body + rp, TEST_KEY_ID);
     rp += sizeof(TEST_KEY_ID);
+
+    assert_int_equal(*(body + rp + sizeof(TEST_LABEL) - 1), 0);
+    assert_string_equal(body + rp, TEST_LABEL);
+    rp += sizeof(TEST_LABEL);
 
     assert_int_equal(*(body + rp + sizeof(TEST_PROMPT) - 1), 0);
     assert_string_equal(body + rp, TEST_PROMPT);
@@ -740,6 +748,7 @@ static int test_pam_cert_check_ex(uint32_t status, uint8_t *body, size_t blen,
                                     TEST_TOKEN_NAME,
                                     TEST_MODULE_NAME,
                                     TEST_KEY_ID,
+                                    TEST_LABEL,
                                     TEST_PROMPT,
                                     NULL,
                                     NULL };
@@ -749,6 +758,7 @@ static int test_pam_cert_check_ex(uint32_t status, uint8_t *body, size_t blen,
                                      TEST_TOKEN_NAME,
                                      TEST_MODULE_NAME,
                                      TEST2_KEY_ID,
+                                     TEST2_LABEL,
                                      TEST2_PROMPT,
                                      NULL,
                                      NULL };
@@ -756,10 +766,10 @@ static int test_pam_cert_check_ex(uint32_t status, uint8_t *body, size_t blen,
     assert_int_equal(status, 0);
 
     check_strings[0] = name;
-    check_strings[5] = nss_name;
+    check_strings[6] = nss_name;
     check_len = check_string_array_len(check_strings);
     check2_strings[0] = name;
-    check2_strings[5] = nss_name;
+    check2_strings[6] = nss_name;
     check2_len = check_string_array_len(check2_strings);
 
 
@@ -843,6 +853,7 @@ static int test_pam_cert2_token2_check_ex(uint32_t status, uint8_t *body,
                                      TEST_TOKEN2_NAME,
                                      TEST_MODULE_NAME,
                                      TEST2_KEY_ID,
+                                     TEST2_LABEL,
                                      TEST2_PROMPT,
                                      NULL,
                                      NULL };
@@ -850,7 +861,7 @@ static int test_pam_cert2_token2_check_ex(uint32_t status, uint8_t *body,
     assert_int_equal(status, 0);
 
     check2_strings[0] = name;
-    check2_strings[5] = nss_name;
+    check2_strings[6] = nss_name;
     check2_len = check_string_array_len(check2_strings);
 
     SAFEALIGN_COPY_UINT32(&val, body + rp, &rp);
@@ -895,7 +906,7 @@ static int test_pam_cert_X_token_X_check_ex(uint32_t status, uint8_t *body,
     assert_int_equal(status, 0);
 
     check_strings[0] = name;
-    check_strings[5] = nss_name;
+    check_strings[6] = nss_name;
     check_len = check_string_array_len(check_strings);
 
     SAFEALIGN_COPY_UINT32(&val, body + rp, &rp);
@@ -946,6 +957,7 @@ static int test_pam_cert5_check(uint32_t status, uint8_t *body, size_t blen)
                                      TEST_TOKEN_NAME,
                                      TEST_MODULE_NAME,
                                      TEST5_KEY_ID,
+                                     TEST5_LABEL,
                                      TEST5_PROMPT,
                                      NULL,
                                      NULL };

--- a/src/tests/test_CA/Makefile.am
+++ b/src/tests/test_CA/Makefile.am
@@ -6,6 +6,7 @@ dist_noinst_DATA = \
     SSSD_test_cert_0003.config \
     SSSD_test_cert_0004.config \
     SSSD_test_cert_0005.config \
+    SSSD_test_cert_0006.config \
     SSSD_test_cert_key_0001.pem \
     SSSD_test_cert_key_0002.pem \
     SSSD_test_cert_key_0003.pem \
@@ -25,7 +26,7 @@ pubkeys = $(addprefix SSSD_test_cert_pubsshkey_,$(addsuffix .pub,$(ids)))
 pubkeys_h = $(addprefix SSSD_test_cert_pubsshkey_,$(addsuffix .h,$(ids)))
 pkcs12 = $(addprefix SSSD_test_cert_pkcs12_,$(addsuffix .pem,$(ids)))
 
-extra = softhsm2_none softhsm2_one softhsm2_two softhsm2_2tokens softhsm2_ocsp
+extra = softhsm2_none softhsm2_one softhsm2_two softhsm2_2tokens softhsm2_ocsp softhsm2_2certs_same_id
 if HAVE_FAKETIME
 extra += SSSD_test_CA_expired_crl.pem
 endif
@@ -41,6 +42,14 @@ $(pwdfile):
 SSSD_test_CA.pem: $(openssl_ca_key) $(openssl_ca_config) serial
 	$(OPENSSL) req -batch -config ${openssl_ca_config} -x509 -new -nodes -key $< -sha256 -days 1024 -set_serial 0 -extensions v3_ca -out $@
 
+# SSSD_test_cert_0006 should use the same key as SSSD_test_cert_0001
+.INTERMEDIATE: SSSD_test_cert_req_0006.pem
+SSSD_test_cert_req_0006.pem: $(srcdir)/SSSD_test_cert_key_0001.pem $(srcdir)/SSSD_test_cert_0006.config
+	if [ $(shell grep -c req_exts $(srcdir)/SSSD_test_cert_0006.config) -eq 0 ]; then \
+		$(OPENSSL) req -new -nodes -key $< -config $(srcdir)/SSSD_test_cert_0006.config -out $@ ; \
+	else \
+		$(OPENSSL) req -new -nodes -key $< -reqexts req_exts -config $(srcdir)/SSSD_test_cert_0006.config -out $@ ; \
+	fi
 
 SSSD_test_cert_req_%.pem: $(srcdir)/SSSD_test_cert_key_%.pem $(srcdir)/SSSD_test_cert_%.config
 	if [ $(shell grep -c req_exts $(srcdir)/SSSD_test_cert_$*.config) -eq 0 ]; then \
@@ -51,6 +60,9 @@ SSSD_test_cert_req_%.pem: $(srcdir)/SSSD_test_cert_key_%.pem $(srcdir)/SSSD_test
 
 SSSD_test_cert_x509_%.pem: SSSD_test_cert_req_%.pem $(openssl_ca_config) SSSD_test_CA.pem
 	$(OPENSSL) ca -config ${openssl_ca_config} -batch -notext -keyfile $(openssl_ca_key) -in $< -days 200 -extensions usr_cert -out $@
+
+SSSD_test_cert_pkcs12_0006.pem: SSSD_test_cert_x509_0006.pem $(srcdir)/SSSD_test_cert_key_0001.pem $(pwdfile)
+	$(OPENSSL) pkcs12 -export -in SSSD_test_cert_x509_0006.pem -inkey $(srcdir)/SSSD_test_cert_key_0001.pem -nodes -passout file:$(pwdfile) -out $@
 
 SSSD_test_cert_pkcs12_%.pem: SSSD_test_cert_x509_%.pem $(srcdir)/SSSD_test_cert_key_%.pem $(pwdfile)
 	$(OPENSSL) pkcs12 -export -in SSSD_test_cert_x509_$*.pem -inkey $(srcdir)/SSSD_test_cert_key_$*.pem -nodes -passout file:$(pwdfile) -out $@
@@ -127,6 +139,18 @@ softhsm2_ocsp: softhsm2_ocsp.conf SSSD_test_cert_x509_0005.pem
 
 softhsm2_ocsp.conf:
 	@echo "directories.tokendir = "$(abs_top_builddir)"/src/tests/test_CA/softhsm2_ocsp" > $@
+	@echo "objectstore.backend = file" >> $@
+	@echo "slots.removable = true" >> $@
+
+softhsm2_2certs_same_id: softhsm2_2certs_same_id.conf SSSD_test_cert_x509_0001.pem SSSD_test_cert_x509_0006.pem
+	mkdir $@
+	SOFTHSM2_CONF=./$< $(SOFTHSM2_UTIL) --init-token  --label "SSSD Test Token" --pin 123456 --so-pin 123456 --free
+	GNUTLS_PIN=123456 SOFTHSM2_CONF=./$< $(P11TOOL) --provider=$(SOFTHSM2_PATH) --write --no-mark-private --load-certificate=SSSD_test_cert_x509_0006.pem --login  --label 'SSSD test cert 0006' --id '11111111'
+	GNUTLS_PIN=123456 SOFTHSM2_CONF=./$< $(P11TOOL) --provider=$(SOFTHSM2_PATH) --write --no-mark-private --load-certificate=SSSD_test_cert_x509_0001.pem --login  --label 'SSSD test cert 0001' --id '11111111'
+	GNUTLS_PIN=123456 SOFTHSM2_CONF=./$< $(P11TOOL) --provider=$(SOFTHSM2_PATH) --write --load-privkey=$(srcdir)/SSSD_test_cert_key_0001.pem --login  --label 'SSSD test cert 0001' --id '11111111'
+
+softhsm2_2certs_same_id.conf:
+	@echo "directories.tokendir = "$(abs_top_builddir)"/src/tests/test_CA/softhsm2_2certs_same_id" > $@
 	@echo "objectstore.backend = file" >> $@
 	@echo "slots.removable = true" >> $@
 

--- a/src/tests/test_CA/SSSD_test_cert_0006.config
+++ b/src/tests/test_CA/SSSD_test_cert_0006.config
@@ -1,0 +1,20 @@
+# This certificate is used in
+# - src/tests/cmocka/test_pam_srv.c
+# and should use the same key-pair as SSSD_test_cert_0001
+[ req ]
+distinguished_name = req_distinguished_name
+prompt = no
+
+[ req_distinguished_name ]
+O = SSSD
+OU = SSSD test
+CN = SSSD test cert 0006
+
+[ req_exts ]
+basicConstraints = CA:FALSE
+nsCertType = client, email
+nsComment = "SSSD test Certificate"
+subjectKeyIdentifier = hash
+keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth, emailProtection
+subjectAltName = email:sssd-devel@lists.fedorahosted.org,URI:https://github.com/SSSD/sssd//

--- a/src/util/authtok-utils.h
+++ b/src/util/authtok-utils.h
@@ -39,6 +39,9 @@
  * @param[in]  key_id      Key ID of the certificate
  * @param[in]  key_id_len  Length of the key id of the certificate, if 0
  *                         strlen() will be called internally
+ * @param[in]  label       Label of the certificate
+ * @param[in]  label_len   Length of the label of the certificate, if 0
+ *                         strlen() will be called internally
  * @param[in]  buf         memory buffer of size buf_len, may be NULL
  * @param[in]  buf_len     size of memory buffer buf
  *
@@ -53,6 +56,7 @@ errno_t sss_auth_pack_sc_blob(const char *pin, size_t pin_len,
                               const char *token_name, size_t token_name_len,
                               const char *module_name, size_t module_name_len,
                               const char *key_id, size_t key_id_len,
+                              const char *label, size_t label_len,
                               uint8_t *buf, size_t buf_len,
                               size_t *_sc_blob_len);
 /**
@@ -112,6 +116,10 @@ errno_t sss_auth_unpack_2fa_blob(TALLOC_CTX *mem_ctx,
  * @param[out] _token_name_len   Length of the token name
  * @param[out] _module_name      Name of PKCS#11 module, null terminated
  * @param[out] _module_name_len  Length of the module name
+ * @param[out] _key_id           Key ID of the certificate, null terminated
+ * @param[out] _key_id_len       Length of the key ID
+ * @param[out] _labe l           Label of the certificate, null terminated
+ * @param[out] _label_len        Length of the label
  *
  * @return     EOK       on success
  *             EINVAL    if input data is not consistent
@@ -122,7 +130,8 @@ errno_t sss_auth_unpack_sc_blob(TALLOC_CTX *mem_ctx,
                                  char **pin, size_t *_pin_len,
                                  char **token_name, size_t *_token_name_len,
                                  char **module_name, size_t *_module_name_len,
-                                 char **key_id, size_t *_key_id_len);
+                                 char **key_id, size_t *_key_id_len,
+                                 char **label, size_t *_label_len);
 
 /**
  * @brief Return a pointer to the PIN string in the memory buffer

--- a/src/util/authtok.h
+++ b/src/util/authtok.h
@@ -296,6 +296,10 @@ void sss_authtok_set_sc_keypad(struct sss_auth_token *tok);
  *                        terminated string containing the PKCS#11 key id
  * @param key_id_len      The length of the key id string, if set to 0 it will be
  *                        calculated
+ * @param label           A pointer to a const char *, that will point to a null
+ *                        terminated string containing the PKCS#11 label
+ * @param label_len       The length of the label string, if set to 0 it will be
+ *                        calculated
  *
  * @return       EOK on success
  *               EINVAL unexpected or inval input
@@ -306,7 +310,8 @@ errno_t sss_authtok_set_sc(struct sss_auth_token *tok,
                            const char *pin, size_t pin_len,
                            const char *token_name, size_t token_name_len,
                            const char *module_name, size_t module_name_len,
-                           const char *key_id, size_t key_id_len);
+                           const char *key_id, size_t key_id_len,
+                           const char *label, size_t label_len);
 /**
  * @brief Set a Smart Card authentication data, replacing any previous data
  *
@@ -342,6 +347,10 @@ errno_t sss_authtok_set_sc_from_blob(struct sss_auth_token *tok,
  *                              a null terminated string holding the PKCS#11
  *                              key id, may not be modified or freed
  * @param[out] _key_id_len      Length of the PKCS#11 key id
+ * @param[out] _label           A pointer to a const char *, that will point to
+ *                              a null terminated string holding the PKCS#11
+ *                              label, may not be modified or freed
+ * @param[out] _label_len       Length of the PKCS#11 label
  *
  * Any of the output pointers may be NULL if the caller does not need the
  * specific item.
@@ -356,7 +365,8 @@ errno_t sss_authtok_get_sc(struct sss_auth_token *tok,
                            const char **_pin, size_t *_pin_len,
                            const char **_token_name, size_t *_token_name_len,
                            const char **_module_name, size_t *_module_name_len,
-                           const char **_key_id, size_t *_key_id_len);
+                           const char **_key_id, size_t *_key_id_len,
+                           const char **_label, size_t *_label_len);
 
 
 /**


### PR DESCRIPTION
The key-id might not be sufficient to identify a certificate on a Smartcard
since it is possible that multiple certificates will use the same key.

This patch adds the certificate label to the Smartcard authtok item to
about the ambiguity if the key-id is used for multiple certificates.

Currently the key-id read from the Smartcard is used as key value for the
gdm choice list dialog. Since it might be possible that multiple
certificates use the same key and hence the same key-id this is not a
suitable value.

With this patch the string representation of a numerial counter is used.

Resolves: https://github.com/SSSD/sssd/issues/5400