### PR TITLE
kcm: check socket path loaded from configuration

### DIFF
--- a/src/man/sssd-kcm.8.xml
+++ b/src/man/sssd-kcm.8.xml
@@ -203,6 +203,13 @@ systemctl restart sssd-kcm.service
                     <para>
                         Default: <replaceable>/var/run/.heim_org.h5l.kcm-socket</replaceable>
                     </para>
+                    <para>
+                        <phrase condition="have_systemd">
+                            Note: on platforms where systemd is supported, the
+                            socket path is overwritten by the one defined in
+                            the sssd-kcm.socket unit file.
+                        </phrase>
+                    </para>
                 </listitem>
             </varlistentry>
             <varlistentry>


### PR DESCRIPTION
There are three major execution flows for this change:
1. If kcm socket path is not defined in sssd configuration, then log it and fall back to the default location.
2. If kcm socket path is defined in sssd configuration but the location is invalid, then log it and fail.
3. If kcm socket path is defined in sssd configuration and the location is valid, then use it.

Apart from that some unit and integration tests have been implement to check that the changes work as expected.

I wonder if the changes included in confdb_get_string() should be ported to all confdb_get_*() methods.

Resolves: https://github.com/SSSD/sssd/issues/5406