### PR TITLE
ifp: fix original fix use-after-free

### DIFF
--- a/src/responder/ifp/ifpsrv_cmd.c
+++ b/src/responder/ifp/ifpsrv_cmd.c
@@ -128,10 +128,10 @@ static void ifp_user_get_attr_done(struct tevent_req *subreq)
         tevent_req_error(req, ERR_INTERNAL);
         return;
     }
-    fqdn = talloc_steal(state, fqdn);
 
     if (state->search_type == SSS_DP_USER) {
-        /* throw away the result and perform attr search */
+        /* throw away the result but keep the fqdn and perform attr search */
+        fqdn = talloc_steal(state, fqdn);
         talloc_zfree(state->res);
 
         ret = sysdb_get_user_attr_with_views(state, state->dom, fqdn,


### PR DESCRIPTION
The original fix stole the fqdn too earlier. Only for SSS_DP_USER
requests the steal is important. For other request where the first
result is returned to the caller the original version
might even cause issues since the name does not belong to the memory
hierarchy of the result anymore.

Resolves: https://github.com/SSSD/sssd/issues/5382