### PR TITLE
fp: fix original fix use-after-free - 1.16 version

### DIFF
--- a/src/responder/ifp/ifpsrv_cmd.c
+++ b/src/responder/ifp/ifpsrv_cmd.c
@@ -124,7 +124,6 @@ ifp_user_get_attr_unpack_msg(struct ifp_attr_req *attr_req)
     if (attr_req->attrs == NULL) {
         return ENOMEM;
     }
-    fqdn = talloc_steal(state, fqdn);
 
     ai = 0;
     for (i = 0; i < nattrs; i++) {
@@ -576,7 +575,8 @@ static void ifp_user_get_attr_done(struct tevent_req *subreq)
     }
 
     if (state->search_type == SSS_DP_USER) {
-        /* throw away the result and perform attr search */
+        /* throw away the result but keep the fqdn and perform attr search */
+        fqdn = talloc_steal(state, fqdn);
         talloc_zfree(state->res);
 
         ret = sysdb_get_user_attr_with_views(state, state->dom, fqdn,


### PR DESCRIPTION
This should have been a cherry-pick of
3b158934cbb8f87cbfaf1650389b8dcd654b92ca but the cherry-pick of the
original patch was broken and placed the change into a different function.

This patch fixes this by directly placing the change at the right place.

Resolves:
https://github.com/SSSD/sssd/issues/5382