### PR TITLE
KCM: avoid NULL deref

### DIFF
--- a/src/responder/kcm/kcmsrv_op_queue.c
+++ b/src/responder/kcm/kcmsrv_op_queue.c
@@ -122,14 +122,11 @@ static int kcm_op_queue_entry_destructor(struct kcm_ops_queue_entry *entry)
 {
     struct kcm_ops_queue_entry *next_entry;
     struct tevent_immediate *imm;
-    bool terminating;
-
-    terminating = entry->queue->qctx->kctx->rctx->shutting_down;
 
     if (entry == NULL) {
         return 1;
     /* Prevent use-after-free of req when shutting down with non-empty queue */
-    } else if (terminating) {
+    } else if (entry->queue->qctx->kctx->rctx->shutting_down) {
         return 0;
     }
 


### PR DESCRIPTION
Fixes following issue:
```
/src/responder/kcm/kcmsrv_op_queue.c:129: check_after_deref: Null-checking "entry" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
 #   127|       terminating = entry->queue->qctx->kctx->rctx->shutting_down;
 #   128|
 #   129|->     if (entry == NULL) {
 #   130|           return 1;
 #   131|       /* Prevent use-after-free of req when shutting down with non-empty queue */
```