### PR TITLE
tests: Adding tests to cover ad discovery improvements using cldap

### DIFF
--- a/src/tests/multihost/adsites/conftest.py
+++ b/src/tests/multihost/adsites/conftest.py
@@ -1,0 +1,305 @@
+
+""" Common AD Fixtures """
+from __future__ import print_function
+import subprocess
+import time
+import pytest
+import os
+import posixpath
+from sssd.testlib.common.paths import SSSD_DEFAULT_CONF, NSSWITCH_DEFAULT_CONF
+from sssd.testlib.common.qe_class import session_multihost
+from sssd.testlib.common.exceptions import SSSDException
+from sssd.testlib.common.samba import sambaTools
+from sssd.testlib.common.utils import ADOperations
+from sssd.testlib.common.utils import sssdTools
+
+
+def pytest_configure():
+    """ Namespace hook, Adds below dict to pytest namespace """
+    pytest.num_masters = 0
+    pytest.num_ad = 2
+    pytest.num_atomic = 0
+    pytest.num_replicas = 0
+    pytest.num_clients = 1
+    pytest.num_others = 0
+
+# ######## Function scoped Fixtures ####################
+
+
+@pytest.fixture(scope="function")
+def smbconfig(session_multihost, request):
+    """ Configure smb.conf """
+    sambaclient = sambaTools(session_multihost.client[0],
+                             session_multihost.ad[0])
+    sambaclient.smbadsconf()
+
+    def restore():
+        """ Restore smb.conf """
+        restoresmb = 'cp -f /etc/samba/smb.conf.orig /etc/samba/smb.conf'
+        session_multihost.client[0].run_command(restoresmb, raiseonerr=False)
+        removebkup = 'rm -f /etc/samba/smb.conf.orig'
+        session_multihost.client[0].run_command(removebkup, raiseonerr=False)
+    request.addfinalizer(restore)
+
+
+@pytest.fixture(scope='function')
+def run_powershell_script(session_multihost, request):
+    """ Run Powershell script """
+    cwd = os.path.dirname(os.path.abspath(__file__))
+    split_cwd = cwd.split('/')
+    idx = split_cwd.index('pytest')
+    path_list = split_cwd[:idx + 1]
+    sssd_qe_path = '/'.join(path_list)
+    data_path = "%s/data" % sssd_qe_path
+
+    def _script(name):
+        """ Run powershell script """
+        filename = name
+        remote_file_path = posixpath.join('/home/administrator', filename)
+        source_file_path = posixpath.join(data_path, filename)
+        session_multihost.ad[0].transport.put_file(source_file_path,
+                                                   remote_file_path)
+        pwrshell_cmd = 'powershell.exe -inputformat '\
+                       'none -noprofile ./%s' % filename
+        cmd = session_multihost.ad[0].run_command(pwrshell_cmd,
+                                                  raiseonerr=False)
+        return cmd
+    return _script
+
+
+@pytest.fixture(scope="function")
+def adjoin(session_multihost, request):
+    """ Join to AD using net ads command """
+    ad_realm = session_multihost.ad[0].realm
+    ad_ip = session_multihost.ad[0].ip
+    client_ad = sssdTools(session_multihost.client[0], session_multihost.ad[0])
+
+    client_ad.disjoin_ad()  # Make sure system is disjoined from AD
+    client_ad.create_kdcinfo(ad_realm, ad_ip)
+    kinit = "kinit Administrator"
+    ad_password = session_multihost.ad[0].ssh_password
+    try:
+        session_multihost.client[0].run_command(kinit, stdin_text=ad_password)
+    except subprocess.CalledProcessError:
+        pytest.fail("kinit failed")
+
+    def _join(membersw=None):
+        """ Join AD """
+        if membersw == 'samba':
+            client_ad.join_ad(ad_realm, ad_password, mem_sw='samba')
+        else:
+            client_ad.join_ad(ad_realm, ad_password)
+
+    def adleave():
+        """ Disjoin AD """
+        client_ad.disjoin_ad()
+        remove_keytab = 'rm -f /etc/krb5.keytab'
+        kdestroy_cmd = 'kdestroy -A'
+        session_multihost.client[0].run_command(kdestroy_cmd)
+        session_multihost.client[0].run_command(remove_keytab)
+    request.addfinalizer(adleave)
+    return _join
+
+
+@pytest.fixture(scope="function")
+def get_rid(session_multihost, create_aduser_group):
+    """
+    Find Relative ID from object SID
+    :param obj session_multihost: multihost object
+    :Return: RID value
+    """
+    (user, _) = create_aduser_group
+    client = sssdTools(session_multihost.client[0], session_multihost.ad[0])
+    client.clear_sssd_cache()
+    ad_user = '{}@{}'.format(user, session_multihost.ad[0].domainname)
+    getent = 'getent passwd %s' % ad_user
+    cmd = session_multihost.client[0].run_command(getent, raiseonerr=False)
+    if cmd.returncode == 0:
+        rid = client.find_rid(ad_user)
+        return (ad_user, rid)
+    else:
+        pytest.fail("%s User lookup failed" % ad_user)
+
+
+@pytest.fixture(scope="function")
+def keytab_sssd_conf(session_multihost, request, adjoin):
+    """ Add parameters required for keytab rotation in sssd.conf """
+    adjoin(membersw='samba')
+    client = sssdTools(session_multihost.client[0], session_multihost.ad[0])
+    client.backup_sssd_conf()
+    sssd_params = {'ad_maximum_machine_account_password_age': '1',
+                   'ad_machine_account_password_renewal_opts': '300:15',
+                   'debug_level': '9'}
+    domain_name = client.get_domain_section_name()
+    domain_section = 'domain/{}'.format(domain_name)
+    client.sssd_conf(domain_section, sssd_params,)
+
+    def restore_sssd_conf():
+        """ Restore original sssd.conf """
+        client.restore_sssd_conf()
+    request.addfinalizer(restore_sssd_conf)
+
+
+@pytest.fixture(scope="function")
+def cifsmount(session_multihost, request):
+    """ Mount cifs share and create files with
+    different permissions
+    """
+    ad_user = 'idmfoouser1'
+    ad_group = 'idmfoogroup1'
+    kinit = 'kinit %s' % ad_user
+    server = session_multihost.master[0].sys_hostname.strip().split('.')[0]
+    share_path = '/mnt/samba/share1'
+    session_multihost.client[0].run_command(kinit, stdin_text='Secret123')
+    mountcifs = "mount -t cifs -o cifsacl "\
+                "-o sec=krb5 -o username=%s //%s/share1"\
+                " /mnt/samba/share1" % (ad_user, server)
+    cmd = session_multihost.client[0].run_command(mountcifs, raiseonerr=False)
+    time.sleep(5)
+    if cmd.returncode != 0:
+        journalctl = 'journalctl -x -n 50 --no-pager'
+        session_multihost.client[0].run_command(journalctl)
+
+    def cifsunmount():
+        """ Umount the cifs shares """
+        umount = "umount /mnt/samba/share1"
+        cmd = session_multihost.client[0].run_command(umount, raiseonerr=False)
+        assert cmd.returncode == 0
+        kdestroy = 'kdestroy -A'
+        session_multihost.client[0].run_command(kdestroy, raiseonerr=False)
+    request.addfinalizer(cifsunmount)
+
+
+@pytest.fixture(scope='function')
+def backupsssdconf(session_multihost, request):
+    """ Backup and restore sssd.conf """
+    bkup = 'cp -f %s %s.orig' % (SSSD_DEFAULT_CONF,
+                                 SSSD_DEFAULT_CONF)
+    session_multihost.client[0].run_command(bkup)
+    session_multihost.client[0].service_sssd('stop')
+
+    def restoresssdconf():
+        """ Restore sssd.conf """
+        restore = 'cp -f %s.orig %s' % (SSSD_DEFAULT_CONF, SSSD_DEFAULT_CONF)
+        session_multihost.client[0].run_command(restore)
+    request.addfinalizer(restoresssdconf)
+
+
+@pytest.fixture(scope='function')
+def create_site(session_multihost, request):
+    ad2_hostname = session_multihost.ad[1].hostname
+    ad2_shostname = ad2_hostname.strip().split('.')[0]
+    site = "Raleigh"
+
+    cmd_create_site = "powershell.exe -inputformat none -noprofile " \
+                      "'(New-ADReplicationSite -Name \"%s\" " \
+                      "-Confirm:$false)'" % site
+    cmd_move_ad2 = "powershell.exe -inputformat none -noprofile " \
+                   "'(Move-ADDirectoryServer -Identity \"%s\" -Site \"%s\" " \
+                   "-Confirm:$false)'" % (ad2_shostname, site)
+
+    session_multihost.ad[0].run_command(cmd_create_site)
+    session_multihost.ad[0].run_command(cmd_move_ad2)
+
+    def teardown_site():
+        cmd_move_ad2back = "powershell.exe -inputformat none -noprofile " \
+                           "'(Move-ADDirectoryServer -Identity \"%s\" " \
+                           "-Site \"Default-First-Site-Name\" " \
+                           "-Confirm:$false)'" % ad2_shostname
+        cmd_remove_site2 = "powershell.exe -inputformat none -noprofile " \
+                           "'(Remove-ADReplicationSite \"%s\" " \
+                           "-Confirm:$false)'" % site
+        session_multihost.ad[0].run_command(cmd_move_ad2back)
+        session_multihost.ad[0].run_command(cmd_remove_site2)
+
+    request.addfinalizer(teardown_site)
+
+
+# ############## class scoped Fixtures ##############################
+
+
+@pytest.fixture(scope="class")
+def multihost(session_multihost, request):
+    """ Multihost fixture to be used by tests
+    :param obj session_multihost: multihost object
+    :return obj session_multihost: return multihost object
+    :Exceptions: None
+    """
+    if hasattr(request.cls(), 'class_setup'):
+        request.cls().class_setup(session_multihost)
+        request.addfinalizer(
+            lambda: request.cls().class_teardown(session_multihost))
+    return session_multihost
+
+
+@pytest.fixture(scope="class")
+def clear_sssd_cache(session_multihost):
+    """ Clear sssd cache """
+    client = sssdTools(session_multihost.client[0])
+    client.clear_sssd_cache()
+
+
+@pytest.fixture(scope="class")
+def joinad(session_multihost, request):
+    """ class fixture to join AD using realm """
+    client = sssdTools(session_multihost.client[0], session_multihost.ad[0])
+    client.disjoin_ad()  # Make sure system is disjoined from AD
+    kinit = "kinit Administrator"
+    ad_password = session_multihost.ad[0].ssh_password
+    realm_output = client.join_ad()
+    try:
+        session_multihost.client[0].service_sssd('restart')
+    except SSSDException:
+        cmd = 'cat /etc/sssd/sssd.conf'
+        session_multihost.client[0].run_command(cmd)
+        journal = 'journalctl -x -n 150 --no-pager'
+        session_multihost.client[0].run_command(journal)
+    retry = 0
+    while (retry != 5):
+        cmd = session_multihost.client[0].run_command(kinit,
+                                                      stdin_text=ad_password,
+                                                      raiseonerr=False)
+        if cmd.returncode == 0:
+            break
+        else:
+            retry += 1
+            time.sleep(5)
+
+    def disjoin():
+        """ Disjoin system from Windows AD """
+        client.disjoin_ad()
+        stop_sssd = 'systemctl stop sssd'
+        remove_keytab = 'rm -f /etc/krb5.keytab'
+        kdestroy_cmd = 'kdestroy -A'
+        session_multihost.client[0].run_command(stop_sssd)
+        session_multihost.client[0].run_command(remove_keytab)
+        session_multihost.client[0].run_command(kdestroy_cmd)
+    request.addfinalizer(disjoin)
+
+# ################### Session scoped fixtures #########################
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_session(request, session_multihost):
+    """ Setup Session """
+    client = sssdTools(session_multihost.client[0])
+    realm = session_multihost.ad[0].realm
+    ad_host = session_multihost.ad[0].sys_hostname
+    try:
+        master = sssdTools(session_multihost.master[0])
+    except IndexError:
+        pass
+    else:
+        master.server_install_pkgs()
+        master.update_resolv_conf(session_multihost.ad[0].ip)
+    client.client_install_pkgs()
+    client.update_resolv_conf(session_multihost.ad[0].ip)
+    client.clear_sssd_cache()
+    client.systemsssdauth(realm, ad_host)
+
+    def teardown_session():
+        """ Teardown session """
+        session_multihost.client[0].service_sssd('stop')
+        remove_sssd_conf = 'rm -f /etc/sssd/sssd.conf'
+        session_multihost.client[0].run_command(remove_sssd_conf)
+    request.addfinalizer(teardown_session)

--- a/src/tests/multihost/adsites/pytest.ini
+++ b/src/tests/multihost/adsites/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+   adsites: tests the require two domain controllers

--- a/src/tests/multihost/adsites/readme.rst
+++ b/src/tests/multihost/adsites/readme.rst
@@ -1,0 +1,134 @@
+AD Provider Test Suite
+======================
+
+This directory contains test automation for SSSD AD Provider. 
+
+
+Fixtures
+========
+
+
+session
+*******
+
+* setup_session: This fixtures does the following tasks:
+  
+  
+  * Install common required packages like 
+  * Updated /etc/resolv.conf with Windows IP Address
+  * Clear sssd cache 
+  * Configure system to use sssd authentication
+
+
+* teardown_session: This is not a fixtures but a teardown of ``setup_session`` 
+
+  * Restores resolv.conf
+  * Stop sssd service
+  * remove sssd.conf 
+
+
+class
+*****
+
+* multihost: This fixture returns multihost object. Also using builtin request
+  fixture we pass ``class_setup`` and ``class_teardown``.  If the test suite defines
+  class_setup and class_teardown functions, multihost object will be available
+  to execute any remote functions. 
+
+* clear_sssd_cache: Stops sssd service. Removes cache files from
+  ``/var/lib/sss/db`` and starts sssd service. Sleeps for 10 seconds.
+
+* enable_autofs_schema: Backup sssd.conf and Edit sssd.conf and specify
+  ``autofs_provider = ad`` and ``debug_level = 9`` 
+
+* enable_ad_sudoschema: Enable AD Sudo Schema 
+
+* create_ad_sudousers: Create users in Windows Active Directory with username
+  from ``sudo_idmuser1`` to ``sudo_idmuser10``.
+
+* sudorules: Create AD sudo rules ``less_user_rule1`` to ``less_user_rule10``::
+
+  
+   # less_user_rule1, Sudoers, juno.test
+   dn: CN=less_user_rule1,OU=Sudoers,DC=juno,DC=test
+   objectClass: top
+   objectClass: sudoRole
+   cn: less_user_rule1  
+   distinguishedName: CN=less_user_rule1,OU=Sudoers,DC=juno,DC=test
+   instanceType: 4
+   whenCreated: 20190416073735.0Z
+   whenChanged: 20190416073736.0Z
+   uSNCreated: 1283544
+   uSNChanged: 1283547
+   name: less_user_rule1
+   objectGUID:: wYiyH7dlT0G/5y40LPgHpw==
+   objectCategory: CN=sudoRole,CN=Schema,CN=Configuration,DC=juno,DC=test
+   dSCorePropagationData: 16010101000000.0Z
+   sudoHost: ALL
+   sudoUser: sudo_idmuserN
+   sudoUser: sudo_idmuserN@JUNO.TEST
+   sudoOption: !authenticate
+   sudoOption: !requiretty
+   sudoCommand: /usr/bin/less
+  
+* joinad: Join the system to Windows AD using realm with membercli-software
+  being adcli. 
+
+
+
+function
+********
+
+* smbconfig: Configure smb.conf ::
+    
+    [global]
+    workgroup = <DOMAIN>
+    security = ads
+    realm = <DOMAIN.COM>
+    netbios name = <samba-client-shortname>
+    kerberos method = secrets and keytab
+    client signing = yes
+    client use spnego = yes
+    log file = /var/log/samba/log.%m
+    max log size = 50
+    log level = 9
+
+
+* create_adgrp: fixture to create AD Groups . Runs ``adgroup.ps1`` powershell
+  script. powershell script::
+
+    #Following Powershell script will add the group in AD server
+    #and set GroupScope as Global and GroupCtegory as Security and
+    #also set MemberOf BuiltIn group as Administrator
+
+    Import-Module ActiveDirectory
+
+    $grname = -join ((65..90) + (97..122) | Get-Random -Count 7 | % {[char]$_})
+
+    Write-Host $grname
+
+    New-ADGroup -Name $grname -GroupScope Global -GroupCategory Security
+
+    Add-ADPrincipalGroupMembership -MemberOf Administrators -Identity $grname
+
+ 
+
+* create_aduser_group: Creates AD user ``testuser<randomnumber>`` and AD Groups
+  ``testgroup<randomnumber>``
+
+* add_nisobject: 
+
+  * uses Indirect parameterization and takes map name as the parameter from
+    test case. (example: ``/export``, ``/project1``)
+  * Installs nfs-utils package on nfs server and starts  nfs-server. 
+  * Add map based on request parameter. 
+
+
+* set_autofs_search_base: Enable autofs search base in sssd.conf 
+
+* add_user_in_domain_local_group: Add domain local AD group
+  ``ltestgoup<randomnumber>`` 
+
+* add_principals: Add ``HTTP`` and ``NFS`` service principals in Windows AD
+
+

--- a/src/tests/multihost/adsites/test_adsites.py
+++ b/src/tests/multihost/adsites/test_adsites.py
@@ -1,0 +1,262 @@
+from __future__ import print_function
+import time
+import pytest
+from sssd.testlib.common.utils import sssdTools
+
+
+@pytest.mark.adsites
+class Testadsites(object):
+    """
+    @Title: IDM-SSSD-TC: ad_provider: adsites:
+    Improve AD site discovery process
+    Test cases for BZ: 1819012
+
+    @Steps:
+    1. Join client to AD
+    2. Start SSSD and enable debug
+    3. Create secondary site, move second domain controller to second site 
+    """
+    @pytest.mark.adsites
+    def test_001_ad_startup_discovery(self, multihost, adjoin):
+        """
+        @Title: IDM-SSSD-TC: ad_startup_discovery
+        * grep sssd domain logs for cldap ping
+        * grep sssd logs for cldap ping parallel batch
+        * grep sssd logs for cldap ping domain discovery
+        """
+        adjoin(membersw='adcli')
+        client = sssdTools(multihost.client[0], multihost.ad[0])
+        domain = client.get_domain_section_name()
+        domain_section = 'domain/{}'.format(domain)
+        sssd_params = {'debug_level': '0xFFF0'}
+        client.sssd_conf(domain_section, sssd_params)
+
+        ad1 = multihost.ad[0].hostname
+        ad2 = multihost.ad[1].hostname
+        multihost.client[0].service_sssd('start')
+
+        cmd_id = 'id Administrator@%s' % domain
+        multihost.client[0].run_command(cmd_id)
+
+        cmd_check_ping = 'grep -ire ad_cldap_ping_send ' \
+                         '/var/log/sssd/sssd_%s.log | ' \
+                         'grep -ire \"Found 2 domain controllers in domain ' \
+                         'Default-First-Site-Name._sites.%s\"'\
+                         % (domain, domain)
+        check_ping = multihost.client[0].run_command(cmd_check_ping,
+                                                     raiseonerr=False)
+        assert check_ping.returncode == 0
+        cmd_check_batch1 = 'grep -ire ad_cldap_ping_parallel_batch' \
+                           ' /var/log/sssd/sssd_%s.log | ' \
+                           'grep -ire \" %s\"' % (domain, ad1)
+        check_batch1 = multihost.client[0].run_command(cmd_check_batch1,
+                                                       raiseonerr=False)
+        cmd_check_batch2 = 'grep -ire ad_cldap_ping_parallel_batch' \
+                           ' /var/log/sssd/sssd_%s.log | ' \
+                           'grep -ire \" %s\"' % (domain, ad2)
+        check_batch2 = multihost.client[0].run_command(cmd_check_batch2,
+                                                       raiseonerr=False)
+        if check_batch1.returncode == 0 or check_batch2.returncode == 0:
+            assert True
+        else:
+            assert False
+        cmd_check_discovery = 'grep -ire ad_cldap_ping_domain_discovery_done' \
+                              ' /var/log/sssd/sssd_%s.log | ' \
+                              'grep -ire \"Found 2 domain controllers in' \
+                              ' domain Default-First-Site-Name._sites.%s\"'\
+                              % (domain, domain)
+        check_discovery = multihost.client[0].run_command(cmd_check_discovery,
+                                                          raiseonerr=False)
+        assert check_discovery.returncode == 0
+
+    @pytest.mark.adsites
+    def test_002_ad_startup_discovery_one_server_unreachable(self, multihost,
+                                                             adjoin):
+        """
+        @Title: IDM-SSSD-TC: ad_startup_discovery_one_server_unreachable
+        * grep sssd domain logs for cldap ping
+        * grep sssd logs for cldap ping parallel batch
+        * grep sssd logs for cldap ping domain discovery
+        """
+        adjoin(membersw='adcli')
+        client = sssdTools(multihost.client[0], multihost.ad[0])
+        domain = client.get_domain_section_name()
+        domain_section = 'domain/{}'.format(domain)
+        sssd_params = {'debug_level': '0xFFF0'}
+        client.sssd_conf(domain_section, sssd_params)
+
+        ad1 = multihost.ad[0].hostname
+        ad2 = multihost.ad[1].hostname
+        ad2ip = multihost.ad[1].ip
+
+        cmd_dnf_firewalld = 'dnf install -y firewalld'
+        multihost.client[0].run_command(cmd_dnf_firewalld)
+        cmd_start_firewalld = 'systemctl start firewalld'
+        multihost.client[0].run_command(cmd_start_firewalld)
+        fw_add = 'firewall-cmd --permanent --direct --add-rule ipv4 ' \
+                 'filter OUTPUT 0 -d %s -j DROP' % ad2ip
+        fw_reload = 'firewall-cmd --reload'
+        multihost.client[0].run_command(fw_add, raiseonerr=True)
+        multihost.client[0].run_command(fw_reload, raiseonerr=True)
+        multihost.client[0].service_sssd('start')
+
+        cmd_check_ping = 'grep -ire ad_cldap_ping_send ' \
+                         '/var/log/sssd/sssd_%s.log | ' \
+                         'grep -ire \"Found 2 domain controllers in domain ' \
+                         'Default-First-Site-Name._sites.%s\"'\
+                         % (domain, domain)
+        check_ping = multihost.client[0].run_command(cmd_check_ping,
+                                                     raiseonerr=False)
+        assert check_ping.returncode == 0
+        cmd_check_batch1 = 'grep -ire ad_cldap_ping_parallel_batch' \
+                           ' /var/log/sssd/sssd_%s.log | ' \
+                           'grep -ire \" %s\"' % (domain, ad1)
+        check_batch1 = multihost.client[0].run_command(cmd_check_batch1,
+                                                       raiseonerr=False)
+        cmd_check_batch2 = 'grep -ire ad_cldap_ping_parallel_batch' \
+                           ' /var/log/sssd/sssd_%s.log | ' \
+                           'grep -ire \" %s\"' % (domain, ad2)
+        check_batch2 = multihost.client[0].run_command(cmd_check_batch2,
+                                                       raiseonerr=False)
+        if check_batch1.returncode == 1 and check_batch2.returncode == 0:
+            assert True
+        else:
+            assert False
+        cmd_check_discovery = 'grep -ire ad_cldap_ping_domain_discovery_done' \
+                              ' /var/log/sssd/sssd_%s.log | ' \
+                              'grep -ire \"Found 2 domain' \
+                              ' controllers in domain ' \
+                              'Default-First-Site-Name._sites.%s\"'\
+                              % (domain, domain)
+        check_discovery = multihost.client[0].run_command(cmd_check_discovery,
+                                                          raiseonerr=False)
+        assert check_discovery.returncode == 0
+
+        fw_stop = 'systemctl stop firewalld'
+        multihost.client[0].run_command(fw_stop, raiseonerr=True)
+        fw_remove = 'dnf remove -y firewalld'
+        multihost.client[0].run_command(fw_remove, raiseonerr=True)
+
+    @pytest.mark.adsites
+    def test_003_ad_startup_discovery_two_different_sites(self, multihost,
+                                                          adjoin, create_site):
+        """
+         @Title: IDM-SSSD-TC: ad_startup_discovery_two_different_sites
+        * grep sssd domain logs for cldap ping
+        * grep sssd logs for cldap ping parallel batch
+        * grep sssd logs for cldap ping domain discovery
+        """
+        adjoin(membersw='adcli')
+        client = sssdTools(multihost.client[0], multihost.ad[0])
+        domain = client.get_domain_section_name()
+        domain_section = 'domain/{}'.format(domain)
+        sssd_params = {'debug_level': '0xFFF0'}
+        client.sssd_conf(domain_section, sssd_params)
+
+        ad1 = multihost.ad[0].hostname
+        ad2 = multihost.ad[1].hostname
+        multihost.client[0].service_sssd('start')
+
+        cmd_check_ping = 'grep -ire ad_cldap_ping_send' \
+                         ' /var/log/sssd/sssd_%s.log | ' \
+                         'grep -ire \"Found 2 domain controllers in domain ' \
+                         'Default-First-Site-Name._sites.%s\"'\
+                         % (domain, domain)
+        check_ping = multihost.client[0].run_command(cmd_check_ping,
+                                                     raiseonerr=False)
+        assert check_ping.returncode == 0
+        cmd_check_batch1 = 'grep -ire ad_cldap_ping_parallel_batch' \
+                           ' /var/log/sssd/sssd_%s.log | ' \
+                           'grep -ire \" %s\"' % (domain, ad1)
+        check_batch1 = multihost.client[0].run_command(cmd_check_batch1,
+                                                       raiseonerr=False)
+        cmd_check_batch2 = 'grep -ire ad_cldap_ping_parallel_batch' \
+                           ' /var/log/sssd/sssd_%s.log | ' \
+                           'grep -ire \" %s\"' % (domain, ad2)
+        check_batch2 = multihost.client[0].run_command(cmd_check_batch2,
+                                                       raiseonerr=False)
+        if check_batch1.returncode == 0 or check_batch2.returncode == 0:
+            assert True
+        else:
+            assert False
+        cmd_check_discovery = 'grep -ire ad_cldap_ping_domain_discovery_done' \
+                              ' /var/log/sssd/sssd_%s.log | ' \
+                              'grep -ire \"Found 2 domain' \
+                              ' controllers in domain ' \
+                              'Default-First-Site-Name._sites.%s\"'\
+                              % (domain, domain)
+        check_discovery = multihost.client[0].run_command(cmd_check_discovery,
+                                                          raiseonerr=False)
+        assert check_discovery.returncode == 0
+
+    @pytest.mark.adsites
+    def test_004_ad_startup_discovery_one_server_unreachable(self,
+                                                             multihost,
+                                                             adjoin,
+                                                             create_site):
+        """
+        @Title: IDM-SSSD-TC:
+        ad_startup_discovery_two_different_sites_one_server_unreachable
+        * grep sssd domain logs for cldap ping
+        * grep sssd logs for cldap ping parallel batch
+        * grep sssd logs for cldap ping domain discovery
+        """
+        adjoin(membersw='adcli')
+        client = sssdTools(multihost.client[0], multihost.ad[0])
+        domain = client.get_domain_section_name()
+        domain_section = 'domain/{}'.format(domain)
+        sssd_params = {'debug_level': '0xFFF0'}
+        client.sssd_conf(domain_section, sssd_params)
+
+        ad1 = multihost.ad[0].hostname
+        ad2 = multihost.ad[1].hostname
+        ad2ip = multihost.ad[1].ip
+
+        cmd_dnf_firewalld = 'dnf install -y firewalld'
+        multihost.client[0].run_command(cmd_dnf_firewalld)
+        cmd_start_firewalld = 'systemctl start firewalld'
+        multihost.client[0].run_command(cmd_start_firewalld)
+        fw_add = 'firewall-cmd --permanent --direct --add-rule ipv4 ' \
+                 'filter OUTPUT 0 -d %s -j DROP' % ad2ip
+        fw_reload = 'firewall-cmd --reload'
+        multihost.client[0].run_command(fw_add, raiseonerr=True)
+        multihost.client[0].run_command(fw_reload, raiseonerr=True)
+
+        multihost.client[0].service_sssd('start')
+
+        cmd_check_ping = 'grep -ire ad_cldap_ping_send' \
+                         ' /var/log/sssd/sssd_%s.log | ' \
+                         'grep -ire \"Found 2 domain controllers in domain ' \
+                         'Default-First-Site-Name._sites.%s\"'\
+                         % (domain, domain)
+        check_ping = multihost.client[0].run_command(cmd_check_ping,
+                                                     raiseonerr=False)
+        assert check_ping.returncode == 0
+        cmd_check_batch1 = 'grep -ire ad_cldap_ping_parallel_batch' \
+                           ' /var/log/sssd/sssd_%s.log | ' \
+                           'grep -ire \" %s\"' % (domain, ad1)
+        check_batch1 = multihost.client[0].run_command(cmd_check_batch1,
+                                                       raiseonerr=False)
+        cmd_check_batch2 = 'grep -ire ad_cldap_ping_parallel_batch' \
+                           ' /var/log/sssd/sssd_%s.log | ' \
+                           'grep -ire \" %s\"' % (domain, ad2)
+        check_batch2 = multihost.client[0].run_command(cmd_check_batch2,
+                                                       raiseonerr=False)
+        if check_batch1.returncode == 1 and check_batch2.returncode == 0:
+            assert True
+        else:
+            assert False
+        cmd_check_discovery = 'grep -ire ad_cldap_ping_domain_discovery_done' \
+                              ' /var/log/sssd/sssd_%s.log | ' \
+                              'grep -ire \"Found 2 domain' \
+                              ' controllers in domain ' \
+                              'Default-First-Site-Name._sites.%s\"'\
+                              % (domain, domain)
+        check_discovery = multihost.client[0].run_command(cmd_check_discovery,
+                                                          raiseonerr=False)
+        assert check_discovery.returncode == 0
+
+        fw_stop = 'systemctl stop firewalld'
+        multihost.client[0].run_command(fw_stop, raiseonerr=True)
+        fw_remove = 'dnf remove -y firewalld'
+        multihost.client[0].run_command(fw_remove, raiseonerr=True)


### PR DESCRIPTION
* This test requires a primary and secondary domain controller so AD can be moved between sites
* Currently contains four test cases
** Two DCs in one site no restrictions.
** Two DCs in one site, traffic blocked to the other DC
** DCs in seperate sites no restrictions
** DCs in seperate sites, traffic blocked to the other DC

Signed-off-by: Dan Lavu <dlavu@redhat.com>

SSSD-2497