### PR TITLE
Logs review

### DIFF
--- a/src/db/sysdb.c
+++ b/src/db/sysdb.c
@@ -1489,7 +1489,7 @@ errno_t sysdb_attrs_primary_name(struct sysdb_ctx *sysdb,
          * decide which name is correct.
          */
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "Cannot save entry. Unable to determine groupname\n");
+              "Can't match the name to the RDN\n");
         ret = EINVAL;
         goto done;
     }

--- a/src/db/sysdb_autofs.c
+++ b/src/db/sysdb_autofs.c
@@ -243,14 +243,14 @@ sysdb_get_map_byname(TALLOC_CTX *mem_ctx,
               "Error looking up autofs map [%s]\n", safe_map_name);
         goto done;
     } else if (ret == ENOENT) {
-        DEBUG(SSSDBG_TRACE_FUNC, "No such map\n");
+        DEBUG(SSSDBG_TRACE_FUNC, "No such map [%s]\n", safe_map_name);
         *_map = NULL;
         goto done;
     }
 
     if (count != 1) {
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "More than one map named %s\n", safe_map_name);
+              "More than one map named [%s]\n", safe_map_name);
         goto done;
     }
 

--- a/src/db/sysdb_iphosts.c
+++ b/src/db/sysdb_iphosts.c
@@ -222,14 +222,14 @@ sysdb_store_host(struct sss_domain_info *domain,
                  * sort it out.
                  */
                 for (j = 0; j < res->count; j++) {
-                    DEBUG(SSSDBG_TRACE_FUNC,
+                    DEBUG(SSSDBG_CRIT_FAILURE,
                           "Corrupt cache entry [%s] detected. Deleting\n",
                            ldb_dn_canonical_string(tmp_ctx,
                                                    res->msgs[j]->dn));
 
                     ret = sysdb_delete_entry(sysdb, res->msgs[j]->dn, true);
                     if (ret != EOK) {
-                        DEBUG(SSSDBG_MINOR_FAILURE,
+                        DEBUG(SSSDBG_OP_FAILURE,
                               "Could not delete corrupt cache entry [%s]\n",
                                ldb_dn_canonical_string(tmp_ctx,
                                                        res->msgs[j]->dn));
@@ -262,7 +262,7 @@ sysdb_store_host(struct sss_domain_info *domain,
 
                     ret = sysdb_delete_entry(sysdb, res->msgs[0]->dn, true);
                     if (ret != EOK) {
-                        DEBUG(SSSDBG_MINOR_FAILURE,
+                        DEBUG(SSSDBG_OP_FAILURE,
                               "Could not delete cache entry [%s]\n",
                                ldb_dn_canonical_string(tmp_ctx,
                                                        res->msgs[0]->dn));
@@ -298,7 +298,7 @@ sysdb_store_host(struct sss_domain_info *domain,
 
                 ret = sysdb_delete_entry(sysdb, res->msgs[i]->dn, true);
                 if (ret != EOK) {
-                    DEBUG(SSSDBG_MINOR_FAILURE,
+                    DEBUG(SSSDBG_OP_FAILURE,
                           "Could not delete corrupt cache entry [%s]\n",
                            ldb_dn_canonical_string(tmp_ctx,
                                                    res->msgs[i]->dn));
@@ -318,7 +318,7 @@ sysdb_store_host(struct sss_domain_info *domain,
                     /* Delete the entry from the previous pass */
                     ret = sysdb_delete_entry(sysdb, update_dn, true);
                     if (ret != EOK) {
-                        DEBUG(SSSDBG_MINOR_FAILURE,
+                        DEBUG(SSSDBG_OP_FAILURE,
                               "Could not delete cache entry [%s]\n",
                                ldb_dn_canonical_string(tmp_ctx,
                                                        update_dn));

--- a/src/db/sysdb_ipnetworks.c
+++ b/src/db/sysdb_ipnetworks.c
@@ -261,7 +261,7 @@ sysdb_store_ipnetwork(struct sss_domain_info *domain,
 
                 ret = sysdb_delete_entry(sysdb, res->msgs[0]->dn, true);
                 if (ret != EOK) {
-                    DEBUG(SSSDBG_MINOR_FAILURE,
+                    DEBUG(SSSDBG_OP_FAILURE,
                             "Could not delete cache entry [%s]\n",
                             ldb_dn_canonical_string(tmp_ctx,
                                                     res->msgs[0]->dn));
@@ -296,7 +296,7 @@ sysdb_store_ipnetwork(struct sss_domain_info *domain,
 
                 ret = sysdb_delete_entry(sysdb, res->msgs[i]->dn, true);
                 if (ret != EOK) {
-                    DEBUG(SSSDBG_MINOR_FAILURE,
+                    DEBUG(SSSDBG_OP_FAILURE,
                           "Could not delete corrupt cache entry [%s]\n",
                            ldb_dn_canonical_string(tmp_ctx,
                                                    res->msgs[i]->dn));
@@ -315,7 +315,7 @@ sysdb_store_ipnetwork(struct sss_domain_info *domain,
                     /* Delete the entry from the previous pass */
                     ret = sysdb_delete_entry(sysdb, update_dn, true);
                     if (ret != EOK) {
-                        DEBUG(SSSDBG_MINOR_FAILURE,
+                        DEBUG(SSSDBG_OP_FAILURE,
                               "Could not delete cache entry [%s]\n",
                                ldb_dn_canonical_string(tmp_ctx,
                                                        update_dn));

--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -4942,9 +4942,15 @@ static errno_t sysdb_update_members_ex(struct sss_domain_info *domain,
             ret = sysdb_remove_group_member(domain, del_groups[i],
                                             member, type, is_dn);
             if (ret != EOK) {
-                DEBUG(SSSDBG_CRIT_FAILURE,
-                      "Could not remove member [%s] from group [%s]. "
-                          "Skipping\n", member, del_groups[i]);
+                if (ret != ENOENT) {
+                    DEBUG(SSSDBG_CRIT_FAILURE,
+                          "Could not remove member [%s] from group [%s]. "
+                              "Skipping\n", member, del_groups[i]);
+                } else {
+                    DEBUG(SSSDBG_FUNC_DATA,
+                          "No member [%s] in group [%s]. "
+                              "Skipping\n", member, del_groups[i]);
+                }
                 /* Continue on, we should try to finish the rest */
             }
         }

--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -4928,9 +4928,15 @@ static errno_t sysdb_update_members_ex(struct sss_domain_info *domain,
             ret = sysdb_add_group_member(domain, add_groups[i],
                                          member, type, is_dn);
             if (ret != EOK) {
-                DEBUG(SSSDBG_CRIT_FAILURE,
-                      "Could not add member [%s] to group [%s]. "
-                          "Skipping.\n", member, add_groups[i]);
+                if (ret != EEXIST) {
+                    DEBUG(SSSDBG_CRIT_FAILURE,
+                          "Could not add member [%s] to group [%s]. "
+                              "Skipping.\n", member, add_groups[i]);
+                } else {
+                    DEBUG(SSSDBG_FUNC_DATA,
+                          "Group [%s] already has member [%s]. Skipping.\n",
+                          add_groups[i], member);
+                }
                 /* Continue on, we should try to finish the rest */
             }
         }

--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -157,7 +157,7 @@ static int sysdb_delete_cache_entry(struct ldb_context *ldb,
         /* fall through */
         SSS_ATTRIBUTE_FALLTHROUGH;
     default:
-        DEBUG(SSSDBG_CRIT_FAILURE, "LDB Error: %s(%d)\nError Message: [%s]\n",
+        DEBUG(SSSDBG_CRIT_FAILURE, "LDB Error: %s (%d); error message: [%s]\n",
                   ldb_strerror(ret), ret, ldb_errstring(ldb));
         return sysdb_error_to_errno(ret);
     }
@@ -3420,7 +3420,7 @@ int sysdb_search_custom(TALLOC_CTX *mem_ctx,
         goto done;
     }
     if (!ldb_dn_validate(basedn)) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Failed to create DN.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "Syntactically invalid subtree DN.\n");
         ret = EINVAL;
         goto done;
     }
@@ -3463,7 +3463,7 @@ int sysdb_search_custom_by_name(TALLOC_CTX *mem_ctx,
         goto done;
     }
     if (!ldb_dn_validate(basedn)) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Failed to create DN.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "Syntactically invalid DN.\n");
         ret = EINVAL;
         goto done;
     }
@@ -3545,7 +3545,7 @@ errno_t sysdb_search_by_orig_dn(TALLOC_CTX *mem_ctx,
     default:
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Trying to perform a search by orig_dn using a "
-              "non-supported type\n");
+              "non-supported type %d\n", type);
         ret = EINVAL;
         goto done;
     }
@@ -3690,8 +3690,9 @@ int sysdb_delete_custom(struct sss_domain_info *domain,
         break;
 
     default:
-        DEBUG(SSSDBG_CRIT_FAILURE, "LDB Error: %s(%d)\nError Message: [%s]\n",
-                  ldb_strerror(ret), ret, ldb_errstring(domain->sysdb->ldb));
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "ldb_delete failed: %s (%d); error Message: [%s]\n",
+              ldb_strerror(ret), ret, ldb_errstring(domain->sysdb->ldb));
         ret = sysdb_error_to_errno(ret);
         break;
     }

--- a/src/db/sysdb_search.c
+++ b/src/db/sysdb_search.c
@@ -2393,7 +2393,7 @@ errno_t sysdb_get_direct_parents(TALLOC_CTX *mem_ctx,
     } else if (mtype == SYSDB_MEMBER_GROUP) {
         dn = sysdb_group_strdn(tmp_ctx, dom->name, name);
     } else {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unknown member type\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unknown member type %d\n", mtype);
         ret = EINVAL;
         goto done;
     }
@@ -2453,13 +2453,14 @@ errno_t sysdb_get_direct_parents(TALLOC_CTX *mem_ctx,
         tmp_str = ldb_msg_find_attr_as_string(direct_sysdb_groups[i],
                                                 SYSDB_NAME, NULL);
         if (!tmp_str) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "A group with no name?\n");
             /* This should never happen, but if it does, just continue */
             continue;
         }
 
         direct_parents[pi] = talloc_strdup(direct_parents, tmp_str);
         if (!direct_parents[pi]) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "A group with no name?\n");
+            DEBUG(SSSDBG_CRIT_FAILURE, "talloc_strdup() failed\n");
             ret = EIO;
             goto done;
         }
@@ -2537,7 +2538,8 @@ errno_t sysdb_get_real_name(TALLOC_CTX *mem_ctx,
 
     cname = ldb_msg_find_attr_as_string(msg, SYSDB_NAME, NULL);
     if (!cname) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "A user with no name?\n");
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "User '%s' without a name?\n", name_or_upn_or_sid);
         ret = ENOENT;
         goto done;
     }

--- a/src/db/sysdb_search.c
+++ b/src/db/sysdb_search.c
@@ -2523,8 +2523,13 @@ errno_t sysdb_get_real_name(TALLOC_CTX *mem_ctx,
         }
         if (ret != EOK) {
             /* User cannot be found in cache */
-            DEBUG(SSSDBG_OP_FAILURE, "Cannot find user [%s] in cache\n",
-                                     name_or_upn_or_sid);
+            if (ret != ENOENT) {
+                DEBUG(SSSDBG_OP_FAILURE, "Failed to find user [%s] in cache: %d\n",
+                                         name_or_upn_or_sid, ret);
+            } else {
+                DEBUG(SSSDBG_TRACE_FUNC, "User [%s] is missing in cache\n",
+                                         name_or_upn_or_sid);
+            }
             goto done;
         }
     } else if (res->count == 1) {

--- a/src/db/sysdb_selinux.c
+++ b/src/db/sysdb_selinux.c
@@ -234,7 +234,7 @@ errno_t sysdb_delete_usermaps(struct sss_domain_info *domain)
     ret = sysdb_delete_recursive(sysdb, dn, true);
     talloc_free(dn);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "sysdb_delete_recursive failed.\n");
+        DEBUG(SSSDBG_OP_FAILURE, "sysdb_delete_recursive failed.\n");
         return ret;
     }
 

--- a/src/db/sysdb_services.c
+++ b/src/db/sysdb_services.c
@@ -252,7 +252,7 @@ sysdb_store_service(struct sss_domain_info *domain,
 
                 ret = sysdb_delete_entry(sysdb, res->msgs[0]->dn, true);
                 if (ret != EOK) {
-                    DEBUG(SSSDBG_MINOR_FAILURE,
+                    DEBUG(SSSDBG_OP_FAILURE,
                           "Could not delete cache entry [%s]\n",
                            ldb_dn_canonical_string(tmp_ctx,
                                                    res->msgs[0]->dn));
@@ -290,7 +290,7 @@ sysdb_store_service(struct sss_domain_info *domain,
 
                 ret = sysdb_delete_entry(sysdb, res->msgs[i]->dn, true);
                 if (ret != EOK) {
-                    DEBUG(SSSDBG_MINOR_FAILURE,
+                    DEBUG(SSSDBG_OP_FAILURE,
                           "Could not delete corrupt cache entry [%s]\n",
                            ldb_dn_canonical_string(tmp_ctx,
                                                    res->msgs[i]->dn));
@@ -310,7 +310,7 @@ sysdb_store_service(struct sss_domain_info *domain,
                     /* Delete the entry from the previous pass */
                     ret = sysdb_delete_entry(sysdb, update_dn, true);
                     if (ret != EOK) {
-                        DEBUG(SSSDBG_MINOR_FAILURE,
+                        DEBUG(SSSDBG_OP_FAILURE,
                               "Could not delete cache entry [%s]\n",
                                ldb_dn_canonical_string(tmp_ctx,
                                                        update_dn));

--- a/src/db/sysdb_sudo.c
+++ b/src/db/sysdb_sudo.c
@@ -480,7 +480,8 @@ sysdb_get_sudo_user_info(TALLOC_CTX *mem_ctx,
                     sss_get_cased_name(sysdb_groupnames, groupname,
                                        domain->case_sensitive);
                 if (sysdb_groupnames[num_groups] == NULL) {
-                    DEBUG(SSSDBG_MINOR_FAILURE, "Cannot strdup %s\n", groupname);
+                    DEBUG(SSSDBG_CRIT_FAILURE,
+                          "sss_get_cased_name() failed for '%s'\n", groupname);
                     continue;
                 }
                 num_groups++;

--- a/src/db/sysdb_upgrade.c
+++ b/src/db/sysdb_upgrade.c
@@ -2455,7 +2455,7 @@ int sysdb_upgrade_19(struct sysdb_ctx *sysdb, const char **ver)
 
     ret = add_object_category(sysdb->ldb, ctx);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "add_object_category failed.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "add_object_category failed: %d\n", ret);
         goto done;
     }
 

--- a/src/db/sysdb_views.c
+++ b/src/db/sysdb_views.c
@@ -556,12 +556,12 @@ errno_t sysdb_store_override(struct sss_domain_info *domain,
         if (ret == ENOENT) {
             DEBUG(SSSDBG_CRIT_FAILURE, "Object to override does not exists.\n");
         } else {
-            DEBUG(SSSDBG_OP_FAILURE, "sysdb_search_entry failed.\n");
+            DEBUG(SSSDBG_CRIT_FAILURE, "sysdb_search_entry failed.\n");
         }
         goto done;
     }
     if (count != 1) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Base searched returned more than one object.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "Base search returned more than one object.\n");
         ret = EINVAL;
         goto done;
     }
@@ -660,7 +660,7 @@ errno_t sysdb_store_override(struct sss_domain_info *domain,
                                      SYSDB_OVERRIDE_GROUP_CLASS);
             break;
         default:
-            DEBUG(SSSDBG_CRIT_FAILURE, "Unexpected object type.\n");
+            DEBUG(SSSDBG_CRIT_FAILURE, "Unexpected object type %d.\n", type);
             ret = EINVAL;
             goto done;
         }

--- a/src/lib/certmap/sss_certmap_krb5_match.c
+++ b/src/lib/certmap/sss_certmap_krb5_match.c
@@ -220,7 +220,6 @@ static int parse_krb5_get_eku_value(TALLOC_CTX *mem_ctx,
 
     for (c = 0; eku_list[c] != NULL; c++) {
         for (k = 0; sss_ext_key_usage[k].name != NULL; k++) {
-CM_DEBUG(ctx, "[%s][%s].", eku_list[c], sss_ext_key_usage[k].name);
             if (strcasecmp(eku_list[c], sss_ext_key_usage[k].name) == 0) {
                 comp->eku_oid_list[e] = talloc_strdup(comp->eku_oid_list,
                                                       sss_ext_key_usage[k].oid);

--- a/src/man/include/debug_levels.xml
+++ b/src/man/include/debug_levels.xml
@@ -100,6 +100,7 @@
         introduced in 1.7.0.
     </para>
     <para>
-        <emphasis>Default</emphasis>: 0
+        <emphasis>Default</emphasis>: 0x0070 (i.e. fatal, critical and serious
+        failures; corresponds to setting 2 in decimal notation)
     </para>
 </listitem>

--- a/src/man/include/debug_levels_tools.xml
+++ b/src/man/include/debug_levels_tools.xml
@@ -81,6 +81,7 @@
         introduced in 1.7.0.
     </para>
     <para>
-        <emphasis>Default</emphasis>: 0
+        <emphasis>Default</emphasis>: 0x0070 (i.e. fatal, critical and serious
+        failures; corresponds to setting 2 in decimal notation)
     </para>
 </listitem>

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -1435,7 +1435,7 @@ static void monitor_quit(struct mt_ctx *mt_ctx, int ret)
                         DEBUG(SSSDBG_CRIT_FAILURE,
                               "Child [%s] terminated with a signal\n", svc->name);
                     } else {
-                        DEBUG(SSSDBG_FATAL_FAILURE,
+                        DEBUG(SSSDBG_CRIT_FAILURE,
                               "Child [%s] did not exit cleanly\n", svc->name);
                         /* Forcibly kill this child */
                         kill(-svc->pid, SIGKILL);
@@ -2059,7 +2059,7 @@ static void monitor_sbus_connected(struct tevent_req *req)
 
     ret = sbus_connection_add_path_map(ctx->sbus_conn, paths);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to add paths [%d]: %s\n",
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to add paths [%d]: %s\n",
               ret, sss_strerror(ret));
         goto done;
     }
@@ -2271,7 +2271,7 @@ static void mt_svc_restart(struct tevent_context *ev,
         add_new_provider(svc->mt_ctx, svc->name, svc->restarts + 1);
     } else {
         /* Invalid type? */
-        DEBUG(SSSDBG_CRIT_FAILURE,
+        DEBUG(SSSDBG_FATAL_FAILURE,
               "BUG: Invalid child process type [%d]\n", svc->type);
     }
 
@@ -2580,14 +2580,14 @@ int main(int argc, const char *argv[])
         switch (ret) {
         case EPERM:
         case EACCES:
-            DEBUG(SSSDBG_CRIT_FAILURE,
+            DEBUG(SSSDBG_FATAL_FAILURE,
                   CONF_FILE_PERM_ERROR_MSG, config_file);
-            sss_log(SSS_LOG_ALERT, CONF_FILE_PERM_ERROR_MSG, config_file);
+            sss_log(SSS_LOG_CRIT, CONF_FILE_PERM_ERROR_MSG, config_file);
             break;
         default:
-            DEBUG(SSSDBG_CRIT_FAILURE,
+            DEBUG(SSSDBG_FATAL_FAILURE,
                  "SSSD couldn't load the configuration database.\n");
-            sss_log(SSS_LOG_ALERT,
+            sss_log(SSS_LOG_CRIT,
                    "SSSD couldn't load the configuration database [%d]: %s.\n",
                     ret, strerror(ret));
             break;

--- a/src/p11_child/p11_child_common.c
+++ b/src/p11_child/p11_child_common.c
@@ -125,7 +125,7 @@ static errno_t p11c_recv_data(TALLOC_CTX *mem_ctx, int fd, char **pin)
 
     str = talloc_strndup(mem_ctx, (char *) buf, len);
     if (str == NULL) {
-        DEBUG(SSSDBG_OP_FAILURE, "talloc_strndup failed.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "talloc_strndup failed.\n");
         return ENOMEM;
     }
 

--- a/src/p11_child/p11_child_common_utils.c
+++ b/src/p11_child/p11_child_common_utils.c
@@ -107,6 +107,9 @@ errno_t parse_cert_verify_opts(TALLOC_CTX *mem_ctx, const char *verify_opts,
                   "Found 'no_verification' option, "
                   "disabling verification completely. "
                   "This should not be used in production.\n");
+            sss_log(SSS_LOG_CRIT,
+                    "Smart card certificate verification disabled completely. "
+                    "This should not be used in production.");
             cert_verify_opts->do_verification = false;
         } else if (strncasecmp(opts[c], OCSP_DEFAUL_RESPONDER,
                                OCSP_DEFAUL_RESPONDER_LEN) == 0) {

--- a/src/p11_child/p11_child_openssl.c
+++ b/src/p11_child/p11_child_openssl.c
@@ -226,7 +226,7 @@ static char *get_issuer_subject_str(TALLOC_CTX *mem_ctx, X509 *cert)
 
     bio_mem = BIO_new(BIO_s_mem());
     if (bio_mem == NULL) {
-        DEBUG(SSSDBG_OP_FAILURE, "BIO_new failed.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "BIO_new failed.\n");
         return NULL;
     }
 
@@ -591,7 +591,7 @@ errno_t init_p11_ctx(TALLOC_CTX *mem_ctx, const char *ca_db,
     ret = SSL_library_init();
 #endif
     if (ret != 1) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Failed to initialize OpenSSL.\n");
+        DEBUG(SSSDBG_FATAL_FAILURE, "Failed to initialize OpenSSL.\n");
         return EIO;
     }
 

--- a/src/providers/ad/ad_cldap_ping.c
+++ b/src/providers/ad/ad_cldap_ping.c
@@ -467,7 +467,7 @@ ad_cldap_ping_domain_send(TALLOC_CTX *mem_ctx,
     domains[0] = discovery_domain;
     domains[1] = NULL;
     if (domains[0] == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!");
+        DEBUG(SSSDBG_CRIT_FAILURE, "Bad argument (discovery_domain)");
         ret = ENOMEM;
         goto done;
     }

--- a/src/providers/ad/ad_common.c
+++ b/src/providers/ad/ad_common.c
@@ -1072,15 +1072,14 @@ ad_resolve_callback(void *private_data, struct fo_server *server)
     }
 
     if (!service->gc->uri) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Failed to append to URI\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "NULL GC URI\n");
         ret = ENOMEM;
         goto done;
     }
     DEBUG(SSSDBG_CONF_SETTINGS, "Constructed GC uri '%s'\n", service->gc->uri);
 
     if (service->gc->sockaddr == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE,
-                "resolv_get_sockaddr_address failed.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "NULL GC sockaddr\n");
         ret = EIO;
         goto done;
     }
@@ -1100,7 +1099,7 @@ ad_resolve_callback(void *private_data, struct fo_server *server)
 done:
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "Error: [%s]\n", strerror(ret));
+              "Error: %d [%s]\n", ret, strerror(ret));
     }
     talloc_free(tmp_ctx);
     return;

--- a/src/providers/ad/ad_dyndns.c
+++ b/src/providers/ad/ad_dyndns.c
@@ -63,7 +63,7 @@ errno_t ad_dyndns_init(struct be_ctx *be_ctx,
      */
     ret = ad_get_dyndns_options(be_ctx, ad_opts);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Could not set AD options\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "Could not get AD dyndns options\n");
         return ret;
     }
 
@@ -209,8 +209,8 @@ static void ad_dyndns_update_connect_done(struct tevent_req *subreq)
 
     ret = ldap_url_parse(ctx->service->sdap->uri, &lud);
     if (ret != LDAP_SUCCESS) {
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Failed to parse ldap URI (%s)!\n", ctx->service->sdap->uri);
+        DEBUG(SSSDBG_CRIT_FAILURE, "Failed to parse ldap URI '%s': %d\n",
+              ctx->service->sdap->uri, ret);
         ret = EINVAL;
         goto done;
     }

--- a/src/providers/ad/ad_gpo.c
+++ b/src/providers/ad/ad_gpo.c
@@ -671,7 +671,9 @@ ad_gpo_ace_includes_client_sid(const char *user_sid,
 
     err = sss_idmap_sid_to_smb_sid(idmap_ctx, user_sid, &user_dom_sid);
     if (err != IDMAP_SUCCESS) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Failed to initialize idmap context.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "sss_idmap_sid_to_smb_sid() failed for user_sid '%s': %d\n",
+              user_sid, err);
         return EFAULT;
     }
 
@@ -684,7 +686,9 @@ ad_gpo_ace_includes_client_sid(const char *user_sid,
 
     err = sss_idmap_sid_to_smb_sid(idmap_ctx, host_sid, &host_dom_sid);
     if (err != IDMAP_SUCCESS) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Failed to initialize idmap context.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "sss_idmap_sid_to_smb_sid() failed for host_sid '%s': %d\n",
+              host_sid, err);
         return EFAULT;
     }
 
@@ -698,7 +702,9 @@ ad_gpo_ace_includes_client_sid(const char *user_sid,
     for (i = 0; i < group_size; i++) {
         err = sss_idmap_sid_to_smb_sid(idmap_ctx, group_sids[i], &group_dom_sid);
         if (err != IDMAP_SUCCESS) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "Failed to initialize idmap context.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "sss_idmap_sid_to_smb_sid() failed for group_sid '%s': %d\n",
+              group_sids[i], err);
             return EFAULT;
         }
         included = ad_gpo_dom_sid_equal(&ace_dom_sid, group_dom_sid);
@@ -4777,14 +4783,14 @@ gpo_fork_child(struct tevent_req *req)
     if (ret == -1) {
         ret = errno;
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "pipe failed [%d][%s].\n", errno, strerror(errno));
+              "pipe (from) failed [%d][%s].\n", errno, strerror(errno));
         goto fail;
     }
     ret = pipe(pipefd_to_child);
     if (ret == -1) {
         ret = errno;
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "pipe failed [%d][%s].\n", errno, strerror(errno));
+              "pipe (to) failed [%d][%s].\n", errno, strerror(errno));
         goto fail;
     }
 

--- a/src/providers/ad/ad_machine_pw_renewal.c
+++ b/src/providers/ad/ad_machine_pw_renewal.c
@@ -171,14 +171,14 @@ ad_machine_account_password_renewal_send(TALLOC_CTX *mem_ctx,
     if (ret == -1) {
         ret = errno;
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "pipe failed [%d][%s].\n", ret, strerror(ret));
+              "pipe (from) failed [%d][%s].\n", ret, strerror(ret));
         goto done;
     }
     ret = pipe(pipefd_to_child);
     if (ret == -1) {
         ret = errno;
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "pipe failed [%d][%s].\n", ret, strerror(ret));
+              "pipe (to) failed [%d][%s].\n", ret, strerror(ret));
         goto done;
     }
 
@@ -354,7 +354,8 @@ errno_t ad_machine_account_password_renewal_init(struct be_ctx *be_ctx,
     }
 
     if (opt_list_size != 2) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Wrong number of renewal options.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "Wrong number of renewal options %d\n",
+              opt_list_size);
         ret = EINVAL;
         goto done;
     }

--- a/src/providers/ad/ad_pac.c
+++ b/src/providers/ad/ad_pac.c
@@ -120,7 +120,11 @@ errno_t check_if_pac_is_available(TALLOC_CTX *mem_ctx,
 
     ret = find_user_entry(mem_ctx, dom, ar, &msg);
     if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "find_user_entry failed.\n");
+        if (ret == ENOENT) {
+            DEBUG(SSSDBG_FUNC_DATA, "find_user_entry didn't find user entry.\n");
+        } else {
+            DEBUG(SSSDBG_OP_FAILURE, "find_user_entry failed.\n");
+        }
         return ret;
     }
 

--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -299,7 +299,7 @@ ad_subdom_ad_ctx_new(struct be_ctx *be_ctx,
 
     subdom_conf_path = subdomain_create_conf_path(id_ctx, subdom);
     if (subdom_conf_path == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "subdom_conf_path failed\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "subdomain_create_conf_path failed\n");
         return ENOMEM;
     }
 

--- a/src/providers/be_dyndns.c
+++ b/src/providers/be_dyndns.c
@@ -1111,7 +1111,8 @@ be_nsupdate_args(TALLOC_CTX *mem_ctx,
         argc++;
         break;
     default:
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unknown nsupdate auth type\n");
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Unknown nsupdate auth type %d\n", auth_type);
         goto fail;
     }
 

--- a/src/providers/be_ptask.c
+++ b/src/providers/be_ptask.c
@@ -251,7 +251,7 @@ static void be_ptask_schedule(struct be_ptask *task,
     task->timer = tevent_add_timer(task->ev, task, tv, be_ptask_execute, task);
     if (task->timer == NULL) {
         /* nothing we can do about it */
-        DEBUG(SSSDBG_CRIT_FAILURE, "FATAL: Unable to schedule task [%s]\n",
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to schedule task [%s]\n",
                                     task->name);
         be_ptask_disable(task);
     }

--- a/src/providers/be_refresh.c
+++ b/src/providers/be_refresh.c
@@ -125,7 +125,8 @@ static errno_t be_refresh_get_values(TALLOC_CTX *mem_ctx,
         base_dn = sysdb_netgroup_base_dn(mem_ctx, domain);
         break;
     default:
-        DEBUG(SSSDBG_CRIT_FAILURE, "Uknown or unsupported refresh type\n");
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Uknown or unsupported refresh type %d\n", type);
         return ERR_INTERNAL;
         break;
     }

--- a/src/providers/data_provider/dp.c
+++ b/src/providers/data_provider/dp.c
@@ -109,7 +109,7 @@ dp_init_interface(struct data_provider *provider)
 
     ret = sbus_connection_add_path_map(provider->sbus_conn, paths);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to add paths [%d]: %s\n",
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to add paths [%d]: %s\n",
               ret, sss_strerror(ret));
     }
 
@@ -196,7 +196,7 @@ dp_init_send(TALLOC_CTX *mem_ctx,
         (sbus_server_on_connection_cb)dp_client_init,
         (sbus_server_on_connection_data)state->provider);
     if (subreq == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to create subrequest!\n");
         ret = ENOMEM;
         goto done;
     }

--- a/src/providers/data_provider/dp_target_sudo.c
+++ b/src/providers/data_provider/dp_target_sudo.c
@@ -42,13 +42,13 @@ static errno_t dp_sudo_parse_message(TALLOC_CTX *mem_ctx,
 
     ret = sbus_iterator_read_u(read_iter, &dp_flags);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Failed, to parse the message!\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "Failed to parse the message (flags)!\n");
         return ret;
     }
 
     ret = sbus_iterator_read_u(read_iter, &sudo_type);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Failed, to parse the message!\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "Failed to parse the message (type)!\n");
         return ret;
     }
 
@@ -66,13 +66,15 @@ static errno_t dp_sudo_parse_message(TALLOC_CTX *mem_ctx,
         /* read rules_num */
         ret = sbus_iterator_read_u(read_iter, &num_rules);
         if (ret != EOK) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "Failed, to parse the message!\n");
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Failed to parse the message (num rules)!\n");
             return ret;
         }
 
         ret = sbus_iterator_read_as(mem_ctx, read_iter, &rules);
         if (ret != EOK) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "Failed, to parse the message!\n");
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Failed to parse the message (rules)!\n");
             return ret;
         }
         break;

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -402,7 +402,7 @@ static void check_if_online(struct be_ctx *be_ctx, int delay)
                                   check_if_online_delayed, be_ctx);
 
     if (time_event == NULL) {
-        DEBUG(SSSDBG_OP_FAILURE,
+        DEBUG(SSSDBG_CRIT_FAILURE,
               "Scheduling check_if_online_delayed failed.\n");
         goto failed;
     }
@@ -415,7 +415,6 @@ static void check_if_online(struct be_ctx *be_ctx, int delay)
 
 failed:
     be_ctx->check_online_ref_count--;
-    DEBUG(SSSDBG_CRIT_FAILURE, "Failed to run a check_online test.\n");
 
     if (be_ctx->check_online_ref_count == 0) {
         reset_fo(be_ctx);

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -624,7 +624,7 @@ static void dp_initialized(struct tevent_req *req)
 
     ret = be_register_monitor_iface(be_ctx->mon_conn, be_ctx);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to register monitor interface "
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to register monitor interface "
               "[%d]: %s\n", ret, sss_strerror(ret));
         goto done;
     }

--- a/src/providers/data_provider_fo.c
+++ b/src/providers/data_provider_fo.c
@@ -651,7 +651,7 @@ errno_t be_resolve_server_process(struct tevent_req *subreq,
         srvaddr = fo_get_server_hostent(state->srv);
         if (!srvaddr) {
             DEBUG(SSSDBG_CRIT_FAILURE,
-                  "FATAL: No hostent available for server (%s)\n",
+                  "No hostent available for server (%s)\n",
                   fo_get_server_str_name(state->srv));
             return EFAULT;
         }

--- a/src/providers/data_provider_opts.c
+++ b/src/providers/data_provider_opts.c
@@ -233,7 +233,7 @@ static int dp_copy_options_ex(TALLOC_CTX *memctx,
             }
             if (ret != EOK) {
                 DEBUG(SSSDBG_CRIT_FAILURE,
-                      "Failed to retrieve value for option (%s)\n",
+                      "Failed to copy value for option (%s)\n",
                        opts[i].opt_name);
                 goto done;
             }
@@ -249,7 +249,7 @@ static int dp_copy_options_ex(TALLOC_CTX *memctx,
             }
             if (ret != EOK) {
                 DEBUG(SSSDBG_CRIT_FAILURE,
-                      "Failed to retrieve value for option (%s)\n",
+                      "Failed to copy value for option (%s)\n",
                       opts[i].opt_name);
                 goto done;
             }
@@ -265,7 +265,7 @@ static int dp_copy_options_ex(TALLOC_CTX *memctx,
             }
             if (ret != EOK) {
                 DEBUG(SSSDBG_CRIT_FAILURE,
-                      "Failed to retrieve value for option (%s)\n",
+                      "Failed to copy value for option (%s)\n",
                        opts[i].opt_name);
                 goto done;
             }

--- a/src/providers/data_provider_req.h
+++ b/src/providers/data_provider_req.h
@@ -39,6 +39,7 @@
 #define BE_REQ_USER_AND_GROUP 0x0012
 #define BE_REQ_BY_UUID        0x0013
 #define BE_REQ_BY_CERT        0x0014
+#define BE_REQ__LAST          BE_REQ_BY_CERT /* must be equal to max REQ number */
 #define BE_REQ_TYPE_MASK      0x00FF
 
 /**

--- a/src/providers/files/files_ops.c
+++ b/src/providers/files/files_ops.c
@@ -395,7 +395,7 @@ static errno_t refresh_override_attrs(struct files_id_ctx *id_ctx,
                              override_attrs, &count, &msgs);
     if (ret != EOK) {
         if (ret == ENOENT) {
-            DEBUG(SSSDBG_OP_FAILURE, "No overrides, nothing to do.\n");
+            DEBUG(SSSDBG_TRACE_FUNC, "No overrides, nothing to do.\n");
             ret = EOK;
         } else {
             DEBUG(SSSDBG_OP_FAILURE, "sysdb_search_entry failed.\n");

--- a/src/providers/ipa/ipa_access.c
+++ b/src/providers/ipa/ipa_access.c
@@ -671,7 +671,7 @@ static void ipa_pam_access_handler_done(struct tevent_req *subreq)
     talloc_free(subreq);
 
     if (ret == ENOENT) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "No HBAC rules find, denying access\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "No HBAC rules found, denying access\n");
         state->pd->pam_status = PAM_PERM_DENIED;
         goto done;
     } else if (ret != EOK) {

--- a/src/providers/ipa/ipa_common.c
+++ b/src/providers/ipa/ipa_common.c
@@ -781,8 +781,7 @@ int ipa_get_auth_options(struct ipa_options *ipa_opts,
                                     dp_opt_get_string(ipa_opts->auth,
                                                       KRB5_REALM));
         if (value == NULL) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "Cannot set %s!\n",
-                     ipa_opts->auth[KRB5_FAST_PRINCIPAL].opt_name);
+            DEBUG(SSSDBG_CRIT_FAILURE, "talloc_asprintf() failed\n");
             ret = ENOMEM;
             goto done;
         }
@@ -851,7 +850,7 @@ static void ipa_resolve_callback(void *private_data, struct fo_server *server)
     srvaddr = fo_get_server_hostent(server);
     if (!srvaddr) {
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "FATAL: No hostent available for server (%s)\n",
+              "No hostent available for server (%s)\n",
                   fo_get_server_str_name(server));
         talloc_free(tmp_ctx);
         return;

--- a/src/providers/ipa/ipa_hbac_common.c
+++ b/src/providers/ipa/ipa_hbac_common.c
@@ -423,7 +423,7 @@ hbac_eval_user_element(TALLOC_CTX *mem_ctx,
     ret = sysdb_initgroups(tmp_ctx, domain, username, &res);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "sysdb_asq_search failed [%d]: %s\n", ret, sss_strerror(ret));
+              "sysdb_initgroups() failed [%d]: %s\n", ret, sss_strerror(ret));
         goto done;
     }
 

--- a/src/providers/ipa/ipa_hbac_services.c
+++ b/src/providers/ipa/ipa_hbac_services.c
@@ -487,7 +487,7 @@ hbac_service_attrs_to_rule(TALLOC_CTX *mem_ctx,
             /* Original DN matched a single service. Get the service name */
             name = ldb_msg_find_attr_as_string(msgs[0], IPA_CN, NULL);
             if (name == NULL) {
-                DEBUG(SSSDBG_CRIT_FAILURE, "Attribute is missing!\n");
+                DEBUG(SSSDBG_CRIT_FAILURE, "Attribute IPA_CN is missing!\n");
                 ret = EFAULT;
                 goto done;
             }
@@ -523,7 +523,7 @@ hbac_service_attrs_to_rule(TALLOC_CTX *mem_ctx,
                 /* Original DN matched a single group. Get the groupname */
                 name = ldb_msg_find_attr_as_string(msgs[0], IPA_CN, NULL);
                 if (name == NULL) {
-                    DEBUG(SSSDBG_CRIT_FAILURE, "Attribute is missing!\n");
+                    DEBUG(SSSDBG_CRIT_FAILURE, "Attribute IPA_CN is missing!\n");
                     ret = EFAULT;
                     goto done;
                 }

--- a/src/providers/ipa/ipa_hbac_users.c
+++ b/src/providers/ipa/ipa_hbac_users.c
@@ -124,7 +124,7 @@ get_ipa_groupname(TALLOC_CTX *mem_ctx,
     if (strcasecmp("cn", account_comp_name) != 0) {
         /* The third component name is not "cn" */
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "Expected cn in second component, got %s\n", account_comp_name);
+              "Expected cn in third component, got %s\n", account_comp_name);
         ret = ERR_UNEXPECTED_ENTRY_TYPE;
         goto done;
     }
@@ -135,7 +135,7 @@ get_ipa_groupname(TALLOC_CTX *mem_ctx,
                     account_comp_val->length) != 0) {
         /* The third component value is not "accounts" */
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "Expected cn accounts second component, got %s\n",
+              "Expected accounts third component, got %s\n",
               (const char *) account_comp_val->data);
         ret = ERR_UNEXPECTED_ENTRY_TYPE;
         goto done;

--- a/src/providers/ipa/ipa_id.c
+++ b/src/providers/ipa/ipa_id.c
@@ -266,7 +266,7 @@ ipa_initgr_get_overrides_send(TALLOC_CTX *memctx,
     }
     state->groups_id_attr = talloc_strdup(state, groups_id_attr);
     if (state->groups_id_attr == NULL) {
-        DEBUG(SSSDBG_OP_FAILURE, "talloc_strdup failed.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "talloc_strdup failed.\n");
         ret = ENOMEM;
         goto done;
     }

--- a/src/providers/ipa/ipa_init.c
+++ b/src/providers/ipa/ipa_init.c
@@ -317,10 +317,10 @@ static errno_t ipa_init_client_mode(struct be_ctx *be_ctx,
     ret = sysdb_get_view_name(ipa_id_ctx, be_ctx->domain->sysdb,
                               &ipa_id_ctx->view_name);
     if (ret == ENOENT) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Cannot find view name in the cache. "
+        DEBUG(SSSDBG_MINOR_FAILURE, "Cannot find view name in the cache. "
               "Will do online lookup later.\n");
     } else if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "sysdb_get_view_name() failed [%d]: %s\n",
+        DEBUG(SSSDBG_CRIT_FAILURE, "sysdb_get_view_name() failed [%d]: %s\n",
               ret, sss_strerror(ret));
         return ret;
     }

--- a/src/providers/ipa/ipa_s2n_exop.c
+++ b/src/providers/ipa/ipa_s2n_exop.c
@@ -2224,7 +2224,8 @@ static void ipa_s2n_get_user_done(struct tevent_req *subreq)
 
         break;
     default:
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unexpected request type.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Unexpected request type %d.\n", state->request_type);
         ret = EINVAL;
         goto done;
     }

--- a/src/providers/ipa/ipa_selinux.c
+++ b/src/providers/ipa/ipa_selinux.c
@@ -681,7 +681,7 @@ static errno_t selinux_fork_child(struct selinux_child_state *state)
     if (ret == -1) {
         ret = errno;
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "pipe failed [%d][%s].\n", errno, sss_strerror(errno));
+              "pipe (from) failed [%d][%s].\n", errno, sss_strerror(errno));
         return ret;
     }
 
@@ -689,7 +689,7 @@ static errno_t selinux_fork_child(struct selinux_child_state *state)
     if (ret == -1) {
         ret = errno;
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "pipe failed [%d][%s].\n", errno, sss_strerror(errno));
+              "pipe (to) failed [%d][%s].\n", errno, sss_strerror(errno));
         return ret;
     }
 

--- a/src/providers/ipa/ipa_session.c
+++ b/src/providers/ipa/ipa_session.c
@@ -668,7 +668,7 @@ ipa_pam_session_handler_get_deskprofile_user_info(TALLOC_CTX *mem_ctx,
 
     if (res->count != 1) {
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "sysdb_getpwnam() got more users than expected. "
+              "sysdb_getpwnam() returned unexpected amount of users. "
               "Expected [%d], got [%d]\n", 1, res->count);
         ret = EINVAL;
         goto done;

--- a/src/providers/ipa/ipa_session.c
+++ b/src/providers/ipa/ipa_session.c
@@ -570,7 +570,7 @@ ipa_pam_session_handler_done(struct tevent_req *subreq)
     talloc_free(subreq);
 
     if (ret == ENOENT) {
-        DEBUG(SSSDBG_IMPORTANT_INFO, "No Desktop Profile rules found\n");
+        DEBUG(SSSDBG_FUNC_DATA, "No Desktop Profile rules found\n");
         if (!state->session_ctx->no_rules_found) {
             state->session_ctx->no_rules_found = true;
             state->session_ctx->last_request = time(NULL);

--- a/src/providers/ipa/ipa_subdomains_ext_groups.c
+++ b/src/providers/ipa/ipa_subdomains_ext_groups.c
@@ -840,7 +840,8 @@ static void ipa_add_ad_memberships_get_next(struct tevent_req *req)
         }
 
         if (missing_groups) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "There are unresolved external group "
+            /* this might be HBAC or sudo rule */
+            DEBUG(SSSDBG_FUNC_DATA, "There are unresolved external group "
                                        "memberships even after all groups "
                                        "have been looked up on the LDAP "
                                        "server.\n");

--- a/src/providers/ipa/ipa_subdomains_id.c
+++ b/src/providers/ipa/ipa_subdomains_id.c
@@ -506,7 +506,13 @@ struct tevent_req *ipa_get_subdom_acct_send(TALLOC_CTX *memctx,
             break;
         default:
             ret = EINVAL;
-            DEBUG(SSSDBG_OP_FAILURE, "Invalid sub-domain request type.\n");
+            if (state->entry_type > BE_REQ__LAST) {
+                DEBUG(SSSDBG_OP_FAILURE, "Invalid sub-domain request type %d.\n",
+                      state->entry_type);
+            } else {
+                DEBUG(SSSDBG_TRACE_FUNC, "Unhandled sub-domain request type %d.\n",
+                      state->entry_type);
+            }
     }
     if (ret != EOK) goto fail;
 

--- a/src/providers/ipa/ipa_subdomains_id.c
+++ b/src/providers/ipa/ipa_subdomains_id.c
@@ -1309,7 +1309,7 @@ ipa_get_ad_acct_ad_part_done(struct tevent_req *subreq)
 
         state->object_sid = talloc_strdup(state, sid);
         if (state->object_sid == NULL) {
-            DEBUG(SSSDBG_OP_FAILURE, "talloc_strdup failed.\n");
+            DEBUG(SSSDBG_CRIT_FAILURE, "talloc_strdup failed.\n");
             ret = ENOMEM;
             goto fail;
         }
@@ -1521,7 +1521,7 @@ static errno_t ipa_get_ad_apply_override_step(struct tevent_req *req)
 
         state->ar->filter_value = talloc_strdup(state->ar, obj_name);
         if (state->ar->filter_value == NULL) {
-            DEBUG(SSSDBG_OP_FAILURE, "talloc_strdup failed.\n");
+            DEBUG(SSSDBG_CRIT_FAILURE, "talloc_strdup failed.\n");
             return ENOMEM;
         }
         state->ar->filter_type = BE_FILTER_NAME;

--- a/src/providers/ipa/ipa_subdomains_server.c
+++ b/src/providers/ipa/ipa_subdomains_server.c
@@ -513,7 +513,7 @@ static void ipa_getkeytab_exec(const char *ccache,
 
     gkt_env[0] = talloc_asprintf(NULL, "KRB5CCNAME=%s", ccache);
     if (gkt_env[0] == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Failed to format KRB5CCNAME\n");
+        DEBUG(SSSDBG_FATAL_FAILURE, "Failed to format KRB5CCNAME\n");
         exit(1);
     }
 
@@ -522,7 +522,7 @@ static void ipa_getkeytab_exec(const char *ccache,
     ret = unlink(keytab_path);
     if (ret == -1) {
         ret = errno;
-        DEBUG(SSSDBG_CRIT_FAILURE,
+        DEBUG(SSSDBG_FATAL_FAILURE,
               "Failed to unlink the temporary ccname [%d][%s]\n",
               ret, sss_strerror(ret));
         exit(1);
@@ -533,12 +533,12 @@ static void ipa_getkeytab_exec(const char *ccache,
                  "-r", "-s", server, "-p", principal, "-k", keytab_path, NULL,
                  gkt_env);
 
-    DEBUG(SSSDBG_CRIT_FAILURE,
+    DEBUG(SSSDBG_FATAL_FAILURE,
           "execle returned %d, this shouldn't happen!\n", ret);
 
     /* The child should never end up here */
     ret = errno;
-    DEBUG(SSSDBG_CRIT_FAILURE,
+    DEBUG(SSSDBG_FATAL_FAILURE,
           "execle failed [%d][%s].\n", ret, sss_strerror(ret));
     exit(1);
 }
@@ -748,7 +748,8 @@ static errno_t ipa_server_trusted_dom_setup_1way(struct tevent_req *req)
 
     state->new_keytab = talloc_asprintf(state, "%sXXXXXX", state->keytab);
     if (state->new_keytab == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Cannot set up ipa_get_keytab\n");
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Cannot set up ipa_get_keytab. talloc_asprintf() failed\n");
         return ENOMEM;
     }
 

--- a/src/providers/ipa/ipa_sudo.c
+++ b/src/providers/ipa/ipa_sudo.c
@@ -223,7 +223,7 @@ ipa_sudo_init_ipa_schema(TALLOC_CTX *mem_ctx,
                        ipa_sudorule_map, IPA_OPTS_SUDORULE,
                        &sudo_ctx->sudorule_map);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse attribute map "
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse attribute map (rule) "
               "[%d]: %s\n", ret, sss_strerror(ret));
         goto done;
     }
@@ -232,7 +232,7 @@ ipa_sudo_init_ipa_schema(TALLOC_CTX *mem_ctx,
                        ipa_sudocmdgroup_map, IPA_OPTS_SUDOCMDGROUP,
                        &sudo_ctx->sudocmdgroup_map);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse attribute map "
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse attribute map (cmdgroup) "
               "[%d]: %s\n", ret, sss_strerror(ret));
         goto done;
     }
@@ -241,7 +241,7 @@ ipa_sudo_init_ipa_schema(TALLOC_CTX *mem_ctx,
                        ipa_sudocmd_map, IPA_OPTS_SUDOCMD,
                        &sudo_ctx->sudocmd_map);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse attribute map "
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse attribute map (cmd) "
               "[%d]: %s\n", ret, sss_strerror(ret));
         goto done;
     }
@@ -250,16 +250,16 @@ ipa_sudo_init_ipa_schema(TALLOC_CTX *mem_ctx,
                          CONFDB_SUDO_THRESHOLD, CONFDB_DEFAULT_SUDO_THRESHOLD,
                          &sudo_ctx->sudocmd_threshold);
     if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "Could not parse sudo search base\n");
-        return ret;
+        DEBUG(SSSDBG_CRIT_FAILURE, "Could not get sudo threshold\n");
+        goto done;
     }
 
     ret = sdap_parse_search_base(sudo_ctx, sudo_ctx->sdap_opts->basic,
                                  SDAP_SUDO_SEARCH_BASE,
                                  &sudo_ctx->sudo_sb);
     if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "Could not parse sudo search base\n");
-        return ret;
+        DEBUG(SSSDBG_CRIT_FAILURE, "Could not parse sudo search base\n");
+        goto done;
     }
 
     ret = ipa_sudo_ptask_setup(be_ctx, sudo_ctx);

--- a/src/providers/ipa/ipa_sudo_async.c
+++ b/src/providers/ipa/ipa_sudo_async.c
@@ -520,7 +520,7 @@ ipa_sudo_fetch_addtl_cmdgroups_done(struct tevent_req *subreq)
         goto done;
     }
 
-    DEBUG(SSSDBG_IMPORTANT_INFO, "Received %zu additional command groups\n",
+    DEBUG(SSSDBG_FUNC_DATA, "Received %zu additional command groups\n",
           num_attrs);
 
     ret = ipa_sudo_filter_rules_bycmdgroups(state, state->domain, attrs,
@@ -609,7 +609,7 @@ ipa_sudo_fetch_rules_done(struct tevent_req *subreq)
         goto done;
     }
 
-    DEBUG(SSSDBG_IMPORTANT_INFO, "Received %zu sudo rules\n", num_attrs);
+    DEBUG(SSSDBG_FUNC_DATA, "Received %zu sudo rules\n", num_attrs);
 
     ret = ipa_sudo_conv_rules(state->conv, attrs, num_attrs);
     if (ret != EOK) {
@@ -689,7 +689,7 @@ ipa_sudo_fetch_cmdgroups_done(struct tevent_req *subreq)
         goto done;
     }
 
-    DEBUG(SSSDBG_IMPORTANT_INFO, "Received %zu sudo command groups\n",
+    DEBUG(SSSDBG_FUNC_DATA, "Received %zu sudo command groups\n",
           num_attrs);
 
     ret = ipa_sudo_conv_cmdgroups(state->conv, attrs, num_attrs);
@@ -769,7 +769,7 @@ ipa_sudo_fetch_cmds_done(struct tevent_req *subreq)
         goto done;
     }
 
-    DEBUG(SSSDBG_IMPORTANT_INFO, "Received %zu sudo commands\n", num_attrs);
+    DEBUG(SSSDBG_FUNC_DATA, "Received %zu sudo commands\n", num_attrs);
 
     ret = ipa_sudo_conv_cmds(state->conv, attrs, num_attrs);
     if (ret != EOK) {
@@ -1109,7 +1109,7 @@ done:
     if (in_transaction) {
         sret = sysdb_transaction_cancel(state->sysdb);
         if (sret != EOK) {
-            DEBUG(SSSDBG_OP_FAILURE, "Could not cancel transaction\n");
+            DEBUG(SSSDBG_CRIT_FAILURE, "Could not cancel transaction\n");
         }
     }
 

--- a/src/providers/ipa/ipa_sudo_conversion.c
+++ b/src/providers/ipa/ipa_sudo_conversion.c
@@ -801,7 +801,7 @@ convert_host(TALLOC_CTX *mem_ctx,
         *skip_entry = true;
         return NULL;
     } else if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "ipa_get_rdn() failed on value %s [%d]: %s\n",
+        DEBUG(SSSDBG_CRIT_FAILURE, "ipa_get_rdn() failed on value %s [%d]: %s\n",
               value, ret, sss_strerror(ret));
         return NULL;
     }
@@ -841,7 +841,7 @@ convert_user(TALLOC_CTX *mem_ctx,
         *skip_entry = true;
         return NULL;
     } else if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "ipa_get_rdn() failed on value %s [%d]: %s\n",
+        DEBUG(SSSDBG_CRIT_FAILURE, "ipa_get_rdn() failed on value %s [%d]: %s\n",
               value, ret, sss_strerror(ret));
         return NULL;
     }
@@ -904,7 +904,7 @@ convert_group(TALLOC_CTX *mem_ctx,
         *skip_entry = true;
         return NULL;
     } else if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "ipa_get_rdn() failed on value %s [%d]: %s\n",
+        DEBUG(SSSDBG_CRIT_FAILURE, "ipa_get_rdn() failed on value %s [%d]: %s\n",
               value, ret, sss_strerror(ret));
         return NULL;
     }

--- a/src/providers/ipa/ipa_views.c
+++ b/src/providers/ipa/ipa_views.c
@@ -232,7 +232,7 @@ static errno_t get_dp_id_data_for_xyz(TALLOC_CTX *mem_ctx, const char *val,
     ar->filter_value = talloc_strdup(ar, val);
     ar->domain = talloc_strdup(ar, domain_name);
     if (ar->filter_value == NULL || ar->domain == NULL) {
-        DEBUG(SSSDBG_OP_FAILURE, "talloc_strdup failed.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "talloc_strdup failed.\n");
         talloc_free(ar);
         return ENOMEM;
     }
@@ -471,7 +471,7 @@ static void ipa_get_ad_override_done(struct tevent_req *subreq)
 
     ret = ipa_get_ad_override_qualify_name(state);
     if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "Cannot qualify object name\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "Cannot qualify object name\n");
         goto fail;
     }
 

--- a/src/providers/krb5/krb5_access.c
+++ b/src/providers/krb5/krb5_access.c
@@ -78,7 +78,8 @@ struct tevent_req *krb5_access_send(TALLOC_CTX *mem_ctx,
     }
 
     if (pd->cmd != SSS_PAM_ACCT_MGMT) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unexpected pam task.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Unexpected pam task %d.\n", pd->cmd);
         ret = EINVAL;
         goto done;
     }

--- a/src/providers/krb5/krb5_auth.c
+++ b/src/providers/krb5/krb5_auth.c
@@ -499,7 +499,7 @@ struct tevent_req *krb5_auth_send(TALLOC_CTX *mem_ctx,
                 /* handle empty password gracefully */
                 if (authtok_type == SSS_AUTHTOK_TYPE_EMPTY) {
                     DEBUG(SSSDBG_CRIT_FAILURE,
-                          "Illegal zero-length authtok for user [%s]\n",
+                          "Illegal empty authtok for user [%s]\n",
                            pd->user);
                     state->pam_status = PAM_AUTH_ERR;
                     state->dp_err = DP_ERR_OK;
@@ -854,7 +854,7 @@ static void krb5_auth_done(struct tevent_req *subreq)
             ret = EOK;
             goto done;
         default:
-            DEBUG(SSSDBG_CRIT_FAILURE, "Unexpected PAM task\n");
+            DEBUG(SSSDBG_CRIT_FAILURE, "Unexpected PAM task %d\n", pd->cmd);
             ret = EINVAL;
             goto done;
         }

--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -258,7 +258,7 @@ static void sss_krb5_expire_callback_func(krb5_context context, void *data,
 
     blob = talloc_array(kr->pd, uint32_t, 2);
     if (blob == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "talloc_size failed.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "talloc_array failed.\n");
         return;
     }
 
@@ -525,7 +525,8 @@ static krb5_error_code tokeninfo_matches(TALLOC_CTX *mem_ctx,
                                      out_token, out_pin);
         break;
     default:
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unsupported authtok type.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Unsupported authtok type %d\n", sss_authtok_get_type(auth_tok));
     }
 
     return EINVAL;
@@ -1087,7 +1088,7 @@ static errno_t pack_response_packet(TALLOC_CTX *mem_ctx, errno_t error,
 
     buf = talloc_array(mem_ctx, uint8_t, size);
     if (!buf) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Insufficient memory to create message.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "talloc_array failed\n");
         return ENOMEM;
     }
 
@@ -1958,13 +1959,12 @@ static errno_t changepw_child(struct krb5_req *kr, bool prelim)
                                           &msg_len, &msg);
         if (ret != EOK) {
             DEBUG(SSSDBG_CRIT_FAILURE,
-                  "pack_user_info_chpass_error failed.\n");
+                  "pack_user_info_chpass_error failed [%d]\n", ret);
         } else {
             ret = pam_add_response(kr->pd, SSS_PAM_USER_INFO, msg_len,
                                    msg);
             if (ret != EOK) {
-                DEBUG(SSSDBG_CRIT_FAILURE,
-                      "pam_add_response failed.\n");
+                DEBUG(SSSDBG_CRIT_FAILURE, "pam_add_response failed.\n");
             }
         }
         return kerr;
@@ -2036,13 +2036,12 @@ static errno_t changepw_child(struct krb5_req *kr, bool prelim)
                                               &user_resp_len, &user_resp);
             if (ret != EOK) {
                 DEBUG(SSSDBG_CRIT_FAILURE,
-                      "pack_user_info_chpass_error failed.\n");
+                      "pack_user_info_chpass_error failed [%d]\n", ret);
             } else {
                 ret = pam_add_response(kr->pd, SSS_PAM_USER_INFO, user_resp_len,
                                        user_resp);
                 if (ret != EOK) {
-                    DEBUG(SSSDBG_CRIT_FAILURE,
-                          "pam_add_response failed.\n");
+                    DEBUG(SSSDBG_CRIT_FAILURE, "pam_add_response failed.\n");
                 }
             }
         }
@@ -2448,7 +2447,7 @@ static errno_t unpack_buffer(uint8_t *buf, size_t size,
 
     pd = create_pam_data(kr);
     if (pd == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "talloc_zero failed.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "create_pam_data failed.\n");
         return ENOMEM;
     }
     kr->pd = pd;
@@ -3110,7 +3109,7 @@ static int k5c_setup(struct krb5_req *kr, uint32_t offline)
 
     kr->creds = calloc(1, sizeof(krb5_creds));
     if (kr->creds == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "talloc_zero failed.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "calloc failed.\n");
         return ENOMEM;
     }
 
@@ -3345,7 +3344,7 @@ int main(int argc, const char *argv[])
 
     kr = talloc_zero(NULL, struct krb5_req);
     if (kr == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "talloc failed.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "talloc_zero failed.\n");
         ret = ENOMEM;
         goto done;
     }
@@ -3403,7 +3402,7 @@ int main(int argc, const char *argv[])
 
     ret = k5c_setup(kr, offline);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "krb5_child_setup failed.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "k5c_setup failed.\n");
         goto done;
     }
 

--- a/src/providers/krb5/krb5_child_handler.c
+++ b/src/providers/krb5/krb5_child_handler.c
@@ -449,14 +449,14 @@ static errno_t fork_child(struct tevent_req *req)
     if (ret == -1) {
         ret = errno;
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "pipe failed [%d][%s].\n", errno, strerror(errno));
+              "pipe (from) failed [%d][%s].\n", errno, strerror(errno));
         goto fail;
     }
     ret = pipe(pipefd_to_child);
     if (ret == -1) {
         ret = errno;
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "pipe failed [%d][%s].\n", errno, strerror(errno));
+              "pipe (to) failed [%d][%s].\n", errno, strerror(errno));
         goto fail;
     }
 

--- a/src/providers/krb5/krb5_common.c
+++ b/src/providers/krb5/krb5_common.c
@@ -793,7 +793,7 @@ static void krb5_resolve_callback(void *private_data, struct fo_server *server)
 
     krb5_service = talloc_get_type(private_data, struct krb5_service);
     if (!krb5_service) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "FATAL: Bad private_data\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "Bad private_data\n");
         return;
     }
 
@@ -1110,7 +1110,7 @@ void remove_krb5_info_files_callback(void *pvt)
                                               ctx->kdc_service_name);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "be_fo_run_callbacks_at_next_request failed, "
+              "be_fo_run_callbacks_at_next_request(kdc_service_name) failed, "
                   "krb5 info files will not be removed, because "
                   "it is unclear if they will be recreated properly.\n");
         return;
@@ -1120,7 +1120,7 @@ void remove_krb5_info_files_callback(void *pvt)
                                             ctx->kpasswd_service_name);
         if (ret != EOK) {
             DEBUG(SSSDBG_CRIT_FAILURE,
-                  "be_fo_run_callbacks_at_next_request failed, "
+                  "be_fo_run_callbacks_at_next_request(kpasswd_service_name) failed, "
                       "krb5 info files will not be removed, because "
                       "it is unclear if they will be recreated properly.\n");
             return;

--- a/src/providers/krb5/krb5_delayed_online_authentication.c
+++ b/src/providers/krb5/krb5_delayed_online_authentication.c
@@ -173,7 +173,7 @@ static errno_t authenticate_stored_users(
         ret = hash_lookup(uid_table, &key, &value);
 
         if (ret == HASH_SUCCESS) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "User [%s] is still logged in, "
+            DEBUG(SSSDBG_FUNC_DATA, "User [%s] is still logged in, "
                       "trying online authentication.\n", pd->user);
 
             auth_data = talloc_zero(deferred_auth_ctx->be_ctx,
@@ -193,7 +193,7 @@ static errno_t authenticate_stored_users(
                 }
             }
         } else {
-            DEBUG(SSSDBG_CRIT_FAILURE, "User [%s] is not logged in anymore, "
+            DEBUG(SSSDBG_FUNC_DATA, "User [%s] is not logged in anymore, "
                       "discarding online authentication.\n", pd->user);
             talloc_free(pd);
         }

--- a/src/providers/krb5/krb5_renew_tgt.c
+++ b/src/providers/krb5/krb5_renew_tgt.c
@@ -405,7 +405,7 @@ static errno_t check_ccache_files(struct renew_tgt_ctx *renew_tgt_ctx)
 
     base_dn = sysdb_user_base_dn(tmp_ctx, renew_tgt_ctx->be_ctx->domain);
     if (base_dn == NULL) {
-        DEBUG(SSSDBG_OP_FAILURE, "sysdb_base_dn failed.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "sysdb_base_dn failed.\n");
         ret = ENOMEM;
         goto done;
     }
@@ -440,7 +440,7 @@ static errno_t check_ccache_files(struct renew_tgt_ctx *renew_tgt_ctx)
 
         ret = sss_parse_internal_fqname(tmp_ctx, user_name, NULL, &user_dom);
         if (ret != EOK) {
-            DEBUG(SSSDBG_OP_FAILURE,
+            DEBUG(SSSDBG_CRIT_FAILURE,
                   "Cannot parse internal fqname [%d]: %s\n",
                   ret, sss_strerror(ret));
             goto done;

--- a/src/providers/krb5/krb5_utils.c
+++ b/src/providers/krb5/krb5_utils.c
@@ -287,7 +287,7 @@ char *expand_ccname_template(TALLOC_CTX *mem_ctx, struct krb5child_req *kr,
                 name = sss_output_name(tmp_ctx, kr->pd->user, case_sensitive, 0);
                 if (name == NULL) {
                     DEBUG(SSSDBG_CRIT_FAILURE,
-                          "sss_get_cased_name failed\n");
+                          "sss_output_name failed\n");
                     goto done;
                 }
 

--- a/src/providers/ldap/ldap_auth.c
+++ b/src/providers/ldap/ldap_auth.c
@@ -64,7 +64,7 @@ static errno_t add_expired_warning(struct pam_data *pd, long exp_time)
 
     data = talloc_array(pd, uint32_t, 2);
     if (data == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "talloc_size failed.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "talloc_array failed.\n");
         return ENOMEM;
     }
 
@@ -249,7 +249,8 @@ errno_t check_pwexpire_policy(enum pwexpire pw_expire_type,
         ret = EOK;
         break;
     default:
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unknown password expiration type.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Unknown password expiration type %d.\n", pw_expire_type);
         ret = EINVAL;
     }
 
@@ -1355,9 +1356,10 @@ static void sdap_pam_chpass_handler_auth_done(struct tevent_req *subreq)
         case PWEXPIRE_NONE:
             break;
         default:
-            DEBUG(SSSDBG_CRIT_FAILURE, "Unknown password expiration type.\n");
-                state->pd->pam_status = PAM_SYSTEM_ERR;
-                goto done;
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Unknown password expiration type %d.\n", pw_expire_type);
+            state->pd->pam_status = PAM_SYSTEM_ERR;
+            goto done;
         }
     }
 

--- a/src/providers/ldap/ldap_child.c
+++ b/src/providers/ldap/ldap_child.c
@@ -223,7 +223,7 @@ static int lc_verify_keytab_ex(const char *principal,
             /* This should never happen. The API docs for this function
              * specify only success for this function
              */
-            DEBUG(SSSDBG_CRIT_FAILURE,"Could not free keytab entry contents\n");
+            DEBUG(SSSDBG_CRIT_FAILURE, "Could not free keytab entry contents\n");
             /* This is non-fatal, so we'll continue here */
         }
 

--- a/src/providers/ldap/ldap_init.c
+++ b/src/providers/ldap/ldap_init.c
@@ -43,8 +43,8 @@ struct ldap_init_ctx {
 };
 
 /* Please use this only for short lists */
-errno_t check_order_list_for_duplicates(char **list,
-                                        bool case_sensitive)
+static errno_t check_order_list_for_duplicates(char **list,
+                                               bool case_sensitive)
 {
     size_t c;
     size_t d;

--- a/src/providers/ldap/ldap_options.c
+++ b/src/providers/ldap/ldap_options.c
@@ -408,14 +408,15 @@ int ldap_get_options(TALLOC_CTX *memctx,
         sss_erase_talloc_mem_securely(cleartext);
         talloc_free(cleartext);
         if (ret != EOK) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "dp_opt_set_string failed.\n");
+            DEBUG(SSSDBG_CRIT_FAILURE, "dp_opt_set_blob(authtok) failed.\n");
             goto done;
         }
 
         ret = dp_opt_set_string(opts->basic, SDAP_DEFAULT_AUTHTOK_TYPE,
                                 "password");
         if (ret != EOK) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "dp_opt_set_string failed.\n");
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "dp_opt_set_string(authtok_type) failed.\n");
             goto done;
         }
     }
@@ -629,7 +630,8 @@ int ldap_get_autofs_options(TALLOC_CTX *memctx,
             default_entry_map = rfc2307bis_autofs_entry_map;
             break;
         default:
-            DEBUG(SSSDBG_CRIT_FAILURE, "Unknown LDAP schema!\n");
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Unknown LDAP schema %d!\n", opts->schema_type);
             return EINVAL;
     }
 

--- a/src/providers/ldap/sdap.c
+++ b/src/providers/ldap/sdap.c
@@ -371,7 +371,7 @@ int sdap_get_map(TALLOC_CTX *memctx,
 
         if (map[i].def_name && !map[i].name) {
             DEBUG(SSSDBG_CRIT_FAILURE,
-                  "Failed to retrieve value for %s\n", map[i].opt_name);
+                  "Failed to process value for %s\n", map[i].opt_name);
             talloc_zfree(map);
             return EINVAL;
         }
@@ -532,7 +532,8 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
             if (!vals) {
                 ldap_get_option(sh->ldap, LDAP_OPT_RESULT_CODE, &lerrno);
                 if (lerrno != LDAP_SUCCESS) {
-                    DEBUG(SSSDBG_CRIT_FAILURE, "LDAP Library error: %d(%s)\n",
+                    DEBUG(SSSDBG_CRIT_FAILURE,
+                          "ldap_get_values_len() failed: %d(%s)\n",
                           lerrno, sss_ldap_err2string(lerrno));
                     ret = EIO;
                     goto done;
@@ -613,7 +614,7 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
 
     ldap_get_option(sh->ldap, LDAP_OPT_RESULT_CODE, &lerrno);
     if (lerrno) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "LDAP Library error: %d(%s)\n",
+        DEBUG(SSSDBG_CRIT_FAILURE, "ldap_get_option() failed: %d(%s)\n",
               lerrno, sss_ldap_err2string(lerrno));
         ret = EIO;
         goto done;
@@ -884,7 +885,8 @@ errno_t setup_tls_config(struct dp_option *basic_opts)
             ldap_opt_x_tls_require_cert = LDAP_OPT_X_TLS_HARD;
         }
         else {
-            DEBUG(SSSDBG_CRIT_FAILURE, "Unknown value for tls_reqcert.\n");
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Unknown value for tls_reqcert '%s'.\n", tls_opt);
             return EINVAL;
         }
         /* LDAP_OPT_X_TLS_REQUIRE_CERT has to be set as a global option,
@@ -893,7 +895,8 @@ errno_t setup_tls_config(struct dp_option *basic_opts)
                               &ldap_opt_x_tls_require_cert);
         if (ret != LDAP_OPT_SUCCESS) {
             DEBUG(SSSDBG_CRIT_FAILURE,
-                  "ldap_set_option failed: %s\n", sss_ldap_err2string(ret));
+                  "ldap_set_option(req_cert) failed: %s\n",
+                  sss_ldap_err2string(ret));
             return EIO;
         }
     }
@@ -903,7 +906,8 @@ errno_t setup_tls_config(struct dp_option *basic_opts)
         ret = ldap_set_option(NULL, LDAP_OPT_X_TLS_CACERTFILE, tls_opt);
         if (ret != LDAP_OPT_SUCCESS) {
             DEBUG(SSSDBG_CRIT_FAILURE,
-                  "ldap_set_option failed: %s\n", sss_ldap_err2string(ret));
+                  "ldap_set_option(cacertfile) failed: %s\n",
+                  sss_ldap_err2string(ret));
             return EIO;
         }
     }
@@ -913,7 +917,8 @@ errno_t setup_tls_config(struct dp_option *basic_opts)
         ret = ldap_set_option(NULL, LDAP_OPT_X_TLS_CACERTDIR, tls_opt);
         if (ret != LDAP_OPT_SUCCESS) {
             DEBUG(SSSDBG_CRIT_FAILURE,
-                  "ldap_set_option failed: %s\n", sss_ldap_err2string(ret));
+                  "ldap_set_option(cacertdir) failed: %s\n",
+                  sss_ldap_err2string(ret));
             return EIO;
         }
     }
@@ -923,7 +928,8 @@ errno_t setup_tls_config(struct dp_option *basic_opts)
         ret = ldap_set_option(NULL, LDAP_OPT_X_TLS_CERTFILE, tls_opt);
         if (ret != LDAP_OPT_SUCCESS) {
             DEBUG(SSSDBG_CRIT_FAILURE,
-                  "ldap_set_option failed: %s\n", sss_ldap_err2string(ret));
+                  "ldap_set_option(certfile) failed: %s\n",
+                  sss_ldap_err2string(ret));
             return EIO;
         }
     }
@@ -933,7 +939,8 @@ errno_t setup_tls_config(struct dp_option *basic_opts)
         ret = ldap_set_option(NULL, LDAP_OPT_X_TLS_KEYFILE, tls_opt);
         if (ret != LDAP_OPT_SUCCESS) {
             DEBUG(SSSDBG_CRIT_FAILURE,
-                  "ldap_set_option failed: %s\n", sss_ldap_err2string(ret));
+                  "ldap_set_option(keyfile) failed: %s\n",
+                  sss_ldap_err2string(ret));
             return EIO;
         }
     }
@@ -943,7 +950,8 @@ errno_t setup_tls_config(struct dp_option *basic_opts)
         ret = ldap_set_option(NULL, LDAP_OPT_X_TLS_CIPHER_SUITE, tls_opt);
         if (ret != LDAP_OPT_SUCCESS) {
             DEBUG(SSSDBG_CRIT_FAILURE,
-                  "ldap_set_option failed: %s\n", sss_ldap_err2string(ret));
+                  "ldap_set_option(cipher) failed: %s\n",
+                  sss_ldap_err2string(ret));
             return EIO;
         }
     }

--- a/src/providers/ldap/sdap_access.c
+++ b/src/providers/ldap/sdap_access.c
@@ -317,7 +317,8 @@ static errno_t sdap_access_check_next_rule(struct sdap_access_req_ctx *state,
 
         default:
             DEBUG(SSSDBG_CRIT_FAILURE,
-                  "Unexpected access rule type. Access denied.\n");
+                  "Unexpected access rule type %d. Access denied.\n",
+                  state->access_ctx->access_rule[state->current_rule]);
             ret = ERR_ACCESS_DENIED;
         }
 
@@ -1220,13 +1221,13 @@ static errno_t sdap_save_user_cache_bool(struct sss_domain_info *domain,
     attrs = sysdb_new_attrs(NULL);
     if (attrs == NULL) {
         ret = ENOMEM;
-        DEBUG(SSSDBG_CRIT_FAILURE, "Could not set up attrs\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "Could not create attrs\n");
         goto done;
     }
 
     ret = sysdb_attrs_add_bool(attrs, attr_name, value);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Could not set up attrs\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "Could not set up attr value\n");
         goto done;
     }
 
@@ -1787,7 +1788,7 @@ errno_t sdap_access_ppolicy_step(struct tevent_req *req)
                                    false);
 
     if (subreq == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "sdap_access_ppolicy_send failed.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "sdap_get_generic_send failed.\n");
         ret = ENOMEM;
         goto done;
     }
@@ -1913,7 +1914,7 @@ static void sdap_access_ppolicy_step_done(struct tevent_req *subreq)
             ret = sdap_access_decide_offline(state->cached_access);
         } else {
             DEBUG(SSSDBG_CRIT_FAILURE,
-                  "sdap_get_generic_send() returned error [%d][%s]\n",
+                  "sdap_id_op_done() returned error [%d][%s]\n",
                   ret, sss_strerror(ret));
         }
 

--- a/src/providers/ldap/sdap_async.c
+++ b/src/providers/ldap/sdap_async.c
@@ -749,7 +749,7 @@ sdap_modify_send(TALLOC_CTX *mem_ctx,
 
     ret = ldap_modify_ext(state->sh->ldap, dn, mods, NULL, NULL, &msgid);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Failed to send operation!\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "ldap_modify_ext() failed [%d]\n", ret);
         goto done;
     }
 
@@ -2120,7 +2120,7 @@ static int sdap_x_deref_create_control(struct sdap_handle *sh,
 
     ret = ldap_create_deref_control_value(sh->ldap, ds, &derefval);
     if (ret != LDAP_SUCCESS) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "sss_ldap_control_create failed: %s\n",
+        DEBUG(SSSDBG_CRIT_FAILURE, "ldap_create_deref_control_value failed: %s\n",
                   ldap_err2string(ret));
         return ret;
     }
@@ -2129,7 +2129,7 @@ static int sdap_x_deref_create_control(struct sdap_handle *sh,
                               1, &derefval, 1, ctrl);
     ldap_memfree(derefval.bv_val);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "sss_ldap_control_create failed\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "sdap_control_create failed %d\n", ret);
         return ret;
     }
 
@@ -2875,7 +2875,8 @@ static void sdap_deref_search_done(struct tevent_req *subreq)
                 &state->reply_count, &state->reply);
         break;
     default:
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unknown deref method\n");
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Unknown deref method %d\n", state->deref_type);
         tevent_req_error(req, EINVAL);
         return;
     }

--- a/src/providers/ldap/sdap_async_autofs.c
+++ b/src/providers/ldap/sdap_async_autofs.c
@@ -720,7 +720,7 @@ sdap_autofs_setautomntent_send(TALLOC_CTX *memctx,
                                       dp_opt_get_int(state->opts->basic,
                                                      SDAP_SEARCH_TIMEOUT));
     if (!subreq) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "sdap_get_automntmap_send failed\n");
         ret = ENOMEM;
         goto fail;
     }

--- a/src/providers/ldap/sdap_async_connection.c
+++ b/src/providers/ldap/sdap_async_connection.c
@@ -694,10 +694,10 @@ static struct tevent_req *simple_bind_send(TALLOC_CTX *memctx,
                               LDAP_OPT_RESULT_CODE, &ldap_err);
         if (ret != LDAP_OPT_SUCCESS) {
             DEBUG(SSSDBG_CRIT_FAILURE,
-                  "ldap_bind failed (couldn't get ldap error)\n");
+                  "ldap_sasl_bind failed (couldn't get ldap error)\n");
             ret = LDAP_LOCAL_ERROR;
         } else {
-            DEBUG(SSSDBG_CRIT_FAILURE, "ldap_bind failed (%d)[%s]\n",
+            DEBUG(SSSDBG_CRIT_FAILURE, "ldap_sasl_bind failed (%d)[%s]\n",
                       ldap_err, sss_ldap_err2string(ldap_err));
             ret = ldap_err;
         }
@@ -988,7 +988,7 @@ static struct tevent_req *sasl_bind_send(TALLOC_CTX *memctx,
                                        (*sdap_sasl_interact), state);
     if (ret != LDAP_SUCCESS) {
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "ldap_sasl_bind failed (%d)[%s]\n",
+              "ldap_sasl_interactive_bind_s failed (%d)[%s]\n",
                ret, sss_ldap_err2string(ret));
 
         optret = sss_ldap_get_diagnostic_msg(state, state->sh->ldap,

--- a/src/providers/ldap/sdap_async_groups.c
+++ b/src/providers/ldap/sdap_async_groups.c
@@ -883,10 +883,7 @@ static int sdap_save_grpmem(TALLOC_CTX *memctx,
     const char *check_name;
 
     if (dom->ignore_group_members) {
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Group members are ignored, nothing to do. If you see this " \
-              "message it might indicate an error in the group processing " \
-              "logic.\n");
+        DEBUG(SSSDBG_TRACE_FUNC, "Group members are ignored, nothing to do.\n");
         return EOK;
     }
 

--- a/src/providers/ldap/sdap_async_groups.c
+++ b/src/providers/ldap/sdap_async_groups.c
@@ -1270,7 +1270,7 @@ sdap_process_group_send(TALLOC_CTX *memctx,
 
     /* Group without members */
     if (el->num_values == 0) {
-        DEBUG(SSSDBG_OP_FAILURE, "No Members. Done!\n");
+        DEBUG(SSSDBG_FUNC_DATA, "No Members. Done!\n");
         ret = EOK;
         goto done;
     }

--- a/src/providers/ldap/sdap_async_groups.c
+++ b/src/providers/ldap/sdap_async_groups.c
@@ -2249,7 +2249,7 @@ static void sdap_nested_done(struct tevent_req *subreq)
 
     if (hash_count(state->missing_external) == 0) {
         /* No external members. Processing complete */
-        DEBUG(SSSDBG_TRACE_INTERNAL, "No external members, done");
+        DEBUG(SSSDBG_TRACE_INTERNAL, "No external members, done\n");
         tevent_req_done(req);
         return;
     }

--- a/src/providers/ldap/sdap_async_initgroups.c
+++ b/src/providers/ldap/sdap_async_initgroups.c
@@ -1043,6 +1043,10 @@ static void sdap_initgr_nested_search(struct tevent_req *subreq)
         state->groups[state->groups_cur] = talloc_steal(state->groups,
                                                         groups[0]);
         state->groups_cur++;
+    } else if (count == 0) {
+        /* this might be HBAC or sudo rule */
+        DEBUG(SSSDBG_FUNC_DATA, "Object %s not found. Skipping\n",
+              state->group_dns[state->cur]);
     } else {
         DEBUG(SSSDBG_OP_FAILURE,
               "Search for group %s, returned %zu results. Skipping\n",

--- a/src/providers/ldap/sdap_async_initgroups.c
+++ b/src/providers/ldap/sdap_async_initgroups.c
@@ -345,7 +345,7 @@ int sdap_initgr_common_store(struct sysdb_ctx *sysdb,
                                          add_groups, ldap_groups,
                                          ldap_groups_count);
         if (ret != EOK) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "Adding incomplete users failed\n");
+            DEBUG(SSSDBG_CRIT_FAILURE, "Adding incomplete groups failed\n");
             goto done;
         }
     }

--- a/src/providers/ldap/sdap_async_initgroups_ad.c
+++ b/src/providers/ldap/sdap_async_initgroups_ad.c
@@ -378,7 +378,7 @@ static void sdap_ad_resolve_sids_done(struct tevent_req *subreq)
         /* Group was not found, we will ignore the error and continue with
          * next group. This may happen for example if the group is built-in,
          * but a custom search base is provided. */
-        DEBUG(SSSDBG_CRIT_FAILURE,
+        DEBUG(SSSDBG_MINOR_FAILURE,
               "Unable to resolve SID %s - will try next sid.\n",
               state->current_sid);
     } else if (ret != EOK || sdap_error != EOK || dp_error != DP_ERR_OK) {

--- a/src/providers/ldap/sdap_async_sudo.c
+++ b/src/providers/ldap/sdap_async_sudo.c
@@ -111,7 +111,7 @@ static void sdap_sudo_load_sudoers_done(struct tevent_req *subreq)
         return;
     }
 
-    DEBUG(SSSDBG_IMPORTANT_INFO, "Received %zu sudo rules\n",
+    DEBUG(SSSDBG_FUNC_DATA, "Received %zu sudo rules\n",
           state->num_rules);
 
     tevent_req_done(req);
@@ -665,7 +665,7 @@ done:
     if (in_transaction) {
         sret = sysdb_transaction_cancel(state->sysdb);
         if (sret != EOK) {
-            DEBUG(SSSDBG_OP_FAILURE, "Could not cancel transaction\n");
+            DEBUG(SSSDBG_CRIT_FAILURE, "Could not cancel transaction\n");
         }
     }
 

--- a/src/providers/ldap/sdap_child_helpers.c
+++ b/src/providers/ldap/sdap_child_helpers.c
@@ -95,14 +95,14 @@ static errno_t sdap_fork_child(struct tevent_context *ev,
     if (ret == -1) {
         ret = errno;
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "pipe failed [%d][%s].\n", ret, strerror(ret));
+              "pipe(from) failed [%d][%s].\n", ret, strerror(ret));
         goto fail;
     }
     ret = pipe(pipefd_to_child);
     if (ret == -1) {
         ret = errno;
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "pipe failed [%d][%s].\n", ret, strerror(ret));
+              "pipe(to) failed [%d][%s].\n", ret, strerror(ret));
         goto fail;
     }
 
@@ -332,7 +332,7 @@ struct tevent_req *sdap_get_tgt_send(TALLOC_CTX *mem_ctx,
 
     ret = set_tgt_child_timeout(req, ev, timeout);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "activate_child_timeout_handler failed.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "set_tgt_child_timeout failed.\n");
         goto fail;
     }
 

--- a/src/providers/ldap/sdap_hostid.c
+++ b/src/providers/ldap/sdap_hostid.c
@@ -166,7 +166,7 @@ hosts_get_done(struct tevent_req *subreq)
     }
 
     if (state->count == 0) {
-        DEBUG(SSSDBG_OP_FAILURE,
+        DEBUG(SSSDBG_FUNC_DATA,
               "No host with name [%s] found.\n", state->name);
 
         ret = sysdb_delete_ssh_host(state->domain, state->name);

--- a/src/providers/ldap/sdap_id_op.c
+++ b/src/providers/ldap/sdap_id_op.c
@@ -563,7 +563,7 @@ static void sdap_id_op_connect_done(struct tevent_req *subreq)
                    "is enabled.\n");
         } else {
             /* be is going offline as there is no more servers to try */
-            DEBUG(SSSDBG_CRIT_FAILURE,
+            DEBUG(SSSDBG_OP_FAILURE,
                   "Failed to connect, going offline (%d [%s])\n",
                    ret, strerror(ret));
             is_offline = true;

--- a/src/providers/proxy/proxy_auth.c
+++ b/src/providers/proxy/proxy_auth.c
@@ -68,7 +68,7 @@ static struct tevent_req *proxy_child_send(TALLOC_CTX *mem_ctx,
 
     req = tevent_req_create(mem_ctx, &state, struct proxy_child_ctx);
     if (req == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Could not send PAM request to child\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "tevent_req_create() failed\n");
         return NULL;
     }
 
@@ -391,7 +391,7 @@ static void proxy_child_init_done(struct tevent_req *subreq) {
      */
     sig_ctx = talloc_zero(child_ctx->auth_ctx, struct proxy_child_sig_ctx);
     if(sig_ctx == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "tevent_add_signal failed.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "talloc_zero failed.\n");
         tevent_req_error(req, ENOMEM);
         return;
     }
@@ -753,7 +753,7 @@ proxy_pam_handler_send(TALLOC_CTX *mem_ctx,
         pd->pam_status = PAM_SUCCESS;
         goto immediately;
     default:
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unsupported PAM task.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unsupported PAM task %d\n", pd->cmd);
         pd->pam_status = PAM_MODULE_UNKNOWN;
         goto immediately;
     }

--- a/src/providers/proxy/proxy_child.c
+++ b/src/providers/proxy/proxy_child.c
@@ -270,7 +270,7 @@ static errno_t call_pam_stack(const char *pam_target, struct pam_data *pd)
                 }
                 break;
             default:
-                DEBUG(SSSDBG_CRIT_FAILURE, "unknown PAM call\n");
+                DEBUG(SSSDBG_CRIT_FAILURE, "unknown PAM call %d\n", pd->cmd);
                 pam_status=PAM_ABORT;
         }
 
@@ -383,13 +383,13 @@ proxy_cli_init(struct pc_ctx *ctx)
     ret = sss_iface_connect_address(ctx, ctx->ev, sbus_cliname, sbus_address,
                                     NULL, &ctx->conn);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to connect to %s\n", sbus_address);
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to connect to %s\n", sbus_address);
         goto done;
     }
 
     ret = sbus_connection_add_path_map(ctx->conn, paths);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to add paths [%d]: %s\n",
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to add paths [%d]: %s\n",
               ret, sss_strerror(ret));
         goto done;
     }
@@ -580,7 +580,7 @@ int main(int argc, const char *argv[])
         return 3;
     }
 
-    DEBUG(SSSDBG_CRIT_FAILURE,
+    DEBUG(SSSDBG_IMPORTANT_INFO,
           "Proxy child for domain [%s] started!\n", domain);
 
     /* loop on main */

--- a/src/providers/proxy/proxy_client.c
+++ b/src/providers/proxy/proxy_client.c
@@ -116,7 +116,7 @@ proxy_client_init(struct sbus_connection *conn,
 
     ret = sbus_connection_add_path_map(conn, paths);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to add paths [%d]: %s\n",
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to add paths [%d]: %s\n",
               ret, sss_strerror(ret));
     }
 

--- a/src/providers/proxy/proxy_id.c
+++ b/src/providers/proxy/proxy_id.c
@@ -170,7 +170,7 @@ handle_getpw_result(enum nss_status status, struct passwd *pwd,
     switch (status) {
     case NSS_STATUS_NOTFOUND:
 
-        DEBUG(SSSDBG_MINOR_FAILURE, "User not found.\n");
+        DEBUG(SSSDBG_TRACE_FUNC, "User not found.\n");
         *del_user = true;
         break;
 
@@ -979,9 +979,7 @@ static int get_gr_name(struct proxy_id_ctx *ctx,
     grp = talloc(tmpctx, struct group);
     if (!grp) {
         ret = ENOMEM;
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "proxy -> getgrnam_r failed for '%s': [%d] %s\n",
-              i_name, ret, strerror(ret));
+        DEBUG(SSSDBG_CRIT_FAILURE, "talloc() failed\n");
         goto done;
     }
 

--- a/src/resolv/async_resolv.c
+++ b/src/resolv/async_resolv.c
@@ -177,7 +177,7 @@ add_timeout_timer(struct tevent_context *ev, struct resolv_ctx *ctx)
     ctx->timeout_watcher = tevent_add_timer(ev, ctx, tv, check_fd_timeouts,
                                             ctx);
     if (ctx->timeout_watcher == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "tevent_add_timer() failed\n");
     }
 }
 

--- a/src/responder/autofs/autofssrv.c
+++ b/src/responder/autofs/autofssrv.c
@@ -85,7 +85,7 @@ autofs_register_service_iface(struct autofs_ctx *autofs_ctx,
 
     ret = sbus_connection_add_path(rctx->mon_conn, SSS_BUS_PATH, &iface_svc);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to register service interface"
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to register service interface"
               "[%d]: %s\n", ret, sss_strerror(ret));
     }
 

--- a/src/responder/autofs/autofssrv_cmd.c
+++ b/src/responder/autofs/autofssrv_cmd.c
@@ -477,7 +477,7 @@ sss_autofs_cmd_setautomntent(struct cli_ctx *cli_ctx)
                                             autofs_ctx->rctx->ncache, 0, NULL,
                                             cmd_ctx->mapname);
     if (req == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "cache_req_autofs_map_by_name_send failed\n");
         ret = ENOMEM;
         goto done;
     }
@@ -685,7 +685,7 @@ sss_autofs_cmd_getautomntent(struct cli_ctx *cli_ctx)
 
     req = autofs_setent_send(cli_ctx, cli_ctx->ev, autofs_ctx, cmd_ctx->mapname);
     if (req == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "autofs_setent_send failed\n");
         ret = ENOMEM;
         goto done;
     }
@@ -886,7 +886,7 @@ sss_autofs_cmd_getautomntbyname(struct cli_ctx *cli_ctx)
                                               cmd_ctx->mapname,
                                               cmd_ctx->keyname);
     if (req == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "cache_req_autofs_entry_by_name_send failed\n");
         ret = ENOMEM;
         goto done;
     }

--- a/src/responder/common/cache_req/cache_req.c
+++ b/src/responder/common/cache_req/cache_req.c
@@ -1187,7 +1187,7 @@ static errno_t cache_req_process_input(TALLOC_CTX *mem_ctx,
     subreq = sss_parse_inp_send(mem_ctx, cr->rctx, default_domain,
                                 cr->data->name.input);
     if (subreq == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "sss_parse_inp_send() failed\n");
         return ENOMEM;
     }
 

--- a/src/responder/common/cache_req/plugins/cache_req_object_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_object_by_name.c
@@ -47,8 +47,8 @@ cache_req_object_by_name_well_known(TALLOC_CTX *mem_ctx,
     }
 
     if (domname == NULL || name == NULL) {
-        CACHE_REQ_DEBUG(SSSDBG_OP_FAILURE, cr, "Unable to split [%s] in "
-                        "name and odmain part. Skipping detection of "
+        CACHE_REQ_DEBUG(SSSDBG_FUNC_DATA, cr, "Unable to split [%s] in "
+                        "name and domain part. Skipping detection of "
                         "well-known name.\n", data->name.input);
         return ENOENT;
     }

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -116,7 +116,7 @@ static errno_t get_client_cred(struct cli_ctx *cctx)
     if (ret != EOK) {
         ret = errno;
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "getsock failed [%d][%s].\n", ret, strerror(ret));
+              "getsockopt failed [%d][%s].\n", ret, strerror(ret));
         return ret;
     }
     if (client_cred_len != sizeof(struct ucred)) {
@@ -805,7 +805,7 @@ sss_dp_on_reconnect(struct sbus_connection *conn,
                                             SSS_BUS_PATH,
                                             be_conn->cli_name);
     if (req == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "sbus_call_dp_client_Register_send() failed\n");
         return;
     }
 

--- a/src/responder/common/responder_get_domains.c
+++ b/src/responder/common/responder_get_domains.c
@@ -630,7 +630,7 @@ static void sss_parse_inp_done(struct tevent_req *subreq)
                                      state->rawinp,
                                      &state->domname, &state->name);
     if (ret == EAGAIN && state->domname != NULL && state->name == NULL) {
-        DEBUG(SSSDBG_OP_FAILURE,
+        DEBUG(SSSDBG_FUNC_DATA,
               "Unknown domain in [%s]\n", state->rawinp);
         state->error = ERR_DOMAIN_NOT_FOUND;
     } else if (ret != EOK) {

--- a/src/responder/common/responder_iface.c
+++ b/src/responder/common/responder_iface.c
@@ -127,7 +127,7 @@ sss_resp_register_sbus_iface(struct sbus_connection *conn,
 
     ret = sbus_connection_add_path_map(conn, paths);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to add paths [%d]: %s\n",
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to add paths [%d]: %s\n",
               ret, sss_strerror(ret));
     }
 
@@ -151,7 +151,7 @@ sss_resp_register_service_iface(struct resp_ctx *rctx)
 
     ret = sbus_connection_add_path(rctx->mon_conn, SSS_BUS_PATH, &iface_svc);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to register service interface"
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to register service interface"
               "[%d]: %s\n", ret, sss_strerror(ret));
     }
 

--- a/src/responder/ifp/ifp_iface/ifp_iface.c
+++ b/src/responder/ifp/ifp_iface/ifp_iface.c
@@ -264,7 +264,7 @@ ifp_register_sbus_interface(struct sbus_connection *conn,
 
     ret = sbus_connection_add_path_map(conn, paths);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to add paths [%d]: %s\n",
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to add paths [%d]: %s\n",
               ret, sss_strerror(ret));
     }
 

--- a/src/responder/ifp/ifpsrv.c
+++ b/src/responder/ifp/ifpsrv.c
@@ -67,7 +67,7 @@ sysbus_init(TALLOC_CTX *mem_ctx,
     sysbus = sbus_connect_system(mem_ctx, ev, dbus_name,
                                  &ifp_ctx->rctx->last_request_time);
     if (sysbus == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to connect to system bus!\n");
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to connect to system bus!\n");
         return ERR_NO_SYSBUS;
     }
 
@@ -75,13 +75,13 @@ sysbus_init(TALLOC_CTX *mem_ctx,
 
     ret = ifp_register_sbus_interface(sysbus, ifp_ctx);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Could not register interfaces\n");
+        DEBUG(SSSDBG_FATAL_FAILURE, "Could not register interfaces\n");
         goto done;
     }
 
     ret = ifp_register_nodes(ifp_ctx, sysbus);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Could not register nodes factories\n");
+        DEBUG(SSSDBG_FATAL_FAILURE, "Could not register nodes factories\n");
         goto done;
     }
 
@@ -148,7 +148,7 @@ ifp_register_service_iface(struct ifp_ctx *ifp_ctx,
 
     ret = sbus_connection_add_path(rctx->mon_conn, SSS_BUS_PATH, &iface_svc);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to register service interface"
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to register service interface"
               "[%d]: %s\n", ret, sss_strerror(ret));
     }
 

--- a/src/responder/ifp/ifpsrv_util.c
+++ b/src/responder/ifp/ifpsrv_util.c
@@ -341,7 +341,7 @@ immediately:
     list_ctx->paths = talloc_realloc(list_ctx, list_ctx->paths, const char *,
                                      list_ctx->paths_max + 1);
     if (list_ctx->paths == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "talloc_zero_array() failed\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "talloc_realloc() failed\n");
         ret = ENOMEM;
         goto done;
     }

--- a/src/responder/nss/nss_cmd.c
+++ b/src/responder/nss/nss_cmd.c
@@ -121,7 +121,7 @@ static errno_t nss_getby_name(struct cli_ctx *cli_ctx,
     subreq = nss_get_object_send(cmd_ctx, cli_ctx->ev, cli_ctx,
                                  data, memcache, rawname, 0);
     if (subreq == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "nss_get_object_send() failed\n");
         ret = ENOMEM;
         goto done;
     }
@@ -187,7 +187,7 @@ static errno_t nss_getby_id(struct cli_ctx *cli_ctx,
     subreq = nss_get_object_send(cmd_ctx, cli_ctx->ev, cli_ctx,
                                  data, memcache, NULL, id);
     if (subreq == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "nss_get_object_send() failed\n");
         ret = ENOMEM;
         goto done;
     }
@@ -240,7 +240,7 @@ static errno_t nss_getby_svc(struct cli_ctx *cli_ctx,
     subreq = nss_get_object_send(cmd_ctx, cli_ctx->ev, cli_ctx,
                                  data, SSS_MC_NONE, NULL, 0);
     if (subreq == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "nss_get_object_send() failed\n");
         return ENOMEM;
     }
 
@@ -376,7 +376,7 @@ static errno_t nss_getby_cert(struct cli_ctx *cli_ctx,
     subreq = nss_get_object_send(cmd_ctx, cli_ctx->ev, cli_ctx,
                                  data, SSS_MC_NONE, NULL, 0);
     if (subreq == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "nss_get_object_send() failed\n");
         ret = ENOMEM;
         goto done;
     }
@@ -433,7 +433,7 @@ static errno_t nss_getby_sid(struct cli_ctx *cli_ctx,
     subreq = nss_get_object_send(cmd_ctx, cli_ctx->ev, cli_ctx,
                                  data, SSS_MC_NONE, NULL, 0);
     if (subreq == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "nss_get_object_send() failed\n");
         ret = ENOMEM;
         goto done;
     }
@@ -488,7 +488,7 @@ static errno_t nss_getby_addr(struct cli_ctx *cli_ctx,
     subreq = nss_get_object_send(cmd_ctx, cli_ctx->ev, cli_ctx,
                                  data, memcache, NULL, 0);
     if (subreq == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "nss_get_object_send() failed\n");
         ret = ENOMEM;
         goto done;
     }
@@ -640,7 +640,7 @@ static errno_t nss_setent(struct cli_ctx *cli_ctx,
 
     subreq = nss_setent_send(cli_ctx, cli_ctx->ev, cli_ctx, type, enum_ctx);
     if (subreq == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "nss_setent_send() failed\n");
         return ENOMEM;
     }
 
@@ -697,7 +697,7 @@ static errno_t nss_getent(struct cli_ctx *cli_ctx,
 
     subreq = nss_setent_send(cli_ctx, cli_ctx->ev, cli_ctx, type, enum_ctx);
     if (subreq == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create setent request!\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "nss_setent_send() failed\n");
         ret = ENOMEM;
         goto done;
     }
@@ -829,7 +829,7 @@ static errno_t sss_nss_setnetgrent(struct cli_ctx *cli_ctx,
     subreq = nss_setnetgrent_send(cli_ctx, cli_ctx->ev, cli_ctx, type,
                                   nss_ctx->netgrent, state_ctx->netgroup);
     if (subreq == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "nss_setnetgrent_send() failed\n");
         ret = ENOMEM;
         goto done;
     }
@@ -904,7 +904,7 @@ static errno_t nss_getnetgrent(struct cli_ctx *cli_ctx,
                                   cmd_ctx->nss_ctx->netgrent,
                                   cmd_ctx->state_ctx->netgroup);
     if (subreq == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "nss_setnetgrent_send() failed\n");
         return ENOMEM;
     }
 

--- a/src/responder/nss/nss_iface.c
+++ b/src/responder/nss/nss_iface.c
@@ -67,7 +67,7 @@ nss_update_initgr_memcache(struct nss_ctx *nctx,
     ret = sysdb_initgroups(tmp_ctx, dom, fq_name, &res);
     if (ret != EOK && ret != ENOENT) {
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "Failed to make request to our cache! [%d][%s]\n",
+              "sysdb_initgroups() failed [%d][%s]\n",
               ret, strerror(ret));
         goto done;
     }
@@ -234,7 +234,7 @@ nss_register_backend_iface(struct sbus_connection *conn,
 
     ret = sbus_connection_add_path(conn, SSS_BUS_PATH, &iface);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to register service interface"
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to register service interface"
               "[%d]: %s\n", ret, sss_strerror(ret));
     }
 

--- a/src/responder/nss/nss_protocol_netgr.c
+++ b/src/responder/nss/nss_protocol_netgr.c
@@ -159,7 +159,7 @@ nss_protocol_fill_netgrent(struct nss_ctx *nss_ctx,
             ret = nss_protocol_fill_netgr_member(packet, entry, &rp);
             break;
         default:
-            DEBUG(SSSDBG_CRIT_FAILURE, "Unexpected value type!\n");
+            DEBUG(SSSDBG_CRIT_FAILURE, "Unexpected value type %d!\n", entry->type);
             ret = ERR_INTERNAL;
             break;
         }

--- a/src/responder/nss/nsssrv.c
+++ b/src/responder/nss/nsssrv.c
@@ -347,7 +347,7 @@ nss_register_service_iface(struct nss_ctx *nss_ctx,
 
     ret = sbus_connection_add_path(rctx->mon_conn, SSS_BUS_PATH, &iface_svc);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to register service interface"
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to register service interface"
               "[%d]: %s\n", ret, sss_strerror(ret));
     }
 

--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -138,7 +138,7 @@ static void inform_user(struct pam_data* pd, const char *pam_message)
     ret = pack_user_info_msg(pd, pam_message, &msg_len, &msg);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "pack_user_info_account_expired failed.\n");
+              "pack_user_info_msg failed.\n");
     } else {
         ret = pam_add_response(pd, SSS_PAM_USER_INFO, msg_len, msg);
         if (ret != EOK) {

--- a/src/responder/pam/pamsrv_p11.c
+++ b/src/responder/pam/pamsrv_p11.c
@@ -810,7 +810,7 @@ struct tevent_req *pam_check_cert_send(TALLOC_CTX *mem_ctx,
     } else if (pd->cmd == SSS_PAM_PREAUTH) {
         extra_args[arg_c++] = "--pre";
     } else {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unexpected PAM command [%d}.\n", pd->cmd);
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unexpected PAM command [%d].\n", pd->cmd);
         ret = EINVAL;
         goto done;
     }

--- a/src/responder/pam/pamsrv_p11.c
+++ b/src/responder/pam/pamsrv_p11.c
@@ -425,7 +425,7 @@ bool may_do_cert_auth(struct pam_ctx *pctx, struct pam_data *pd)
         }
     }
     if (pctx->smartcard_services[c] == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE,
+        DEBUG(SSSDBG_CONF_SETTINGS,
               "Smartcard authentication for service [%s] not supported.\n",
               pd->service);
         return false;

--- a/src/sbus/router/sbus_router_handler.c
+++ b/src/sbus/router/sbus_router_handler.c
@@ -239,7 +239,8 @@ sbus_signal_handler(struct sbus_connection *conn,
     list = sbus_router_listeners_lookup(router->listeners, meta->interface,
                                         meta->member);
     if (list == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "We do not listen to this signal!\n");
+        /* Most probably not fully initialized yet */
+        DEBUG(SSSDBG_FUNC_DATA, "We do not listen to this signal!\n");
         return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
     }
 

--- a/src/sss_iface/sss_iface.c
+++ b/src/sss_iface/sss_iface.c
@@ -116,8 +116,8 @@ sss_iface_connect_address(TALLOC_CTX *mem_ctx,
 
     conn = sbus_connect_private(mem_ctx, ev, address,
                                 conn_name, last_request_time);
-    if (conn == NULL) {
-        return ENOMEM;
+    if (conn == NULL) { /* most probably sbus_dbus_connect_address() failed */
+        return EFAULT;
     }
 
     *_conn = conn;

--- a/src/util/child_common.c
+++ b/src/util/child_common.c
@@ -768,7 +768,7 @@ void exec_child_ex(TALLOC_CTX *mem_ctx,
                              binary, extra_argv, extra_args_only,
                              &argv);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "prepare_child_argv.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "prepare_child_argv() failed.\n");
         exit(EXIT_FAILURE);
     }
 

--- a/src/util/debug.h
+++ b/src/util/debug.h
@@ -91,8 +91,8 @@ int get_fd_from_debug_file(void);
 /* enables all debug levels;
    0x0800 isn't used for historical reasons: 0x1FFF0 - 0x0800 = 0x1F7F0
 */
-#define SSSDBG_MASK_ALL       0x1F7F0
-#define SSSDBG_DEFAULT        SSSDBG_FATAL_FAILURE
+#define SSSDBG_MASK_ALL  0x1F7F0
+#define SSSDBG_DEFAULT   (SSSDBG_FATAL_FAILURE|SSSDBG_CRIT_FAILURE|SSSDBG_OP_FAILURE)
 
 #define SSSDBG_TIMESTAMP_UNRESOLVED   -1
 #define SSSDBG_TIMESTAMP_DEFAULT       1

--- a/src/util/domain_info_utils.c
+++ b/src/util/domain_info_utils.c
@@ -207,7 +207,7 @@ find_domain_by_object_name_ex(struct sss_domain_info *domain,
     ret = sss_parse_internal_fqname(tmp_ctx, object_name,
                                     NULL, &domainname);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse name '%s' [%d]: %s\n",
+        DEBUG(SSSDBG_MINOR_FAILURE, "Unable to parse name '%s' [%d]: %s\n",
                                     object_name, ret, sss_strerror(ret));
         goto done;
     }

--- a/src/util/server.c
+++ b/src/util/server.c
@@ -678,6 +678,8 @@ int server_setup(const char *name, int flags,
             return ret;
         }
     }
+    DEBUG(SSSDBG_IMPORTANT_INFO,
+          "Starting with debug level = %#.4x\n", debug_level);
 
     /* Setup the internal watchdog */
     ret = confdb_get_int(ctx->confdb_ctx, conf_entry,

--- a/src/util/server.c
+++ b/src/util/server.c
@@ -374,7 +374,7 @@ static void te_server_hup(struct tevent_context *ev,
     struct logrotate_ctx *lctx =
             talloc_get_type(private_data, struct logrotate_ctx);
 
-    DEBUG(SSSDBG_CRIT_FAILURE, "Received SIGHUP. Rotating logfiles.\n");
+    DEBUG(SSSDBG_IMPORTANT_INFO, "Received SIGHUP. Rotating logfiles.\n");
 
     ret = server_common_rotate_logs(lctx->confdb, lctx->confdb_path);
     if (ret != EOK) {

--- a/src/util/server.c
+++ b/src/util/server.c
@@ -462,6 +462,7 @@ int server_setup(const char *name, int flags,
     int watchdog_interval;
     pid_t my_pid;
     char *pidfile_name;
+    int cfg_debug_level = SSSDBG_INVALID;
 
     my_pid = getpid();
     ret = setpgid(my_pid, my_pid);
@@ -588,20 +589,20 @@ int server_setup(const char *name, int flags,
         /* set debug level if any in conf_entry */
         ret = confdb_get_int(ctx->confdb_ctx, conf_entry,
                              CONFDB_SERVICE_DEBUG_LEVEL,
-                             SSSDBG_UNRESOLVED,
-                             &debug_level);
+                             SSSDBG_INVALID,
+                             &cfg_debug_level);
         if (ret != EOK) {
             DEBUG(SSSDBG_FATAL_FAILURE, "Error reading from confdb (%d) "
                                          "[%s]\n", ret, strerror(ret));
             return ret;
         }
 
-        if (debug_level == SSSDBG_UNRESOLVED) {
+        if (cfg_debug_level == SSSDBG_INVALID) {
             /* Check for the `debug` alias */
             ret = confdb_get_int(ctx->confdb_ctx, conf_entry,
                     CONFDB_SERVICE_DEBUG_LEVEL_ALIAS,
                     SSSDBG_DEFAULT,
-                    &debug_level);
+                    &cfg_debug_level);
             if (ret != EOK) {
                 DEBUG(SSSDBG_FATAL_FAILURE, "Error reading from confdb (%d) "
                                             "[%s]\n", ret, strerror(ret));
@@ -609,7 +610,7 @@ int server_setup(const char *name, int flags,
             }
         }
 
-        debug_level = debug_convert_old_level(debug_level);
+        debug_level = debug_convert_old_level(cfg_debug_level);
     }
 
     /* same for debug timestamps */

--- a/src/util/sss_sockets.c
+++ b/src/util/sss_sockets.c
@@ -322,7 +322,7 @@ struct tevent_req *sssd_async_socket_init_send(TALLOC_CTX *mem_ctx,
 
     ret = set_fcntl_flags(state->sd, FD_CLOEXEC, O_NONBLOCK);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "settting fd flags failed.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "setting fd flags failed.\n");
         goto fail;
     }
 

--- a/src/util/string_utils.c
+++ b/src/util/string_utils.c
@@ -90,7 +90,7 @@ errno_t guid_blob_to_string_buf(const uint8_t *blob, char *str_buf,
     int ret;
 
     if (blob == NULL || str_buf == NULL || buf_size < GUID_STR_BUF_SIZE) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Buffer too small.\n");
+        DEBUG(SSSDBG_OP_FAILURE, "Buffer too small.\n");
         return EINVAL;
     }
 

--- a/src/util/util_errors.c
+++ b/src/util/util_errors.c
@@ -165,6 +165,7 @@ errno_t sss_ldb_error_to_errno(int ldberr)
     case LDB_ERR_OPERATIONS_ERROR:
         return EIO;
     case LDB_ERR_NO_SUCH_OBJECT:
+    case LDB_ERR_NO_SUCH_ATTRIBUTE:
         return ENOENT;
     case LDB_ERR_BUSY:
         return EBUSY;
@@ -174,7 +175,7 @@ errno_t sss_ldb_error_to_errno(int ldberr)
     case LDB_ERR_INVALID_ATTRIBUTE_SYNTAX:
         return EINVAL;
     default:
-        DEBUG(SSSDBG_CRIT_FAILURE,
+        DEBUG(SSSDBG_MINOR_FAILURE,
               "LDB returned unexpected error: [%i]\n",
               ldberr);
         return EFAULT;


### PR DESCRIPTION
This is a set of patches intended to enable higher log level by default.

Currently I target SSSDBG_OP_FAILURE (level 2) as a default (It seems SSSDBG_MINOR_FAILURE level contains legitimate messages that admin can deliberately ignore, and those messages can get quite spammy)

Perhaps several patches are yet missing (I'm awaiting @sumit-bose response) but those already published are ready for review.