### PR TITLE
Offline timeout man update

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -739,12 +739,12 @@
                              offline_timeout + random_offset
                         </para>
                         <para>
-                            The random offset can increment up to 30 seconds.
+                            The random offset value is from 0 to 30.
                             After each unsuccessful attempt to go online,
                             the new interval is recalculated by the following:
                         </para>
                         <para>
-                            new_interval = old_interval*2 + random_offset
+                            new_interval = (old_interval * 2) + random_offset
                         </para>
                         <para>
                             Note that the maximum length of each interval
@@ -768,6 +768,16 @@
                         </para>
                         <para>
                             A value of 0 disables the incrementing behaviour.
+                        </para>
+                        <para>
+                            The value of this parameter should be set in correlation
+                            to offline_timeout parameter value.
+                        </para>
+                        <para>
+                            With offline_timeout set to 60 (default value) there is no point
+                            in setting offlinet_timeout_max to less than 120 as it will
+                            saturate instantly. General rule here should be to set
+                            offline_timeout_max to at least 4 times offline_timeout.
                         </para>
                         <para>
                             Although a value between 0 and offline_timeout may be

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -51,6 +51,7 @@
 #define ONLINE_CB_RETRY 3
 #define ONLINE_CB_RETRY_MAX_DELAY 4
 
+#define OFFLINE_TIMEOUT_RANDOM_OFFSET 30
 #define OFFLINE_TIMEOUT_DEFAULT 60
 #define OFFLINE_TIMEOUT_MAX_DEFAULT 3600
 
@@ -152,9 +153,13 @@ void be_mark_offline(struct be_ctx *ctx)
         offline_timeout = get_offline_timeout(ctx);
         offline_timeout_max = get_offline_timeout_max(ctx);
 
-        ret = be_ptask_create_sync(ctx, ctx,
-                                   offline_timeout, offline_timeout,
-                                   offline_timeout, 30, offline_timeout,
+        ret = be_ptask_create_sync(ctx,
+                                   ctx,
+                                   offline_timeout,
+                                   offline_timeout,
+                                   offline_timeout,
+                                   OFFLINE_TIMEOUT_RANDOM_OFFSET,
+                                   offline_timeout,
                                    offline_timeout_max,
                                    try_to_go_online,
                                    ctx, "Check if online (periodic)",


### PR DESCRIPTION
In some circumstances offline_timeout and offline_timeout_max values may lead to a scenario in which user thinks that
the whole offline interval incrementing mechanics is not working according to logs.
This is false positive error as in this kind of situation offline checking interval just instantly saturates.
This PR adds explanation to this kind of behavior to manual page of SSSD conf.