### PR TITLE
Test: alltests: "enabled" option to domain section

### DIFF
--- a/src/tests/multihost/alltests/test_multidomain.py
+++ b/src/tests/multihost/alltests/test_multidomain.py
@@ -542,7 +542,8 @@ class TestMultiDomain(object):
     def test_0024_bz1884196(self, multihost, multidomain_sssd):
         """
         @Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Check
-        lookup of user when enabled option is True in both ldap domain
+        lookup of user when enabled option is True in ldap1 domain
+        and False in second ldap2 domain
 
         @Bugzilla:
         https://bugzilla.redhat.com/show_bug.cgi?id=1884196

--- a/src/tests/multihost/alltests/test_multidomain.py
+++ b/src/tests/multihost/alltests/test_multidomain.py
@@ -649,7 +649,7 @@ class TestMultiDomain(object):
                     status = 'PASS'
                 else:
                     status = 'FAIL'
-        delete_snip = '/etc/sssd/conf.d/01_snippet.conf'
+        delete_snip = 'rm -f /etc/sssd/conf.d/01_snippet.conf'
         multihost.client[0].run_command(delete_snip, raiseonerr=False)
         assert status == 'PASS'
 
@@ -689,6 +689,6 @@ class TestMultiDomain(object):
                     status = 'PASS'
                 else:
                     status = 'FAIL'
-        delete_snip = '/etc/sssd/conf.d/01_snippet.conf'
+        delete_snip = 'rm -f /etc/sssd/conf.d/01_snippet.conf'
         multihost.client[0].run_command(delete_snip, raiseonerr=False)
         assert status == 'PASS'


### PR DESCRIPTION
Configure multiple domain and check 'enabled' parameter.
It consists of 4 test cases:
1. Add 'enabled = true' in both ldap domains and check userlookups.
2. Check userlookup when 'domains = ldap1' and add 'enabled =
   true' in both ldap1, ldap2 section.
3. Check userlookup when enabled option in snippet file and
   'domains = ' in sssd section.
4. Check userlookup when enabled option is set true in snippet
   file

Verifies:
  Issue: #4743
  Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1884196