### PR TITLE
kcm: decode base64 encoded secret on upgrade path

### DIFF
--- a/src/responder/kcm/kcmsrv_ccache_secdb.c
+++ b/src/responder/kcm/kcmsrv_ccache_secdb.c
@@ -59,6 +59,16 @@ static errno_t sec_get(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
+    if (strcmp(datatype, "simple") == 0) {
+        /* The secret is stored in b64 encoding, we need to decode it first. */
+        data = sss_base64_decode(tmp_ctx, (const char*)data, &len);
+        if (data == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "Cannot decode secret from base64\n");
+            ret = EIO;
+            goto done;
+        }
+    }
+
     buf = sss_iobuf_init_steal(tmp_ctx, data, len);
     if (buf == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Cannot init the iobuf\n");


### PR DESCRIPTION
Previous unefficient code encoded the secret multiple times:
  secret -> base64 -> masterkey -> base64

To allow smooth upgrade for already existant ccache we need to also decode
the secret if it is still in the old format (type == simple). Otherwise
users are not able to log in.

Resolves: https://github.com/SSSD/sssd/issues/5349

To test, build SSSD without recent KCM performance patches. Run SSSD,
login as a Kerberized user to create ccache and log out.

Then apply the patches, and rebuild. Make sure to restart sssd-kcm.
Try to log in - it should fail.

Apply this patch - the login should succeed.