### PR TITLE
Only start sssd.service if there's a configuration file present

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -95,6 +95,15 @@ if HAVE_SYSTEMD_UNIT
 ifp_exec_cmd = $(sssdlibexecdir)/sssd_ifp --uid 0 --gid 0 --dbus-activated
 ifp_systemdservice = SystemdService=sssd-ifp.service
 ifp_restart = Restart=on-failure
+# If sssd is configured with --enable-files-domain, the service is
+# able to start even without a configuration file.  Otherwise, sssd
+# requires a configuration file (either /etc/sssd/sssd.conf, or some
+# snippet under /etc/sssd/sssd.conf.d/) to be present.
+if ADD_FILES_DOMAIN
+condconfigexists =
+else
+condconfigexists = ConditionPathExists=\|/etc/sssd/sssd.conf\nConditionDirectoryNotEmpty=\|/etc/sssd/conf.d/
+endif
 else
 ifp_exec_cmd = $(sssdlibexecdir)/sss_signal
 ifp_systemdservice =
@@ -5111,7 +5120,8 @@ edit_cmd = $(SED) \
         -e 's|@libexecdir[@]|$(libexecdir)|g' \
         -e 's|@pipepath[@]|$(pipepath)|g' \
         -e 's|@prefix[@]|$(prefix)|g' \
-        -e 's|@SSSD_USER[@]|$(SSSD_USER)|g'
+        -e 's|@SSSD_USER[@]|$(SSSD_USER)|g' \
+        -e 's|@condconfigexists[@]|$(condconfigexists)|g'
 
 replace_script = \
     @rm -f $@ $@.tmp; \

--- a/src/sysv/systemd/sssd.service.in
+++ b/src/sysv/systemd/sssd.service.in
@@ -3,6 +3,7 @@ Description=System Security Services Daemon
 # SSSD must be running before we permit user sessions
 Before=systemd-user-sessions.service nss-user-lookup.target
 Wants=nss-user-lookup.target
+@condconfigexists@
 
 [Service]
 Environment=DEBUG_LOGGER=--logger=files


### PR DESCRIPTION
This commit is the follow-up of the discussion that is happening here:

https://bugs.launchpad.net/ubuntu/+source/sssd/+bug/1900642

In a nutshell, SSSD is installed without a configuration file by
default, which means that it's impossible to start it successfully
unless the user has actively created/copied a sssd.conf inside
/etc/sssd.  For this reason, I'd like to suggest that we add
"ConditionPathExists=/etc/sssd/sssd.conf" to sssd.service, which
mitigates the problem of SSSD not properly starting and generating
error messages in the system log.