### PR TITLE
whitespace_test: fix exclusion of debian directory

### DIFF
--- a/src/tests/whitespace_test
+++ b/src/tests/whitespace_test
@@ -4,7 +4,7 @@ set -e -u -o pipefail
 
 # An AWK regex matching tracked file paths to be excluded from the search.
 # Example: '.*\.po|README'
-PATH_EXCLUDE_REGEX='.*\.po|.*\.patch|.*\.diff|\/debian\/.*'
+PATH_EXCLUDE_REGEX='.*\.po|.*\.patch|.*\.diff|debian\/.*'
 
 export GIT_DIR="$ABS_TOP_SRCDIR/.git"
 export GIT_WORK_TREE="$ABS_TOP_SRCDIR"
@@ -16,7 +16,7 @@ fi
 
 {
     # Look for lines with trailing whitespace in all files tracked by Git
-    git grep -n -I '\s\+$' -- "$(git rev-parse --show-toplevel)" ||
+    git grep --full-name -n -I '\s\+$' -- "$(git rev-parse --show-toplevel)" ||
         # Don't fail if no such lines were found anywhere
         [[ $? == 1 ]]
 } |


### PR DESCRIPTION
These tests are supposed to ignore trailing whitespace in files in
the debian directory. However this is not the case with the current
exclude pattern and usage of `git grep`.

Use --full-name with `git grep` to ensure its output is always
relative to the repository root, rather than the current directory.
Additionally remove the leading slash from the exclude pattern as
this will never match the output.