### PR TITLE
krb5_child: use proper umask for DIR type ccaches

### DIFF
--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -972,8 +972,13 @@ static krb5_error_code create_ccache(char *ccname, krb5_creds *creds)
     bool switch_to_cc = false;
 #endif
 
-    /* Set a restrictive umask, just in case we end up creating any file */
-    umask(SSS_DFL_UMASK);
+    /* Set a restrictive umask, just in case we end up creating any file or a
+     * directory. */
+    if (strncmp(ccname, "DIR:", 4) == 0) {
+        umask(SSS_DFL_X_UMASK);
+    } else {
+        umask(SSS_DFL_UMASK);
+    }
 
     /* we create a new context here as the main process one may have been
      * opened as root and contain possibly references (even open handles?)


### PR DESCRIPTION
The current umask only had files in mind and hence only allowed read and
write permissions for the user. If the new directory must be created
for DIR type credentials caches the 'execute' permission is needed as
well so that the user can change into the directory. This patch changes
the umask to allow this if a DIR type credential cache is requested.

Resolves: https://github.com/SSSD/sssd/issues/5436

:fixes: krb5_child uses proper umask for DIR type ccaches