### PR TITLE
test_ca: Look for libsofthsm2 in libdir before falling back to hardcoded paths

### DIFF
--- a/src/external/test_ca.m4
+++ b/src/external/test_ca.m4
@@ -19,7 +19,11 @@ AC_DEFUN([AM_CHECK_TEST_CA],
         fi
     fi
 
-    for p in /usr/lib64/pkcs11/libsofthsm2.so /usr/lib/pkcs11/libsofthsm2.so /usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so; do
+    for p in "$(eval echo ${libdir})"/softhsm/libsofthsm2.so \
+             "$(eval echo ${libdir})"/pkcs11/libsofthsm2.so \
+             /usr/lib*/pkcs11/libsofthsm2.so \
+             /usr/lib/*-linux-gnu*/softhsm/libsofthsm2.so \
+             /usr/lib/softhsm/libsofthsm2.so; do
         if test -f "${p}"; then
             SOFTHSM2_PATH="${p}"
             break;


### PR DESCRIPTION
Right now building SSSD in archs different from amd64 (at least in
debian and derivatives) won't ever get the test_CA built because
libsofthsm2 won't be found (leading also to #5397 at times).

As per this, until they won't provide a pkg-config file (waiting for https://github.com/opendnssec/SoftHSMv2/issues/587):
 - Prioritize looking for libsofthsm2 in configured libdir (will help
   the developer case when using custom prefixes with custom softhsm2)
 - Fallback to /usr prefixes, supporting any arch (not only x86_64)