### PR TITLE
tests: netstat command not found for test

### DIFF
--- a/src/tests/multihost/alltests/test_krb_ldap_connection.py
+++ b/src/tests/multihost/alltests/test_krb_ldap_connection.py
@@ -271,12 +271,12 @@ class TestKrbLdapConnectionTimeout(object):
 
         def find_local_port():
             nsreport = multihost.client[0].run_command(
-                ["netstat", "-antp"], log_stdout=False).stdout_text
+                ["ss", "-ant"], log_stdout=False).stdout_text
             lines = nsreport.splitlines()
             lines1 = []
 
             for i in lines:
-                if i.find('389') != -1 and i.find('ESTABLISHED') != -1:
+                if i.find('389') != -1 and i.find('ESTAB') != -1:
                     lines1.append(i)
             del lines
 


### PR DESCRIPTION
netstat command is not available in latest rhel 8.4 by default.