### PR TITLE
gssapi: default pam_gssapi_services to NULL in domain section and coverity fixes

### DIFF
--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -1582,7 +1582,7 @@ static int confdb_get_domain_internal(struct confdb_ctx *cdb,
     }
 
     tmp = ldb_msg_find_attr_as_string(res->msgs[0], CONFDB_PAM_GSSAPI_SERVICES,
-                                      "-");
+                                      NULL);
     if (tmp != NULL) {
         ret = split_on_separator(domain, tmp, ',', true, true,
                                  &domain->gssapi_services, NULL);


### PR DESCRIPTION
We need to distinguish when the option is not set in domain section and when
it is is explicitly disabled. Now if it is not set, domain->gssapi_services
is NULL and we'll use value from the pam section.

Without this change, the value in the pam section is ignored.