### PR TITLE
UTIL: find_domain_by_object_name_ex() changed log level (1-16 backport)

### DIFF
--- a/src/util/domain_info_utils.c
+++ b/src/util/domain_info_utils.c
@@ -207,7 +207,7 @@ find_domain_by_object_name_ex(struct sss_domain_info *domain,
     ret = sss_parse_internal_fqname(tmp_ctx, object_name,
                                     NULL, &domainname);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse name '%s' [%d]: %s\n",
+        DEBUG(SSSDBG_MINOR_FAILURE, "Unable to parse name '%s' [%d]: %s\n",
                                     object_name, ret, sss_strerror(ret));
         goto done;
     }


### PR DESCRIPTION
It's up to user of this function to judge if fail to parse fqname is
a critical error.

(cherry picked from commit bd2f38abe95645b9b16b12d12dac6008b0d2a03b)

1-16 backport for RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1910131