### PR TITLE
TESTS: Split tier1 tests with new pytest marker

### DIFF
--- a/src/tests/multihost/alltests/pytest.ini
+++ b/src/tests/multihost/alltests/pytest.ini
@@ -21,6 +21,7 @@ markers =
     proxy: Tests related to sssd-proxy
     fips: Tests related to fips when auth_provider is krb5
     ssh: Tests related to ssh responder
-    tier1: tier1 test cases
+    tier1: tier1 test cases with run time of aproximately 60 minutes
+    tier1_2: tier1 test cases split to keep runtime upto 60 minutes
     tier2: tier2 test cases
     tier3: tier3 test cases

--- a/src/tests/multihost/alltests/test_sssctl_ldap.py
+++ b/src/tests/multihost/alltests/test_sssctl_ldap.py
@@ -13,7 +13,7 @@ from constants import ds_instance_name
 @pytest.mark.sssctl
 class Testsssctl(object):
     """ This is test case class for sssctl suite """
-    @pytest.mark.tier1
+    @pytest.mark.tier1_2
     def test_0001_bz1638295(self, multihost, backupsssdconf):
         """
         @Title: IDM-SSSD-TC: sssctl: sssctl user-checks does not show custom
@@ -37,7 +37,7 @@ class Testsssctl(object):
             result = find.search(cmd.stdout_text)
             assert result is not None
 
-    @pytest.mark.tier1
+    @pytest.mark.tier1_2
     def test_0002_bz1638295(self, multihost, backupsssdconf):
         """
         @Title: IDM-SSSD-TC: sssctl: sssctl user-checks does not show custom
@@ -61,7 +61,7 @@ class Testsssctl(object):
             result = find.search(cmd.stdout_text)
             assert result is not None
 
-    @pytest.mark.tier1
+    @pytest.mark.tier1_2
     def test_0003_bz1638295(self, multihost, localusers, backupsssdconf):
         """
         @Title: IDM-SSSD-TC: sssctl: sssctl user-checks does not show custom
@@ -85,7 +85,7 @@ class Testsssctl(object):
             result = find.search(cmd.stdout_text)
             assert result is not None
 
-    @pytest.mark.tier1
+    @pytest.mark.tier1_2
     def test_0004_bz1638295(self, multihost, localusers, backupsssdconf):
         """
         @Title: IDM-SSSD-TC: sssctl: sssctl user-checks does not show custom
@@ -110,7 +110,7 @@ class Testsssctl(object):
             result = find.search(cmd.stdout_text)
             assert result is not None
 
-    @pytest.mark.tier1
+    @pytest.mark.tier1_2
     def test_0005_bz1638295(self, multihost, localusers, backupsssdconf):
         """
         @Title: IDM-SSSD-TC: sssctl: sssctl user-checks does not show custom
@@ -131,7 +131,7 @@ class Testsssctl(object):
         result = find.search(cmd.stderr_text)
         assert result is not None
 
-    @pytest.mark.tier1
+    @pytest.mark.tier1_2
     def test_0006_bz1638295(self, multihost, backupsssdconf):
         """
         @Title: IDM-SSSD-TC: sssctl: sssctl user-checks does not show custom
@@ -155,7 +155,7 @@ class Testsssctl(object):
             result = find.search(cmd.stdout_text)
             assert result is not None
 
-    @pytest.mark.tier1
+    @pytest.mark.tier1_2
     def test_0007_bz1638295(self, multihost, localusers, backupsssdconf):
         """
         @Title: IDM-SSSD-TC: sssctl: sssctl user-checks does not show custom
@@ -179,7 +179,7 @@ class Testsssctl(object):
             result = find.search(cmd.stdout_text)
             assert result is not None
 
-    @pytest.mark.tier1
+    @pytest.mark.tier1_2
     def test_0008_bz1761047(self, multihost):
         """
         @Title: sssctl: Null dereference in
@@ -208,7 +208,7 @@ class Testsssctl(object):
         tools.sssd_conf("domain/proxy", proxy_params, 'delete')
         multihost.client[0].run_command(cat, raiseonerr=False)
 
-    @pytest.mark.tier1
+    @pytest.mark.tier1_2
     def test_0009_bz1751691(self, multihost, backupsssdconf):
         """
         @Title: IDM-SSSD-TC: sssctl: sssctl domain-list command displays
@@ -230,7 +230,7 @@ class Testsssctl(object):
                 result = find.search(cmd.stdout_text)
                 assert result is not None
 
-    @pytest.mark.tier1
+    @pytest.mark.tier1_2
     def test_0010_bz1628122(self, multihost):
         """
         @Title: sssctl: Printing incorrect information
@@ -261,7 +261,7 @@ class Testsssctl(object):
             else:
                 assert False, 'domain status conflict'
 
-    @pytest.mark.tier1
+    @pytest.mark.tier1_2
     def test_0011_bz1406678(self, multihost):
         """
         @Title: sssctl: sssd started before network

--- a/src/tests/multihost/alltests/test_sssctl_local.py
+++ b/src/tests/multihost/alltests/test_sssctl_local.py
@@ -11,7 +11,7 @@ class Testsssctl(object):
     """
     This is test case class for sssctl suite
     """
-    @pytest.mark.tier1
+    @pytest.mark.tier1_2
     def test_0001_bz1640576(self, multihost, localusers):
         """
         @Title: IDM-SSSD-TC: sssctl: sssctl reports incorrect
@@ -33,7 +33,7 @@ class Testsssctl(object):
             cmd = multihost.client[0].run_command(sssctl_cmd, raiseonerr=False)
             assert 'Cache entry expiration time: Never' in cmd.stdout_text
 
-    @pytest.mark.tier1
+    @pytest.mark.tier1_2
     def test_0002_bz1599207(self, multihost, backupsssdconf, localusers):
         """
         @Title: IDM-SSSD-TC: sssctl: sssd tools do not handle the implicit

--- a/src/tests/multihost/alltests/test_sudo.py
+++ b/src/tests/multihost/alltests/test_sudo.py
@@ -13,7 +13,7 @@ from constants import ds_instance_name
 class TestSudo(object):
     """ Sudo test suite """
 
-    @pytest.mark.tier1
+    @pytest.mark.tier1_2
     def test_bz1294670(self, multihost, backupsssdconf, localusers):
         """
         @Title: sudo: Local users with local sudo rules causes LDAP queries


### PR DESCRIPTION
Runtime for tier1 tests is currently 70 minutes. It will continue to
grow as we add new tests to it and the time for execution would increase
as well. To keep the job to run within 60 minutes, we are adding a new
marker "tier1_2" and a new job. This job will run in parallel on
separate resources to bring down the total time taken for execution.