### PR TITLE
SBUS: set sbus_name before dp_init_send()

### DIFF
--- a/src/providers/data_provider/dp.h
+++ b/src/providers/data_provider/dp.h
@@ -122,11 +122,11 @@ dp_init_send(TALLOC_CTX *mem_ctx,
              struct tevent_context *ev,
              struct be_ctx *be_ctx,
              uid_t uid,
-             gid_t gid);
+             gid_t gid,
+             const char *sbus_name);
 
 errno_t dp_init_recv(TALLOC_CTX *mem_ctx,
-                     struct tevent_req *req,
-                     const char **_sbus_name);
+                     struct tevent_req *req);
 
 bool _dp_target_enabled(struct data_provider *provider,
                         const char *module_name,

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -565,7 +565,15 @@ errno_t be_process_init(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    req = dp_init_send(be_ctx, be_ctx->ev, be_ctx, be_ctx->uid, be_ctx->gid);
+    be_ctx->sbus_name = sss_iface_domain_bus(be_ctx, be_ctx->domain);
+    if (be_ctx->sbus_name == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Could not get sbus backend name.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    req = dp_init_send(be_ctx, be_ctx->ev, be_ctx, be_ctx->uid, be_ctx->gid,
+                       be_ctx->sbus_name);
     if (req == NULL) {
         ret = ENOMEM;
         goto done;
@@ -612,7 +620,7 @@ static void dp_initialized(struct tevent_req *req)
 
     be_ctx = tevent_req_callback_data(req, struct be_ctx);
 
-    ret = dp_init_recv(be_ctx, req, &be_ctx->sbus_name);
+    ret = dp_init_recv(be_ctx, req);
     talloc_zfree(req);
     if (ret !=  EOK) {
         goto done;


### PR DESCRIPTION
Some async task might access sbus_name before dp_initialized() was executed

Resolves: https://github.com/SSSD/sssd/issues/5466