### PR TITLE
pam: refresh certificate maps at the end of initial domains lookup

### DIFF
--- a/src/responder/autofs/autofssrv.c
+++ b/src/responder/autofs/autofssrv.c
@@ -142,7 +142,7 @@ autofs_process_init(TALLOC_CTX *mem_ctx,
         goto fail;
     }
 
-    ret = schedule_get_domains_task(rctx, rctx->ev, rctx, NULL);
+    ret = schedule_get_domains_task(rctx, rctx->ev, rctx, NULL, NULL, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "schedule_get_domains_tasks failed.\n");
         goto fail;

--- a/src/responder/common/responder.h
+++ b/src/responder/common/responder.h
@@ -366,10 +366,13 @@ errno_t sss_dp_get_account_domain_recv(TALLOC_CTX *mem_ctx,
                                        struct tevent_req *req,
                                        char **_domain);
 
+typedef void (get_domains_callback_fn_t)(void *);
 errno_t schedule_get_domains_task(TALLOC_CTX *mem_ctx,
                                   struct tevent_context *ev,
                                   struct resp_ctx *rctx,
-                                  struct sss_nc_ctx *optional_ncache);
+                                  struct sss_nc_ctx *optional_ncache,
+                                  get_domains_callback_fn_t *callback,
+                                  void *callback_pvt);
 
 errno_t csv_string_to_uid_array(TALLOC_CTX *mem_ctx, const char *csv_string,
                                 bool allow_sss_loop,

--- a/src/responder/ifp/ifpsrv.c
+++ b/src/responder/ifp/ifpsrv.c
@@ -266,7 +266,7 @@ int ifp_process_init(TALLOC_CTX *mem_ctx,
         return EIO;
     }
 
-    ret = schedule_get_domains_task(rctx, rctx->ev, rctx, NULL);
+    ret = schedule_get_domains_task(rctx, rctx->ev, rctx, NULL, NULL, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
               "schedule_get_domains_tasks failed.\n");

--- a/src/responder/nss/nsssrv.c
+++ b/src/responder/nss/nsssrv.c
@@ -557,7 +557,8 @@ int nss_process_init(TALLOC_CTX *mem_ctx,
     }
     responder_set_fd_limit(fd_limit);
 
-    ret = schedule_get_domains_task(rctx, rctx->ev, rctx, nctx->rctx->ncache);
+    ret = schedule_get_domains_task(rctx, rctx->ev, rctx, nctx->rctx->ncache,
+                                    NULL, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "schedule_get_domains_tasks failed.\n");
         goto fail;

--- a/src/responder/pac/pacsrv.c
+++ b/src/responder/pac/pacsrv.c
@@ -129,7 +129,7 @@ int pac_process_init(TALLOC_CTX *mem_ctx,
         goto fail;
     }
 
-    ret = schedule_get_domains_task(rctx, rctx->ev, rctx, NULL);
+    ret = schedule_get_domains_task(rctx, rctx->ev, rctx, NULL, NULL, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "schedule_get_domains_tasks failed.\n");
         goto fail;

--- a/src/responder/pam/pamsrv.c
+++ b/src/responder/pam/pamsrv.c
@@ -246,7 +246,8 @@ static int pam_process_init(TALLOC_CTX *mem_ctx,
     }
     responder_set_fd_limit(fd_limit);
 
-    ret = schedule_get_domains_task(rctx, rctx->ev, rctx, pctx->rctx->ncache);
+    ret = schedule_get_domains_task(rctx, rctx->ev, rctx, pctx->rctx->ncache,
+                                    NULL, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "schedule_get_domains_tasks failed.\n");
         goto done;

--- a/src/responder/ssh/sshsrv.c
+++ b/src/responder/ssh/sshsrv.c
@@ -126,7 +126,7 @@ int ssh_process_init(TALLOC_CTX *mem_ctx,
         goto fail;
     }
 
-    ret = schedule_get_domains_task(rctx, rctx->ev, rctx, NULL);
+    ret = schedule_get_domains_task(rctx, rctx->ev, rctx, NULL, NULL, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "schedule_get_domains_tasks failed.\n");
         goto fail;

--- a/src/responder/sudo/sudosrv.c
+++ b/src/responder/sudo/sudosrv.c
@@ -102,7 +102,7 @@ int sudo_process_init(TALLOC_CTX *mem_ctx,
         goto fail;
     }
 
-    ret = schedule_get_domains_task(rctx, rctx->ev, rctx, NULL);
+    ret = schedule_get_domains_task(rctx, rctx->ev, rctx, NULL, NULL, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "schedule_get_domains_tasks failed.\n");
         goto fail;

--- a/src/tests/cmocka/test_responder_common.c
+++ b/src/tests/cmocka/test_responder_common.c
@@ -265,7 +265,7 @@ void test_schedule_get_domains_task(void **state)
     ret = schedule_get_domains_task(dummy_ncache_ptr,
                                     parse_inp_ctx->rctx->ev,
                                     parse_inp_ctx->rctx,
-                                    dummy_ncache_ptr);
+                                    dummy_ncache_ptr, NULL, NULL);
     assert_int_equal(ret, EOK);
 
     ret = test_ev_loop(parse_inp_ctx->tctx);


### PR DESCRIPTION
During startup SSSD's responders send a getDomains request to all backends
to refresh some domain related needed by the responders.

The PAM responder specifically needs the certificate mapping and matching
rules when Smartcard authentication is enable. Currently the rules are not
refreshed at the end of the initial request but the code assumed that the
related structures are initialized after the request finished.

To avoid a race condition this patch adds a callback to the end of the
request to make sure the rules are properly refreshed even if they are
already initialized before.

Resolves: https://github.com/SSSD/sssd/issues/5469