### PR TITLE
man: sss_override clarification

### DIFF
--- a/src/man/sss_override.8.xml
+++ b/src/man/sss_override.8.xml
@@ -44,6 +44,12 @@
             <emphasis>sss_override</emphasis> prints message when a restart is
             required.
         </para>
+        <para>
+            <emphasis>NOTE:</emphasis> The options provided in this man page
+            only work with <quote>ldap</quote> and <quote>AD</quote> <quote>
+            id_provider</quote>. IPA overrides can be managed centrally
+            on the IPA server.
+        </para>
     </refsect1>
 
     <refsect1 id='commands'>


### PR DESCRIPTION
Clarify sss_override in man pages to indicate that the option is only
supported in LDAP and AD provider.

Resolves: https://github.com/SSSD/sssd/issues/5471