### PR TITLE
sudo runas: do not add '%' to external groups in IPA

### DIFF
--- a/src/providers/ipa/ipa_sudo_conversion.c
+++ b/src/providers/ipa/ipa_sudo_conversion.c
@@ -939,6 +939,12 @@ convert_runasextusergroup(TALLOC_CTX *mem_ctx,
                           const char *value,
                           bool *skip_entry)
 {
+    if (value == NULL)
+        return NULL;
+
+    if (value[0] == '%')
+        return talloc_strdup(mem_ctx, value);
+
     return talloc_asprintf(mem_ctx, "%%%s", value);
 }
 


### PR DESCRIPTION
When IPA allows to add AD users and groups directly to sudo rules
(FreeIPA 4.9.1 or later), external groups will already have '%' prefix.
Thus, we don't need to add additional '%'.

Fixes: https://github.com/SSSD/sssd/issues/5475
Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>