### PR TITLE
DEBUG: Drop custom syslog identifier from journald

### DIFF
--- a/src/util/sss_log.c
+++ b/src/util/sss_log.c
@@ -105,9 +105,9 @@ static void sss_log_internal(int priority, int facility, const char *format,
     syslog_priority = sss_to_syslog(priority);
     sd_journal_send("MESSAGE=%s", message,
                     "SSSD_DOMAIN=%s", domain,
+                    "SSSD_PRG_NAME=sssd[%s]", debug_prg_name,
                     "PRIORITY=%i", syslog_priority,
                     "SYSLOG_FACILITY=%i", LOG_FAC(facility),
-                    "SYSLOG_IDENTIFIER=sssd[%s]", debug_prg_name,
                     NULL);
 
     free(message);


### PR DESCRIPTION
 `SYSLOG_IDENTIFIER` field is removed from logging output to journald. The default behavior will use the program name automatically.

This ensures that if there is rsyslog in place, producing BSD-format syslog output (RFC 3164), then there are no unexpected `[` characters. The resulting syslog output will also be aligned with the behavior of `--with-syslog=syslog` which uses the program name by default.

`SSSD_PRG_NAME` field has been added to the journald log as well, to be consistent with the `DEBUG()` output. This field holds the value that `SYSLOG_IDENTIFIER` had previously and can be used for filtering journal as a drop-in replacement.

---

Initial PR commit replaced square brackets `[]` in `SYSLOG_IDENTIFIER` with parentheses `()`.

Replacing lines forwarded to syslog using rsyslog from

- `sssd[sudo][1234]: `
- `sssd[be[EXAMPLE.COM]][1235]: `

to

- `sssd(sudo)[1234]: `
- `sssd(be(EXAMPLE.COM))[1235]: `

This was dropped after comments from @alexey-tikhonov below, and replaced with the `SYSLOG_IDENTIFIER` to `SSSD_PRG_NAME` change.