### PR TITLE
krb5: allow to use subdomain realm during authentication

### DIFF
--- a/src/config/SSSDConfig/sssdoptions.py
+++ b/src/config/SSSDConfig/sssdoptions.py
@@ -348,6 +348,7 @@ class SSSDOptions(object):
         'krb5_fast_principal': _("Selects the principal to use for FAST"),
         'krb5_canonicalize': _("Enables principal canonicalization"),
         'krb5_use_enterprise_principal': _("Enables enterprise principals"),
+        'krb5_use_subdomain_realm': _("Enables using of subdomains realms for authentication"),
         'krb5_map_user': _('A mapping from user names to Kerberos principal names'),
 
         # [provider/krb5/chpass]

--- a/src/config/SSSDConfigTest.py
+++ b/src/config/SSSDConfigTest.py
@@ -738,6 +738,7 @@ class SSSDConfigTestSSSDDomain(unittest.TestCase):
              'krb5_fast_principal',
              'krb5_canonicalize',
              'krb5_use_enterprise_principal',
+             'krb5_use_subdomain_realm',
              'krb5_use_kdcinfo',
              'krb5_map_user'])
 
@@ -901,6 +902,7 @@ class SSSDConfigTestSSSDDomain(unittest.TestCase):
             'krb5_fast_principal',
             'krb5_canonicalize',
             'krb5_use_enterprise_principal',
+            'krb5_use_subdomain_realm',
             'krb5_use_kdcinfo',
             'krb5_map_user']
 
@@ -1118,6 +1120,7 @@ class SSSDConfigTestSSSDDomain(unittest.TestCase):
              'krb5_fast_principal',
              'krb5_canonicalize',
              'krb5_use_enterprise_principal',
+             'krb5_use_subdomain_realm',
              'krb5_use_kdcinfo',
              'krb5_map_user'])
 

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -633,6 +633,7 @@ option = krb5_renew_interval
 option = krb5_server
 option = krb5_store_password_if_offline
 option = krb5_use_enterprise_principal
+option = krb5_use_subdomain_realm
 option = krb5_use_fast
 option = krb5_use_kdcinfo
 option = krb5_validate

--- a/src/config/etc/sssd.api.d/sssd-ad.conf
+++ b/src/config/etc/sssd.api.d/sssd-ad.conf
@@ -152,6 +152,7 @@ krb5_renew_interval = str, None, false
 krb5_use_fast = str, None, false
 krb5_fast_principal = str, None, false
 krb5_use_enterprise_principal = bool, None, false
+krb5_use_subdomain_realm = bool, None, false
 krb5_map_user = str, None, false
 
 [provider/ad/access]

--- a/src/config/etc/sssd.api.d/sssd-ipa.conf
+++ b/src/config/etc/sssd.api.d/sssd-ipa.conf
@@ -163,6 +163,7 @@ krb5_renew_interval = str, None, false
 krb5_use_fast = str, None, false
 krb5_fast_principal = str, None, false
 krb5_use_enterprise_principal = bool, None, false
+krb5_use_subdomain_realm = bool, None, false
 krb5_map_user = str, None, false
 
 [provider/ipa/access]

--- a/src/config/etc/sssd.api.d/sssd-krb5.conf
+++ b/src/config/etc/sssd.api.d/sssd-krb5.conf
@@ -21,6 +21,7 @@ krb5_use_fast = str, None, false
 krb5_fast_principal = str, None, false
 krb5_canonicalize = bool, None, false
 krb5_use_enterprise_principal = bool, None, false
+krb5_use_subdomain_realm = bool, None, false
 krb5_map_user = str, None, false
 
 [provider/krb5/access]

--- a/src/man/sssd-krb5.5.xml
+++ b/src/man/sssd-krb5.5.xml
@@ -557,6 +557,25 @@
                 </varlistentry>
 
                 <varlistentry>
+                    <term>krb5_use_subdomain_realm (boolean)</term>
+                    <listitem>
+                        <para>
+                            Specifies to use subdomains realms for the
+                            authentication of users from trusted domains. This
+                            option can be set to 'true' if enterprise principals
+                            are used with upnSuffixes which are not known on the
+                            parent domain KDCs. If the option is set to 'true'
+                            SSSD will try to send the request directly to a KDC
+                            of the trusted domain the user is coming from.
+                        </para>
+
+                        <para>
+                            Default: false
+                        </para>
+                    </listitem>
+                </varlistentry>
+
+                <varlistentry>
                     <term>krb5_map_user (string)</term>
                     <listitem>
                         <para>

--- a/src/providers/ad/ad_opts.c
+++ b/src/providers/ad/ad_opts.c
@@ -187,6 +187,7 @@ struct dp_option ad_def_krb5_opts[] = {
     { "krb5_use_kdcinfo", DP_OPT_BOOL, BOOL_TRUE, BOOL_TRUE },
     { "krb5_kdcinfo_lookahead", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "krb5_map_user", DP_OPT_STRING, NULL_STRING, NULL_STRING },
+    { "krb5_use_subdomain_realm", DP_OPT_BOOL, BOOL_FALSE, BOOL_FALSE },
     DP_OPTION_TERMINATOR
 };
 

--- a/src/providers/ipa/ipa_opts.c
+++ b/src/providers/ipa/ipa_opts.c
@@ -328,6 +328,7 @@ struct dp_option ipa_def_krb5_opts[] = {
     { "krb5_use_kdcinfo", DP_OPT_BOOL, BOOL_TRUE, BOOL_TRUE },
     { "krb5_kdcinfo_lookahead", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "krb5_map_user", DP_OPT_STRING, NULL_STRING, NULL_STRING },
+    { "krb5_use_subdomain_realm", DP_OPT_BOOL, BOOL_FALSE, BOOL_FALSE },
     DP_OPTION_TERMINATOR
 };
 

--- a/src/providers/krb5/krb5_common.h
+++ b/src/providers/krb5/krb5_common.h
@@ -63,6 +63,7 @@ enum krb5_opts {
     KRB5_USE_KDCINFO,
     KRB5_KDCINFO_LOOKAHEAD,
     KRB5_MAP_USER,
+    KRB5_USE_SUBDOMAIN_REALM,
 
     KRB5_OPTS
 };
@@ -237,5 +238,6 @@ krb5_error_code copy_keytab_into_memory(TALLOC_CTX *mem_ctx, krb5_context kctx,
                                         krb5_keytab *_mem_keytab);
 
 errno_t set_extra_args(TALLOC_CTX *mem_ctx, struct krb5_ctx *krb5_ctx,
+                       struct sss_domain_info *domain,
                        const char ***krb5_child_extra_args);
 #endif /* __KRB5_COMMON_H__ */

--- a/src/providers/krb5/krb5_opts.c
+++ b/src/providers/krb5/krb5_opts.c
@@ -44,5 +44,6 @@ struct dp_option default_krb5_opts[] = {
     { "krb5_use_kdcinfo", DP_OPT_BOOL, BOOL_TRUE, BOOL_TRUE },
     { "krb5_kdcinfo_lookahead", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "krb5_map_user", DP_OPT_STRING, NULL_STRING, NULL_STRING },
+    { "krb5_use_subdomain_realm", DP_OPT_BOOL, BOOL_FALSE, BOOL_FALSE },
     DP_OPTION_TERMINATOR
 };

--- a/src/tests/cmocka/test_krb5_common.c
+++ b/src/tests/cmocka/test_krb5_common.c
@@ -87,7 +87,7 @@ void test_set_extra_args(void **state)
     char *gid_opt;
     const char **krb5_child_extra_args;
 
-    ret = set_extra_args(NULL, NULL, NULL);
+    ret = set_extra_args(NULL, NULL, NULL, NULL);
     assert_int_equal(ret, EINVAL);
 
     krb5_ctx = talloc_zero(global_talloc_context, struct krb5_ctx);
@@ -98,7 +98,7 @@ void test_set_extra_args(void **state)
     gid_opt = talloc_asprintf(krb5_ctx, "--fast-ccache-gid=%"SPRIgid, getgid());
     assert_non_null(gid_opt);
 
-    ret = set_extra_args(global_talloc_context, krb5_ctx,
+    ret = set_extra_args(global_talloc_context, krb5_ctx, NULL,
                          &krb5_child_extra_args);
     assert_int_equal(ret, EOK);
     assert_string_equal(krb5_child_extra_args[0], uid_opt);
@@ -107,7 +107,7 @@ void test_set_extra_args(void **state)
     talloc_free(krb5_child_extra_args);
 
     krb5_ctx->canonicalize = true;
-    ret = set_extra_args(global_talloc_context, krb5_ctx,
+    ret = set_extra_args(global_talloc_context, krb5_ctx, NULL,
                          &krb5_child_extra_args);
     assert_int_equal(ret, EOK);
     assert_string_equal(krb5_child_extra_args[0], uid_opt);
@@ -117,7 +117,7 @@ void test_set_extra_args(void **state)
     talloc_free(krb5_child_extra_args);
 
     krb5_ctx->realm = discard_const(TEST_REALM);
-    ret = set_extra_args(global_talloc_context, krb5_ctx,
+    ret = set_extra_args(global_talloc_context, krb5_ctx, NULL,
                          &krb5_child_extra_args);
     assert_int_equal(ret, EOK);
     assert_string_equal(krb5_child_extra_args[0], uid_opt);
@@ -129,7 +129,7 @@ void test_set_extra_args(void **state)
 
     /* --fast-principal will be only set if FAST is used */
     krb5_ctx->fast_principal = discard_const(TEST_FAST_PRINC);
-    ret = set_extra_args(global_talloc_context, krb5_ctx,
+    ret = set_extra_args(global_talloc_context, krb5_ctx, NULL,
                          &krb5_child_extra_args);
     assert_int_equal(ret, EOK);
     assert_string_equal(krb5_child_extra_args[0], uid_opt);
@@ -140,7 +140,7 @@ void test_set_extra_args(void **state)
     talloc_free(krb5_child_extra_args);
 
     krb5_ctx->use_fast_str = discard_const(TEST_FAST_STR);
-    ret = set_extra_args(global_talloc_context, krb5_ctx,
+    ret = set_extra_args(global_talloc_context, krb5_ctx, NULL,
                          &krb5_child_extra_args);
     assert_int_equal(ret, EOK);
     assert_string_equal(krb5_child_extra_args[0], uid_opt);
@@ -155,7 +155,7 @@ void test_set_extra_args(void **state)
 
     krb5_ctx->lifetime_str = discard_const(TEST_LIFE_STR);
     krb5_ctx->rlife_str = discard_const(TEST_RLIFE_STR);
-    ret = set_extra_args(global_talloc_context, krb5_ctx,
+    ret = set_extra_args(global_talloc_context, krb5_ctx, NULL,
                          &krb5_child_extra_args);
     assert_int_equal(ret, EOK);
     assert_string_equal(krb5_child_extra_args[0], uid_opt);
@@ -241,6 +241,9 @@ void test_sss_krb5_check_options(void **state)
     ret = sss_krb5_check_options(opts, test_ctx->tctx->dom, krb5_ctx);
     assert_int_equal(ret, EOK);
     assert_true(krb5_ctx->canonicalize);
+
+    ret = dp_opt_set_bool(opts, KRB5_USE_SUBDOMAIN_REALM, true);
+    assert_int_equal(ret, EOK);
 
     talloc_free(krb5_ctx);
     talloc_free(opts);


### PR DESCRIPTION
Resolves: https://github.com/SSSD/sssd/issues/4759

:feature: `krb5_use_subdomain_realm=True` can now be used then subdomain user
  principal names with different upnSuffixes not found in parent domain as it
  requires to be supported on serverside, but not implemented in samba yet.