### PR TITLE
alltests: password_policy: Removing the log debug messages

### DIFF
--- a/src/tests/multihost/alltests/test_password_policy.py
+++ b/src/tests/multihost/alltests/test_password_policy.py
@@ -73,15 +73,6 @@ class TestPasswordCheck(object):
                                                      'bumblebee@123',
                                                      'bumblebee')
             assert change_pass == 5
-            log1 = re.compile(
-                r'Failed\spreliminary\scheck\sby\spassword\sservice')
-            time.sleep(10)
-            test_str_log = multihost.client[0].get_file_contents(
-                '/var/log/secure')
-            # time.sleep(5)
-            cat_cmd = 'cat /var/log/secure'
-            multihost.client[0].run_command(cat_cmd)
-            assert log1.search(test_str_log.decode())
 
     @pytest.mark.tier2
     def test_0003_smallnewpass(self, multihost):


### PR DESCRIPTION
Removing the debug messages since it's neither from PAM, SSSD,
nor passwd and test does not depend on this dubug messages.

Signed-off-by: Madhuri Upadhye <mupadhye@redhat.com>