### PR TITLE
ssh: restore default debug level

### DIFF
--- a/src/sss_client/ssh/sss_ssh_authorizedkeys.c
+++ b/src/sss_client/ssh/sss_ssh_authorizedkeys.c
@@ -32,7 +32,7 @@
 int main(int argc, const char **argv)
 {
     TALLOC_CTX *mem_ctx = NULL;
-    int pc_debug = SSSDBG_DEFAULT;
+    int pc_debug = SSSDBG_FATAL_FAILURE;
     const char *pc_domain = NULL;
     const char *pc_user = NULL;
     struct poptOption long_options[] = {

--- a/src/sss_client/ssh/sss_ssh_knownhostsproxy.c
+++ b/src/sss_client/ssh/sss_ssh_knownhostsproxy.c
@@ -174,7 +174,7 @@ connect_proxy_command(char **args)
 int main(int argc, const char **argv)
 {
     TALLOC_CTX *mem_ctx = NULL;
-    int pc_debug = SSSDBG_DEFAULT;
+    int pc_debug = SSSDBG_FATAL_FAILURE;
     int pc_port = 22;
     const char *pc_domain = NULL;
     const char *pc_host = NULL;


### PR DESCRIPTION
The recent change of the default debug level for the main SSSD
components affected the ssh helpers sss_ssh_authorizedkeys and
sss_ssh_knownhostsproxy as well.

To avoid any confusion about unexpected debug messages this patch
restores to original value for the two helpers.

Resolves: https://github.com/SSSD/sssd/issues/5488