### PR TITLE
BUILD: fixes gpo_child linking issue

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4738,7 +4738,8 @@ gpo_child_LDADD = \
     $(POPT_LIBS) \
     $(DHASH_LIBS) \
     $(INI_CONFIG_LIBS) \
-    $(SMBCLIENT_LIBS)
+    $(SMBCLIENT_LIBS) \
+    $(SAMBA_UTIL_LIBS)
 
 proxy_child_SOURCES = \
     src/providers/proxy/proxy_child.c \

--- a/src/external/samba.m4
+++ b/src/external/samba.m4
@@ -30,6 +30,14 @@ without them. In this case, you will need to execute configure script
 with argument --without-samba
     ]]))
 
+    PKG_CHECK_MODULES(SAMBA_UTIL, samba-util, ,
+        AC_MSG_ERROR([[Please install libsamba-util development libraries.
+libsamba-util libraries are necessary for building ad and ipa provider.
+If you do not want to build these providers it is possible to build SSSD
+without them. In this case, you will need to execute configure script
+with argument --without-samba
+    ]]))
+
     if test x"$HAVE_LIBINI_CONFIG_V1_1" != x1; then
         AC_MSG_ERROR([[Please install libini_config development libraries
 v1.1.0, or newer. libini_config libraries are necessary for building ipa


### PR DESCRIPTION
/usr/bin/ld: src/util/gpo_child-signal.o (symbol from plugin): undefined reference to symbol 'BlockSignals@@SAMBA_UTIL_0.0.1'

Resolves: https://github.com/SSSD/sssd/issues/5385