### PR TITLE
pam_sss_gss: support authentication indicators

### DIFF
--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -1603,6 +1603,19 @@ static int confdb_get_domain_internal(struct confdb_ctx *cdb,
         }
     }
 
+    tmp = ldb_msg_find_attr_as_string(res->msgs[0],
+                                      CONFDB_PAM_GSSAPI_INDICATORS_MAP,
+                                      NULL);
+    if (tmp != NULL && tmp[0] != '\0') {
+        ret = split_on_separator(domain, tmp, ',', true, true,
+                                 &domain->gssapi_indicators_map, NULL);
+        if (ret != 0) {
+            DEBUG(SSSDBG_FATAL_FAILURE,
+                  "Cannot parse %s\n", CONFDB_PAM_GSSAPI_INDICATORS_MAP);
+            goto done;
+        }
+    }
+
     domain->has_views = false;
     domain->view_name = NULL;
 

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -146,6 +146,7 @@
 #define CONFDB_PAM_INITGROUPS_SCHEME "pam_initgroups_scheme"
 #define CONFDB_PAM_GSSAPI_SERVICES "pam_gssapi_services"
 #define CONFDB_PAM_GSSAPI_CHECK_UPN "pam_gssapi_check_upn"
+#define CONFDB_PAM_GSSAPI_INDICATORS_MAP "pam_gssapi_indicators_map"
 
 /* SUDO */
 #define CONFDB_SUDO_CONF_ENTRY "config/sudo"
@@ -437,6 +438,8 @@ struct sss_domain_info {
     /* List of PAM services that are allowed to authenticate with GSSAPI. */
     char **gssapi_services;
     char *gssapi_check_upn; /* true | false | NULL */
+    /* List of indicators associated with the specific PAM service */
+    char **gssapi_indicators_map;
 };
 
 /**

--- a/src/config/SSSDConfig/sssdoptions.py
+++ b/src/config/SSSDConfig/sssdoptions.py
@@ -106,6 +106,8 @@ class SSSDOptions(object):
         'pam_initgroups_scheme' : _('When shall the PAM responder force an initgroups request'),
         'pam_gssapi_services' : _('List of PAM services that are allowed to authenticate with GSSAPI.'),
         'pam_gssapi_check_upn' : _('Whether to match authenticated UPN with target user'),
+        'pam_gssapi_indicators_map' : _('List of pairs <PAM service>:<authentication indicator> that '
+                                        'must be enforced for PAM access with GSSAPI authentication'),
 
         # [sudo]
         'sudo_timed': _('Whether to evaluate the time-based attributes in sudo rules'),

--- a/src/config/SSSDConfigTest.py
+++ b/src/config/SSSDConfigTest.py
@@ -655,7 +655,8 @@ class SSSDConfigTestSSSDDomain(unittest.TestCase):
             'cached_auth_timeout',
             'auto_private_groups',
             'pam_gssapi_services',
-            'pam_gssapi_check_upn']
+            'pam_gssapi_check_upn',
+            'pam_gssapi_indicators_map']
 
         self.assertTrue(type(options) == dict,
                         "Options should be a dictionary")
@@ -1036,7 +1037,8 @@ class SSSDConfigTestSSSDDomain(unittest.TestCase):
             'cached_auth_timeout',
             'auto_private_groups',
             'pam_gssapi_services',
-            'pam_gssapi_check_upn']
+            'pam_gssapi_check_upn',
+            'pam_gssapi_indicators_map']
 
         self.assertTrue(type(options) == dict,
                         "Options should be a dictionary")

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -141,6 +141,7 @@ option = p11_uri
 option = pam_initgroups_scheme
 option = pam_gssapi_services
 option = pam_gssapi_check_upn
+option = pam_gssapi_indicators_map
 
 [rule/allowed_sudo_options]
 validator = ini_allowed_options
@@ -441,6 +442,7 @@ option = re_expression
 option = auto_private_groups
 option = pam_gssapi_services
 option = pam_gssapi_check_upn
+option = pam_gssapi_indicators_map
 
 #Entry cache timeouts
 option = entry_cache_user_timeout
@@ -838,6 +840,7 @@ option = use_fully_qualified_names
 option = auto_private_groups
 option = pam_gssapi_services
 option = pam_gssapi_check_upn
+option = pam_gssapi_indicators_map
 
 [rule/sssd_checks]
 validator = sssd_checks

--- a/src/config/etc/sssd.api.conf
+++ b/src/config/etc/sssd.api.conf
@@ -82,6 +82,7 @@ p11_uri = str, None, false
 pam_initgroups_scheme = str, None, false
 pam_gssapi_services = str, None, false
 pam_gssapi_check_upn = bool, None, false
+pam_gssapi_indicators_map = str, None, false
 
 [sudo]
 # sudo service
@@ -203,6 +204,7 @@ re_expression = str, None, false
 auto_private_groups = str, None, false
 pam_gssapi_services = str, None, false
 pam_gssapi_check_upn = bool, None, false
+pam_gssapi_indicators_map = str, None, false
 
 #Entry cache timeouts
 entry_cache_user_timeout = int, None, false

--- a/src/db/sysdb_subdomains.c
+++ b/src/db/sysdb_subdomains.c
@@ -191,6 +191,7 @@ struct sss_domain_info *new_subdomain(TALLOC_CTX *mem_ctx,
     dom->override_gid = parent->override_gid;
 
     dom->gssapi_services = parent->gssapi_services;
+    dom->gssapi_indicators_map = parent->gssapi_indicators_map;
 
     if (parent->sysdb == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Missing sysdb context in parent domain.\n");
@@ -270,6 +271,17 @@ check_subdom_config_file(struct confdb_ctx *confdb,
         DEBUG(SSSDBG_OP_FAILURE,
               "Failed to get %s option for the subdomain: %s\n",
               CONFDB_PAM_GSSAPI_CHECK_UPN, subdomain->name);
+        goto done;
+    }
+
+    /* allow to set pam_gssapi_indicators_map */
+    ret = confdb_get_string_as_list(confdb, subdomain, sd_conf_path,
+                                    CONFDB_PAM_GSSAPI_INDICATORS_MAP,
+                                    &subdomain->gssapi_indicators_map);
+    if (ret != EOK && ret != ENOENT) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Failed to get %s option for the subdomain: %s\n",
+              CONFDB_PAM_GSSAPI_INDICATORS_MAP, subdomain->name);
         goto done;
     }
 

--- a/src/man/pam_sss_gss.8.xml
+++ b/src/man/pam_sss_gss.8.xml
@@ -70,6 +70,19 @@
                 <manvolnum>5</manvolnum>
             </citerefentry> for more details on these options.
         </para>
+        <para>
+            Some Kerberos deployments allow to assocate authentication
+            indicators with a particular pre-authentication method used to
+            obtain the ticket granting ticket by the user.
+            <command>pam_sss_gss.so</command> allows to enforce presence of
+            authentication indicators in the service tickets before a particular
+            PAM service can be accessed.
+        </para>
+        <para>
+            If <option>pam_gssapi_indicators_map</option> is set in the [pam] or
+            domain section of sssd.conf, then SSSD will perform a check of the
+            presence of any configured indicators in the service ticket.
+        </para>
     </refsect1>
 
     <refsect1 id='options'>

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -1771,6 +1771,70 @@ pam_gssapi_services = sudo, sudo-i
                         </para>
                     </listitem>
                 </varlistentry>
+                <varlistentry>
+                    <term>pam_gssapi_indicators_map</term>
+                    <listitem>
+                        <para>
+                           Comma separated list of authentication indicators required
+                           to be present in a Kerberos ticket to access a PAM service
+                           that is allowed to try GSSAPI authentication using
+                           pam_sss_gss.so module.
+                        </para>
+                        <para>
+                           Each element of the list can be either an authentication indicator
+                           name or a pair <quote>service:indicator</quote>. Indicators not
+                           prefixed with the PAM service name will be required to access any
+                           PAM service configured to be used with
+                           <option>pam_gssapi_services</option>. A resulting list of indicators
+                           per PAM service is then checked against indicators in the Kerberos
+                           ticket during authentication by pam_sss_gss.so. Any indicator from the
+                           ticket that matches the resulting list of indicators for the PAM service
+                           would grant access. If none of the indicators in the list match, access
+                           will be denied. If the resulting list of indicators for the PAM service
+                           is empty, the check will not prevent the access.
+                        </para>
+                        <para>
+                           To disable GSSAPI authentication indicator check, set this option
+                           to <quote>-</quote> (dash). To disable the check for a specific PAM
+                           service, add <quote>service:-</quote>.
+                        </para>
+                        <para>
+                           Note: This option can also be set per-domain which
+                           overwrites the value in [pam] section. It can also
+                           be set for trusted domain which overwrites the value
+                           in the domain section.
+                        </para>
+                        <para>
+                            Following authentication indicators are supported by IPA Kerberos deployments:
+                            <itemizedlist>
+                                <listitem>
+                                    <para>pkinit -- pre-authentication using X.509 certificates -- whether stored in files or on smart cards.</para>
+                                </listitem>
+                                <listitem>
+                                    <para>hardened -- SPAKE pre-authentication or any pre-authentication wrapped in a FAST channel.</para>
+                                </listitem>
+                                <listitem>
+                                    <para>radius -- pre-authentication with the help of a RADIUS server.</para>
+                                </listitem>
+                                <listitem>
+                                    <para>otp -- pre-authentication using integrated two-factor authentication (2FA or one-time password, OTP) in IPA.</para>
+                                </listitem>
+                            </itemizedlist>
+                        </para>
+                        <para>
+                            Example: to require access to SUDO services only
+                            for users which obtained their Kerberos tickets
+                            with a X.509 certificate pre-authentication
+                            (PKINIT), set
+                                <programlisting>
+pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
+                            </programlisting>
+                        </para>
+                        <para>
+                            Default: not set (use of authentication indicators is not required)
+                        </para>
+                    </listitem>
+                </varlistentry>
             </variablelist>
         </refsect2>
 

--- a/src/responder/pam/pamsrv.c
+++ b/src/responder/pam/pamsrv.c
@@ -370,6 +370,27 @@ static int pam_process_init(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
+    ret = confdb_get_string(pctx->rctx->cdb, pctx, CONFDB_PAM_CONF_ENTRY,
+                            CONFDB_PAM_GSSAPI_INDICATORS_MAP, "-", &tmpstr);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE,
+              "Failed to determine gssapi services.\n");
+        goto done;
+    }
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Found value [%s] for option [%s].\n", tmpstr,
+                                 CONFDB_PAM_GSSAPI_INDICATORS_MAP);
+
+    if (tmpstr != NULL) {
+        ret = split_on_separator(pctx, tmpstr, ',', true, true,
+                                 &pctx->gssapi_indicators_map, NULL);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "split_on_separator() failed [%d]: [%s].\n", ret,
+                  sss_strerror(ret));
+            goto done;
+        }
+    }
+
     /* The responder is initialized. Now tell it to the monitor. */
     ret = sss_monitor_service_init(rctx, rctx->ev, SSS_BUS_PAM,
                                    SSS_PAM_SBUS_SERVICE_NAME,

--- a/src/responder/pam/pamsrv.h
+++ b/src/responder/pam/pamsrv.h
@@ -65,6 +65,8 @@ struct pam_ctx {
 
     /* List of PAM services that are allowed to authenticate with GSSAPI. */
     char **gssapi_services;
+    /* List of authentication indicators associated with a PAM service */
+    char **gssapi_indicators_map;
     bool gssapi_check_upn;
 };
 


### PR DESCRIPTION
MIT Kerberos allows to associate authentication indicators with the
issued ticket based on the way how the TGT was obtained. The indicators
present in the TGT then copied to service tickets. There are two ways to
check the authentication indicators:

 - when KDC issues a service ticket, a policy at KDC side can reject the
   ticket issuance based on a lack of certain indicator

 - when a server application presented with a service ticket from a
   client, it can verify that this ticket contains intended
   authentication indicators before authorizing access from the client.

Add support to validate presence of a specific (set of) authentication
indicator(s) in pam_sss_gss when validating a user's TGT.

This concept can be used to only allow access to a PAM service when user
is in possession of a ticket obtained using some of pre-authentication
mechanisms that require multiple factors: smart-cards (PKINIT), 2FA
tokens (otp/radius), etc.

Resolves: https://github.com/SSSD/sssd/issues/5482
Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>