### PR TITLE
pam_sss: Don't fail on deskprofiles phase for AD users

### DIFF
--- a/src/providers/ipa/ipa_session.c
+++ b/src/providers/ipa/ipa_session.c
@@ -510,7 +510,7 @@ ipa_pam_session_handler_send(TALLOC_CTX *mem_ctx,
      * that this operation is done. */
     ret = ipa_pam_session_handler_get_deskprofile_user_info(
                                                         state,
-                                                        state->be_ctx->domain,
+                                                        params->domain,
                                                         pd->user,
                                                         &state->shortname,
                                                         &state->domain,


### PR DESCRIPTION
By default (if session_provider is not none) during session setup pam_sss attempts to fetch desktop rules and profiles for user from IPA domain. As part of this job, the data provider looks for the user info(uid and gid) in IPA domain but fails to do that for AD user from a trusted domain returning PAM_SESSION_ERR.

The requested target domain has been already found in `dp_req_new` and may be referenced as `params->domain`. This change doesn't introduce the possibility to fetch deskprofiles for AD users, but at least, doesn't break PAM authentication for them.

Fixes: https://github.com/SSSD/sssd/issues/5499