### PR TITLE
SSSD Log: write_krb5info_file word replacement

### DIFF
--- a/src/providers/ad/ad_common.c
+++ b/src/providers/ad/ad_common.c
@@ -1091,7 +1091,8 @@ ad_resolve_callback(void *private_data, struct fo_server *server)
                                                  ad_krb5info_file_filter);
         if (ret != EOK) {
             DEBUG(SSSDBG_MINOR_FAILURE,
-                  "write_krb5info_file failed, authentication might fail.\n");
+                  "write to %s/kdcinfo.%s failed, authentication might fail.\n",
+                  PUBCONF_PATH, service->krb5_service->realm);
         }
     }
 

--- a/src/providers/ipa/ipa_common.c
+++ b/src/providers/ipa/ipa_common.c
@@ -891,7 +891,8 @@ static void ipa_resolve_callback(void *private_data, struct fo_server *server)
                                                  NULL);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE,
-                  "write_krb5info_file failed, authentication might fail.\n");
+                  "write to %s/kdcinfo.%s failed, authentication might fail.\n",
+                  PUBCONF_PATH, service->krb5_service->realm);
         }
     }
 

--- a/src/providers/ipa/ipa_subdomains.c
+++ b/src/providers/ipa/ipa_subdomains.c
@@ -2734,7 +2734,8 @@ static errno_t ipa_subdomains_write_kdcinfo_write_step(struct sss_domain_info *d
                               SSS_KRB5KDC_FO_SRV);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
-                "write_krb5info_file failed, authentication might fail.\n");
+              "write to %s/kdcinfo.%s failed, authentication might fail.\n",
+              PUBCONF_PATH, krb5_service->realm);
         goto done;
     }
 

--- a/src/providers/krb5/krb5_common.c
+++ b/src/providers/krb5/krb5_common.c
@@ -804,7 +804,8 @@ static void krb5_resolve_callback(void *private_data, struct fo_server *server)
                                                  NULL);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE,
-                  "write_krb5info_file failed, authentication might fail.\n");
+                  "write to %s/kdcinfo.%s failed, authentication might fail.\n",
+                  PUBCONF_PATH, krb5_service->realm);
         }
     }
 }


### PR DESCRIPTION
Replace write_krb5info_file in SSSD log file with exact filename.

Resolves: https://github.com/SSSD/sssd/issues/5505