### PR TITLE
spec file: don't enable implicit files domain on RHEL

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -479,7 +479,6 @@ autoreconf -ivf
 %configure \
     --disable-rpath \
     --disable-static \
-    --enable-files-domain \
     --enable-gss-spnego-for-zero-maxssf \
     --enable-nfsidmaplibdir=%{_libdir}/libnfsidmap \
     --enable-nsslibdir=%{_libdir} \
@@ -499,6 +498,7 @@ autoreconf -ivf
     --with-syslog=journald \
     --with-test-dir=/dev/shm \
 %if 0%{?fedora}
+    --enable-files-domain \
     --disable-polkit-rules-path \
 %endif
     %{nil}


### PR DESCRIPTION
Corresponding code is built and users can enable files domain
on a as-needed basis. But there is little value running it on
RHEL "as is" by default.

(As a reminder, as a comment in this file says, this is a
"SSSD SPEC file for Fedora 34+ and RHEL-9+")

Originally it was opened as https://src.fedoraproject.org/rpms/sssd/pull-request/8 but @pbrezina asked to move it upstream.