### PR TITLE
spec: remove setuid bit from child helpers if sssd user is root

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -7,6 +7,13 @@
 %global sssd_user root
 %endif
 
+# Set setuid bit on child helpers if we support non-root user.
+%if "%{sssd_user}" == "root"
+%global child_attrs 0750
+%else
+%global child_attrs 4750
+%endif
+
 # we don't want to provide private python extension libs
 %define __provides_exclude_from %{python3_sitearch}/.*\.so$
 
@@ -751,8 +758,8 @@ done
 %files krb5-common
 %license COPYING
 %attr(755,%{sssd_user},%{sssd_user}) %dir %{pubconfpath}/krb5.include.d
-%attr(4750,root,%{sssd_user}) %{_libexecdir}/%{servicename}/ldap_child
-%attr(4750,root,%{sssd_user}) %{_libexecdir}/%{servicename}/krb5_child
+%attr(%{child_attrs},root,%{sssd_user}) %{_libexecdir}/%{servicename}/ldap_child
+%attr(%{child_attrs},root,%{sssd_user}) %{_libexecdir}/%{servicename}/krb5_child
 
 %files krb5 -f sssd_krb5.lang
 %license COPYING
@@ -767,7 +774,7 @@ done
 %license COPYING
 %attr(700,%{sssd_user},%{sssd_user}) %dir %{keytabdir}
 %{_libdir}/%{name}/libsss_ipa.so
-%attr(4750,root,%{sssd_user}) %{_libexecdir}/%{servicename}/selinux_child
+%attr(%{child_attrs},root,%{sssd_user}) %{_libexecdir}/%{servicename}/selinux_child
 %{_mandir}/man5/sssd-ipa.5*
 
 %files ad -f sssd_ad.lang
@@ -778,7 +785,7 @@ done
 
 %files proxy
 %license COPYING
-%attr(4750,root,%{sssd_user}) %{_libexecdir}/%{servicename}/proxy_child
+%attr(%{child_attrs},root,%{sssd_user}) %{_libexecdir}/%{servicename}/proxy_child
 %{_libdir}/%{name}/libsss_proxy.so
 
 %files dbus -f sssd_dbus.lang


### PR DESCRIPTION
The setuid bit is only needed if sssd runs as non-root user.