### PR TITLE
TEST: Update test docstrings to enable auto polarion updates

### DIFF
--- a/src/tests/multihost/ad/test_adparameters.py
+++ b/src/tests/multihost/ad/test_adparameters.py
@@ -1,4 +1,10 @@
-""" AD-Provider BZ Automations """
+""" AD-Provider BZ Automations
+
+:requirement: ad_parameters
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 from __future__ import print_function
 import time
 import random
@@ -18,21 +24,19 @@ class TestBugzillaAutomation(object):
     def test_0001_bz1296618(self, multihost, adjoin,
                             create_aduser_group):
         """
-        @Title: IDM-SSSD-TC: ad_provider: ad_parameters: Properly remove
-        OriginalMemberOf attribute from SSSD cache if user has no secondary
-        groups anymore
-
-        @steps:
-
-        1. Run id <ad user>
-        2. Run ldbsearch -H <Domain-cache> name=AD user
-        3. Remove AD users membership of Group
-        4. Stop, clear cache and start sssd
-        5. Run ldbsearch -H <Domain-cache> name=AD user
-
-        @Expectedresults:
-        1. AD Users cache Entry should not have OriginalMember of
-         attribute having Windows AD Group DN
+        :title: IDM-SSSD-TC: ad_provider: ad_parameters: Properly remove
+         OriginalMemberOf attribute from SSSD cache if user has no secondary
+         groups anymore
+        :id: af7fd9fd-e044-461c-ad51-c91c0b371018
+        :steps:
+          1. Run id <ad user>
+          2. Run ldbsearch -H <Domain-cache> name=AD user
+          3. Remove AD users membership of Group
+          4. Stop, clear cache and start sssd
+          5. Run ldbsearch -H <Domain-cache> name=AD user
+        :expectedresults:
+          1. AD Users cache Entry should not have OriginalMember of
+             attribute having Windows AD Group DN
         """
         adjoin(membersw='adcli')
         (aduser, adgroup) = create_aduser_group
@@ -67,18 +71,18 @@ class TestBugzillaAutomation(object):
     @pytest.mark.tier1
     def test_0002_bz1287209(self, multihost, adjoin, create_aduser_group):
         """
-        :Title: IDM-SSSD-TC: ad_provider: ad_parameters: Allow short usernames
-        in trust setups
-
-        @setup
-        1. Modify sssd.conf and set "full_name_format=%1$s" in  Domain section
-
-        @steps:
-        1. Run command "su -ADUser@Domain -c whoami"
-
-        @Expectedresults:
-        1.Output of whoami command should display only the User part without
-        Domain part ,Ex: "ADUser"
+        :title: IDM-SSSD-TC: ad_provider: ad_parameters: Allow short usernames
+         in trust setups
+        :id: 651a0fb6-7199-40af-aafb-5edff3e17d39
+        :customerscenario: True
+        :steps:
+          1. Modify sssd.conf and set "full_name_format=%1$s" in  Domain
+             section
+          2. Run command "su -ADUser@Domain -c whoami"
+        :expectedresults:
+          1. Should succeed
+          2. Output of whoami command should display only the User part without
+             Domain part ,Ex: "ADUser"
         """
         adjoin(membersw='adcli')
         (ad_user, _) = create_aduser_group
@@ -101,16 +105,15 @@ class TestBugzillaAutomation(object):
     @pytest.mark.tier1
     def test_0003_bz1421622(self, multihost, adjoin, create_aduser_group):
         """
-        :Title: IDM-SSSD-TC: ad_provider: ad_parameters: Users or Groups are
-        cached as mixed-case resulting in users unable to sign in
-
-        @Steps:
-        1. Run command "#getent group <group_name>"
-        2. Run command "#sssctl group-show <group_name>"
-
-        @Expectedresults:
-        1. Group look up should successful.
-        2. Get successful information about cached group.
+        :title: IDM-SSSD-TC: ad_provider: ad_parameters: Users or Groups are
+         cached as mixed-case resulting in users unable to sign in
+        :id: 164201c2-61f4-4bbc-b936-fd0050d2fa08
+        :steps:
+          1. Run command "#getent group <group_name>"
+          2. Run command "#sssctl group-show <group_name>"
+        :expectedresults:
+          1. Group look up should successful.
+          2. Get successful information about cached group.
         """
         logger_cmd = 'logger test_0003_bz1421622'
         multihost.client[0].run_command(logger_cmd, raiseonerr=False)
@@ -135,24 +138,23 @@ class TestBugzillaAutomation(object):
     @pytest.mark.tier2
     def test_0004_bz1407960(self, multihost, create_aduser_group, smbconfig):
         """
-        :Title: IDM-SSSD-TC: ad_provider: ad_parameters: wbcLookupSid() fails
-        in pdomain is NULL
-
-        @steps:
-        1. Leave the already join AD system
-        2. Joined to AD using net ads command
-        3. Obtain cache Kerberos ticket-granting ticket by Administrator
-        4. Check the user info.
-        5. Leave the system from AD Domain, using net ads
-        6. Join system to AD using realmd
-
-        :Expectedresults:
-        1. Successfully leave the already join AD system
-        2. Successfully joined to AD using net ads command
-        3. Obtained cache Kerberos ticket-granting ticket by Administartor
-        4. Successfully check the user info without any segfault
-        5. Successfully leave the system from AD Domain, using net ads
-        6. Successfully join system to AD using realmd
+        :title: IDM-SSSD-TC: ad_provider: ad_parameters: wbcLookupSid() fails
+         in pdomain is NULL
+        :id: f444b01e-8c78-41f2-8aa7-7fb9cff87162
+        :steps:
+          1. Leave the already join AD system
+          2. Joined to AD using net ads command
+          3. Obtain cache Kerberos ticket-granting ticket by Administrator
+          4. Check the user info.
+          5. Leave the system from AD Domain, using net ads
+          6. Join system to AD using realmd
+        :expectedresults:
+          1. Successfully leave the already join AD system
+          2. Successfully joined to AD using net ads command
+          3. Obtained cache Kerberos ticket-granting ticket by Administartor
+          4. Successfully check the user info without any segfault
+          5. Successfully leave the system from AD Domain, using net ads
+          6. Successfully join system to AD using realmd
         """
         (ad_user, _) = create_aduser_group
         password = multihost.ad[0].ssh_password
@@ -195,9 +197,11 @@ class TestBugzillaAutomation(object):
     @pytest.mark.tier1
     def test_00015_authselect_cannot_validate_its_own_files(self, multihost):
         """
-        :Title: authselect: authselect cannot validate its own files
-        @bugzilla:
-        https://bugzilla.redhat.com/show_bug.cgi?id=1734302
+        :title: authselect: authselect cannot validate its own files
+        :id: 67bec814-d67b-4469-9662-58354889d549
+        :requirement: IDM-SSSD-REQ :: Authselect replaced authconfig
+        :casecomponent: authselect
+        :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1734302
         """
         password = multihost.ad[0].ssh_password
         client = sssdTools(multihost.client[0])
@@ -222,21 +226,21 @@ class TestBugzillaAutomation(object):
     @pytest.mark.tier1
     def test_0005_BZ1527149_BZ1549675(self, multihost, adjoin, create_adgrp):
         """
-        :Title: IDM-SSSD-TC: ad_provider: ad_parameters: AD BUILTIN groups are
-        cached with gidNumber equal to 0
-
-        @Setup:
-        1. Create AD group with scope as "Global" and type "Security"
-        2. Update the properties newly created group and update under
+        :title: IDM-SSSD-TC: ad_provider: ad_parameters: AD BUILTIN groups are
+         cached with gidNumber equal to 0
+        :id: d31bffa6-4313-44af-b103-9ea4bc715e72
+        :customerscenario: True
+        :steps:
+          1. Create AD group with scope as "Global" and type "Security"
+          2. Update the properties newly created group and update under
            "Member of" tab and add Users BUILTIN group.
-
-        @Steps:
-        1. Check the group lookup for BUILTIN group.
-        2. Check the cache entry, for built in group.
-
-        @Expectedresults:
-        1. Group lookup should give empty output.
-        2. Should not list the entry for built in group
+          3. Check the group lookup for BUILTIN group.
+          4. Check the cache entry, for built in group.
+        :expectedresults:
+          1. Should succeed
+          2. Should succeed
+          3. Group lookup should give empty output.
+          4. Should not list the entry for built in group
         """
         adjoin(membersw='adcli')
         client = sssdTools(multihost.client[0])
@@ -266,20 +270,20 @@ class TestBugzillaAutomation(object):
                             create_domain_local_group,
                             add_user_in_domain_local_group):
         """
-        @Title: IDM-SSSD-TC: ad_provider: ad_parameters: Groups go missing
-        with PAC enabled in sssd
-
-        @Steps:
-        1. Update sssd with pac.
-        2. Remove the sssd cache.
-        3. Check user lookup and check entry for all groups in output.
-        4. Check ldbsearch and check entry for all groups for that user
-
-        @expectedResults
-        1. Successfully update PAC enabled service in sssd.
-        2. Successfully remove the sssd cache.
-        3. User and group lookup should be successfull
-        4. Get successful information about domain local group in ldbsearch.
+        :title: IDM-SSSD-TC: ad_provider: ad_parameters: Groups go missing
+         with PAC enabled in sssd
+        :id: 505be110-0b3c-46ea-8be8-15c9ee2291f4
+        :customerscenario: True
+        :steps:
+          1. Update sssd with pac.
+          2. Remove the sssd cache.
+          3. Check user lookup and check entry for all groups in output.
+          4. Check ldbsearch and check entry for all groups for that user
+        :expectedResults
+          1. Successfully update PAC enabled service in sssd.
+          2. Successfully remove the sssd cache.
+          3. User and group lookup should be successfull
+          4. Get successful information about domain local group in ldbsearch.
         """
         adjoin(membersw='adcli')
         (ad_user, _) = create_aduser_group
@@ -316,22 +320,21 @@ class TestBugzillaAutomation(object):
     @pytest.mark.tier2
     def test_0007_bz1361597(self, multihost, adjoin, create_aduser_group):
         """
-        @Title: IDM-SSSD-TC: ad_provider: ad_parameters: Test if we can lookup
-        the AD group with one member
-
-        @Steps:
-        1. Lookup the group.
-        2. Add only one user to the group as the member.
-        3. Lookup the group.
-        4. Delete the member.
-        5. Lookup the group.
-
-        @Expectedresults:
-        1. Look must be successful.
-        2. User must be added to the group as a member successfully.
-        3. Look must be successful.
-        4. Member should be deleted successfully.
-        5. Lookup must be successful.
+        :title: IDM-SSSD-TC: ad_provider: ad_parameters: Test if we can lookup
+         the AD group with one member
+        :id: 03cde0b0-27ae-43bd-84ff-96bceb0a15db
+        :steps:
+          1. Lookup the group.
+          2. Add only one user to the group as the member.
+          3. Lookup the group.
+          4. Delete the member.
+          5. Lookup the group.
+        :expectedresults:
+          1. Look must be successful.
+          2. User must be added to the group as a member successfully.
+          3. Look must be successful.
+          4. Member should be deleted successfully.
+          5. Lookup must be successful.
         """
         adjoin(membersw='adcli')
         multihost.client[0].service_sssd('stop')
@@ -385,19 +388,19 @@ class TestBugzillaAutomation(object):
     @pytest.mark.tier3
     def test_0008_bz1431858(self, multihost, adjoin):
         """
-        @Title : IDM-SSSD-TC: ad_provider: ad_parameters: Wrong principal is
-        found with ad provider having long hostname
-
-        @Setup:
-        1. Provision windows hostname longer than 15 chracters
-        2. Provision RHEL machine and install SSSD
-        3. Add a user to AD.
-
-        @Steps:
-        1. Lookup user
-
-        @Expectedresults:
-        1. Lookup should be successful.
+        :title : IDM-SSSD-TC: ad_provider: ad_parameters: Wrong principal is
+         found with ad provider having long hostname
+        :id: 8ce3e54b-6b4d-4a35-b751-47020db1ac97
+        :steps:
+          1. Provision windows hostname longer than 15 chracters
+          2. Provision RHEL machine and install SSSD
+          3. Add a user to AD.
+          4. Lookup user
+        :expectedresults:
+          1. Should succeed
+          2. Should succeed
+          3. Should succeed
+          4. Lookup should be successful
         """
         adjoin(membersw='adcli')
         user = "Administrator"
@@ -411,16 +414,16 @@ class TestBugzillaAutomation(object):
     @pytest.mark.tier1
     def test_0009_bz1565761(self, multihost, adjoin):
         """
-        @Title : IDM-SSSD-TC: ad_provider: ad_parameters: SSSD reports minor
-        failures trying to resolve well-known SIDs
-
-        @Steps:
-        1. Lookup user
-        2. Grep "Domain not found"
-
-        @Expected Results:
-        1. Lookup should be successful.
-        2. Empty output
+        :title : IDM-SSSD-TC: ad_provider: ad_parameters: SSSD reports minor
+         failures trying to resolve well-known SIDs
+        :id: 65cc1f42-92b0-4e3e-8752-5ed9bac2fd6d
+        :customerscenario: True
+        :steps:
+          1. Lookup user
+          2. Grep "Domain not found"
+        :expectedresults:
+          1. Lookup should be successful.
+          2. Empty output
         """
         adjoin(membersw='adcli')
         user = "Administrator"
@@ -435,15 +438,16 @@ class TestBugzillaAutomation(object):
     @pytest.mark.tier1
     def test_0010_bz1527662(self, multihost, adjoin):
         """
-        @Title: ad_parameters: Handle conflicting e-mail addresses
-        more gracefully
-        @steps:
-        1. create ad user akhomic1 having mail akhomic1b@<domain>
-        2. create ad user akhomic1b
-        3. login as akhomic1 user
-
-        @expected Results:
-        1. akhomic1 and akhomic1b should  successfully login
+        :title: ad_parameters: Handle conflicting e-mail addresses
+         more gracefully
+        :id: 21b13b8f-0fc5-44e0-9ce0-e59f74826db0
+        :customerscenario: True
+        :steps:
+          1. create ad user akhomic1 having mail akhomic1b@<domain>
+          2. create ad user akhomic1b
+          3. login as akhomic1 user
+        :expectedresults:
+          1. akhomic1 and akhomic1b should  successfully login
         """
         adjoin(membersw='adcli')
         user_list = ['akhomic1', 'akhomic1b']
@@ -471,8 +475,10 @@ class TestBugzillaAutomation(object):
     @pytest.mark.tier1
     def test_0011_bz1571526(self, multihost, adjoin):
         """
-        @Title: ad_parameters: sssd should give warning
-        when changing ldap schema from AD to others
+        :title: ad_parameters: sssd should give warning
+         when changing ldap schema from AD to others
+        :id: ae2fc714-e698-492f-8d80-4d180e049cc3
+        :customerscenario: True
         """
         adjoin(membersw='adcli')
         client = sssdTools(multihost.client[0])
@@ -492,21 +498,19 @@ class TestBugzillaAutomation(object):
     @pytest.mark.tier1
     def test_0012_bz1738532(self, multihost, adjoin, create_aduser_group):
         """
-        :Title: ad_parameters: lookup identity does not work in some cases
-
-        @setup
-        1. Add user and set its UPN different from the username,
-        Ex: TestUserUPN@ad.vm
-
-        @steps:
-        1. Run command "dbus-send --print-reply --system
-        --dest=org.freedesktop.sssd.infopipe /org/freedesktop/sssd/
-        infopipe org.freedesktop.sssd.infopipe.GetUserAttr string:
-        TestUserUPN@ad.vm array:string:name"
-
-        @Expectedresults:
-        1.Output of above command should not give any error message
-        suppose to get username in output.
+        :title: ad_parameters: lookup identity does not work in some cases
+        :id: b8382774-e568-4e5b-b787-bdd4db380c28
+        :steps:
+          1. Add user and set its UPN different from the username,
+            Ex: TestUserUPN@ad.vm
+          2. Run command "dbus-send --print-reply --system
+             --dest=org.freedesktop.sssd.infopipe /org/freedesktop/sssd/
+             infopipe org.freedesktop.sssd.infopipe.GetUserAttr string:
+             TestUserUPN@ad.vm array:string:name"
+        :expectedresults:
+          1. Should succeed
+          2. Output of above command should not give any error message
+             suppose to get username in output.
         """
         adjoin(membersw='adcli')
         (ad_user, _) = create_aduser_group
@@ -536,8 +540,9 @@ class TestBugzillaAutomation(object):
     @pytest.mark.tier1
     def test_0013_bz1794016(self, multihost, adjoin):
         """
-        @Title: sssd_be frequently crashes when refresh_expired_interval
-        is set and files provider is also enabled
+        :title: sssd_be frequently crashes when refresh_expired_interval
+         is set and files provider is also enabled
+        :id: ac5e99cc-2d81-48f7-82ff-622f1c6b3684
         """
         adjoin(membersw='adcli')
         realm = multihost.ad[0].domainname.strip().upper()
@@ -570,23 +575,22 @@ class TestBugzillaAutomation(object):
     def test_0014_user_filtering(self, multihost,
                                  adjoin, create_aduser_group):
         """
-        @Title: SSSD user filtering is failing
-        after files provider rebuilds cache
-        Bz: 1824323
-
-        @Steps:
-        1. Join RHEL to the AD-server
-        2. Create two ADusers on AD
-        3. Add one ADuser in filter_users in nss section
-        4. Restart sssd
-        5. Make sure that filtered user is not returned by SSSD
-        6. Add a local user and fetch that user information
-        7. Again Make sure that filtered user is not returned by SSSD
-
-        @Expected Results:
-        1. filtered user should not be returned after localuser addition
-        2. Other AD-users should be returned correctly
-
+        :title: SSSD user filtering is failing
+         after files provider rebuilds cache
+        :id: a85acb65-a8af-4397-b4e0-fa9e093b86d7
+        :customerscenario: True
+        :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1824323
+        :steps:
+          1. Join RHEL to the AD-server
+          2. Create two ADusers on AD
+          3. Add one ADuser in filter_users in nss section
+          4. Restart sssd
+          5. Make sure that filtered user is not returned by SSSD
+          6. Add a local user and fetch that user information
+          7. Again Make sure that filtered user is not returned by SSSD
+        :expectedresults:
+          1. filtered user should not be returned after localuser addition
+          2. Other AD-users should be returned correctly
         """
         adjoin(membersw='adcli')
         (aduser, _) = create_aduser_group
@@ -626,22 +630,21 @@ class TestBugzillaAutomation(object):
                              adjoin, fetch_ca_cert,
                              create_aduser_group):
         """
-        @Title: Force LDAPS over 636 with AD Access Provider
-        Bz: 1762415
-
-        @Steps:
-        1. Join RHEL to the AD-server
-        2. Block 389 port on client with iptable
-        3. Enable 'ad_use_ldaps' option sssd.conf
-        4. Add channel bindings /etc/openldap/ldap.conf
-        4. Restart sssd
-        5. Run id <Username>
-        6. Parse sssd log file for port used to contact AD
-
-        @Expected Results:
-        1. User information should be returned correctly
-        2. Logs should show that port 636 was used to contact AD
-
+        :title: Force LDAPS over 636 with AD Access Provider
+        :id: 12d0c340-9c50-4583-97c1-23f9f583522c
+        :customerscenario: True
+        :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1762415
+        :steps:
+          1. Join RHEL to the AD-server
+          2. Block 389 port on client with iptable
+          3. Enable 'ad_use_ldaps' option sssd.conf
+          4. Add channel bindings /etc/openldap/ldap.conf
+          4. Restart sssd
+          5. Run id <Username>
+          6. Parse sssd log file for port used to contact AD
+        :expectedresults:
+          1. User information should be returned correctly
+          2. Logs should show that port 636 was used to contact AD
         """
         adjoin(membersw='adcli')
         (aduser, adgroup) = create_aduser_group
@@ -702,10 +705,9 @@ class TestBugzillaAutomation(object):
     @pytest.mark.tier2
     def test_0017_gssspnego_adjoin(self, multihost):
         """
-        @Title: Verify sssd uses GSS-SPNEGO when communicating to AD
-
-        @Bugzilla:
-        https://bugzilla.redhat.com/show_bug.cgi?id=1707963
+        :title: Verify sssd uses GSS-SPNEGO when communicating to AD
+        :id: 9d8b68a0-1208-446c-9dbd-93ee1f934903
+        :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1707963
         """
         tools = sssdTools(multihost.client[0])
         ad_hostname = multihost.ad[0].sys_hostname
@@ -752,10 +754,11 @@ class TestBugzillaAutomation(object):
     @pytest.mark.tier1
     def test_0018_bz1734040(self, multihost, adjoin):
         """
-        @Title: ad_parameters: sssd crash in ad_get_account_domain_search
+        :title: ad_parameters: sssd crash in ad_get_account_domain_search
+        :id: dcca509e-b316-4010-a173-20f541dafd52
+        :customerscenario: True
+        :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1734040
         """
-        # Automation of bug
-        # https://bugzilla.redhat.com/show_bug.cgi?id=1734040
         adjoin(membersw='adcli')
         client = sssdTools(multihost.client[0])
         domain_name = client.get_domain_section_name()

--- a/src/tests/multihost/ad/test_automount.py
+++ b/src/tests/multihost/ad/test_automount.py
@@ -1,4 +1,10 @@
-""" Test cases for autofs responder """
+""" Test cases for autofs responder
+
+:requirement: AD Provider - automount
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 
 from __future__ import print_function
 import subprocess
@@ -11,28 +17,28 @@ from sssd.testlib.common.utils import sssdTools
 @pytest.mark.automount
 class Testautofsresponder(object):
     """ Autofs responder test cases
-        @setup
-        1. Configure nfs server exporting /export
-        2. Load autofs maps to Active Directory under
-           ou=automout,dc=<ad-domain>,dc=test
-        3. Add an nisMapEntry in automount specifying nfs server,
-           directory and file system(nfs)
-        4. Join RHEL7 client to Windows AD using realm
+
+    :setup:
+      1. Configure nfs server exporting /export
+      2. Load autofs maps to Active Directory under
+         ou=automout,dc=<ad-domain>,dc=test
+      3. Add an nisMapEntry in automount specifying nfs server,
+         directory and file system(nfs)
+      4. Join RHEL7 client to Windows AD using realm
     """
     @pytest.mark.parametrize('add_nisobject', ['/export'], indirect=True)
     @pytest.mark.tier1
     def test_001_searchbasedn(self, multihost, add_nisobject):
         """
-        @Title: IDM-SSSD-TC: AD-Provider Automount: Verify automount rules
-        are searched from basedn
-
-        1. Edit sssd.conf and specify autofs_provider = ad and restart autofs
-
-        @Steps:
-        1. Access /export share
-
-        @expectedResults:
-        1. /export share should be mounted successfully
+        :title: IDM-SSSD-TC: AD-Provider Automount: Verify automount rules
+         are searched from basedn
+        :id: 48baf5ef-3757-45fd-954d-93c94264f880
+        :steps:
+          1. Edit sssd.conf and specify autofs_provider = ad and restart autofs
+          2. Access /export share
+        :expectedresults:
+          1. Should succeed
+          2. /export share should be mounted successfully
         """
         # pylint: disable=unused-argument
         multihost.master[0].run_command(['touch', '/export/nfs-test'])
@@ -55,20 +61,19 @@ class Testautofsresponder(object):
     @pytest.mark.tier1
     def test_002_offline(self, multihost, add_nisobject):
         """
-        @Title: IDM-SSSD-TC: AD-Provider Automount: Verify automount
-        maps are retrieved from cache when sssd is offline
-
-        @Setup:
-        1. Edit sssd.conf and specify autofs_provider = ad
-        2. Restart Autofs
-
-        @Steps:
-        1. pkill -USR1 sssd
-        2. access /export/nfs-test
-
-        @expectedResults:
-        1. sssd should be offline
-        2. /export/nfs-test share should be accessible from client
+        :title: IDM-SSSD-TC: AD-Provider Automount: Verify automount
+         maps are retrieved from cache when sssd is offline
+        :id: 84f3c1ba-0321-4c3b-89c7-de90b4f32639
+        :steps:
+          1. Edit sssd.conf and specify autofs_provider = ad
+          2. Restart Autofs
+          3. pkill -USR1 sssd
+          4. access /export/nfs-test
+        :expectedresults:
+          1. Should succeed
+          2. Should succeed
+          3. sssd should be offline
+          4. /export/nfs-test share should be accessible from client
         """
         multihost.master[0].run_command(['touch', '/export/nfs-test'])
         for service in ['sssd', 'autofs']:
@@ -99,21 +104,20 @@ class Testautofsresponder(object):
     def test_003_setbasedn(self, multihost, set_autofs_search_base,
                            add_nisobject):
         """
-        @Title: IDM-SSSD-TC: AD-Provider Automount: Verify automount
-        rules are searched when ldap_autofs_search_base is set
-
-        @Setup
-        1. Edit sssd.conf and specify below parameters: autofs_provider = ad
+        :title: IDM-SSSD-TC: AD-Provider Automount: Verify automount
+         rules are searched when ldap_autofs_search_base is set
+        :id: e8dbd94d-c557-4533-8ab7-bc891e1609a3
+        :steps:
+          1. Edit sssd.conf and specify below parameters: autofs_provider = ad
            ldap_autofs_search_base = ou=automount,dc=<ad-domain>
-        2. Restart sssd
-
-        @Steps:
-        1. Execute automount -m
-        2. Access /export shared
-
-        @expectedResults:
-        1. automount -m should succeed and show maps from AD
-        2. client is able mount nfs share /export
+          2. Restart sssd
+          3. Execute automount -m
+          4. Access /export shared
+        :expectedresults:
+          1. Should succeed
+          2. Should succeed
+          3. automount -m should succeed and show maps from AD
+          4. client is able mount nfs share /export
         """
         # pylint: disable=unused-argument
         journalctl_cmd = "journalctl -x -n 50 --no-pager"
@@ -139,20 +143,19 @@ class Testautofsresponder(object):
     def test_004_autofsnone(self, multihost, set_autofs_search_base,
                             add_nisobject):
         """
-        @Title: IDM-SSSD-TC: AD-Provider Automount: Verify maps are
-        loaded from cache and maps are accessible when autofs_provider is None
-
-        1. Set autofs_provider = None
-
-        @Steps:
-        1. Restart sssd service
-        2. Execute automount -m
-        3. Run ls -l /export/nfs-share
-
-        @expectedResults:
-        1. sssd service should be started successfully
-        2. automount -m should execute successfully
-        3. /export/nfs-share should be accessible
+        :title: IDM-SSSD-TC: AD-Provider Automount: Verify maps are
+         loaded from cache and maps are accessible when autofs_provider is None
+        :id: 82e5a42d-a097-4604-bcd2-9e8af71bd511
+        :steps:
+          1. Set autofs_provider = None
+          2. Restart sssd service
+          3. Execute automount -m
+          4. Run ls -l /export/nfs-share
+        :expectedresults:
+          1. Should succeed
+          2. sssd service should be started successfully
+          3. automount -m should execute successfully
+          4. /export/nfs-share should be accessible
         """
         multihost.master[0].run_command(['touch', '/export/nfs-test'])
         for service in ['sssd', 'autofs']:
@@ -192,17 +195,16 @@ class Testautofsresponder(object):
     def test_005_autofsnotset(self, multihost, set_autofs_search_base,
                               add_nisobject):
         """
-        @Title: IDM-SSSD-TC: AD-Provider Automount: Verify automount maps are
-        loaded from Active Directory when autofs provider is not set
-        in sssd.conf
-
-        1. Make sure autofs_provider is not set in sssd.conf,
-
-        @Steps:
-        1. Access nfs share /export/nfs-test
-
-        @expectedResults:
-        1. Verify automount maps are loaded from AD and client is able to
+        :title: IDM-SSSD-TC: AD-Provider Automount: Verify automount maps are
+         loaded from Active Directory when autofs provider is not set
+         in sssd.conf
+        :id: a05ac41a-6668-4cde-8109-498baa5300b6
+        :steps:
+          1. Make sure autofs_provider is not set in sssd.conf,
+          2. Access nfs share /export/nfs-test
+        :expectedresults:
+          1. autofs_provider is not set
+          2. Verify automount maps are loaded from AD and client is able to
            mount nfs share
         """
         # pylint: disable=unused-argument
@@ -231,19 +233,18 @@ class Testautofsresponder(object):
     def test_006_updatedmaps(self, multihost, set_autofs_search_base,
                              add_nisobject):
         """
-        @Title: IDM-SSSD-TC: AD-Provider Automount: Verify sssd properly
-        updates cache when automount maps are updated with more entries
-        in Active Directory
-
-        1. Add /project1 entry to auto.direct map
-        2. Restart autofs
-
-        @Steps:
-        1. Access /project1 nfs share
-
-        @expectedResults:
-        1. Verify /project1 can be mounted on nfs client
-
+        :title: IDM-SSSD-TC: AD-Provider Automount: Verify sssd properly
+         updates cache when automount maps are updated with more entries
+         in Active Directory
+        :id: b0e28b05-468a-438c-bf8f-044f1ec73b05
+        :steps:
+          1. Add /project1 entry to auto.direct map
+          2. Restart autofs
+          3. Access /project1 nfs share
+        :expectedresults:
+          1. Should succeed
+          2. Should succeed
+          3. Verify /project1 can be mounted on nfs client
         """
         # pylint: disable=unused-argument
         nfstest = '/project1/project1-test'

--- a/src/tests/multihost/ad/test_cifs.py
+++ b/src/tests/multihost/ad/test_cifs.py
@@ -1,4 +1,10 @@
-""" CIFS Test cases """
+""" CIFS Test cases
+
+:requirement: cifs
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 import time
 import pytest
 
@@ -9,24 +15,26 @@ import pytest
 @pytest.mark.tier2
 @pytest.mark.cifs
 class Testcifs(object):
-    """ Samba IDMAP and CIFS Automations """
+    """ Samba IDMAP and CIFS Automations
+
+    :setup:
+      1. Join RHEL system to windows AD domain using below command
+         $ realm join -v TESTRELM.TEST --membership-software=samba
+      2. configure smb.conf to use sss as idmap backend
+         idmap config * : backend = sss
+         idmap config * : range   = 200000-2147483647
+      3. Restart winbind
+    """
 
     @pytest.mark.tier1
     def test_0001_wbinfo(self, multihost):
         """
-        @Title: IDM-SSSD-TC: samba_idmap: Samba can not
-        register sss idmap module due to SMB_IDMAP_INTERFACE_VERSION
-
-        @Setup:
-        1. Join RHEL system to windows AD domain using below command
-           $ realm join -v TESTRELM.TEST --membership-software=samba
-        2. configure smb.conf to use sss as idmap backend
-           idmap config * : backend = sss
-           idmap config * : range   = 200000-2147483647
-        3. Restart winbind
-
-        @Steps:
-        1. Run wbinfo -i <DOMAIN>\administrator
+        :title: IDM-SSSD-TC: samba_idmap: Samba can not
+         register sss idmap module due to SMB_IDMAP_INTERFACE_VERSION
+        :id: bad2770e-75de-4b41-af47-e9a38b8c0e73
+        :requirement: IDM-SSSD-REQ: Samba with sssd as idmap backend
+        :steps: Run wbinfo -i <DOMAIN>\\administrator
+        :expectedresults: wbinfo command should be successfull
         """
         realm = multihost.ad[0].realm
         wb_cmd = 'wbinfo -i {}{}{}'.format(realm, '\\\\', "administrator")
@@ -35,7 +43,10 @@ class Testcifs(object):
 
     @pytest.mark.tier2
     def test_0002_smb1mount(self, multihost):
-        """ @Title: cifs: mount samba share using smb1 protocol """
+        """
+        :title: cifs: mount samba share using smb1 protocol
+        :id: b82b6c93-1857-449c-bfbb-2a184e12cce6
+        """
         ad_user = 'idmfoouser1'
         ad_group = 'idmfoogroup1'
         realm = multihost.ad[0].realm
@@ -58,7 +69,10 @@ class Testcifs(object):
         multihost.client[0].run_command(kdestroy, raiseonerr=False)
 
     def test_0003_smb3mount(self, multihost):
-        """ @Title: cifs: mount samba share using encrypted smb3 protocol """
+        """
+        :title: cifs: mount samba share using encrypted smb3 protocol
+        :id: 1b10f6f2-d91e-4ea4-a56a-985cd9f9d884
+        """
         ad_user = 'idmfoouser1'
         ad_group = 'idmfoogroup1'
         realm = multihost.ad[0].realm
@@ -97,7 +111,10 @@ class Testcifs(object):
         multihost.client[0].run_command(kdestroy, raiseonerr=False)
 
     def test_0004_writeable(self, multihost):
-        """ @Title: cifs: verify samba share is writeable """
+        """
+        :title: cifs: verify samba share is writeable
+        :id: abd21985-ebd3-4c9d-987c-6e6da32bb922
+        """
         realm = multihost.ad[0].realm
         netbiosname = multihost.ad[0].netbiosname
         for idx in range(1, 3):
@@ -140,7 +157,10 @@ class Testcifs(object):
             multihost.client[0].run_command(kdestroy, raiseonerr=False)
 
     def test_0005_aclcheck(self, multihost, cifsmount):
-        """ @Title: cifs: verify cifs acls on samba share with smb1 mount"""
+        """
+        :title: cifs: verify cifs acls on samba share with smb1 mount
+        :id: b6f86e6b-03f7-4d76-8450-9b2d3d1ed71e
+        """
         ad_user = 'idmfoouser1'
         ad_group = 'idmfoogroup1'
         realm = multihost.ad[0].realm
@@ -190,8 +210,10 @@ class Testcifs(object):
             assert usersid in acl_list
 
     def test_0006_readfromclient(self, multihost, cifsmount):
-        """@Title: verify files modified on server
-        are reflected properly on client
+        """
+        :title: verify files modified on server
+         are reflected properly on client
+        :id: d8861167-2815-4aaa-abeb-1ac9183e3627
         """
         ad_user = 'idmfoouser1'
         ad_group = 'idmfoogroup1'
@@ -218,8 +240,10 @@ class Testcifs(object):
             assert 'testwrite1' in cmd.stdout_text
 
     def test_0007_readfromserver(self, multihost, cifsmount):
-        """@Title: verify files modified on client
-        are reflected properly on server
+        """
+        :title: verify files modified on client
+         are reflected properly on server
+        :id: 0b8e677b-159b-49c0-9b85-3effdd22642d
         """
         ad_user = 'idmfoouser1'
         ad_group = 'idmfoogroup1'

--- a/src/tests/multihost/ad/test_hostkeytabrotation.py
+++ b/src/tests/multihost/ad/test_hostkeytabrotation.py
@@ -1,4 +1,10 @@
-""" Keytab Rotation Test cases """
+""" Keytab Rotation Test cases
+
+:requirement: IDM-SSSD-REQ: Active Directory host keytab renewal
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 
 from __future__ import print_function
 import subprocess
@@ -12,27 +18,27 @@ from sssd.testlib.common.samba import sambaTools
 @pytest.mark.keytabrotation
 class TestHostKeytabRotation(object):
     """ Keytab Rotation Test cases
-    @setup:
-    1.  Configure RHEL client to join to Windows AD using
+
+    :setup:
+      1. Configure RHEL client to join to Windows AD using
         realm
-    2. set machine password age to 1 day in sssd.conf
+      2. set machine password age to 1 day in sssd.conf
     """
 
     @pytest.mark.tier2
     def test_001_rotation(self, multihost, keytab_sssd_conf):
         """
-        @Title: IDM-SSSD-TC: AD-Provider Keytab Rotation:
-        Verify New entries in keytab should have new KVNO after keytab rotation
-
-        @Steps:
-        1. Set pwdLastSet attribute of computer account to 0
-        2. Restart sssd
-        3. sssd calls adcli and new host entries are added /etc/krb5.keytab
-
-        @expectedResults:
-        1. pwdLastSet Attribute should be 0
-        2. Verify sssd restart successfully
-        3. Verify /etc/krb5.keytab has new kvno apart from older entries
+        :title: IDM-SSSD-TC: AD-Provider Keytab Rotation: Verify New entries in
+         keytab should have new KVNO after keytab rotation
+        :id: 26551713-7a82-489f-adc5-8543caa97dd2
+        :steps:
+          1. Set pwdLastSet attribute of computer account to 0
+          2. Restart sssd
+          3. sssd calls adcli and new host entries are added /etc/krb5.keytab
+        :expectedresults:
+          1. pwdLastSet Attribute should be 0
+          2. Verify sssd restart successfully
+          3. Verify /etc/krb5.keytab has new kvno apart from older entries
         """
         # Get current keytab entries
         client = sssdTools(multihost.client[0], multihost.ad[0])
@@ -75,16 +81,16 @@ class TestHostKeytabRotation(object):
     @pytest.mark.tier2
     def test_002_updatedkeytab(self, multihost, keytab_sssd_conf):
         """
-        @Title: IDM-SSSD-TC: AD-Provider Keytab Rotation:
-        Verify with updated Keytab Authentication using
-        host credentials is successful
-
-        @Steps:
-        1. kinit using new HOST principal
-        2. Do ldapsearch using GSSAPI bind
-
-        @expectedResults:
-        1. kinit and ldapsearch  should be successful
+        :title: IDM-SSSD-TC: AD-Provider Keytab Rotation:
+         Verify with updated Keytab Authentication using
+         host credentials is successful
+        :id: 21176af3-614e-417f-87b6-13d8dfe7f33a
+        :steps:
+          1. kinit using new HOST principal
+          2. Do ldapsearch using GSSAPI bind
+        :expectedresults:
+          1. kinit should be successful
+          2. ldapsearch should be successful
         """
         client = sssdTools(multihost.client[0], multihost.ad[0])
         client_hostname = multihost.client[0].sys_hostname.split('.')[0]
@@ -126,20 +132,19 @@ class TestHostKeytabRotation(object):
     @pytest.mark.tier2
     def test_003_delentry(self, multihost, keytab_sssd_conf):
         """
-        @Title: IDM-SSSD-TC: AD-Provider Keytab Rotation:
-        Verify the oldest host principal entries are deleted
-        after succesful machine password
-
-        @Steps:
-        1. Reset Machine password again by setting pwdlastSet attribute to 0
-        2. Restart sssd service
-        3. klist -k /etc/krb5.keytab
-
-        @expectedResults:
-        1. pwdLastSet attribute should be 0
-        2. sssd service should be successfully restarted
-        3. Verify adcli rotates keytab entries and the oldest keytab
-           entry with KVNO 2 is deleted
+        :title: IDM-SSSD-TC: AD-Provider Keytab Rotation:
+         Verify the oldest host principal entries are deleted
+         after succesful machine password
+        :id: 0812dcbf-5d58-4ff8-9891-789f1a5ce8d4
+        :steps:
+          1. Reset Machine password again by setting pwdlastSet attribute to 0
+          2. Restart sssd service
+          3. klist -k /etc/krb5.keytab
+        :expectedresults:
+          1. pwdLastSet attribute should be 0
+          2. sssd service should be successfully restarted
+          3. Verify adcli rotates keytab entries and the oldest keytab
+             entry with KVNO 2 is deleted
         """
         client = sssdTools(multihost.client[0], multihost.ad[0])
         client.reset_machine_password()
@@ -194,24 +199,23 @@ class TestHostKeytabRotation(object):
     @pytest.mark.tier3
     def test_004_multiplespn(self, multihost, keytab_sssd_conf):
         """
-        @Title: IDM-SSSD-TC: AD-Provider Keytab Rotation:
-        Add Multiple SPN(http,nfs) to the client host and
-        verify all the SPN entries are rotated
-
-        @Steps:
-        1. ADD HTTP SPN for client using net ads keytab cli
-        2. ADD NFS SPN for client using net ads keytab cli
-        3. Reset Machine password by setting pwdLastSet to 0
-        4. Restart sssd
-        5. klist -k /etc/krb5.keytab
-
-        @expectedResults:
-        1. klist -k /etc/krb5.keytab should HTTP entries
-        2. klist -k /etc/krb5.keytab should NFS entries
-        3. pwdLastSet attribute should be 0
-        4. sssd service should be restarted successfully
-        5. New HTTP and NFS entries with new kvno should be added to
-           /etc/krb5.keytab
+        :title: IDM-SSSD-TC: AD-Provider Keytab Rotation:
+         Add Multiple SPN(http,nfs) to the client host and
+         verify all the SPN entries are rotated
+        :id: a66c325f-09e2-4a81-8b76-b863dead7e92
+        :steps:
+          1. ADD HTTP SPN for client using net ads keytab cli
+          2. ADD NFS SPN for client using net ads keytab cli
+          3. Reset Machine password by setting pwdLastSet to 0
+          4. Restart sssd
+          5. klist -k /etc/krb5.keytab
+        :expectedresults:
+          1. klist -k /etc/krb5.keytab should HTTP entries
+          2. klist -k /etc/krb5.keytab should NFS entries
+          3. pwdLastSet attribute should be 0
+          4. sssd service should be restarted successfully
+          5. New HTTP and NFS entries with new kvno should be added to
+             /etc/krb5.keytab
         """
         client = sssdTools(multihost.client[0], multihost.ad[0])
         client.reset_machine_password()
@@ -249,22 +253,21 @@ class TestHostKeytabRotation(object):
     @pytest.mark.tier3
     def test_005_deletespn(self, multihost, keytab_sssd_conf):
         """
-        @Title: IDM-SSSD-TC: AD-Provider Keytab Rotation:
-        Removing SPN from AD and verify removed SPN entries
-        are not renewed upon renewal
-
-        @Steps:
-        1. Delete HTTP SPN using setspn.exe  cli from AD
-        2. Reset Machine password by setting pwdLastSet attribute to 0
-        3. Restart sssd
-        4. klist -k /etc/krb5.keytab
-
-        @expectedResults:
-        1. HTTP SPN should be deleted
-        2. pwdLastSet attribute should be 0
-        3. sssd service should be restarted successfuly
-        4. Verify no new HTTP Entries with new KVNO are added in
-           /etc/krb5.keytab
+        :title: IDM-SSSD-TC: AD-Provider Keytab Rotation:
+         Removing SPN from AD and verify removed SPN entries
+         are not renewed upon renewal
+        :id: 6430387a-a715-44b4-81e3-7c012d887e00
+        :steps:
+          1. Delete HTTP SPN using setspn.exe  cli from AD
+          2. Reset Machine password by setting pwdLastSet attribute to 0
+          3. Restart sssd
+          4. klist -k /etc/krb5.keytab
+        :expectedresults:
+          1. HTTP SPN should be deleted
+          2. pwdLastSet attribute should be 0
+          3. sssd service should be restarted successfuly
+          4. Verify no new HTTP Entries with new KVNO are added in
+             /etc/krb5.keytab
         """
         client = sssdTools(multihost.client[0], multihost.ad[0])
         sambaclient = sambaTools(multihost.client[0], multihost.ad[0])

--- a/src/tests/multihost/ad/test_id_mapping.py
+++ b/src/tests/multihost/ad/test_id_mapping.py
@@ -1,5 +1,9 @@
-"""
-Bug 1268902 SSSD doesn't set the ID mapping range automatically
+"""Bug 1268902 SSSD doesn't set the ID mapping range automatically
+
+:requirement: IDM-SSSD-REQ: Active Directory host keytab renewal
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
 """
 import re
 import time
@@ -10,18 +14,19 @@ from sssd.testlib.common.utils import sssdTools
 @pytest.mark.usefixtures('joinad')
 @pytest.mark.idmaprange
 class Testidmaprange(object):
-    """
-    Test cases for BZ: 1268902
-    SSSD doesn't set the ID mapping range automatically
-    @Setup:
-    1. Join to AD using adcli command.
-    2. Add the user using adcli user add.
+    """ Test cases for BZ: 1268902
+
+    :setup:
+      1. Join to AD using adcli command.
+      2. Add the user using adcli user add.
+    :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1268902
     """
     @pytest.mark.tier1
     def test_001_findrid(self, multihost, get_rid):
         """
-        @Title: IDM-SSSD-TC: Support large AD RIDs automatically: Find RID
-        value from objectSID
+        :title: IDM-SSSD-TC: Support large AD RIDs automatically: Find RID
+         value from objectSID
+        :id: ecb488b2-7694-4e68-9ee7-8833cb7100b1
         """
         (_, rid) = get_rid
         assert rid != 0 or rid is not None
@@ -29,8 +34,9 @@ class Testidmaprange(object):
     @pytest.mark.tier1
     def test_002_rangelessthansid(self, multihost, get_rid):
         """
-        @Title: IDM-SSSD-TC: Support large AD RIDs automatically: Verify user
-        lookup when ldap idmap range size less than sids
+        :title: IDM-SSSD-TC: Support large AD RIDs automatically: Verify user
+         lookup when ldap idmap range size less than sids
+        :id: de6144c2-ac5a-4b00-a7e1-bd6a87f99134
         """
         (ad_user, rid) = get_rid
         new_rid = str(rid - 1)
@@ -53,8 +59,9 @@ class Testidmaprange(object):
     @pytest.mark.tier2
     def test_003_disablerange(self, multihost, get_rid):
         """
-        @Title: IDM-SSSD-TC: Support large AD RIDs automatically: Verify user
-        lookup when ldap idmap range size less than sids with disable feature
+        :title: IDM-SSSD-TC: Support large AD RIDs automatically: Verify user
+         lookup when ldap idmap range size less than sids with disable feature
+        :id: 13d9a69a-de96-4884-872d-579191740cc0
         """
         (ad_user, rid) = get_rid
         assert rid != 0 or rid is not None
@@ -88,8 +95,9 @@ class Testidmaprange(object):
     @pytest.mark.tier2
     def test_004_rangeequalsid(self, multihost, get_rid):
         """
-        @Title: IDM-SSSD-TC: Support large AD RIDs automatically: Verify user
-        lookup when ldap idmap range size equal to sids
+        :title: IDM-SSSD-TC: Support large AD RIDs automatically: Verify user
+         lookup when ldap idmap range size equal to sids
+        :id: 3687ca8c-5b40-434e-b699-0598b1db19e4
         """
         (ad_user, new_rid) = get_rid
         multihost.client[0].service_sssd('stop')
@@ -119,8 +127,9 @@ class Testidmaprange(object):
     @pytest.mark.tier2
     def test_005_disablerange(self, multihost, get_rid):
         """
-        @Title: IDM-SSSD-TC: Support large AD RIDs automatically: Verify user
-        lookup when ldap idmap range size equal to sids with disable feature
+        :title: IDM-SSSD-TC: Support large AD RIDs automatically: Verify user
+         lookup when ldap idmap range size equal to sids with disable feature
+        :id: 6682d1c8-2ea8-47a2-9d67-3d48e0949816
         """
         (ad_user, new_rid) = get_rid
         multihost.client[0].service_sssd('stop')
@@ -153,8 +162,9 @@ class Testidmaprange(object):
     @pytest.mark.tier2
     def test_006_rangevalues(self, multihost, get_rid):
         """
-        @Title: IDM-SSSD-TC: Support large AD RIDs automatically: Verify user
-        lookup when ldap idmap range size near border values
+        :title: IDM-SSSD-TC: Support large AD RIDs automatically: Verify user
+         lookup when ldap idmap range size near border values
+        :id: 54178ed0-10b4-4d23-b134-c8c99ebbd724
         """
         rid_list = []
         (ad_user, rid) = get_rid
@@ -190,9 +200,10 @@ class Testidmaprange(object):
     @pytest.mark.tier2
     def test_007_disablerangevalues(self, multihost, get_rid):
         """
-        @Title: IDM-SSSD-TC: Support large AD RIDs automatically: Verify user
-        lookup when ldap idmap range size near border values with disable
-        feature
+        :title: IDM-SSSD-TC: Support large AD RIDs automatically: Verify user
+         lookup when ldap idmap range size near border values with disable
+         feature
+        :id: 58e85bda-9b03-45c6-b508-5d3bb56ea6cf
         """
         rid_list = []
         (ad_user, rid) = get_rid

--- a/src/tests/multihost/ad/test_samba_data.py
+++ b/src/tests/multihost/ad/test_samba_data.py
@@ -1,4 +1,10 @@
-""" Automation for RFE related to --add-samba-data to adcli """
+""" Automation for RFE related to --add-samba-data to adcli
+
+:casecomponent: sssd
+:requirement: Add support for passing --add-samba-data to adcli
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 from __future__ import print_function
 import subprocess
 import time
@@ -14,7 +20,8 @@ class Testsmbsecretrotation(object):
     @pytest.mark.tier2
     def test_0001_rotation(self, multihost):
         """
-        @Title: Verify machine passwd updates local smb secrets
+        :title: Verify machine passwd updates local smb secrets
+        :id: 3d08ea1c-6724-4bc9-ac62-b8be66486ee4
         """
         # Get current hash of /var/lib/samba/private/secrets.tdb
         hash_cmd = 'sha1hmac /var/lib/samba/private/secrets.tdb'

--- a/src/tests/multihost/ad/test_sudo.py
+++ b/src/tests/multihost/ad/test_sudo.py
@@ -1,4 +1,10 @@
-""" AD Sudo test cases """
+""" AD Sudo test cases
+
+:requirement: ad_sudo
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 import pytest
 import paramiko
 from sssd.testlib.common.utils import SSHClient
@@ -32,17 +38,18 @@ class TestSudo(object):
         client.clear_sssd_cache()
 
     def test_001_bz1380436(self, multihost):
-        """@Title: IDM-SSSD-TC: ad_provider: ad_sudo: ignore case
-        on case insenstive Domain
-
-        @setup:
-        1. Add sudo rules containing upper and lower case user names
-        2. Login with lower and upper user case names
-
-        @expectedResuls:
-        1. Verify the the user when logged in with upper
-        and lower case can fetch the sudo rules from AD
-
+        """
+        :title: IDM-SSSD-TC: ad_provider: ad_sudo: ignore case
+         on case insenstive Domain
+        :id: 6cc67f37-808a-4b2c-a2cc-e4e4812388f4
+        :customerscenario: True
+        :steps:
+          1. Add sudo rules containing upper and lower case user names
+          2. Login with lower and upper user case names
+        :expectedresults:
+          1. Should succeed
+          2. Verify the the user when logged in with upper
+             and lower case can fetch the sudo rules from AD
         Note: This test case also cover BZ-1622109 and BZ-bz1519287
         Sudo rules used in the fixture contains multiple
         sudoUser attributes added.
@@ -71,18 +78,22 @@ class TestSudo(object):
                         assert '/usr/bin/less\n' in result
 
     def test_002_bz1372440(self, multihost):
-        """@Title: IDM-SSSD-TC: ad_provider: ad_sudo: AD managed sudo groups
-        will not work with sssd
+        """
+        :title: IDM-SSSD-TC: ad_provider: ad_sudo: AD managed sudo groups
+         will not work with sssd
+        :id: 56616411-d56a-4e3f-b732-a39a4fae8bbc
+        :steps:
+          1. Add sudo rules with sudoUser attribute set to group names
+             (%sudo_idmgroup1 which has member sudo_idmuser1)
+          2. Add users to the group.
+          3. Verify sudo_idmuser1 can fetch the sudo rule
+          4. Run the required command as sudo
 
-        @setup:
-        1. Add sudo rules with sudoUser attribute set to group names
-           (%sudo_idmgroup1 which has member sudo_idmuser1)
-        2. Add users to the group.
-        3. List the sudo commands allowed for the user
-
-        @expectedResuls:
-        1. Verify sudo_idmuser1 can fetch the sudo rule and run
-        the required command  as sudo
+        :expectedresults:
+          1. Should succeed
+          2. Should succeed
+          3. Should succeed
+          4. Should succeed
         """
         multihost.client[0].service_sssd('restart')
         aduser = 'sudo_idmuser1'
@@ -105,22 +116,24 @@ class TestSudo(object):
 
     def test_003_support_non_posix_group_in_sudorule(self, multihost):
         """
-        @Title: IDM-SSSD-TC: ad_provider: ad_sudo: support non-posix
-        groups in sudo rules
-        @Bugzilla:
-        https://bugzilla.redhat.com/show_bug.cgi?id=1826272
-
-        @setup:
-        1. Create a non-posix group in the AD and add an AD-user as a
-           members to it
-        2. Add a sudo rule in the /etc/sudoers file for this user with
-           '%:<group_name>'
-        3. List the sudo commands allowed for the user
-        4. Disable ldap_id_mapping on client
-
-        @expectedResuls:
-        1. Verify sudo_userx can fetch the sudo rule and run
-        the required command  as sudo
+        :title: IDM-SSSD-TC: ad_provider: ad_sudo: support non-posix
+         groups in sudo rules
+        :id: b2def0eb-772d-41b4-b496-f7b3cb61169d
+        :customerscenario: True
+        :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1826272
+        :steps:
+          1. Disable ldap_id_mapping on client
+          2. Create a non-posix group in the AD and add an AD-user as a
+             members to it
+          3. Add a sudo rule in the /etc/sudoers file for this user with
+             '%:<group_name>'
+          4. List the sudo commands allowed for the user
+        :expectedresults:
+          1. Should succeed
+          2. Should succeed
+          3. Should succeed
+          4. Verify sudo_userx can fetch the sudo rule and run
+             the required command  as sudo
         """
         client = sssdTools(multihost.client[0], multihost.ad[0])
         domain_name = multihost.ad[0].domainname

--- a/src/tests/multihost/alltests/test_automount.py
+++ b/src/tests/multihost/alltests/test_automount.py
@@ -1,4 +1,10 @@
-""" Test cases for autofs responder """
+""" Test cases for autofs responder
+
+:requirement: Ldap Provider - automount
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 
 from __future__ import print_function
 import re
@@ -13,28 +19,29 @@ from sssd.testlib.common.utils import sssdTools
 @pytest.mark.automount
 class Testautofsresponder(object):
     """ Autofs responder test cases
-        @setup
-        1. Configure nfs server exporting /export
-        2. Load autofs maps to Directory Server under
-           ou=automout,dc=example,dc=test
-        3. Add an nisMapEntry in automount specifying nfs server,
-           directory and file system(nfs)
-        4. Join RHEL7 client to Windows AD using realm
+
+        :setup:
+          1. Configure nfs server exporting /export
+          2. Load autofs maps to Directory Server under
+             ou=automout,dc=example,dc=test
+          3. Add an nisMapEntry in automount specifying nfs server,
+             directory and file system(nfs)
+          4. Join RHEL7 client to Windows AD using realm
     """
     @pytest.mark.parametrize('add_nisobject', ['/export'], indirect=True)
     @pytest.mark.tier1
     def test_001_searchbasedn(self, multihost, add_nisobject):
         """
-        @Title: IDM-SSSD-TC: LDAP-Provider Automount: Verify automount rules
-        are searched from basedn
-
-        1. Edit sssd.conf and specify autofs_provider = ldap and restart autofs
-
-        @Steps:
-        1. Access /export share
-
-        @expectedResults:
-        1. /export share should be mounted successfully
+        :title: IDM-SSSD-TC: LDAP-Provider: Automount: Verify automount rules
+         are searched from basedn
+        :id: f0b8962d-446b-412e-959a-41182d906dbf
+        :steps:
+          1. Edit sssd.conf and specify autofs_provider = ldap and restart
+             autofs
+          2. Access /export share
+        :expectedresults:
+          1. Should succeed
+          2. /export share should be mounted successfully
         """
         # pylint: disable=unused-argument
         multihost.master[0].run_command(['touch', '/export/nfs-test'])
@@ -57,20 +64,19 @@ class Testautofsresponder(object):
     @pytest.mark.tier1
     def test_002_offline(self, multihost, add_nisobject):
         """
-        @Title: IDM-SSSD-TC: ldap-Provider Automount: Verify automount
-        maps are retrieved from cache when sssd is offline
-
-        @Setup:
-        1. Edit sssd.conf and specify autofs_provider = ldap
-        2. Restart Autofs
-
-        @Steps:
-        1. pkill -USR1 sssd
-        2. access /export/nfs-test
-
-        @expectedResults:
-        1. sssd should be offline
-        2. /export/nfs-test share should be accessible from client
+        :title: IDM-SSSD-TC: LDAP-Provider Automount: Verify automount
+         maps are retrieved from cache when sssd is offline
+        :id: 5e85710a-bd86-416b-82aa-10f254421381
+        :steps:
+          1. Edit sssd.conf and specify autofs_provider = ldap
+          2. Restart Autofs
+          3. pkill -USR1 sssd
+          4. access /export/nfs-test
+        :expectedresults:
+          1. Should succeed
+          2. Should succeed
+          3. sssd should be offline
+          4. /export/nfs-test share should be accessible from client
         """
         multihost.master[0].run_command(['touch', '/export/nfs-test'])
         for service in ['sssd', 'autofs']:
@@ -101,21 +107,21 @@ class Testautofsresponder(object):
     def test_003_setbasedn(self, multihost, set_autofs_search_base,
                            add_nisobject):
         """
-        @Title: IDM-SSSD-TC: ldap-Provider Automount: Verify automount
-        rules are searched when ldap_autofs_search_base is set
-
-        @Setup
-        1. Edit sssd.conf and specify below parameters: autofs_provider = ldap
-           ldap_autofs_search_base = ou=automount,dc=example,dc=test
-        2. Restart sssd
-
-        @Steps:
-        1. Execute automount -m
-        2. Access /export shared
-
-        @expectedResults:
-        1. automount -m should succeed and show maps from AD
-        2. client is able mount nfs share /export
+        :title: IDM-SSSD-TC: LDAP-Provider Automount: Verify automount
+         rules are searched when ldap_autofs_search_base is set
+        :id: 76e7449e-226a-47c5-bc7f-0bb6b9e749e7
+        :steps:
+          1. Edit sssd.conf and specify below parameters:
+             autofs_provider = ldap
+             ldap_autofs_search_base = ou=automount,dc=example,dc=test
+          2. Restart sssd
+          3. Execute automount -m
+          4. Access /export shared
+        :expectedresults:
+          1. Should succeed
+          2. Should succeed
+          3. automount -m should succeed and show maps from AD
+          4. client is able mount nfs share /export
         """
         # pylint: disable=unused-argument
         journalctl_cmd = "journalctl -x -n 50 --no-pager"
@@ -141,20 +147,19 @@ class Testautofsresponder(object):
     def test_004_autofsnone(self, multihost, set_autofs_search_base,
                             add_nisobject):
         """
-        @Title: IDM-SSSD-TC: ldap-Provider Automount: Verify maps are
-        loaded from cache and maps are accessible when autofs_provider is None
-
-        1. Set autofs_provider = None
-
-        @Steps:
-        1. Restart sssd service
-        2. Execute automount -m
-        3. Run ls -l /export/nfs-share
-
-        @expectedResults:
-        1. sssd service should be started successfully
-        2. automount -m should execute successfully
-        3. /export/nfs-share should be accessible
+        :title: IDM-SSSD-TC: LDAP-Provider Automount: Verify maps are
+         loaded from cache and maps are accessible when autofs_provider is None
+        :id: 67daac8b-c7c2-4dca-8331-5e95fd21b483
+        :steps:
+          1. Set autofs_provider = None
+          2. Restart sssd service
+          3. Execute automount -m
+          4. Run ls -l /export/nfs-share
+        :expectedresults:
+          1. Should succeed
+          2. sssd service should be started successfully
+          3. automount -m should execute successfully
+          4. /export/nfs-share should be accessible
         """
         multihost.master[0].run_command(['touch', '/export/nfs-test'])
         for service in ['sssd', 'autofs']:
@@ -194,17 +199,14 @@ class Testautofsresponder(object):
     def test_005_autofsnotset(self, multihost, set_autofs_search_base,
                               add_nisobject):
         """
-        @Title: IDM-SSSD-TC: ldap-Provider Automount: Verify automount maps are
-        loaded from Directory Server when autofs provider is not set
-        in sssd.conf
-
-        1. Make sure autofs_provider is not set in sssd.conf,
-
-        @Steps:
-        1. Access nfs share /export/nfs-test
-
-        @expectedResults:
-        1. Verify automount maps are loaded from AD and client is able to
+        :title: IDM-SSSD-TC: LDAP-Provider: Automount: Verify automount maps
+         are loaded from Directory Server when autofs provider is not set
+         in sssd.conf
+        :id: 3d93a51c-332c-4a88-af68-71a92e8a1b8e
+        :steps:
+          1. Access nfs share /export/nfs-test with autofs provider not set
+        :expectedresults:
+          1. Verify automount maps are loaded from AD and client is able to
            mount nfs share
         """
         # pylint: disable=unused-argument
@@ -233,19 +235,18 @@ class Testautofsresponder(object):
     def test_006_updatedmaps(self, multihost, set_autofs_search_base,
                              add_nisobject):
         """
-        @Title: IDM-SSSD-TC: ldap-Provider Automount: Verify sssd properly
-        updates cache when automount maps are updated with more entries
-        in Directory server
-
-        1. Add /project1 entry to auto.direct map
-        2. Restart autofs
-
-        @Steps:
-        1. Access /project1 nfs share
-
-        @expectedResults:
-        1. Verify /project1 can be mounted on nfs client
-
+        :title: IDM-SSSD-TC: LDAP-Provider Automount: Verify sssd properly
+         updates cache when automount maps are updated with more entries
+         in Directory server
+        :id: 0509a594-bd7a-45d6-b40b-4efcdc6b27f0
+        :steps:
+          1. Add /project1 entry to auto.direct map
+          2. Restart autofs
+          3. Access /project1 nfs share
+        :expectedresults:
+          1. Should succeed
+          2. Should succeed
+          3. Verify /project1 can be mounted on nfs client
         """
         # pylint: disable=unused-argument
         nfstest = '/project1/project1-test'
@@ -267,14 +268,17 @@ class Testautofsresponder(object):
     @pytest.mark.tier2
     def test_007_1206221(self, multihost, set_dslimits, indirect_nismaps):
         """
-        @Title: automount: sssd should not always read
-        entire autofs map from ldap
-        setup:
-        1. Add Indirect map auto.idmtest which has mount point keys
-           from foo1 to foo20 pointing to /projects/foo1 to /projects/foo20
-        2. Set sizelimit to 10 on Directory server.
-
-        Verify all the map keys are accessible
+        :title: automount: sssd should not always read
+         entire autofs map from ldap
+        :id: e79723ce-ad26-44ae-82ff-1afaae22f188
+        :customerscenario: True
+        :steps:
+          1. Add Indirect map auto.idmtest which has mount point keys
+             from foo1 to foo20 pointing to /projects/foo1 to /projects/foo20
+          2. Set sizelimit to 10 on Directory server.
+        :expectedresults:
+          1. Should succeed
+          2. Verify all the map keys are accessible
         """
         for service in ['sssd', 'autofs']:
             restart = 'systemctl restart %s' % service
@@ -295,12 +299,14 @@ class Testautofsresponder(object):
     def test_008_wildcardsearch(self, multihost, indirect_nismaps,
                                 set_ldap_uri):
         """
-        @Title: automount: sssd should not use wildcard
-        search to fetch map keys
-        setup:
-        1. Add Indirect map auto.idmtest which has mount point keys
+        :title: automount: sssd should not use wildcard
+         search to fetch map keys
+        :id: 92640015-52b9-4e76-9e63-ea7357eec9cd
+        :steps:
+          1. Add Indirect map auto.idmtest which has mount point keys
            from foo1 to foo20 pointing to /projects/foo1 to /projects/foo20
-        Verify sssd doesn't use (cn=*)(objectclass=nisObject)
+        :expectedresults:
+          1. Verify sssd doesn't use (cn=*)(objectclass=nisObject)
         """
         auto_pcapfile = '/tmp/automount.pcap'
         ldap_host = multihost.master[0].sys_hostname

--- a/src/tests/multihost/alltests/test_autoprivategroup.py
+++ b/src/tests/multihost/alltests/test_autoprivategroup.py
@@ -1,4 +1,11 @@
-""" Automation of auto private groups"""
+""" Automation of auto private groups
+
+:requirement: IDM-SSSD-REQ: SSSD can automatically create\
+ user private groups for users
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 from __future__ import print_function
 import pytest
 from sssd.testlib.common.utils import sssdTools
@@ -13,8 +20,9 @@ class TestAutoPrivateGroups(object):
     @pytest.mark.tier1
     def test_0001_bz1695577(self, multihost, backupsssdconf):
         """
-        :Title: user_private_group: auto_private_group set to hybrid
-        uid equals to gid and group exists
+        :title: user_private_group: auto_private_group set to hybrid
+         uid equals to gid and group exists
+        :id: 19675eaa-d459-40da-985c-b8e89f8bea40
         """
         multihost.client[0].service_sssd('stop')
         tools = sssdTools(multihost.client[0])
@@ -41,8 +49,9 @@ class TestAutoPrivateGroups(object):
     @pytest.mark.tier1
     def test_0002_bz1695577(self, multihost, backupsssdconf):
         """
-        :Title: user_private_group: auto_private_group set to hybrid
-        uid does not equals to gid and group does exists
+        :title: user_private_group: auto_private_group set to hybrid
+         uid does not equals to gid and group does exists
+        :id: bd7cda5a-49d9-4ca7-8dc6-c0f6c39b494a
         """
         multihost.client[0].service_sssd('stop')
         tools = sssdTools(multihost.client[0])

--- a/src/tests/multihost/alltests/test_config_merging.py
+++ b/src/tests/multihost/alltests/test_config_merging.py
@@ -1,4 +1,10 @@
-""" Automation of configuration merging"""
+""" Automation of configuration merging
+
+:requirement: IDM-SSSD-REQ: Configuration merging
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 from __future__ import print_function
 import re
 from random import choice
@@ -18,8 +24,9 @@ class TestConfigMerge(object):
     @pytest.mark.tier1
     def test_0001_verifypermission(self, multihost):
         """
-        @Title: IDM-SSSD-TC: Configuration merging: Verify the permission of
-        snippet files
+        :title: IDM-SSSD-TC: Configuration merging: Verify the permission of
+         snippet files
+        :id: 6e52a34b-0dda-4c84-8964-72915026ec8c
        """
         multihost.client[0].service_sssd('stop')
         section = "domain/%s" % ds_instance_name
@@ -47,8 +54,9 @@ class TestConfigMerge(object):
     @pytest.mark.tier1
     def test_0002_hiddenfiles(self, multihost):
         """
-        @Title: IDM-SSSD-TC: Configuration merging: SSSD reads all *.conf
-        files, that are not starting with a . (hidden files)
+        :title: IDM-SSSD-TC: Configuration merging: SSSD reads all *.conf
+         files, that are not starting with a . (hidden files)
+        :id: 2428bb6b-535d-46b9-a092-a9c9c3f141fa
         """
         multihost.client[0].service_sssd('stop')
         dom_section = "domain/%s" % ds_instance_name
@@ -66,8 +74,9 @@ class TestConfigMerge(object):
     @pytest.mark.tier1
     def test_0003_lastreadparameter(self, multihost):
         """
-        @Title: IDM-SSSD-TC: Configuration merging: SSSD will use the last
-        read parameter if the same option appears multiple times.
+        :title: IDM-SSSD-TC: Configuration merging: SSSD will use the last
+         read parameter if the same option appears multiple times.
+        :id: 57b4f8c5-08fe-46af-b7e3-e8271d72e41e
         """
         multihost.client[0].service_sssd('stop')
         dom_section = "domain/%s" % ds_instance_name
@@ -95,8 +104,9 @@ class TestConfigMerge(object):
     @pytest.mark.tier1
     def test_0004_formatsnippetfile(self, multihost):
         """
-        @Title: IDM-SSSD-TC: Configuration merging: Verify the format of
-        snippet files
+        :title: IDM-SSSD-TC: Configuration merging: Verify the format of
+         snippet files
+        :id: 8496df1b-32ef-45cd-9d9f-34dcd18656ad
         """
         multihost.client[0].service_sssd('stop')
         dom_section = "domain/%s" % ds_instance_name
@@ -119,8 +129,9 @@ class TestConfigMerge(object):
     @pytest.mark.tier1
     def test_0005_ownershisnippetfile(self, multihost):
         """
-        @Title: IDM-SSSD-TC: Configuration merging: Verify the ownership of
-        snippet files
+        :title: IDM-SSSD-TC: Configuration merging: Verify the ownership of
+         snippet files
+        :id: b89f0403-67ee-4f6b-8c17-bdc4f5213d4f
         """
         multihost.client[0].service_sssd('stop')
         gen = sssdTools(multihost.client[0])
@@ -167,8 +178,9 @@ class TestConfigMerge(object):
     @pytest.mark.tier1
     def test_0006_bz1372258(self, multihost):
         """
-        @Title: IDM-SSSD-TC: Configuration merging: Add path to files when
-        pattern matching fails
+        :title: IDM-SSSD-TC: Configuration merging: Add path to files when
+         pattern matching fails
+        :id: f5620fe5-0576-41b3-acff-f9fceab13206
         """
         multihost.client[0].service_sssd('stop')
         section = "domain/%s" % ds_instance_name
@@ -189,8 +201,10 @@ class TestConfigMerge(object):
     @pytest.mark.tier1
     def test_0007_bz1466503(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration merging: Verify scenario when no
-        sssd.conf and the snippets should be working
+        :title: IDM-SSSD-TC: Configuration merging: Verify scenario when no
+         sssd.conf and the snippets should be working
+        :id: 0148559d-19d0-4909-b7f2-9d8fc8165db4
+        :customerscenario: True
         """
         tools = sssdTools(multihost.client[0])
         multihost.client[0].service_sssd('stop')
@@ -214,8 +228,9 @@ class TestConfigMerge(object):
     @pytest.mark.tier1
     def test_0008_bz1466503(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration merging: Verify scenario when no
-        sssd.conf and wrong snippets should not be working
+        :title: IDM-SSSD-TC: Configuration merging: Verify scenario when no
+         sssd.conf and wrong snippets should not be working
+        :id: 4b4c340b-0b1d-419d-9347-66e9b068bfff
         """
         tools = sssdTools(multihost.client[0])
         multihost.client[0].service_sssd('stop')
@@ -238,9 +253,10 @@ class TestConfigMerge(object):
     @pytest.mark.tier1
     def test_0009_bz1666307(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration merging: sssctl config-check
-        giving the wrong error message when there are only snippet files
-        and no sssd. conf
+        :title: IDM-SSSD-TC: Configuration merging: sssctl config-check
+         giving the wrong error message when there are only snippet files
+         and no sssd. conf
+        :id: e7ca51e4-c41e-41ba-8335-bcc35ec43867
         """
         tools = sssdTools(multihost.client[0])
         multihost.client[0].service_sssd('stop')
@@ -270,8 +286,10 @@ class TestConfigMerge(object):
     @pytest.mark.tier1
     def test_0010_bz1723273(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration merging: Verify error in snippet
-        file created under /etc/sssd/conf.d and /tmp/test/conf.d/
+        :title: IDM-SSSD-TC: Configuration merging: Verify error in snippet
+         file created under /etc/sssd/conf.d and /tmp/test/conf.d/
+        :id: 5ee4557b-952a-45b3-98f7-7fc98715c53b
+        :customerscenario: True
         """
         multihost.client[0].service_sssd('stop')
         cp_cmd = "mkdir -p /tmp/test/conf.d; cp /etc/sssd/sssd.conf /tmp/test/"

--- a/src/tests/multihost/alltests/test_config_validation.py
+++ b/src/tests/multihost/alltests/test_config_validation.py
@@ -1,4 +1,10 @@
-""" Automation of configuration validation"""
+""" Automation of configuration validation
+
+:requirement: IDM-SSSD-REQ: Configuration validation
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 
 from __future__ import print_function
 import re
@@ -18,8 +24,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0001_searchbase(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: Verify typos in option
-        name (not value) of configuration file
+        :title: IDM-SSSD-TC: Configuration validation: Verify typos in option
+         name (not value) of configuration file
+        :id: e15fcc7f-1a5d-49f2-b995-3963d0e8d1e5
         """
         section = "domain/%s" % ds_instance_name
         domain_params = {'ldap_search_base': ''}
@@ -36,8 +43,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0002_domainname(self, multihost, backupsssdconf):
         """
-        @Title:  IDM-SSSD-TC: Configuration validation: Verify typos in domain
-        name of configuration file
+        :title:  IDM-SSSD-TC: Configuration validation: Verify typos in domain
+         name of configuration file
+        :id: 9188aa83-012d-4358-8387-e09cec1aa25d
         """
         sssdcfg = multihost.client[0].get_file_contents('/etc/sssd/sssd.conf')
         sssdcfg = re.sub(b'domain/%s' % ds_instance_name.encode('utf-8'),
@@ -52,8 +60,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0003_snippetfile(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: Verify typos in option
-        name (not value) of snippet files
+        :title: IDM-SSSD-TC: Configuration validation: Verify typos in option
+         name (not value) of snippet files
+        :id: 7e3f57f6-aa7c-4c30-841b-d81ba98d2e29
         """
         section = "domain/%s" % ds_instance_name
         content = "[%s]\nfully_quailified_name = False" % section
@@ -72,8 +81,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0004_snippetfile(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: Verify typos in domain
-        name of snippet files
+        :title: IDM-SSSD-TC: Configuration validation: Verify typos in domain
+         name of snippet files
+        :id: 0f3a8809-594f-41d0-a52a-2d7365e23b09
         """
         file_content = "[dmain/%s]\nfully_quailified_name = False" \
                        % ds_instance_name
@@ -92,8 +102,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0005_misplaced(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: Verify misplaced
-        options
+        :title: IDM-SSSD-TC: Configuration validation: Verify misplaced
+         options
+        :id: ba3278f1-d80c-429f-ac00-f96a9f0f0f0f
         """
         section = "domain/%s" % ds_instance_name
         sssd_params = {'services': ''}
@@ -110,8 +121,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0006_sameerrors(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: Verify same error when
-        sssd is started
+        :title: IDM-SSSD-TC: Configuration validation: Verify same error when
+         sssd is started
+        :id: ab843b71-6f23-45f5-899e-6c66aabee936
         """
         for status in ['start', 'stop']:
             multihost.client[0].service_sssd(status)
@@ -130,8 +142,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0007_equalsign(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: No equal sign between
-        option name and value
+        :title: IDM-SSSD-TC: Configuration validation: No equal sign between
+         option name and value
+        :id: 17fddf2e-07fe-4b1a-b6e2-7028b12c7ef8
         """
         sssdcfg = multihost.client[0].get_file_contents(SSSD_DEFAULT_CONF)
         sssdcfg = re.sub(b'id_provider = ldap',
@@ -146,8 +159,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0008_specialcharacter(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: Option name contains
-        special character
+        :title: IDM-SSSD-TC: Configuration validation: Option name contains
+         special character
+        :id: c4d9c29b-d3a6-4a44-ba88-317d46930916
         """
         section = "domain/%s" % ds_instance_name
         tools = sssdTools(multihost.client[0])
@@ -163,8 +177,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0009_sectionname(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: Verify typos in
-        section name
+        :title: IDM-SSSD-TC: Configuration validation: Verify typos in
+         section name
+        :id: 8c03a1a1-2833-4216-86b3-1c97bf5276ca
         """
         sssdcfg = multihost.client[0].get_file_contents(SSSD_DEFAULT_CONF)
         instance_name = ds_instance_name.encode('utf-8')
@@ -181,8 +196,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0010_splcharacters(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: Verify typos
-        (special character) in section name
+        :title: IDM-SSSD-TC: Configuration validation: Verify typos
+         (special character) in section name
+        :id: de98c544-2f4a-4540-a180-34352b063db2
         """
         sssdcfg = multihost.client[0].get_file_contents(SSSD_DEFAULT_CONF)
         instance_name = ds_instance_name.encode('utf-8')
@@ -199,8 +215,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0011_splcharacters(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: Verify typos (special
-        character) in domain name
+        :title: IDM-SSSD-TC: Configuration validation: Verify typos (special
+         character) in domain name
+        :id: b2a70e9a-2bab-489a-a93d-7508aceb5cd8
         """
         sssdcfg = multihost.client[0].get_file_contents(SSSD_DEFAULT_CONF)
         instance_name = ds_instance_name.encode('utf-8')
@@ -217,8 +234,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0012_forwardslash(self, multihost, backupsssdconf):
         """
-        @Title:  IDM-SSSD-TC: Configuration validation: Forward slash is not
-        present between domain name and section name
+        :title: IDM-SSSD-TC: Configuration validation: Forward slash is not
+         present between domain name and section name
+        :id: d7a73c48-3e92-46aa-864d-40ddeeebdcfb
         """
         sssdcfg = multihost.client[0].get_file_contents(SSSD_DEFAULT_CONF)
         instance_name = ds_instance_name.encode('utf-8')
@@ -234,8 +252,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0013_sectiontypos(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation:
-        Typo in sssd section name
+        :title: IDM-SSSD-TC: Configuration validation:
+         Typo in sssd section name
+        :id: 1d049368-3088-4fd9-9c12-9c379cf7639b
         """
         sssdcfg = multihost.client[0].get_file_contents(SSSD_DEFAULT_CONF)
         sssdcfg = re.sub(b'.sssd.',
@@ -250,8 +269,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0014_pamsection(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: Typos in pam section
-        name
+        :title: IDM-SSSD-TC: Configuration validation: Typos in pam section
+         name
+        :id: 1d9ac54d-278c-441f-8ad8-5e127e137039
         """
         tools = sssdTools(multihost.client[0])
         pam_params = {'debug_level': '9'}
@@ -265,8 +285,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0015_nsssection(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: Typos in nss section
-        name
+        :title: IDM-SSSD-TC: Configuration validation: Typos in nss section
+         name
+        :id: 0506e544-5d96-43c9-bc61-407c991a565f
         """
         tools = sssdTools(multihost.client[0])
         pam_params = {'debug_level': '9'}
@@ -280,8 +301,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0016_verifypermission(self, multihost):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: Verify the permission
-        of default configuration file
+        :title: IDM-SSSD-TC: Configuration validation: Verify the permission
+         of default configuration file
+        :id: e395db40-f61f-4a74-992c-a52f58c58d25
         """
         cfgget = '/etc/sssd/sssd.conf'
         chmod = 'chmod 0777 %s' % cfgget
@@ -297,8 +319,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0017_verifyownership(self, multihost):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: Verify the ownership
-        of default configuration file
+        :title: IDM-SSSD-TC: Configuration validation: Verify the ownership
+         of default configuration file
+        :id: d2737dfc-ece2-42ad-9af4-410c58d91766
         """
         cfgget = '/etc/sssd/sssd.conf'
         user = (''.join(choice(ascii_uppercase) for _ in range(10)))
@@ -323,8 +346,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0018_closingbrackets(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: Verify the closing
-        bracket for sssd section
+        :title: IDM-SSSD-TC: Configuration validation: Verify the closing
+         bracket for sssd section
+        :id: ab53035f-9662-447e-8645-abb0d520de87
         """
         sssdcfg = multihost.client[0].get_file_contents(SSSD_DEFAULT_CONF)
         sssdcfg = re.sub(b'.sssd.',
@@ -339,8 +363,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0019_openingbracket(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: Check starting square
-        bracket in domain section
+        :title: IDM-SSSD-TC: Configuration validation: Check starting square
+         bracket in domain section
+        :id: 665a2792-f1ca-4e6a-b0fd-378b10328537
         """
         sssdcfg = multihost.client[0].get_file_contents(SSSD_DEFAULT_CONF)
         instance_name = ds_instance_name.encode('utf-8')
@@ -356,8 +381,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0020_fatalerror(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: No sssctl commands can
-        be run if the configuration has fatal errors
+        :title: IDM-SSSD-TC: Configuration validation: No sssctl commands can
+         be run if the configuration has fatal errors
+        :id: b483e14b-b263-4e4b-a6f7-539badc76aa4
         """
         sssdcfg = multihost.client[0].get_file_contents(SSSD_DEFAULT_CONF)
         instance_name = ds_instance_name.encode('utf-8')
@@ -377,8 +403,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0021_twodomain(self, multihost, multidomain_sssd):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: Verify typo in option
-        name with multiple domains in default configuration file
+        :title: IDM-SSSD-TC: Configuration validation: Verify typo in option
+         name with multiple domains in default configuration file
+        :id: c240e28a-996f-482b-bac7-9a68c737192c
         """
         multidomain_sssd(domains='ldap_ldap')
         sssdcfg = multihost.client[0].get_file_contents(SSSD_DEFAULT_CONF)
@@ -397,8 +424,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0022_fatalerror(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: No sssctl commands can
-        be run if the configuration has fatal errors
+        :title: IDM-SSSD-TC: Configuration validation: No sssctl commands can
+         be run if the configuration has fatal errors (2)
+        :id: 9c7d169e-0999-4544-8df6-685f0e33023a
         """
         rm_cmd = 'rm -f %s' % SSSD_DEFAULT_CONF
         multihost.client[0].run_command(rm_cmd, raiseonerr=False)
@@ -411,8 +439,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0023_checkldaphostobjectdomain(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: Check
-        ldap_host_object_class option in domain section
+        :title: IDM-SSSD-TC: Configuration validation: Check
+         ldap_host_object_class option in domain section
+        :id: d072b8e7-4981-431f-949d-34d8c12a2d6c
         """
         section = "domain/%s" % ds_instance_name
         tools = sssdTools(multihost.client[0])
@@ -426,8 +455,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0024_checkldaphostobjectsssd(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: Check
-        ldap_host_object_class option in sssd section
+        :title: IDM-SSSD-TC: Configuration validation: Check
+         ldap_host_object_class option in sssd section
+        :id: d25f61ca-f75f-4a66-a43d-495bc0325fef
         """
         section = "sssd"
         tools = sssdTools(multihost.client[0])
@@ -444,9 +474,11 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0025_check2FA(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: Check false
-        warnings are logged in sssd.log file after enabling 2FA prompting
-        settings in sssd.conf
+        :title: IDM-SSSD-TC: Configuration validation: Check false
+         warnings are logged in sssd.log file after enabling 2FA prompting
+         settings in sssd.conf
+        :id: 3a1060db-0120-4270-b669-aae8923613a0
+        :customerscenario: True
         """
         # Automation of BZ1856861
         tools = sssdTools(multihost.client[0])
@@ -467,9 +499,11 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0026_checkchilddomain(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: sssctl config-check
-        reports errors when auto_private_groups is disabled or enabled in
-        child domains
+        :title: IDM-SSSD-TC: Configuration validation: sssctl config-check
+         reports errors when auto_private_groups is disabled or enabled in
+         child domains
+        :id: 40722365-9c34-4230-9a7a-9d958acf078d
+        :customerscenario: True
         """
         # Automation of BZ1791892
         tools = sssdTools(multihost.client[0])
@@ -486,8 +520,10 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0027_bz1723273(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration merging: sssctl config-check
-        complains about non-existing snippet dirctory
+        :title: IDM-SSSD-TC: Configuration merging: sssctl config-check
+         complains about non-existing snippet dirctory
+        :id: 8ed183c4-5102-492a-ada1-a6876978be1f
+        :customerscenario: True
         """
         cp_cmd = "mkdir /tmp/test; cp /etc/sssd/sssd.conf /tmp/test/"
         multihost.client[0].run_command(cp_cmd, raiseonerr=False)
@@ -504,9 +540,10 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0028_bz1723273(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration merging: sssctl config-check
-        gives error message when copied conf file does not have proper
-        ownership and permission
+        :title: IDM-SSSD-TC: Configuration merging: sssctl config-check
+         gives error message when copied conf file does not have proper
+         ownership and permission
+        :id: 6453d102-167c-44a2-9332-80379bcd6f46
         """
         cp_cmd = "mkdir /tmp/test; cp /etc/sssd/sssd.conf /tmp/test/"
         chmod_cmd = "chmod 777 /tmp/test/sssd.conf"
@@ -526,8 +563,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0029_bz1723273(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: Verify typos in option
-        name of copied configuration file
+        :title: IDM-SSSD-TC: Configuration validation: Verify typos in option
+         name of copied configuration file
+        :id: bf6663f3-eed1-4a0b-97d5-f2e68eec0dbf
         """
         tools = sssdTools(multihost.client[0])
         section = "domain/%s" % ds_instance_name
@@ -551,8 +589,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0030_bz1723273(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: Does not complain
-        about snippet directory after adding with proper permissions
+        :title: IDM-SSSD-TC: Configuration validation: Does not complain
+         about snippet directory after adding with proper permissions
+        :id: 7a1946ca-f32a-4749-bf49-dbc643c120a5
         """
         tools = sssdTools(multihost.client[0])
         section = "domain/%s" % ds_instance_name
@@ -575,8 +614,9 @@ class TestConfigValidation(object):
     @pytest.mark.tier1
     def test_0031_bz1723273(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: Configuration validation: complains about non
-        existing snippet directory
+        :title: IDM-SSSD-TC: Configuration validation: complains about non
+         existing snippet directory
+        :id: 3d30164f-b80b-4594-883d-1783d9337031
         """
         sssctl_cmd = 'sssctl config-check -c /tmp/test/sssd.conf -s ' \
                      '/tmp/does/not/exists'

--- a/src/tests/multihost/alltests/test_failover.py
+++ b/src/tests/multihost/alltests/test_failover.py
@@ -1,4 +1,10 @@
-""" Automation for sssd failover  """
+""" Automation for sssd failover
+
+:requirement: IDM-SSSD-REQ : Failover
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 import pytest
 import time
 from sssd.testlib.common.utils import sssdTools
@@ -12,18 +18,19 @@ from constants import ds_instance_name
 @pytest.mark.failover
 class TestFailover(object):
     """ Bug 1283798 failover automation
-    @Setup:
-    1. Configure Directory servers on 2 Hosts (ldap1, ldap2)
-    with TLS
-    2. Configure sssd.conf on client with auth_provider: ldap
-    3. specify ldaps in ldap_uri pointing to 2 directory servers
-    example: ldap_uri: ldaps://ldap1, ldaps://ldap2
+    :setup:
+      1. Configure Directory servers on 2 Hosts (ldap1, ldap2)
+      with TLS
+      2. Configure sssd.conf on client with auth_provider: ldap
+      3. specify ldaps in ldap_uri pointing to 2 directory servers
+      example: ldap_uri: ldaps://ldap1, ldaps://ldap2
     """
     @pytest.mark.tier2
     def test_0001_getent(self, multihost):
         """
-        @Title: failover: Verify users can be queried from
-        second directory server when first directory server is down
+        :title: failover: Verify users can be queried from
+         second directory server when first directory server is down
+        :id: 0d145340-e147-4da7-acd0-f1c29891c397
         """
         # query ldap users when both ldaps servers are working
         user = 'foo0@%s' % ds_instance_name
@@ -54,8 +61,9 @@ class TestFailover(object):
     @pytest.mark.tier2
     def test_0002_login(self, multihost):
         """
-        @Title: failover: Verify users can login when the first
-        ldap server is down
+        :title: failover: Verify users can login when the first
+         ldap server is down
+        :id: 9c0e0448-3fc2-44c7-96f8-9b8b44fa5cba
         """
         user = 'foo2@%s' % ds_instance_name
         stop_ds1 = 'systemctl stop dirsrv@example'
@@ -79,8 +87,9 @@ class TestFailover(object):
     @pytest.mark.tier2
     def test_0003_stopsecondds(self, multihost):
         """
-        @Title: failover: Stop second ldap server and verify
-        users are able to login from first ldap server
+        :title: failover: Stop second ldap server and verify
+         users are able to login from first ldap server
+        :id: cf15aea7-a626-4ed2-a205-9180ddfe29b2
         """
         stop_ds2 = 'systemctl stop dirsrv@example'
         cmd = multihost.master[1].run_command(stop_ds2, raiseonerr=False)

--- a/src/tests/multihost/alltests/test_hosts.py
+++ b/src/tests/multihost/alltests/test_hosts.py
@@ -1,4 +1,10 @@
-"""Tests related to host map and network map"""
+"""Tests related to host map and network map
+
+:requirement: SSSD NSS should support host map
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 from __future__ import print_function
 from sssd.testlib.common.utils import sssdTools
 import pytest
@@ -9,13 +15,15 @@ import pytest
 class TestHostMaps(object):
     """
     SSSD NSS should support host map
-    @bugzilla:
-    https://bugzilla.redhat.com/show_bug.cgi?id=1340908
+    :bugzilla:
+     https://bugzilla.redhat.com/show_bug.cgi?id=1340908
     """
     @pytest.mark.tier1
     def test_001_ldap_iphost_search_base(self, multihost):
         """
-        :Title:hosts: Test ldap_iphost_search_base field
+        :title: hosts: Test ldap_iphost_search_base field
+        :id: a5b82f87-e4f2-49ce-bfc2-e23f5020219d
+        :customerscenario: True
         """
         client = sssdTools(multihost.client[0])
         domain_params = {'ldap_iphost_search_base':
@@ -42,7 +50,8 @@ class TestHostMaps(object):
     @pytest.mark.tier1
     def test_002_ldap_iphost_object_class(self, multihost):
         """
-        :Title:hosts: Test ldap_iphost_object_class field
+        :title: hosts: Test ldap_iphost_object_class field
+        :id: eed161fa-1310-43b7-90e6-dd99846d9cbe
         """
         client = sssdTools(multihost.client[0])
         domain_params = {'ldap_iphost_object_class': 'ipHost'}
@@ -68,7 +77,8 @@ class TestHostMaps(object):
     @pytest.mark.tier1
     def test_003_ldap_iphost_name(self, multihost):
         """
-        :Title:hosts: Test ldap_iphost_name field
+        :title: hosts: Test ldap_iphost_name field
+        :id: 00ae3874-f3ef-4121-bb89-1fce554ddbef
         """
         client = sssdTools(multihost.client[0])
         domain_params = {'ldap_iphost_name': 'cn'}
@@ -94,7 +104,8 @@ class TestHostMaps(object):
     @pytest.mark.tier1
     def test_004_ldap_iphost_number(self, multihost):
         """
-        :Title:hosts: Test ldap_iphost_number field
+        :title: hosts: Test ldap_iphost_number field
+        :id: f78b0874-411c-45f4-8497-e1544d01fdbc
         """
         client = sssdTools(multihost.client[0])
         domain_params = {'ldap_iphost_number': 'ipHostNumber'}
@@ -120,7 +131,8 @@ class TestHostMaps(object):
     @pytest.mark.tier1
     def test_005_ldap_ipnetwork_search_base(self, multihost):
         """
-        :Title:hosts: Test ldap_ipnetwork_search_base field
+        :title: hosts: Test ldap_ipnetwork_search_base field
+        :id: 075bd1e0-8db2-4cc4-bfdf-99fbbe8df62d
         """
         client = sssdTools(multihost.client[0])
         domain_params = {'ldap_ipnetwork_search_base':
@@ -140,7 +152,8 @@ class TestHostMaps(object):
     @pytest.mark.tier1
     def test_006_ldap_ipnetwork_object_class(self, multihost):
         """
-        :Title:hosts: Test ldap_ipnetwork_object_class field
+        :title: hosts: Test ldap_ipnetwork_object_class field
+        :id: fcf249c4-4501-4ff3-a916-5ab13cccc349
         """
         client = sssdTools(multihost.client[0])
         domain_params = {'ldap_ipnetwork_object_class': 'ipNetwork'}
@@ -159,7 +172,8 @@ class TestHostMaps(object):
     @pytest.mark.tier1
     def test_007_ldap_ipnetwork_name(self, multihost):
         """
-        :Title:hosts: Test ldap_ipnetwork_name field
+        :title: hosts: Test ldap_ipnetwork_name field
+        :id: 8d90a533-7d42-4dd4-aab1-c8c3e25cb60a
         """
         client = sssdTools(multihost.client[0])
         domain_params = {'ldap_ipnetwork_name': 'cn'}
@@ -178,7 +192,8 @@ class TestHostMaps(object):
     @pytest.mark.tier1
     def test_008_ldap_ipnetwork_number(self, multihost):
         """
-        :Title:hosts: Test ldap_ipnetwork_number field
+        :title: hosts: Test ldap_ipnetwork_number field
+        :id: ae1df923-5115-4f58-8650-d4a187cf8f7e
         """
         client = sssdTools(multihost.client[0])
         domain_params = {'ldap_ipnetwork_number': 'ipNetworkNumber'}
@@ -197,8 +212,9 @@ class TestHostMaps(object):
     @pytest.mark.tier1
     def test_009_ipnetwork_iphost(self, multihost):
         """
-        :Title:hosts: Test ldap_ipnetwork_search_base
-        and ldap_iphost_search_base fields
+        :title: hosts: Test ldap_ipnetwork_search_base
+         and ldap_iphost_search_base fields
+        :id: 6394baf6-d285-40ef-8182-262ef29d4e33
         """
         client = sssdTools(multihost.client[0])
         domain_params = {

--- a/src/tests/multihost/alltests/test_journald.py
+++ b/src/tests/multihost/alltests/test_journald.py
@@ -1,4 +1,10 @@
-""" Automation of sanity/journald suite"""
+""" Automation of sanity/journald suite
+
+:requirement: IDM-SSSD-REQ : Journal based logging
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 from __future__ import print_function
 import pytest
 import re
@@ -16,8 +22,9 @@ class TestJournald(object):
     @pytest.mark.tier1
     def test_0001_bz1115508(self, multihost, enable_multiple_responders):
         """
-        @Title: IDM-SSSD-TC: sanity: journald: Send debug logs to journald by
-        default bz1115508
+        :title: IDM-SSSD-TC: sanity: journald: Send debug logs to journald by
+         default bz1115508
+        :id: 649107d8-7457-4da3-91c7-32b5bb493fb7
         """
         date = "date" + " --rfc-3339=ns"
         cmd = multihost.client[0].run_command(date, raiseonerr=False)
@@ -67,7 +74,8 @@ class TestJournald(object):
     @pytest.mark.tier1
     def test_0002_bz1460724(self, multihost, enable_multiple_responders):
         """
-        @Title: IDM-SSSD-TC: sanity: journald: SYSLOG_IDENTIFIER is different
+        :title: IDM-SSSD-TC: sanity: journald: SYSLOG_IDENTIFIER is different
+        :id: c30e6899-6c6b-42bb-a9a3-4aacd589908e
         """
         pgrep = multihost.client[0].run_command(["pgrep", "-af", "sssd"],
                                                 raiseonerr=False)

--- a/src/tests/multihost/alltests/test_kcm.py
+++ b/src/tests/multihost/alltests/test_kcm.py
@@ -1,5 +1,9 @@
-"""
-Automation of kcm related bugs
+"""Automation of kcm related bugs
+
+:requirement: IDM-SSSD-REQ :: SSSD KCM as default Kerberos CCACHE provider
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
 """
 
 from __future__ import print_function
@@ -23,11 +27,11 @@ class TestKcm(object):
     @pytest.mark.tier1_2
     def test_client_timeout(self, multihost, backupsssdconf):
         """
-        :Title: kcm: Increase client idle
-        timeout to 5 minutes
-
-        @bugzilla:
-        https://bugzilla.redhat.com/show_bug.cgi?id=1884205
+        :title: kcm: Increase client idle
+         timeout to 5 minutes
+        :id: 6933cb85-1616-4b7f-a049-e81ab4c05347
+        :bugzilla:
+         https://bugzilla.redhat.com/show_bug.cgi?id=1884205
         """
         client = sssdTools(multihost.client[0])
         domain_params = {'debug_level': '9'}

--- a/src/tests/multihost/alltests/test_krb5.py
+++ b/src/tests/multihost/alltests/test_krb5.py
@@ -1,4 +1,8 @@
-""" Automation of Krb5 tests """
+""" Automation of Krb5 tests
+
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 from __future__ import print_function
 import pytest
 from sssd.testlib.common.utils import sssdTools
@@ -15,12 +19,15 @@ class TestKrbWithLogin(object):
                                                     localusers,
                                                     backupsssdconf):
         """
-        :Title: krb5: access_provider = krb5 is not
-        working in RHEL8 while restricting logins
-        based on .k5login file
-
-        @bugzilla:
-        https://bugzilla.redhat.com/show_bug.cgi?id=1734094
+        :title: krb5: access_provider = krb5 is not
+         working in RHEL8 while restricting logins
+         based on .k5login file
+        :id: dfc177ff-58a7-4697-8d23-e444928c7092
+        :casecomponent: authselect
+        :customerscenario: True
+        :requirement: IDM-SSSD-REQ :: Authselect replaced authconfig
+        :bugzilla:
+         https://bugzilla.redhat.com/show_bug.cgi?id=1734094
         """
         multihost.client[0].run_command(f'authselect '
                                         f'select sssd '

--- a/src/tests/multihost/alltests/test_krb_fips.py
+++ b/src/tests/multihost/alltests/test_krb_fips.py
@@ -1,4 +1,10 @@
-""" Basic fips sanity test cases for sssd """
+""" Basic fips sanity test cases for sssd
+
+:requirement: IDM-SSSD-REQ : KRB5 Provider
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 
 import time
 import re
@@ -22,9 +28,10 @@ class Testkrbfips(object):
     @pytest.mark.tier1
     def test_krb_ptr_hash_crash_1792331(self, multihost):
         """
-        @Title: sssd_be crashes when krb5_realm and krb5_server
-        is omitted and auth_provider is krb5
-        Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1792331
+        :title: sssd_be crashes when krb5_realm and krb5_server
+         is omitted and auth_provider is krb5
+        :id: b1321b02-4a29-4285-8c85-36f925496463
+        :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1792331
         """
         tools = sssdTools(multihost.client[0])
         domain_name = tools.get_domain_section_name()
@@ -56,7 +63,8 @@ class Testkrbfips(object):
 
     def test_fips_login(self, multihost):
         """
-        @Title: Verify kerberos user can login successfully in fips mode.
+        :title: Verify kerberos user can login successfully in fips mode
+        :id: 0ec0efc9-85dd-4a66-9802-65f3b122b7da
         """
         tools = sssdTools(multihost.client[0])
         domain_name = tools.get_domain_section_name()
@@ -73,10 +81,14 @@ class Testkrbfips(object):
     @pytest.mark.tier1_2
     def test_kcm_not_store_tgt(self, multihost, backupsssdconf):
         """
-        :Title: sssd-kcm does not store TGT with ssh
-        login using GSSAPI
-        @bugzilla:
-        https://bugzilla.redhat.com/show_bug.cgi?id=1722842
+        :title: sssd-kcm does not store TGT with ssh
+         login using GSSAPI
+        :id: 9a79474c-26c5-4aeb-9f26-f2ada0e9f453
+        :customerscenario: True
+        :requirement:
+         IDM-SSSD-REQ :: SSSD KCM as default Kerberos CCACHE provider
+        :bugzilla:
+         https://bugzilla.redhat.com/show_bug.cgi?id=1722842
         """
         client = sssdTools(multihost.client[0])
         domain_params = {'debug_level': '10',
@@ -104,10 +116,12 @@ class Testkrbfips(object):
 
     def test_child_logs_after_receiving_hup(self, multihost):
         """
-        :Title: sssd fails to release file descriptor on child
-        logs after receiving hup
-        @bugzilla:
-        https://bugzilla.redhat.com/show_bug.cgi?id=1544457
+        :title: sssd fails to release file descriptor on child
+         logs after receiving hup
+        :id: 3e28f453-fae8-4f52-82d0-757a5bdd0b06
+        :customerscenario: True
+        :bugzilla:
+         https://bugzilla.redhat.com/show_bug.cgi?id=1544457
         """
         tools = sssdTools(multihost.client[0])
         domain_name = tools.get_domain_section_name()
@@ -151,9 +165,11 @@ class Testkrbfips(object):
     @pytest.mark.tier1
     def test_sssd_not_check_gss_spengo(self, multihost, backupsssdconf):
         """
-        :Title: krb5/fips: sssd does not properly check GSS-SPNEGO
-        @bugzilla:
-        https://bugzilla.redhat.com/show_bug.cgi?id=1868054
+        :title: krb5/fips: sssd does not properly check GSS-SPNEGO
+        :id: 8ba5427e-8abe-44b9-adaa-878d2418b189
+        :customerscenario: True
+        :bugzilla:
+         https://bugzilla.redhat.com/show_bug.cgi?id=1868054
         """
         client = sssdTools(multihost.client[0])
         domain_name = client.get_domain_section_name()
@@ -183,7 +199,8 @@ class Testkrbfips(object):
 
     def test_fips_as_req(self, multihost):
         """
-        @Title: krb5/fips: verify sssd accepts only elisted fips approved types
+        :title: krb5/fips: verify sssd accepts only elisted fips approved types
+        :id: c5ab16d5-8636-4f50-992b-aa0f05e1a9e5
         """
         tools = sssdTools(multihost.client[0])
         domain_name = tools.get_domain_section_name()
@@ -222,7 +239,8 @@ class Testkrbfips(object):
 
     def test_fips_as_rep(self, multihost):
         """
-        @Title: krb5/fips: verify sssd accepts only elisted fips approved types
+        :title: krb5/fips: verify sssd accepts only elisted fips approved types
+        :id: f8452ecd-e13c-4485-83d3-83e25d7d544a
         """
         tools = sssdTools(multihost.client[0])
         domain_name = tools.get_domain_section_name()
@@ -269,7 +287,8 @@ class Testkrbfips(object):
 
     def test_login_fips_weak_crypto(self, multihost):
         """
-        @Title: krb5/fips: verify login fails when weak crypto is presented.
+        :title: krb5/fips: verify login fails when weak crypto is presented
+        :id: cdd2ef0d-4921-40b3-b61e-0b271b2d5e00
         """
         ldap_uri = 'ldap://%s' % (multihost.master[0].sys_hostname)
         ds_rootdn = 'cn=Directory Manager'
@@ -322,8 +341,9 @@ class Testkrbfips(object):
 
     def test_ldap_gssapi(self, multihost):
         """
-        @Title: krb5/fips: verify sssd is able to create gssapi connection
-        with fips approved etype.
+        :title: krb5/fips: verify sssd is able to create gssapi connection
+         with fips approved etype.
+        :id: 8e80ddc7-fe6a-4729-91b6-f1fbae0dad73
         """
         cmd = 'cat /etc/sssd/sssd.conf'
         multihost.client[0].run_command(cmd)
@@ -355,8 +375,9 @@ class Testkrbfips(object):
 
     def test_tgs_nonfips(self, multihost):
         """
-        @Title: krb5/fips: Verify sssd fails to create gssapi connection
-        with weak etypes
+        :title: krb5/fips: Verify sssd fails to create gssapi connection
+         with weak etypes
+        :id: f9623bc8-6305-45f1-ab6c-b9c2d18cdb8e
         """
         tools = sssdTools(multihost.client[0])
         host = multihost.client[0].sys_hostname

--- a/src/tests/multihost/alltests/test_krb_ldap_connection.py
+++ b/src/tests/multihost/alltests/test_krb_ldap_connection.py
@@ -1,3 +1,10 @@
+"""Automation for krb ldap connection
+
+:requirement: krb_ldap_connection
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 from __future__ import print_function
 import subprocess
 import time
@@ -30,10 +37,11 @@ class TestKrbLdapConnectionTimeout(object):
     @pytest.mark.tier3
     def test_0001_timeoutdefault(self, multihost):
         """
-        @Title: IDM-SSSD-TC: krb_provider: krb_ldap_connection:
-        Test if connection expires for the default value of ldap connection
-        timeout that is 900 seconds(15 minutes) after that it should release
-        the connention
+        :title: IDM-SSSD-TC: krb_provider: krb_ldap_connection:
+         Test if connection expires for the default value of ldap connection
+         timeout that is 900 seconds(15 minutes) after that it should release
+         the connention
+        :id: 53ba0b29-f5fc-4daa-8730-04a8aec91829
         """
         domain_params = {'ldap_connection_expire_timeout': None}
         sssdTools(
@@ -55,9 +63,10 @@ class TestKrbLdapConnectionTimeout(object):
     @pytest.mark.tier3
     def test_0002_timeout100(self, multihost):
         """
-        @Title: IDM-SSSD-TC: krb_provider: krb_ldap_connection:
-        Test for arbitrary value  ldap connection timeout that is 100
-        seconds after that it should release the connection
+        :title: IDM-SSSD-TC: krb_provider: krb_ldap_connection:
+         Test for arbitrary value ldap connection timeout that is 100
+         seconds after that it should release the connection
+        :id: bb8dee0a-8ade-4618-b616-589bfcd46ef3
         """
         multihost.client[0].log.info(
             '\n\n\nTesting for ldap_connection_expire_'
@@ -79,11 +88,12 @@ class TestKrbLdapConnectionTimeout(object):
     @pytest.mark.tier3
     def test_0003_timeouttimeoutoutofrange(self, multihost):
         """
-        @Title: IDM-SSSD-TC: krb_provider: krb_ldap_connection:
-        Test for out of range vlue of ldap connection timeout that
-        is value out of range of integer. SSSD sevice must
-        fail to restart successfully after entring that value
-        in configuration
+        :title: IDM-SSSD-TC: krb_provider: krb_ldap_connection:
+         Test for out of range value of ldap connection timeout that
+         is value out of range of integer
+        :id: a3773739-41c7-4379-82d0-721d6993633c
+        :expectedresults: SSSD sevice must fail to restart
+         successfully after entring that value in configuration
         """
 
         multihost.client[0].log.info(
@@ -138,10 +148,12 @@ class TestKrbLdapConnectionTimeout(object):
     @pytest.mark.tier3
     def test_0004_timeoutminus100(self, multihost):
         """
-        @Title: IDM-SSSD-TC: krb_provider: krb_ldap_connection:
-        Test of invalid value of ldap connection timeout that is
-        -100 in our case. It shoud instatly release the connection
-        after establishing
+        :title: IDM-SSSD-TC: krb_provider: krb_ldap_connection:
+         Test of invalid value of ldap connection timeout that is
+         -100 in our case.
+        :id: d68b6d42-30bd-4abb-bbf4-363388da931d
+        :expectedresults: It shoud instatly release the
+         connection after establishing
         """
         multihost.client[0].log.info(
             '\n\n\nTesting for ldap_connection_expire_'
@@ -163,9 +175,11 @@ class TestKrbLdapConnectionTimeout(object):
     @pytest.mark.tier3
     def test_0005_timeout0(self, multihost):
         """
-        @Title: IDM-SSSD-TC: krb_provider: krb_ldap_connection:Test for
-        value of ldap connection timeout 0. It should have to release
-        the connection instantly after establishing.
+        :title: IDM-SSSD-TC: krb_provider: krb_ldap_connection:Test for
+         value of ldap connection timeout 0.
+        :id: 39af02aa-0860-4189-afc9-3ead42fd5fc1
+        :expectedresults: It should have to release
+         the connection instantly after establishing
         """
         multihost.client[0].log.info(
             '\n\n\nTesting for ldap_connection_expire_'
@@ -187,10 +201,12 @@ class TestKrbLdapConnectionTimeout(object):
     @pytest.mark.tier3
     def test_0006_timeoutkrb(self, multihost):
         """
-        @Title: IDM-SSSD-TC: krb_provider: krb_ldap_connection:
-        Test for krb. In this case value of timeout depends upon
-        max value of lifetime of ticket that is in our case is 120 seconds
-        (2 mins). After that it should have to release the connection
+        :title: IDM-SSSD-TC: krb_provider: krb_ldap_connection:
+         Test for krb
+        :id: b8b3e2ab-d24e-4da8-b750-e405f25c6908
+        :expectedresults: In this case value of timeout depends upon
+         max value of lifetime of ticket that is in our case is 120 seconds
+         (2 mins). After that it should have to release the connection
         """
         cmd_mod_user = ["kadmin.local", "-q", "modprinc -maxlife 2mins foo1"]
         multihost.master[0].run_command(cmd_mod_user)

--- a/src/tests/multihost/alltests/test_ldap_extra_attrs.py
+++ b/src/tests/multihost/alltests/test_ldap_extra_attrs.py
@@ -1,4 +1,10 @@
-""" Automation of ldap_extra_attr suite"""
+""" Automation of ldap_extra_attr suite
+
+:requirement: ldap_extra_attrs
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 from __future__ import print_function
 import re
 import pytest
@@ -16,8 +22,10 @@ class TestLdapExtraAttrs(object):
     @pytest.mark.tier1
     def test_0001_bz1362023(self, multihost):
         """
-        :Title: IDM-SSSD-TC: ldap_extra_attrs: Verify the bz1362023, SSSD
-        fails to start when ldap_user_extra_attrs contains mail
+        :title: IDM-SSSD-TC: ldap_extra_attrs: SSSD fails to start
+          when ldap_user_extra_attrs contains mail
+        :id: 260d62d3-91c1-4d42-b783-df031ad34223
+        :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1362023
         """
         services = "nss, pam, ifp"
         ldap_extra_attr = {'ldap_user_extra_attrs':
@@ -37,8 +45,9 @@ class TestLdapExtraAttrs(object):
     @pytest.mark.tier1
     def test_0002_givenmail(self, multihost):
         """
-        :Title: IDM-SSSD-TC: ldap_extra_attrs: Verify the entry of option
-        value given_email:mail in cache data
+        :title: IDM-SSSD-TC: ldap_extra_attrs: Verify the entry of option
+         value given_email:mail in cache data
+        :id: f0fb818e-5706-4444-915d-15e4f5fc6c9e
         """
         tools = sssdTools(multihost.client[0])
         multihost.client[0].service_sssd('stop')
@@ -64,8 +73,10 @@ class TestLdapExtraAttrs(object):
     @pytest.mark.tier1
     def test_0003_checkldb(self, multihost):
         """
-        :Title: IDM-SSSD-TC: ldap_extra_attrs: Verify recently added
-        attribute should be in cache db along with their value
+        :title: IDM-SSSD-TC: ldap_extra_attrs: Verify recently added
+         attribute should be in cache db along with their value
+        :id: 7bc84c52-d6d6-4ac0-89e1-128b01d7f8ae
+        :customerscenario: True
         """
         tools = sssdTools(multihost.client[0])
         multihost.client[0].service_sssd('stop')
@@ -98,8 +109,9 @@ class TestLdapExtraAttrs(object):
     @pytest.mark.tier1
     def test_0004_negativecache(self, multihost):
         """
-        :Title: IDM-SSSD-TC: ldap_extra_attrs: Check whether, not added
-        parameter of user is displaying in cache or not
+        :title: IDM-SSSD-TC: ldap_extra_attrs: Check whether, not added
+         parameter of user is displaying in cache or not
+        :id: 208d78dd-1af3-468c-ab4b-c98b79a412a3
         """
         tools = sssdTools(multihost.client[0])
         multihost.client[0].service_sssd('stop')
@@ -126,9 +138,10 @@ class TestLdapExtraAttrs(object):
     @pytest.mark.tier1
     def test_0005_ldapextraattrs(self, multihost):
         """
-        :Title: IDM-SSSD-TC: ldap_extra_attrs: Check sssd should start with
-        options ldap_user_email and ldap_user_extra_attrs and check entries in
-        cache
+        :title: IDM-SSSD-TC: ldap_extra_attrs: Check sssd should start with
+         options ldap_user_email and ldap_user_extra_attrs and check entries in
+         cache
+        :id: f10bca5c-ead4-426a-b173-12e9f79f01b4
         """
         tools = sssdTools(multihost.client[0])
         multihost.client[0].service_sssd('stop')
@@ -162,9 +175,9 @@ class TestLdapExtraAttrs(object):
     @pytest.mark.tier1
     def test_0006_bz1667252(self, multihost):
         """
-        @Title: ifp: crash when requesting extra attributes
-
-        BZ:1667252 crash when requesting extra attributes
+        :title: ifp: crash when requesting extra attributes
+        :id: 617c7909-039c-48a6-ba1a-79ebedea4186
+        :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1667252
         """
         tools = sssdTools(multihost.client[0])
         sssd_params = {'services': 'nss, pam, ifp'}

--- a/src/tests/multihost/alltests/test_ldap_library_debug_level.py
+++ b/src/tests/multihost/alltests/test_ldap_library_debug_level.py
@@ -1,3 +1,10 @@
+"""Automation for ldap_library_debug_level
+
+:requirement: IDM-SSSD-REQ : LDAP Provider
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 from __future__ import print_function
 import re
 import pytest
@@ -13,8 +20,9 @@ class TestLdapLibDebugLevel(object):
     @pytest.mark.tier1_2
     def test_0001_bz1884207(self, multihost, backupsssdconf):
         """
-        @Title: ldap_library_debug_level: Check ldap_library_debug_level
-        option with config-check
+        :title: ldap_library_debug_level: Check ldap_library_debug_level
+         option with config-check
+        :id: b753a633-53ca-42ba-974e-cab6bfad17d2
         """
         section = "domain/%s" % ds_instance_name
         tools = sssdTools(multihost.client[0])
@@ -28,8 +36,9 @@ class TestLdapLibDebugLevel(object):
     @pytest.mark.tier1_2
     def test_0002_bz1884207(self, multihost, backupsssdconf):
         """
-        @Title: ldap_library_debug_level: Set ldap_library_debug_level to
-        zero and check corresponding logs
+        :title: ldap_library_debug_level: Set ldap_library_debug_level to
+         zero and check corresponding logs
+        :id: 6cf52e0f-594b-42b7-a933-6bf4257603c9
         """
         section = "domain/%s" % ds_instance_name
         tools = sssdTools(multihost.client[0])
@@ -44,8 +53,9 @@ class TestLdapLibDebugLevel(object):
     @pytest.mark.tier1_2
     def test_0003_bz1884207(self, multihost, backupsssdconf):
         """
-        @Title: ldap_library_debug_level: Set ldap_library_debug_level to
-        two and check corresponding logs
+        :title: ldap_library_debug_level: Set ldap_library_debug_level to
+         two and check corresponding logs
+        :id: 97e03505-d5f3-45df-b6ed-f7ede1106f07
         """
         section = "domain/%s" % ds_instance_name
         tools = sssdTools(multihost.client[0])

--- a/src/tests/multihost/alltests/test_misc.py
+++ b/src/tests/multihost/alltests/test_misc.py
@@ -1,4 +1,10 @@
-""" Automation of misc bugs """
+""" Automation of misc bugs
+
+:requirement: IDM-SSSD-REQ : LDAP Provider
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 
 from __future__ import print_function
 import re
@@ -23,10 +29,10 @@ class TestMisc(object):
     def test_0001_ldapcachepurgetimeout(self,
                                         multihost, backupsssdconf):
         """
-        @Title: ldap_purge_cache_timeout validates most of
-        the entries once the cleanup task kicks in.
-
-        Bugzilla: 1471808
+        :title: ldap_purge_cache_timeout validates most of
+         the entries once the cleanup task kicks in.
+        :id: 5ed009f4-6462-402c-a1fe-4bef7fb0ef73
+        :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1471808
         """
         tools = sssdTools(multihost.client[0])
         multihost.client[0].service_sssd('stop')
@@ -69,9 +75,10 @@ class TestMisc(object):
     def test_0002_offbyonereconn(self,
                                  multihost, backupsssdconf):
         """
-        @Title: off by one in reconnection retries option intepretation
-
-        Bugzilla: 1801401
+        :title: off by one in reconnection retries option intepretation
+        :id: 85c5357d-0cc4-4a32-b36a-00ed530865ad
+        :customerscenario: True
+        :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1801401
         """
         tools = sssdTools(multihost.client[0])
         domainname = tools.get_domain_section_name()
@@ -104,11 +111,12 @@ class TestMisc(object):
     def test_0003_sssd_crashes_after_update(self, multihost,
                                             backupsssdconf):
         """
-        :Title: misc: sssd crashes after last update to
-        sssd-common-1.16.4-37.el7_8.1
-
-        @bugzilla:
-        https://bugzilla.redhat.com/show_bug.cgi?id=1854317
+        :title: misc: sssd crashes after last update to
+         sssd-common-1.16.4-37.el7_8.1
+        :id: 55cbdb9c-c62e-4604-8c77-9d70dd333a50
+        :customerscenario: True
+        :bugzilla:
+         https://bugzilla.redhat.com/show_bug.cgi?id=1854317
         """
         tools = sssdTools(multihost.client[0])
         domain_name = tools.get_domain_section_name()
@@ -163,15 +171,14 @@ class TestMisc(object):
     @pytest.mark.tier1
     def test_0004_sssd_api_conf(self, multihost, backupsssdconf):
         """
-        @Title: sssd.api.conf and sssd.api.d
-        should belong to python-sssdconfig package
-
-        @Description: Verify by removing sssd-common that
-        sssd.api.conf, sssd.api.d is part of python-sssdconfig package
-
-        @Bugzilla
-        https://bugzilla.redhat.com/show_bug.cgi?id=1800564 (RHEL7.8)
-        https://bugzilla.redhat.com/show_bug.cgi?id=1829470 (RHEL8.2)
+        :title: sssd.api.conf and sssd.api.d
+         should belong to python-sssdconfig package
+        :id: 4c6bd6a2-d7eb-4c2c-9346-a89b2bdd553e
+        :description: Verify by removing sssd-common that
+         sssd.api.conf, sssd.api.d is part of python-sssdconfig package
+        :bugzilla:
+         https://bugzilla.redhat.com/show_bug.cgi?id=1800564 (RHEL7.8)
+         https://bugzilla.redhat.com/show_bug.cgi?id=1829470 (RHEL8.2)
         """
         # remove sssd-common package
         rpm_remove = 'rpm -e sssd-common --nodeps'
@@ -197,10 +204,12 @@ class TestMisc(object):
     def test_0005_getent_homedirectory(self, multihost,
                                        backupsssdconf):
         """
-        :Title: misc: fallback_homedir returns '/'
-        for empty home directories in passwd file
-        @bugzilla:
-        https://bugzilla.redhat.com/show_bug.cgi?id=1660693
+        :title: misc: fallback_homedir returns '/'
+         for empty home directories in passwd file
+        :id: 69a6b54e-a8eb-4145-8554-c5e666d82276
+        :customerscenario: True
+        :bugzilla:
+         https://bugzilla.redhat.com/show_bug.cgi?id=1660693
         """
         multihost.client[0].service_sssd('restart')
         ldap_uri = 'ldap://%s' % (multihost.master[0].sys_hostname)

--- a/src/tests/multihost/alltests/test_multidomain.py
+++ b/src/tests/multihost/alltests/test_multidomain.py
@@ -1,4 +1,10 @@
-"""Test cases for Multidomain"""
+"""Test cases for Multidomain
+
+:requirement: multiple_domains
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 from __future__ import print_function
 import re
 import datetime
@@ -17,10 +23,9 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0001_proxyldap2(self, multihost, multidomain_sssd):
         """
-        @Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Check config
-        ldb filter users per domain for puser10 in proxy domain
-
-        multidomain_sssd(domains='proxy_ldap2')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Check config
+         ldb filter users per domain for puser10 in proxy domain
+        :id: aeed42e2-5b9b-4b04-b5f2-ea832250c38e
         """
         multidomain_sssd(domains='proxy_ldap2')
         tools = sssdTools(multihost.client[0])
@@ -38,10 +43,9 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0002_proxyldap2(self, multihost, multidomain_sssd):
         """
-        @Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Check config
-        ldb filter users per domain for puser10 in ldap domain
-
-        multidomain_sssd(domains='proxy_ldap2')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Check config
+         ldb filter users per domain for puser10 in ldap domain
+        :id: 847490b5-0687-4443-bbf5-96c5a7dd2c9f
         """
         multidomain_sssd(domains='proxy_ldap2')
         tools = sssdTools(multihost.client[0])
@@ -59,10 +63,9 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0003_proxyldap2(self, multihost, multidomain_sssd):
         """
-        @Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain:
-        checking lookup and authentication for proxy domain with filter_users
-
-        multidomain_sssd(domains='proxy_ldap2')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain:
+         checking lookup and authentication for proxy domain with filter_users
+        :id: fb7d6f18-1c47-48f6-852f-824850b9f2d2
         """
         multidomain_sssd(domains='proxy_ldap2')
         tools = sssdTools(multihost.client[0])
@@ -88,10 +91,9 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0004_proxyldap2(self, multihost, multidomain_sssd):
         """
-        @Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain:
-        checking lookup and authentication for ldap domain with filter_users
-
-        multidomain_sssd(domains='proxy_ldap2')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain:
+         checking lookup and authentication for ldap domain with filter_users
+        :id: 7aa98ea5-1790-4407-b897-a15e8ebcf775
         """
         multidomain_sssd(domains='proxy_ldap2')
         tools = sssdTools(multihost.client[0])
@@ -117,11 +119,10 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0005_proxyldap2(self, multihost, multidomain_sssd):
         """
-        @Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: proxy
-        provider is not working with enumerate=true when trying to fetch
-        all groups
-
-        multidomain_sssd(domains='proxy_ldap2')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: proxy
+         provider is not working with enumerate=true when trying to fetch
+         all groups
+        :id: d6e5958d-e719-4aab-b4a4-705f97191dfe
         """
         # Automation of BZ1665867
         multidomain_sssd(domains='proxy_ldap2')
@@ -143,10 +144,9 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0006_filesproxy(self, multihost, multidomain_sssd):
         """
-        :Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: lookup
-        and ldbsearch with files and proxy domain
-
-        multidomain_sssd(domains='files_proxy')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: lookup
+         and ldbsearch with files and proxy domain
+        :id: 01b34e45-d291-41f3-b54b-3364ce63e079
         """
         multidomain_sssd(domains='files_proxy')
         ret = multihost.client[0].service_sssd('start')
@@ -171,10 +171,9 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0007_filesproxy(self, multihost, multidomain_sssd, localusers):
         """
-        :Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: lookup for
-        localusers with domain files and proxy
-
-        multidomain_sssd(domains='files_proxy')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: lookup for
+         localusers with domain files and proxy
+        :id: 33cd81a6-26a1-4235-8ef7-ebb52f6b6db2
         """
         multidomain_sssd(domains='files_proxy')
         ret = multihost.client[0].service_sssd('start')
@@ -196,10 +195,9 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0008_filesproxy(self, multihost, multidomain_sssd, localusers):
         """
-        :Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Attempt to
-        modify LDAP domain User with domain files and proxy
-
-        multidomain_sssd(domains='files_proxy')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Attempt to
+         modify LDAP domain User with domain files and proxy
+        :id: ecabce85-b620-45b9-a08a-d975952766a5
         """
         multidomain_sssd(domains='files_proxy')
         multihost.client[0].service_sssd('start')
@@ -212,10 +210,9 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0009_filesproxy(self, multihost, multidomain_sssd, localusers):
         """
-        :Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Attempt to
-        delete LDAP domain User with domain files and proxy
-
-        multidomain_sssd(domains='files_proxy')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Attempt to
+         delete LDAP domain User with domain files and proxy
+        :id: 327f75fc-d4f8-4d51-b140-117edf5f55eb
         """
         multidomain_sssd(domains='files_proxy')
         multihost.client[0].service_sssd('start')
@@ -228,10 +225,9 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0010_filesproxy(self, multihost, multidomain_sssd, localusers):
         """
-        :Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Attempt to
-        modify group with domain files and proxy
-
-        multidomain_sssd(domains='files_proxy')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Attempt to
+         modify group with domain files and proxy
+        :id: 662aaa9b-de83-4e43-8c9f-b8910e96644e
         """
         multidomain_sssd(domains='files_proxy')
         multihost.client[0].service_sssd('start')
@@ -245,10 +241,9 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0011_filesproxy(self, multihost, multidomain_sssd, localusers):
         """
-        :Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain:  Attempt to
-        delete group with domain files and proxy
-
-        multidomain_sssd(domains='files_proxy')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain:  Attempt to
+         delete group with domain files and proxy
+        :id: 28ecf278-b5bd-4d87-a63e-051010e55c5e
         """
         multidomain_sssd(domains='files_proxy')
         multihost.client[0].service_sssd('start')
@@ -262,10 +257,9 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0012_filesldap(self, multihost, multidomain_sssd):
         """
-        :Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: ldbsearch
-        for local and ldap domain
-
-        multidomain_sssd(domains='local_ldap')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: ldbsearch
+         for local and ldap domain
+        :id: bfb68697-9365-49ed-b277-1fef5cf0569b
         """
         multidomain_sssd(domains='local_ldap')
         ret = multihost.client[0].service_sssd('start')
@@ -292,10 +286,9 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0013_filesldap(self, multihost, multidomain_sssd, localusers):
         """
-        @Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: User and
-        group lookup for local and ldap domain
-
-        multidomain_sssd(domains='local_ldap')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: User and
+         group lookup for local and ldap domain
+        :id: 50cc738c-d522-426f-a2cb-6e2ee37db86b
         """
         multidomain_sssd(domains='local_ldap')
         ret = multihost.client[0].service_sssd('start')
@@ -317,10 +310,9 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0014_filesldap(self, multihost, multidomain_sssd, localusers):
         """
-        @Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Attempt to
-        modify ldap user with local group id
-
-        multidomain_sssd(domains='local_ldap')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Attempt to
+         modify ldap user with local group id
+        :id: 399362ee-ad63-4679-9409-6b15db3b6f63
         """
         multidomain_sssd(domains='local_ldap')
         multihost.client[0].service_sssd('start')
@@ -333,10 +325,9 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0015_filesldap(self, multihost, multidomain_sssd, localusers):
         """
-        @Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Attempt to
-        delete ldap user
-
-        multidomain_sssd(domains='local_ldap')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Attempt to
+         delete ldap user
+        :id: 51db041b-880d-4b4b-a68c-fec92cdee291
         """
         multidomain_sssd(domains='local_ldap')
         multihost.client[0].service_sssd('start')
@@ -349,10 +340,9 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0016_filesldap(self, multihost, multidomain_sssd, localusers):
         """
-        @Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Attempt to
-        modify ldap group
-
-        multidomain_sssd(domains='local_ldap')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Attempt to
+         modify ldap group
+        :id: cc3242cf-876e-4f58-bcd1-1532551bedf2
         """
         multidomain_sssd(domains='local_ldap')
         multihost.client[0].service_sssd('start')
@@ -366,10 +356,9 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0017_filesldap(self, multihost, multidomain_sssd, localusers):
         """
-        @Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Attempt to
-        delete ldap domain group
-
-        multidomain_sssd(domains='local_ldap')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Attempt to
+         delete ldap domain group
+        :id: 1a7a5a67-13a9-48d7-bf67-29238d5056fd
         """
         multidomain_sssd(domains='local_ldap')
         multihost.client[0].service_sssd('start')
@@ -383,10 +372,9 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0018_filesfiles(self, multihost, multidomain_sssd):
         """
-        @Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: sssd fails
-        to start with two local domain
-
-        multidomain_sssd(domains='files_files')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: sssd fails
+         to start with two local domain
+        :id: 8235b854-2527-480f-8d9f-d82b426149f4
         """
         multidomain_sssd(domains='files_files')
         result = multihost.client[0].service_sssd('start')
@@ -395,10 +383,9 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0019_ldapldap(self, multihost, multidomain_sssd):
         """
-        @Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: ldb search
-        for users from two ldap domains
-
-        multidomain_sssd(domains='ldap_ldap')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: ldb search
+         for users from two ldap domains
+        :id: d00b674b-1f5a-4c72-ab5e-fe091a12c42c
         """
         multidomain_sssd(domains='ldap_ldap')
         ret = multihost.client[0].service_sssd('start')
@@ -422,10 +409,9 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0020_ldapldap(self, multihost, multidomain_sssd):
         """
-        @Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: checking
-        users and groups lookup for two ldap domains
-
-        multidomain_sssd(domains='ldap_ldap')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: checking
+         users and groups lookup for two ldap domains
+        :id: db99d818-ca66-45df-9b3e-2167cc50fab7
         """
         multidomain_sssd(domains='ldap_ldap')
         ret = multihost.client[0].service_sssd('start')
@@ -443,33 +429,11 @@ class TestMultiDomain(object):
                 assert cmd.returncode == 0
 
     @pytest.mark.tier2
-    def test_0021_ldapldap(self, multihost, multidomain_sssd):
-        """
-        @Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: User
-        information not updated on login for secondary domains bz678593
-
-        multidomain_sssd(domains='ldap_ldap')
-        """
-        multidomain_sssd(domains='ldap_ldap')
-        ret = multihost.client[0].service_sssd('start')
-        assert ret == 0
-        suffix = ['p', 'q']
-        for dom in range(2):
-            for idx in range(5):
-                user = '%suser%d@ldap%d' % (suffix[dom], idx, dom + 1)
-                ssh = SSHClient(multihost.client[0].external_hostname,
-                                username=user,
-                                password='Secret123')
-                assert ssh.connect
-                ssh.close()
-
-    @pytest.mark.tier2
     def test_0022_ldapldap(self, multihost, multidomain_sssd):
         """
-        @Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: User
-        information not updated on login for secondary domains bz678593
-
-        multidomain_sssd(domains='ldap_ldap')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: User
+         information not updated on login for secondary domains bz678593
+        :id: df54756c-b141-4127-8e51-75ead63df10c
         """
         multidomain_sssd(domains='ldap_ldap')
         ret = multihost.client[0].service_sssd('start')
@@ -492,12 +456,11 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0023_ldapldap(self, multihost, multidomain_sssd):
         """
-         @Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Login time
-        increases strongly while authenticating against a user from second
-        domain
-        Automation of BZ694905
-
-         multidomain_sssd(domains='ldap_ldap')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Login time
+         increases strongly while authenticating against a user from second
+         domain
+        :id: 29bdabfd-49ca-4040-a08d-b2b6adbde2cd
+        :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=694905
          """
         multidomain_sssd(domains='ldap_ldap')
         client_tools = sssdTools(multihost.client[0])
@@ -541,14 +504,12 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0024_bz1884196(self, multihost, multidomain_sssd):
         """
-        @Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Check
-        lookup of user when enabled option is True in ldap1 domain
-        and False in second ldap2 domain
-
-        @Bugzilla:
-        https://bugzilla.redhat.com/show_bug.cgi?id=1884196
-
-        multidomain_sssd(domains='ldap_ldap')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Check
+         lookup of user when enabled option is True in ldap1 domain
+         and False in second ldap2 domain
+        :id: a7ce3941-ba2c-407a-bed0-468aaab51fdb
+        :bugzilla:
+         https://bugzilla.redhat.com/show_bug.cgi?id=1884196
         """
         multidomain_sssd(domains='ldap_ldap')
         tools = sssdTools(multihost.client[0])
@@ -581,14 +542,12 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0025_bz1884196(self, multihost, multidomain_sssd):
         """
-        @Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Check user
-        when domains parameter has single domain but enabled True in both ldap
-        domain
-
-        @Bugzilla:
-        https://bugzilla.redhat.com/show_bug.cgi?id=1884196
-
-        multidomain_sssd(domains='ldap_ldap')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Check user
+         when domains parameter has single domain but enabled True in both ldap
+         domain
+        :id: 33b9c044-3eef-472b-b9f9-d5de9f718c94
+        :bugzilla:
+         https://bugzilla.redhat.com/show_bug.cgi?id=1884196
         """
         multidomain_sssd(domains='ldap_ldap')
         tools = sssdTools(multihost.client[0])
@@ -616,13 +575,11 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0026_bz1884196(self, multihost, multidomain_sssd):
         """
-        @Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Check
-        enabled option with snippet file
-
-        @Bugzilla:
-        https://bugzilla.redhat.com/show_bug.cgi?id=1884196
-
-        multidomain_sssd(domains='ldap_ldap')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Check
+         enabled option with snippet file
+        :id: 6fd1e9af-4039-49a1-bf4b-9925b042add5
+        :bugzilla:
+         https://bugzilla.redhat.com/show_bug.cgi?id=1884196
         """
         multidomain_sssd(domains='ldap_ldap')
         tools = sssdTools(multihost.client[0])
@@ -657,14 +614,12 @@ class TestMultiDomain(object):
     @pytest.mark.tier2
     def test_0027_bz1884196(self, multihost, multidomain_sssd):
         """
-        @Title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Check
-        enabled option with snippet file and empty value of domains
-        parameter in sssd section
-
-        @Bugzilla:
-        https://bugzilla.redhat.com/show_bug.cgi?id=1884196
-
-        multidomain_sssd(domains='ldap_ldap')
+        :title: IDM-SSSD-TC: ldap_provider: test_for_multidomain: Check
+         enabled option with snippet file and empty value of domains
+         parameter in sssd section
+        :id: bf65b8c7-f3ab-4ac1-a9a4-ad3377625a39
+        :bugzilla:
+         https://bugzilla.redhat.com/show_bug.cgi?id=1884196
         """
         multidomain_sssd(domains='ldap_ldap')
         tools = sssdTools(multihost.client[0])

--- a/src/tests/multihost/alltests/test_netgroup.py
+++ b/src/tests/multihost/alltests/test_netgroup.py
@@ -1,4 +1,10 @@
-""" Automation of Netgroup suite"""
+""" Automation of Netgroup suite
+
+:requirement: netgroup
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 
 import time
 import ldap
@@ -14,8 +20,10 @@ class TestNetgroup(object):
     @pytest.mark.tier1
     def test_0001_bz1502686(self, multihost):
         """
-        :Title: IDM-SSSD-TC: ldap_provider: netgroup: SSSD crashes in nss
-        responder after netgroup timeout when backend is offline
+        :title: IDM-SSSD-TC: ldap_provider: netgroup: SSSD crashes in nss
+         responder after netgroup timeout when backend is offline
+        :id: 2e5823a2-835b-45fd-a2be-36b20856e726
+        :customerscenario: True
         """
         hostname = multihost.master[0].sys_hostname
         bad_ldap_uri = "ldaps://typo.%s" % hostname
@@ -70,8 +78,9 @@ class TestNetgroup(object):
     @pytest.mark.tier1
     def test_0002_bz1406437(self, multihost):
         """
-        :Title: IDM-SSSD-TC: ldap_provider: netgroup: sssctl netgroup-show
-        Cannot allocate memory
+        :title: IDM-SSSD-TC: ldap_provider: netgroup: sssctl netgroup-show
+         Cannot allocate memory
+        :id: bdcf03d6-fe5d-44fd-9517-f812dacaf6af
         """
         multihost.client[0].service_sssd('stop')
         tools = sssdTools(multihost.client[0])
@@ -93,12 +102,12 @@ class TestNetgroup(object):
     @pytest.mark.tier1
     def test_0003_background_refresh(self, multihost):
         """
-        :Title: netgroup: background refresh task does not refresh
-        updated netgroup entries
-
-        @Bugzilla:
-        https://bugzilla.redhat.com/show_bug.cgi?id=1779486 (RHEL8.2)
-        https://bugzilla.redhat.com/show_bug.cgi?id=1822461 (RHEL7.8)
+        :title: netgroup: background refresh task does not refresh
+         updated netgroup entries
+        :id: b17d904d-0d64-4f4a-bbad-4c7f63e1faf2
+        :bugzilla:
+         https://bugzilla.redhat.com/show_bug.cgi?id=1779486 (RHEL8.2)
+         https://bugzilla.redhat.com/show_bug.cgi?id=1822461 (RHEL7.8)
         """
         multihost.client[0].service_sssd('stop')
         tools = sssdTools(multihost.client[0])

--- a/src/tests/multihost/alltests/test_offline.py
+++ b/src/tests/multihost/alltests/test_offline.py
@@ -1,4 +1,10 @@
-""" Automation of offline suite"""
+""" Automation of offline suite
+
+:requirement: offline
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 from __future__ import print_function
 import time
 import pytest
@@ -15,9 +21,10 @@ class TestOffline(object):
     @pytest.mark.tier1
     def test_0001_bz1416150(self, multihost):
         """
-        :Title: IDM-SSSD-TC: ldap_provider: offline: Log to syslog when sssd
-        cannot contact servers goes offline
-        offline.
+        :title: IDM-SSSD-TC: ldap_provider: offline: Log to syslog when sssd
+         cannot contact servers goes offline
+         offline.
+        :id: fd062319-fa78-4a9e-98ad-be6636b36c5e
         """
         hostname = multihost.master[0].sys_hostname
         bad_ldap_uri = "ldaps://typo.%s" % (hostname)

--- a/src/tests/multihost/alltests/test_password_policy.py
+++ b/src/tests/multihost/alltests/test_password_policy.py
@@ -1,4 +1,10 @@
-""" Automation of password policy test suite"""
+""" Automation of password policy test suite
+
+:requirement: password_policy
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 from __future__ import print_function
 from constants import ds_instance_name
 from sssd.testlib.common.utils import sssdTools
@@ -18,9 +24,10 @@ class TestPasswordCheck(object):
     @pytest.mark.tier2
     def test_0001_chnageuserpass(self, multihost):
         """
-        @Title: IDM-SSSD-TC: ldap_provider: password_policy: Change users
-        password with ldap_pwmodify_mode in sssd.conf
-
+        :title: IDM-SSSD-TC: ldap_provider: password_policy: Change users
+         password with ldap_pwmodify_mode in sssd.conf
+        :id: dc70641a-bf1b-445c-926c-7ca693a87615
+        :customerscenario: True
         """
         # Automation of BZ795044(rhel7) and BZ1695574(rhel8)
         # "exop" will change password with extended operation,
@@ -53,8 +60,9 @@ class TestPasswordCheck(object):
     @pytest.mark.tier2
     def test_0002_newpassnotmatch(self, multihost):
         """
-        @Title: IDM-SSSD-TC: ldap_provider: password_policy: New password is
-        not matching with retype password with ldap_pwmodify_mode in sssd.conf
+        :title: IDM-SSSD-TC: ldap_provider: password_policy: New password is
+         not matching with retype password with ldap_pwmodify_mode in sssd.conf
+        :id: ef5a83f3-4560-46dd-b7e7-c6bbdf0da551
        """
         # Automation of BZ795044(rhel7) and BZ1695574(rhel8)
         # "exop" will change password with extended operation,
@@ -77,8 +85,9 @@ class TestPasswordCheck(object):
     @pytest.mark.tier2
     def test_0003_smallnewpass(self, multihost):
         """
-        @Title: IDM-SSSD-TC: ldap_provider: password_policy: Check new
-        password quality check with ldap_pwmodify_mode in sssd.conf
+        :title: IDM-SSSD-TC: ldap_provider: password_policy: Check new
+         password quality check with ldap_pwmodify_mode in sssd.conf
+        :id: 00c39f98-3420-4e95-ac96-0929fe771eff
        """
         # Automation of BZ795044(rhel7) and BZ1695574(rhel8)
         # "exop" will change password with extended operation,
@@ -107,8 +116,9 @@ class TestPasswordCheck(object):
     @pytest.mark.tier2
     def test_0004_wrongcurrentpass(self, multihost):
         """
-        @Title: IDM-SSSD-TC: ldap_provider: password_policy: Check wrong
-        current password with ldap_pwmodify_mode in sssd.conf
+        :title: IDM-SSSD-TC: ldap_provider: password_policy: Check wrong
+         current password with ldap_pwmodify_mode in sssd.conf
+        :id: 12ce875a-d8b9-4165-980a-f649459f45f0
         """
         # Automation of BZ795044(rhel7) and BZ1695574(rhel8)
         # "exop" will change password with extended operation,

--- a/src/tests/multihost/alltests/test_proxy.py
+++ b/src/tests/multihost/alltests/test_proxy.py
@@ -1,4 +1,10 @@
-""" test cases for sssd proxy """
+""" test cases for sssd proxy
+
+:requirement: IDM-SSSD-REQ : Proxy Provider
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 
 import time
 import re
@@ -20,7 +26,8 @@ class TestsssdProxy(object):
     @pytest.mark.tier1
     def test_0001_1724717(self, multihost):
         """
-        @Title: proxy: sssd-proxy crashes resolving groups with no members
+        :title: proxy: sssd-proxy crashes resolving groups with no members
+        :id: 28b64673-8f1b-46c1-b0dd-6eaba9f80b2c
         """
         # backup sssd.conf
         backup = 'cp -f /etc/sssd/sssd.conf /etc/sssd/sssd.conf.backup'

--- a/src/tests/multihost/alltests/test_services.py
+++ b/src/tests/multihost/alltests/test_services.py
@@ -1,4 +1,10 @@
-""" Automation of sanity/services suite"""
+""" Automation of sanity/services suite
+
+:requirement: IDM-SSSD-REQ : Configuration and Service Management
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 from __future__ import print_function
 import pytest
 import paramiko
@@ -14,8 +20,9 @@ class TestServices(object):
     @pytest.mark.tier1
     def test_0001_bz1432010(self, multihost):
         """
-        :Title: IDM-SSSD-TC: sanity: services: SSSD ships a drop-in
-        configuration snippet in /etc/systemd/system
+        :title: IDM-SSSD-TC: sanity: services: SSSD ships a drop-in
+         configuration snippet in /etc/systemd/system
+        :id: 755973b3-200c-456d-8057-f4a6b093e3f4
         """
         rpm_grep = 'rpm -ql sssd-common'
         cmd = multihost.client[0].run_command(rpm_grep, raiseonerr=False)
@@ -24,8 +31,9 @@ class TestServices(object):
     @pytest.mark.tier1
     def test_0002_1736796(self, multihost, localusers):
         """
-        :Title: config: "default_domain_suffix" should not
-        cause files domain entries to be qualified, this can break sudo access
+        :title: config: "default_domain_suffix" should not
+         cause files domain entries to be qualified, this can break sudo access
+        :id: 4b7bdeff-51ba-46ed-b8e1-0685515b87a0
         """
         users = localusers
         for user in users.keys():
@@ -64,7 +72,9 @@ class TestServices(object):
     @pytest.mark.tier1
     def test_0003_bz1713368(self, multihost):
         """
-        :Title: services: Add sssd-dbus package as a dependency of sssd-tools
+        :title: services: Add sssd-dbus package as a dependency of sssd-tools
+        :id: dfbdcb9f-09ed-4467-97a6-0407c779dd08
+        :customerscenario: True
         """
         # sssd-dbus is a weak dependency of sssd-tools package so we did not
         # get sssd-dbus in '# yum deplist sssd-tools' command
@@ -81,10 +91,12 @@ class TestServices(object):
     @pytest.mark.tier1
     def test_0004_membership_with_files_provider(self, multihost):
         """
-        :Title: services: SSSD must be able to resolve
-        membership involving root with files provider
-        @bugzilla:
-        https://bugzilla.redhat.com/show_bug.cgi?id=1794607
+        :title: services: SSSD must be able to resolve
+         membership involving root with files provider
+        :id: ca7adb25-6a2b-4f09-b5ed-dc083226c6c9
+        :customerscenario: True
+        :bugzilla:
+         https://bugzilla.redhat.com/show_bug.cgi?id=1794607
         """
         # take backup:
         back_up = "cp -vf /etc/pam.d/su /etc/pam.d/su_bkp"
@@ -112,11 +124,13 @@ class TestServices(object):
     @pytest.mark.tier1
     def test_0005_sssd_stops_monitoring(self, multihost):
         """
-        :Title: services: When the passwd or group files
-        are replaced, sssd stops monitoring the file for
-        inotify events, and no updates are triggered
-        @bugzilla:
-        https://bugzilla.redhat.com/show_bug.cgi?id=1827432
+        :title: services: When the passwd or group files
+         are replaced, sssd stops monitoring the file for
+         inotify events, and no updates are triggered
+        :id: c6bf72fa-75be-4004-b04b-b5ea3e662c7d
+        :customerscenario: True
+        :bugzilla:
+         https://bugzilla.redhat.com/show_bug.cgi?id=1827432
         """
         group_bkp = "cp -vf /etc/group /etc/group_bkp"
         multihost.client[0].run_command(group_bkp, raiseonerr=False)

--- a/src/tests/multihost/alltests/test_ssh_authorizedkeys.py
+++ b/src/tests/multihost/alltests/test_ssh_authorizedkeys.py
@@ -1,4 +1,10 @@
-""" Tests related to Caching of ssh keys """
+""" Tests related to Caching of ssh keys
+
+:requirement: ssh_authorizedkeys
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 
 import pytest
 import time
@@ -18,8 +24,11 @@ class TestSSHkeys(object):
     @pytest.mark.tier1
     @pytest.mark.fips
     def test_0001_bz1137013(self, multihost, create_ssh_keys):
-        """ @Title: ssh_authorizedkeys: OpenSSH LPK support
-        by default bz1137013 """
+        """
+        :title: ssh_authorizedkeys: OpenSSH LPK support
+         by default bz1137013
+        :id: 82c962b4-e740-4774-a3d1-b6e93a00bf26
+        """
         tools = sssdTools(multihost.client[0])
         domain_name = tools.get_domain_section_name()
         user = 'foo1@%s' % domain_name

--- a/src/tests/multihost/alltests/test_sssctl_ldap.py
+++ b/src/tests/multihost/alltests/test_sssctl_ldap.py
@@ -1,4 +1,10 @@
-""" Automation of sssctl suite with ldap and krb5 provider"""
+""" Automation of sssctl suite with ldap and krb5 provider
+
+:requirement: IDM-SSSD-REQ: Status utility
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 
 from __future__ import print_function
 import re
@@ -16,8 +22,9 @@ class Testsssctl(object):
     @pytest.mark.tier1_2
     def test_0001_bz1638295(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: sssctl: sssctl user-checks does not show custom
-        IFP user_attributes with allowed_uids equal to root and ldap user
+        :title: IDM-SSSD-TC: sssctl: sssctl user-checks does not show custom
+         IFP user_attributes with allowed_uids equal to root and ldap user
+        :id: aaa3c20e-176c-404a-8845-37a524222b14
         """
         tools = sssdTools(multihost.client[0])
         multihost.client[0].service_sssd('stop')
@@ -40,8 +47,9 @@ class Testsssctl(object):
     @pytest.mark.tier1_2
     def test_0002_bz1638295(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: sssctl: sssctl user-checks does not show custom
-        IFP user_attributes with allowed_uids equal to 0 and ldap user's uid
+        :title: IDM-SSSD-TC: sssctl: sssctl user-checks does not show custom
+         IFP user_attributes with allowed_uids equal to 0 and ldap user's uid
+        :id: 8f7f57ea-bc3d-4b1b-989f-b3b4d3c88a14
         """
         tools = sssdTools(multihost.client[0])
         multihost.client[0].service_sssd('stop')
@@ -64,8 +72,9 @@ class Testsssctl(object):
     @pytest.mark.tier1_2
     def test_0003_bz1638295(self, multihost, localusers, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: sssctl: sssctl user-checks does not show custom
-        IFP user_attributes with allowed_uids equal to root and localuser
+        :title: IDM-SSSD-TC: sssctl: sssctl user-checks does not show custom
+         IFP user_attributes with allowed_uids equal to root and localuser
+        :id: 4aafb8f5-3fad-46b3-91a3-e431e872a4af
         """
         tools = sssdTools(multihost.client[0])
         multihost.client[0].service_sssd('stop')
@@ -88,9 +97,10 @@ class Testsssctl(object):
     @pytest.mark.tier1_2
     def test_0004_bz1638295(self, multihost, localusers, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: sssctl: sssctl user-checks does not show custom
-        IFP user_attributes with allowed_uids equal to root's and
-        localuser's uid
+        :title: IDM-SSSD-TC: sssctl: sssctl user-checks does not show custom
+         IFP user_attributes with allowed_uids equal to root's and
+         localuser's uid
+        :id: e46353b3-904f-4226-b6fa-4444c67861b0
         """
         tools = sssdTools(multihost.client[0])
         multihost.client[0].service_sssd('stop')
@@ -113,8 +123,9 @@ class Testsssctl(object):
     @pytest.mark.tier1_2
     def test_0005_bz1638295(self, multihost, localusers, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: sssctl: sssctl user-checks does not show custom
-        IFP user_attributes with allowed_uids equal to localuser's uids
+        :title: IDM-SSSD-TC: sssctl: sssctl user-checks does not show custom
+         IFP user_attributes with allowed_uids equal to localuser's uids
+        :id: 96b47d83-e123-42fc-8952-381975e95f9b
         """
         tools = sssdTools(multihost.client[0])
         multihost.client[0].service_sssd('stop')
@@ -134,8 +145,9 @@ class Testsssctl(object):
     @pytest.mark.tier1_2
     def test_0006_bz1638295(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: sssctl: sssctl user-checks does not show custom
-        IFP user_attributes with allowed_uids equal to 0 and ldap user
+        :title: IDM-SSSD-TC: sssctl: sssctl user-checks does not show custom
+         IFP user_attributes with allowed_uids equal to 0 and ldap user
+        :id: 78cb0086-0107-49e1-93ca-efcc4a414aad
         """
         tools = sssdTools(multihost.client[0])
         multihost.client[0].service_sssd('stop')
@@ -158,8 +170,10 @@ class Testsssctl(object):
     @pytest.mark.tier1_2
     def test_0007_bz1638295(self, multihost, localusers, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: sssctl: sssctl user-checks does not show custom
-        IFP user_attributes with allowed_uids equal to root and localuser's uid
+        :title: IDM-SSSD-TC: sssctl: sssctl user-checks does not show custom
+         IFP user_attributes with allowed_uids equal to root and localuser's
+         uid
+        :id: 90f6f768-d006-4d8a-a289-5be50205aa0e
         """
         tools = sssdTools(multihost.client[0])
         multihost.client[0].service_sssd('stop')
@@ -182,8 +196,9 @@ class Testsssctl(object):
     @pytest.mark.tier1_2
     def test_0008_bz1761047(self, multihost):
         """
-        @Title: sssctl: Null dereference in
-        sssctl/sssctl_domains.c:sssctl_domain_status_active_server()
+        :title: sssctl: Null dereference in
+         sssctl/sssctl_domains.c:sssctl_domain_status_active_server()
+        :id: bf38d933-5eaf-43cc-b763-55cacf447bd1
         """
         tools = sssdTools(multihost.client[0])
         domain_name = tools.get_domain_section_name()
@@ -211,8 +226,9 @@ class Testsssctl(object):
     @pytest.mark.tier1_2
     def test_0009_bz1751691(self, multihost, backupsssdconf):
         """
-        @Title: IDM-SSSD-TC: sssctl: sssctl domain-list command displays
-        results intermittently
+        :title: IDM-SSSD-TC: sssctl: sssctl domain-list command displays
+         results intermittently
+        :id: 09fed728-1631-44fa-ad5d-082cba4a8ea2
         """
         tools = sssdTools(multihost.client[0])
         multihost.client[0].service_sssd('stop')
@@ -233,8 +249,9 @@ class Testsssctl(object):
     @pytest.mark.tier1_2
     def test_0010_bz1628122(self, multihost):
         """
-        @Title: sssctl: Printing incorrect information
-        about domain with sssctl utility
+        :title: sssctl: Printing incorrect information
+         about domain with sssctl utility
+        :id: 6997a8a4-0531-4e51-a10b-8c1d5791b67b
         """
         tools = sssdTools(multihost.client[0])
         multihost.client[0].service_sssd('stop')
@@ -264,8 +281,10 @@ class Testsssctl(object):
     @pytest.mark.tier1_2
     def test_0011_bz1406678(self, multihost):
         """
-        @Title: sssctl: sssd started before network
-        sssd to go online once network service starts after it
+        :title: sssctl: sssd started before network
+         sssd to go online once network service starts after it
+        :id: f734660f-269e-49fd-9864-00de54b11b2c
+        :customerscenario: True
         """
         tools = sssdTools(multihost.client[0])
         domain_name = tools.get_domain_section_name()

--- a/src/tests/multihost/alltests/test_sssctl_local.py
+++ b/src/tests/multihost/alltests/test_sssctl_local.py
@@ -1,4 +1,10 @@
-""" Automation of sssctl suite"""
+""" Automation of sssctl suite
+
+:requirement: IDM-SSSD-REQ: Status utility
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 from __future__ import print_function
 import pytest
 from sssd.testlib.common.utils import sssdTools
@@ -14,8 +20,9 @@ class Testsssctl(object):
     @pytest.mark.tier1_2
     def test_0001_bz1640576(self, multihost, localusers):
         """
-        @Title: IDM-SSSD-TC: sssctl: sssctl reports incorrect
-        information about local user's cache entry expiration time
+        :title: IDM-SSSD-TC: sssctl: sssctl reports incorrect
+         information about local user's cache entry expiration time
+        :id: 9315c119-8c69-4685-836d-0f71b5d0684c
         """
         users = localusers
         tools = sssdTools(multihost.client[0])
@@ -36,8 +43,9 @@ class Testsssctl(object):
     @pytest.mark.tier1_2
     def test_0002_bz1599207(self, multihost, backupsssdconf, localusers):
         """
-        @Title: IDM-SSSD-TC: sssctl: sssd tools do not handle the implicit
-        domain
+        :title: IDM-SSSD-TC: sssctl: sssd tools do not handle the implicit
+         domain
+        :id: b5ff4e8f-ce9f-4731-bbaa-bf2a8425dc15
         """
         users = localusers
         tools = sssdTools(multihost.client[0])

--- a/src/tests/multihost/alltests/test_sudo.py
+++ b/src/tests/multihost/alltests/test_sudo.py
@@ -1,3 +1,10 @@
+"""Automation tests for sudo
+
+:requirement: sudo
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 import time
 import re
 import pytest
@@ -16,7 +23,8 @@ class TestSudo(object):
     @pytest.mark.tier1_2
     def test_bz1294670(self, multihost, backupsssdconf, localusers):
         """
-        @Title: sudo: Local users with local sudo rules causes LDAP queries
+        :title: sudo: Local users with local sudo rules causes LDAP queries
+        :id: e8c5c396-e5e5-4eff-84f8-feff01defda1
         """
         # enable sudo with authselect
         authselect_cmd = 'authselect select sssd with-sudo'
@@ -72,8 +80,9 @@ class TestSudo(object):
     def test_timed_sudoers_entry(self,
                                  multihost, backupsssdconf, timed_sudoers):
         """
-        @Title: sudo: sssd accepts timed entries without minutes and or
-        seconds to attribute
+        :title: sudo: sssd accepts timed entries without minutes and or
+         seconds to attribute
+        :id: 5103a796-6c7f-4af0-b7b8-64c7338f0934
         """
         # pylint: disable=unused-argument
         tools = sssdTools(multihost.client[0])

--- a/src/tests/multihost/basic/test_basic.py
+++ b/src/tests/multihost/basic/test_basic.py
@@ -1,4 +1,10 @@
-""" SSSD Sanity Test Cases """
+""" SSSD Sanity Test Cases
+
+:requirement: IDM-SSSD-REQ : KRB5 Provider
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 import time
 from sssd.testlib.common.utils import SSHClient
 import configparser as ConfigParser
@@ -10,7 +16,8 @@ class TestSanitySSSD(object):
     """ Basic Sanity Test cases """
     def test_ssh_user_login(self, multihost):
         """
-        @Title: Login: Check ssh login as LDAP user with Kerberos credentials
+        :title: Login: Check ssh login as LDAP user with Kerberos credentials
+        :id: b7600a46-1827-486a-ae2e-cbedad6ddf41
         """
         try:
             ssh = SSHClient(multihost.master[0].sys_hostname,
@@ -23,7 +30,8 @@ class TestSanitySSSD(object):
 
     def test_kinit(self, multihost):
         """
-        @Title: Login: Verify kinit is successfull after user login
+        :title: Login: Verify kinit is successfull after user login
+        :id: 5e15e9e9-c559-49b8-a164-abe13d82d0fd
         """
         try:
             ssh = SSHClient(multihost.master[0].sys_hostname,
@@ -41,7 +49,10 @@ class TestSanitySSSD(object):
                 ssh.close()
 
     def test_offline_ssh_login(self, multihost):
-        """@Title: Login: Verify offline ssh login"""
+        """
+        :title: Login: Verify offline ssh login
+        :id: 90e9a834-a1f9-4bef-bdae-57a7b411cce4
+        """
         multihost.master[0].transport.get_file('/etc/sssd/sssd.conf',
                                                '/tmp/sssd.conf')
         sssdconfig = ConfigParser.RawConfigParser()

--- a/src/tests/multihost/basic/test_config.py
+++ b/src/tests/multihost/basic/test_config.py
@@ -1,4 +1,10 @@
-""" SSSD Configuration-related Test Cases """
+""" SSSD Configuration-related Test Cases
+
+:requirement: IDM-SSSD-REQ: Configuration merging
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 import configparser as ConfigParser
 import pytest
 from utils_config import set_param, remove_section
@@ -21,8 +27,9 @@ class TestSSSDConfig(object):
 
     def test_sssd_genconf_sssd_running(self, multihost):
         """
-        @Title: config: sssd --genconf is able to re-generate
-        the configuration even while SSSD is running.
+        :title: config: sssd --genconf is able to re-generate
+         the configuration even while SSSD is running
+        :id: 078721e9-536b-4fd8-a36d-bd94673228fc
         """
         multihost.master[0].service_sssd('restart')
 
@@ -36,8 +43,9 @@ class TestSSSDConfig(object):
 
     def test_sssd_genconf_section_only(self, multihost):
         """
-        @Title: config: sssd --genconf-section only
-        refreshes those sections given on the command line
+        :title: config: sssd --genconf-section only
+         refreshes those sections given on the command line
+        :id: 011bf2ad-4a2a-4350-adfa-7826349e262f
         """
         multihost.master[0].service_sssd('restart')
 
@@ -59,8 +67,9 @@ class TestSSSDConfig(object):
 
     def test_sssd_genconf_add_remove_section(self, multihost):
         """
-        @Title: config: sssd --genconf-section can not only modify
-        existing configuration sections, but also add a new section
+        :title: config: sssd --genconf-section can not only modify
+         existing configuration sections, but also add a new section
+        :id: 8df66b51-aadc-456e-8f27-a1a787e61769
         """
         # Establish a baseline
         multihost.master[0].service_sssd('restart')
@@ -89,11 +98,11 @@ class TestSSSDConfig(object):
 
     def test_sssd_genconf_no_such_section(self, multihost):
         """
-        @Title: config: Referencing a non-existant section must not fail
-
-        @Description: Referencing a non-existant section must not fail,
-        because we want to call this command from the systemd unit files
-        and by default the sections don't have to be present
+        :title: config: Referencing a non-existant section must not fail
+        :id: 4e160dcc-9789-4f3f-b8d4-c67d27ef4a1c
+        :description: Referencing a non-existant section must not fail,
+         because we want to call this command from the systemd unit files
+         and by default the sections don't have to be present
         """
         multihost.master[0].service_sssd('restart')
         multihost.master[0].run_command(

--- a/src/tests/multihost/basic/test_files.py
+++ b/src/tests/multihost/basic/test_files.py
@@ -1,5 +1,9 @@
-"""
-Files test provider cases
+"""Files test provider cases
+
+:requirement: IDM-SSSD-REQ :: SSSD is default for local resolution
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
 """
 import pytest
 from sssd.testlib.common.utils import SSHClient
@@ -24,32 +28,35 @@ class TestImplicitFilesProvider(object):
     """
     def test_files_does_not_handle_root(self, multihost):
         """
-        @Title: files: files provider does not handle root
+        :title: files: files provider does not handle root
+        :id: 5aa5165d-379f-4fc6-b4ed-b32b66406d4f
         """
         exit_status, _ = get_sss_user(multihost, 'root')
         assert exit_status == 2
 
     def test_files_sanity(self, multihost):
         """
-        @Title: files: Test that the files provider can resolve a user
+        :title: files: Test that the files provider can resolve a user
+        :id: 242cd094-b04d-4857-981a-8624573dde84
         """
         exit_status, _ = get_sss_user(multihost, 'lcl1')
         assert exit_status == 0
 
     def test_files_enumeration(self, multihost):
         """
-        @Title: files: Verify files provider do not enumerate
-
-        @Description: Since nss_files enumerates and libc would
-        concatenate the results, the files provider of SSSD should
-        not enumerate
+        :title: files: Verify files provider do not enumerate
+        :id: e6d922bf-3af2-4cea-8570-6dd9233da624
+        :description: Since nss_files enumerates and libc would
+         concatenate the results, the files provider of SSSD should
+         not enumerate
         """
         cmd = multihost.master[0].run_command('getent passwd -s sss')
         assert len(cmd.stdout_text) == 0
 
     def test_no_homedir_no_slash(self, multihost):
         """
-        @Title: files: Test that sssd returns an empty value with no homedir
+        :title: files: Test that sssd returns an empty value with no homedir
+        :id: 58010941-f1d6-453f-86f7-ade11dc81bb5
         """
         exit_status, output = get_sss_user(multihost, 'no_home_user')
         assert exit_status == 0

--- a/src/tests/multihost/basic/test_ifp.py
+++ b/src/tests/multihost/basic/test_ifp.py
@@ -1,5 +1,9 @@
-"""
-InfoPipe test cases
+"""InfoPipe test cases
+
+:requirement: IDM-SSSD-REQ : Configuration and Service Management
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
 """
 
 import pytest
@@ -11,7 +15,8 @@ class TestInfoPipe(object):
     """
     def test_ifp_extra_attributes_property(self, multihost):
         """
-        @Title: ifp: requesting the extraAttributes property works
+        :title: ifp: requesting the extraAttributes property works
+        :id: 23b8c7e8-df4b-47ef-b38e-0503040e1d67
         see e.g.  https://github.com/SSSD/sssd/issues/4891
         """
         dbus_send_cmd = \

--- a/src/tests/multihost/basic/test_kcm.py
+++ b/src/tests/multihost/basic/test_kcm.py
@@ -1,4 +1,10 @@
-""" KCM Responder Sanity Test Cases """
+""" KCM Responder Sanity Test Cases
+
+:requirement: IDM-SSSD-REQ :: SSSD KCM as default Kerberos CCACHE provider
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 from sssd.testlib.common.utils import SSHClient
 import paramiko
 import pytest
@@ -46,7 +52,8 @@ class TestSanityKCM(object):
 
     def test_kinit_kcm(self, multihost, enable_kcm):
         """
-        @Title: kcm: Run kinit with KRB5CCNAME=KCM
+        :title: kcm: Run kinit with KRB5CCNAME=KCM
+        :id: 245eecf6-04b9-4c9f-8685-681d184fbbcf
         """
         self._start_kcm(multihost)
         try:
@@ -70,7 +77,8 @@ class TestSanityKCM(object):
 
     def test_ssh_login_kcm(self, multihost, enable_kcm):
         """
-        @Title: kcm: Verify ssh logins are successuful with kcm as default
+        :title: kcm: Verify ssh logins are successuful with kcm as default
+        :id: 458ed1e4-b908-40d3-b2fd-392e8d2dcf4b
         """
         # pylint: disable=unused-argument
         _pytest_fixture = [enable_kcm]
@@ -87,12 +95,12 @@ class TestSanityKCM(object):
 
     def test_kcm_debug_level_set(self, multihost, enable_kcm):
         """
-        @Title: kcm: After kcm section with debug
-        level set restaring sssd-kcm service enables kcm debugging
-
-        @Description: Test that just adding a [kcm] section and restarting
-        the kcm service enables debugging without having to restart the
-        whole sssd
+        :title: kcm: After kcm section with debug
+         level set restaring sssd-kcm service enables kcm debugging
+        :id: 31c74bfc-69d5-46bd-aef8-a5581970832e
+        :description: Test that just adding a [kcm] section and restarting
+         the kcm service enables debugging without having to restart the
+         whole sssd
         """
         # Start from a known-good state where the configuration is refreshed
         # by the monitor and logging is completely disabled
@@ -138,8 +146,9 @@ class TestSanityKCM(object):
 
     def test_kdestroy_retval(self, multihost, enable_kcm):
         """
-        @Title: kcm: Test that destroying an empty cache does
-        not return a non-zero return code
+        :title: kcm: Test that destroying an empty cache does
+         not return a non-zero return code
+        :id: 2826097f-e6d7-4d99-ac85-3ee081aa681a
         """
         ssh = SSHClient(multihost.master[0].sys_hostname,
                         username='foo3', password='Secret123')
@@ -155,9 +164,9 @@ class TestSanityKCM(object):
 
     def test_ssh_forward_creds(self, multihost, enable_kcm):
         """
-        @Title: kcm: Test that SSH can forward credentials with KCM
-
-        A regression test for https://github.com/SSSD/sssd/issues/4863
+        :title: kcm: Test that SSH can forward credentials with KCM
+        :id: f4b0c785-a895-48a1-a55e-7519cf221393
+        :ticket: https://github.com/SSSD/sssd/issues/4863
         """
         ssh = SSHClient(multihost.master[0].sys_hostname,
                         username='foo3', password='Secret123')
@@ -184,8 +193,9 @@ class TestSanityKCM(object):
 
     def test_kvno_display(self, multihost, enable_kcm):
         """
-        @Title: kcm: Test kvno correctly displays version numbers of principals
-        #https://github.com/SSSD/sssd/issues/4763
+        :title: kcm: Test kvno correctly displays version numbers of principals
+        :id: 7c9178e6-fea5-44a1-b473-76667624cee2
+        :ticket: https://github.com/SSSD/sssd/issues/4763
         """
         ssh = SSHClient(multihost.master[0].sys_hostname,
                         username='foo4', password='Secret123')
@@ -206,7 +216,8 @@ class TestSanityKCM(object):
                               enable_kcm,
                               create_many_user_principals):
         """
-        @Title: kcm: Make sure the quota limits a client, but only that client
+        :title: kcm: Make sure the quota limits a client, but only that client
+        :id: 3ac8f62e-05e4-4ca7-b588-145fd6258c2a
         """
         # It is easier to keep these tests stable and independent from others
         # if they start from a clean slate
@@ -253,10 +264,10 @@ class TestSanityKCM(object):
                                        enable_kcm,
                                        create_many_user_principals):
         """
-        @Title: kcm: Quota increase
-
-        Increasing the peruid quota allows a client to store more
-        data
+        :title: kcm: Quota increase
+        :id: 0b3cab49-befb-4ab2-bb12-b102d94249aa
+        :description: Increasing the peruid quota allows a client to store
+         more data
         """
         # It is easier to keep these tests stable and independent from others
         # if they start from a clean slate
@@ -293,10 +304,10 @@ class TestSanityKCM(object):
                                    multihost,
                                    enable_kcm):
         """
-        @Title: kcm: Quota enforcement
-
-        Set a prohibitive quota for the per-ccache payload limit and
-        make sure it gets enforced
+        :title: kcm: Quota enforcement
+        :id: cb3daadb-c5e7-48f8-b419-11c616f0d602
+        :description: Set a prohibitive quota for the per-ccache payload
+         limit and make sure it gets enforced
         """
         # It is easier to keep these tests stable and independent from others
         # if they start from a clean slate

--- a/src/tests/multihost/basic/test_ldap.py
+++ b/src/tests/multihost/basic/test_ldap.py
@@ -1,4 +1,10 @@
-""" SSSD LDAP provider tests """
+""" SSSD LDAP provider tests
+
+:requirement: IDM-SSSD-REQ : LDAP Provider
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 
 import re
 import time
@@ -127,8 +133,9 @@ class TestLDAPChpass(object):
 
     def test_ldap_chpass_extop(self, multihost):
         """
-        @Title: chpass: Test password change using the default extended
-        operation
+        :title: chpass: Test password change using the default extended
+         operation
+        :id: 4b3ab9a6-d26f-484d-994f-8bc74c31b9dd
         """
         self._change_test_reset_password(multihost)
 
@@ -137,6 +144,7 @@ class TestLDAPChpass(object):
                                 set_ldap_auth_provider,
                                 set_ldap_pwmodify_mode_ldap_modify):
         """
-        @Title: chpass: Test password change using LDAP modify
+        :title: chpass: Test password change using LDAP modify
+        :id: 554c989d-f99b-4722-925b-5be54a33af89
         """
         self._change_test_reset_password(multihost)

--- a/src/tests/multihost/basic/test_sssctl_config_check.py
+++ b/src/tests/multihost/basic/test_sssctl_config_check.py
@@ -1,4 +1,10 @@
-"""sssctl config-check Test Cases"""
+"""sssctl config-check Test Cases
+
+:requirement: IDM-SSSD-REQ: Status utility
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 
 import pytest
 import re
@@ -7,8 +13,9 @@ import re
 class TestSssctlConfigCheck(object):
     def test_verify_typo_option_name(self, multihost):
         """
-        @Title: sssctl: Verify typos in option name (not value)
-        of configuration file
+        :title: sssctl: Verify typos in option name (not value)
+         of configuration file
+        :id: 4089f5d6-cdeb-4bcb-9028-cabd97d43045
         """
         cfgget = '/etc/sssd/sssd.conf'
         cfgput = '/tmp/sssd.conf.backup'
@@ -36,7 +43,8 @@ class TestSssctlConfigCheck(object):
 
     def test_verify_typo_domain_name(self, multihost):
         """
-        @Title: sssctl: Verify typos in domain name of configuration file
+        :title: sssctl: Verify typos in domain name of configuration file
+        :id: a5d3a3a5-f832-4fc6-a628-9165dab69dd2
         """
         cfgget = '/etc/sssd/sssd.conf'
         cfgput = '/tmp/sssd.conf.backup'
@@ -64,7 +72,8 @@ class TestSssctlConfigCheck(object):
 
     def test_misplaced_option(self, multihost):
         """
-        @Title: sssctl: Verify misplace options in default configuration file
+        :title: sssctl: Verify misplace options in default configuration file
+        :id: ed814158-dea5-4f62-8500-fe62087332f9
         """
         cfgget = '/etc/sssd/sssd.conf'
         cfgput = '/tmp/sssd.conf.backup'

--- a/src/tests/multihost/basic/test_sudo.py
+++ b/src/tests/multihost/basic/test_sudo.py
@@ -1,4 +1,10 @@
-""" SUDO responder sanity Test Cases """
+""" SUDO responder sanity Test Cases
+
+:requirement: sudo
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 from sssd.testlib.common.utils import SSHClient
 import paramiko
 import pytest
@@ -11,7 +17,8 @@ class TestSanitySudo(object):
                              enable_sss_sudo_nsswitch,
                              set_case_sensitive_false):
         """
-        @Title: sudo: Verify case sensitivity in sudo responder
+        :title: sudo: Verify case sensitivity in sudo responder
+        :id: 64ab80be-17fd-4c3b-9d9b-7d07c6279975
         """
         # pylint: disable=unused-argument
         _pytest_fixtures = [case_sensitive_sudorule, enable_sss_sudo_nsswitch,
@@ -38,8 +45,9 @@ class TestSanitySudo(object):
                                   generic_sudorule,
                                   set_entry_cache_sudo_timeout):
         """
-        @Title: sudo: Verify refreshing expired sudo rules
-        do not crash sssd_sudo
+        :title: sudo: Verify refreshing expired sudo rules
+         do not crash sssd_sudo
+        :id: 532513b2-15bc-46ac-8fc9-19fd0bf485c4
         """
         # pylint: disable=unused-argument
         _pytest_fixtures = [enable_sss_sudo_nsswitch, generic_sudorule,

--- a/src/tests/multihost/ipa/test_adhbac.py
+++ b/src/tests/multihost/ipa/test_adhbac.py
@@ -1,4 +1,10 @@
-""" IPA AD Trust HBAC Cases """
+""" IPA AD Trust HBAC Cases
+
+:requirement: HBAC (ipa_provider)
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 import pytest
 import time
 import re
@@ -15,8 +21,9 @@ class TestADTrustHbac(object):
     """ AD Trust HBAC Test cases """
     def test_allowed_ad_group(self, multihost):
         """
-        @Title: Verify Member of allowed AD Group
-        through hbac is able to login
+        :title: Verify Member of allowed AD Group
+         through hbac is able to login
+        :id: 401fb710-b876-4693-92d0-86a75b94973f
         """
         ipa_server_tools = ipaTools(multihost.master[0])
         ipa_client = sssdTools(multihost.client[0])
@@ -65,8 +72,9 @@ class TestADTrustHbac(object):
 
     def test_disallowed_ad_group(self, multihost, create_aduser_group):
         """
-        @Title: Verify Member of denied AD Group through
-        hbac is not able to login
+        :title: Verify Member of denied AD Group through
+         hbac is not able to login
+        :id: 7092f403-ca58-4683-89b8-400c64dd0a1d
         """
         (aduser, adgroup) = create_aduser_group
         ipa_server_tools = ipaTools(multihost.master[0])
@@ -117,8 +125,9 @@ class TestADTrustHbac(object):
 
     def test_multiple_ad_groups(self, multihost):
         """
-        @Title: Verify hbac evaluation when user is member
-        of multiple AD Groups and with different hbac rules
+        :title: Verify hbac evaluation when user is member
+         of multiple AD Groups and with different hbac rules
+        :id: eb78448d-8a4d-4800-9334-8d8cdb8b0af2
         """
         ipa_server_tools = ipaTools(multihost.master[0])
         ipa_client = sssdTools(multihost.client[0])
@@ -175,7 +184,8 @@ class TestADTrustHbac(object):
 
     def test_hbac_nested_group(self, multihost):
         """
-        @Title: Verify hbac evaluation of AD Nested Groups
+        :title: Verify hbac evaluation of AD Nested Groups
+        :id: f7fc6349-daba-43c2-be4e-e13923e201f9
         """
         ipa_server_tools = ipaTools(multihost.master[0])
         ipa_client = sssdTools(multihost.client[0])

--- a/src/tests/multihost/ipa/test_adtrust.py
+++ b/src/tests/multihost/ipa/test_adtrust.py
@@ -1,4 +1,10 @@
-""" IPA AD Trust Sanity tests """
+""" IPA AD Trust Sanity tests
+
+:requirement: IDM-SSSD-REQ: Testing SSSD in IPA Provider
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 
 import pytest
 import time
@@ -11,7 +17,10 @@ from sssd.testlib.common.exceptions import SSSDException
 class TestADTrust(object):
     """ IPA AD Trust tests """
     def test_basic_sssctl_list(self, multihost):
-        """ @Title: Verify sssctl lists trusted domain  """
+        """
+        :title: Verify sssctl lists trusted domain
+        :id: 8da8919d-524c-4498-8dc8-608eb5e139b0
+        """
         domain_list = 'sssctl domain-list'
         ad_domain_name = multihost.ad[0].domainname
         cmd = multihost.master[0].run_command(domain_list, raiseonerr=False)
@@ -19,8 +28,10 @@ class TestADTrust(object):
         assert ad_domain_name in mylist
 
     def test_ipaserver_sss_cache_user(self, multihost):
-        """ @Title: Verify AD user is cached on IPA server
-        when ipa client queries AD User
+        """
+        :title: Verify AD user is cached on IPA server
+         when ipa client queries AD User
+        :id: 4a48ee7a-62d1-4eea-9f33-7df3fccc908e
         """
         ipaserver = sssdTools(multihost.master[0])
         domain_name = ipaserver.get_domain_section_name()
@@ -38,11 +49,11 @@ class TestADTrust(object):
 
     def test_enforce_gid(self, multihost):
         """
-        @Title: Verify whether the new gid is enforceable when
-        gid of AD Group Domain Users is overridden
-
-        @Bugzilla:
-        https://bugzilla.redhat.com/show_bug.cgi?id=1817219
+        :title: Verify whether the new gid is enforceable when
+         gid of AD Group Domain Users is overridden
+        :id: 3581c7c0-d598-4e34-bb9b-9d791b93ec65
+        :bugzilla:
+         https://bugzilla.redhat.com/show_bug.cgi?id=1817219
         """
         create_view = 'ipa idview-add  foo_bar'
         multihost.master[0].run_command(create_view)
@@ -68,10 +79,10 @@ class TestADTrust(object):
 
     def test_honour_idoverride(self, multihost, create_aduser_group):
         """
-        @Title: Verify sssd honours the customized ID View
-
-        @Bugzilla:
-        https://bugzilla.redhat.com/show_bug.cgi?id=1826720
+        :title: Verify sssd honours the customized ID View
+        :id: 0c0dcfbb-6099-4c61-81c9-3bd3a003ff58
+        :bugzilla:
+         https://bugzilla.redhat.com/show_bug.cgi?id=1826720
         """
         (aduser, adgroup) = create_aduser_group
         domain = multihost.ad[0].domainname

--- a/src/tests/multihost/ipa/test_hbac.py
+++ b/src/tests/multihost/ipa/test_hbac.py
@@ -1,4 +1,10 @@
-""" IPA hbac test cases """
+""" IPA hbac test cases
+
+:requirement: HBAC (ipa_provider)
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 import pytest
 import time
 import re
@@ -16,7 +22,10 @@ import pexpect
 class Testipahbac(object):
 
     def test_sssctl_sshd(self, multihost, hbac_sshd_rule):
-        """@Title: hbac: Verify using sssctl sshd service is allowed """
+        """
+        :title: hbac: Verify using sssctl sshd service is allowed
+        :id: 33a4288a-6c05-4472-a956-378736e030c8
+        """
         sssctl_cmd = 'sssctl user-checks -s sshd foobar1'
         test_pam = re.compile(r'%s' % 'pam_acct_mgmt: Success')
         cmd = multihost.client[0].run_command(sssctl_cmd)
@@ -28,7 +37,10 @@ class Testipahbac(object):
         assert STATUS == 'PASS'
 
     def test_hbac_changes(self, multihost, hbac_sshd_rule):
-        """@Title: hbac: verify hbac rule changes are applied """
+        """
+        :title: hbac: verify hbac rule changes are applied
+        :id: fcd4fc73-2425-46f8-8d66-95a49b5fb361
+        """
         update_rule = "ipa hbacrule-remove-user --users='foobar1' test1"
         multihost.master[0].run_command(update_rule)
         sssctl_cmd = 'sssctl user-checks -s sshd foobar1'
@@ -43,8 +55,9 @@ class Testipahbac(object):
 
     def test_hbac_refresh_time(self, multihost):
         """
-        @Title: hbac: Verify cached hbac rule is applied
-        for the refresh time period
+        :title: hbac: Verify cached hbac rule is applied
+         for the refresh time period
+        :id: c839fd33-65da-4252-82cf-5ba88ad02f55
         """
         ipa_server = ipaTools(multihost.master[0])
         ipa_client = ipaTools(multihost.client[0])
@@ -86,8 +99,9 @@ class Testipahbac(object):
 
     def test_multiple_hbac_rules(self, multihost):
         """
-        @Title: hbac: Verify HBAC Evaluation happens per service
-        when user is associated  with multiple hbac rules
+        :title: hbac: Verify HBAC Evaluation happens per service
+         when user is associated  with multiple hbac rules
+        :id: 6981b637-f4ea-449b-8916-60cc938c4d0f
         """
         ipa_server = ipaTools(multihost.master[0])
         client_host = multihost.client[0].sys_hostname
@@ -107,8 +121,9 @@ class Testipahbac(object):
 
     def test_nested_groups(self, multihost):
         """
-        @Title: hbac: Verify hbac evaluation works as expected
-        with nested group evaluation
+        :title: hbac: Verify hbac evaluation works as expected
+         with nested group evaluation
+        :id: fb2fd287-b217-487c-a59a-d827c426b0bb
         """
         ipa_server = ipaTools(multihost.master[0])
         client_host = multihost.client[0].sys_hostname
@@ -147,8 +162,11 @@ class Testipahbac(object):
         assert STATUS == 'PASS'
 
     def test_auto_private_group(self, multihost):
-        """@Title: hbac: Verify hbac rule associated with
-        User private Groups """
+        """
+        :title: hbac: Verify hbac rule associated with
+         User private Groups
+        :id: 99904ccd-bf2f-4c09-9636-92e036e19a0e
+        """
         ipa_server = ipaTools(multihost.master[0])
         sssd_client = sssdTools(multihost.client[0])
         domain_name = '%s/%s' % ('domain',

--- a/src/tests/multihost/ipa/test_misc.py
+++ b/src/tests/multihost/ipa/test_misc.py
@@ -1,4 +1,10 @@
-""" Miscellaneous IPA Bug Automations """
+""" Miscellaneous IPA Bug Automations
+
+:requirement: IDM-SSSD-REQ: Testing SSSD in IPA Provider
+:casecomponent: sssd
+:subsystemteam: sst_identity_management
+:upstream: yes
+"""
 
 import pytest
 import time
@@ -11,12 +17,14 @@ import re
 class Testipabz(object):
     """ IPA BZ Automations """
     def test_blank_kinit(self, multihost):
-        """@Title: verify sssd fails to start with
-        invalid default keytab file
-
-        BZ:1748292
-        systemctl status sssd says No such file or directory
-        about "default" when keytab exists but is empty file
+        """
+        :title: verify sssd fails to start with
+         invalid default keytab file
+        :id: 525cbe28-f835-4d2e-9583-d3f614b8486e
+        :requirement: IDM-SSSD-REQ : KRB5 Provider
+        :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1748292
+        :description: systemctl status sssd says No such file or
+         directory about "default" when keytab exists but is empty file
         """
         tools = sssdTools(multihost.client[0])
         # stop sssd
@@ -49,15 +57,14 @@ class Testipabz(object):
 
     def test_sssdConfig_remove_Domains(self, multihost):
         """
-        @Title: Verify SSSDConfig.save_domain API removes
-        all autofs entries from sssd.conf
-
-        @Description:
-        SSSDConfig.save_domain(domain) does not always
-        remove all entries removed from domain
-
-        @Bugzilla:
-        https://bugzilla.redhat.com/show_bug.cgi?id=1796989
+        :title: Verify SSSDConfig.save_domain API removes
+         all autofs entries from sssd.conf
+        :id: 3efaf0af-58a7-4631-8555-da8a7bbcf351
+        :description:
+         SSSDConfig.save_domain(domain) does not always
+         remove all entries removed from domain
+        :bugzilla:
+         https://bugzilla.redhat.com/show_bug.cgi?id=1796989
         """
         tools = sssdTools(multihost.client[0])
         setup_automount = "ipa-client-automount --location default -U " \


### PR DESCRIPTION
These docstring updates are a requirement to enable automatic updates
into polarion using betelguese tool. It will help to add/update test
cases and import test results from CI. Each test case must have 'id' to
make it unique. The tool will use it to update the respective case and
will avoid adding duplicate test case in polarion.