### PR TITLE
responder: fix warning in activate_unix_sockets

### DIFF
--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -1001,10 +1001,11 @@ int activate_unix_sockets(struct resp_ctx *rctx,
                           connection_setup_t conn_setup)
 {
     int ret;
+
+#ifdef HAVE_SYSTEMD
     struct sockaddr_un sockaddr;
     socklen_t sockaddr_len = sizeof(sockaddr);
 
-#ifdef HAVE_SYSTEMD
     if (rctx->lfd == -1 && rctx->priv_lfd == -1) {
         int numfds = (rctx->sock_name ? 1 : 0)
                      + (rctx->priv_sock_name ? 1 : 0);


### PR DESCRIPTION
The warning is with systemd disabled.

```
src/responder/common/responder_common.c: In function ‘activate_unix_sockets’:
src/responder/common/responder_common.c:1005:15: error: unused variable ‘sockaddr_len’ [-Werror=unused-variable]
 1005 |     socklen_t sockaddr_len = sizeof(sockaddr);
```