### PR TITLE
fix selinux warnings

### DIFF
--- a/src/util/selinux.c
+++ b/src/util/selinux.c
@@ -43,7 +43,7 @@
  */
 int selinux_file_context(const char *dst_name)
 {
-    security_context_t scontext = NULL;
+    char *scontext = NULL;
 
     if (is_selinux_enabled() == 1) {
         /* Get the default security context for this file */

--- a/src/util/util_creds.h
+++ b/src/util/util_creds.h
@@ -27,7 +27,7 @@
 #include <selinux/context.h>
 #define SELINUX_CTX context_t
 #include <selinux/selinux.h>
-#define SEC_CTX security_context_t
+#define SEC_CTX char *
 
 #define SELINUX_context_new context_new
 #define SELINUX_context_free context_free

--- a/src/util/util_creds.h
+++ b/src/util/util_creds.h
@@ -25,9 +25,9 @@
 #ifdef HAVE_SELINUX
 
 #include <selinux/context.h>
-#define SELINUX_CTX context_t
+typedef context_t SELINUX_CTX;
 #include <selinux/selinux.h>
-#define SEC_CTX char *
+typedef char * SEC_CTX;
 
 #define SELINUX_context_new context_new
 #define SELINUX_context_free context_free
@@ -41,8 +41,8 @@
 
 #else /* not HAVE_SELINUX */
 
-#define SELINUX_CTX void *
-#define SEC_CTX void *
+typedef void * SELINUX_CTX;
+typedef void * SEC_CTX;
 
 #define SELINUX_context_new(x) NULL
 #define SELINUX_context_free(x) (x) = NULL


### PR DESCRIPTION
selinux: fix warning ‘matchpathcon’ is deprecated

   ``` src/util/selinux.c: In function ‘selinux_file_context’: 
   src/util/selinux.c:50:9: error: ‘matchpathcon’ is deprecated: Use
   selabel_lookup instead [-Werror=deprecated-declarations]
     50 |         if (matchpathcon(dst_name, 0, &scontext) < 0) {
   ```

   selinux: fix warning ‘security_context_t’ is deprecated

   The type is now deprecated, char * should be used instead 
   https://github.com/SELinuxProject/selinux/commit/9eb9c9327563014ad6a807814e7975424642d5b9