### PR TITLE
spec: do not use systemd to restart services with RefuseManualStart=true

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -956,18 +956,20 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d / -s /sbin/nologin -c "Us
 
 %postun common
 %systemd_postun_with_restart sssd-autofs.socket
-%systemd_postun_with_restart sssd-autofs.service
 %systemd_postun_with_restart sssd-nss.socket
-%systemd_postun_with_restart sssd-nss.service
 %systemd_postun_with_restart sssd-pac.socket
-%systemd_postun_with_restart sssd-pac.service
 %systemd_postun_with_restart sssd-pam.socket
 %systemd_postun_with_restart sssd-pam-priv.socket
-%systemd_postun_with_restart sssd-pam.service
 %systemd_postun_with_restart sssd-ssh.socket
-%systemd_postun_with_restart sssd-ssh.service
 %systemd_postun_with_restart sssd-sudo.socket
-%systemd_postun_with_restart sssd-sudo.service
+
+# Services have RefuseManualStart=true, therefore we can't request restart.
+%systemd_postun sssd-autofs.service
+%systemd_postun sssd-nss.service
+%systemd_postun sssd-pac.service
+%systemd_postun sssd-pam.service
+%systemd_postun sssd-ssh.service
+%systemd_postun sssd-sudo.service
 
 %post dbus
 %systemd_post sssd-ifp.service


### PR DESCRIPTION
These service unit files have RefuseManualStart=true, therefore they can
be controlled only as a dependency via the main sssd.service or socket
activation.

Resolves: https://github.com/SSSD/sssd/issues/5521

:fixes: SSSD spec file `%postun` no longer tries to restart services that
  can not be restarted directly to stop produce systemd warnings