### PR TITLE
Log performance improvements.

### DIFF
--- a/src/util/debug.c
+++ b/src/util/debug.c
@@ -272,7 +272,7 @@ void sss_vdebug_fn(const char *file,
                    va_list ap)
 {
     struct timeval tv;
-    struct tm *tm;
+    struct tm tm;
 
 #ifdef WITH_JOURNALD
     errno_t ret;
@@ -300,10 +300,10 @@ void sss_vdebug_fn(const char *file,
 
     if (debug_timestamps) {
         gettimeofday(&tv, NULL);
-        tm = localtime(&tv.tv_sec);
+        localtime_r(&tv.tv_sec, &tm);
         debug_printf("(%d-%02d-%02d %2d:%02d:%02d",
-                     tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
-                     tm->tm_hour, tm->tm_min, tm->tm_sec);
+                     tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
+                     tm.tm_hour, tm.tm_min, tm.tm_sec);
         if (debug_microseconds) {
             debug_printf(":%.6ld", tv.tv_usec);
         }

--- a/src/util/debug.c
+++ b/src/util/debug.c
@@ -273,6 +273,7 @@ void sss_vdebug_fn(const char *file,
 {
     struct timeval tv;
     struct tm tm;
+    time_t t;
 
 #ifdef WITH_JOURNALD
     errno_t ret;
@@ -299,8 +300,13 @@ void sss_vdebug_fn(const char *file,
 #endif
 
     if (debug_timestamps) {
-        gettimeofday(&tv, NULL);
-        localtime_r(&tv.tv_sec, &tm);
+        if (debug_microseconds) {
+            gettimeofday(&tv, NULL);
+            t = tv.tv_sec;
+        } else {
+            t = time(NULL);
+        }
+        localtime_r(&t, &tm);
         debug_printf("(%d-%02d-%02d %2d:%02d:%02d",
                      tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
                      tm.tm_hour, tm.tm_min, tm.tm_sec);

--- a/src/util/debug.c
+++ b/src/util/debug.c
@@ -271,6 +271,8 @@ void sss_vdebug_fn(const char *file,
                    const char *format,
                    va_list ap)
 {
+    static time_t last_time;
+    static char last_time_str[128];
     struct timeval tv;
     struct tm tm;
     time_t t;
@@ -306,14 +308,19 @@ void sss_vdebug_fn(const char *file,
         } else {
             t = time(NULL);
         }
-        localtime_r(&t, &tm);
-        debug_printf("(%d-%02d-%02d %2d:%02d:%02d",
+        if (t != last_time) {
+            last_time = t;
+            localtime_r(&t, &tm);
+            snprintf(last_time_str, sizeof(last_time_str),
+                     "(%d-%02d-%02d %2d:%02d:%02d",
                      tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
                      tm.tm_hour, tm.tm_min, tm.tm_sec);
-        if (debug_microseconds) {
-            debug_printf(":%.6ld", tv.tv_usec);
         }
-        debug_printf("): ");
+        if (debug_microseconds) {
+            debug_printf("%s:%.6ld): ", last_time_str, tv.tv_usec);
+        } else {
+            debug_printf("%s): ", last_time_str);
+        }
     }
 
     debug_printf("[%s] [%s] (%#.4x): ", debug_prg_name, function, level);


### PR DESCRIPTION
A set of patches intended to improve log performance.

As a result, time spent in a trivial test:
```
    for (c = 0; c < 10000000; ++c) {
        DEBUG(SSSDBG_OP_FAILURE, "Message %d\n", c);
    }
```
with "--debug-timestamps=1 --debug-microseconds=0" is reduced on my machine from ~34 to ~14 seconds (i.e. ~55% faster).