### PR TITLE
Covscan fixes

### DIFF
--- a/src/lib/sifp/sss_sifp_attrs.c
+++ b/src/lib/sifp/sss_sifp_attrs.c
@@ -96,7 +96,7 @@ sss_sifp_find_attr_as_bool(sss_sifp_attr **attrs,
                            const char *name,
                            bool *_value)
 {
-    sss_sifp_error ret;
+    sss_sifp_error ret = SSS_SIFP_ATTR_MISSING;
     GET_ATTR(attrs, name, SSS_SIFP_ATTR_TYPE_BOOL, boolean, *_value, ret);
     return ret;
 }
@@ -106,7 +106,7 @@ sss_sifp_find_attr_as_int16(sss_sifp_attr **attrs,
                             const char *name,
                             int16_t *_value)
 {
-    sss_sifp_error ret;
+    sss_sifp_error ret = SSS_SIFP_ATTR_MISSING;
     GET_ATTR(attrs, name, SSS_SIFP_ATTR_TYPE_INT16, int16, *_value, ret);
     return ret;
 }
@@ -116,7 +116,7 @@ sss_sifp_find_attr_as_uint16(sss_sifp_attr **attrs,
                              const char *name,
                              uint16_t *_value)
 {
-    sss_sifp_error ret;
+    sss_sifp_error ret = SSS_SIFP_ATTR_MISSING;
     GET_ATTR(attrs, name, SSS_SIFP_ATTR_TYPE_UINT16, uint16, *_value, ret);
     return ret;
 }
@@ -126,7 +126,7 @@ sss_sifp_find_attr_as_int32(sss_sifp_attr **attrs,
                             const char *name,
                             int32_t *_value)
 {
-    sss_sifp_error ret;
+    sss_sifp_error ret = SSS_SIFP_ATTR_MISSING;
     GET_ATTR(attrs, name, SSS_SIFP_ATTR_TYPE_INT32, int32, *_value, ret);
     return ret;
 }
@@ -136,7 +136,7 @@ sss_sifp_find_attr_as_uint32(sss_sifp_attr **attrs,
                              const char *name,
                              uint32_t *_value)
 {
-    sss_sifp_error ret;
+    sss_sifp_error ret = SSS_SIFP_ATTR_MISSING;
     GET_ATTR(attrs, name, SSS_SIFP_ATTR_TYPE_UINT32, uint32, *_value, ret);
     return ret;
 }
@@ -146,7 +146,7 @@ sss_sifp_find_attr_as_int64(sss_sifp_attr **attrs,
                             const char *name,
                             int64_t *_value)
 {
-    sss_sifp_error ret;
+    sss_sifp_error ret = SSS_SIFP_ATTR_MISSING;
     GET_ATTR(attrs, name, SSS_SIFP_ATTR_TYPE_INT64, int64, *_value, ret);
     return ret;
 }
@@ -156,7 +156,7 @@ sss_sifp_find_attr_as_uint64(sss_sifp_attr **attrs,
                              const char *name,
                              uint64_t *_value)
 {
-    sss_sifp_error ret;
+    sss_sifp_error ret = SSS_SIFP_ATTR_MISSING;
     GET_ATTR(attrs, name, SSS_SIFP_ATTR_TYPE_UINT64, uint64, *_value, ret);
     return ret;
 }
@@ -166,7 +166,7 @@ sss_sifp_find_attr_as_string(sss_sifp_attr **attrs,
                              const char *name,
                              const char **_value)
 {
-    sss_sifp_error ret;
+    sss_sifp_error ret = SSS_SIFP_ATTR_MISSING;
     const char *value = NULL;
 
     GET_ATTR(attrs, name, SSS_SIFP_ATTR_TYPE_STRING, str, value, ret);
@@ -219,7 +219,7 @@ sss_sifp_find_attr_as_bool_array(sss_sifp_attr **attrs,
                                  unsigned int *_num_values,
                                  bool **_value)
 {
-    sss_sifp_error ret;
+    sss_sifp_error ret = SSS_SIFP_ATTR_MISSING;
     GET_ATTR_ARRAY(attrs, name, SSS_SIFP_ATTR_TYPE_BOOL, boolean,
                    *_num_values, *_value, ret);
     return ret;
@@ -231,7 +231,7 @@ sss_sifp_find_attr_as_int16_array(sss_sifp_attr **attrs,
                                   unsigned int *_num_values,
                                   int16_t **_value)
 {
-    sss_sifp_error ret;
+    sss_sifp_error ret = SSS_SIFP_ATTR_MISSING;
     GET_ATTR_ARRAY(attrs, name, SSS_SIFP_ATTR_TYPE_INT16, int16,
                    *_num_values, *_value, ret);
     return ret;
@@ -243,7 +243,7 @@ sss_sifp_find_attr_as_uint16_array(sss_sifp_attr **attrs,
                                    unsigned int *_num_values,
                                    uint16_t **_value)
 {
-    sss_sifp_error ret;
+    sss_sifp_error ret = SSS_SIFP_ATTR_MISSING;
     GET_ATTR_ARRAY(attrs, name, SSS_SIFP_ATTR_TYPE_UINT16, uint16,
                    *_num_values, *_value, ret);
     return ret;
@@ -255,7 +255,7 @@ sss_sifp_find_attr_as_int32_array(sss_sifp_attr **attrs,
                                   unsigned int *_num_values,
                                   int32_t **_value)
 {
-    sss_sifp_error ret;
+    sss_sifp_error ret = SSS_SIFP_ATTR_MISSING;
     GET_ATTR_ARRAY(attrs, name, SSS_SIFP_ATTR_TYPE_INT32, int32,
                    *_num_values, *_value, ret);
     return ret;
@@ -267,7 +267,7 @@ sss_sifp_find_attr_as_uint32_array(sss_sifp_attr **attrs,
                                    unsigned int *_num_values,
                                    uint32_t **_value)
 {
-    sss_sifp_error ret;
+    sss_sifp_error ret = SSS_SIFP_ATTR_MISSING;
     GET_ATTR_ARRAY(attrs, name, SSS_SIFP_ATTR_TYPE_UINT32, uint32,
                    *_num_values, *_value, ret);
     return ret;
@@ -279,7 +279,7 @@ sss_sifp_find_attr_as_int64_array(sss_sifp_attr **attrs,
                                   unsigned int *_num_values,
                                   int64_t **_value)
 {
-    sss_sifp_error ret;
+    sss_sifp_error ret = SSS_SIFP_ATTR_MISSING;
     GET_ATTR_ARRAY(attrs, name, SSS_SIFP_ATTR_TYPE_INT64, int64,
                    *_num_values, *_value, ret);
     return ret;
@@ -291,7 +291,7 @@ sss_sifp_find_attr_as_uint64_array(sss_sifp_attr **attrs,
                                    unsigned int *_num_values,
                                    uint64_t **_value)
 {
-    sss_sifp_error ret;
+    sss_sifp_error ret = SSS_SIFP_ATTR_MISSING;
     GET_ATTR_ARRAY(attrs, name, SSS_SIFP_ATTR_TYPE_UINT64, uint64,
                    *_num_values, *_value, ret);
     return ret;
@@ -303,7 +303,7 @@ sss_sifp_find_attr_as_string_array(sss_sifp_attr **attrs,
                                    unsigned int *_num_values,
                                    const char * const **_value)
 {
-    sss_sifp_error ret;
+    sss_sifp_error ret = SSS_SIFP_ATTR_MISSING;
     char **value;
 
     GET_ATTR_ARRAY(attrs, name, SSS_SIFP_ATTR_TYPE_STRING, str,

--- a/src/sbus/server/sbus_server.c
+++ b/src/sbus/server/sbus_server.c
@@ -146,6 +146,10 @@ sbus_server_symlink_create(const char *filename,
 {
     errno_t ret;
 
+    if (symlink_filename == NULL) {
+        return EINVAL;
+    }
+
     DEBUG(SSSDBG_TRACE_LIBS, "Symlinking the dbus path %s to a link %s\n",
               filename, symlink_filename);
     errno = 0;

--- a/src/sss_client/pam_sss_prompt_config.c
+++ b/src/sss_client/pam_sss_prompt_config.c
@@ -98,6 +98,7 @@ static void pc_free_password(struct prompt_config *pc)
 {
     if (pc != NULL && pc_get_type(pc) == PC_TYPE_PASSWORD) {
         free(pc->data.password.prompt);
+        pc->data.password.prompt = NULL;
     }
     return;
 }
@@ -106,7 +107,9 @@ static void pc_free_2fa(struct prompt_config *pc)
 {
     if (pc != NULL && pc_get_type(pc) == PC_TYPE_2FA) {
         free(pc->data.two_fa.prompt_1st);
+        pc->data.two_fa.prompt_1st = NULL;
         free(pc->data.two_fa.prompt_2nd);
+        pc->data.two_fa.prompt_2nd = NULL;
     }
     return;
 }
@@ -115,6 +118,7 @@ static void pc_free_2fa_single(struct prompt_config *pc)
 {
     if (pc != NULL && pc_get_type(pc) == PC_TYPE_2FA_SINGLE) {
         free(pc->data.two_fa_single.prompt);
+        pc->data.two_fa_single.prompt = NULL;
     }
     return;
 }
@@ -123,6 +127,7 @@ static void pc_free_sc_pin(struct prompt_config *pc)
 {
     if (pc != NULL && pc_get_type(pc) == PC_TYPE_SC_PIN) {
         free(pc->data.sc_pin.prompt);
+        pc->data.sc_pin.prompt = NULL;
     }
     return;
 }
@@ -153,6 +158,7 @@ void pc_list_free(struct prompt_config **pc_list)
             return;
         }
         free(pc_list[c]);
+        pc_list[c] = NULL;
     }
     free(pc_list);
 }
@@ -541,6 +547,7 @@ errno_t pc_list_from_response(int size, uint8_t *buf,
 done:
     if (ret != EOK) {
         pc_list_free(pl);
+        pl = NULL;
     }
 
     return ret;


### PR DESCRIPTION
This is overtake of PR #5498 (based on https://github.com/SSSD/sssd/pull/5498#issuecomment-789576996 comment)

Two patches were taken "as is".
Patch "symlink() expects non-NULL second argument" was slightly amended (different error code used).
One patch was skipped as I either don't understand it or it's not entirely correct.