### PR TITLE
ldap: retry ldap_install_tls() when watchdog interruption

### DIFF
--- a/src/util/util.h
+++ b/src/util/util.h
@@ -750,6 +750,7 @@ int sss_unique_filename(TALLOC_CTX *owner, char *path_tmpl);
 /* from util_watchdog.c */
 int setup_watchdog(struct tevent_context *ev, int interval);
 void teardown_watchdog(void);
+int get_watchdog_ticks(void);
 
 /* from files.c */
 int sss_remove_tree(const char *root);

--- a/src/util/util_errors.c
+++ b/src/util/util_errors.c
@@ -143,6 +143,8 @@ struct err_string error_to_str[] = {
     { "Error while parsing configuration file" }, /* ERR_INI_PARSE_FAILED */
     { "Failed to add configuration snippets" }, /* ERR_INI_ADD_SNIPPETS_FAILED */
 
+    { "TLS handshake was interrupted"}, /* ERR_TLS_HANDSHAKE_INTERRUPTED */
+
     { "ERR_LAST" } /* ERR_LAST */
 };
 

--- a/src/util/util_errors.h
+++ b/src/util/util_errors.h
@@ -164,6 +164,8 @@ enum sssd_errors {
     ERR_INI_PARSE_FAILED,
     ERR_INI_ADD_SNIPPETS_FAILED,
 
+    ERR_TLS_HANDSHAKE_INTERRUPTED,
+
     ERR_LAST            /* ALWAYS LAST */
 };
 

--- a/src/util/util_watchdog.c
+++ b/src/util/util_watchdog.c
@@ -259,3 +259,8 @@ void teardown_watchdog(void)
     /* and kill the watchdog event */
     talloc_free(watchdog_ctx.te);
 }
+
+int get_watchdog_ticks(void)
+{
+    return __sync_add_and_fetch(&watchdog_ctx.ticks, 0);
+}


### PR DESCRIPTION
When the call to ldap_install_tls() fails because the watchdog
interrupted it, retry it. The watchdog interruption is detected by
checking the value of the ticks before and after the call to
ldap_install_tls().

Resolves: #5531