### PR TITLE
SPEC: added 'BuildRequires: po4a'

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -123,6 +123,7 @@ BuildRequires: softhsm >= 2.1.0
 BuildRequires: systemd-devel
 BuildRequires: systemtap-sdt-devel
 BuildRequires: uid_wrapper
+BuildRequires: po4a
 
 %description
 Provides a set of daemons to manage access to remote directories and


### PR DESCRIPTION
'po4a' is needed when building from srpm made from upstream sources, i.e.
without prepared translations.