### PR TITLE
NSS: Clear negative cache when SIGHUP received

### DIFF
--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -721,6 +721,11 @@ static int service_signal_clear_memcache(struct mt_svc *svc)
     return service_signal(svc, sbus_call_service_clearMemcache_send,
                           sbus_call_service_clearMemcache_recv);
 }
+static int service_signal_clear_negcache(struct mt_svc *svc)
+{
+    return service_signal(svc, sbus_call_service_clearNegcache_send,
+                          sbus_call_service_clearNegcache_recv);
+}
 static int service_signal_clear_enum_cache(struct mt_svc *svc)
 {
     return service_signal(svc, sbus_call_service_clearEnumCache_send,
@@ -1342,18 +1347,26 @@ static void monitor_hup(struct tevent_context *ev,
     struct mt_ctx *ctx = talloc_get_type(private_data, struct mt_ctx);
     struct mt_svc *cur_svc;
 
-    DEBUG(SSSDBG_CRIT_FAILURE, "Received SIGHUP.\n");
+    DEBUG(SSSDBG_IMPORTANT_INFO, "Monitor received SIGHUP\n");
 
     /* Send D-Bus message to other services to rotate their logs.
      * NSS service receives also message to clear memory caches. */
     for(cur_svc = ctx->svc_list; cur_svc; cur_svc = cur_svc->next) {
+        DEBUG(SSSDBG_TRACE_FUNC, "Log rotate triggered for: %s\n", cur_svc->name);
         service_signal_rotate(cur_svc);
         if (!strcmp(NSS_SBUS_SERVICE_NAME, cur_svc->name)) {
+            DEBUG(SSSDBG_TRACE_FUNC, "NSS negcache cleaning\n");
+            service_signal_clear_negcache(cur_svc);
+
+            DEBUG(SSSDBG_TRACE_FUNC, "NSS memcache cleaning\n");
             service_signal_clear_memcache(cur_svc);
+
+            DEBUG(SSSDBG_TRACE_FUNC, "NSS enum_cache cleaning\n");
             service_signal_clear_enum_cache(cur_svc);
         }
 
         if (!strcmp(SSS_AUTOFS_SBUS_SERVICE_NAME, cur_svc->name)) {
+            DEBUG(SSSDBG_TRACE_FUNC, "AUTOFS enum_cache cleaning\n");
             service_signal_clear_enum_cache(cur_svc);
         }
 

--- a/src/responder/common/negcache.h
+++ b/src/responder/common/negcache.h
@@ -159,7 +159,7 @@ errno_t sss_ncache_prepopulate(struct sss_nc_ctx *ncache,
                                struct confdb_ctx *cdb,
                                struct resp_ctx *rctx);
 
-/* Flush the negcache and then repopulate */
+/* Flush the negcache permament entries and then repopulate them */
 errno_t sss_ncache_reset_repopulate_permanent(struct resp_ctx *rctx,
                                               struct sss_nc_ctx *ncache);
 

--- a/src/sss_iface/sbus_sss_client_async.c
+++ b/src/sss_iface/sbus_sss_client_async.c
@@ -2436,6 +2436,24 @@ sbus_call_service_clearMemcache_recv
 }
 
 struct tevent_req *
+sbus_call_service_clearNegcache_send
+    (TALLOC_CTX *mem_ctx,
+     struct sbus_connection *conn,
+     const char *busname,
+     const char *object_path)
+{
+    return sbus_method_in__out__send(mem_ctx, conn, NULL,
+        busname, object_path, "sssd.service", "clearNegcache");
+}
+
+errno_t
+sbus_call_service_clearNegcache_recv
+    (struct tevent_req *req)
+{
+    return sbus_method_in__out__recv(req);
+}
+
+struct tevent_req *
 sbus_call_service_goOffline_send
     (TALLOC_CTX *mem_ctx,
      struct sbus_connection *conn,

--- a/src/sss_iface/sbus_sss_client_async.h
+++ b/src/sss_iface/sbus_sss_client_async.h
@@ -448,6 +448,17 @@ sbus_call_service_clearMemcache_recv
     (struct tevent_req *req);
 
 struct tevent_req *
+sbus_call_service_clearNegcache_send
+    (TALLOC_CTX *mem_ctx,
+     struct sbus_connection *conn,
+     const char *busname,
+     const char *object_path);
+
+errno_t
+sbus_call_service_clearNegcache_recv
+    (struct tevent_req *req);
+
+struct tevent_req *
 sbus_call_service_goOffline_send
     (TALLOC_CTX *mem_ctx,
      struct sbus_connection *conn,

--- a/src/sss_iface/sbus_sss_interface.h
+++ b/src/sss_iface/sbus_sss_interface.h
@@ -863,6 +863,28 @@
         (handler_send), (handler_recv), (data)); \
 })
 
+/* Method: sssd.service.clearNegcache */
+#define SBUS_METHOD_SYNC_sssd_service_clearNegcache(handler, data) ({ \
+    SBUS_CHECK_SYNC((handler), (data)); \
+    sbus_method_sync("clearNegcache", \
+        &_sbus_sss_args_sssd_service_clearNegcache, \
+        NULL, \
+        _sbus_sss_invoke_in__out__send, \
+        NULL, \
+        (handler), (data)); \
+})
+
+#define SBUS_METHOD_ASYNC_sssd_service_clearNegcache(handler_send, handler_recv, data) ({ \
+    SBUS_CHECK_SEND((handler_send), (data)); \
+    SBUS_CHECK_RECV((handler_recv)); \
+    sbus_method_async("clearNegcache", \
+        &_sbus_sss_args_sssd_service_clearNegcache, \
+        NULL, \
+        _sbus_sss_invoke_in__out__send, \
+        NULL, \
+        (handler_send), (handler_recv), (data)); \
+})
+
 /* Method: sssd.service.goOffline */
 #define SBUS_METHOD_SYNC_sssd_service_goOffline(handler, data) ({ \
     SBUS_CHECK_SYNC((handler), (data)); \

--- a/src/sss_iface/sbus_sss_symbols.c
+++ b/src/sss_iface/sbus_sss_symbols.c
@@ -438,6 +438,16 @@ _sbus_sss_args_sssd_service_clearMemcache = {
 };
 
 const struct sbus_method_arguments
+_sbus_sss_args_sssd_service_clearNegcache = {
+    .input = (const struct sbus_argument[]){
+        {NULL}
+    },
+    .output = (const struct sbus_argument[]){
+        {NULL}
+    }
+};
+
+const struct sbus_method_arguments
 _sbus_sss_args_sssd_service_goOffline = {
     .input = (const struct sbus_argument[]){
         {NULL}

--- a/src/sss_iface/sbus_sss_symbols.h
+++ b/src/sss_iface/sbus_sss_symbols.h
@@ -125,6 +125,9 @@ extern const struct sbus_method_arguments
 _sbus_sss_args_sssd_service_clearMemcache;
 
 extern const struct sbus_method_arguments
+_sbus_sss_args_sssd_service_clearNegcache;
+
+extern const struct sbus_method_arguments
 _sbus_sss_args_sssd_service_goOffline;
 
 extern const struct sbus_method_arguments

--- a/src/sss_iface/sss_iface.xml
+++ b/src/sss_iface/sss_iface.xml
@@ -20,6 +20,7 @@
         <method name="resetOffline" />
         <method name="rotateLogs" />
         <method name="clearMemcache" />
+        <method name="clearNegcache" />
         <method name="clearEnumCache" />
         <method name="sysbusReconnect" />
     </interface>

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -55,12 +55,19 @@
 
 #define ENUM_INDICATOR "*"
 
+/*
+ * CLEAR_MC_FLAG is a flag file used to notify NSS responder
+ * that SIGHUP signal it received was triggered by sss_cache
+ * as a call for memory cache clearing. During the procedure
+ * this file is deleted by NSS responder to notify back
+ * sss_cache that memory cache clearing was completed.
+ */
 #define CLEAR_MC_FLAG "clear_mc_flag"
 
-/** Default secure umask */
+/* Default secure umask */
 #define SSS_DFL_UMASK 0177
 
-/** Secure mask with executable bit */
+/* Secure mask with executable bit */
 #define SSS_DFL_X_UMASK 0077
 
 #ifndef NULL


### PR DESCRIPTION
When NSS receives SIGHUP signal it clears memory cache.
As a part of signal handling procedure negative cache
should be also cleared.

Resolves: https://github.com/SSSD/sssd/issues/4973