### PR TITLE
nss client: make innetgr() thread safe

### DIFF
--- a/src/responder/nss/nss_protocol.h
+++ b/src/responder/nss/nss_protocol.h
@@ -154,12 +154,6 @@ nss_protocol_fill_netgrent(struct nss_ctx *nss_ctx,
                            struct cache_req_result *result);
 
 errno_t
-nss_protocol_fill_setnetgrent(struct nss_ctx *nss_ctx,
-                              struct nss_cmd_ctx *cmd_ctx,
-                              struct sss_packet *packet,
-                              struct cache_req_result *result);
-
-errno_t
 nss_protocol_fill_svcent(struct nss_ctx *nss_ctx,
                          struct nss_cmd_ctx *cmd_ctx,
                          struct sss_packet *packet,

--- a/src/responder/nss/nss_protocol_netgr.c
+++ b/src/responder/nss/nss_protocol_netgr.c
@@ -115,7 +115,6 @@ nss_protocol_fill_netgrent(struct nss_ctx *nss_ctx,
     size_t body_len;
     uint8_t *body;
     errno_t ret;
-    unsigned int start;
 
     idx = cmd_ctx->enum_index;
     entries = cmd_ctx->enum_ctx->netgroup;
@@ -141,13 +140,8 @@ nss_protocol_fill_netgrent(struct nss_ctx *nss_ctx,
         goto done;
     }
 
-    num_results = 0;
-    start = idx->result;
+    num_results = 1; /* group was found */
     for (; entries[idx->result] != NULL; idx->result++) {
-        if ((idx->result - start) >= cmd_ctx->enum_limit) {
-            /* We have reached result limit. */
-            break;
-        }
 
         entry = entries[idx->result];
 
@@ -181,29 +175,6 @@ done:
 
     sss_packet_get_body(packet, &body, &body_len);
     SAFEALIGN_COPY_UINT32(body, &num_results, NULL);
-    SAFEALIGN_SETMEM_UINT32(body + sizeof(uint32_t), 0, NULL); /* reserved */
-
-    return EOK;
-}
-
-errno_t
-nss_protocol_fill_setnetgrent(struct nss_ctx *nss_ctx,
-                              struct nss_cmd_ctx *cmd_ctx,
-                              struct sss_packet *packet,
-                              struct cache_req_result *result)
-{
-    size_t body_len;
-    uint8_t *body;
-    errno_t ret;
-
-    /* Two fields (length and reserved). */
-    ret = sss_packet_grow(packet, 2 * sizeof(uint32_t));
-    if (ret != EOK) {
-        return ret;
-    }
-
-    sss_packet_get_body(packet, &body, &body_len);
-    SAFEALIGN_SET_UINT32(body, 1, NULL); /* Netgroup was found. */
     SAFEALIGN_SETMEM_UINT32(body + sizeof(uint32_t), 0, NULL); /* reserved */
 
     return EOK;

--- a/src/sss_client/nss_netgroup.c
+++ b/src/sss_client/nss_netgroup.c
@@ -209,7 +209,11 @@ enum nss_status _nss_sss_setnetgrent(const char *netgroup,
         goto out;
     }
 
-    free(repbuf);
+    result->data = (char *) repbuf;
+    result->data_size = replen;
+    /* skip metadata fields */
+    result->idx.position = NETGR_METADATA_COUNT;
+
     nret = NSS_STATUS_SUCCESS;
 
 out:
@@ -221,19 +225,15 @@ static enum nss_status internal_getnetgrent_r(struct __netgrent *result,
                                               char *buffer, size_t buflen,
                                               int *errnop)
 {
-    struct sss_cli_req_data rd;
     struct sss_nss_netgr_rep netgrrep;
     uint8_t *repbuf;
     size_t replen;
-    uint32_t num_results;
-    enum nss_status nret;
-    uint32_t num_entries;
     int ret;
 
     /* Caught once glibc passing in buffer == 0x0 */
     if (!buffer || !buflen) {
-	*errnop = ERANGE;
-	return NSS_STATUS_TRYAGAIN;
+        *errnop = ERANGE;
+        return NSS_STATUS_TRYAGAIN;
     }
 
     /* If we're already processing result data, continue to
@@ -260,36 +260,7 @@ static enum nss_status internal_getnetgrent_r(struct __netgrent *result,
         return NSS_STATUS_SUCCESS;
     }
 
-    /* Release memory, if any */
-    CLEAR_NETGRENT_DATA(result);
-
-    /* retrieve no more than SSS_NSS_MAX_ENTRIES at a time */
-    num_entries = SSS_NSS_MAX_ENTRIES;
-    rd.len = sizeof(uint32_t);
-    rd.data = &num_entries;
-
-    nret = sss_nss_make_request(SSS_NSS_GETNETGRENT, &rd,
-                                &repbuf, &replen, errnop);
-    if (nret != NSS_STATUS_SUCCESS) {
-        return nret;
-    }
-
-    /* Get number of results from repbuf. */
-    SAFEALIGN_COPY_UINT32(&num_results, repbuf, NULL);
-
-    /* no results if not found */
-    if ((num_results == 0) || (replen <= NETGR_METADATA_COUNT)) {
-        free(repbuf);
-        return NSS_STATUS_RETURN;
-    }
-
-    result->data = (char *) repbuf;
-    result->data_size = replen;
-    /* skip metadata fields */
-    result->idx.position = NETGR_METADATA_COUNT;
-
-    /* call again ourselves, this will return the first result */
-    return internal_getnetgrent_r(result, buffer, buflen, errnop);
+    return NSS_STATUS_RETURN;
 }
 
 enum nss_status _nss_sss_getnetgrent_r(struct __netgrent *result,
@@ -298,32 +269,18 @@ enum nss_status _nss_sss_getnetgrent_r(struct __netgrent *result,
 {
     enum nss_status nret;
 
-    sss_nss_lock();
+    /* no lock needed because results are already stored in result */
     nret = internal_getnetgrent_r(result, buffer, buflen, errnop);
-    sss_nss_unlock();
 
     return nret;
 }
 
 enum nss_status _nss_sss_endnetgrent(struct __netgrent *result)
 {
-    enum nss_status nret;
-    int errnop;
-    int saved_errno = errno;
-
-    sss_nss_lock();
-
+    /* no lock needed because resources in the responder are already
+     * released */
     /* make sure we do not have leftovers, and release memory */
     CLEAR_NETGRENT_DATA(result);
 
-    nret = sss_nss_make_request(SSS_NSS_ENDNETGRENT,
-                                NULL, NULL, NULL, &errnop);
-    if (nret != NSS_STATUS_SUCCESS) {
-        errno = errnop;
-    } else {
-        errno = saved_errno;
-    }
-
-    sss_nss_unlock();
-    return nret;
+    return NSS_STATUS_SUCCESS;
 }

--- a/src/tests/intg/Makefile.am
+++ b/src/tests/intg/Makefile.am
@@ -62,6 +62,18 @@ getsockopt_wrapper_la_LDFLAGS = \
     -avoid-version \
     -module
 
+bin_PROGRAMS = sss_netgroup_thread_test
+
+sss_netgroup_thread_test_SOURCES = \
+    sss_netgroup_thread_test.c \
+    $(NULL)
+sss_netgroup_thread_test_CFLAGS = \
+    $(AM_CFLAGS) \
+    $(NULL)
+sss_netgroup_thread_test_LDADD = \
+    -lpthread \
+    $(NULL)
+
 dist_dbussysconf_DATA = cwrap-dbus-system.conf
 
 install-data-hook:
@@ -162,7 +174,7 @@ clean-local:
 PAM_CERT_DB_PATH="$(abs_builddir)/../test_CA/SSSD_test_CA.pem"
 SOFTHSM2_CONF="$(abs_builddir)/../test_CA/softhsm2_one.conf"
 
-intgcheck-installed: config.py passwd group pam_sss_service pam_sss_alt_service pam_sss_sc_required pam_sss_try_sc pam_sss_allow_missing_name pam_sss_domains
+intgcheck-installed: config.py passwd group pam_sss_service pam_sss_alt_service pam_sss_sc_required pam_sss_try_sc pam_sss_allow_missing_name pam_sss_domains sss_netgroup_thread_test
 	pipepath="$(DESTDIR)$(pipepath)"; \
 	if test $${#pipepath} -gt 80; then \
 	    echo "error: Pipe directory path too long," \

--- a/src/tests/intg/sss_netgroup_thread_test.c
+++ b/src/tests/intg/sss_netgroup_thread_test.c
@@ -1,0 +1,81 @@
+/*
+    Helper program to test if innetgr() is thread-safe
+
+    Authors:
+        Sumit Bose <sbose@redhat.com>
+
+    Copyright (c) 2021 Red Hat, Inc.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <pthread.h>
+#include <pwd.h>
+#include <grp.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <sys/types.h>
+
+
+
+struct data {
+    const char *group;
+    const char *host;
+    const char *user;
+    const char *domain;
+    bool *failed;
+};
+
+static void *full_netgroup(void *arg)
+{
+    int ret;
+    size_t c = 0;
+    struct data *data = arg;
+
+    do {
+        ret = innetgr(data->group, data->host, data->user, data->domain);
+        if (ret != 1) {
+            *(data->failed) = true;
+        }
+        c++;
+    } while (!*(data->failed) && c<100000);
+
+    pthread_exit(NULL);
+}
+
+int main()
+{
+    pthread_t thread[2];
+    bool failed[2] = {false, false};
+
+    struct data data[3] = {{"ng1", "host1", "user924", "domain1", &failed[0]},
+                           {"ng2", "host2", "user925", "domain2", &failed[1]},
+                           {NULL, NULL, NULL, NULL, NULL}};
+
+
+    pthread_create(&thread[0], NULL, full_netgroup, &data[0]);
+    pthread_create(&thread[1], NULL, full_netgroup, &data[1]);
+
+    pthread_join(thread[1], NULL);
+    pthread_join(thread[0], NULL);
+
+    if (failed[0] || failed[1]) {
+        printf ("Test failed.\n");
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
The innetgr() call is expected to be thread safe but SSSD's the current
implementation isn't. In glibc innetgr() is implementend by calling the
setnetgrent(), getnetgrent(), endgrent() sequence with a private context
(struct __netgrent) with provides a member where NSS modules can store data
between the calls.

With this patch setnetgrent() will read all required data from the NSS
responder and store it in the data member of the __netgrent struct.
Upcoming getnetgrent() calls will only operate on the stored data and not
connect to the NSS responder anymore. endgrent() will free the data. Since
the netgroup data is read in a single request to the NSS responder
protected by a mutex and stored in private context of innetgr() this call
is now thread-safe.

Resolves: https://github.com/SSSD/sssd/issues/5540