### PR TITLE
nss client: make innetgr() thread safe

### DIFF
--- a/src/sss_client/sss_cli.h
+++ b/src/sss_client/sss_cli.h
@@ -636,6 +636,12 @@ enum nss_status sss_nss_make_request(enum sss_cli_command cmd,
                                      uint8_t **repbuf, size_t *replen,
                                      int *errnop);
 
+enum nss_status sss_nss_make_request_fd(enum sss_cli_command cmd,
+                                        struct sss_cli_req_data *rd,
+                                        int *fd,
+                                        uint8_t **repbuf, size_t *replen,
+                                        int *errnop);
+
 enum nss_status sss_nss_make_request_timeout(enum sss_cli_command cmd,
                                              struct sss_cli_req_data *rd,
                                              int timeout,

--- a/src/tests/intg/Makefile.am
+++ b/src/tests/intg/Makefile.am
@@ -62,6 +62,18 @@ getsockopt_wrapper_la_LDFLAGS = \
     -avoid-version \
     -module
 
+bin_PROGRAMS = sss_netgroup_thread_test
+
+sss_netgroup_thread_test_SOURCES = \
+    sss_netgroup_thread_test.c \
+    $(NULL)
+sss_netgroup_thread_test_CFLAGS = \
+    $(AM_CFLAGS) \
+    $(NULL)
+sss_netgroup_thread_test_LDADD = \
+    -lpthread \
+    $(NULL)
+
 dist_dbussysconf_DATA = cwrap-dbus-system.conf
 
 install-data-hook:
@@ -162,7 +174,7 @@ clean-local:
 PAM_CERT_DB_PATH="$(abs_builddir)/../test_CA/SSSD_test_CA.pem"
 SOFTHSM2_CONF="$(abs_builddir)/../test_CA/softhsm2_one.conf"
 
-intgcheck-installed: config.py passwd group pam_sss_service pam_sss_alt_service pam_sss_sc_required pam_sss_try_sc pam_sss_allow_missing_name pam_sss_domains
+intgcheck-installed: config.py passwd group pam_sss_service pam_sss_alt_service pam_sss_sc_required pam_sss_try_sc pam_sss_allow_missing_name pam_sss_domains sss_netgroup_thread_test
 	pipepath="$(DESTDIR)$(pipepath)"; \
 	if test $${#pipepath} -gt 80; then \
 	    echo "error: Pipe directory path too long," \

--- a/src/tests/intg/sss_netgroup_thread_test.c
+++ b/src/tests/intg/sss_netgroup_thread_test.c
@@ -1,0 +1,60 @@
+#define _GNU_SOURCE /* for pthread_yield */
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <pthread.h>
+#include <pwd.h>
+#include <grp.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <sys/types.h>
+
+
+
+struct data {
+    char *group;
+    char *host;
+    char *user;
+    char *domain;
+    bool *failed;
+};
+
+static void *full_netgroup(void *arg)
+{
+    int ret;
+    size_t c = 0;
+    struct data *data = arg;
+
+    do {
+        ret = innetgr(data->group, data->host, data->user, data->domain);
+        if (ret != 1) {
+            *(data->failed) = true;
+        }
+        c++;
+    } while (!*(data->failed) && c<100000);
+
+    pthread_exit(NULL);
+}
+
+int main()
+{
+    pthread_t thread[2];
+    bool failed = false;
+
+    struct data data[3] = {{"ng1", "host1", "user924", "domain1", &failed},
+                           {"ng2", "host2", "user925", "domain2", &failed},
+                           {NULL, NULL, NULL, NULL, NULL}};
+
+
+    pthread_create(&thread[0], NULL, full_netgroup, &data[0]);
+    pthread_create(&thread[1], NULL, full_netgroup, &data[1]);
+
+    pthread_join(thread[1], NULL);
+    pthread_join(thread[0], NULL);
+
+    if (failed) {
+        printf ("Test failed.\n");
+    }
+
+    return failed ? 1 : 0;
+}

--- a/src/tests/intg/test_netgroup.py
+++ b/src/tests/intg/test_netgroup.py
@@ -510,3 +510,27 @@ def test_offline_netgroups(add_tripled_netgroup):
     res, _, netgrps = get_sssd_netgroups("tripled_netgroup")
     assert res == NssReturnCode.SUCCESS
     assert netgrps == [("host", "user", "domain")]
+
+@pytest.fixture
+def add_thread_test_netgroup(request, ldap_conn):
+    ent_list = ldap_ent.List(ldap_conn.ds_inst.base_dn)
+
+    triple_list = []
+    for i in range(1,999):
+        triple_list.append("(host1,user" + str(i) + ",domain1)");
+    ent_list.add_netgroup("ng1", triple_list)
+
+    triple_list = []
+    for i in range(1,999):
+        triple_list.append("(host2,user" + str(i) + ",domain2)");
+    ent_list.add_netgroup("ng2", triple_list)
+
+    create_ldap_fixture(request, ldap_conn, ent_list)
+    conf = format_basic_conf(ldap_conn, SCHEMA_RFC2307_BIS)
+    create_conf_fixture(request, conf)
+    create_sssd_fixture(request)
+    return None
+
+def test_innetgr_with_threads(add_thread_test_netgroup):
+
+    subprocess.check_call(["sss_netgroup_thread_test"])


### PR DESCRIPTION
The innetgr() call is expected to be thread safe but SSSD's the current
implementation isn't. In glibc innetgr() is implementend by calling the
setnetgrent(), getnetgrent(), endgrent() sequence with a private context
(struct __netgrent) with provides a member where NSS modules can store data
between the calls.

With this patch setnetgrent() will open a new connection to the NSS
responder and stores the file descriptor in the data member of
__netgrent struct so that the following getnetgrent() and endgrent() will
use the same connection. Since the NSS responder stores the netgroup
lookups related data in a per connection context and a new thread will open
a new connection the implementation is thread safe.

Resolves: https://github.com/SSSD/sssd/issues/5540