### PR TITLE
systemd configs: add CAP_DAC_OVERRIDE for ifp in certain case

### DIFF
--- a/src/sysv/systemd/sssd-ifp.service.in
+++ b/src/sysv/systemd/sssd-ifp.service.in
@@ -10,5 +10,5 @@ EnvironmentFile=-@environment_file@
 Type=dbus
 BusName=org.freedesktop.sssd.infopipe
 ExecStart=@ifp_exec_cmd@ ${DEBUG_LOGGER}
-CapabilityBoundingSet=CAP_IPC_LOCK CAP_CHOWN CAP_DAC_READ_SEARCH CAP_FOWNER CAP_SETGID CAP_SETUID
+CapabilityBoundingSet= @additional_caps@ CAP_IPC_LOCK CAP_CHOWN CAP_DAC_READ_SEARCH CAP_FOWNER CAP_SETGID CAP_SETUID
 @ifp_restart@


### PR DESCRIPTION
Commit fd7ce7b3de9647eb6de75c3dd3974b44d860078e missed ifp.

This fixes https://bugzilla.redhat.com/show_bug.cgi?id=1937654