### PR TITLE
files: split update into batches

### DIFF
--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -1622,6 +1622,18 @@ static int confdb_get_domain_internal(struct confdb_ctx *cdb,
     domain->view_name = NULL;
 
     domain->state = DOM_ACTIVE;
+
+    domain->fallback_to_nss = false;
+    if (is_files_provider(domain)) {
+        ret = get_entry_as_bool(res->msgs[0], &domain->fallback_to_nss,
+                                CONFDB_DOMAIN_FALLBACK_TO_NSS, true);
+        if(ret != EOK) {
+            DEBUG(SSSDBG_FATAL_FAILURE,
+                  "Invalid value for %s\n", CONFDB_DOMAIN_FALLBACK_TO_NSS);
+            goto done;
+        }
+    }
+
     domain->not_found_counter = 0;
 
     *_domain = domain;

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -253,6 +253,7 @@
 #define CONFDB_DOMAIN_TYPE_POSIX "posix"
 #define CONFDB_DOMAIN_TYPE_APP "application"
 #define CONFDB_DOMAIN_INHERIT_FROM "inherit_from"
+#define CONFDB_DOMAIN_FALLBACK_TO_NSS "fallback_to_nss"
 
 /* Local Provider */
 #define CONFDB_LOCAL_DEFAULT_SHELL   "default_shell"
@@ -424,6 +425,7 @@ struct sss_domain_info {
     struct sss_domain_info *next;
 
     enum sss_domain_state state;
+    bool fallback_to_nss;
     char **sd_inherit;
 
     /* Do not use the forest pointer directly in new code, but rather the

--- a/src/man/sssd-files.5.xml
+++ b/src/man/sssd-files.5.xml
@@ -122,6 +122,32 @@
                     </listitem>
                 </varlistentry>
 
+                <varlistentry>
+                    <term>fallback_to_nss (boolean)</term>
+                    <listitem>
+                        <para>
+                            While updating the internal data SSSD will return an
+                            error and let the client continue with the next NSS
+                            module. This helps to avoid delays when using the
+                            default system files
+                            <filename>/etc/passwd</filename> and
+                            <filename>/etc/group</filename> and the NSS
+                            configuration has 'sss' before 'files' for the
+                            'passwd' and 'group' maps.
+                        </para>
+                        <para>
+                            If the files provider is configured to monitor other
+                            files it makes sense to set this option to 'False'
+                            to avoid inconsistent behavior because in general
+                            there would be no other NSS module which can be used
+                            as a fallback.
+                        </para>
+                        <para>
+                            Default: True
+                        </para>
+                    </listitem>
+                </varlistentry>
+
             </variablelist>
         </para>
     </refsect1>

--- a/src/providers/files/files_ops.c
+++ b/src/providers/files/files_ops.c
@@ -449,26 +449,15 @@ done:
 }
 
 static errno_t sf_enum_groups(struct files_id_ctx *id_ctx,
-                              const char *group_file);
+                              struct group **groups, size_t start, size_t size);
 
-errno_t sf_enum_users(struct files_id_ctx *id_ctx,
-                      const char *passwd_file)
+static errno_t sf_enum_users(struct files_id_ctx *id_ctx, struct passwd **users,
+                             size_t start, size_t size)
 {
     errno_t ret;
-    TALLOC_CTX *tmp_ctx = NULL;
-    struct passwd **users = NULL;
+    size_t i;
 
-    tmp_ctx = talloc_new(NULL);
-    if (tmp_ctx == NULL) {
-        return ENOMEM;
-    }
-
-    ret = enum_files_users(tmp_ctx, passwd_file, &users);
-    if (ret != EOK) {
-        goto done;
-    }
-
-    for (size_t i = 0; users[i]; i++) {
+    for (i = start; users[i] != NULL && i < (start + size); i++) {
         ret = save_file_user(id_ctx, users[i]);
         if (ret != EOK) {
             DEBUG(SSSDBG_MINOR_FAILURE,
@@ -478,16 +467,19 @@ errno_t sf_enum_users(struct files_id_ctx *id_ctx,
         }
     }
 
-    ret = refresh_override_attrs(id_ctx, SYSDB_MEMBER_USER);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_MINOR_FAILURE,
-              "Failed to refresh override attributes, "
-              "override values might not be available.\n");
+    if (users[i] == NULL) {
+        ret = refresh_override_attrs(id_ctx, SYSDB_MEMBER_USER);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "Failed to refresh override attributes, "
+                  "override values might not be available.\n");
+        }
+
+        ret = EOK;
+    } else {
+        ret = EAGAIN;
     }
 
-    ret = EOK;
-done:
-    talloc_free(tmp_ctx);
     return ret;
 }
 
@@ -665,29 +657,25 @@ done:
 }
 
 static errno_t sf_enum_groups(struct files_id_ctx *id_ctx,
-                              const char *group_file)
+                              struct group **groups, size_t start, size_t size)
 {
     errno_t ret;
     TALLOC_CTX *tmp_ctx = NULL;
-    struct group **groups = NULL;
     const char **cached_users = NULL;
+    size_t i;
 
     tmp_ctx = talloc_new(NULL);
     if (tmp_ctx == NULL) {
         return ENOMEM;
     }
 
-    ret = enum_files_groups(tmp_ctx, group_file, &groups);
-    if (ret != EOK) {
-        goto done;
-    }
-
     cached_users = get_cached_user_names(tmp_ctx, id_ctx->domain);
     if (cached_users == NULL) {
+        ret = ENOMEM;
         goto done;
     }
 
-    for (size_t i = 0; groups[i]; i++) {
+    for (i = start; groups[i] != NULL && i < (start + size); i++) {
         ret = save_file_group(id_ctx, groups[i], cached_users);
         if (ret != EOK) {
             DEBUG(SSSDBG_MINOR_FAILURE,
@@ -696,93 +684,266 @@ static errno_t sf_enum_groups(struct files_id_ctx *id_ctx,
         }
     }
 
-    ret = refresh_override_attrs(id_ctx, SYSDB_MEMBER_GROUP);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_MINOR_FAILURE,
-              "Failed to refresh override attributes, "
-              "override values might not be available.\n");
+    if (groups[i] == NULL) {
+        ret = refresh_override_attrs(id_ctx, SYSDB_MEMBER_GROUP);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "Failed to refresh override attributes, "
+                  "override values might not be available.\n");
+        }
+
+        ret = EOK;
+    } else {
+        ret = EAGAIN;
     }
 
-    ret = EOK;
 done:
     talloc_free(tmp_ctx);
     return ret;
 }
 
-static errno_t sf_enum_files(struct files_id_ctx *id_ctx,
-                             uint8_t flags)
+enum update_steps {
+    DELETE_USERS,
+    READ_USERS,
+    SAVE_USERS,
+    DELETE_GROUPS,
+    READ_GROUPS,
+    SAVE_GROUPS,
+    UPDATE_FINISH,
+    UPDATE_DONE,
+};
+
+struct sf_enum_files_state {
+    struct files_id_ctx *id_ctx;
+    uint8_t flags;
+    struct tevent_timer *te;
+    enum update_steps current_step;
+    size_t step;
+    bool in_transaction;
+    size_t batch_size;
+    size_t obj_idx;
+    size_t file_idx;
+    struct passwd **users;
+    struct group **groups;
+    uint32_t delay;
+    uint32_t initial_delay;
+};
+
+static void sf_enum_files_first_step(struct tevent_context *ev,
+                                     struct tevent_timer *te,
+                                     struct timeval tv,
+                                     void *data);
+static struct tevent_req *sf_enum_files_send(struct files_id_ctx *id_ctx,
+                                             uint8_t flags)
 {
+    struct tevent_req *req;
+    struct sf_enum_files_state *state;
+    struct timeval tv;
     errno_t ret;
-    errno_t tret;
-    bool in_transaction = false;
+
+    req = tevent_req_create(id_ctx, &state, struct sf_enum_files_state);
+    if (req == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
+        return NULL;
+    }
+
+    state->id_ctx = id_ctx;
+    state->flags = flags;
+    state->step = 0;
+    state->batch_size = 1000;
+    state->obj_idx = 0;
+    state->file_idx = 0;
+    state->initial_delay = 100;
+    state->delay = 100;
+
+    if (state->flags & SF_UPDATE_PASSWD) {
+        state->current_step = DELETE_USERS;
+    } else if (state->flags & SF_UPDATE_GROUP) {
+        state->current_step = DELETE_GROUPS;
+    }
+
+    tv = tevent_timeval_current_ofs(0, state->initial_delay);
+    state->te = tevent_add_timer(id_ctx->be->ev, state, tv,
+                                 sf_enum_files_first_step, req);
+    if (state->te == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Unable to schedule files update.\n");
+        ret = EFAULT;
+        goto done;
+    }
 
     ret = sysdb_transaction_start(id_ctx->domain->sysdb);
     if (ret != EOK) {
         goto done;
     }
-    in_transaction = true;
+    state->in_transaction = true;
 
-    if (flags & SF_UPDATE_PASSWD) {
+    return req;
+
+done:
+    tevent_req_error(req, ret);
+    tevent_req_post(req, id_ctx->be->ev);
+    return req;
+}
+
+static void sf_enum_files_first_step(struct tevent_context *ev,
+                                     struct tevent_timer *te,
+                                     struct timeval tv,
+                                     void *data)
+{
+    errno_t ret;
+    errno_t tret;
+    struct sf_enum_files_state *state;
+    struct tevent_req *req;
+    struct files_id_ctx *id_ctx;
+    const char *filename = NULL;
+
+    req = talloc_get_type(data, struct tevent_req);
+    state = tevent_req_data(req, struct sf_enum_files_state);
+
+    state->te = NULL;
+    id_ctx = state->id_ctx;
+
+    switch (state->current_step) {
+    case DELETE_USERS:
+        DEBUG(SSSDBG_TRACE_ALL, "Step DELETE_USERS.\n");
         ret = delete_all_users(id_ctx->domain);
         if (ret != EOK) {
             goto done;
         }
-
+        state->file_idx = 0;
+        state->current_step = READ_USERS;
+        break;
+    case READ_USERS:
+        DEBUG(SSSDBG_TRACE_ALL, "Step READ_USERS.\n");
+        talloc_zfree(state->users);
+        state->obj_idx = 0;
         /* All users were deleted, therefore we need to enumerate each file again */
-        for (size_t i = 0; id_ctx->passwd_files[i] != NULL; i++) {
-            ret = sf_enum_users(id_ctx, id_ctx->passwd_files[i]);
-            if (ret == ENOENT) {
+        if (id_ctx->passwd_files[state->file_idx] != NULL) {
+            filename = id_ctx->passwd_files[state->file_idx++];
+            ret = enum_files_users(state, filename, &state->users);
+            if (ret == EOK) {
+                state->current_step = SAVE_USERS;
+            } else if (ret == ENOENT) {
                 DEBUG(SSSDBG_MINOR_FAILURE,
                       "The file %s does not exist (yet), skipping\n",
-                      id_ctx->passwd_files[i]);
-                continue;
+                      filename);
             } else if (ret != EOK) {
                 DEBUG(SSSDBG_OP_FAILURE,
-                      "Cannot enumerate users from %s, aborting\n",
-                      id_ctx->passwd_files[i]);
+                      "Cannot enumerate groups from %s, aborting\n",
+                      filename);
+                goto done;
+            }
+        } else {
+            if (state->flags & SF_UPDATE_GROUP) {
+                state->current_step = DELETE_GROUPS;
+            } else {
+                state->current_step = UPDATE_FINISH;
+            }
+        }
+        break;
+    case SAVE_USERS:
+        DEBUG(SSSDBG_TRACE_ALL, "Step SAVE_USERS.\n");
+        if (state->users != NULL) {
+            ret = sf_enum_users(id_ctx, state->users,
+                                state->obj_idx, state->batch_size);
+            if (ret == EOK) {
+                state->current_step = READ_USERS;
+            } else if (ret == EAGAIN) {
+                state->obj_idx += state->batch_size;
+            } else {
+                DEBUG(SSSDBG_OP_FAILURE, "Saving users failed.\n");
                 goto done;
             }
         }
-    }
-
-    if (flags & SF_UPDATE_GROUP) {
+        break;
+    case DELETE_GROUPS:
+        DEBUG(SSSDBG_TRACE_ALL, "Step DELETE_GROUPS.\n");
         ret = delete_all_groups(id_ctx->domain);
         if (ret != EOK) {
             goto done;
         }
-
+        state->file_idx = 0;
+        state->current_step = READ_GROUPS;
+        break;
+    case READ_GROUPS:
+        DEBUG(SSSDBG_TRACE_ALL, "Step READ_GROUPS.\n");
+        talloc_zfree(state->groups);
+        state->obj_idx = 0;
         /* All groups were deleted, therefore we need to enumerate each file again */
-        for (size_t i = 0; id_ctx->group_files[i] != NULL; i++) {
-            ret = sf_enum_groups(id_ctx, id_ctx->group_files[i]);
-            if (ret == ENOENT) {
+        if (id_ctx->group_files[state->file_idx] != NULL) {
+            filename = id_ctx->group_files[state->file_idx++];
+            ret = enum_files_groups(state, filename, &state->groups);
+            if (ret == EOK) {
+                state->current_step = SAVE_GROUPS;
+            } else if (ret == ENOENT) {
                 DEBUG(SSSDBG_MINOR_FAILURE,
                       "The file %s does not exist (yet), skipping\n",
-                      id_ctx->group_files[i]);
-                continue;
+                      filename);
             } else if (ret != EOK) {
                 DEBUG(SSSDBG_OP_FAILURE,
                       "Cannot enumerate groups from %s, aborting\n",
-                      id_ctx->group_files[i]);
+                      filename);
+                goto done;
+            }
+        } else {
+            state->current_step = UPDATE_FINISH;
+        }
+        break;
+    case SAVE_GROUPS:
+        DEBUG(SSSDBG_TRACE_ALL, "Step SAVE_GROUPS.\n");
+        if (state->groups != NULL) {
+            ret = sf_enum_groups(id_ctx, state->groups,
+                                 state->obj_idx, state->batch_size);
+            if (ret == EOK) {
+                state->current_step = READ_GROUPS;
+            } else if (ret == EAGAIN) {
+                state->obj_idx += state->batch_size;
+            } else {
+                DEBUG(SSSDBG_OP_FAILURE, "Saving groups failed.\n");
                 goto done;
             }
         }
-    }
+        break;
+    case UPDATE_FINISH:
+        DEBUG(SSSDBG_TRACE_ALL, "Step UPDATE_FINISH.\n");
+        ret = dp_add_sr_attribute(id_ctx->be);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Failed to add session recording attribute, ignored.\n");
+        }
 
-    ret = dp_add_sr_attribute(id_ctx->be);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Failed to add session recording attribute, ignored.\n");
-    }
+        ret = sysdb_transaction_commit(id_ctx->domain->sysdb);
+        if (ret != EOK) {
+            goto done;
+        }
+        state->in_transaction = false;
 
-    ret = sysdb_transaction_commit(id_ctx->domain->sysdb);
-    if (ret != EOK) {
+        state->current_step = UPDATE_DONE;
+
+        ret = EOK;
+        break;
+    default:
+        DEBUG(SSSDBG_CRIT_FAILURE, "Undefined update step [%zu].\n",
+                                   state->current_step);
+        ret = EINVAL;
         goto done;
     }
-    in_transaction = false;
 
-    ret = EOK;
+    if (state->current_step != UPDATE_DONE) {
+        tv = tevent_timeval_current_ofs(0, state->delay);
+        state->te = tevent_add_timer(id_ctx->be->ev, state, tv,
+                                     sf_enum_files_first_step, req);
+        if (state->te == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE, "Unable to schedule files update.\n");
+            ret = EFAULT;
+            goto done;
+        }
+
+        return;
+    }
+
 done:
-    if (in_transaction) {
+    if (state->in_transaction) {
         tret = sysdb_transaction_cancel(id_ctx->domain->sysdb);
         if (tret != EOK) {
             DEBUG(SSSDBG_CRIT_FAILURE,
@@ -790,7 +951,20 @@ done:
         }
     }
 
-    return ret;
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else {
+        tevent_req_error(req, ret);
+    }
+
+    return;
+}
+
+static errno_t sf_enum_files_recv(struct tevent_req *req)
+{
+    TEVENT_REQ_RETURN_ON_ERROR(req);
+
+    return EOK;
 }
 
 static void sf_cb_done(struct files_id_ctx *id_ctx)
@@ -803,9 +977,11 @@ static void sf_cb_done(struct files_id_ctx *id_ctx)
     }
 }
 
+static void sf_passwd_cb_done(struct tevent_req *req);
 static int sf_passwd_cb(const char *filename, uint32_t flags, void *pvt)
 {
     struct files_id_ctx *id_ctx;
+    struct tevent_req *req;
     errno_t ret;
 
     id_ctx = talloc_get_type(pvt, struct files_id_ctx);
@@ -826,7 +1002,30 @@ static int sf_passwd_cb(const char *filename, uint32_t flags, void *pvt)
      * only then edits passwd and adds the user. The reverse is not needed,
      * because member/memberof links are established when groups are saved.
      */
-    ret = sf_enum_files(id_ctx, SF_UPDATE_BOTH);
+    req = sf_enum_files_send(id_ctx, SF_UPDATE_BOTH);
+    if (req == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to start files update.\n");
+        ret = ENOMEM;
+        id_ctx->updating_passwd = false;
+        sf_cb_done(id_ctx);
+        files_account_info_finished(id_ctx, BE_REQ_USER, ret);
+        return ret;
+    }
+
+    tevent_req_set_callback(req, sf_passwd_cb_done, id_ctx);
+
+    return EOK;
+}
+
+static void sf_passwd_cb_done(struct tevent_req *req)
+{
+    struct files_id_ctx *id_ctx;
+    errno_t ret;
+
+    id_ctx = tevent_req_callback_data(req, struct files_id_ctx);
+
+    ret = sf_enum_files_recv(req);
+    talloc_zfree(req);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
               "Could not update files: [%d]: %s\n",
@@ -839,13 +1038,14 @@ done:
     id_ctx->updating_passwd = false;
     sf_cb_done(id_ctx);
     files_account_info_finished(id_ctx, BE_REQ_USER, ret);
-    return ret;
 }
 
+static void sf_group_cb_done(struct tevent_req *req);
 static int sf_group_cb(const char *filename, uint32_t flags, void *pvt)
 {
     struct files_id_ctx *id_ctx;
     errno_t ret;
+    struct tevent_req *req;
 
     id_ctx = talloc_get_type(pvt, struct files_id_ctx);
     if (id_ctx == NULL) {
@@ -861,7 +1061,30 @@ static int sf_group_cb(const char *filename, uint32_t flags, void *pvt)
     dp_sbus_reset_groups_memcache(id_ctx->be->provider);
     dp_sbus_reset_initgr_memcache(id_ctx->be->provider);
 
-    ret = sf_enum_files(id_ctx, SF_UPDATE_GROUP);
+    req = sf_enum_files_send(id_ctx, SF_UPDATE_GROUP);
+    if (req == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to start files update.\n");
+        ret = ENOMEM;
+        id_ctx->updating_groups = false;
+        sf_cb_done(id_ctx);
+        files_account_info_finished(id_ctx, BE_REQ_GROUP, ret);
+        return ret;
+    }
+
+    tevent_req_set_callback(req, sf_group_cb_done, id_ctx);
+
+    return EOK;
+}
+
+static void sf_group_cb_done(struct tevent_req *req)
+{
+    struct files_id_ctx *id_ctx;
+    errno_t ret;
+
+    id_ctx = tevent_req_callback_data(req, struct files_id_ctx);
+
+    ret = sf_enum_files_recv(req);
+    talloc_zfree(req);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
               "Could not update files: [%d]: %s\n",
@@ -874,19 +1097,33 @@ done:
     id_ctx->updating_groups = false;
     sf_cb_done(id_ctx);
     files_account_info_finished(id_ctx, BE_REQ_GROUP, ret);
-    return ret;
 }
 
+static void startup_enum_files_done(struct tevent_req *req);
 static void startup_enum_files(struct tevent_context *ev,
                                struct tevent_immediate *imm,
                                void *pvt)
 {
     struct files_id_ctx *id_ctx = talloc_get_type(pvt, struct files_id_ctx);
-    errno_t ret;
+    struct tevent_req *req;
 
     talloc_zfree(imm);
 
-    ret = sf_enum_files(id_ctx, SF_UPDATE_BOTH);
+    req = sf_enum_files_send(id_ctx, SF_UPDATE_BOTH);
+    if (req == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Could not update files after startup.\n");
+        return;
+    }
+
+    tevent_req_set_callback(req, startup_enum_files_done, NULL);
+}
+
+static void startup_enum_files_done(struct tevent_req *req)
+{
+    errno_t ret;
+
+    ret = sf_enum_files_recv(req);
+    talloc_zfree(req);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
               "Could not update files after startup: [%d]: %s\n",

--- a/src/providers/files/files_private.h
+++ b/src/providers/files/files_private.h
@@ -63,7 +63,11 @@ struct files_ctx *sf_init(TALLOC_CTX *mem_ctx,
                           const char **group_files,
                           struct files_id_ctx *id_ctx);
 
+errno_t sf_add_certmap_req(struct files_refresh_ctx *refresh_ctx,
+                           struct tevent_req *req);
 /* files_id.c */
+void handle_certmap(struct tevent_req *req);
+
 struct tevent_req *
 files_account_info_handler_send(TALLOC_CTX *mem_ctx,
                                struct files_id_ctx *id_ctx,

--- a/src/providers/files/files_private.h
+++ b/src/providers/files/files_private.h
@@ -34,6 +34,12 @@
 
 #include "providers/data_provider/dp.h"
 
+enum refresh_task_status {
+    REFRESH_NOT_RUNNIG = 0,
+    REFRESH_WAITING_TO_START,
+    REFRESH_ACTIVE
+};
+
 struct files_id_ctx {
     struct be_ctx *be;
     struct sss_domain_info *domain;
@@ -43,8 +49,7 @@ struct files_id_ctx {
     const char **passwd_files;
     const char **group_files;
 
-    bool updating_passwd;
-    bool updating_groups;
+    struct files_refresh_ctx *refresh_ctx;
 
     struct tevent_req *users_req;
     struct tevent_req *groups_req;

--- a/src/responder/common/cache_req/cache_req_search.c
+++ b/src/responder/common/cache_req/cache_req_search.c
@@ -495,6 +495,15 @@ static void cache_req_search_done(struct tevent_req *subreq)
     state->dp_success = state->cr->plugin->dp_recv_fn(subreq, state->cr);
     talloc_zfree(subreq);
 
+    /* Do not try to read from cache if the domain is inconsistent */
+    if (sss_domain_get_state(state->cr->domain) == DOM_INCONSISTENT) {
+        CACHE_REQ_DEBUG(SSSDBG_TRACE_FUNC, state->cr, "Domain inconsistent, "
+                        "we will not return cached data\n");
+
+        ret = ENOENT;
+        goto done;
+    }
+
     /* Get result from cache again. */
     ret = cache_req_search_cache(state, state->cr, &state->result);
     if (ret != EOK) {

--- a/src/responder/common/responder_dp.c
+++ b/src/responder/common/responder_dp.c
@@ -41,6 +41,12 @@ sss_dp_account_files_params(struct sss_domain_info *dom,
             return EOK;
         }
 
+        if (sss_domain_fallback_to_nss(dom)) {
+            DEBUG(SSSDBG_TRACE_INTERNAL,
+                  "Domain files is not consistent, falling back to nss.\n");
+            return ENOENT;
+        }
+
         DEBUG(SSSDBG_TRACE_INTERNAL,
               "Domain files is not consistent, issuing update\n");
     }

--- a/src/tests/intg/test_files_provider.py
+++ b/src/tests/intg/test_files_provider.py
@@ -151,6 +151,7 @@ def files_domain_only(request):
 
         [domain/files]
         id_provider = files
+        fallback_to_nss = False
     """).format(**locals())
     create_conf_fixture(request, conf)
     create_sssd_fixture(request)
@@ -180,6 +181,7 @@ def files_multiple_sources(request):
 
         [domain/files]
         id_provider = files
+        fallback_to_nss = False
         passwd_files = {passwd_list}
         group_files = {group_list}
         debug_level = 10
@@ -214,6 +216,7 @@ def files_multiple_sources_nocreate(request):
 
         [domain/files]
         id_provider = files
+        fallback_to_nss = False
         passwd_files = {passwd_list}
         group_files = {group_list}
         debug_level = 10
@@ -269,6 +272,7 @@ def no_files_domain(request):
 
         [domain/disabled.files]
         id_provider = files
+        fallback_to_nss = False
     """).format(**locals())
     create_conf_fixture(request, conf)
     create_sssd_fixture(request)
@@ -307,6 +311,7 @@ def domain_resolution_order(request):
 
         [domain/files]
         id_provider = files
+        fallback_to_nss = False
     """).format(**locals())
     create_conf_fixture(request, conf)
     create_sssd_fixture(request)
@@ -323,6 +328,7 @@ def default_domain_suffix(request):
 
         [domain/files]
         id_provider = files
+        fallback_to_nss = False
     """).format(**locals())
     create_conf_fixture(request, conf)
     create_sssd_fixture(request)
@@ -338,6 +344,7 @@ def override_homedir_and_shell(request):
 
         [domain/files]
         id_provider = files
+        fallback_to_nss = False
         override_homedir = /test/bar
         override_shell = /bin/bar
 

--- a/src/tests/intg/test_pam_responder.py
+++ b/src/tests/intg/test_pam_responder.py
@@ -141,6 +141,7 @@ def format_pam_cert_auth_conf(config):
         [domain/auth_only]
         debug_level = 10
         id_provider = files
+        fallback_to_nss = False
 
         [certmap/auth_only/user1]
         matchrule = <SUBJECT>.*CN=SSSD test cert 0001.*
@@ -172,6 +173,7 @@ def format_pam_cert_auth_conf_name_format(config):
         full_name_format = %2$s\\%1$s
         debug_level = 10
         id_provider = files
+        fallback_to_nss = False
 
         [certmap/auth_only/user1]
         matchrule = <SUBJECT>.*CN=SSSD test cert 0001.*
@@ -195,6 +197,7 @@ def format_pam_krb5_auth(config, kdc_instance):
         [domain/krb5_auth]
         debug_level = 10
         id_provider = files
+        fallback_to_nss = False
         auth_provider = krb5
 
         krb5_realm = PAMKRB5TEST
@@ -219,6 +222,7 @@ def format_pam_krb5_auth_domains(config, kdc_instance):
         [domain/wrong.dom1]
         debug_level = 10
         id_provider = files
+        fallback_to_nss = False
         auth_provider = krb5
 
         krb5_realm = WRONG1REALM
@@ -227,6 +231,7 @@ def format_pam_krb5_auth_domains(config, kdc_instance):
         [domain/wrong.dom2]
         debug_level = 10
         id_provider = files
+        fallback_to_nss = False
         auth_provider = krb5
 
         krb5_realm = WRONG2REALM
@@ -235,6 +240,7 @@ def format_pam_krb5_auth_domains(config, kdc_instance):
         [domain/wrong.dom3]
         debug_level = 10
         id_provider = files
+        fallback_to_nss = False
         auth_provider = krb5
 
         krb5_realm = WRONG3REALM
@@ -243,6 +249,7 @@ def format_pam_krb5_auth_domains(config, kdc_instance):
         [domain/krb5_auth]
         debug_level = 10
         id_provider = files
+        fallback_to_nss = False
         auth_provider = krb5
 
         krb5_realm = PAMKRB5TEST

--- a/src/util/domain_info_utils.c
+++ b/src/util/domain_info_utils.c
@@ -901,6 +901,11 @@ void sss_domain_set_state(struct sss_domain_info *dom,
           "Domain %s is %s\n", dom->name, domain_state_str(dom));
 }
 
+bool sss_domain_fallback_to_nss(struct sss_domain_info *dom)
+{
+    return dom->fallback_to_nss;
+}
+
 bool sss_domain_is_forest_root(struct sss_domain_info *dom)
 {
     return (dom->forest_root == dom);

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -588,6 +588,7 @@ struct sss_domain_info *find_domain_by_sid(struct sss_domain_info *domain,
 enum sss_domain_state sss_domain_get_state(struct sss_domain_info *dom);
 void sss_domain_set_state(struct sss_domain_info *dom,
                           enum sss_domain_state state);
+bool sss_domain_fallback_to_nss(struct sss_domain_info *dom);
 bool sss_domain_is_forest_root(struct sss_domain_info *dom);
 const char *sss_domain_type_str(struct sss_domain_info *dom);
 


### PR DESCRIPTION
If the files managed by the files provider contain many users or groups
processing them might take a considerable amount of time. To keep the
backend responsive this patch splits the update into multiple steps
running one after the other but returning to the main loop in between.

This avoids issues during startup because the watchdog timer state is
reset properly. Additionally SBUS messages are process and as a result
the domain can be marked inconsistent in the frontends properly.