### PR TITLE
pam_sss: fixed potential mem leak

### DIFF
--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -1720,6 +1720,7 @@ static int prompt_multi_cert_gdm(pam_handle_t *pamh, struct pam_items *pi)
         ret = asprintf(&cai->choice_list_id, "%zu", c);
         if (ret == -1) {
             cai->choice_list_id = NULL;
+            free(prompt);
             ret = ENOMEM;
             goto done;
         }


### PR DESCRIPTION
Fixes following covscan issue:
```
Error: RESOURCE_LEAK (CWE-772): [#def1]
src/sss_client/pam_sss.c:1714: alloc_arg: "asprintf" allocates memory that is stored into "prompt".
src/sss_client/pam_sss.c:1765: leaked_storage: Variable "prompt" going out of scope leaks the storage it points to.
 # 1763|       free(response);
 # 1764|
 # 1765|->     return ret;
 # 1766|   #else
 # 1767|       return ENOTSUP;
```

https://bugzilla.redhat.com/show_bug.cgi?id=1938876