### PR TITLE
AD GPO: respect ad_gpo_implicit_deny if no GPO is present

### DIFF
--- a/src/providers/ad/ad_gpo.c
+++ b/src/providers/ad/ad_gpo.c
@@ -2472,7 +2472,15 @@ ad_gpo_process_gpo_done(struct tevent_req *subreq)
             }
         }
 
-        ret = EOK;
+        if (state->gpo_implicit_deny == true) {
+            DEBUG(SSSDBG_TRACE_FUNC,
+                  "No applicable GPOs have been found and ad_gpo_implicit_deny"
+                  " is set to 'true'. The user will be denied access.\n");
+            ret = ERR_ACCESS_DENIED;
+        } else {
+            ret = EOK;
+        }
+
         goto done;
     }
 


### PR DESCRIPTION
Currently ad_gpo_implicit_deny=True is not applied if there is no GPO at
all for the given client. With this patch this case is handled as
expected as well.

Resolves: https://github.com/SSSD/sssd/issues/5561

:fixes: respect ad_gpo_implicit_deny if no GPO is present