### PR TITLE
DEBUG: Error is printed when everything is ok

### DIFF
--- a/src/util/sss_ini.c
+++ b/src/util/sss_ini.c
@@ -856,11 +856,11 @@ int sss_ini_read_sssd_conf(struct sss_ini *self,
             DEBUG(SSSDBG_CRIT_FAILURE,
                   "Permission check on config file failed.\n");
             return ERR_INI_INVALID_PERMISSION;
-        } else {
-            DEBUG(SSSDBG_CONF_SETTINGS,
-                  "File %1$s does not exist.\n",
-                  (config_file ? config_file : "NULL"));
         }
+    } else {
+        DEBUG(SSSDBG_CONF_SETTINGS,
+              "File %1$s does not exist.\n",
+              (config_file ? config_file : "NULL"));
     }
 
     ret = sss_ini_parse(self);


### PR DESCRIPTION
Due to invalid condition error message that config file does not exist
is printed when there is actually no problem. This update fixes
the condition.

Thanks @alexey-tikhonov for pointing this out.
