### PR TITLE
SSSD Log: log_timeout_parameter_display

### DIFF
--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -795,7 +795,8 @@ static errno_t init_cached_auth_timeout(struct confdb_ctx *cdb,
                          CONFDB_PAM_CRED_TIMEOUT, 0, &cred_expiration);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "Failed to read expiration time of offline credentials.\n");
+              "Failed to read expiration time [%s] of offline credentials.\n",
+              CONFDB_PAM_CRED_TIMEOUT);
         goto done;
     }
 
@@ -936,7 +937,8 @@ static int confdb_get_domain_internal(struct confdb_ctx *cdb,
                          300, &memcache_timeout);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
-              "Unable to get memory cache entry timeout.\n");
+              "Unable to get memory cache entry timeout [%s].\n",
+              CONFDB_MEMCACHE_TIMEOUT);
         goto done;
     }
 

--- a/src/providers/fail_over.c
+++ b/src/providers/fail_over.c
@@ -1034,7 +1034,8 @@ fo_resolve_service_send(TALLOC_CTX *mem_ctx, struct tevent_context *ev,
     ret = fo_resolve_service_activate_timeout(req, ev,
                                         ctx->opts->service_resolv_timeout);
     if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "Could not set service timeout\n");
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Could not set service timeout [dns_resolver_timeout]\n");
         goto done;
     }
 
@@ -1100,7 +1101,7 @@ fo_resolve_service_activate_timeout(struct tevent_req *req,
         return ENOMEM;
     }
 
-    DEBUG(SSSDBG_TRACE_INTERNAL, "Resolve timeout set to %lu seconds\n",
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Resolve timeout [dns_resolver_timeout] set to %lu seconds\n",
           timeout_seconds);
     return EOK;
 }

--- a/src/providers/ldap/sdap_async.c
+++ b/src/providers/ldap/sdap_async.c
@@ -419,7 +419,7 @@ static void sdap_op_timeout(struct tevent_req *req)
     }
 
     /* signal the caller that we have a timeout */
-    DEBUG(SSSDBG_TRACE_LIBS, "Issuing timeout for %d\n", op->msgid);
+    DEBUG(SSSDBG_TRACE_LIBS, "Issuing timeout [ldap_opt_timeout] for message id %d\n", op->msgid);
     op->callback(op, NULL, ETIMEDOUT, op->data);
 }
 
@@ -1520,8 +1520,7 @@ static errno_t sdap_get_generic_ext_step(struct tevent_req *req)
             if (optret == LDAP_SUCCESS) {
                 DEBUG(SSSDBG_MINOR_FAILURE, "Connection error: %s\n", errmsg);
                 sss_log(SSS_LOG_ERR, "LDAP connection error: %s", errmsg);
-            }
-            else {
+            } else {
                 sss_log(SSS_LOG_ERR, "LDAP connection error, %s",
                                      sss_ldap_err2string(lret));
             }
@@ -1803,10 +1802,18 @@ static void generic_ext_search_handler(struct tevent_req *subreq,
 
     ret = sdap_get_generic_ext_recv(subreq, req, &ref_count, &refs);
     talloc_zfree(subreq);
+
     if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "sdap_get_generic_ext_recv failed [%d]: %s\n",
-              ret, sss_strerror(ret));
+        if (ret == ETIMEDOUT) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "sdap_get_generic_ext_recv failed: [%d]: %s "
+                  "[ldap_search_timeout]\n",
+                  ret, sss_strerror(ret));
+        } else {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "sdap_get_generic_ext_recv request failed: [%d]: %s\n",
+                  ret, sss_strerror(ret));
+        }
         tevent_req_error(req, ret);
         return;
     }
@@ -2414,10 +2421,18 @@ static void sdap_sd_search_done(struct tevent_req *subreq)
                                     &state->ref_count,
                                     &state->refs);
     talloc_zfree(subreq);
+
     if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "sdap_get_generic_ext_recv failed [%d]: %s\n",
-              ret, sss_strerror(ret));
+        if (ret == ETIMEDOUT) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "sdap_get_generic_ext_recv request failed: [%d]: %s "
+                  "[ldap_network_timeout]\n",
+                  ret, sss_strerror(ret));
+        } else {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "sdap_get_generic_ext_recv request failed: [%d]: %s\n",
+                  ret, sss_strerror(ret));
+        }
         tevent_req_error(req, ret);
         return;
     }

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -401,7 +401,8 @@ static void responder_idle_handler(struct tevent_context *ev,
     }
 
     DEBUG(SSSDBG_TRACE_INTERNAL,
-          "Re-scheduling the idle timeout for the responder [%p]\n", rctx);
+          "Re-scheduling the idle timeout [%s] for the responder [%p]\n",
+          CONFDB_RESPONDER_IDLE_TIMEOUT, rctx);
 
 end:
     schedule_responder_idle_timer(rctx);
@@ -427,7 +428,8 @@ static errno_t schedule_responder_idle_timer(struct resp_ctx *rctx)
     }
 
     DEBUG(SSSDBG_TRACE_INTERNAL,
-          "Re-scheduling the idle timeout for the responder [%p]\n", rctx);
+          "Re-scheduling the idle timeout [%s] for the responder [%p]\n",
+          CONFDB_RESPONDER_IDLE_TIMEOUT, rctx);
 
     return EOK;
 }
@@ -441,14 +443,15 @@ static errno_t setup_responder_idle_timer(struct resp_ctx *rctx)
     ret = schedule_responder_idle_timer(rctx);
     if (ret != EOK) {
         DEBUG(SSSDBG_TRACE_INTERNAL,
-              "Error scheduling the idle timeout for the responder [%p]: "
+              "Error scheduling the idle timeout [%s] for the responder [%p]: "
               "%d [%s]\n",
-              rctx, ret, sss_strerror(ret));
+              CONFDB_RESPONDER_IDLE_TIMEOUT, rctx, ret, sss_strerror(ret));
         return ret;
     }
 
     DEBUG(SSSDBG_TRACE_INTERNAL,
-          "Setting up the idle timeout for the responder [%p]\n", rctx);
+          "Setting up the idle timeout [%s] for the responder [%p]\n",
+          CONFDB_RESPONDER_IDLE_TIMEOUT, rctx);
 
     return EOK;
 }
@@ -652,7 +655,8 @@ static void client_idle_handler(struct tevent_context *ev,
 
     if (cctx->last_request_time > now) {
         DEBUG(SSSDBG_IMPORTANT_INFO,
-              "Time shift detected, re-scheduling the client timeout\n");
+              "Time shift detected, re-scheduling the client timeout [%s].\n",
+              CONFDB_RESPONDER_CLI_IDLE_TIMEOUT);
         goto done;
     }
 
@@ -1143,7 +1147,8 @@ static errno_t responder_init_ncache(TALLOC_CTX *mem_ctx,
                          15, &tmp_value);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
-              "Fatal failure of setup negative cache timeout.\n");
+              "Fatal failure of setup negative cache timeout [%s].\n",
+              CONFDB_NSS_ENTRY_NEG_TIMEOUT);
         ret = ENOENT;
         goto done;
     }
@@ -1162,7 +1167,8 @@ static errno_t responder_init_ncache(TALLOC_CTX *mem_ctx,
                          &tmp_value);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
-              "Fatal failure of setup negative cache timeout.\n");
+              "Fatal failure of setup negative cache timeout [%s].\n",
+              CONFDB_RESPONDER_LOCAL_NEG_TIMEOUT);
         ret = ENOENT;
         goto done;
     }
@@ -1298,8 +1304,8 @@ int sss_process_init(TALLOC_CTX *mem_ctx,
                          &rctx->client_idle_timeout);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
-              "Cannot get the client idle timeout [%d]: %s\n",
-               ret, strerror(ret));
+              "Cannot get the client idle timeout [%s] [%d]: %s\n",
+              CONFDB_RESPONDER_CLI_IDLE_TIMEOUT, ret, strerror(ret));
         goto fail;
     }
 
@@ -1331,13 +1337,17 @@ int sss_process_init(TALLOC_CTX *mem_ctx,
                          GET_DOMAINS_DEFAULT_TIMEOUT, &rctx->domains_timeout);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
-              "Cannot get the default domain timeout [%d]: %s\n",
-               ret, strerror(ret));
+              "Cannot get the default domain timeout [%s] [%d]: %s\n",
+              CONFDB_RESPONDER_GET_DOMAINS_TIMEOUT, ret, strerror(ret));
         goto fail;
     }
 
     if (rctx->domains_timeout < 0) {
-        DEBUG(SSSDBG_CONF_SETTINGS, "timeout can't be set to negative value, setting default\n");
+        DEBUG(SSSDBG_CONF_SETTINGS,
+              "timeout [%s] can't be set to negative value, "
+              "setting default [%d] seconds.\n",
+              CONFDB_RESPONDER_GET_DOMAINS_TIMEOUT,
+              GET_DOMAINS_DEFAULT_TIMEOUT);
         rctx->domains_timeout = GET_DOMAINS_DEFAULT_TIMEOUT;
     }
 
@@ -1663,8 +1673,8 @@ errno_t responder_setup_idle_timeout_config(struct resp_ctx *rctx)
                          &rctx->idle_timeout);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
-              "Cannot get the responder idle timeout [%d]: %s\n",
-              ret, sss_strerror(ret));
+              "Cannot get the responder idle timeout [%s] [%d]: %s\n",
+              CONFDB_RESPONDER_IDLE_TIMEOUT, ret, sss_strerror(ret));
         goto fail;
     }
 
@@ -1689,9 +1699,10 @@ errno_t responder_setup_idle_timeout_config(struct resp_ctx *rctx)
         if (ret != EOK) {
             DEBUG(SSSDBG_MINOR_FAILURE,
                   "An error occurred when setting up the responder's idle "
-                  "timeout for the responder [%p]: %s [%d].\n"
+                  "timeout [%s] for the responder [%p]: %s [%d].\n"
                   "The responder won't be automatically shutdown after %d "
-                  "seconds inactive. \n",
+                  "seconds inactive.\n",
+                  CONFDB_RESPONDER_IDLE_TIMEOUT,
                   rctx, sss_strerror(ret), ret,
                   rctx->idle_timeout);
         }

--- a/src/responder/kcm/kcm.c
+++ b/src/responder/kcm/kcm.c
@@ -106,8 +106,8 @@ static int kcm_get_config(struct kcm_ctx *kctx)
                          &kctx->rctx->client_idle_timeout);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
-              "Cannot get the client idle timeout [%d]: %s\n",
-               ret, strerror(ret));
+              "Cannot get the client idle timeout [%s] [%d]: %s\n",
+               CONFDB_RESPONDER_CLI_IDLE_TIMEOUT, ret, strerror(ret));
         goto done;
     }
 
@@ -142,7 +142,8 @@ static int kcm_get_config(struct kcm_ctx *kctx)
         ret = responder_setup_idle_timeout_config(kctx->rctx);
         if (ret != EOK) {
             DEBUG(SSSDBG_MINOR_FAILURE,
-                  "Cannot set up idle responder timeout\n");
+                  "Cannot set up idle responder timeout [%s].\n",
+                  CONFDB_RESPONDER_IDLE_TIMEOUT);
             /* Not fatal */
         }
     }

--- a/src/responder/nss/nsssrv.c
+++ b/src/responder/nss/nsssrv.c
@@ -80,7 +80,8 @@ nss_clear_memcache(TALLOC_CTX *mem_ctx,
                          300, &memcache_timeout);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
-              "Unable to get memory cache entry timeout.\n");
+              "Unable to get memory cache entry timeout [%s].\n",
+              CONFDB_MEMCACHE_TIMEOUT);
         goto done;
     }
 

--- a/src/responder/nss/nsssrv_mmap_cache.c
+++ b/src/responder/nss/nsssrv_mmap_cache.c
@@ -1298,7 +1298,7 @@ errno_t sss_mmap_cache_init(TALLOC_CTX *mem_ctx, const char *name,
         return EOK;
     }
     DEBUG(SSSDBG_CONF_SETTINGS,
-          "Fast '%s' mmap cache: timeout = %d, slots = %zu\n",
+          "Fast '%s' mmap cache: memcache_timeout = %d, slots = %zu\n",
           mc_type_to_str(type), (int)timeout, n_elem);
 
     mc_ctx = talloc_zero(mem_ctx, struct sss_mc_ctx);

--- a/src/responder/pac/pacsrv.c
+++ b/src/responder/pac/pacsrv.c
@@ -125,7 +125,8 @@ int pac_process_init(TALLOC_CTX *mem_ctx,
                          &pac_ctx->pac_lifetime);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
-              "Failed to setup negative cache timeout.\n");
+              "Failed to setup pac lifetime timeout [%s].\n",
+              CONFDB_PAC_LIFETIME);
         goto fail;
     }
 

--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -1375,8 +1375,8 @@ static errno_t check_cert(TALLOC_CTX *mctx,
                              &wait_for_card_timeout);
         if (ret != EOK) {
             DEBUG(SSSDBG_CRIT_FAILURE,
-                  "Failed to read wait_for_card_timeout from confdb: [%d]: %s\n",
-                  ret, sss_strerror(ret));
+                  "Failed to read [%s] from confdb: [%d]: %s\n",
+                  CONFDB_PAM_WAIT_FOR_CARD_TIMEOUT, ret, sss_strerror(ret));
             return ret;
         }
 

--- a/src/responder/secrets/secsrv.c
+++ b/src/responder/secrets/secsrv.c
@@ -156,8 +156,8 @@ static int sec_get_config(struct sec_ctx *sctx)
                          &sctx->rctx->client_idle_timeout);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
-              "Cannot get the client idle timeout [%d]: %s\n",
-               ret, strerror(ret));
+              "Cannot get the client idle timeout [%s] [%d]: %s\n",
+               CONFDB_RESPONDER_CLI_IDLE_TIMEOUT, ret, strerror(ret));
         goto fail;
     }
 


### PR DESCRIPTION
Display timeout parameter in SSSD logs.

Resolves: https://github.com/SSSD/sssd/issues/5514