### PR TITLE
nss: prefer homedir overrides over override_homedir option

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -725,6 +725,12 @@ sss_view_ldb_msg_find_element(struct sss_domain_info *dom,
                               const struct ldb_message *msg,
                               const char *attr_name);
 
+const char *sss_view_ldb_msg_find_attr_as_string_ex(struct sss_domain_info *dom,
+                                                  const struct ldb_message *msg,
+                                                  const char *attr_name,
+                                                  const char *default_value,
+                                                  bool *is_override);
+
 const char *sss_view_ldb_msg_find_attr_as_string(struct sss_domain_info *dom,
                                                  const struct ldb_message *msg,
                                                  const char *attr_name,

--- a/src/db/sysdb_views.c
+++ b/src/db/sysdb_views.c
@@ -1788,14 +1788,19 @@ done:
     return val;
 }
 
-const char *sss_view_ldb_msg_find_attr_as_string(struct sss_domain_info *dom,
-                                                 const struct ldb_message *msg,
-                                                 const char *attr_name,
-                                                 const char * default_value)
+const char *sss_view_ldb_msg_find_attr_as_string_ex(struct sss_domain_info *dom,
+                                                  const struct ldb_message *msg,
+                                                  const char *attr_name,
+                                                  const char *default_value,
+                                                  bool *is_override)
 {
     TALLOC_CTX *tmp_ctx = NULL;
     const char *val;
     char *override_attr_name;
+
+    if (is_override != NULL) {
+        *is_override = false;
+    }
 
     if (DOM_HAS_VIEWS(dom)) {
         tmp_ctx = talloc_new(NULL);
@@ -1816,6 +1821,9 @@ const char *sss_view_ldb_msg_find_attr_as_string(struct sss_domain_info *dom,
         if (ldb_msg_find_element(msg, override_attr_name) != NULL) {
             val = ldb_msg_find_attr_as_string(msg, override_attr_name,
                                               default_value);
+            if (is_override != NULL && val != default_value) {
+                *is_override = true;
+            }
             goto done;
         }
     }
@@ -1825,4 +1833,13 @@ const char *sss_view_ldb_msg_find_attr_as_string(struct sss_domain_info *dom,
 done:
     talloc_free(tmp_ctx);
     return val;
+}
+
+const char *sss_view_ldb_msg_find_attr_as_string(struct sss_domain_info *dom,
+                                                 const struct ldb_message *msg,
+                                                 const char *attr_name,
+                                                 const char *default_value)
+{
+    return sss_view_ldb_msg_find_attr_as_string_ex(dom, msg, attr_name,
+                                                   default_value, NULL);
 }

--- a/src/man/include/override_homedir.xml
+++ b/src/man/include/override_homedir.xml
@@ -65,5 +65,13 @@ override_homedir = /home/%u
         Default: Not set (SSSD will use the value
         retrieved from LDAP)
     </para>
+    <para>
+        Please note, the home directory from a specific override for the user,
+        either locally (see
+        <citerefentry><refentrytitle>sss_override</refentrytitle>
+        <manvolnum>8</manvolnum></citerefentry>) or centrally managed IPA
+        id-overrides, has a higher precedence and will be used instead of the
+        value given by override_homedir.
+    </para>
 </listitem>
 </varlistentry>


### PR DESCRIPTION
Currently the override_homedir option will overwrite every home
directory even if a dedicated user override exists. With this patch a
home directory from a dedicated override will be preferred.

Resolves: https://github.com/SSSD/sssd/issues/5589

:relnote: A home directory from a dedicated user override, either local
or centrally managed by IPA, will have a higher precedence than the
override_homedir option.