### PR TITLE
BUILD: prefer PCRE2 over PCRE

### DIFF
--- a/contrib/ci/sssd.supp
+++ b/contrib/ci/sssd.supp
@@ -70,6 +70,18 @@
    ...
 }
 
+# And the same, as above, for pcre2
+{
+   sssd-leak-sss_names_pcre2
+   Memcheck:Leak
+   fun:malloc
+   fun:pcre2_compile_8
+   fun:sss_regexp_pcre2_compile
+   fun:sss_regexp_new
+   fun:sss_names_init_from_args
+   ...
+}
+
 # Ignore tests exiting and abandoning cmocka state, concerns dyndns test
 {
    sssd-leak-cmocka-exit

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -112,7 +112,7 @@ BuildRequires: openssl-devel
 BuildRequires: p11-kit-devel
 BuildRequires: pam_wrapper
 BuildRequires: pam-devel
-BuildRequires: pcre-devel
+BuildRequires: pcre2-devel
 BuildRequires: pkgconfig
 BuildRequires: popt-devel
 BuildRequires: python3-devel

--- a/src/external/libpcre.m4
+++ b/src/external/libpcre.m4
@@ -3,37 +3,37 @@ AC_SUBST(PCRE_CFLAGS)
 
 PKG_CHECK_MODULES(
     [PCRE],
-    [libpcre],
+    [libpcre2-8],
     [
         found_libpcre=yes
-        PKG_CHECK_EXISTS(
-            libpcre >= 7,
-            [AC_MSG_NOTICE([PCRE version is 7 or higher])],
-            [
-                AC_MSG_NOTICE([PCRE version is below 7])
-                AC_DEFINE(
-                    [HAVE_LIBPCRE_LESSER_THAN_7],
-                    1,
-                    [Define if libpcre version is less than 7]
-                )
-            ]
+        AC_DEFINE(
+            [HAVE_LIBPCRE2],
+            1,
+            [Define if libpcre2 is present]
+        )
+        AC_DEFINE(
+            [PCRE2_CODE_UNIT_WIDTH],
+            8,
+            [Define libpcre2 unit size]
         )
     ],
     [
         PKG_CHECK_MODULES(
-            [PCRE2],
-            [libpcre2-8],
+            [PCRE],
+            [libpcre],
             [
                 found_libpcre=yes
-                AC_DEFINE(
-                    [HAVE_LIBPCRE2],
-                    1,
-                    [Define if libpcre2 is present]
-                )
-                AC_DEFINE(
-                    [PCRE2_CODE_UNIT_WIDTH],
-                    8,
-                    [Define libpcre2 unit size]
+                PKG_CHECK_EXISTS(
+                    libpcre >= 7,
+                    [AC_MSG_NOTICE([PCRE version is 7 or higher])],
+                    [
+                        AC_MSG_NOTICE([PCRE version is below 7])
+                        AC_DEFINE(
+                            [HAVE_LIBPCRE_LESSER_THAN_7],
+                            1,
+                            [Define if libpcre version is less than 7]
+                        )
+                    ]
                 )
             ],
             [found_libpcre=no]

--- a/src/tests/cmocka/test_dp_opts.c
+++ b/src/tests/cmocka/test_dp_opts.c
@@ -225,7 +225,7 @@ void opt_test_get(void **state)
                                TEST_DOM_NAME, TEST_ID_PROVIDER, params);
     assert_non_null(tctx);
 
-    ret = dp_get_options(global_talloc_context, tctx->confdb, tctx->conf_dom_path,
+    ret = dp_get_options(tctx, tctx->confdb, tctx->conf_dom_path,
                          test_def_opts, OPT_NUM_OPTS, &opts);
     assert_int_equal(ret, EOK);
 
@@ -262,6 +262,8 @@ void opt_test_get(void **state)
 
     bo = dp_opt_get_bool(opts, OPT_BOOL_FALSE);
     assert_true(bo == false);
+
+    talloc_free(tctx);
 }
 
 static int opt_test_getset_setup(void **state)

--- a/src/tests/cmocka/test_nested_groups.c
+++ b/src/tests/cmocka/test_nested_groups.c
@@ -882,7 +882,7 @@ static int nested_group_external_member_teardown(void **state)
     }
 
     talloc_free(test_ctx->ext_ctx);
-    return nested_groups_test_setup(*state);
+    return nested_groups_test_teardown(*state);
 }
 
 static void nested_external_done(struct tevent_req *req)

--- a/src/util/sss_regexp.c
+++ b/src/util/sss_regexp.c
@@ -42,7 +42,7 @@ struct _sss_regexp_t {
     char *matched_string;
 };
 
-int sss_regexp_pcre2_destroy(sss_regexp_t *self)
+static int sss_regexp_pcre2_destroy(sss_regexp_t *self)
 {
     if (self->re) {
         pcre2_code_free(self->re);
@@ -56,7 +56,7 @@ int sss_regexp_pcre2_destroy(sss_regexp_t *self)
     return 0;
 }
 
-int sss_regexp_pcre2_compile(sss_regexp_t *self,
+static int sss_regexp_pcre2_compile(sss_regexp_t *self,
                              const char *pattern,
                              int options)
 {
@@ -81,7 +81,7 @@ int sss_regexp_pcre2_compile(sss_regexp_t *self,
     return EOK;
 }
 
-int sss_regexp_pcre2_match(sss_regexp_t *self,
+static int sss_regexp_pcre2_match(sss_regexp_t *self,
                            const char *subject,
                            int startoffset,
                            int options)
@@ -105,7 +105,7 @@ int sss_regexp_pcre2_match(sss_regexp_t *self,
                        NULL);
 }
 
-int sss_regexp_pcre2_get_named_substring(sss_regexp_t *self,
+static int sss_regexp_pcre2_get_named_substring(sss_regexp_t *self,
                                          const char *name,
                                          const char **value)
 {
@@ -135,7 +135,7 @@ struct _sss_regexp_t {
     const char *subject;
 };
 
-int sss_regexp_pcre1_destroy(sss_regexp_t *self)
+static int sss_regexp_pcre1_destroy(sss_regexp_t *self)
 {
     if (self->re) {
         pcre_free(self->re);
@@ -146,7 +146,7 @@ int sss_regexp_pcre1_destroy(sss_regexp_t *self)
     return 0;
 }
 
-int sss_regexp_pcre1_compile(sss_regexp_t *self,
+static int sss_regexp_pcre1_compile(sss_regexp_t *self,
                              const char *pattern,
                              int options)
 {
@@ -168,7 +168,7 @@ int sss_regexp_pcre1_compile(sss_regexp_t *self,
     return EOK;
 }
 
-int sss_regexp_pcre1_match(sss_regexp_t *self,
+static int sss_regexp_pcre1_match(sss_regexp_t *self,
                            const char *subject,
                            int startoffset,
                            int options)
@@ -187,7 +187,7 @@ int sss_regexp_pcre1_match(sss_regexp_t *self,
                      SSS_REGEXP_OVEC_SIZE);
 }
 
-int sss_regexp_pcre1_get_named_substring(sss_regexp_t *self,
+static int sss_regexp_pcre1_get_named_substring(sss_regexp_t *self,
                                          const char *name,
                                          const char **value)
 {
@@ -212,7 +212,7 @@ int sss_regexp_pcre1_get_named_substring(sss_regexp_t *self,
 /*
  * sss_regexp talloc destructor
  */
-int sss_regexp_destroy(sss_regexp_t *self)
+static int sss_regexp_destroy(sss_regexp_t *self)
 {
     if (!self) return -1;
 #ifdef HAVE_LIBPCRE2

--- a/src/util/sss_regexp.c
+++ b/src/util/sss_regexp.c
@@ -214,7 +214,7 @@ static int sss_regexp_pcre1_get_named_substring(sss_regexp_t *self,
  */
 static int sss_regexp_destroy(sss_regexp_t *self)
 {
-    if (!self) return -1;
+    if (!self) return 0;
 #ifdef HAVE_LIBPCRE2
     return sss_regexp_pcre2_destroy(self);
 #else


### PR DESCRIPTION
:relnote:This release deprecates pcre1 support. This support will be
removed completely in following releases.