### PR TITLE
sss_cache: reset original timestamp and USN

### DIFF
--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -2021,6 +2021,7 @@ int sysdb_add_user(struct sss_domain_info *domain,
     TALLOC_CTX *tmp_ctx;
     struct ldb_message *msg;
     struct sysdb_attrs *id_attrs;
+    struct ldb_message_element *el = NULL;
     uint32_t id;
     int ret;
     bool posix;
@@ -2168,6 +2169,12 @@ int sysdb_add_user(struct sss_domain_info *domain,
                                  ((cache_timeout) ?
                                   (now + cache_timeout) : 0));
     if (ret) goto done;
+
+    ret = sysdb_attrs_get_el_ext(attrs, SYSDB_INITGR_EXPIRE, false, &el);
+    if (ret == ENOENT) {
+        ret = sysdb_attrs_add_time_t(attrs, SYSDB_INITGR_EXPIRE, 0);
+        if (ret) goto done;
+    }
 
     ret = sysdb_set_user_attr(domain, name, attrs, SYSDB_MOD_REP);
     if (ret) goto done;

--- a/src/tools/sss_cache.c
+++ b/src/tools/sss_cache.c
@@ -568,6 +568,12 @@ static errno_t invalidate_entry(TALLOC_CTX *ctx,
                     ret = sysdb_attrs_add_time_t(sys_attrs,
                             SYSDB_INITGR_EXPIRE, 1);
                     if (ret != EOK) return ret;
+                    ret = sysdb_attrs_add_string(sys_attrs,
+                            SYSDB_ORIG_MODSTAMP, "1");
+                    if (ret != EOK) return ret;
+                    ret = sysdb_attrs_add_uint32(sys_attrs,
+                            SYSDB_USN, 1);
+                    if (ret != EOK) return ret;
 
                     ret = sysdb_set_user_attr(domain, name, sys_attrs,
                                               SYSDB_MOD_REP);
@@ -577,6 +583,13 @@ static errno_t invalidate_entry(TALLOC_CTX *ctx,
                     ret = sysdb_invalidate_user_cache_entry(domain, name);
                     break;
                 case TYPE_GROUP:
+                    ret = sysdb_attrs_add_string(sys_attrs,
+                            SYSDB_ORIG_MODSTAMP, "1");
+                    if (ret != EOK) return ret;
+                    ret = sysdb_attrs_add_uint32(sys_attrs,
+                            SYSDB_USN, 1);
+                    if (ret != EOK) return ret;
+
                     ret = sysdb_set_group_attr(domain, name, sys_attrs,
                                                SYSDB_MOD_REP);
                     if (ret != EOK) break;

--- a/src/tools/sssctl/sssctl_cache.c
+++ b/src/tools/sssctl/sssctl_cache.c
@@ -177,7 +177,7 @@ static errno_t attr_initgr(TALLOC_CTX *mem_ctx,
     errno_t ret;
 
     ret = sysdb_attrs_get_uint32_t(entry, attr, &value);
-    if (ret == ENOENT) {
+    if (ret == ENOENT || (ret == EOK && value == 0)) {
         *_value = "Initgroups were not yet performed";
         return EOK;
     } else if (ret != EOK) {


### PR DESCRIPTION
Currently the sss_cache utility only resets the internal/operational
timestamp attributes to indicate that the object should be refreshed. But
the timestamp cache also stored the last modification time and the update
sequence number (USN) of the original LDAP attribute to detect changes of
the original object. During some types of refreshes those options might be
checked, currently the modification timestamp during group updates, and
might prevent that the data object is refresh because it was assume that
the original object did not change.

Since it is expected that after calling e.g. sss_cache -E the cached
objects are refreshed unconditionally it makes sense to reset those
attributes in the timestamp cache as well.

Resolves: https://github.com/SSSD/sssd/issues/5596