### PR TITLE
man: clarify priority in sss-certmap man page

### DIFF
--- a/src/man/sss-certmap.5.xml
+++ b/src/man/sss-certmap.5.xml
@@ -52,6 +52,14 @@
             Internally the priority is treated as unsigned 32bit integer, using
             a priority value larger than 4294967295 will cause an error.
         </para>
+        <para>
+            If multiple rules have the same priority and only one of the related
+            matching rules applies, this rule will be chosen. If there are
+            multiple rules with the same priority which matches, one is chosen
+            but which one is undefined. To avoid this undefined behavior either
+            use different priorities or make the matching rules more specific
+            e.g. by using distinct &lt;ISSUER&gt; patterns.
+        </para>
     </refsect2>
     <refsect2 id='match'>
         <title>MATCHING RULE</title>


### PR DESCRIPTION
Explain in the man page what is expected when two or more mapping and
matching rules have the same priority.

Resolves: https://github.com/SSSD/sssd/issues/4415