### PR TITLE
ipa: read auto_private_groups from id range if available

### DIFF
--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -354,6 +354,7 @@ enum sss_domain_mpg_mode {
     MPG_DISABLED,
     MPG_ENABLED,
     MPG_HYBRID,
+    MPG_DEFAULT, /* Use default value for given id mapping. */
 };
 
 /**

--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -165,6 +165,7 @@
 #define SYSDB_SECONDARY_BASE_RID "secondaryBaseRID"
 #define SYSDB_DOMAIN_ID "domainID"
 #define SYSDB_ID_RANGE_TYPE "idRangeType"
+#define SYSDB_ID_RANGE_MPG "idRangeMPG"
 
 #define SYSDB_CERTMAP_PRIORITY "priority"
 #define SYSDB_CERTMAP_MATCHING_RULE "matchingRule"
@@ -344,6 +345,7 @@ struct range_info {
     uint32_t secondary_base_rid;
     char *trusted_dom_sid;
     char *range_type;
+    enum sss_domain_mpg_mode mpg_mode;
 };
 
 struct certmap_info {
@@ -563,6 +565,12 @@ errno_t sysdb_subdomain_delete(struct sysdb_ctx *sysdb, const char *name);
 errno_t sysdb_subdomain_content_delete(struct sysdb_ctx *sysdb,
                                        const char *name);
 
+errno_t
+sysdb_subdomain_get_id_by_name(TALLOC_CTX *mem_ctx,
+                               struct sysdb_ctx *sysdb,
+                               const char *name,
+                               const char **_id);
+
 /* The utility function to create a subdomain sss_domain_info object is handy
  * for unit tests, so it should be available in a headerr.
  */
@@ -584,6 +592,10 @@ struct sss_domain_info *new_subdomain(TALLOC_CTX *mem_ctx,
 errno_t sysdb_get_ranges(TALLOC_CTX *mem_ctx, struct sysdb_ctx *sysdb,
                              size_t *range_count,
                              struct range_info ***range_list);
+errno_t sysdb_get_range(TALLOC_CTX *mem_ctx,
+                        struct sysdb_ctx *sysdb,
+                        const char *forest,
+                        struct range_info **_range);
 errno_t sysdb_range_create(struct sysdb_ctx *sysdb, struct range_info *range);
 errno_t sysdb_update_ranges(struct sysdb_ctx *sysdb,
                             struct range_info **ranges);

--- a/src/providers/ipa/ipa_common.h
+++ b/src/providers/ipa/ipa_common.h
@@ -36,6 +36,7 @@
 #define IPA_ID_RANGE_SIZE "ipaIDRangeSize"
 #define IPA_BASE_RID "ipaBaseRID"
 #define IPA_SECONDARY_BASE_RID "ipaSecondaryBaseRID"
+#define IPA_ID_RANGE_MPG "ipaAutoPrivateGroups"
 
 struct ipa_service {
     struct sdap_service *sdap;

--- a/src/providers/ipa/ipa_idmap.c
+++ b/src/providers/ipa/ipa_idmap.c
@@ -333,6 +333,16 @@ errno_t ipa_ranges_parse_results(TALLOC_CTX *mem_ctx,
             goto done;
         }
 
+        ret = sysdb_attrs_get_string(reply[c], IPA_ID_RANGE_MPG, &value);
+        if (ret == EOK) {
+            r->mpg_mode = str_to_domain_mpg_mode(value);
+        } else if (ret == ENOENT) {
+            r->mpg_mode = MPG_DEFAULT;
+        } else {
+            DEBUG(SSSDBG_OP_FAILURE, "sysdb_attrs_get_string failed.\n");
+            goto done;
+        }
+
         ret = get_idmap_data_from_range(r, domain_name, &name1, &sid1, &rid1,
                                         &range1, &mapping1);
         if (ret == ERR_UNSUPPORTED_RANGE_TYPE) {

--- a/src/responder/common/cache_req/cache_req.c
+++ b/src/responder/common/cache_req/cache_req.c
@@ -259,6 +259,11 @@ cache_req_validate_domain(struct cache_req *cr,
         return false;
     }
 
+    ok = !cr->data->hybrid_lookup || domain->mpg_mode == MPG_HYBRID;
+    if (ok == false) {
+        return false;
+    }
+
     return true;
 }
 

--- a/src/responder/common/cache_req/cache_req.h
+++ b/src/responder/common/cache_req/cache_req.h
@@ -175,6 +175,10 @@ void
 cache_req_data_set_propogate_offline_status(struct cache_req_data *data,
                                             bool propogate_offline_status);
 
+void
+cache_req_data_set_hybrid_lookup(struct cache_req_data *data,
+                                 bool hybrid_lookup);
+
 enum cache_req_type
 cache_req_data_get_type(struct cache_req_data *data);
 

--- a/src/responder/common/cache_req/cache_req_data.c
+++ b/src/responder/common/cache_req/cache_req_data.c
@@ -467,6 +467,19 @@ cache_req_data_set_propogate_offline_status(struct cache_req_data *data,
     data->propogate_offline_status = propogate_offline_status;
 }
 
+void
+cache_req_data_set_hybrid_lookup(struct cache_req_data *data,
+                                 bool hybrid_lookup)
+{
+    if (data == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "cache_req_data should never be NULL\n");
+        return;
+    }
+
+    data->hybrid_lookup = hybrid_lookup;
+}
+
+
 enum cache_req_type
 cache_req_data_get_type(struct cache_req_data *data)
 {

--- a/src/responder/common/cache_req/cache_req_private.h
+++ b/src/responder/common/cache_req/cache_req_private.h
@@ -106,6 +106,9 @@ struct cache_req_data {
 
     /* if set, ERR_OFFLINE is returned if data provider is offline */
     bool propogate_offline_status;
+
+    /* if set, only domains with MPG_HYBRID are searched */
+    bool hybrid_lookup;
 };
 
 struct tevent_req *

--- a/src/responder/nss/nss_protocol_sid.c
+++ b/src/responder/nss/nss_protocol_sid.c
@@ -63,6 +63,7 @@ nss_get_id_type(struct nss_cmd_ctx *cmd_ctx,
                 enum sss_id_type *_type)
 {
     errno_t ret;
+    bool mpg;
 
     if (cmd_ctx->sid_id_type != SSS_ID_TYPE_NOT_SPECIFIED) {
         *_type = cmd_ctx->sid_id_type;
@@ -75,9 +76,8 @@ nss_get_id_type(struct nss_cmd_ctx *cmd_ctx,
         return EOK;
     }
 
-    ret = find_sss_id_type(result->msgs[0],
-                           sss_domain_is_mpg(result->domain),
-                           _type);
+    mpg = sss_domain_is_mpg(result->domain) || sss_domain_is_hybrid(result->domain);
+    ret = find_sss_id_type(result->msgs[0], mpg, _type);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
               "Unable to find ID type [%d]: %s\n", ret, sss_strerror(ret));

--- a/src/tests/cmocka/test_ipa_idmap.c
+++ b/src/tests/cmocka/test_ipa_idmap.c
@@ -57,33 +57,35 @@ void test_get_idmap_data_from_range(void **state)
     } d[] = {
         /* working IPA_RANGE_LOCAL range */
         {{RANGE_NAME, BASE_ID, RANGE_SIZE, BASE_RID, SECONDARY_BASE_RID,
-          NULL, discard_const(IPA_RANGE_LOCAL)},
+          NULL, discard_const(IPA_RANGE_LOCAL), MPG_DEFAULT},
          EOK, DOMAIN_NAME, NULL, 0, {BASE_ID, RANGE_MAX}, true},
         /* working old-style IPA_RANGE_LOCAL range without range type */
         {{RANGE_NAME, BASE_ID, RANGE_SIZE, BASE_RID, SECONDARY_BASE_RID,
-          NULL, NULL},
+          NULL, NULL, MPG_DEFAULT},
          EOK, DOMAIN_NAME, NULL, 0, {BASE_ID, RANGE_MAX}, true},
         /* old-style IPA_RANGE_LOCAL without SID and secondary base rid */
-        {{RANGE_NAME, BASE_ID, RANGE_SIZE, BASE_RID, 0, NULL, NULL},
+        {{RANGE_NAME, BASE_ID, RANGE_SIZE, BASE_RID, 0, NULL, NULL,
+          MPG_DEFAULT},
          EINVAL, NULL, NULL, 0, {0, 0}, false},
         /* old-style range with SID and secondary base rid */
         {{RANGE_NAME, BASE_ID, RANGE_SIZE, BASE_RID, SECONDARY_BASE_RID,
-          DOMAIN_SID, NULL},
+          DOMAIN_SID, NULL, MPG_DEFAULT},
          EINVAL, NULL, NULL, 0, {0, 0}, false},
         /* working IPA_RANGE_AD_TRUST range */
         {{RANGE_NAME, BASE_ID, RANGE_SIZE, BASE_RID, 0, DOMAIN_SID,
-          discard_const(IPA_RANGE_AD_TRUST)},
+          discard_const(IPA_RANGE_AD_TRUST), MPG_DEFAULT},
          EOK, DOMAIN_SID, DOMAIN_SID, BASE_RID, {BASE_ID, RANGE_MAX}, false},
         /* working old-style IPA_RANGE_AD_TRUST range without range type */
-        {{RANGE_NAME, BASE_ID, RANGE_SIZE, BASE_RID, 0, DOMAIN_SID, NULL},
+        {{RANGE_NAME, BASE_ID, RANGE_SIZE, BASE_RID, 0, DOMAIN_SID, NULL,
+          MPG_DEFAULT},
          EOK, DOMAIN_SID, DOMAIN_SID, BASE_RID, {BASE_ID, RANGE_MAX}, false},
         /* working IPA_RANGE_AD_TRUST_POSIX range */
         {{RANGE_NAME, BASE_ID, RANGE_SIZE, BASE_RID, 0, DOMAIN_SID,
-          discard_const(IPA_RANGE_AD_TRUST_POSIX)},
+          discard_const(IPA_RANGE_AD_TRUST_POSIX), MPG_DEFAULT},
          EOK, DOMAIN_SID, DOMAIN_SID, 0, {BASE_ID, RANGE_MAX}, true},
         /* IPA_RANGE_AD_TRUST range  with unsupported type */
         {{RANGE_NAME, BASE_ID, RANGE_SIZE, BASE_RID, 0, DOMAIN_SID,
-          discard_const("unsupported-range")},
+          discard_const("unsupported-range"), MPG_DEFAULT},
          ERR_UNSUPPORTED_RANGE_TYPE, NULL, NULL, 0, {0, 0}, false},
         {{0}, 0, NULL, NULL, 0, {0, 0}, false}
     };
@@ -275,11 +277,11 @@ void test_ipa_ranges_parse_results(void **state)
     struct sysdb_attrs *reply[5];
     struct range_info **range_list;
     struct range_info r[5] = {
-        { discard_const("range1"), 1000, 500, 0, 1000, discard_const("S-1-2-1"), discard_const(IPA_RANGE_AD_TRUST) },
-        { discard_const("range2"), 2000, 500, 0, 2000, discard_const("S-1-2-2"), discard_const(IPA_RANGE_AD_TRUST) },
-        { discard_const("range3"), 3000, 500, 0, 3000, discard_const("S-1-2-3"), discard_const("unsupported-type") },
-        { discard_const("range4"), 4000, 500, 0, 4000, discard_const("S-1-2-4"), discard_const(IPA_RANGE_AD_TRUST) },
-        { discard_const("range5"), 5000, 500, 0, 5000, discard_const("S-1-2-5"), discard_const(IPA_RANGE_AD_TRUST) }
+        { discard_const("range1"), 1000, 500, 0, 1000, discard_const("S-1-2-1"), discard_const(IPA_RANGE_AD_TRUST), MPG_DEFAULT },
+        { discard_const("range2"), 2000, 500, 0, 2000, discard_const("S-1-2-2"), discard_const(IPA_RANGE_AD_TRUST), MPG_DEFAULT },
+        { discard_const("range3"), 3000, 500, 0, 3000, discard_const("S-1-2-3"), discard_const("unsupported-type"), MPG_DEFAULT },
+        { discard_const("range4"), 4000, 500, 0, 4000, discard_const("S-1-2-4"), discard_const(IPA_RANGE_AD_TRUST), MPG_DEFAULT },
+        { discard_const("range5"), 5000, 500, 0, 5000, discard_const("S-1-2-5"), discard_const(IPA_RANGE_AD_TRUST), MPG_DEFAULT }
     };
 
     for (c = 0; c < count; c++) {

--- a/src/util/domain_info_utils.c
+++ b/src/util/domain_info_utils.c
@@ -966,6 +966,11 @@ bool sss_domain_is_mpg(struct sss_domain_info *domain)
     return domain->mpg_mode == MPG_ENABLED;
 }
 
+bool sss_domain_is_hybrid(struct sss_domain_info *domain)
+{
+    return domain->mpg_mode == MPG_HYBRID;
+}
+
 enum sss_domain_mpg_mode get_domain_mpg_mode(struct sss_domain_info *domain)
 {
     return domain->mpg_mode;
@@ -980,6 +985,8 @@ const char *str_domain_mpg_mode(enum sss_domain_mpg_mode mpg_mode)
         return "false";
     case MPG_HYBRID:
         return "hybrid";
+    case MPG_DEFAULT:
+        return "default";
     }
 
     return NULL;
@@ -993,7 +1000,10 @@ enum sss_domain_mpg_mode str_to_domain_mpg_mode(const char *str_mpg_mode)
         return MPG_ENABLED;
     } else if (strcasecmp(str_mpg_mode, "HYBRID") == 0) {
         return MPG_HYBRID;
+    } else if (strcasecmp(str_mpg_mode, "DEFAULT") == 0) {
+        return MPG_DEFAULT;
     }
+
 
     DEBUG(SSSDBG_MINOR_FAILURE,
           "Invalid value for %s\n, assuming disabled",

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -626,6 +626,8 @@ bool sss_domain_info_get_output_fqnames(struct sss_domain_info *domain);
 
 bool sss_domain_is_mpg(struct sss_domain_info *domain);
 
+bool sss_domain_is_hybrid(struct sss_domain_info *domain);
+
 enum sss_domain_mpg_mode get_domain_mpg_mode(struct sss_domain_info *domain);
 const char *str_domain_mpg_mode(enum sss_domain_mpg_mode mpg_mode);
 enum sss_domain_mpg_mode str_to_domain_mpg_mode(const char *str_mpg_mode);


### PR DESCRIPTION
The functionality depends on new attribute in IPA:
* https://github.com/freeipa/freeipa/pull/5712 (already merged)

It defaults to current behavior if the attribute is not present.

Resolves: https://github.com/SSSD/sssd/issues/4216

:feature: `auto_private_groups` option can be set centrally through
  ID range setting in IPA (see `ipa idrange` commands family)