### PR TITLE
KCM: return KRB5_FCC_INTERNAL for unknown or not implemented operation

### DIFF
--- a/src/responder/kcm/kcmsrv_cmd.c
+++ b/src/responder/kcm/kcmsrv_cmd.c
@@ -197,7 +197,7 @@ static errno_t kcm_input_parse(struct kcm_reqbuf *reqbuf,
     if (op_io->op == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Did not find a KCM operation handler for the requested opcode\n");
-        return ERR_KCM_MALFORMED_IN_PKT;
+        return ERR_KCM_OP_NOT_IMPLEMENTED;
     }
 
     /* The operation only receives the payload, not the opcode or the protocol info */
@@ -643,7 +643,7 @@ krb5_error_code sss2krb5_error(errno_t err)
     case EACCES:
         return KRB5_FCC_PERM;
     case ERR_KCM_OP_NOT_IMPLEMENTED:
-        return KRB5_CC_NOSUPP;
+        return KRB5_FCC_INTERNAL;
     case ERR_WRONG_NAME_FORMAT:
         return KRB5_CC_BADNAME;
     case ERR_NO_MATCHING_CREDS:


### PR DESCRIPTION
sssd-kcm should follow Heimdal's return codes. Heimdal returns `KRB5_FCC_INTERNAL`
for cases where operation code is not known or not implemented. See:

* https://github.com/heimdal/heimdal/blob/master/kcm/protocol.c#L1785
* https://github.com/heimdal/heimdal/blob/master/kcm/protocol.c#L1792

We returned different codes before this patch which makes Kerberos to differentiate
between Heimdal and sssd implementation. This leads to errors like:

* https://github.com/krb5/krb5/pull/1178#issuecomment-838289703

Resolves: https://github.com/SSSD/sssd/issues/5628