### PR TITLE
Improve assertion when verifying paths for Python modules

### DIFF
--- a/src/tests/pyhbac-test.py
+++ b/src/tests/pyhbac-test.py
@@ -88,7 +88,8 @@ class PyHbacImport(unittest.TestCase):
             print("Could not load the pyhbac module. Please check if it is "
                   "compiled", file=sys.stderr)
             raise e
-        self.assertEqual(pyhbac.__file__, MODPATH + "/pyhbac.so")
+        self.assertEqual(os.path.realpath(pyhbac.__file__),
+                         os.path.realpath(MODPATH + "/pyhbac.so"))
 
 
 class PyHbacRuleElementTest(unittest.TestCase):

--- a/src/tests/pysss-test.py
+++ b/src/tests/pysss-test.py
@@ -58,7 +58,8 @@ class PysssImport(unittest.TestCase):
             print("Could not load the pysss module. Please check if it is "
                   "compiled", file=sys.stderr)
             raise ex
-        self.assertEqual(pysss.__file__, MODPATH + "/pysss.so")
+        self.assertEqual(os.path.realpath(pysss.__file__),
+                         os.path.realpath(MODPATH + "/pysss.so"))
 
 
 class PysssEncryptTest(unittest.TestCase):

--- a/src/tests/pysss_murmur-test.py
+++ b/src/tests/pysss_murmur-test.py
@@ -59,7 +59,8 @@ class PySssMurmurImport(unittest.TestCase):
             print("Could not load the pysss_murmur module. "
                   "Please check if it is compiled", file=sys.stderr)
             raise e
-        self.assertEqual(pysss_murmur.__file__, MODPATH + "/pysss_murmur.so")
+        self.assertEqual(os.path.realpath(pysss_murmur.__file__),
+                         os.path.realpath(MODPATH + "/pysss_murmur.so"))
 
 
 class PySssMurmurTestNeg(unittest.TestCase):


### PR DESCRIPTION
In Ubuntu we're facing a problem where the 3 Python tests under
src/tests/*-test.py are failing due to cosmetical differences between
what the `.__file__` method returns and what `MODPATH` ends up being.

I have not been able to pinpoint exactly what is causing this issue;
it only happens when SSSD is built inside a chroot environment (with
sbuild, for example).  The logs look like this:

```python
F
======================================================================
FAIL: testImport (__main__.PyHbacImport)
Import the module and assert it comes from tree
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/src/tests/pyhbac-test.py", line 91, in testImport
    self.assertEqual(pyhbac.__file__, MODPATH + "/pyhbac.so")
AssertionError: '/<<PKGBUILDDIR>>/build/./tp_pyhbac_xw2omut2/pyhbac.so' != './tp_pyhbac_xw2omut2/pyhbac.so'
- /<<PKGBUILDDIR>>/build/./tp_pyhbac_xw2omut2/pyhbac.so
+ ./tp_pyhbac_xw2omut2/pyhbac.so
```

Given that the intention of the test is to verify that the two paths
are equal, I suggest that we do this slight improvement and call
`os.path.realpath` before comparing both paths.  This way we guarantee
that they're both properly canonicalized.

I have verified that the tests still pass with this change.