### PR TITLE
UTIL/SECRETS: mistype fix

### DIFF
--- a/src/util/secrets/secrets.c
+++ b/src/util/secrets/secrets.c
@@ -1000,14 +1000,14 @@ errno_t sss_sec_list_cc_uuids(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-	uuid_list = talloc_zero_array(tmp_ctx, const char *, res->count);
+    uuid_list = talloc_zero_array(tmp_ctx, const char *, res->count);
     if (uuid_list == NULL) {
         ret = ENOMEM;
         goto done;
     }
 
-	uid_list = talloc_zero_array(tmp_ctx, const char *, res->count);
-    if (uuid_list == NULL) {
+    uid_list = talloc_zero_array(tmp_ctx, const char *, res->count);
+    if (uid_list == NULL) {
         ret = ENOMEM;
         goto done;
     }


### PR DESCRIPTION
Wrong variable was tested after mem allocation.

Also fixes following covscan issues:
```
Error: DEADCODE (CWE-561):
sssd-2.5.0/src/util/secrets/secrets.c:1004: cond_notnull: Condition "uuid_list == NULL", taking false branch. Now the value of "uuid_list" is not "NULL".
sssd-2.5.0/src/util/secrets/secrets.c:1010: notnull: At condition "uuid_list == NULL", the value of "uuid_list" cannot be "NULL".
sssd-2.5.0/src/util/secrets/secrets.c:1010: dead_error_condition: The condition "uuid_list == NULL" cannot be true.
sssd-2.5.0/src/util/secrets/secrets.c:1011: dead_error_begin: Execution cannot reach this statement: "ret = 12;".
 # 1009|   	uid_list = talloc_zero_array(tmp_ctx, const char *, res->count);
 # 1010|       if (uuid_list == NULL) {
 # 1011|->         ret = ENOMEM;
 # 1012|           goto done;
 # 1013|       }
```