### PR TITLE
TOOLS: removed unneeded debug message

### DIFF
--- a/src/tools/common/sss_tools.c
+++ b/src/tools/common/sss_tools.c
@@ -512,7 +512,6 @@ int sss_tool_main(int argc, const char **argv,
 
     uid = getuid();
     if (uid != 0) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Running under %d, must be root\n", uid);
         ERROR("%1$s must be run as root\n", argv[0]);
         return EXIT_FAILURE;
     }


### PR DESCRIPTION
This message was logged before `sss_tool_init()` that sets debug level,
thus ignoring configured debug level.

Since the same message is printed via `ERROR` on a next line, this log
message doesn't add any information and can be simply removed.