### PR TITLE
SSSD man: man_dns_resolver_parameter_modification

### DIFF
--- a/src/man/include/dns_options.xml
+++ b/src/man/include/dns_options.xml
@@ -1,0 +1,52 @@
+<variablelist>
+    <varlistentry>
+        <term>
+            dns_resolver_server_timeout (integer)
+        </term>
+        <listitem>
+            <para>
+                Defines the amount of time (in milliseconds) SSSD
+                would wait for a response from a DNS server before
+                trying the query via another DNS server.
+            </para>
+            <para>
+                Default: 1000
+            </para>
+        </listitem>
+    </varlistentry>
+
+    <varlistentry>
+        <term>
+            dns_resolver_op_timeout (integer)
+        </term>
+        <listitem>
+            <para>
+                Defines the amount of time (in seconds) to
+                resolve a single DNS query (e.g. resolution of a
+                hostname or an SRV record) before trying the
+                next hostname or DNS discovery.
+            </para>
+            <para>
+                Default: 3
+            </para>
+        </listitem>
+    </varlistentry>
+
+    <varlistentry>
+        <term>
+            dns_resolver_timeout (integer)
+        </term>
+        <listitem>
+            <para>
+                Defines the amount of time (in seconds) to wait
+                for a reply from the internal failover service
+                before assuming that the service is unreachable.
+                If this timeout is reached, the domain will
+                continue to operate in offline mode.
+            </para>
+            <para>
+                Default: 6
+            </para>
+        </listitem>
+    </varlistentry>
+</variablelist>

--- a/src/man/include/failover.xml
+++ b/src/man/include/failover.xml
@@ -64,60 +64,8 @@
             you can consider changing the time outs.
         </para>
         <para>
-            This section lists the available tunables. Please refer to their
-            description in the
-            <citerefentry>
-                <refentrytitle>sssd.conf</refentrytitle><manvolnum>5</manvolnum>
-            </citerefentry>,
-            manual page.
-            <variablelist>
-                <varlistentry>
-                    <term>
-                        dns_resolver_server_timeout
-                    </term>
-                    <listitem>
-                        <para>
-                            Time in milliseconds that sets how long would SSSD
-                            talk to a single DNS server before trying next one.
-                        </para>
-                        <para>
-                            Default: 1000
-                        </para>
-                    </listitem>
-                </varlistentry>
-                <varlistentry>
-                    <term>
-                        dns_resolver_op_timeout
-                    </term>
-                    <listitem>
-                        <para>
-                            Time in seconds to tell how long would SSSD try
-                            to resolve single DNS query (e.g. resolution of a
-                            hostname or an SRV record) before trying the next
-                            hostname or discovery domain.
-                        </para>
-                        <para>
-                            Default: 3
-                        </para>
-                    </listitem>
-                </varlistentry>
-                <varlistentry>
-                    <term>
-                        dns_resolver_timeout
-                    </term>
-                    <listitem>
-                        <para>
-                            How long would SSSD try to resolve a failover
-                            service. This service resolution internally might
-                            include several steps, such as resolving DNS SRV
-                            queries or locating the site.
-                        </para>
-                        <para>
-                            Default: 6
-                        </para>
-                    </listitem>
-                </varlistentry>
-            </variablelist>
+            This section lists the available tunables.
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="dns_options.xml" />
         </para>
         <para>
             For LDAP-based providers, the resolve operation is performed

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -3407,6 +3407,45 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                 </varlistentry>
 
                 <varlistentry>
+                    <term>dns_resolver_server_timeout (integer)</term>
+                    <listitem>
+                        <para>
+                            Defines the amount of time (in milliseconds)
+                            SSSD would try to talk to DNS server before
+                            trying next DNS server.
+                        </para>
+                        <para>
+                            Please see the section <quote>FAILOVER</quote>
+                            for more information about the service
+                            resolution.
+                        </para>
+                        <para>
+                            Default: 1000
+                        </para>
+                    </listitem>
+                </varlistentry>
+
+                <varlistentry>
+                    <term>dns_resolver_op_timeout (integer)</term>
+                    <listitem>
+                        <para>
+                            Defines the amount of time (in seconds) to
+                            wait to resolve single DNS query
+                            (e.g. resolution of a hostname or an SRV record)
+                            before try next hostname or DNS discovery.
+                        </para>
+                        <para>
+                            Please see the section <quote>FAILOVER</quote>
+                            for more information about the service
+                            resolution.
+                        </para>
+                        <para>
+                            Default: 3
+                        </para>
+                    </listitem>
+                </varlistentry>
+
+                <varlistentry>
                     <term>dns_resolver_timeout (integer)</term>
                     <listitem>
                         <para>

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -3405,67 +3405,11 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                         </para>
                     </listitem>
                 </varlistentry>
+            </variablelist>
 
-                <varlistentry>
-                    <term>dns_resolver_server_timeout (integer)</term>
-                    <listitem>
-                        <para>
-                            Defines the amount of time (in milliseconds)
-                            SSSD would try to talk to DNS server before
-                            trying next DNS server.
-                        </para>
-                        <para>
-                            Please see the section <quote>FAILOVER</quote>
-                            for more information about the service
-                            resolution.
-                        </para>
-                        <para>
-                            Default: 1000
-                        </para>
-                    </listitem>
-                </varlistentry>
+                <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="include/dns_options.xml" />
 
-                <varlistentry>
-                    <term>dns_resolver_op_timeout (integer)</term>
-                    <listitem>
-                        <para>
-                            Defines the amount of time (in seconds) to
-                            wait to resolve single DNS query
-                            (e.g. resolution of a hostname or an SRV record)
-                            before try next hostname or DNS discovery.
-                        </para>
-                        <para>
-                            Please see the section <quote>FAILOVER</quote>
-                            for more information about the service
-                            resolution.
-                        </para>
-                        <para>
-                            Default: 3
-                        </para>
-                    </listitem>
-                </varlistentry>
-
-                <varlistentry>
-                    <term>dns_resolver_timeout (integer)</term>
-                    <listitem>
-                        <para>
-                            Defines the amount of time (in seconds) to
-                            wait for a reply from the internal fail over
-                            service before assuming that the service is
-                            unreachable. If this timeout is reached, the
-                            domain will continue to operate in offline mode.
-                        </para>
-                        <para>
-                            Please see the section <quote>FAILOVER</quote>
-                            for more information about the service
-                            resolution.
-                        </para>
-                        <para>
-                            Default: 6
-                        </para>
-                    </listitem>
-                </varlistentry>
-
+            <variablelist>
                 <varlistentry>
                     <term>dns_discovery_domain (string)</term>
                     <listitem>


### PR DESCRIPTION
Adding parameter dns_resolver_server_timeout
and dns_resolver_op_timeout in sssd.conf

Resolves: https://github.com/SSSD/sssd/issues/5616