### PR TITLE
responder: fix covscan issues

### DIFF
--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -1041,7 +1041,8 @@ int activate_unix_sockets(struct resp_ctx *rctx,
 
             ret = getsockname(rctx->lfd, (struct sockaddr *) &sockaddr, &sockaddr_len);
             if (ret == EOK) {
-                if (memcmp(rctx->sock_name, sockaddr.sun_path, strlen(rctx->sock_name)) != 0) {
+                if (rctx->sock_name &&
+                    memcmp(rctx->sock_name, sockaddr.sun_path, strlen(rctx->sock_name)) != 0) {
                     DEBUG(SSSDBG_CONF_SETTINGS,
                           "Warning: socket path defined in systemd unit (%s) and sssd.conf (%s) don't match\n",
                           sockaddr.sun_path, rctx->sock_name);


### PR DESCRIPTION
Fix two covscan issues that I accidentally included in commit
f890fc4b592767f3f0b2bd5515cbd9516505ebe9.

Error: FORWARD_NULL (CWE-476): [#def60]
sssd-2.4.0/src/responder/common/responder_common.c:1009: var_compare_op: Comparing "rctx->sock_name" to null implies that "rctx->sock_name" might be null.
sssd-2.4.0/src/responder/common/responder_common.c:1039: var_deref_model: Passing null pointer "rctx->sock_name" to "strlen", which dereferences it.

Error: CLANG_WARNING: [#def61]
sssd-2.4.0/src/responder/common/responder_common.c:1039:64: warning[core.NonNullParamChecker]: Null pointer passed to 1st parameter expecting 'nonnull'

Resolves: https://github.com/SSSD/sssd/issues/5638