### PR TITLE
krb5_child: Honor Kerberos keytab location

### DIFF
--- a/src/man/sssd-krb5.5.xml
+++ b/src/man/sssd-krb5.5.xml
@@ -244,7 +244,7 @@
                             credentials obtained from KDCs.
                         </para>
                         <para>
-                            Default: /etc/krb5.keytab
+                            Default: System keytab, normally <filename>/etc/krb5.keytab</filename>
                         </para>
                     </listitem>
                 </varlistentry>

--- a/src/providers/ad/ad_opts.c
+++ b/src/providers/ad/ad_opts.c
@@ -173,7 +173,7 @@ struct dp_option ad_def_krb5_opts[] = {
     { "krb5_ccachedir", DP_OPT_STRING, { DEFAULT_CCACHE_DIR }, NULL_STRING },
     { "krb5_ccname_template", DP_OPT_STRING, NULL_STRING, NULL_STRING},
     { "krb5_auth_timeout", DP_OPT_NUMBER, { .number = 6 }, NULL_NUMBER },
-    { "krb5_keytab", DP_OPT_STRING, { "/etc/krb5.keytab" }, NULL_STRING },
+    { "krb5_keytab", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "krb5_validate", DP_OPT_BOOL, BOOL_TRUE, BOOL_TRUE },
     { "krb5_kpasswd", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "krb5_backup_kpasswd", DP_OPT_STRING, NULL_STRING, NULL_STRING },

--- a/src/providers/krb5/krb5_child_handler.c
+++ b/src/providers/krb5/krb5_child_handler.c
@@ -119,8 +119,8 @@ static errno_t create_send_buffer(struct krb5child_req *kr,
 
     keytab = dp_opt_get_cstring(kr->krb5_ctx->opts, KRB5_KEYTAB);
     if (keytab == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Missing keytab option.\n");
-        return EINVAL;
+        DEBUG(SSSDBG_TRACE_FUNC, "krb5_keytab not set for domain in sssd.conf\n");
+        keytab = "";
     }
 
     validate = dp_opt_get_bool(kr->krb5_ctx->opts, KRB5_VALIDATE) ? 1 : 0;

--- a/src/providers/krb5/krb5_opts.c
+++ b/src/providers/krb5/krb5_opts.c
@@ -29,7 +29,7 @@ struct dp_option default_krb5_opts[] = {
     { "krb5_ccachedir", DP_OPT_STRING, { DEFAULT_CCACHE_DIR }, NULL_STRING },
     { "krb5_ccname_template", DP_OPT_STRING, NULL_STRING, NULL_STRING},
     { "krb5_auth_timeout", DP_OPT_NUMBER, { .number = 6 }, NULL_NUMBER },
-    { "krb5_keytab", DP_OPT_STRING, { "/etc/krb5.keytab" }, NULL_STRING },
+    { "krb5_keytab", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "krb5_validate", DP_OPT_BOOL, BOOL_FALSE, BOOL_FALSE },
     { "krb5_kpasswd", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "krb5_backup_kpasswd", DP_OPT_STRING, NULL_STRING, NULL_STRING },


### PR DESCRIPTION
Kerberos keytab location can be specified per domain in sssd.conf.
If it is not specified - default path is used: /etc/krb5.keytab
The problem is that default path itself can be redefined for kerberos
by adding entry in krb5.conf:

  [libdefaults]
  default_keytab_name = /<PATH>/krb5.keytab

krb5_child will still use /etc/krb5.keytab as default value which
will cause an error.

This patch adds config checking to krb5_child.
If keytab parameter will be set to /etc/krb5.keytab,
krb5_child will validate it against krb5.conf and eventually
overwritte with value presented there.