### PR TITLE
README: Update documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ SSSD maintains two release streams - stable and LTM. Releases designated as
 LTM are long-term maintenance releases and will see bugfixes and security
 patches for a longer time than other releases.
 
-The list of all releases is maintained together with [SSSD documentation](https://sssd.io/docs/users/releases.html).
+The list of all releases is maintained together with [SSSD documentation](https://sssd.io/releases.html).
 
 ## Building and installation from source
-Please see the [our developer documentation](https://sssd.io/docs/developers/).
+Please see the [our developer documentation](https://sssd.io/contrib/building-sssd.html).
 
 ## Documentation
 The most up-to-date documentation can be found at https://sssd.io.
@@ -31,7 +31,7 @@ Its source code is hosted at https://github.com/SSSD/sssd.github.io.
 
 ## Submitting bugs
 Please file an issue in the [SSSD github instance](https://github.com/SSSD/sssd/issues).
-Make sure to follow the [guide on reporting SSSD bugs](https://sssd.io/docs/users/reporting_bugs.html).
+Make sure to follow the [guide on reporting SSSD bugs](https://sssd.io/docs/reporting-bugs.html).
 
 ## Licensing
 Please see the file called [COPYING](COPYING).


### PR DESCRIPTION
Documentation links in README are broken due to sssd.io website
content recent update. This PR fix this and remaps links to point
correct content in new upstream documentation.