### PR TITLE
TEST: Use absolute path for the MODPATH assertions in python tests

### DIFF
--- a/src/tests/pyhbac-test.py
+++ b/src/tests/pyhbac-test.py
@@ -27,7 +27,7 @@ import copy
 import tempfile
 
 BUILD_DIR = os.getenv('builddir') or "."
-TEST_DIR = os.getenv('SSS_TEST_DIR') or "."
+TEST_DIR = os.path.realpath(os.getenv('SSS_TEST_DIR') or ".")
 MODPATH = tempfile.mkdtemp(prefix="tp_pyhbac_", dir=TEST_DIR)
 
 

--- a/src/tests/pysss-test.py
+++ b/src/tests/pysss-test.py
@@ -26,7 +26,7 @@ import os
 import tempfile
 
 BUILD_DIR = os.getenv('builddir') or "."
-TEST_DIR = os.getenv('SSS_TEST_DIR') or "."
+TEST_DIR = os.path.realpath(os.getenv('SSS_TEST_DIR') or ".")
 MODPATH = tempfile.mkdtemp(prefix="tp_pysss_", dir=TEST_DIR)
 
 

--- a/src/tests/pysss_murmur-test.py
+++ b/src/tests/pysss_murmur-test.py
@@ -25,7 +25,7 @@ import os
 import tempfile
 
 BUILD_DIR = os.getenv('builddir') or "."
-TEST_DIR = os.getenv('SSS_TEST_DIR') or "."
+TEST_DIR = os.path.realpath(os.getenv('SSS_TEST_DIR') or ".")
 MODPATH = tempfile.mkdtemp(prefix="tp_pysss_murmur_", dir=TEST_DIR)
 
 


### PR DESCRIPTION
Since 2.5.0 I had these 3 tests fail with the following assertion error:

```
======================================================================
FAIL: testImport (__main__.PyHbacImport)
Import the module and assert it comes from tree
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/build/sssd/src/sssd-2.5.0/src/tests/pyhbac-test.py", line 91, in testImport
    self.assertEqual(pyhbac.__file__, MODPATH + "/pyhbac.so")
AssertionError: '/build/sssd/src/sssd-2.5.0/./tp_pyhbac_za3ox6lp/pyhbac.so' != './tp_pyhbac_za3ox6lp/pyhbac.so'
- /build/sssd/src/sssd-2.5.0/./tp_pyhbac_za3ox6lp/pyhbac.so
+ ./tp_pyhbac_za3ox6lp/pyhbac.so
```

I don't know what changed but the issue here is related to a long-standing bug [1] in `tempfile.mkdtemp` where the returned path is not absolute if the dir parameter is relative, despite the documentation saying that the returned path is always absolute.

[1] https://bugs.python.org/issue7325