### PR TITLE
pac: allow larger PACs

### DIFF
--- a/src/responder/common/responder_packet.c
+++ b/src/responder/common/responder_packet.c
@@ -227,6 +227,7 @@ int sss_packet_recv(struct sss_packet *packet, int fd)
             break;
 
         case SSS_GSSAPI_SEC_CTX:
+        case SSS_PAC_ADD_PAC_USER:
             max_recv_size = SSS_GSSAPI_PACKET_MAX_RECV_SIZE;
             break;
 


### PR DESCRIPTION
Currently the PAC responder only accepts request which are about 1k in
size. Since a PAC can be larger there are cases where the PAC is not
accepted by the PAC responder. Recently SSS_GSSAPI_PACKET_MAX_RECV_SIZE
was added to be able to handle Kerberos tickets which can be also larger
than 1k. Since typically if present the PAC is the largest part of a
Kerberos ticket it make sense to use the same limit for the PAC
responder.

Resolves: https://github.com/SSSD/sssd/issues/5650