### PR TITLE
kcm: use %zu as format for size_t

### DIFF
--- a/src/responder/kcm/kcm_renew.c
+++ b/src/responder/kcm/kcm_renew.c
@@ -641,7 +641,7 @@ errno_t kcm_renew_all_tgts(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    DEBUG(SSSDBG_TRACE_FUNC, "Found [%lu] renewal entries.\n", count - 1);
+    DEBUG(SSSDBG_TRACE_FUNC, "Found [%zu] renewal entries.\n", count - 1);
     for (int i = 0; i < count - 1; i++) {
         cc = cc_list[i];
         DEBUG(SSSDBG_TRACE_FUNC,

--- a/src/responder/kcm/kcmsrv_ccache_secdb.c
+++ b/src/responder/kcm/kcmsrv_ccache_secdb.c
@@ -977,7 +977,7 @@ static errno_t ccdb_secdb_list_all_cc(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    DEBUG(SSSDBG_TRACE_INTERNAL, "Found [%lu] ccache uuids\n", uuid_list_count);
+    DEBUG(SSSDBG_TRACE_INTERNAL, "Found [%zu] ccache uuids\n", uuid_list_count);
 
     /* New count is full cc list size minus getpwuid() failures */
     ret = ccdb_secdb_get_cc_for_uuid(mem_ctx, uuid_list_count, uuid_list,


### PR DESCRIPTION
size_t might be a different integer type on different platforms. The %z
length modifier was added to handle this.

Resolves: https://github.com/SSSD/sssd/issues/2765