### PR TITLE
test: replace deprecated libcheck macros

### DIFF
--- a/src/tests/ad_ldap_opt-tests.c
+++ b/src/tests/ad_ldap_opt-tests.c
@@ -41,11 +41,11 @@ START_TEST(test_compare_opts)
 
     ret = compare_dp_options(default_basic_opts, SDAP_OPTS_BASIC,
                              ad_def_ldap_opts);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 
     ret = compare_dp_options(default_krb5_opts, KRB5_OPTS,
                              ad_def_krb5_opts);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 }
 END_TEST
 
@@ -56,27 +56,27 @@ START_TEST(test_compare_sdap_attrs)
     /* General Attributes */
     ret = compare_sdap_attr_maps(generic_attr_map, SDAP_AT_GENERAL,
                                  ad_2008r2_attr_map);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 
     /* User Attributes */
     ret = compare_sdap_attr_maps(rfc2307_user_map, SDAP_OPTS_USER,
                                  ad_2008r2_user_map);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 
     /* Group Attributes */
     ret = compare_sdap_attr_maps(rfc2307_group_map, SDAP_OPTS_GROUP,
                                  ad_2008r2_group_map);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 
     /* Netgroup Attributes */
     ret = compare_sdap_attr_maps(netgroup_map, SDAP_OPTS_NETGROUP,
                                  ad_netgroup_map);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 
     /* Service Attributes */
     ret = compare_sdap_attr_maps(service_map, SDAP_OPTS_SERVICES,
                                  ad_service_map);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 }
 END_TEST
 

--- a/src/tests/auth-tests.c
+++ b/src/tests/auth-tests.c
@@ -62,13 +62,13 @@ static int setup_sysdb_tests(struct sysdb_test_ctx **ctx)
     /* (relative to current dir) */
     ret = mkdir(TESTS_PATH, 0775);
     if (ret == -1 && errno != EEXIST) {
-        fail("Could not create %s directory", TESTS_PATH);
+        ck_abort_msg("Could not create %s directory", TESTS_PATH);
         return EFAULT;
     }
 
     test_ctx = talloc_zero(NULL, struct sysdb_test_ctx);
     if (test_ctx == NULL) {
-        fail("Could not allocate memory for test context");
+        ck_abort_msg("Could not allocate memory for test context");
         return ENOMEM;
     }
 
@@ -77,14 +77,14 @@ static int setup_sysdb_tests(struct sysdb_test_ctx **ctx)
      */
     test_ctx->ev = tevent_context_init(test_ctx);
     if (test_ctx->ev == NULL) {
-        fail("Could not create event context");
+        ck_abort_msg("Could not create event context");
         talloc_free(test_ctx);
         return EIO;
     }
 
     conf_db = talloc_asprintf(test_ctx, "%s/%s", TESTS_PATH, TEST_CONF_FILE);
     if (conf_db == NULL) {
-        fail("Out of memory, aborting!");
+        ck_abort_msg("Out of memory, aborting!");
         talloc_free(test_ctx);
         return ENOMEM;
     }
@@ -93,7 +93,7 @@ static int setup_sysdb_tests(struct sysdb_test_ctx **ctx)
     /* Connect to the conf db */
     ret = confdb_init(test_ctx, &test_ctx->confdb, conf_db);
     if (ret != EOK) {
-        fail("Could not initialize connection to the confdb");
+        ck_abort_msg("Could not initialize connection to the confdb");
         talloc_free(test_ctx);
         return ret;
     }
@@ -102,7 +102,7 @@ static int setup_sysdb_tests(struct sysdb_test_ctx **ctx)
     ret = confdb_add_param(test_ctx->confdb, true,
                            "config/sssd", "domains", val);
     if (ret != EOK) {
-        fail("Could not initialize domains placeholder");
+        ck_abort_msg("Could not initialize domains placeholder");
         talloc_free(test_ctx);
         return ret;
     }
@@ -111,7 +111,7 @@ static int setup_sysdb_tests(struct sysdb_test_ctx **ctx)
     ret = confdb_add_param(test_ctx->confdb, true,
                            "config/domain/FILES", "id_provider", val);
     if (ret != EOK) {
-        fail("Could not initialize provider");
+        ck_abort_msg("Could not initialize provider");
         talloc_free(test_ctx);
         return ret;
     }
@@ -120,7 +120,7 @@ static int setup_sysdb_tests(struct sysdb_test_ctx **ctx)
     ret = confdb_add_param(test_ctx->confdb, true,
                            "config/domain/FILES", "enumerate", val);
     if (ret != EOK) {
-        fail("Could not initialize FILES domain");
+        ck_abort_msg("Could not initialize FILES domain");
         talloc_free(test_ctx);
         return ret;
     }
@@ -129,7 +129,7 @@ static int setup_sysdb_tests(struct sysdb_test_ctx **ctx)
     ret = confdb_add_param(test_ctx->confdb, true,
                            "config/domain/FILES", "cache_credentials", val);
     if (ret != EOK) {
-        fail("Could not initialize FILES domain");
+        ck_abort_msg("Could not initialize FILES domain");
         talloc_free(test_ctx);
         return ret;
     }
@@ -137,7 +137,7 @@ static int setup_sysdb_tests(struct sysdb_test_ctx **ctx)
     ret = sssd_domain_init(test_ctx, test_ctx->confdb, "files",
                            TESTS_PATH, &test_ctx->domain);
     if (ret != EOK) {
-        fail("Could not initialize connection to the sysdb (%d)", ret);
+        ck_abort_msg("Could not initialize connection to the sysdb (%d)", ret);
         talloc_free(test_ctx);
         return ret;
     }
@@ -165,43 +165,43 @@ static void do_failed_login_test(uint32_t failed_login_attempts,
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_unless(ret == EOK, "Could not set up the test");
+    ck_assert_msg(ret == EOK, "Could not set up the test");
 
     val[0] = talloc_asprintf(test_ctx, "%u", offline_failed_login_attempts);
-    fail_unless(val[0] != NULL, "talloc_sprintf failed");
+    ck_assert_msg(val[0] != NULL, "talloc_sprintf failed");
     ret = confdb_add_param(test_ctx->confdb, true,
                            "config/pam", CONFDB_PAM_FAILED_LOGIN_ATTEMPTS, val);
-    fail_unless(ret == EOK, "Could not set offline_failed_login_attempts");
+    ck_assert_msg(ret == EOK, "Could not set offline_failed_login_attempts");
 
     val[0] = talloc_asprintf(test_ctx, "%u", offline_failed_login_delay);
     ret = confdb_add_param(test_ctx->confdb, true,
                            "config/pam", CONFDB_PAM_FAILED_LOGIN_DELAY, val);
-    fail_unless(ret == EOK, "Could not set offline_failed_login_delay");
+    ck_assert_msg(ret == EOK, "Could not set offline_failed_login_delay");
 
     ldb_msg = ldb_msg_new(test_ctx);
-    fail_unless(ldb_msg != NULL, "ldb_msg_new failed");
+    ck_assert_msg(ldb_msg != NULL, "ldb_msg_new failed");
 
     ret = ldb_msg_add_fmt(ldb_msg, SYSDB_FAILED_LOGIN_ATTEMPTS, "%u",
                           failed_login_attempts);
-    fail_unless(ret == EOK, "ldb_msg_add_string failed");
+    ck_assert_msg(ret == EOK, "ldb_msg_add_string failed");
 
     ret = ldb_msg_add_fmt(ldb_msg, SYSDB_LAST_FAILED_LOGIN, "%lld",
                           (long long) last_failed_login);
-    fail_unless(ret == EOK, "ldb_msg_add_string failed");
+    ck_assert_msg(ret == EOK, "ldb_msg_add_string failed");
 
     ret = check_failed_login_attempts(test_ctx->confdb, ldb_msg,
                                       &returned_failed_login_attempts,
                                       &delayed_until);
-    fail_unless(ret == expected_result,
+    ck_assert_msg(ret == expected_result,
                 "check_failed_login_attempts returned wrong error code, "
                 "expected [%d], got [%d]", expected_result, ret);
 
-    fail_unless(returned_failed_login_attempts == expected_counter,
+    ck_assert_msg(returned_failed_login_attempts == expected_counter,
                 "check_failed_login_attempts returned wrong number of failed "
                 "login attempts, expected [%d], got [%d]",
                 expected_counter, failed_login_attempts);
 
-    fail_unless(delayed_until == expected_delay,
+    ck_assert_msg(delayed_until == expected_delay,
                 "check_failed_login_attempts wrong delay, "
                 "expected [%ld], got [%ld]",
                 expected_delay, delayed_until);

--- a/src/tests/check_and_open-tests.c
+++ b/src/tests/check_and_open-tests.c
@@ -46,12 +46,12 @@ void setup_check_and_open(void)
     mode_t old_umask;
 
     filename = strdup(FILENAME_TEMPLATE);
-    fail_unless(filename != NULL, "strdup failed");
+    ck_assert_msg(filename != NULL, "strdup failed");
 
     old_umask = umask(SSS_DFL_UMASK);
     ret = mkstemp(filename);
     umask(old_umask);
-    fail_unless(ret != -1, "mkstemp failed [%d][%s]", errno, strerror(errno));
+    ck_assert_msg(ret != -1, "mkstemp failed [%d][%s]", errno, strerror(errno));
     close(ret);
 
     uid = getuid();
@@ -66,13 +66,13 @@ void teardown_check_and_open(void)
 
     if (fd != -1) {
         ret = close(fd);
-        fail_unless(ret == 0, "close failed [%d][%s]", errno, strerror(errno));
+        ck_assert_msg(ret == 0, "close failed [%d][%s]", errno, strerror(errno));
     }
 
-    fail_unless(filename != NULL, "unknown filename");
+    ck_assert_msg(filename != NULL, "unknown filename");
     ret = unlink(filename);
     free(filename);
-    fail_unless(ret == 0, "unlink failed [%d][%s]", errno, strerror(errno));
+    ck_assert_msg(ret == 0, "unlink failed [%d][%s]", errno, strerror(errno));
 }
 
 START_TEST(test_wrong_filename)
@@ -81,9 +81,9 @@ START_TEST(test_wrong_filename)
 
     ret = check_and_open_readonly("/bla/bla/bla", &fd,
                                   uid, gid, S_IFREG|mode, 0);
-    fail_unless(ret == ENOENT,
+    ck_assert_msg(ret == ENOENT,
                 "check_and_open_readonly succeeded on non-existing file");
-    fail_unless(fd == -1, "check_and_open_readonly file descriptor not -1");
+    ck_assert_msg(fd == -1, "check_and_open_readonly file descriptor not -1");
 }
 END_TEST
 
@@ -95,20 +95,20 @@ START_TEST(test_symlink)
 
     newpath_length = strlen(filename) + strlen(SUFFIX) + 1;
     newpath = malloc((newpath_length) * sizeof(char));
-    fail_unless(newpath != NULL, "malloc failed");
+    ck_assert_msg(newpath != NULL, "malloc failed");
 
     ret = snprintf(newpath, newpath_length, "%s%s", filename, SUFFIX);
-    fail_unless(ret == newpath_length - 1,
+    ck_assert_msg(ret == newpath_length - 1,
                 "snprintf failed: expected [%zd] got [%d]", newpath_length - 1,
                                                            ret);
 
     ret = symlink(filename, newpath);
-    fail_unless(ret == 0, "symlink failed [%d][%s]", ret, strerror(errno));
+    ck_assert_msg(ret == 0, "symlink failed [%d][%s]", ret, strerror(errno));
 
     ret = check_file(newpath, uid, gid, S_IFREG|mode, 0, NULL, false);
     unlink(newpath);
 
-    fail_unless(ret == EINVAL,
+    ck_assert_msg(ret == EINVAL,
                 "check_and_open_readonly succeeded on symlink");
     free(newpath);
 }
@@ -122,20 +122,20 @@ START_TEST(test_follow_symlink)
 
     newpath_length = strlen(filename) + strlen(SUFFIX) + 1;
     newpath = malloc((newpath_length) * sizeof(char));
-    fail_unless(newpath != NULL, "malloc failed");
+    ck_assert_msg(newpath != NULL, "malloc failed");
 
     ret = snprintf(newpath, newpath_length, "%s%s", filename, SUFFIX);
-    fail_unless(ret == newpath_length - 1,
+    ck_assert_msg(ret == newpath_length - 1,
                 "snprintf failed: expected [%zd] got [%d]", newpath_length - 1,
                                                            ret);
 
     ret = symlink(filename, newpath);
-    fail_unless(ret == 0, "symlink failed [%d][%s]", ret, strerror(errno));
+    ck_assert_msg(ret == 0, "symlink failed [%d][%s]", ret, strerror(errno));
 
     ret = check_file(newpath, uid, gid, S_IFREG|mode, 0, NULL, true);
     unlink(newpath);
 
-    fail_unless(ret == EOK,
+    ck_assert_msg(ret == EOK,
                 "check_and_open_readonly failed on symlink with follow=true");
     free(newpath);
 }
@@ -146,9 +146,9 @@ START_TEST(test_not_regular_file)
     int ret;
 
     ret = check_and_open_readonly("/dev/null", &fd, uid, gid, S_IFREG|mode, 0);
-    fail_unless(ret == EINVAL,
+    ck_assert_msg(ret == EINVAL,
                 "check_and_open_readonly succeeded on non-regular file");
-    fail_unless(fd == -1, "check_and_open_readonly file descriptor not -1");
+    ck_assert_msg(fd == -1, "check_and_open_readonly file descriptor not -1");
 }
 END_TEST
 
@@ -157,9 +157,9 @@ START_TEST(test_wrong_uid)
     int ret;
 
     ret = check_and_open_readonly(filename, &fd, uid+1, gid, S_IFREG|mode, 0);
-    fail_unless(ret == EINVAL,
+    ck_assert_msg(ret == EINVAL,
                 "check_and_open_readonly succeeded with wrong uid");
-    fail_unless(fd == -1, "check_and_open_readonly file descriptor not -1");
+    ck_assert_msg(fd == -1, "check_and_open_readonly file descriptor not -1");
 }
 END_TEST
 
@@ -168,9 +168,9 @@ START_TEST(test_wrong_gid)
     int ret;
 
     ret = check_and_open_readonly(filename, &fd, uid, gid+1, S_IFREG|mode, 0);
-    fail_unless(ret == EINVAL,
+    ck_assert_msg(ret == EINVAL,
                 "check_and_open_readonly succeeded with wrong gid");
-    fail_unless(fd == -1, "check_and_open_readonly file descriptor not -1");
+    ck_assert_msg(fd == -1, "check_and_open_readonly file descriptor not -1");
 }
 END_TEST
 
@@ -180,9 +180,9 @@ START_TEST(test_wrong_permission)
 
     ret = check_and_open_readonly(filename, &fd,
                                   uid, gid, S_IFREG|mode|S_IWOTH, 0);
-    fail_unless(ret == EINVAL,
+    ck_assert_msg(ret == EINVAL,
                 "check_and_open_readonly succeeded with wrong mode");
-    fail_unless(fd == -1, "check_and_open_readonly file descriptor not -1");
+    ck_assert_msg(fd == -1, "check_and_open_readonly file descriptor not -1");
 }
 END_TEST
 
@@ -191,9 +191,9 @@ START_TEST(test_ok)
     int ret;
 
     ret = check_and_open_readonly(filename, &fd, uid, gid, S_IFREG|mode, 0);
-    fail_unless(ret == EOK,
+    ck_assert_msg(ret == EOK,
                 "check_and_open_readonly failed");
-    fail_unless(fd >= 0,
+    ck_assert_msg(fd >= 0,
                 "check_and_open_readonly returned illegal file descriptor");
 }
 END_TEST
@@ -205,15 +205,15 @@ START_TEST(test_write)
     errno_t my_errno;
 
     ret = check_and_open_readonly(filename, &fd, uid, gid, S_IFREG|mode, 0);
-    fail_unless(ret == EOK,
+    ck_assert_msg(ret == EOK,
                 "check_and_open_readonly failed");
-    fail_unless(fd >= 0,
+    ck_assert_msg(fd >= 0,
                 "check_and_open_readonly returned illegal file descriptor");
 
     size = write(fd, "abc", 3);
     my_errno = errno;
-    fail_unless(size == -1, "check_and_open_readonly file is not readonly");
-    fail_unless(my_errno == EBADF,
+    ck_assert_msg(size == -1, "check_and_open_readonly file is not readonly");
+    ck_assert_msg(my_errno == EBADF,
                 "write failed for other reason than readonly");
 }
 END_TEST

--- a/src/tests/cmocka/test_expire_common.c
+++ b/src/tests/cmocka/test_expire_common.c
@@ -29,7 +29,7 @@
 #include <cmocka.h>
 #include <time.h>
 
-#include "tests/common_check.h"
+#include "tests/common.h"
 #include "tests/cmocka/test_expire_common.h"
 
 #define MAX_VAL 100

--- a/src/tests/cmocka/test_ldap_auth.c
+++ b/src/tests/cmocka/test_ldap_auth.c
@@ -28,7 +28,7 @@
 #include <sys/types.h>
 #include <cmocka.h>
 
-#include "tests/common_check.h"
+#include "tests/common.h"
 #include "providers/ldap/ldap_auth.h"
 #include "tests/cmocka/test_expire_common.h"
 

--- a/src/tests/cmocka/test_sdap_access.c
+++ b/src/tests/cmocka/test_sdap_access.c
@@ -29,7 +29,7 @@
 #include <cmocka.h>
 #include <ldb.h>
 
-#include "tests/common_check.h"
+#include "tests/common.h"
 #include "tests/cmocka/test_expire_common.h"
 #include "tests/cmocka/test_sdap_access.h"
 

--- a/src/tests/cmocka/test_search_bases.c
+++ b/src/tests/cmocka/test_search_bases.c
@@ -35,7 +35,6 @@
 #include "providers/ldap/ldap_common.h"
 #include "providers/ldap/sdap.h"
 #include "dhash.h"
-#include "tests/common_check.h"
 
 enum sss_test_get_by_dn {
     DN_NOT_IN_DOMS, /* dn is not in any domain           */

--- a/src/tests/common_check.c
+++ b/src/tests/common_check.c
@@ -29,12 +29,12 @@
 
 void ck_leak_check_setup(void)
 {
-    fail_unless(leak_check_setup() == true,
+    ck_assert_msg(leak_check_setup() == true,
                 "Cannot set up leaks test: %s\n", check_leaks_err_msg());
 }
 
 void ck_leak_check_teardown(void)
 {
-    fail_unless(leak_check_teardown() == true,
+    ck_assert_msg(leak_check_teardown() == true,
                 "Cannot tear down leaks test: %s\n", check_leaks_err_msg());
 }

--- a/src/tests/common_check.h
+++ b/src/tests/common_check.h
@@ -31,6 +31,11 @@ void ck_leak_check_setup(void);
 void ck_leak_check_teardown(void);
 
 #define ck_leaks_push(ctx) check_leaks_push(ctx)
-#define ck_leaks_pop(ctx) fail_unless(check_leaks_pop(ctx) == true, "%s", check_leaks_err_msg())
+#define ck_leaks_pop(ctx) ck_assert_msg(check_leaks_pop(ctx) == true, "%s", check_leaks_err_msg())
+
+#define sss_ck_fail_if_msg(expr, ...) \
+  (expr) ? \
+     _ck_assert_failed(__FILE__, __LINE__, "Assertion '"#expr"' failed" , ## __VA_ARGS__) : \
+     _mark_point(__FILE__, __LINE__)
 
 #endif /* __TESTS_COMMON_CHECK_H__ */

--- a/src/tests/crypto-tests.c
+++ b/src/tests/crypto-tests.c
@@ -46,7 +46,7 @@ START_TEST(test_sss_password_encrypt_decrypt)
     int expected = EOK;
 
     test_ctx = talloc_new(NULL);
-    fail_if(test_ctx == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(test_ctx == NULL, "Failed to allocate memory");
     ck_leaks_push(test_ctx);
 
     for (i=0; password[i]; i++) {
@@ -57,9 +57,9 @@ START_TEST(test_sss_password_encrypt_decrypt)
         ret = sss_password_decrypt(test_ctx, obfpwd, &ctpwd);
         ck_assert_int_eq(ret, expected);
 
-        fail_if(ctpwd == NULL,
+        sss_ck_fail_if_msg(ctpwd == NULL,
                 "sss_password_decrypt must not return NULL");
-        fail_if(strcmp(password[i], ctpwd) != 0,
+        sss_ck_fail_if_msg(strcmp(password[i], ctpwd) != 0,
                 "Unexpected decrypted password. Expected: %s got: %s",
                 password[i], ctpwd);
 
@@ -96,7 +96,7 @@ START_TEST(test_hmac_sha1)
                             out);
         ck_assert_int_eq(ret, expected);
         ck_assert_int_eq(ret, EOK);
-        fail_if(memcmp(out, results[i], SSS_SHA1_LENGTH) != 0,
+        sss_ck_fail_if_msg(memcmp(out, results[i], SSS_SHA1_LENGTH) != 0,
                 "Unexpected result for index: %d", i);
     }
 }
@@ -109,12 +109,12 @@ START_TEST(test_base64_encode)
     char *obfpwd = NULL;
 
     test_ctx = talloc_new(NULL);
-    fail_if(test_ctx == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(test_ctx == NULL, "Failed to allocate memory");
     /* Base64 encode the buffer */
     obfpwd = sss_base64_encode(test_ctx, obfbuf, strlen((const char*)obfbuf));
-    fail_if(obfpwd == NULL,
+    sss_ck_fail_if_msg(obfpwd == NULL,
             "sss_base64_encode must not return NULL");
-    fail_if(strcmp(obfpwd, expected) != 0,
+    sss_ck_fail_if_msg(strcmp(obfpwd, expected) != 0,
             "Got: %s expected value: %s", obfpwd, expected);
 
     talloc_free(test_ctx);
@@ -129,13 +129,13 @@ START_TEST(test_base64_decode)
     const unsigned char expected[] = "test";
 
     test_ctx = talloc_new(NULL);
-    fail_if(test_ctx == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(test_ctx == NULL, "Failed to allocate memory");
     /* Base64 decode the buffer */
     obfbuf = sss_base64_decode(test_ctx, b64encoded, &obflen);
-    fail_if(obfbuf == NULL,
+    sss_ck_fail_if_msg(obfbuf == NULL,
             "sss_base64_decode must not return NULL");
     ck_assert_int_eq(obflen, strlen((const char*)expected));
-    fail_if(memcmp(obfbuf, expected, obflen) != 0,
+    sss_ck_fail_if_msg(memcmp(obfbuf, expected, obflen) != 0,
             "Unexpected vale returned after sss_base64_decode");
 
     talloc_free(test_ctx);
@@ -160,26 +160,26 @@ START_TEST(test_sss_encrypt_decrypt)
     int ret;
 
     test_ctx = talloc_new(NULL);
-    fail_if(test_ctx == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(test_ctx == NULL, "Failed to allocate memory");
 
     ret = sss_encrypt(test_ctx, AES256CBC_HMAC_SHA256, key, key_len,
                       (const uint8_t *)input_text, input_text_len,
                       &cipher_text, &cipher_text_len);
 
-    fail_if(ret != 0, "sss_encrypt failed with error: %d", ret);
-    fail_if(cipher_text_len == 0, "cipher_text_len must not be zero");
+    sss_ck_fail_if_msg(ret != 0, "sss_encrypt failed with error: %d", ret);
+    sss_ck_fail_if_msg(cipher_text_len == 0, "cipher_text_len must not be zero");
 
     ret = memcmp(input_text, cipher_text, input_text_len);
-    fail_if(ret == 0, "Input and encrypted text has common prefix");
+    sss_ck_fail_if_msg(ret == 0, "Input and encrypted text has common prefix");
 
     ret = sss_decrypt(test_ctx, AES256CBC_HMAC_SHA256, key, key_len,
                       cipher_text, cipher_text_len,
                       &plain_text, &plain_text_len);
-    fail_if(ret != 0, "sss_decrypt failed with error: %d", ret);
+    sss_ck_fail_if_msg(ret != 0, "sss_decrypt failed with error: %d", ret);
     ck_assert_int_eq(plain_text_len, input_text_len);
 
     ret = memcmp(plain_text, input_text, input_text_len);
-    fail_if(ret != 0, "input text is not the same as de-encrypted text");
+    sss_ck_fail_if_msg(ret != 0, "input text is not the same as de-encrypted text");
 
     talloc_free(test_ctx);
 }
@@ -195,21 +195,21 @@ START_TEST(test_s3crypt_sha512)
     const char *expected_hash = "$6$tU67Q/9h3tm5WJ.U$aL9gjCfiSZQewHTI6A4/MHCVWrMCiJZ.gNXEIw6HO39XGbg.s2nTyGlYXeoQyQtDll3XSbIZN41fJEC3v7ELy0";
 
     test_ctx = talloc_new(NULL);
-    fail_if(test_ctx == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(test_ctx == NULL, "Failed to allocate memory");
 
     ret = s3crypt_gen_salt(test_ctx, &salt);
-    fail_if(ret != 0, "s3crypt_gen_salt failed with error: %d", ret);
+    sss_ck_fail_if_msg(ret != 0, "s3crypt_gen_salt failed with error: %d", ret);
 
     ret = s3crypt_sha512(test_ctx, password, salt, &userhash);
-    fail_if(ret != 0, "s3crypt_sha512 failed with error: %d", ret);
+    sss_ck_fail_if_msg(ret != 0, "s3crypt_sha512 failed with error: %d", ret);
 
     ret = s3crypt_sha512(test_ctx, password, userhash, &comphash);
-    fail_if(ret != 0, "s3crypt_sha512 failed with error: %d", ret);
+    sss_ck_fail_if_msg(ret != 0, "s3crypt_sha512 failed with error: %d", ret);
     ck_assert_str_eq(userhash, comphash);
     talloc_free(comphash);
 
     ret = s3crypt_sha512(test_ctx, password, expected_hash, &comphash);
-    fail_if(ret != 0, "s3crypt_sha512 failed with error: %d", ret);
+    sss_ck_fail_if_msg(ret != 0, "s3crypt_sha512 failed with error: %d", ret);
     ck_assert_str_eq(expected_hash, comphash);
 
     talloc_free(test_ctx);

--- a/src/tests/debug-tests.c
+++ b/src/tests/debug-tests.c
@@ -28,7 +28,7 @@
 #include <errno.h>
 #include <string.h>
 #include "util/util.h"
-#include "tests/common.h"
+#include "tests/common_check.h"
 
 void sss_set_logger(const char *logger);  /* from debug.c */
 
@@ -57,7 +57,7 @@ START_TEST(test_debug_convert_old_level_old_format)
     for (old_level = 0; old_level < N_ELEMENTS(levels); old_level++) {
         expected_level |= levels[old_level];
 
-        fail_unless(debug_convert_old_level(old_level) == expected_level,
+        ck_assert_msg(debug_convert_old_level(old_level) == expected_level,
                     "Invalid conversion of %d", old_level);
     }
 }
@@ -65,55 +65,55 @@ END_TEST
 
 START_TEST(test_debug_convert_old_level_new_format)
 {
-    fail_unless(
+    ck_assert_msg(
         debug_convert_old_level(SSSDBG_UNRESOLVED) == SSSDBG_FATAL_FAILURE,
         "Invalid conversion of SSSDBG_UNRESOLVED"
     );
-    fail_unless(
+    ck_assert_msg(
         debug_convert_old_level(SSSDBG_FATAL_FAILURE) == SSSDBG_FATAL_FAILURE,
         "Invalid conversion of SSSDBG_FATAL_FAILURE"
     );
-    fail_unless(
+    ck_assert_msg(
         debug_convert_old_level(SSSDBG_CRIT_FAILURE) == SSSDBG_CRIT_FAILURE,
         "Invalid conversion of SSSDBG_CRIT_FAILURE"
     );
-    fail_unless(
+    ck_assert_msg(
         debug_convert_old_level(SSSDBG_OP_FAILURE) == SSSDBG_OP_FAILURE,
         "Invalid conversion of SSSDBG_OP_FAILURE"
     );
-    fail_unless(
+    ck_assert_msg(
         debug_convert_old_level(SSSDBG_MINOR_FAILURE) == SSSDBG_MINOR_FAILURE,
         "Invalid conversion of SSSDBG_MINOR_FAILURE"
     );
-    fail_unless(
+    ck_assert_msg(
         debug_convert_old_level(SSSDBG_CONF_SETTINGS) == SSSDBG_CONF_SETTINGS,
         "Invalid conversion of SSSDBG_CONF_SETTINGS"
     );
-    fail_unless(
+    ck_assert_msg(
         debug_convert_old_level(SSSDBG_FUNC_DATA) == SSSDBG_FUNC_DATA,
         "Invalid conversion of SSSDBG_FUNC_DATA"
     );
-    fail_unless(
+    ck_assert_msg(
         debug_convert_old_level(SSSDBG_TRACE_FUNC) == SSSDBG_TRACE_FUNC,
         "Invalid conversion of SSSDBG_TRACE_FUNC"
     );
-    fail_unless(
+    ck_assert_msg(
         debug_convert_old_level(SSSDBG_TRACE_LIBS) == SSSDBG_TRACE_LIBS,
         "Invalid conversion of SSSDBG_TRACE_LIBS"
     );
-    fail_unless(
+    ck_assert_msg(
         debug_convert_old_level(SSSDBG_TRACE_INTERNAL) == SSSDBG_TRACE_INTERNAL,
         "Invalid conversion of SSSDBG_TRACE_INTERNAL"
     );
-    fail_unless(
+    ck_assert_msg(
         debug_convert_old_level(SSSDBG_TRACE_ALL) == SSSDBG_TRACE_ALL,
         "Invalid conversion of SSSDBG_TRACE_ALL"
     );
-    fail_unless(
+    ck_assert_msg(
         debug_convert_old_level(SSSDBG_TRACE_LDB) == SSSDBG_TRACE_LDB,
         "Invalid conversion of SSSDBG_TRACE_LDB"
     );
-    fail_unless(
+    ck_assert_msg(
         debug_convert_old_level(SSSDBG_MASK_ALL) == SSSDBG_MASK_ALL,
         "Invalid conversion of SSSDBG_MASK_ALL"
     );
@@ -355,11 +355,11 @@ START_TEST(test_debug_is_set_single_no_timestamp)
         errno = 0;
         result = test_helper_debug_check_message(levels[i]);
 
-        fail_if(result == DEBUG_TEST_ERROR,
+        sss_ck_fail_if_msg(result == DEBUG_TEST_ERROR,
                 "Expecting DEBUG_TEST_ERROR, got: %d, error: %s",
                 result, strerror(errno));
 
-        fail_unless(result == EOK,
+        ck_assert_msg(result == EOK,
                     "Test of level %#.4x failed - message don't match",
                     levels[i]);
     }
@@ -396,14 +396,14 @@ START_TEST(test_debug_is_set_single_timestamp)
         errno = 0;
         result = test_helper_debug_check_message(levels[i]);
 
-        fail_if(result == DEBUG_TEST_ERROR,
+        sss_ck_fail_if_msg(result == DEBUG_TEST_ERROR,
                 "Expecting DEBUG_TEST_ERROR, got: %d, error: %s",
                 result, strerror(errno));
 
-        fail_if(result == DEBUG_TEST_NOK_TS,
+        sss_ck_fail_if_msg(result == DEBUG_TEST_NOK_TS,
                 "Test of level %#.4x failed - invalid timestamp", levels[i]);
 
-        fail_unless(result == EOK,
+        ck_assert_msg(result == EOK,
                     "Test of level %#.4x failed - message don't match",
                     levels[i]);
     }
@@ -440,14 +440,14 @@ START_TEST(test_debug_is_set_single_timestamp_microseconds)
         errno = 0;
         result = test_helper_debug_check_message(levels[i]);
 
-        fail_if(result == DEBUG_TEST_ERROR,
+        sss_ck_fail_if_msg(result == DEBUG_TEST_ERROR,
                 "Expecting DEBUG_TEST_ERROR, got: %d, error: %s",
                 result, strerror(errno));
 
-        fail_if(result == DEBUG_TEST_NOK_TS,
+        sss_ck_fail_if_msg(result == DEBUG_TEST_NOK_TS,
                 "Test of level %#.4x failed - invalid timestamp", levels[i]);
 
-        fail_unless(result == EOK,
+        ck_assert_msg(result == EOK,
                     "Test of level %#.4x failed - message don't match",
                     levels[i]);
     }
@@ -485,11 +485,11 @@ START_TEST(test_debug_is_notset_no_timestamp)
         errno = 0;
         result = test_helper_debug_is_empty_message(levels[i]);
 
-        fail_if(result == DEBUG_TEST_ERROR,
+        sss_ck_fail_if_msg(result == DEBUG_TEST_ERROR,
                 "Expecting DEBUG_TEST_ERROR, got: %d, error: %s",
                 result, strerror(errno));
 
-        fail_unless(result == EOK,
+        ck_assert_msg(result == EOK,
                     "Test of level %#.4x failed - message has been written",
                     levels[i]);
     }
@@ -527,11 +527,11 @@ START_TEST(test_debug_is_notset_timestamp)
         errno = 0;
         result = test_helper_debug_is_empty_message(levels[i]);
 
-        fail_if(result == DEBUG_TEST_ERROR,
+        sss_ck_fail_if_msg(result == DEBUG_TEST_ERROR,
                 "Expecting DEBUG_TEST_ERROR, got: %d, error: %s",
                 result, strerror(errno));
 
-        fail_unless(result == EOK,
+        ck_assert_msg(result == EOK,
                     "Test of level %#.4x failed - message has been written",
                     levels[i]);
     }
@@ -568,11 +568,11 @@ START_TEST(test_debug_is_notset_timestamp_microseconds)
         errno = 0;
         result = test_helper_debug_is_empty_message(levels[i]);
 
-        fail_if(result == DEBUG_TEST_ERROR,
+        sss_ck_fail_if_msg(result == DEBUG_TEST_ERROR,
                 "Expecting DEBUG_TEST_ERROR, got: %d, error: %s",
                 result, strerror(errno));
 
-        fail_unless(result == EOK,
+        ck_assert_msg(result == EOK,
                     "Test of level %#.4x failed - message has been written",
                     levels[i]);
     }
@@ -601,7 +601,7 @@ START_TEST(test_debug_is_set_true)
 
     for (i = 0; i < N_ELEMENTS(levels); i++) {
         result = DEBUG_IS_SET(levels[i]);
-        fail_unless(result > 0,
+        ck_assert_msg(result > 0,
                     "Test of level %#.4x failed - result is 0x%.4x",
                     levels[i], result);
     }
@@ -631,7 +631,7 @@ START_TEST(test_debug_is_set_false)
         debug_level = all_set & ~levels[i];
 
         result = DEBUG_IS_SET(levels[i]);
-        fail_unless(result == 0,
+        ck_assert_msg(result == 0,
                     "Test of level %#.4x failed - result is 0x%.4x",
                     levels[i], result);
     }

--- a/src/tests/dlopen-tests.c
+++ b/src/tests/dlopen-tests.c
@@ -31,7 +31,7 @@
 #include <limits.h>
 #include <check.h>
 #include <dirent.h>
-#include "tests/common.h"
+#include "tests/common_check.h"
 
 #define LIBPFX ABS_BUILD_DIR "/" LT_OBJDIR
 
@@ -189,13 +189,13 @@ static char **get_so_files(size_t *_list_size)
     char **libraries;
 
     n = scandir(LIBPFX, &namelist, file_so_filter, alphasort);
-    fail_unless(n > 0, "Failed to scan dirrectory: " LIBPFX);
+    ck_assert_msg(n > 0, "Failed to scan dirrectory: " LIBPFX);
 
     libraries = calloc(n + 1, sizeof(char *));
 
     for (int i = 0; i < n; ++i) {
         libraries[i] = strdup(namelist[i]->d_name);
-        fail_if(libraries[i] == NULL, "Failed to allocate memory");
+        sss_ck_fail_if_msg(libraries[i] == NULL, "Failed to allocate memory");
 
         free(namelist[i]);
     }
@@ -231,7 +231,7 @@ START_TEST(test_dlopen_base)
 
     for (i = 0; so[i].name != NULL; i++) {
         ok = recursive_dlopen(so[i].libs, 0, &errmsg);
-        fail_unless(ok, "Error opening %s: [%s]", so[i].name, errmsg);
+        ck_assert_msg(ok, "Error opening %s: [%s]", so[i].name, errmsg);
 
         remove_library_from_list(so[i].name, found_libraries,
                                  found_libraries_size);
@@ -245,7 +245,7 @@ START_TEST(test_dlopen_base)
     }
     free(found_libraries);
 
-    fail_if(unchecked_library, "Unchecked library found");
+    sss_ck_fail_if_msg(unchecked_library, "Unchecked library found");
 }
 END_TEST
 

--- a/src/tests/files-tests.c
+++ b/src/tests/files-tests.c
@@ -33,7 +33,7 @@
 
 #include "config.h"
 #include "util/util.h"
-#include "tests/common.h"
+#include "tests/common_check.h"
 
 #define TESTS_PATH "tp_" BASE_FILE_STEM
 
@@ -89,16 +89,16 @@ static int create_simple_file(const char *name, const char *content)
     int ret;
 
     fd = open(name, O_WRONLY | O_CREAT | O_TRUNC, 0700);
-    fail_if(fd == -1, "Cannot create simple file\n");
+    sss_ck_fail_if_msg(fd == -1, "Cannot create simple file\n");
 
     size = write(fd, "abc", 3);
-    fail_if(size == -1, "Cannot write to file\n");
+    sss_ck_fail_if_msg(size == -1, "Cannot write to file\n");
 
     ret = fsync(fd);
-    fail_if(ret == -1, "Cannot sync file\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot sync file\n");
 
     ret = close(fd);
-    fail_if(ret == -1, "Cannot close file\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot close file\n");
 
     return ret;
 }
@@ -109,46 +109,46 @@ START_TEST(test_remove_tree)
     char origpath[PATH_MAX+1];
 
     errno = 0;
-    fail_unless(getcwd(origpath, PATH_MAX) == origpath, "Cannot getcwd\n");
-    fail_unless(errno == 0, "Cannot getcwd\n");
+    ck_assert_msg(getcwd(origpath, PATH_MAX) == origpath, "Cannot getcwd\n");
+    ck_assert_msg(errno == 0, "Cannot getcwd\n");
 
     DEBUG(SSSDBG_FUNC_DATA, "About to delete %s\n", dir_path);
 
     /* create a file */
     ret = chdir(dir_path);
-    fail_if(ret == -1, "Cannot chdir1\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot chdir1\n");
 
     ret = create_simple_file("bar", "bar");
-    fail_if(ret == -1, "Cannot create file1\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot create file1\n");
 
     /* create a subdir and file inside it */
     ret = mkdir("subdir", 0700);
-    fail_if(ret == -1, "Cannot create subdir\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot create subdir\n");
 
     ret = chdir("subdir");
-    fail_if(ret == -1, "Cannot chdir\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot chdir\n");
 
     ret = create_simple_file("foo", "foo");
-    fail_if(ret == -1, "Cannot create file\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot create file\n");
 
     /* create another subdir, empty this time */
     ret = mkdir("subdir2", 0700);
-    fail_if(ret == -1, "Cannot create subdir\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot create subdir\n");
 
     ret = chdir(origpath);
-    fail_if(ret == -1, "Cannot chdir2\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot chdir2\n");
 
     /* go back */
     ret = chdir(origpath);
-    fail_if(ret == -1, "Cannot chdir\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot chdir\n");
 
     /* and finally wipe it out.. */
     ret = sss_remove_tree(dir_path);
-    fail_unless(ret == EOK, "remove_tree failed\n");
+    ck_assert_msg(ret == EOK, "remove_tree failed\n");
 
     /* check if really gone */
     ret = access(dir_path, F_OK);
-    fail_unless(ret == -1, "directory still there after remove_tree\n");
+    ck_assert_msg(ret == -1, "directory still there after remove_tree\n");
 }
 END_TEST
 
@@ -158,49 +158,49 @@ START_TEST(test_remove_subtree)
     char origpath[PATH_MAX+1];
 
     errno = 0;
-    fail_unless(getcwd(origpath, PATH_MAX) == origpath, "Cannot getcwd\n");
-    fail_unless(errno == 0, "Cannot getcwd\n");
+    ck_assert_msg(getcwd(origpath, PATH_MAX) == origpath, "Cannot getcwd\n");
+    ck_assert_msg(errno == 0, "Cannot getcwd\n");
 
     DEBUG(SSSDBG_FUNC_DATA, "About to delete %s\n", dir_path);
 
     /* create a file */
     ret = chdir(dir_path);
-    fail_if(ret == -1, "Cannot chdir1\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot chdir1\n");
 
     ret = create_simple_file("bar", "bar");
-    fail_if(ret == -1, "Cannot create file1\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot create file1\n");
 
     /* create a subdir and file inside it */
     ret = mkdir("subdir", 0700);
-    fail_if(ret == -1, "Cannot create subdir\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot create subdir\n");
 
     ret = chdir("subdir");
-    fail_if(ret == -1, "Cannot chdir\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot chdir\n");
 
     ret = create_simple_file("foo", "foo");
-    fail_if(ret == -1, "Cannot create file\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot create file\n");
 
     /* create another subdir, empty this time */
     ret = mkdir("subdir2", 0700);
-    fail_if(ret == -1, "Cannot create subdir\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot create subdir\n");
 
     ret = chdir(origpath);
-    fail_if(ret == -1, "Cannot chdir2\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot chdir2\n");
 
     /* go back */
     ret = chdir(origpath);
-    fail_if(ret == -1, "Cannot chdir\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot chdir\n");
 
     /* and finally wipe it out.. */
     ret = sss_remove_subtree(dir_path);
-    fail_unless(ret == EOK, "remove_subtree failed\n");
+    ck_assert_msg(ret == EOK, "remove_subtree failed\n");
 
     /* check if really gone */
     ret = access(dir_path, F_OK);
-    fail_unless(ret == 0, "directory was deleted\n");
+    ck_assert_msg(ret == 0, "directory was deleted\n");
 
     ret = rmdir(dir_path);
-    fail_unless(ret == 0, "unable to delete root directory\n");
+    ck_assert_msg(ret == 0, "unable to delete root directory\n");
 }
 END_TEST
 
@@ -212,43 +212,43 @@ START_TEST(test_simple_copy)
     int fd = -1;
 
     errno = 0;
-    fail_unless(getcwd(origpath, PATH_MAX) == origpath, "Cannot getcwd\n");
-    fail_unless(errno == 0, "Cannot getcwd\n");
+    ck_assert_msg(getcwd(origpath, PATH_MAX) == origpath, "Cannot getcwd\n");
+    ck_assert_msg(errno == 0, "Cannot getcwd\n");
 
     /* create a file */
     ret = chdir(dir_path);
-    fail_if(ret == -1, "Cannot chdir1\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot chdir1\n");
 
     ret = create_simple_file("bar", "bar");
-    fail_if(ret == -1, "Cannot create file1\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot create file1\n");
 
     /* create a subdir and file inside it */
     ret = mkdir("subdir", 0700);
-    fail_if(ret == -1, "Cannot create subdir\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot create subdir\n");
 
     ret = chdir("subdir");
-    fail_if(ret == -1, "Cannot chdir\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot chdir\n");
 
     ret = create_simple_file("foo", "foo");
-    fail_if(ret == -1, "Cannot create file\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot create file\n");
 
     /* go back */
     ret = chdir(origpath);
-    fail_if(ret == -1, "Cannot chdir\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot chdir\n");
 
     /* and finally copy.. */
     DEBUG(SSSDBG_FUNC_DATA,
           "Will copy from '%s' to '%s'\n", dir_path, dst_path);
     ret = sss_copy_tree(dir_path, dst_path, 0700, uid, gid);
-    fail_unless(ret == EOK, "copy_tree failed\n");
+    ck_assert_msg(ret == EOK, "copy_tree failed\n");
 
     /* check if really copied */
     ret = access(dst_path, F_OK);
-    fail_unless(ret == 0, "destination directory not there\n");
+    ck_assert_msg(ret == 0, "destination directory not there\n");
 
     tmp = talloc_asprintf(test_ctx, "%s/bar", dst_path);
     ret = check_and_open_readonly(tmp, &fd, uid, gid, S_IFREG|S_IRWXU, 0);
-    fail_unless(ret == EOK, "Cannot open %s\n", tmp);
+    ck_assert_msg(ret == EOK, "Cannot open %s\n", tmp);
     close(fd);
     talloc_free(tmp);
 }
@@ -264,34 +264,34 @@ START_TEST(test_copy_file)
     int fd = -1;
 
     errno = 0;
-    fail_unless(getcwd(origpath, PATH_MAX) == origpath, "Cannot getcwd\n");
-    fail_unless(errno == 0, "Cannot getcwd\n");
+    ck_assert_msg(getcwd(origpath, PATH_MAX) == origpath, "Cannot getcwd\n");
+    ck_assert_msg(errno == 0, "Cannot getcwd\n");
 
     /* create a file */
     ret = chdir(dir_path);
-    fail_if(ret == -1, "Cannot chdir1\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot chdir1\n");
 
     ret = create_simple_file("foo", "foo");
-    fail_if(ret == -1, "Cannot create foo\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot create foo\n");
     foo_path = talloc_asprintf(tmp_ctx, "%s/foo", dir_path);
     bar_path = talloc_asprintf(tmp_ctx, "%s/bar", dst_path);
 
     /* create a file */
     ret = chdir(origpath);
-    fail_if(ret == -1, "Cannot chdir1\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot chdir1\n");
 
     /* Copy this file to a new file */
     DEBUG(SSSDBG_FUNC_DATA,
           "Will copy from 'foo' to 'bar'\n");
     ret = sss_copy_file_secure(foo_path, bar_path, 0700, uid, gid, 0);
-    fail_unless(ret == EOK, "copy_file_secure failed\n");
+    ck_assert_msg(ret == EOK, "copy_file_secure failed\n");
 
     /* check if really copied */
     ret = access(bar_path, F_OK);
-    fail_unless(ret == 0, "destination file 'bar' not there\n");
+    ck_assert_msg(ret == 0, "destination file 'bar' not there\n");
 
     ret = check_and_open_readonly(bar_path, &fd, uid, gid, S_IFREG|S_IRWXU, 0);
-    fail_unless(ret == EOK, "Cannot open %s\n", bar_path);
+    ck_assert_msg(ret == EOK, "Cannot open %s\n", bar_path);
     close(fd);
     talloc_free(tmp_ctx);
 }
@@ -305,37 +305,37 @@ START_TEST(test_copy_symlink)
     struct stat statbuf;
 
     errno = 0;
-    fail_unless(getcwd(origpath, PATH_MAX) == origpath, "Cannot getcwd\n");
-    fail_unless(errno == 0, "Cannot getcwd\n");
+    ck_assert_msg(getcwd(origpath, PATH_MAX) == origpath, "Cannot getcwd\n");
+    ck_assert_msg(errno == 0, "Cannot getcwd\n");
 
     /* create a subdir */
     ret = chdir(dir_path);
-    fail_if(ret == -1, "Cannot chdir\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot chdir\n");
 
     ret = create_simple_file("footarget", "foo");
-    fail_if(ret == -1, "Cannot create file\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot create file\n");
 
     ret = symlink("footarget", "foolink");
-    fail_if(ret == -1, "Cannot create symlink\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot create symlink\n");
 
     /* go back */
     ret = chdir(origpath);
-    fail_if(ret == -1, "Cannot chdir\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot chdir\n");
 
     /* and finally copy.. */
     DEBUG(SSSDBG_FUNC_DATA,
           "Will copy from '%s' to '%s'\n", dir_path, dst_path);
     ret = sss_copy_tree(dir_path, dst_path, 0700, uid, gid);
-    fail_unless(ret == EOK, "copy_tree failed\n");
+    ck_assert_msg(ret == EOK, "copy_tree failed\n");
 
     /* check if really copied */
     ret = access(dst_path, F_OK);
-    fail_unless(ret == 0, "destination directory not there\n");
+    ck_assert_msg(ret == 0, "destination directory not there\n");
 
     tmp = talloc_asprintf(test_ctx, "%s/foolink", dst_path);
     ret = lstat(tmp, &statbuf);
-    fail_unless(ret == 0, "cannot stat the symlink %s\n", tmp);
-    fail_unless(S_ISLNK(statbuf.st_mode), "%s not a symlink?\n", tmp);
+    ck_assert_msg(ret == 0, "cannot stat the symlink %s\n", tmp);
+    ck_assert_msg(S_ISLNK(statbuf.st_mode), "%s not a symlink?\n", tmp);
     talloc_free(tmp);
 }
 END_TEST
@@ -347,33 +347,33 @@ START_TEST(test_copy_node)
     char *tmp;
 
     errno = 0;
-    fail_unless(getcwd(origpath, PATH_MAX) == origpath, "Cannot getcwd\n");
-    fail_unless(errno == 0, "Cannot getcwd\n");
+    ck_assert_msg(getcwd(origpath, PATH_MAX) == origpath, "Cannot getcwd\n");
+    ck_assert_msg(errno == 0, "Cannot getcwd\n");
 
     /* create a node */
     ret = chdir(dir_path);
-    fail_if(ret == -1, "Cannot chdir\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot chdir\n");
 
     ret = mknod("testnode", S_IFIFO | S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH, 0);
-    fail_unless(ret == 0, "cannot stat /dev/null: %s", strerror(errno));
+    ck_assert_msg(ret == 0, "cannot stat /dev/null: %s", strerror(errno));
 
     /* go back */
     ret = chdir(origpath);
-    fail_if(ret == -1, "Cannot chdir\n");
+    sss_ck_fail_if_msg(ret == -1, "Cannot chdir\n");
 
     /* and finally copy.. */
     DEBUG(SSSDBG_FUNC_DATA,
           "Will copy from '%s' to '%s'\n", dir_path, dst_path);
     ret = sss_copy_tree(dir_path, dst_path, 0700, uid, gid);
-    fail_unless(ret == EOK, "copy_tree failed\n");
+    ck_assert_msg(ret == EOK, "copy_tree failed\n");
 
     /* check if really copied and without special files */
     ret = access(dst_path, F_OK);
-    fail_unless(ret == 0, "destination directory not there\n");
+    ck_assert_msg(ret == 0, "destination directory not there\n");
 
     tmp = talloc_asprintf(test_ctx, "%s/testnode", dst_path);
     ret = access(tmp, F_OK);
-    fail_unless(ret == -1, "special file %s exists, it shouldn't\n", tmp);
+    ck_assert_msg(ret == -1, "special file %s exists, it shouldn't\n", tmp);
     talloc_free(tmp);
 }
 END_TEST
@@ -387,28 +387,28 @@ START_TEST(test_create_dir)
 
     errno = 0;
 
-    fail_unless(getcwd(origpath, PATH_MAX) == origpath, "Cannot getcwd\n");
-    fail_unless(errno == 0, "Cannot getcwd\n");
+    ck_assert_msg(getcwd(origpath, PATH_MAX) == origpath, "Cannot getcwd\n");
+    ck_assert_msg(errno == 0, "Cannot getcwd\n");
 
     /* create a dir */
     ret = sss_create_dir(dir_path, "testdir", S_IRUSR | S_IXUSR, uid, gid);
-    fail_unless(ret == EOK, "cannot create dir: %s", strerror(ret));
+    ck_assert_msg(ret == EOK, "cannot create dir: %s", strerror(ret));
 
     new_dir = talloc_asprintf(NULL, "%s/testdir", dir_path);
     ret = stat(new_dir, &info);
-    fail_unless(ret == EOK, "failed to stat '%s'\n", new_dir);
+    ck_assert_msg(ret == EOK, "failed to stat '%s'\n", new_dir);
 
     /* check the dir has been created */
-    fail_unless(S_ISDIR(info.st_mode) != 0, "'%s' is not a dir.\n", new_dir);
+    ck_assert_msg(S_ISDIR(info.st_mode) != 0, "'%s' is not a dir.\n", new_dir);
 
     /* check the permissions are okay */
-    fail_unless((info.st_mode & S_IRUSR) != 0, "Read permission is not set\n");
-    fail_unless((info.st_mode & S_IWUSR) == 0, "Write permission is set\n");
-    fail_unless((info.st_mode & S_IXUSR) != 0, "Exec permission is not set\n");
+    ck_assert_msg((info.st_mode & S_IRUSR) != 0, "Read permission is not set\n");
+    ck_assert_msg((info.st_mode & S_IWUSR) == 0, "Write permission is set\n");
+    ck_assert_msg((info.st_mode & S_IXUSR) != 0, "Exec permission is not set\n");
 
     /* check the owner is okay */
-    fail_unless(info.st_uid == uid, "Dir created with the wrong uid\n");
-    fail_unless(info.st_gid == gid, "Dir created with the wrong gid\n");
+    ck_assert_msg(info.st_uid == uid, "Dir created with the wrong uid\n");
+    ck_assert_msg(info.st_gid == gid, "Dir created with the wrong gid\n");
 
     talloc_free(new_dir);
 }

--- a/src/tests/find_uid-tests.c
+++ b/src/tests/find_uid-tests.c
@@ -41,8 +41,8 @@ START_TEST(test_check_if_uid_is_active_success)
     uid = getuid();
 
     ret = check_if_uid_is_active(uid, &result);
-    fail_unless(ret == EOK, "check_if_uid_is_active failed.");
-    fail_unless(result, "check_if_uid_is_active did not found my uid [%d]",
+    ck_assert_msg(ret == EOK, "check_if_uid_is_active failed.");
+    ck_assert_msg(result, "check_if_uid_is_active did not found my uid [%d]",
                 uid);
 }
 END_TEST
@@ -56,8 +56,8 @@ START_TEST(test_check_if_uid_is_active_fail)
     uid = (uid_t) -4;
 
     ret = check_if_uid_is_active(uid, &result);
-    fail_unless(ret == EOK, "check_if_uid_is_active failed.");
-    fail_unless(!result, "check_if_uid_is_active found (hopefully not active) "
+    ck_assert_msg(ret == EOK, "check_if_uid_is_active failed.");
+    ck_assert_msg(!result, "check_if_uid_is_active found (hopefully not active) "
                          "uid [%d]", uid);
 }
 END_TEST
@@ -72,10 +72,10 @@ START_TEST(test_get_uid_table)
     hash_value_t value;
 
     tmp_ctx = talloc_new(NULL);
-    fail_unless(tmp_ctx != NULL, "talloc_new failed.");
+    ck_assert_msg(tmp_ctx != NULL, "talloc_new failed.");
 
     ret = get_uid_table(tmp_ctx, &table);
-    fail_unless(ret == EOK, "get_uid_table failed.");
+    ck_assert_msg(ret == EOK, "get_uid_table failed.");
 
     uid = getuid();
     key.type = HASH_KEY_ULONG;
@@ -83,7 +83,7 @@ START_TEST(test_get_uid_table)
 
     ret = hash_lookup(table, &key, &value);
 
-    fail_unless(ret == HASH_SUCCESS, "Cannot find my uid [%d] in the table", uid);
+    ck_assert_msg(ret == HASH_SUCCESS, "Cannot find my uid [%d] in the table", uid);
 
     uid = (uid_t) -4;
     key.type = HASH_KEY_ULONG;
@@ -91,7 +91,7 @@ START_TEST(test_get_uid_table)
 
     ret = hash_lookup(table, &key, &value);
 
-    fail_unless(ret == HASH_ERROR_KEY_NOT_FOUND, "Found (hopefully not active) "
+    ck_assert_msg(ret == HASH_ERROR_KEY_NOT_FOUND, "Found (hopefully not active) "
                                                  "uid [%d] in the table", uid);
 
     talloc_free(tmp_ctx);

--- a/src/tests/ipa_hbac-tests.c
+++ b/src/tests/ipa_hbac-tests.c
@@ -75,30 +75,30 @@ static void get_allow_all_rule(TALLOC_CTX *mem_ctx,
      * remote hosts.
      */
     rule = talloc_zero(mem_ctx, struct hbac_rule);
-    fail_if (rule == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rule == NULL, "Failed to allocate memory");
 
     rule->enabled = true;
 
     rule->services = talloc_zero(rule, struct hbac_rule_element);
-    fail_if (rule->services == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rule->services == NULL, "Failed to allocate memory");
     rule->services->category = HBAC_CATEGORY_ALL;
     rule->services->names = NULL;
     rule->services->groups = NULL;
 
     rule->users = talloc_zero(rule, struct hbac_rule_element);
-    fail_if (rule->users == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rule->users == NULL, "Failed to allocate memory");
     rule->users->category = HBAC_CATEGORY_ALL;
     rule->users->names = NULL;
     rule->users->groups = NULL;
 
     rule->targethosts = talloc_zero(rule, struct hbac_rule_element);
-    fail_if (rule->targethosts == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rule->targethosts == NULL, "Failed to allocate memory");
     rule->targethosts->category = HBAC_CATEGORY_ALL;
     rule->targethosts->names = NULL;
     rule->targethosts->groups = NULL;
 
     rule->srchosts = talloc_zero(rule, struct hbac_rule_element);
-    fail_if (rule->srchosts == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rule->srchosts == NULL, "Failed to allocate memory");
     rule->srchosts->category = HBAC_CATEGORY_ALL;
     rule->srchosts->names = NULL;
     rule->srchosts->groups = NULL;
@@ -112,19 +112,19 @@ static void get_test_user(TALLOC_CTX *mem_ctx,
     struct hbac_request_element *new_user;
 
     new_user = talloc_zero(mem_ctx, struct hbac_request_element);
-    fail_if (new_user == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(new_user == NULL, "Failed to allocate memory");
 
     new_user->name = talloc_strdup(new_user, HBAC_TEST_USER);
-    fail_if(new_user->name == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(new_user->name == NULL, "Failed to allocate memory");
 
     new_user->groups = talloc_array(new_user, const char *, 3);
-    fail_if(new_user->groups == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(new_user->groups == NULL, "Failed to allocate memory");
 
     new_user->groups[0] = talloc_strdup(new_user->groups, HBAC_TEST_GROUP1);
-    fail_if(new_user->groups[0] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(new_user->groups[0] == NULL, "Failed to allocate memory");
 
     new_user->groups[1] = talloc_strdup(new_user->groups, HBAC_TEST_GROUP2);
-    fail_if(new_user->groups[1] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(new_user->groups[1] == NULL, "Failed to allocate memory");
 
     new_user->groups[2] = NULL;
 
@@ -137,19 +137,19 @@ static void get_test_service(TALLOC_CTX *mem_ctx,
     struct hbac_request_element *new_service;
 
     new_service = talloc_zero(mem_ctx, struct hbac_request_element);
-    fail_if (new_service == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(new_service == NULL, "Failed to allocate memory");
 
     new_service->name = talloc_strdup(new_service, HBAC_TEST_SERVICE);
-    fail_if(new_service->name == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(new_service->name == NULL, "Failed to allocate memory");
 
     new_service->groups = talloc_array(new_service, const char *, 3);
-    fail_if(new_service->groups == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(new_service->groups == NULL, "Failed to allocate memory");
 
     new_service->groups[0] = talloc_strdup(new_service->groups, HBAC_TEST_SERVICEGROUP1);
-    fail_if(new_service->groups[0] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(new_service->groups[0] == NULL, "Failed to allocate memory");
 
     new_service->groups[1] = talloc_strdup(new_service->groups, HBAC_TEST_SERVICEGROUP2);
-    fail_if(new_service->groups[1] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(new_service->groups[1] == NULL, "Failed to allocate memory");
 
     new_service->groups[2] = NULL;
 
@@ -162,21 +162,21 @@ static void get_test_srchost(TALLOC_CTX *mem_ctx,
     struct hbac_request_element *new_srchost;
 
     new_srchost = talloc_zero(mem_ctx, struct hbac_request_element);
-    fail_if (new_srchost == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(new_srchost == NULL, "Failed to allocate memory");
 
     new_srchost->name = talloc_strdup(new_srchost, HBAC_TEST_SRCHOST);
-    fail_if(new_srchost->name == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(new_srchost->name == NULL, "Failed to allocate memory");
 
     new_srchost->groups = talloc_array(new_srchost, const char *, 3);
-    fail_if(new_srchost->groups == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(new_srchost->groups == NULL, "Failed to allocate memory");
 
     new_srchost->groups[0] = talloc_strdup(new_srchost->groups,
                                            HBAC_TEST_SRCHOSTGROUP1);
-    fail_if(new_srchost->groups[0] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(new_srchost->groups[0] == NULL, "Failed to allocate memory");
 
     new_srchost->groups[1] = talloc_strdup(new_srchost->groups,
                                            HBAC_TEST_SRCHOSTGROUP2);
-    fail_if(new_srchost->groups[1] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(new_srchost->groups[1] == NULL, "Failed to allocate memory");
 
     new_srchost->groups[2] = NULL;
 
@@ -197,7 +197,7 @@ START_TEST(ipa_hbac_test_allow_all)
 
     /* Create a request */
     eval_req = talloc_zero(test_ctx, struct hbac_eval_req);
-    fail_if (eval_req == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(eval_req == NULL, "Failed to allocate memory");
 
     get_test_user(eval_req, &eval_req->user);
     get_test_service(eval_req, &eval_req->service);
@@ -205,22 +205,22 @@ START_TEST(ipa_hbac_test_allow_all)
 
     /* Create the rules to evaluate against */
     rules = talloc_array(test_ctx, struct hbac_rule *, 2);
-    fail_if (rules == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules == NULL, "Failed to allocate memory");
 
     get_allow_all_rule(rules, &rules[0]);
     rules[0]->name = talloc_strdup(rules[0], "Allow All");
-    fail_if(rules[0]->name == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules[0]->name == NULL, "Failed to allocate memory");
     rules[1] = NULL;
 
     /* Validate this rule */
     is_valid = hbac_rule_is_complete(rules[0], &missing_attrs);
-    fail_unless(is_valid, "hbac_rule_is_complete failed");
-    fail_unless(missing_attrs == 0,
+    ck_assert_msg(is_valid, "hbac_rule_is_complete failed");
+    ck_assert_msg(missing_attrs == 0,
                 "Unexpected missing attributes. Got: %"PRIx32, missing_attrs);
 
     /* Evaluate the rules */
     result = hbac_evaluate(rules, eval_req, &info);
-    fail_unless(result == HBAC_EVAL_ALLOW,
+    ck_assert_msg(result == HBAC_EVAL_ALLOW,
                 "Expected [%s], got [%s]; "
                 "Error: [%s]",
                 hbac_result_string(HBAC_EVAL_ALLOW),
@@ -246,7 +246,7 @@ START_TEST(ipa_hbac_test_allow_user)
 
     /* Create a request */
     eval_req = talloc_zero(test_ctx, struct hbac_eval_req);
-    fail_if (eval_req == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(eval_req == NULL, "Failed to allocate memory");
 
     get_test_user(eval_req, &eval_req->user);
     get_test_service(eval_req, &eval_req->service);
@@ -254,17 +254,17 @@ START_TEST(ipa_hbac_test_allow_user)
 
     /* Create the rules to evaluate against */
     rules = talloc_array(test_ctx, struct hbac_rule *, 2);
-    fail_if (rules == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules == NULL, "Failed to allocate memory");
 
     get_allow_all_rule(rules, &rules[0]);
 
     /* Modify the rule to allow only a specific user */
     rules[0]->name = talloc_strdup(rules[0], "Allow user");
-    fail_if(rules[0]->name == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules[0]->name == NULL, "Failed to allocate memory");
     rules[0]->users->category = HBAC_CATEGORY_NULL;
 
     rules[0]->users->names = talloc_array(rules[0], const char *, 2);
-    fail_if(rules[0]->users->names == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules[0]->users->names == NULL, "Failed to allocate memory");
 
     rules[0]->users->names[0] = HBAC_TEST_USER;
     rules[0]->users->names[1] = NULL;
@@ -273,13 +273,13 @@ START_TEST(ipa_hbac_test_allow_user)
 
     /* Validate this rule */
     is_valid = hbac_rule_is_complete(rules[0], &missing_attrs);
-    fail_unless(is_valid, "hbac_rule_is_complete failed");
-    fail_unless(missing_attrs == 0,
+    ck_assert_msg(is_valid, "hbac_rule_is_complete failed");
+    ck_assert_msg(missing_attrs == 0,
                 "Unexpected missing attributes. Got: %"PRIx32, missing_attrs);
 
     /* Evaluate the rules */
     result = hbac_evaluate(rules, eval_req, &info);
-    fail_unless(result == HBAC_EVAL_ALLOW,
+    ck_assert_msg(result == HBAC_EVAL_ALLOW,
                 "Expected [%s], got [%s]; "
                 "Error: [%s]",
                 hbac_result_string(HBAC_EVAL_ALLOW),
@@ -293,13 +293,13 @@ START_TEST(ipa_hbac_test_allow_user)
 
     /* Validate this rule */
     is_valid = hbac_rule_is_complete(rules[0], &missing_attrs);
-    fail_unless(is_valid, "hbac_rule_is_complete failed");
-    fail_unless(missing_attrs == 0,
+    ck_assert_msg(is_valid, "hbac_rule_is_complete failed");
+    ck_assert_msg(missing_attrs == 0,
                 "Unexpected missing attributes. Got: %"PRIx32, missing_attrs);
 
     /* Evaluate the rules */
     result = hbac_evaluate(rules, eval_req, &info);
-    fail_unless(result == HBAC_EVAL_DENY,
+    ck_assert_msg(result == HBAC_EVAL_DENY,
                 "Expected [%s], got [%s]; "
                 "Error: [%s]",
                 hbac_result_string(HBAC_EVAL_DENY),
@@ -326,7 +326,7 @@ START_TEST(ipa_hbac_test_allow_utf8)
 
     /* Create a request */
     eval_req = talloc_zero(test_ctx, struct hbac_eval_req);
-    fail_if (eval_req == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(eval_req == NULL, "Failed to allocate memory");
 
     get_test_user(eval_req, &eval_req->user);
     get_test_service(eval_req, &eval_req->service);
@@ -339,17 +339,17 @@ START_TEST(ipa_hbac_test_allow_utf8)
 
     /* Create the rules to evaluate against */
     rules = talloc_array(test_ctx, struct hbac_rule *, 2);
-    fail_if (rules == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules == NULL, "Failed to allocate memory");
 
     get_allow_all_rule(rules, &rules[0]);
 
     rules[0]->name = talloc_strdup(rules[0], "Allow user");
-    fail_if(rules[0]->name == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules[0]->name == NULL, "Failed to allocate memory");
     rules[0]->users->category = HBAC_CATEGORY_NULL;
 
     /* Modify the rule to allow only a specific user */
     rules[0]->users->names = talloc_array(rules[0], const char *, 2);
-    fail_if(rules[0]->users->names == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules[0]->users->names == NULL, "Failed to allocate memory");
 
     rules[0]->users->names[0] = (const char *) &user_utf8_upcase;
     rules[0]->users->names[1] = NULL;
@@ -358,7 +358,7 @@ START_TEST(ipa_hbac_test_allow_utf8)
     rules[0]->services->category = HBAC_CATEGORY_NULL;
 
     rules[0]->services->names = talloc_array(rules[0], const char *, 2);
-    fail_if(rules[0]->services->names == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules[0]->services->names == NULL, "Failed to allocate memory");
 
     rules[0]->services->names[0] = (const char *) &service_utf8_upcase;
     rules[0]->services->names[1] = NULL;
@@ -367,7 +367,7 @@ START_TEST(ipa_hbac_test_allow_utf8)
     rules[0]->srchosts->category = HBAC_CATEGORY_NULL;
 
     rules[0]->srchosts->names = talloc_array(rules[0], const char *, 2);
-    fail_if(rules[0]->services->names == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules[0]->services->names == NULL, "Failed to allocate memory");
 
     rules[0]->srchosts->names[0] = (const char *) &srchost_utf8_upcase;
     rules[0]->srchosts->names[1] = NULL;
@@ -376,13 +376,13 @@ START_TEST(ipa_hbac_test_allow_utf8)
 
     /* Validate this rule */
     is_valid = hbac_rule_is_complete(rules[0], &missing_attrs);
-    fail_unless(is_valid, "hbac_rule_is_complete failed");
-    fail_unless(missing_attrs == 0,
+    ck_assert_msg(is_valid, "hbac_rule_is_complete failed");
+    ck_assert_msg(missing_attrs == 0,
                 "Unexpected missing attributes. Got: %"PRIx32, missing_attrs);
 
     /* Evaluate the rules */
     result = hbac_evaluate(rules, eval_req, &info);
-    fail_unless(result == HBAC_EVAL_ALLOW,
+    ck_assert_msg(result == HBAC_EVAL_ALLOW,
                 "Expected [%s], got [%s]; "
                 "Error: [%s]",
                 hbac_result_string(HBAC_EVAL_ALLOW),
@@ -397,7 +397,7 @@ START_TEST(ipa_hbac_test_allow_utf8)
 
     /* Evaluate the rules */
     result = hbac_evaluate(rules, eval_req, &info);
-    fail_unless(result == HBAC_EVAL_DENY,
+    ck_assert_msg(result == HBAC_EVAL_DENY,
                 "Expected [%s], got [%s]; "
                 "Error: [%s]",
                 hbac_result_string(HBAC_EVAL_DENY),
@@ -413,13 +413,13 @@ START_TEST(ipa_hbac_test_allow_utf8)
 
     /* Validate this rule */
     is_valid = hbac_rule_is_complete(rules[0], &missing_attrs);
-    fail_unless(is_valid, "hbac_rule_is_complete failed");
-    fail_unless(missing_attrs == 0,
+    ck_assert_msg(is_valid, "hbac_rule_is_complete failed");
+    ck_assert_msg(missing_attrs == 0,
                 "Unexpected missing attributes. Got: %"PRIx32, missing_attrs);
 
     /* Evaluate the rules */
     result = hbac_evaluate(rules, eval_req, &info);
-    fail_unless(result == HBAC_EVAL_DENY,
+    ck_assert_msg(result == HBAC_EVAL_DENY,
                 "Expected [%s], got [%s]; "
                 "Error: [%s]",
                 hbac_result_string(HBAC_EVAL_DENY),
@@ -446,7 +446,7 @@ START_TEST(ipa_hbac_test_allow_group)
 
     /* Create a request */
     eval_req = talloc_zero(test_ctx, struct hbac_eval_req);
-    fail_if (eval_req == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(eval_req == NULL, "Failed to allocate memory");
 
     get_test_user(eval_req, &eval_req->user);
     get_test_service(eval_req, &eval_req->service);
@@ -454,18 +454,18 @@ START_TEST(ipa_hbac_test_allow_group)
 
     /* Create the rules to evaluate against */
     rules = talloc_array(test_ctx, struct hbac_rule *, 2);
-    fail_if (rules == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules == NULL, "Failed to allocate memory");
 
     get_allow_all_rule(rules, &rules[0]);
 
     /* Modify the rule to allow only a group of users */
     rules[0]->name = talloc_strdup(rules[0], "Allow group");
-    fail_if(rules[0]->name == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules[0]->name == NULL, "Failed to allocate memory");
     rules[0]->users->category = HBAC_CATEGORY_NULL;
 
     rules[0]->users->names = NULL;
     rules[0]->users->groups = talloc_array(rules[0], const char *, 2);
-    fail_if(rules[0]->users->groups == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules[0]->users->groups == NULL, "Failed to allocate memory");
 
     rules[0]->users->groups[0] = HBAC_TEST_GROUP1;
     rules[0]->users->groups[1] = NULL;
@@ -474,13 +474,13 @@ START_TEST(ipa_hbac_test_allow_group)
 
     /* Validate this rule */
     is_valid = hbac_rule_is_complete(rules[0], &missing_attrs);
-    fail_unless(is_valid, "hbac_rule_is_complete failed");
-    fail_unless(missing_attrs == 0,
+    ck_assert_msg(is_valid, "hbac_rule_is_complete failed");
+    ck_assert_msg(missing_attrs == 0,
                 "Unexpected missing attributes. Got: %"PRIx32, missing_attrs);
 
     /* Evaluate the rules */
     result = hbac_evaluate(rules, eval_req, &info);
-    fail_unless(result == HBAC_EVAL_ALLOW,
+    ck_assert_msg(result == HBAC_EVAL_ALLOW,
                 "Expected [%s], got [%s]; "
                 "Error: [%s]",
                 hbac_result_string(HBAC_EVAL_ALLOW),
@@ -494,13 +494,13 @@ START_TEST(ipa_hbac_test_allow_group)
 
     /* Validate this rule */
     is_valid = hbac_rule_is_complete(rules[0], &missing_attrs);
-    fail_unless(is_valid, "hbac_rule_is_complete failed");
-    fail_unless(missing_attrs == 0,
+    ck_assert_msg(is_valid, "hbac_rule_is_complete failed");
+    ck_assert_msg(missing_attrs == 0,
                 "Unexpected missing attributes. Got: %"PRIx32, missing_attrs);
 
     /* Evaluate the rules */
     result = hbac_evaluate(rules, eval_req, &info);
-    fail_unless(result == HBAC_EVAL_DENY,
+    ck_assert_msg(result == HBAC_EVAL_DENY,
                 "Expected [%s], got [%s]; "
                 "Error: [%s]",
                 hbac_result_string(HBAC_EVAL_DENY),
@@ -527,7 +527,7 @@ START_TEST(ipa_hbac_test_allow_svc)
 
     /* Create a request */
     eval_req = talloc_zero(test_ctx, struct hbac_eval_req);
-    fail_if (eval_req == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(eval_req == NULL, "Failed to allocate memory");
 
     get_test_user(eval_req, &eval_req->user);
     get_test_service(eval_req, &eval_req->service);
@@ -535,17 +535,17 @@ START_TEST(ipa_hbac_test_allow_svc)
 
     /* Create the rules to evaluate against */
     rules = talloc_array(test_ctx, struct hbac_rule *, 2);
-    fail_if (rules == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules == NULL, "Failed to allocate memory");
 
     get_allow_all_rule(rules, &rules[0]);
 
     /* Modify the rule to allow only a specific service */
     rules[0]->name = talloc_strdup(rules[0], "Allow service");
-    fail_if(rules[0]->name == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules[0]->name == NULL, "Failed to allocate memory");
     rules[0]->services->category = HBAC_CATEGORY_NULL;
 
     rules[0]->services->names = talloc_array(rules[0], const char *, 2);
-    fail_if(rules[0]->services->names == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules[0]->services->names == NULL, "Failed to allocate memory");
 
     rules[0]->services->names[0] = HBAC_TEST_SERVICE;
     rules[0]->services->names[1] = NULL;
@@ -554,13 +554,13 @@ START_TEST(ipa_hbac_test_allow_svc)
 
     /* Validate this rule */
     is_valid = hbac_rule_is_complete(rules[0], &missing_attrs);
-    fail_unless(is_valid, "hbac_rule_is_complete failed");
-    fail_unless(missing_attrs == 0,
+    ck_assert_msg(is_valid, "hbac_rule_is_complete failed");
+    ck_assert_msg(missing_attrs == 0,
                 "Unexpected missing attributes. Got: %"PRIx32, missing_attrs);
 
     /* Evaluate the rules */
     result = hbac_evaluate(rules, eval_req, &info);
-    fail_unless(result == HBAC_EVAL_ALLOW,
+    ck_assert_msg(result == HBAC_EVAL_ALLOW,
                 "Expected [%s], got [%s]; "
                 "Error: [%s]",
                 hbac_result_string(HBAC_EVAL_ALLOW),
@@ -574,13 +574,13 @@ START_TEST(ipa_hbac_test_allow_svc)
 
     /* Validate this rule */
     is_valid = hbac_rule_is_complete(rules[0], &missing_attrs);
-    fail_unless(is_valid, "hbac_rule_is_complete failed");
-    fail_unless(missing_attrs == 0,
+    ck_assert_msg(is_valid, "hbac_rule_is_complete failed");
+    ck_assert_msg(missing_attrs == 0,
                 "Unexpected missing attributes. Got: %"PRIx32, missing_attrs);
 
     /* Evaluate the rules */
     result = hbac_evaluate(rules, eval_req, &info);
-    fail_unless(result == HBAC_EVAL_DENY,
+    ck_assert_msg(result == HBAC_EVAL_DENY,
                 "Expected [%s], got [%s]; "
                 "Error: [%s]",
                 hbac_result_string(HBAC_EVAL_DENY),
@@ -607,7 +607,7 @@ START_TEST(ipa_hbac_test_allow_svcgroup)
 
     /* Create a request */
     eval_req = talloc_zero(test_ctx, struct hbac_eval_req);
-    fail_if (eval_req == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(eval_req == NULL, "Failed to allocate memory");
 
     get_test_user(eval_req, &eval_req->user);
     get_test_service(eval_req, &eval_req->service);
@@ -615,18 +615,18 @@ START_TEST(ipa_hbac_test_allow_svcgroup)
 
     /* Create the rules to evaluate against */
     rules = talloc_array(test_ctx, struct hbac_rule *, 2);
-    fail_if (rules == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules == NULL, "Failed to allocate memory");
 
     get_allow_all_rule(rules, &rules[0]);
 
     /* Modify the rule to allow only a group of users */
     rules[0]->name = talloc_strdup(rules[0], "Allow servicegroup");
-    fail_if(rules[0]->name == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules[0]->name == NULL, "Failed to allocate memory");
     rules[0]->services->category = HBAC_CATEGORY_NULL;
 
     rules[0]->services->names = NULL;
     rules[0]->services->groups = talloc_array(rules[0], const char *, 2);
-    fail_if(rules[0]->services->groups == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules[0]->services->groups == NULL, "Failed to allocate memory");
 
     rules[0]->services->groups[0] = HBAC_TEST_SERVICEGROUP1;
     rules[0]->services->groups[1] = NULL;
@@ -635,13 +635,13 @@ START_TEST(ipa_hbac_test_allow_svcgroup)
 
     /* Validate this rule */
     is_valid = hbac_rule_is_complete(rules[0], &missing_attrs);
-    fail_unless(is_valid, "hbac_rule_is_complete failed");
-    fail_unless(missing_attrs == 0,
+    ck_assert_msg(is_valid, "hbac_rule_is_complete failed");
+    ck_assert_msg(missing_attrs == 0,
                 "Unexpected missing attributes. Got: %"PRIx32, missing_attrs);
 
     /* Evaluate the rules */
     result = hbac_evaluate(rules, eval_req, &info);
-    fail_unless(result == HBAC_EVAL_ALLOW,
+    ck_assert_msg(result == HBAC_EVAL_ALLOW,
                 "Expected [%s], got [%s]; "
                 "Error: [%s]",
                 hbac_result_string(HBAC_EVAL_ALLOW),
@@ -655,13 +655,13 @@ START_TEST(ipa_hbac_test_allow_svcgroup)
 
     /* Validate this rule */
     is_valid = hbac_rule_is_complete(rules[0], &missing_attrs);
-    fail_unless(is_valid, "hbac_rule_is_complete failed");
-    fail_unless(missing_attrs == 0,
+    ck_assert_msg(is_valid, "hbac_rule_is_complete failed");
+    ck_assert_msg(missing_attrs == 0,
                 "Unexpected missing attributes. Got: %"PRIx32, missing_attrs);
 
     /* Evaluate the rules */
     result = hbac_evaluate(rules, eval_req, &info);
-    fail_unless(result == HBAC_EVAL_DENY,
+    ck_assert_msg(result == HBAC_EVAL_DENY,
                 "Expected [%s], got [%s]; "
                 "Error: [%s]",
                 hbac_result_string(HBAC_EVAL_DENY),
@@ -688,7 +688,7 @@ START_TEST(ipa_hbac_test_allow_srchost)
 
     /* Create a request */
     eval_req = talloc_zero(test_ctx, struct hbac_eval_req);
-    fail_if (eval_req == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(eval_req == NULL, "Failed to allocate memory");
 
     get_test_user(eval_req, &eval_req->user);
     get_test_service(eval_req, &eval_req->service);
@@ -696,17 +696,17 @@ START_TEST(ipa_hbac_test_allow_srchost)
 
     /* Create the rules to evaluate against */
     rules = talloc_array(test_ctx, struct hbac_rule *, 2);
-    fail_if (rules == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules == NULL, "Failed to allocate memory");
 
     get_allow_all_rule(rules, &rules[0]);
 
     /* Modify the rule to allow only a specific service */
     rules[0]->name = talloc_strdup(rules[0], "Allow srchost");
-    fail_if(rules[0]->name == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules[0]->name == NULL, "Failed to allocate memory");
     rules[0]->srchosts->category = HBAC_CATEGORY_NULL;
 
     rules[0]->srchosts->names = talloc_array(rules[0], const char *, 2);
-    fail_if(rules[0]->srchosts->names == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules[0]->srchosts->names == NULL, "Failed to allocate memory");
 
     rules[0]->srchosts->names[0] = HBAC_TEST_SRCHOST;
     rules[0]->srchosts->names[1] = NULL;
@@ -715,13 +715,13 @@ START_TEST(ipa_hbac_test_allow_srchost)
 
     /* Validate this rule */
     is_valid = hbac_rule_is_complete(rules[0], &missing_attrs);
-    fail_unless(is_valid, "hbac_rule_is_complete failed");
-    fail_unless(missing_attrs == 0,
+    ck_assert_msg(is_valid, "hbac_rule_is_complete failed");
+    ck_assert_msg(missing_attrs == 0,
                 "Unexpected missing attributes. Got: %"PRIx32, missing_attrs);
 
     /* Evaluate the rules */
     result = hbac_evaluate(rules, eval_req, &info);
-    fail_unless(result == HBAC_EVAL_ALLOW,
+    ck_assert_msg(result == HBAC_EVAL_ALLOW,
                 "Expected [%s], got [%s]; "
                 "Error: [%s]",
                 hbac_result_string(HBAC_EVAL_ALLOW),
@@ -735,13 +735,13 @@ START_TEST(ipa_hbac_test_allow_srchost)
 
     /* Validate this rule */
     is_valid = hbac_rule_is_complete(rules[0], &missing_attrs);
-    fail_unless(is_valid, "hbac_rule_is_complete failed");
-    fail_unless(missing_attrs == 0,
+    ck_assert_msg(is_valid, "hbac_rule_is_complete failed");
+    ck_assert_msg(missing_attrs == 0,
                 "Unexpected missing attributes. Got: %"PRIx32, missing_attrs);
 
     /* Evaluate the rules */
     result = hbac_evaluate(rules, eval_req, &info);
-    fail_unless(result == HBAC_EVAL_DENY,
+    ck_assert_msg(result == HBAC_EVAL_DENY,
                 "Expected [%s], got [%s]; "
                 "Error: [%s]",
                 hbac_result_string(HBAC_EVAL_DENY),
@@ -768,7 +768,7 @@ START_TEST(ipa_hbac_test_allow_srchostgroup)
 
     /* Create a request */
     eval_req = talloc_zero(test_ctx, struct hbac_eval_req);
-    fail_if (eval_req == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(eval_req == NULL, "Failed to allocate memory");
 
     get_test_user(eval_req, &eval_req->user);
     get_test_service(eval_req, &eval_req->service);
@@ -776,18 +776,18 @@ START_TEST(ipa_hbac_test_allow_srchostgroup)
 
     /* Create the rules to evaluate against */
     rules = talloc_array(test_ctx, struct hbac_rule *, 2);
-    fail_if (rules == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules == NULL, "Failed to allocate memory");
 
     get_allow_all_rule(rules, &rules[0]);
 
     /* Modify the rule to allow only a group of users */
     rules[0]->name = talloc_strdup(rules[0], "Allow srchostgroup");
-    fail_if(rules[0]->name == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules[0]->name == NULL, "Failed to allocate memory");
     rules[0]->srchosts->category = HBAC_CATEGORY_NULL;
 
     rules[0]->srchosts->names = NULL;
     rules[0]->srchosts->groups = talloc_array(rules[0], const char *, 2);
-    fail_if(rules[0]->srchosts->groups == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rules[0]->srchosts->groups == NULL, "Failed to allocate memory");
 
     rules[0]->srchosts->groups[0] = HBAC_TEST_SRCHOSTGROUP1;
     rules[0]->srchosts->groups[1] = NULL;
@@ -796,13 +796,13 @@ START_TEST(ipa_hbac_test_allow_srchostgroup)
 
     /* Validate this rule */
     is_valid = hbac_rule_is_complete(rules[0], &missing_attrs);
-    fail_unless(is_valid, "hbac_rule_is_complete failed");
-    fail_unless(missing_attrs == 0,
+    ck_assert_msg(is_valid, "hbac_rule_is_complete failed");
+    ck_assert_msg(missing_attrs == 0,
                 "Unexpected missing attributes. Got: %"PRIx32, missing_attrs);
 
     /* Evaluate the rules */
     result = hbac_evaluate(rules, eval_req, &info);
-    fail_unless(result == HBAC_EVAL_ALLOW,
+    ck_assert_msg(result == HBAC_EVAL_ALLOW,
                 "Expected [%s], got [%s]; "
                 "Error: [%s]",
                 hbac_result_string(HBAC_EVAL_ALLOW),
@@ -816,13 +816,13 @@ START_TEST(ipa_hbac_test_allow_srchostgroup)
 
     /* Validate this rule */
     is_valid = hbac_rule_is_complete(rules[0], &missing_attrs);
-    fail_unless(is_valid, "hbac_rule_is_complete failed");
-    fail_unless(missing_attrs == 0,
+    ck_assert_msg(is_valid, "hbac_rule_is_complete failed");
+    ck_assert_msg(missing_attrs == 0,
                 "Unexpected missing attributes. Got: %"PRIx32, missing_attrs);
 
     /* Evaluate the rules */
     result = hbac_evaluate(rules, eval_req, &info);
-    fail_unless(result == HBAC_EVAL_DENY,
+    ck_assert_msg(result == HBAC_EVAL_DENY,
                 "Expected [%s], got [%s]; "
                 "Error: [%s]",
                 hbac_result_string(HBAC_EVAL_DENY),
@@ -848,14 +848,14 @@ START_TEST(ipa_hbac_test_incomplete)
 
     /* Validate this rule */
     is_valid = hbac_rule_is_complete(rule, &missing_attrs);
-    fail_if(is_valid, "hbac_rule_is_complete failed");
-    fail_unless(missing_attrs | HBAC_RULE_ELEMENT_USERS,
+    sss_ck_fail_if_msg(is_valid, "hbac_rule_is_complete failed");
+    ck_assert_msg(missing_attrs | HBAC_RULE_ELEMENT_USERS,
                 "missing_attrs failed for HBAC_RULE_ELEMENT_USERS");
-    fail_unless(missing_attrs | HBAC_RULE_ELEMENT_SERVICES,
+    ck_assert_msg(missing_attrs | HBAC_RULE_ELEMENT_SERVICES,
                 "missing_attrs failed for HBAC_RULE_ELEMENT_SERVICES");
-    fail_unless(missing_attrs | HBAC_RULE_ELEMENT_TARGETHOSTS,
+    ck_assert_msg(missing_attrs | HBAC_RULE_ELEMENT_TARGETHOSTS,
                 "missing_attrs failed for HBAC_RULE_ELEMENT_TARGETHOSTS");
-    fail_unless(missing_attrs | HBAC_RULE_ELEMENT_SOURCEHOSTS,
+    ck_assert_msg(missing_attrs | HBAC_RULE_ELEMENT_SOURCEHOSTS,
                 "missing_attrs failed for HBAC_RULE_ELEMENT_SOURCEHOSTS");
 
     talloc_free(test_ctx);

--- a/src/tests/ipa_ldap_opt-tests.c
+++ b/src/tests/ipa_ldap_opt-tests.c
@@ -34,7 +34,7 @@
 #include "providers/krb5/krb5_common.h"
 #include "providers/ad/ad_opts.h"
 #include "providers/be_dyndns.h"
-#include "tests/common.h"
+#include "tests/common_check.h"
 
 struct test_domain {
     const char *domain;
@@ -64,20 +64,20 @@ START_TEST(test_domain_to_basedn)
     char *basedn;
 
     tmp_ctx = talloc_new(NULL);
-    fail_unless(tmp_ctx != NULL, "talloc_new failed");
+    ck_assert_msg(tmp_ctx != NULL, "talloc_new failed");
 
     ret = domain_to_basedn(tmp_ctx, NULL, &basedn);
-    fail_unless(ret == EINVAL,
+    ck_assert_msg(ret == EINVAL,
                 "domain_to_basedn does not fail with EINVAL if domain is NULL");
 
     ret = domain_to_basedn(tmp_ctx, "abc", NULL);
-    fail_unless(ret == EINVAL,
+    ck_assert_msg(ret == EINVAL,
                 "domain_to_basedn does not fail with EINVAL if basedn is NULL");
 
     for(i=0; test_domains[i].domain != NULL; i++) {
         ret = domain_to_basedn(tmp_ctx, test_domains[i].domain, &basedn);
-        fail_unless(ret == EOK, "domain_to_basedn failed");
-        fail_unless(strcmp(basedn, test_domains[i].basedn) == 0,
+        ck_assert_msg(ret == EOK, "domain_to_basedn failed");
+        ck_assert_msg(strcmp(basedn, test_domains[i].basedn) == 0,
                     "domain_to_basedn returned wrong basedn, "
                     "get [%s], expected [%s]", basedn, test_domains[i].basedn);
         talloc_free(basedn);
@@ -93,15 +93,15 @@ START_TEST(test_compare_opts)
 
     ret = compare_dp_options(default_basic_opts, SDAP_OPTS_BASIC,
                              ipa_def_ldap_opts);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 
     ret = compare_dp_options(default_krb5_opts, KRB5_OPTS,
                              ipa_def_krb5_opts);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 
     ret = compare_dp_options(ipa_dyndns_opts, DP_OPT_DYNDNS,
                              ad_dyndns_opts);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 }
 END_TEST
 
@@ -112,33 +112,33 @@ START_TEST(test_compare_sdap_attrs)
     /* General Attributes */
     ret = compare_sdap_attr_maps(generic_attr_map, SDAP_AT_GENERAL,
                                  ipa_attr_map);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 
     /* User Attributes */
     ret = compare_sdap_attr_maps(rfc2307_user_map, SDAP_OPTS_USER,
                                  ipa_user_map);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 
     /* Group Attributes */
     ret = compare_sdap_attr_maps(rfc2307_group_map, SDAP_OPTS_GROUP,
                                  ipa_group_map);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 
     /* Service Attributes */
     ret = compare_sdap_attr_maps(service_map, SDAP_OPTS_SERVICES,
                                  ipa_service_map);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 
     /* AutoFS Attributes */
     ret = compare_sdap_attr_maps(rfc2307_autofs_mobject_map,
                                  SDAP_OPTS_AUTOFS_MAP,
                                  ipa_autofs_mobject_map);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 
     ret = compare_sdap_attr_maps(rfc2307_autofs_entry_map,
                                  SDAP_OPTS_AUTOFS_ENTRY,
                                  ipa_autofs_entry_map);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 }
 END_TEST
 
@@ -149,47 +149,47 @@ START_TEST(test_compare_2307_with_2307bis)
     /* User Attributes */
     ret = compare_sdap_attr_maps(rfc2307_user_map, SDAP_OPTS_USER,
                                  rfc2307bis_user_map);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 
     /* Group Attributes */
     ret = compare_sdap_attr_maps(rfc2307_group_map, SDAP_OPTS_GROUP,
                                  rfc2307bis_group_map);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 
     /* AutoFS Attributes */
     ret = compare_sdap_attr_maps(rfc2307_autofs_mobject_map,
                                  SDAP_OPTS_AUTOFS_MAP,
                                  rfc2307bis_autofs_mobject_map);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 
     ret = compare_sdap_attr_maps(rfc2307_autofs_entry_map,
                                  SDAP_OPTS_AUTOFS_ENTRY,
                                  rfc2307bis_autofs_entry_map);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 }
 END_TEST
 
 static void fail_unless_dp_opt_is_terminator(struct dp_option *o)
 {
-    fail_unless(o->opt_name == NULL,
+    ck_assert_msg(o->opt_name == NULL,
                 "Unexpected NULL for opt_name in dp_option");
-    fail_unless(o->type == 0,
+    ck_assert_msg(o->type == 0,
                 "Unexpected 0 for type in dp_option");
-    fail_unless(o->def_val.string == NULL,
+    ck_assert_msg(o->def_val.string == NULL,
                 "Unexpected NULL for def_val.string in dp_option");
-    fail_unless(o->val.string == NULL,
+    ck_assert_msg(o->val.string == NULL,
                 "Unexpected NULL for val.string in dp_option");
 }
 
 static void fail_unless_sdap_opt_is_terminator(struct sdap_attr_map *m)
 {
-    fail_unless(m->name == NULL,
+    ck_assert_msg(m->name == NULL,
                 "Unexpected NULL for name in sdap_attr_map");
-    fail_unless(m->def_name == NULL,
+    ck_assert_msg(m->def_name == NULL,
                 "Unexpected NULL for def_name in sdap_attr_map");
-    fail_unless(m->sys_name == NULL,
+    ck_assert_msg(m->sys_name == NULL,
                 "Unexpected NULL for sys_name in sdap_attr_map");
-    fail_unless(m->opt_name == NULL,
+    ck_assert_msg(m->opt_name == NULL,
                 "Unexpected NULL for opt_name in sdap_attr_map");
 }
 
@@ -267,10 +267,10 @@ START_TEST(test_copy_opts)
     struct dp_option *opts;
 
     tmp_ctx = talloc_new(NULL);
-    fail_unless(tmp_ctx != NULL, "talloc_new failed");
+    ck_assert_msg(tmp_ctx != NULL, "talloc_new failed");
 
     ret = dp_copy_defaults(tmp_ctx, ad_def_ldap_opts, SDAP_OPTS_BASIC, &opts);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 
     for (int i=0; i < SDAP_OPTS_BASIC; i++) {
         char *s1, *s2;
@@ -284,7 +284,7 @@ START_TEST(test_copy_opts)
             s2 = opts[i].def_val.string;
 
             if (s1 != NULL || s2 != NULL) {
-                fail_unless(strcmp(s1, s2) == 0,
+                ck_assert_msg(strcmp(s1, s2) == 0,
                             "Option %s does not have default value after copy\n",
                             opts[i].opt_name);
             }
@@ -294,7 +294,7 @@ START_TEST(test_copy_opts)
             i1 = dp_opt_get_int(opts, i);
             i2 = opts[i].def_val.number;
 
-            fail_unless(i1 == i2,
+            ck_assert_msg(i1 == i2,
                         "Option %s does not have default value after copy\n",
                         opts[i].opt_name);
             break;
@@ -303,7 +303,7 @@ START_TEST(test_copy_opts)
             b1 = dp_opt_get_bool(opts, i);
             b2 = opts[i].def_val.boolean;
 
-            fail_unless(b1 == b2,
+            ck_assert_msg(b1 == b2,
                         "Option %s does not have default value after copy\n",
                         opts[i].opt_name);
             break;
@@ -312,10 +312,10 @@ START_TEST(test_copy_opts)
             bl1 = dp_opt_get_blob(opts, i);
             bl2 = opts[i].def_val.blob;
 
-            fail_unless(bl1.length == bl2.length,
+            ck_assert_msg(bl1.length == bl2.length,
                         "Blobs differ in size for option %s\n",
                         opts[i].opt_name);
-            fail_unless(memcmp(bl1.data, bl2.data, bl1.length) == 0,
+            ck_assert_msg(memcmp(bl1.data, bl2.data, bl1.length) == 0,
                         "Blobs differ in value for option %s\n",
                         opts[i].opt_name);
         }
@@ -332,53 +332,53 @@ START_TEST(test_copy_sdap_map)
 
     ret = sdap_copy_map(global_talloc_context,
                         rfc2307_user_map, SDAP_OPTS_USER, &out_map);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
-    fail_unless(out_map[SDAP_OPTS_USER].name == NULL,
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(out_map[SDAP_OPTS_USER].name == NULL,
                 "Unexpected NULL for name with idx: %d", SDAP_OPTS_USER);
-    fail_unless(out_map[SDAP_OPTS_USER].def_name == NULL,
+    ck_assert_msg(out_map[SDAP_OPTS_USER].def_name == NULL,
                 "Unexpected NULL for def_name with idx: %d", SDAP_OPTS_USER);
-    fail_unless(out_map[SDAP_OPTS_USER].sys_name == NULL,
+    ck_assert_msg(out_map[SDAP_OPTS_USER].sys_name == NULL,
                 "Unexpected NULL for sys_name with idx: %d", SDAP_OPTS_USER);
-    fail_unless(out_map[SDAP_OPTS_USER].opt_name == NULL,
+    ck_assert_msg(out_map[SDAP_OPTS_USER].opt_name == NULL,
                 "Unexpected NULL for opt_name with idx: %d", SDAP_OPTS_USER);
     talloc_free(out_map);
 
     ret = sdap_copy_map(global_talloc_context,
                         rfc2307bis_user_map, SDAP_OPTS_USER, &out_map);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
-    fail_unless(out_map[SDAP_OPTS_USER].name == NULL,
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(out_map[SDAP_OPTS_USER].name == NULL,
                 "Unexpected NULL for name with idx: %d", SDAP_OPTS_USER);
-    fail_unless(out_map[SDAP_OPTS_USER].def_name == NULL,
+    ck_assert_msg(out_map[SDAP_OPTS_USER].def_name == NULL,
                 "Unexpected NULL for def_name with idx: %d", SDAP_OPTS_USER);
-    fail_unless(out_map[SDAP_OPTS_USER].sys_name == NULL,
+    ck_assert_msg(out_map[SDAP_OPTS_USER].sys_name == NULL,
                 "Unexpected NULL for sys_name with idx: %d", SDAP_OPTS_USER);
-    fail_unless(out_map[SDAP_OPTS_USER].opt_name == NULL,
+    ck_assert_msg(out_map[SDAP_OPTS_USER].opt_name == NULL,
                 "Unexpected NULL for opt_name with idx: %d", SDAP_OPTS_USER);
     talloc_free(out_map);
 
     ret = sdap_copy_map(global_talloc_context,
                         ipa_user_map, SDAP_OPTS_USER, &out_map);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
-    fail_unless(out_map[SDAP_OPTS_USER].name == NULL,
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(out_map[SDAP_OPTS_USER].name == NULL,
                 "Unexpected NULL for name with idx: %d", SDAP_OPTS_USER);
-    fail_unless(out_map[SDAP_OPTS_USER].def_name == NULL,
+    ck_assert_msg(out_map[SDAP_OPTS_USER].def_name == NULL,
                 "Unexpected NULL for def_name with idx: %d", SDAP_OPTS_USER);
-    fail_unless(out_map[SDAP_OPTS_USER].sys_name == NULL,
+    ck_assert_msg(out_map[SDAP_OPTS_USER].sys_name == NULL,
                 "Unexpected NULL for sys_name with idx: %d", SDAP_OPTS_USER);
-    fail_unless(out_map[SDAP_OPTS_USER].opt_name == NULL,
+    ck_assert_msg(out_map[SDAP_OPTS_USER].opt_name == NULL,
                 "Unexpected NULL for opt_name with idx: %d", SDAP_OPTS_USER);
     talloc_free(out_map);
 
     ret = sdap_copy_map(global_talloc_context,
                         gen_ad2008r2_user_map, SDAP_OPTS_USER, &out_map);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
-    fail_unless(out_map[SDAP_OPTS_USER].name == NULL,
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(out_map[SDAP_OPTS_USER].name == NULL,
                 "Unexpected NULL for name with idx: %d", SDAP_OPTS_USER);
-    fail_unless(out_map[SDAP_OPTS_USER].def_name == NULL,
+    ck_assert_msg(out_map[SDAP_OPTS_USER].def_name == NULL,
                 "Unexpected NULL for def_name with idx: %d", SDAP_OPTS_USER);
-    fail_unless(out_map[SDAP_OPTS_USER].sys_name == NULL,
+    ck_assert_msg(out_map[SDAP_OPTS_USER].sys_name == NULL,
                 "Unexpected NULL for sys_name with idx: %d", SDAP_OPTS_USER);
-    fail_unless(out_map[SDAP_OPTS_USER].opt_name == NULL,
+    ck_assert_msg(out_map[SDAP_OPTS_USER].opt_name == NULL,
                 "Unexpected NULL for opt_name with idx: %d", SDAP_OPTS_USER);
     talloc_free(out_map);
 }
@@ -396,17 +396,17 @@ START_TEST(test_extra_opts)
 
     ret = sdap_copy_map(global_talloc_context, rfc2307_user_map,
                         SDAP_OPTS_USER, &in_map);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 
     ret = sdap_extend_map(global_talloc_context,
                           in_map,
                           SDAP_OPTS_USER,
                           extra_attrs,
                           &out_map, &new_size);
-    fail_unless(ret == EOK, "[%s]", sss_strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", sss_strerror(ret));
 
     /* Two extra and sentinel */
-    fail_if(new_size == SDAP_OPTS_USER + 3,
+    sss_ck_fail_if_msg(new_size == SDAP_OPTS_USER + 3,
             "new_size [%zu] mest not be equal to[%d]",
             new_size, SDAP_OPTS_USER + 3);
     /* Foo would be saved to sysdb verbatim */
@@ -415,7 +415,7 @@ START_TEST(test_extra_opts)
     /* Bar would be saved to sysdb as baz */
     ck_assert_str_eq(out_map[SDAP_OPTS_USER+1].name, "bar");
     ck_assert_str_eq(out_map[SDAP_OPTS_USER+1].sys_name, "baz");
-    fail_unless(out_map[SDAP_OPTS_USER+2].name == NULL,
+    ck_assert_msg(out_map[SDAP_OPTS_USER+2].name == NULL,
                 "Unexpected NULL for name with id: %d", SDAP_OPTS_USER + 2);
 
     talloc_free(out_map);
@@ -431,19 +431,19 @@ START_TEST(test_no_extra_opts)
 
     ret = sdap_copy_map(global_talloc_context, rfc2307_user_map,
                         SDAP_OPTS_USER, &in_map);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 
     ret = sdap_extend_map(global_talloc_context,
                           in_map,
                           SDAP_OPTS_USER,
                           NULL,
                           &out_map, &new_size);
-    fail_unless(ret == EOK, "[%s]", sss_strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", sss_strerror(ret));
     /* Attributes and sentinel */
-    fail_if(new_size == SDAP_OPTS_USER + 1,
+    sss_ck_fail_if_msg(new_size == SDAP_OPTS_USER + 1,
             "new_size [%zu] mest not be equal to[%d]",
             new_size, SDAP_OPTS_USER + 1);
-    fail_unless(out_map[SDAP_OPTS_USER].name == NULL,
+    ck_assert_msg(out_map[SDAP_OPTS_USER].name == NULL,
                 "Unexpected NULL for name with id: %d", SDAP_OPTS_USER);
 
     talloc_free(out_map);
@@ -462,19 +462,19 @@ START_TEST(test_extra_opts_neg)
 
     ret = sdap_copy_map(global_talloc_context, rfc2307_user_map,
                         SDAP_OPTS_USER, &in_map);
-    fail_unless(ret == EOK, "[%s]", sss_strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", sss_strerror(ret));
 
     ret = sdap_extend_map(global_talloc_context,
                           in_map,
                           SDAP_OPTS_USER,
                           extra_attrs,
                           &out_map, &new_size);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
     /* The faulty attributes would be just skipped */
-    fail_if(new_size == SDAP_OPTS_USER + 1,
+    sss_ck_fail_if_msg(new_size == SDAP_OPTS_USER + 1,
             "new_size [%zu] mest not be equal to[%d]",
             new_size, SDAP_OPTS_USER + 1);
-    fail_unless(out_map[SDAP_OPTS_USER].name == NULL,
+    ck_assert_msg(out_map[SDAP_OPTS_USER].name == NULL,
                 "Unexpected NULL for name with id: %d", SDAP_OPTS_USER);
 
     talloc_free(out_map);
@@ -492,14 +492,14 @@ START_TEST(test_extra_opts_dup)
 
     ret = sdap_copy_map(global_talloc_context, rfc2307_user_map,
                         SDAP_OPTS_USER, &in_map);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 
     ret = sdap_extend_map(global_talloc_context,
                           in_map,
                           SDAP_OPTS_USER,
                           extra_attrs,
                           &out_map, &new_size);
-    fail_unless(ret == ERR_DUP_EXTRA_ATTR, "[%s]", sss_strerror(ret));
+    ck_assert_msg(ret == ERR_DUP_EXTRA_ATTR, "[%s]", sss_strerror(ret));
 
     talloc_free(out_map);
 }
@@ -516,10 +516,10 @@ START_TEST(test_extra_opts_empty_name)
 
     ret = sdap_copy_map(global_talloc_context, rfc2307_user_map,
                         SDAP_OPTS_USER, &in_map);
-    fail_unless(ret == EOK, "[%s]", strerror(ret));
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 
     /* Make sure the name if really NULL */
-    fail_unless(rfc2307_user_map[SDAP_AT_USER_UUID].name == NULL,
+    ck_assert_msg(rfc2307_user_map[SDAP_AT_USER_UUID].name == NULL,
                 "The reference name is not NULL anymore, "
                 "please choose a different attribute.");
 
@@ -528,7 +528,7 @@ START_TEST(test_extra_opts_empty_name)
                           SDAP_OPTS_USER,
                           extra_attrs,
                           &out_map, &new_size);
-    fail_unless(ret == ERR_DUP_EXTRA_ATTR, "[%s]", sss_strerror(ret));
+    ck_assert_msg(ret == ERR_DUP_EXTRA_ATTR, "[%s]", sss_strerror(ret));
 
     talloc_free(out_map);
 }

--- a/src/tests/krb5_utils-tests.c
+++ b/src/tests/krb5_utils-tests.c
@@ -54,24 +54,24 @@ struct krb5child_req *kr;
 
 #define RMDIR(__dir__) do { \
     ret = rmdir(__dir__); \
-    fail_unless(ret == EOK, "rmdir [%s] failed, [%d][%s].", __dir__, \
+    ck_assert_msg(ret == EOK, "rmdir [%s] failed, [%d][%s].", __dir__, \
                 errno, strerror(errno)); \
 } while(0)
 
 void setup_create_dir(void)
 {
-    fail_unless(tmp_ctx == NULL, "Talloc context already initialized.");
+    ck_assert_msg(tmp_ctx == NULL, "Talloc context already initialized.");
     tmp_ctx = talloc_new(NULL);
-    fail_unless(tmp_ctx != NULL, "Cannot create talloc context.");
+    ck_assert_msg(tmp_ctx != NULL, "Cannot create talloc context.");
 }
 
 void teardown_create_dir(void)
 {
     int ret;
-    fail_unless(tmp_ctx != NULL, "Talloc context already freed.");
+    ck_assert_msg(tmp_ctx != NULL, "Talloc context already freed.");
     ret = talloc_free(tmp_ctx);
     tmp_ctx = NULL;
-    fail_unless(ret == 0, "Cannot free talloc context.");
+    ck_assert_msg(ret == 0, "Cannot free talloc context.");
 }
 
 static void check_dir(const char *dirname, uid_t uid, gid_t gid, mode_t mode)
@@ -80,16 +80,16 @@ static void check_dir(const char *dirname, uid_t uid, gid_t gid, mode_t mode)
     int ret;
 
     ret = stat(dirname, &stat_buf);
-    fail_unless(ret == EOK, "stat failed [%d][%s].", errno, strerror(errno));
+    ck_assert_msg(ret == EOK, "stat failed [%d][%s].", errno, strerror(errno));
 
-    fail_unless(S_ISDIR(stat_buf.st_mode), "[%s] is not a directory.", dirname);
-    fail_unless(stat_buf.st_uid == uid, "uid does not match, "
+    ck_assert_msg(S_ISDIR(stat_buf.st_mode), "[%s] is not a directory.", dirname);
+    ck_assert_msg(stat_buf.st_uid == uid, "uid does not match, "
                                         "expected [%d], got [%d].",
                                         uid, stat_buf.st_uid);
-    fail_unless(stat_buf.st_gid == gid, "gid does not match, "
+    ck_assert_msg(stat_buf.st_gid == gid, "gid does not match, "
                                         "expected [%d], got [%d].",
                                         gid, stat_buf.st_gid);
-    fail_unless((stat_buf.st_mode & ~S_IFMT) == mode,
+    ck_assert_msg((stat_buf.st_mode & ~S_IFMT) == mode,
                                            "mode of [%s] does not match, "
                                            "expected [%o], got [%o].", dirname,
                                             mode, (stat_buf.st_mode & ~S_IFMT));
@@ -113,35 +113,35 @@ START_TEST(test_private_ccache_dir_in_user_dir)
     }
 
     cwd = getcwd(NULL, 0);
-    fail_unless(cwd != NULL, "getcwd failed.");
+    ck_assert_msg(cwd != NULL, "getcwd failed.");
 
     user_dir = talloc_asprintf(tmp_ctx, "%s/%s/user", cwd, TESTS_PATH);
     free(cwd);
-    fail_unless(user_dir != NULL, "talloc_asprintf failed.");
+    ck_assert_msg(user_dir != NULL, "talloc_asprintf failed.");
     ret = mkdir(user_dir, 0700);
-    fail_unless(ret == EOK, "mkdir failed.");
+    ck_assert_msg(ret == EOK, "mkdir failed.");
     ret = chown(user_dir, uid, gid);
-    fail_unless(ret == EOK, "chown failed.");
+    ck_assert_msg(ret == EOK, "chown failed.");
 
     dn1 = talloc_asprintf(tmp_ctx, "%s/a", user_dir);
-    fail_unless(dn1 != NULL, "talloc_asprintf failed.");
+    ck_assert_msg(dn1 != NULL, "talloc_asprintf failed.");
     dn2 = talloc_asprintf(tmp_ctx, "%s/b", dn1);
-    fail_unless(dn2 != NULL, "talloc_asprintf failed.");
+    ck_assert_msg(dn2 != NULL, "talloc_asprintf failed.");
     dn3 = talloc_asprintf(tmp_ctx, "%s/c", dn2);
-    fail_unless(dn3 != NULL, "talloc_asprintf failed.");
+    ck_assert_msg(dn3 != NULL, "talloc_asprintf failed.");
     filename = talloc_asprintf(tmp_ctx, "%s/ccfile", dn3);
-    fail_unless(filename != NULL, "talloc_asprintf failed.");
+    ck_assert_msg(filename != NULL, "talloc_asprintf failed.");
 
     ret = chmod(user_dir, 0600);
-    fail_unless(ret == EOK, "chmod failed.");
+    ck_assert_msg(ret == EOK, "chmod failed.");
     ret = sss_krb5_precreate_ccache(filename, uid, gid);
-    fail_unless(ret == EINVAL, "sss_krb5_precreate_ccache does not return EINVAL "
+    ck_assert_msg(ret == EINVAL, "sss_krb5_precreate_ccache does not return EINVAL "
                                "while x-bit is missing.");
 
     ret = chmod(user_dir, 0700);
-    fail_unless(ret == EOK, "chmod failed.");
+    ck_assert_msg(ret == EOK, "chmod failed.");
     ret = sss_krb5_precreate_ccache(filename, uid, gid);
-    fail_unless(ret == EOK, "sss_krb5_precreate_ccache failed.");
+    ck_assert_msg(ret == EOK, "sss_krb5_precreate_ccache failed.");
 
     check_dir(dn3, uid, gid, 0700);
     RMDIR(dn3);
@@ -161,25 +161,25 @@ START_TEST(test_private_ccache_dir_in_wrong_user_dir)
     char *subdirname;
     char *filename;
 
-    fail_unless(getuid() == 0, "This test must be run as root.");
+    ck_assert_msg(getuid() == 0, "This test must be run as root.");
 
     cwd = getcwd(NULL, 0);
-    fail_unless(cwd != NULL, "getcwd failed.");
+    ck_assert_msg(cwd != NULL, "getcwd failed.");
 
     dirname = talloc_asprintf(tmp_ctx, "%s/%s/priv_ccdir", cwd, TESTS_PATH);
     free(cwd);
-    fail_unless(dirname != NULL, "talloc_asprintf failed.");
+    ck_assert_msg(dirname != NULL, "talloc_asprintf failed.");
     ret = mkdir(dirname, 0700);
-    fail_unless(ret == EOK, "mkdir failed.\n");
+    ck_assert_msg(ret == EOK, "mkdir failed.\n");
     ret = chown(dirname, 12346, 12346);
-    fail_unless(ret == EOK, "chown failed.\n");
+    ck_assert_msg(ret == EOK, "chown failed.\n");
     subdirname = talloc_asprintf(tmp_ctx, "%s/subdir", dirname);
-    fail_unless(subdirname != NULL, "talloc_asprintf failed.");
+    ck_assert_msg(subdirname != NULL, "talloc_asprintf failed.");
     filename = talloc_asprintf(tmp_ctx, "%s/ccfile", subdirname);
-    fail_unless(filename != NULL, "talloc_asprintf failed.");
+    ck_assert_msg(filename != NULL, "talloc_asprintf failed.");
 
     ret = sss_krb5_precreate_ccache(filename, 12345, 12345);
-    fail_unless(ret == EINVAL, "Creating private ccache dir in wrong user "
+    ck_assert_msg(ret == EINVAL, "Creating private ccache dir in wrong user "
                                "dir does not failed with EINVAL.");
 
     RMDIR(dirname);
@@ -198,36 +198,36 @@ START_TEST(test_illegal_patterns)
 
     err = sss_regexp_new(NULL, ILLEGAL_PATH_PATTERN, 0, &illegal_re);
 
-    fail_unless(err == 0, "Invalid Regular Expression pattern error %d.\n", err);
-    fail_unless(illegal_re != NULL, "No error but illegal_re is NULL.\n");
+    ck_assert_msg(err == 0, "Invalid Regular Expression pattern error %d.\n", err);
+    ck_assert_msg(illegal_re != NULL, "No error but illegal_re is NULL.\n");
 
     cwd = getcwd(NULL, 0);
-    fail_unless(cwd != NULL, "getcwd failed.");
+    ck_assert_msg(cwd != NULL, "getcwd failed.");
 
     dirname = talloc_asprintf(tmp_ctx, "%s/%s/priv_ccdir", cwd, TESTS_PATH);
     free(cwd);
-    fail_unless(dirname != NULL, "talloc_asprintf failed.");
+    ck_assert_msg(dirname != NULL, "talloc_asprintf failed.");
 
     result = expand_ccname_template(tmp_ctx, kr, "abc/./ccfile", illegal_re, true, true);
-    fail_unless(result == NULL, "expand_ccname_template allowed relative path\n");
+    ck_assert_msg(result == NULL, "expand_ccname_template allowed relative path\n");
 
     filename = talloc_asprintf(tmp_ctx, "%s/abc/./ccfile", dirname);
-    fail_unless(filename != NULL, "talloc_asprintf failed.");
+    ck_assert_msg(filename != NULL, "talloc_asprintf failed.");
     result = expand_ccname_template(tmp_ctx, kr, filename, illegal_re, true, true);
-    fail_unless(result == NULL, "expand_ccname_template allowed "
+    ck_assert_msg(result == NULL, "expand_ccname_template allowed "
                                 "illegal pattern '/./'\n");
 
     filename = talloc_asprintf(tmp_ctx, "%s/abc/../ccfile", dirname);
-    fail_unless(filename != NULL, "talloc_asprintf failed.");
+    ck_assert_msg(filename != NULL, "talloc_asprintf failed.");
     result = expand_ccname_template(tmp_ctx, kr, filename, illegal_re, true, true);
-    fail_unless(result == NULL, "expand_ccname_template allowed "
+    ck_assert_msg(result == NULL, "expand_ccname_template allowed "
                                 "illegal pattern '/../' in filename [%s].",
                                 filename);
 
     filename = talloc_asprintf(tmp_ctx, "%s/abc//ccfile", dirname);
-    fail_unless(filename != NULL, "talloc_asprintf failed.");
+    ck_assert_msg(filename != NULL, "talloc_asprintf failed.");
     result = expand_ccname_template(tmp_ctx, kr, filename, illegal_re, true, true);
-    fail_unless(result == NULL, "expand_ccname_template allowed "
+    ck_assert_msg(result == NULL, "expand_ccname_template allowed "
                                 "illegal pattern '//' in filename [%s].",
                                 filename);
 
@@ -245,32 +245,32 @@ START_TEST(test_cc_dir_create)
     errno_t ret;
 
     cwd = getcwd(NULL, 0);
-    fail_unless(cwd != NULL, "getcwd failed.");
+    ck_assert_msg(cwd != NULL, "getcwd failed.");
 
     dirname = talloc_asprintf(tmp_ctx, "%s/%s/user_dir",
                               cwd, TESTS_PATH);
-    fail_unless(dirname != NULL, "talloc_asprintf failed.");
+    ck_assert_msg(dirname != NULL, "talloc_asprintf failed.");
     residual = talloc_asprintf(tmp_ctx, "DIR:%s/%s", dirname, "ccdir");
-    fail_unless(residual != NULL, "talloc_asprintf failed.");
+    ck_assert_msg(residual != NULL, "talloc_asprintf failed.");
 
     ret = sss_krb5_precreate_ccache(residual, uid, gid);
-    fail_unless(ret == EOK, "sss_krb5_precreate_ccache failed\n");
+    ck_assert_msg(ret == EOK, "sss_krb5_precreate_ccache failed\n");
     ret = rmdir(dirname);
     if (ret < 0) ret = errno;
-    fail_unless(ret == 0, "Cannot remove %s: %s\n", dirname, strerror(ret));
+    ck_assert_msg(ret == 0, "Cannot remove %s: %s\n", dirname, strerror(ret));
     talloc_free(residual);
 
     dirname = talloc_asprintf(tmp_ctx, "%s/%s/user_dir2",
                               cwd, TESTS_PATH);
-    fail_unless(dirname != NULL, "talloc_asprintf failed.");
+    ck_assert_msg(dirname != NULL, "talloc_asprintf failed.");
     residual = talloc_asprintf(tmp_ctx, "DIR:%s/%s", dirname, "ccdir/");
-    fail_unless(residual != NULL, "talloc_asprintf failed.");
+    ck_assert_msg(residual != NULL, "talloc_asprintf failed.");
 
     ret = sss_krb5_precreate_ccache(residual, uid, gid);
-    fail_unless(ret == EOK, "sss_krb5_precreate_ccache failed\n");
+    ck_assert_msg(ret == EOK, "sss_krb5_precreate_ccache failed\n");
     ret = rmdir(dirname);
     if (ret < 0) ret = errno;
-    fail_unless(ret == 0, "Cannot remove %s: %s\n", dirname, strerror(ret));
+    ck_assert_msg(ret == 0, "Cannot remove %s: %s\n", dirname, strerror(ret));
     talloc_free(residual);
     free(cwd);
 }
@@ -284,36 +284,36 @@ void setup_talloc_context(void)
 
     struct pam_data *pd;
     struct krb5_ctx *krb5_ctx;
-    fail_unless(tmp_ctx == NULL, "Talloc context already initialized.");
+    ck_assert_msg(tmp_ctx == NULL, "Talloc context already initialized.");
     tmp_ctx = talloc_new(NULL);
-    fail_unless(tmp_ctx != NULL, "Cannot create talloc context.");
+    ck_assert_msg(tmp_ctx != NULL, "Cannot create talloc context.");
 
     kr = talloc_zero(tmp_ctx, struct krb5child_req);
-    fail_unless(kr != NULL, "Cannot create krb5child_req structure.");
+    ck_assert_msg(kr != NULL, "Cannot create krb5child_req structure.");
 
     pd = create_pam_data(tmp_ctx);
-    fail_unless(pd != NULL, "Cannot create pam_data structure.");
+    ck_assert_msg(pd != NULL, "Cannot create pam_data structure.");
 
     krb5_ctx = talloc_zero(tmp_ctx, struct krb5_ctx);
-    fail_unless(pd != NULL, "Cannot create krb5_ctx structure.");
+    ck_assert_msg(pd != NULL, "Cannot create krb5_ctx structure.");
 
     pd->user = sss_create_internal_fqname(pd, USERNAME, DOMAIN_NAME);
-    fail_unless(pd->user != NULL, "Failed to allocate memory");
+    ck_assert_msg(pd->user != NULL, "Failed to allocate memory");
     kr->uid = atoi(UID);
     kr->upn = discard_const(PRINCIPAL_NAME);
     pd->cli_pid = atoi(PID);
 
     krb5_ctx->opts = talloc_zero_array(tmp_ctx, struct dp_option, KRB5_OPTS);
-    fail_unless(krb5_ctx->opts != NULL, "Cannot created options.");
+    ck_assert_msg(krb5_ctx->opts != NULL, "Cannot created options.");
     for (i = 0; i < KRB5_OPTS; i++) {
         krb5_ctx->opts[i].opt_name = default_krb5_opts[i].opt_name;
         krb5_ctx->opts[i].type = default_krb5_opts[i].type;
         krb5_ctx->opts[i].def_val = default_krb5_opts[i].def_val;
     }
     ret = dp_opt_set_string(krb5_ctx->opts, KRB5_REALM, REALM);
-    fail_unless(ret == EOK, "Failed to set Realm");
+    ck_assert_msg(ret == EOK, "Failed to set Realm");
     ret = dp_opt_set_string(krb5_ctx->opts, KRB5_CCACHEDIR, CCACHE_DIR);
-    fail_unless(ret == EOK, "Failed to set Ccache dir");
+    ck_assert_msg(ret == EOK, "Failed to set Ccache dir");
 
     kr->homedir = HOME_DIRECTORY;
 
@@ -325,10 +325,10 @@ void setup_talloc_context(void)
 void free_talloc_context(void)
 {
     int ret;
-    fail_unless(tmp_ctx != NULL, "Talloc context already freed.");
+    ck_assert_msg(tmp_ctx != NULL, "Talloc context already freed.");
     ret = talloc_free(tmp_ctx);
     tmp_ctx = NULL;
-    fail_unless(ret == 0, "Cannot free talloc context.");
+    ck_assert_msg(ret == 0, "Cannot free talloc context.");
 }
 
 static void do_test(const char *file_template, const char *dir_template,
@@ -338,12 +338,12 @@ static void do_test(const char *file_template, const char *dir_template,
     int ret;
 
     ret = dp_opt_set_string(kr->krb5_ctx->opts, KRB5_CCACHEDIR, dir_template);
-    fail_unless(ret == EOK, "Failed to set Ccache dir");
+    ck_assert_msg(ret == EOK, "Failed to set Ccache dir");
 
     result = expand_ccname_template(tmp_ctx, kr, file_template, NULL, true, true);
 
-    fail_unless(result != NULL, "Cannot expand template [%s].", file_template);
-    fail_unless(strcmp(result, expected) == 0,
+    ck_assert_msg(result != NULL, "Cannot expand template [%s].", file_template);
+    ck_assert_msg(strcmp(result, expected) == 0,
                 "Expansion failed, result [%s], expected [%s].",
                 result, expected);
 }
@@ -372,21 +372,21 @@ START_TEST(test_case_sensitive)
     const char *expected_ci = BASE"_testuser";
 
     kr->pd->user = sss_create_internal_fqname(kr, USERNAME_CASE, DOMAIN_NAME);
-    fail_unless(kr->pd->user != NULL, "Failed to allocate memory");
+    ck_assert_msg(kr->pd->user != NULL, "Failed to allocate memory");
     ret = dp_opt_set_string(kr->krb5_ctx->opts, KRB5_CCACHEDIR, CCACHE_DIR);
-    fail_unless(ret == EOK, "Failed to set Ccache dir");
+    ck_assert_msg(ret == EOK, "Failed to set Ccache dir");
 
     result = expand_ccname_template(tmp_ctx, kr, file_template, NULL, true, true);
 
-    fail_unless(result != NULL, "Cannot expand template [%s].", file_template);
-    fail_unless(strcmp(result, expected_cs) == 0,
+    ck_assert_msg(result != NULL, "Cannot expand template [%s].", file_template);
+    ck_assert_msg(strcmp(result, expected_cs) == 0,
                 "Expansion failed, result [%s], expected [%s].",
                 result, expected_cs);
 
     result = expand_ccname_template(tmp_ctx, kr, file_template, NULL, true, false);
 
-    fail_unless(result != NULL, "Cannot expand template [%s].", file_template);
-    fail_unless(strcmp(result, expected_ci) == 0,
+    ck_assert_msg(result != NULL, "Cannot expand template [%s].", file_template);
+    ck_assert_msg(strcmp(result, expected_ci) == 0,
                 "Expansion failed, result [%s], expected [%s].",
                 result, expected_ci);
 }
@@ -428,11 +428,11 @@ START_TEST(test_ccache_dir)
     do_test(BASE"_%d", CCACHE_DIR, BASE"_"CCACHE_DIR);
 
     ret = dp_opt_set_string(kr->krb5_ctx->opts, KRB5_CCACHEDIR, BASE"_%d");
-    fail_unless(ret == EOK, "Failed to set Ccache dir");
+    ck_assert_msg(ret == EOK, "Failed to set Ccache dir");
 
     result = expand_ccname_template(tmp_ctx, kr, "%d/"FILENAME, NULL, true, true);
 
-    fail_unless(result == NULL, "Using %%d in ccache dir should fail.");
+    ck_assert_msg(result == NULL, "Using %%d in ccache dir should fail.");
 }
 END_TEST
 
@@ -444,11 +444,11 @@ START_TEST(test_pid)
     do_test(BASE"_%P", CCACHE_DIR, BASE"_"PID);
 
     ret = dp_opt_set_string(kr->krb5_ctx->opts, KRB5_CCACHEDIR, BASE"_%P");
-    fail_unless(ret == EOK, "Failed to set Ccache dir");
+    ck_assert_msg(ret == EOK, "Failed to set Ccache dir");
 
     result = expand_ccname_template(tmp_ctx, kr, "%d/"FILENAME, NULL, true, true);
 
-    fail_unless(result == NULL, "Using %%P in ccache dir should fail.");
+    ck_assert_msg(result == NULL, "Using %%P in ccache dir should fail.");
 }
 END_TEST
 
@@ -467,15 +467,15 @@ START_TEST(test_unknown_template)
 
     result = expand_ccname_template(tmp_ctx, kr, test_template, NULL, true, true);
 
-    fail_unless(result == NULL, "Unknown template [%s] should fail.",
+    ck_assert_msg(result == NULL, "Unknown template [%s] should fail.",
                 test_template);
 
     ret = dp_opt_set_string(kr->krb5_ctx->opts, KRB5_CCACHEDIR, BASE"_%X");
-    fail_unless(ret == EOK, "Failed to set Ccache dir");
+    ck_assert_msg(ret == EOK, "Failed to set Ccache dir");
     test_template = "%d/"FILENAME;
     result = expand_ccname_template(tmp_ctx, kr, test_template, NULL, true, true);
 
-    fail_unless(result == NULL, "Unknown template [%s] should fail.",
+    ck_assert_msg(result == NULL, "Unknown template [%s] should fail.",
                 test_template);
 }
 END_TEST
@@ -487,7 +487,7 @@ START_TEST(test_NULL)
 
     result = expand_ccname_template(tmp_ctx, kr, test_template, NULL, true, true);
 
-    fail_unless(result == NULL,
+    ck_assert_msg(result == NULL,
                 "Expected NULL as a result for an empty input for "
                 "NULL template");
 }
@@ -500,8 +500,8 @@ START_TEST(test_no_substitution)
 
     result = expand_ccname_template(tmp_ctx, kr, test_template, NULL, true, true);
 
-    fail_unless(result != NULL, "Cannot expand template [%s].", test_template);
-    fail_unless(strcmp(result, test_template) == 0,
+    ck_assert_msg(result != NULL, "Cannot expand template [%s].", test_template);
+    ck_assert_msg(strcmp(result, test_template) == 0,
                 "Expansion failed, result [%s], expected [%s].",
                 result, test_template);
 }
@@ -517,8 +517,8 @@ START_TEST(test_krb5_style_expansion)
     expected = BASE"/"UID"/"UID"/"UID"/"USERNAME;
     result = expand_ccname_template(tmp_ctx, kr, file_template, NULL, true, true);
 
-    fail_unless(result != NULL, "Cannot expand template [%s].", file_template);
-    fail_unless(strcmp(result, expected) == 0,
+    ck_assert_msg(result != NULL, "Cannot expand template [%s].", file_template);
+    ck_assert_msg(strcmp(result, expected) == 0,
                 "Expansion failed, result [%s], expected [%s].",
                 result, expected);
 
@@ -526,8 +526,8 @@ START_TEST(test_krb5_style_expansion)
     expected = BASE"/%{unknown}";
     result = expand_ccname_template(tmp_ctx, kr, file_template, NULL, true, true);
 
-    fail_unless(result != NULL, "Cannot expand template [%s].", file_template);
-    fail_unless(strcmp(result, expected) == 0,
+    ck_assert_msg(result != NULL, "Cannot expand template [%s].", file_template);
+    ck_assert_msg(strcmp(result, expected) == 0,
                 "Expansion failed, result [%s], expected [%s].",
                 result, expected);
 }
@@ -539,41 +539,41 @@ START_TEST(test_compare_principal_realm)
     bool different_realm;
 
     ret = compare_principal_realm(NULL, "a", &different_realm);
-    fail_unless(ret == EINVAL, "NULL upn does not cause EINVAL.");
+    ck_assert_msg(ret == EINVAL, "NULL upn does not cause EINVAL.");
 
     ret = compare_principal_realm("a", NULL, &different_realm);
-    fail_unless(ret == EINVAL, "NULL realm does not cause EINVAL.");
+    ck_assert_msg(ret == EINVAL, "NULL realm does not cause EINVAL.");
 
     ret = compare_principal_realm("a", "b", NULL);
-    fail_unless(ret == EINVAL, "NULL different_realmbool " \
+    ck_assert_msg(ret == EINVAL, "NULL different_realmbool " \
                                "does not cause EINVAL.");
 
     ret = compare_principal_realm("", "a", &different_realm);
-    fail_unless(ret == EINVAL, "Empty upn does not cause EINVAL.");
+    ck_assert_msg(ret == EINVAL, "Empty upn does not cause EINVAL.");
 
     ret = compare_principal_realm("a", "", &different_realm);
-    fail_unless(ret == EINVAL, "Empty realm does not cause EINVAL.");
+    ck_assert_msg(ret == EINVAL, "Empty realm does not cause EINVAL.");
 
     ret = compare_principal_realm("ABC", "ABC", &different_realm);
-    fail_unless(ret == EINVAL, "Short UPN does not cause EINVAL.");
+    ck_assert_msg(ret == EINVAL, "Short UPN does not cause EINVAL.");
 
     ret = compare_principal_realm("userABC", "ABC", &different_realm);
-    fail_unless(ret == EINVAL, "Missing '@' does not cause EINVAL.");
+    ck_assert_msg(ret == EINVAL, "Missing '@' does not cause EINVAL.");
 
     ret = compare_principal_realm("user@ABC", "ABC", &different_realm);
-    fail_unless(ret == EOK, "Failure with same realm");
-    fail_unless(different_realm == false, "Same realm but " \
+    ck_assert_msg(ret == EOK, "Failure with same realm");
+    ck_assert_msg(different_realm == false, "Same realm but " \
                                           "different_realm is not false.");
 
     ret = compare_principal_realm("user@ABC", "DEF", &different_realm);
-    fail_unless(ret == EOK, "Failure with different realm");
-    fail_unless(different_realm == true, "Different realm but " \
+    ck_assert_msg(ret == EOK, "Failure with different realm");
+    ck_assert_msg(different_realm == true, "Different realm but " \
                                           "different_realm is not true.");
 
     ret = compare_principal_realm("user@ABC", "REALMNAMELONGERTHANUPN",
                                  &different_realm);
-    fail_unless(ret == EOK, "Failure with long realm name.");
-    fail_unless(different_realm == true, "Realm name longer than UPN but "
+    ck_assert_msg(ret == EOK, "Failure with long realm name.");
+    ck_assert_msg(different_realm == true, "Realm name longer than UPN but "
                                          "different_realm is not true.");
 }
 END_TEST
@@ -587,20 +587,20 @@ compare_map_id_name_to_krb_primary(struct map_id_name_to_krb_primary *a,
     errno_t ret;
 
     while (a[i].id_name != NULL && a[i].krb_primary != NULL) {
-        fail_unless(i < len,
+        ck_assert_msg(i < len,
                     "Index: %d mus =t be lowwer than: %zd", i, len);
         ret = sss_utf8_case_eq((const uint8_t*)a[i].id_name,
                                (const uint8_t*)str[i*2]);
-        fail_unless(ret == EOK,
+        ck_assert_msg(ret == EOK,
                     "%s does not match %s", a[i].id_name, str[i*2]);
 
         ret = sss_utf8_case_eq((const uint8_t*)a[i].krb_primary,
                                (const uint8_t*)str[i*2+1]);
-        fail_unless(ret == EOK, "%s does not match %s",
+        ck_assert_msg(ret == EOK, "%s does not match %s",
                     a[i].krb_primary, str[i*2+1]);
         i++;
     }
-    fail_unless(len == i, "%zu != %u", len, i);
+    ck_assert_msg(len == i, "%zu != %u", len, i);
 }
 
 START_TEST(test_parse_krb5_map_user)
@@ -615,51 +615,51 @@ START_TEST(test_parse_krb5_map_user)
     {
         check_leaks_push(mem_ctx);
         ret = parse_krb5_map_user(mem_ctx, NULL, DOMAIN_NAME, &name_to_primary);
-        fail_unless(ret == EOK,
+        ck_assert_msg(ret == EOK,
                     "parse_krb5_map_user failed with error: %d", ret);
-        fail_unless(name_to_primary[0].id_name == NULL,
+        ck_assert_msg(name_to_primary[0].id_name == NULL,
                     "id_name must be NULL. Got: %s",
                     name_to_primary[0].id_name);
-        fail_unless(name_to_primary[0].krb_primary == NULL,
+        ck_assert_msg(name_to_primary[0].krb_primary == NULL,
                     "krb_primary must be NULL. Got: %s",
                     name_to_primary[0].krb_primary);
         talloc_free(name_to_primary);
 
         ret = parse_krb5_map_user(mem_ctx, "", DOMAIN_NAME, &name_to_primary);
-        fail_unless(ret == EOK,
+        ck_assert_msg(ret == EOK,
                     "parse_krb5_map_user failed with error: %d", ret);
-        fail_unless(name_to_primary[0].id_name == NULL,
+        ck_assert_msg(name_to_primary[0].id_name == NULL,
                     "id_name must be NULL. Got: %s",
                     name_to_primary[0].id_name);
-        fail_unless(name_to_primary[0].krb_primary == NULL,
+        ck_assert_msg(name_to_primary[0].krb_primary == NULL,
                     "krb_primary must be NULL. Got: %s",
                     name_to_primary[0].krb_primary);
         talloc_free(name_to_primary);
 
         ret = parse_krb5_map_user(mem_ctx, ",", DOMAIN_NAME, &name_to_primary);
-        fail_unless(ret == EOK,
+        ck_assert_msg(ret == EOK,
                     "parse_krb5_map_user failed with error: %d", ret);
-        fail_unless(name_to_primary[0].id_name == NULL,
+        ck_assert_msg(name_to_primary[0].id_name == NULL,
                     "id_name must be NULL. Got: %s",
                     name_to_primary[0].id_name);
-        fail_unless(name_to_primary[0].krb_primary == NULL,
+        ck_assert_msg(name_to_primary[0].krb_primary == NULL,
                     "krb_primary must be NULL. Got: %s",
                     name_to_primary[0].krb_primary);
         talloc_free(name_to_primary);
 
         ret = parse_krb5_map_user(mem_ctx, ",,", DOMAIN_NAME, &name_to_primary);
-        fail_unless(ret == EOK,
+        ck_assert_msg(ret == EOK,
                     "parse_krb5_map_user failed with error: %d", ret);
-        fail_unless(name_to_primary[0].id_name == NULL,
+        ck_assert_msg(name_to_primary[0].id_name == NULL,
                     "id_name must be NULL. Got: %s",
                     name_to_primary[0].id_name);
-        fail_unless(name_to_primary[0].krb_primary == NULL,
+        ck_assert_msg(name_to_primary[0].krb_primary == NULL,
                     "krb_primary must be NULL. Got: %s",
                     name_to_primary[0].krb_primary);
 
         talloc_free(name_to_primary);
 
-        fail_unless(check_leaks_pop(mem_ctx),
+        ck_assert_msg(check_leaks_pop(mem_ctx),
                     "check_leaks_pop failed");
     }
     /* valid input */
@@ -671,19 +671,19 @@ START_TEST(test_parse_krb5_map_user)
                                    "joe@testdomain", "juser@testdomain",
                                    "jdoe@testdomain", "ßlack@testdomain" };
         ret = parse_krb5_map_user(mem_ctx, p, DOMAIN_NAME, &name_to_primary);
-        fail_unless(ret == EOK,
+        ck_assert_msg(ret == EOK,
                     "parse_krb5_map_user failed with error: %d", ret);
         compare_map_id_name_to_krb_primary(name_to_primary, expected,
                                          sizeof(expected)/sizeof(const char*)/2);
         talloc_free(name_to_primary);
 
         ret = parse_krb5_map_user(mem_ctx, p2, DOMAIN_NAME, &name_to_primary);
-        fail_unless(ret == EOK,
+        ck_assert_msg(ret == EOK,
                     "parse_krb5_map_user failed with error: %d", ret);
         compare_map_id_name_to_krb_primary(name_to_primary,  expected,
                                          sizeof(expected)/sizeof(const char*)/2);
         talloc_free(name_to_primary);
-        fail_unless(check_leaks_pop(mem_ctx),
+        ck_assert_msg(check_leaks_pop(mem_ctx),
                     "check_leaks_pop failed");
     }
     /* invalid input */
@@ -691,35 +691,35 @@ START_TEST(test_parse_krb5_map_user)
         check_leaks_push(mem_ctx);
 
         ret = parse_krb5_map_user(mem_ctx, ":", DOMAIN_NAME, &name_to_primary);
-        fail_unless(ret == EINVAL,
+        ck_assert_msg(ret == EINVAL,
                     "parse_krb5_map_user must fail with EINVAL got: %d", ret);
 
         ret = parse_krb5_map_user(mem_ctx, "joe:", DOMAIN_NAME,
                                   &name_to_primary);
-        fail_unless(ret == EINVAL,
+        ck_assert_msg(ret == EINVAL,
                     "parse_krb5_map_user must fail with EINVAL got: %d", ret);
 
         ret = parse_krb5_map_user(mem_ctx, ":joe", DOMAIN_NAME,
                                   &name_to_primary);
-        fail_unless(ret == EINVAL,
+        ck_assert_msg(ret == EINVAL,
                     "parse_krb5_map_user must fail with EINVAL got: %d", ret);
 
         ret = parse_krb5_map_user(mem_ctx, "joe:,", DOMAIN_NAME,
                                   &name_to_primary);
-        fail_unless(ret == EINVAL,
+        ck_assert_msg(ret == EINVAL,
                     "parse_krb5_map_user must fail with EINVAL got: %d", ret);
 
         ret = parse_krb5_map_user(mem_ctx, ",joe", DOMAIN_NAME,
                                   &name_to_primary);
-        fail_unless(ret == EINVAL,
+        ck_assert_msg(ret == EINVAL,
                     "parse_krb5_map_user must fail with EINVAL got: %d", ret);
 
         ret = parse_krb5_map_user(mem_ctx, "joe:j:user", DOMAIN_NAME,
                                   &name_to_primary);
-        fail_unless(ret == EINVAL,
+        ck_assert_msg(ret == EINVAL,
                     "parse_krb5_map_user must fail with EINVAL got: %d", ret);
 
-        fail_unless(check_leaks_pop(mem_ctx),
+        ck_assert_msg(check_leaks_pop(mem_ctx),
                     "check_leaks_pop failed");
     }
 
@@ -729,17 +729,17 @@ END_TEST
 
 START_TEST(test_sss_krb5_realm_has_proxy)
 {
-    fail_unless(sss_krb5_realm_has_proxy(NULL) == false,
+    ck_assert_msg(sss_krb5_realm_has_proxy(NULL) == false,
                 "sss_krb5_realm_has_proxy did not return false");
 
     setenv("KRB5_CONFIG", "/dev/null", 1);
-    fail_unless(sss_krb5_realm_has_proxy("REALM") == false,
+    ck_assert_msg(sss_krb5_realm_has_proxy("REALM") == false,
                 "sss_krb5_realm_has_proxy did not return false");
 
     setenv("KRB5_CONFIG", ABS_SRC_DIR"/src/tests/krb5_proxy_check_test_data.conf", 1);
-    fail_unless(sss_krb5_realm_has_proxy("REALM") == false,
+    ck_assert_msg(sss_krb5_realm_has_proxy("REALM") == false,
                 "sss_krb5_realm_has_proxy did not return false");
-    fail_unless(sss_krb5_realm_has_proxy("REALM_PROXY") == true,
+    ck_assert_msg(sss_krb5_realm_has_proxy("REALM_PROXY") == true,
                 "sss_krb5_realm_has_proxy did not return true");
 }
 END_TEST

--- a/src/tests/refcount-tests.c
+++ b/src/tests/refcount-tests.c
@@ -36,7 +36,7 @@
 
 /* Fail the test if object 'obj' does not have 'num' references. */
 #define REF_ASSERT(obj, num) \
-    fail_unless(((obj)->DO_NOT_TOUCH_THIS_MEMBER_refcount == (num)), \
+    ck_assert_msg(((obj)->DO_NOT_TOUCH_THIS_MEMBER_refcount == (num)), \
                 "Reference count of " #obj " should be %d but is %d", \
                 (num), (obj)->DO_NOT_TOUCH_THIS_MEMBER_refcount)
 
@@ -68,9 +68,9 @@ struct baz {
 #define CHECK_FILLER(target) do { \
     int _counter; \
     for (_counter = 0; _counter < FILLER_SIZE; _counter++) { \
-        fail_unless((target)->a[_counter] == 'a', "Corrupted memory in "  \
+        ck_assert_msg((target)->a[_counter] == 'a', "Corrupted memory in "  \
                     #target "->a[%d] of size %d", _counter, FILLER_SIZE); \
-        fail_unless((target)->b[_counter] == 'b', "Corrupted memory in "  \
+        ck_assert_msg((target)->b[_counter] == 'b', "Corrupted memory in "  \
                     #target "->b[%d] of size %d", _counter, FILLER_SIZE); \
     } \
 } while (0)
@@ -90,29 +90,29 @@ START_TEST(test_refcount_basic)
 
     /* First allocate our global storage place. */
     global = talloc(NULL, struct container);
-    fail_if(global == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(global == NULL, "Failed to allocate memory");
 
     /* Allocate foo. */
     global->foo = rc_alloc(global, struct foo);
-    fail_if(global->foo == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(global->foo == NULL, "Failed to allocate memory");
     SET_FILLER(global->foo);
     REF_ASSERT(global->foo, 1);
 
     /* Allocate bar. */
     global->bar = rc_alloc(global, struct bar);
-    fail_if(global->bar == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(global->bar == NULL, "Failed to allocate memory");
     SET_FILLER(global->bar);
     REF_ASSERT(global->bar, 1);
 
     /* Allocate baz. */
     global->baz = rc_alloc(global, struct baz);
-    fail_if(global->baz == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(global->baz == NULL, "Failed to allocate memory");
     SET_FILLER(global->baz);
     REF_ASSERT(global->baz, 1);
 
     /* Try multiple attaches. */
     containers = talloc_array(NULL, struct container, 100);
-    fail_if(containers == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(containers == NULL, "Failed to allocate memory");
     for (i = 0; i < 100; i++) {
         containers[i].foo = rc_reference(containers, struct foo, global->foo);
         containers[i].bar = rc_reference(containers, struct bar, global->bar);
@@ -153,15 +153,15 @@ START_TEST(test_refcount_swap)
 
     /* Allocate. */
     container1->foo = rc_alloc(container1, struct foo);
-    fail_if(container1->foo == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(container1->foo == NULL, "Failed to allocate memory");
     SET_FILLER(container1->foo);
 
     /* Reference. */
     container2->foo = rc_reference(container2, struct foo, container1->foo);
-    fail_if(container2->foo == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(container2->foo == NULL, "Failed to allocate memory");
 
     /* Make sure everything is as it should be. */
-    fail_unless(container1->foo == container2->foo,
+    ck_assert_msg(container1->foo == container2->foo,
                 "Values have to be equal. %p == %p",
                 container1->foo, container2->foo);
     REF_ASSERT(container1->foo, 2);

--- a/src/tests/resolv-tests.c
+++ b/src/tests/resolv-tests.c
@@ -65,20 +65,20 @@ static int setup_resolv_test(int timeout, struct resolv_test_ctx **ctx)
 
     test_ctx = talloc_zero(global_talloc_context, struct resolv_test_ctx);
     if (test_ctx == NULL) {
-        fail("Could not allocate memory for test context");
+        ck_abort_msg("Could not allocate memory for test context");
         return ENOMEM;
     }
 
     test_ctx->ev = tevent_context_init(test_ctx);
     if (test_ctx->ev == NULL) {
-        fail("Could not init tevent context");
+        ck_abort_msg("Could not init tevent context");
         talloc_free(test_ctx);
         return EFAULT;
     }
 
     ret = resolv_init(test_ctx, test_ctx->ev, timeout, 2000, &test_ctx->resolv);
     if (ret != EOK) {
-        fail("Could not init resolv context");
+        ck_abort_msg("Could not init resolv context");
         talloc_free(test_ctx);
         return ret;
     }
@@ -172,57 +172,57 @@ START_TEST(test_copy_hostent)
     struct ares_addrttl attl[] = { { addr_1, ttl_1 }, { addr_2, ttl_2 } };
 
     ctx = talloc_new(global_talloc_context);
-    fail_if(ctx == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(ctx == NULL, "Failed to allocate memory");
 
     ck_leaks_push(ctx);
 
     rhe = resolv_copy_hostent_ares(ctx, &he, AF_INET, &attl, 2);
 
-    fail_if(rhe == NULL, "Failed to allocate memory");
-    fail_if(strcmp(rhe->name, name),
+    sss_ck_fail_if_msg(rhe == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(strcmp(rhe->name, name),
             "Unexpectag value for name. Got: %s expecting: %s",
              rhe->name, name);
-    fail_if(strcmp(rhe->aliases[0], alias_1),
+    sss_ck_fail_if_msg(strcmp(rhe->aliases[0], alias_1),
             "Unexpectag value for 1st alias. Got: %s expecting: %s",
             rhe->aliases[0], alias_1);
-    fail_if(strcmp(rhe->aliases[1], alias_2),
+    sss_ck_fail_if_msg(strcmp(rhe->aliases[1], alias_2),
             "Unexpectag value for 2nd alias. Got: %s expecting: %s",
             rhe->aliases[1], alias_2);
-    fail_if(rhe->aliases[2] != NULL,
+    sss_ck_fail_if_msg(rhe->aliases[2] != NULL,
             "Just 2 aliases are expected. Got: %s", rhe->aliases[2]);
     ck_assert_int_eq(rhe->family, AF_INET);
-    fail_if(memcmp(rhe->addr_list[0]->ipaddr, &addr_1, sizeof(addr_1)),
+    sss_ck_fail_if_msg(memcmp(rhe->addr_list[0]->ipaddr, &addr_1, sizeof(addr_1)),
                    "Unexpected binary value for addr_list[0]->ipaddr");
     ck_assert_int_eq(rhe->addr_list[0]->ttl, ttl_1);
-    fail_if(memcmp(rhe->addr_list[1]->ipaddr, &addr_2, sizeof(addr_2)),
+    sss_ck_fail_if_msg(memcmp(rhe->addr_list[1]->ipaddr, &addr_2, sizeof(addr_2)),
                    "Unexpected binary value for rhe->addr_list[1]->ipaddr");
     ck_assert_int_eq(rhe->addr_list[1]->ttl, ttl_2);
-    fail_if(rhe->addr_list[2] != NULL,
+    sss_ck_fail_if_msg(rhe->addr_list[2] != NULL,
             "Just 2 ip addresses are expected. 3rd has to be NULL");
 
     talloc_zfree(rhe);
 
     rhe = resolv_copy_hostent(ctx, &he);
-    fail_if(rhe == NULL, "Failed to allocate memory");
-    fail_if(strcmp(rhe->name, name),
+    sss_ck_fail_if_msg(rhe == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(strcmp(rhe->name, name),
             "Unexpectag value for name. Got: %s expecting: %s",
             rhe->name, name);
-    fail_if(strcmp(rhe->aliases[0], alias_1),
+    sss_ck_fail_if_msg(strcmp(rhe->aliases[0], alias_1),
             "Unexpectag value for 1st alias. Got: %s expecting: %s",
             rhe->aliases[0], alias_1);
-    fail_if(strcmp(rhe->aliases[1], alias_2),
+    sss_ck_fail_if_msg(strcmp(rhe->aliases[1], alias_2),
             "Unexpectag value for 2nd alias. Got: %s expecting: %s",
             rhe->aliases[1], alias_2);
-    fail_if(rhe->aliases[2] != NULL,
+    sss_ck_fail_if_msg(rhe->aliases[2] != NULL,
             "Just 2 aliases are expected. Got: %s", rhe->aliases[2]);
     ck_assert_int_eq(rhe->family, AF_INET);
-    fail_if(memcmp(rhe->addr_list[0]->ipaddr, &addr_2, sizeof(addr_1)),
+    sss_ck_fail_if_msg(memcmp(rhe->addr_list[0]->ipaddr, &addr_2, sizeof(addr_1)),
                    "Unexpected binary value for addr_list[0]->ipaddr");
     ck_assert_int_eq(rhe->addr_list[0]->ttl, RESOLV_DEFAULT_TTL);
-    fail_if(memcmp(rhe->addr_list[1]->ipaddr, &addr_1, sizeof(addr_2)),
+    sss_ck_fail_if_msg(memcmp(rhe->addr_list[1]->ipaddr, &addr_1, sizeof(addr_2)),
                    "Unexpected binary value for addr_list[1]->ipaddr");
     ck_assert_int_eq(rhe->addr_list[1]->ttl, RESOLV_DEFAULT_TTL);
-    fail_if(rhe->addr_list[2] != NULL,
+    sss_ck_fail_if_msg(rhe->addr_list[2] != NULL,
             "Just 2 ip addresses are expected. 3rd has to be NULL");
 
     talloc_free(rhe);
@@ -239,37 +239,37 @@ START_TEST(test_address_to_string)
     char *ptr_addr;
 
     ctx = talloc_new(global_talloc_context);
-    fail_if(ctx == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(ctx == NULL, "Failed to allocate memory");
     ck_leaks_push(ctx);
 
     rhe = test_create_rhostent(ctx, "www.example.com", "1.2.3.4");
-    fail_if(rhe == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rhe == NULL, "Failed to allocate memory");
 
     str_addr = resolv_get_string_address_index(ctx, rhe, 0);
-    fail_if(str_addr == NULL, "Failed to allocate memory");
-    fail_unless(strcmp(str_addr, "1.2.3.4") == 0, "Unexpected address\n");
+    sss_ck_fail_if_msg(str_addr == NULL, "Failed to allocate memory");
+    ck_assert_msg(strcmp(str_addr, "1.2.3.4") == 0, "Unexpected address\n");
     talloc_free(str_addr);
 
     ptr_addr = resolv_get_string_ptr_address(ctx, rhe->family,
                                              rhe->addr_list[0]->ipaddr);
-    fail_if(ptr_addr == NULL, "Failed to allocate memory");
-    fail_unless(strcmp(ptr_addr, "4.3.2.1.in-addr.arpa.") == 0, "Unexpected PTR address\n");
+    sss_ck_fail_if_msg(ptr_addr == NULL, "Failed to allocate memory");
+    ck_assert_msg(strcmp(ptr_addr, "4.3.2.1.in-addr.arpa.") == 0, "Unexpected PTR address\n");
     talloc_free(ptr_addr);
 
     talloc_free(rhe);
 
     rhe = test_create_rhostent(ctx, "www6.example.com", "2607:f8b0:400c:c03::6a");
-    fail_if(rhe == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(rhe == NULL, "Failed to allocate memory");
 
     str_addr = resolv_get_string_address_index(ctx, rhe, 0);
-    fail_if(str_addr == NULL, "resolv_get_string_address_index failed");
-    fail_unless(strcmp(str_addr, "2607:f8b0:400c:c03::6a") == 0, "Unexpected address\n");
+    sss_ck_fail_if_msg(str_addr == NULL, "resolv_get_string_address_index failed");
+    ck_assert_msg(strcmp(str_addr, "2607:f8b0:400c:c03::6a") == 0, "Unexpected address\n");
     talloc_free(str_addr);
 
     ptr_addr = resolv_get_string_ptr_address(ctx, rhe->family,
                                              rhe->addr_list[0]->ipaddr);
-    fail_if(ptr_addr == NULL, "resolv_get_string_ptr_address failed");
-    fail_unless(strcmp(ptr_addr,
+    sss_ck_fail_if_msg(ptr_addr == NULL, "resolv_get_string_ptr_address failed");
+    ck_assert_msg(strcmp(ptr_addr,
                        "a.6.0.0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.c.0.c.0.0.4.0.b.8.f.7.0.6.2.ip6.arpa.") == 0, "Unexpected PTR address\n");
     talloc_free(ptr_addr);
 
@@ -323,7 +323,7 @@ START_TEST(test_resolv_ip_addr)
 
     ret = setup_resolv_test(RESOLV_DEFAULT_TIMEOUT, &test_ctx);
     if (ret != EOK) {
-        fail("Could not set up test");
+        ck_abort_msg("Could not set up test");
         return;
     }
 
@@ -342,7 +342,7 @@ START_TEST(test_resolv_ip_addr)
     }
 
     ck_leaks_pop(test_ctx);
-    fail_unless(ret == EOK, "test_loop failed with error: %d", ret);
+    ck_assert_msg(ret == EOK, "test_loop failed with error: %d", ret);
 
     talloc_zfree(test_ctx);
 }
@@ -393,7 +393,7 @@ START_TEST(test_resolv_localhost)
 
     ret = setup_resolv_test(RESOLV_DEFAULT_TIMEOUT, &test_ctx);
     if (ret != EOK) {
-        fail("Could not set up test");
+        ck_abort_msg("Could not set up test");
         return;
     }
 
@@ -412,7 +412,7 @@ START_TEST(test_resolv_localhost)
     }
 
     ck_leaks_pop(test_ctx);
-    fail_unless(ret == EOK, "test_loop failed with error: %d", ret);
+    ck_assert_msg(ret == EOK, "test_loop failed with error: %d", ret);
 
     talloc_zfree(test_ctx);
 }
@@ -451,7 +451,7 @@ START_TEST(test_resolv_negative)
 
     ret = setup_resolv_test(RESOLV_DEFAULT_TIMEOUT, &test_ctx);
     if (ret != EOK) {
-        fail("Could not set up test");
+        ck_abort_msg("Could not set up test");
         return;
     }
 
@@ -471,7 +471,7 @@ START_TEST(test_resolv_negative)
 
     ck_leaks_pop(test_ctx);
 
-    fail_unless(ret != EOK, "test_loop must failed but got: EOK");
+    ck_assert_msg(ret != EOK, "test_loop must failed but got: EOK");
     ck_assert_int_eq(test_ctx->error, ARES_ENOTFOUND);
     talloc_zfree(test_ctx);
 }
@@ -535,7 +535,7 @@ static void test_internet(struct tevent_req *req)
         break;
     }
     talloc_zfree(req);
-    fail_if(recv_status != EOK, "The recv function failed: %d", recv_status);
+    sss_ck_fail_if_msg(recv_status != EOK, "The recv function failed: %d", recv_status);
     DEBUG(SSSDBG_TRACE_LIBS, "recv status: %d\n", status);
 
     if (rhostent != NULL) {
@@ -557,7 +557,7 @@ START_TEST(test_resolv_internet)
 
     ret = setup_resolv_test(RESOLV_DEFAULT_TIMEOUT, &test_ctx);
     if (ret != EOK) {
-        fail("Could not set up test");
+        ck_abort_msg("Could not set up test");
         return;
     }
     test_ctx->tested_function = TESTING_HOSTNAME;
@@ -576,7 +576,7 @@ START_TEST(test_resolv_internet)
         ret = test_loop(test_ctx);
     }
 
-    fail_unless(ret == EOK, "test_loop failed with error: %d", ret);
+    ck_assert_msg(ret == EOK, "test_loop failed with error: %d", ret);
     ck_leaks_pop(test_ctx);
     talloc_zfree(test_ctx);
 }
@@ -589,17 +589,17 @@ START_TEST(test_resolv_internet_txt)
     struct resolv_test_ctx *test_ctx;
 
     ret = setup_resolv_test(RESOLV_DEFAULT_TIMEOUT, &test_ctx);
-    fail_if(ret != EOK, "Could not set up test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up test");
     test_ctx->tested_function = TESTING_TXT;
 
     ck_leaks_push(test_ctx);
 
     req = resolv_gettxt_send(test_ctx, test_ctx->ev, test_ctx->resolv, txt_host);
-    fail_if(req == NULL, "Function resolv_gettxt_send failed");
+    sss_ck_fail_if_msg(req == NULL, "Function resolv_gettxt_send failed");
 
     tevent_req_set_callback(req, test_internet, test_ctx);
     ret = test_loop(test_ctx);
-    fail_unless(ret == EOK, "test_loop failed with error: %d", ret);
+    ck_assert_msg(ret == EOK, "test_loop failed with error: %d", ret);
 
     ck_leaks_pop(test_ctx);
 
@@ -614,17 +614,17 @@ START_TEST(test_resolv_internet_srv)
     struct resolv_test_ctx *test_ctx;
 
     ret = setup_resolv_test(RESOLV_DEFAULT_TIMEOUT, &test_ctx);
-    fail_if(ret != EOK, "Could not set up test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up test");
     test_ctx->tested_function = TESTING_SRV;
 
     ck_leaks_push(test_ctx);
 
     req = resolv_getsrv_send(test_ctx, test_ctx->ev, test_ctx->resolv, srv_host);
-    fail_if(req == NULL, "Function resolv_getsrv_send failed");
+    sss_ck_fail_if_msg(req == NULL, "Function resolv_getsrv_send failed");
 
     tevent_req_set_callback(req, test_internet, test_ctx);
     ret = test_loop(test_ctx);
-    fail_unless(ret == EOK, "test_loop failed with error: %d", ret);
+    ck_assert_msg(ret == EOK, "test_loop failed with error: %d", ret);
 
     ck_leaks_pop(test_ctx);
 
@@ -664,7 +664,7 @@ START_TEST(test_resolv_free_context)
 
     ret = setup_resolv_test(RESOLV_DEFAULT_TIMEOUT, &test_ctx);
     if (ret != EOK) {
-        fail("Could not set up test");
+        ck_abort_msg("Could not set up test");
         return;
     }
 
@@ -673,7 +673,7 @@ START_TEST(test_resolv_free_context)
                                     default_host_dbs);
     DEBUG(SSSDBG_TRACE_LIBS, "Sent resolv_gethostbyname\n");
     if (req == NULL) {
-        fail("Error calling resolv_gethostbyname_send");
+        ck_abort_msg("Error calling resolv_gethostbyname_send");
         goto done;
     }
 
@@ -685,18 +685,18 @@ START_TEST(test_resolv_free_context)
 
     free_timer = tevent_add_timer(test_ctx->ev, test_ctx, free_tv, resolv_free_context, test_ctx->resolv);
     if (free_timer == NULL) {
-        fail("Error calling tevent_add_timer");
+        ck_abort_msg("Error calling tevent_add_timer");
         goto done;
     }
 
     terminate_timer = tevent_add_timer(test_ctx->ev, test_ctx, terminate_tv, resolv_free_done, test_ctx);
     if (terminate_timer == NULL) {
-        fail("Error calling tevent_add_timer");
+        ck_abort_msg("Error calling tevent_add_timer");
         goto done;
     }
 
     ret = test_loop(test_ctx);
-    fail_unless(ret == EOK, "test_loop failed with error: %d", ret);
+    ck_assert_msg(ret == EOK, "test_loop failed with error: %d", ret);
 
 done:
     talloc_zfree(test_ctx);
@@ -724,7 +724,7 @@ START_TEST(test_resolv_sort_srv_reply)
 
     ret = setup_resolv_test(RESOLV_DEFAULT_TIMEOUT, &test_ctx);
     if (ret != EOK) {
-        fail("Could not set up test");
+        ck_abort_msg("Could not set up test");
         return;
     }
 
@@ -733,7 +733,7 @@ START_TEST(test_resolv_sort_srv_reply)
     /* prepare linked list with reversed values */
     for (i = 0; i<num_replies; i++) {
         r = talloc_zero(test_ctx, struct ares_srv_reply);
-        fail_if(r == NULL, "Failed to allocate memory");
+        sss_ck_fail_if_msg(r == NULL, "Failed to allocate memory");
         r->priority = num_replies-i;
         r->weight   = i;
 
@@ -748,7 +748,7 @@ START_TEST(test_resolv_sort_srv_reply)
 
     /* do the sort */
     ret = resolv_sort_srv_reply(&replies);
-    fail_if(ret != EOK, "resolv_sort_srv_reply failed with error: %d", ret);
+    sss_ck_fail_if_msg(ret != EOK, "resolv_sort_srv_reply failed with error: %d", ret);
 
     /* check if the list is sorted */
     prev = NULL;
@@ -768,7 +768,7 @@ START_TEST(test_resolv_sort_srv_reply)
     replies = NULL;
     for (i = 0; i<num_replies; i++) {
         r = talloc_zero(test_ctx, struct ares_srv_reply);
-        fail_if(r == NULL, "Failed to allocate memory");
+        sss_ck_fail_if_msg(r == NULL, "Failed to allocate memory");
         r->priority = i % 2 + 1;
         r->weight   = i;
 
@@ -783,7 +783,7 @@ START_TEST(test_resolv_sort_srv_reply)
 
     /* do the sort */
     ret = resolv_sort_srv_reply(&replies);
-    fail_if(ret != EOK, "resolv_sort_srv_reply failed with error: %d", ret);
+    sss_ck_fail_if_msg(ret != EOK, "resolv_sort_srv_reply failed with error: %d", ret);
 
     /* clean up */
     prev = NULL;
@@ -811,7 +811,7 @@ START_TEST(test_resolv_sort_srv_reply_zero_weight)
 
     ret = setup_resolv_test(RESOLV_DEFAULT_TIMEOUT, &test_ctx);
     if (ret != EOK) {
-        fail("Could not set up test");
+        ck_abort_msg("Could not set up test");
         return;
     }
 
@@ -820,7 +820,7 @@ START_TEST(test_resolv_sort_srv_reply_zero_weight)
     /* prepare linked list */
     for (i = 0; i < num_replies; i++) {
         r = talloc_zero(test_ctx, struct ares_srv_reply);
-        fail_if(r == NULL, "Failed to allocate memory");
+        sss_ck_fail_if_msg(r == NULL, "Failed to allocate memory");
 
         r->priority = 20;
         r->priority = i <= 3 ? 10 : r->priority;
@@ -838,12 +838,12 @@ START_TEST(test_resolv_sort_srv_reply_zero_weight)
 
     /* do the sort */
     ret = resolv_sort_srv_reply(&replies);
-    fail_if(ret != EOK, "resolv_sort_srv_reply failed with error: %d", ret);
+    sss_ck_fail_if_msg(ret != EOK, "resolv_sort_srv_reply failed with error: %d", ret);
 
     /* check if the list contains all values and is sorted */
     for (i = 0, r = replies; r != NULL; r = r->next, i++) {
         if (r->next != NULL) {
-            fail_unless(r->priority <= r->next->priority,
+            ck_assert_msg(r->priority <= r->next->priority,
                         "Got unsorted values. %d <= %d",
                         r->priority, r->next->priority);
         }
@@ -876,7 +876,7 @@ START_TEST(test_resolv_free_req)
 
     ret = setup_resolv_test(RESOLV_DEFAULT_TIMEOUT, &test_ctx);
     if (ret != EOK) {
-        fail("Could not set up test");
+        ck_abort_msg("Could not set up test");
         return;
     }
 
@@ -886,7 +886,7 @@ START_TEST(test_resolv_free_req)
                                     default_host_dbs);
     DEBUG(SSSDBG_TRACE_LIBS, "Sent resolv_gethostbyname\n");
     if (req == NULL) {
-        fail("Error calling resolv_gethostbyname_send");
+        ck_abort_msg("Error calling resolv_gethostbyname_send");
         goto done;
     }
 
@@ -899,19 +899,19 @@ START_TEST(test_resolv_free_req)
 
     free_timer = tevent_add_timer(test_ctx->ev, test_ctx, free_tv, resolv_free_req, req);
     if (free_timer == NULL) {
-        fail("Error calling tevent_add_timer");
+        ck_abort_msg("Error calling tevent_add_timer");
         goto done;
     }
 
     terminate_timer = tevent_add_timer(test_ctx->ev, test_ctx, terminate_tv, resolv_free_done, test_ctx);
     if (terminate_timer == NULL) {
-        fail("Error calling tevent_add_timer");
+        ck_abort_msg("Error calling tevent_add_timer");
         goto done;
     }
 
     ret = test_loop(test_ctx);
     ck_leaks_pop(test_ctx);
-    fail_unless(ret == EOK, "test_loop failed with error: %d", ret);
+    ck_assert_msg(ret == EOK, "test_loop failed with error: %d", ret);
 
 done:
     talloc_zfree(test_ctx);
@@ -952,7 +952,7 @@ START_TEST(test_resolv_timeout)
 
     ret = setup_resolv_test(0, &test_ctx);
     if (ret != EOK) {
-        fail("Could not set up test");
+        ck_abort_msg("Could not set up test");
         return;
     }
 
@@ -971,7 +971,7 @@ START_TEST(test_resolv_timeout)
         ret = test_loop(test_ctx);
     }
 
-    fail_unless(ret == EOK, "test_loop failed with error: %d", ret);
+    ck_assert_msg(ret == EOK, "test_loop failed with error: %d", ret);
     talloc_zfree(test_ctx);
 }
 END_TEST

--- a/src/tests/responder_socket_access-tests.c
+++ b/src/tests/responder_socket_access-tests.c
@@ -70,15 +70,15 @@ START_TEST(resp_str_to_array_test)
     for (c = 0; s2a_data[c].exp_ret != -1; c++) {
         ret = csv_string_to_uid_array(global_talloc_context, s2a_data[c].inp,
                                       true, &uid_count, &uids);
-        fail_unless(ret == s2a_data[c].exp_ret,
+        ck_assert_msg(ret == s2a_data[c].exp_ret,
                     "csv_string_to_uid_array failed [%d][%s].", ret,
                                                                 strerror(ret));
         if (ret == 0) {
-            fail_unless(uid_count == s2a_data[c].exp_count,
+            ck_assert_msg(uid_count == s2a_data[c].exp_count,
                         "Wrong number of values, expected [%zu], got [%zu].",
                         s2a_data[c].exp_count, uid_count);
             for (d = 0; d < s2a_data[c].exp_count; d++) {
-                fail_unless(uids[d] == s2a_data[c].exp_uids[d],
+                ck_assert_msg(uids[d] == s2a_data[c].exp_uids[d],
                             "Wrong value, expected [%d], got [%d].\n",
                             s2a_data[c].exp_uids[d], uids[d]);
             }
@@ -116,7 +116,7 @@ START_TEST(check_allowed_uids_test)
         ret = check_allowed_uids(uid_check_data[c].uid,
                                  uid_check_data[c].allowed_uids_count,
                                  uid_check_data[c].allowed_uids);
-        fail_unless(ret == uid_check_data[c].exp_ret,
+        ck_assert_msg(ret == uid_check_data[c].exp_ret,
                     "check_allowed_uids failed [%d][%s].", ret, strerror(ret));
     }
 }

--- a/src/tests/sss_idmap-tests.c
+++ b/src/tests/sss_idmap-tests.c
@@ -64,8 +64,8 @@ void idmap_ctx_setup(void)
     err = sss_idmap_init(idmap_talloc, global_talloc_context, idmap_talloc_free,
                          &idmap_ctx);
 
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_init failed.");
-    fail_unless(idmap_ctx != NULL, "sss_idmap_init returned NULL.");
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_init failed.");
+    ck_assert_msg(idmap_ctx != NULL, "sss_idmap_init returned NULL.");
 }
 
 void idmap_ctx_setup_additional_secondary_slices(void)
@@ -75,8 +75,8 @@ void idmap_ctx_setup_additional_secondary_slices(void)
     err = sss_idmap_init(idmap_talloc, global_talloc_context, idmap_talloc_free,
                          &idmap_ctx);
 
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_init failed.");
-    fail_unless(idmap_ctx != NULL, "sss_idmap_init returned NULL.");
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_init failed.");
+    ck_assert_msg(idmap_ctx != NULL, "sss_idmap_init returned NULL.");
 
     idmap_ctx->idmap_opts.rangesize = 10;
     idmap_ctx->idmap_opts.extra_slice_init = 5;
@@ -87,7 +87,7 @@ void idmap_ctx_teardown(void)
     enum idmap_error_code err;
 
     err = sss_idmap_free(idmap_ctx);
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_free failed.");
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_free failed.");
 }
 
 void idmap_add_domain_setup(void)
@@ -96,7 +96,7 @@ void idmap_add_domain_setup(void)
     struct sss_idmap_range range = {IDMAP_RANGE_MIN, IDMAP_RANGE_MAX};
 
     err = sss_idmap_add_domain(idmap_ctx, "test.dom", "S-1-5-21-1-2-3", &range);
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_add_domain failed.");
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_add_domain failed.");
 }
 
 void idmap_add_domain_with_sec_slices_setup(void)
@@ -110,7 +110,7 @@ void idmap_add_domain_with_sec_slices_setup(void)
     err = sss_idmap_add_auto_domain_ex(idmap_ctx, "test.dom", "S-1-5-21-1-2-3",
                                        &range, NULL, 0, false, NULL, NULL);
 
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_add_auto_domain_ex failed.");
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_add_auto_domain_ex failed.");
 }
 
 
@@ -136,7 +136,7 @@ void idmap_add_domain_with_sec_slices_setup_cb_fail(void)
     err = sss_idmap_add_auto_domain_ex(idmap_ctx, "test.dom", "S-1-5-21-1-2-3",
                                        &range, NULL, 0, false, cb, NULL);
 
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_add_auto_domain_ex failed.");
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_add_auto_domain_ex failed.");
 }
 
 
@@ -176,7 +176,7 @@ void idmap_add_domain_with_sec_slices_setup_cb_ok(void)
     err = sss_idmap_add_auto_domain_ex(idmap_ctx, "test.dom", "S-1-5-21-1-2-3",
                                        &range, NULL, 0, false, cb2, pvt);
 
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_add_auto_domain_ex failed.");
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_add_auto_domain_ex failed.");
 }
 
 START_TEST(idmap_test_is_domain_sid)
@@ -191,13 +191,13 @@ START_TEST(idmap_test_is_domain_sid)
                               "S-1-5-21-1-2-3-4",
                               NULL };
 
-    fail_if(is_domain_sid(NULL), "is_domain_sid() returned true for [NULL]");
+    sss_ck_fail_if_msg(is_domain_sid(NULL), "is_domain_sid() returned true for [NULL]");
     for (c = 0; invalid[c] != NULL; c++) {
-        fail_if(is_domain_sid(invalid[c]),
+        sss_ck_fail_if_msg(is_domain_sid(invalid[c]),
                 "is_domain_sid() returned true for [%s]", invalid[c]);
     }
 
-    fail_unless(is_domain_sid("S-1-5-21-1-2-3"),
+    ck_assert_msg(is_domain_sid("S-1-5-21-1-2-3"),
                 "is_domain_sid() returned true for [S-1-5-21-1-2-3]");
 }
 END_TEST
@@ -209,11 +209,11 @@ START_TEST(idmap_test_init_malloc)
 
     err = sss_idmap_init(NULL, NULL, NULL, &ctx);
 
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_init failed.");
-    fail_unless(ctx != NULL, "sss_idmap_init returned NULL.");
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_init failed.");
+    ck_assert_msg(ctx != NULL, "sss_idmap_init returned NULL.");
 
     err = sss_idmap_free(ctx);
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_free failed.");
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_free failed.");
 }
 END_TEST
 
@@ -225,11 +225,11 @@ START_TEST(idmap_test_init_talloc)
     err = sss_idmap_init(idmap_talloc, global_talloc_context, idmap_talloc_free,
                          &ctx);
 
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_init failed.");
-    fail_unless(ctx != NULL, "sss_idmap_init returned NULL.");
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_init failed.");
+    ck_assert_msg(ctx != NULL, "sss_idmap_init returned NULL.");
 
     err = sss_idmap_free(ctx);
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_free failed.");
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_free failed.");
 }
 END_TEST
 
@@ -246,26 +246,26 @@ START_TEST(idmap_test_add_domain_collisions)
     struct sss_idmap_range range2 = {IDMAP_RANGE_MIN2, IDMAP_RANGE_MAX2};
 
     err = sss_idmap_add_domain(idmap_ctx, "test.dom", "S-1-5-21-1-2-3", &range);
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_add_domain failed.");
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_add_domain failed.");
 
     err = sss_idmap_add_domain(idmap_ctx, "test.dom", "S-1-5-21-1-2-4",
                                &range2);
-    fail_unless(err == IDMAP_COLLISION,
+    ck_assert_msg(err == IDMAP_COLLISION,
                 "sss_idmap_add_domain added domain with the same name.");
 
     err = sss_idmap_add_domain(idmap_ctx, "test.dom2", "S-1-5-21-1-2-3",
                                &range2);
-    fail_unless(err == IDMAP_COLLISION,
+    ck_assert_msg(err == IDMAP_COLLISION,
                 "sss_idmap_add_domain added domain with the same SID.");
 
     err = sss_idmap_add_domain(idmap_ctx, "test.dom2", "S-1-5-21-1-2-4",
                                &range);
-    fail_unless(err == IDMAP_COLLISION,
+    ck_assert_msg(err == IDMAP_COLLISION,
                 "sss_idmap_add_domain added domain with the same range.");
 
     err = sss_idmap_add_domain(idmap_ctx, "test.dom2", "S-1-5-21-1-2-4",
                                &range2);
-    fail_unless(err == IDMAP_SUCCESS,
+    ck_assert_msg(err == IDMAP_SUCCESS,
                 "sss_idmap_add_domain failed to add second domain.");
 }
 END_TEST
@@ -278,21 +278,21 @@ START_TEST(idmap_test_add_domain_collisions_ext_mapping)
 
     err = sss_idmap_add_domain_ex(idmap_ctx, "test.dom", "S-1-5-21-1-2-3",
                                   &range, NULL, 0, true);
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_add_domain failed.");
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_add_domain failed.");
 
     err = sss_idmap_add_domain_ex(idmap_ctx, "test.dom", "S-1-5-21-1-2-4",
                                   &range2, NULL, 0, true);
-    fail_unless(err == IDMAP_COLLISION,
+    ck_assert_msg(err == IDMAP_COLLISION,
                 "sss_idmap_add_domain added domain with the same name.");
 
     err = sss_idmap_add_domain_ex(idmap_ctx, "test.dom2", "S-1-5-21-1-2-3",
                                   &range2, NULL, 0, true);
-    fail_unless(err == IDMAP_COLLISION,
+    ck_assert_msg(err == IDMAP_COLLISION,
                 "sss_idmap_add_domain added domain with the same SID.");
 
     err = sss_idmap_add_domain_ex(idmap_ctx, "test.dom2", "S-1-5-21-1-2-4",
                                   &range, NULL, 0, true);
-    fail_unless(err == IDMAP_SUCCESS,
+    ck_assert_msg(err == IDMAP_SUCCESS,
                 "sss_idmap_add_domain failed to add second domain with " \
                 "external mapping and the same range.");
 }
@@ -304,16 +304,16 @@ START_TEST(idmap_test_sid2uid)
     uint32_t id;
 
     err = sss_idmap_sid_to_unix(idmap_ctx, "S-1-5-21-1-2-3333-1000", &id);
-    fail_unless(err == IDMAP_NO_DOMAIN, "sss_idmap_sid_to_unix did not detect "
+    ck_assert_msg(err == IDMAP_NO_DOMAIN, "sss_idmap_sid_to_unix did not detect "
                                         "unknown domain");
 
     err = sss_idmap_sid_to_unix(idmap_ctx, "S-1-5-21-1-2-3-10000", &id);
-    fail_unless(err == IDMAP_NO_RANGE, "sss_idmap_sid_to_unix did not detect "
+    ck_assert_msg(err == IDMAP_NO_RANGE, "sss_idmap_sid_to_unix did not detect "
                                        "RID out of range");
 
     err = sss_idmap_sid_to_unix(idmap_ctx, "S-1-5-21-1-2-3-1000", &id);
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_sid_to_unix failed.");
-    fail_unless(id == (1000 + IDMAP_RANGE_MIN),
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_sid_to_unix failed.");
+    ck_assert_msg(id == (1000 + IDMAP_RANGE_MIN),
                 "sss_idmap_sid_to_unix returned wrong id, "
                 "got [%d], expected [%d].", id, 1000 + IDMAP_RANGE_MIN);
 }
@@ -327,25 +327,25 @@ START_TEST(idmap_test_sid2uid_ss)
     const uint32_t exp_id2 = 832610000;
 
     err = sss_idmap_sid_to_unix(idmap_ctx, "S-1-5-21-1-2-3333-1000", &id);
-    fail_unless(err == IDMAP_NO_DOMAIN, "sss_idmap_sid_to_unix did not detect "
+    ck_assert_msg(err == IDMAP_NO_DOMAIN, "sss_idmap_sid_to_unix did not detect "
                                         "unknown domain");
 
     /* RID out of primary and secondary range */
     err = sss_idmap_sid_to_unix(idmap_ctx, "S-1-5-21-1-2-3-4000000", &id);
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_sid_to_unix failed.");
-    fail_unless(id == exp_id,
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_sid_to_unix failed.");
+    ck_assert_msg(id == exp_id,
                 "sss_idmap_sid_to_unix returned wrong id, "
                 "got [%d], expected [%d].", id, exp_id);
 
     err = sss_idmap_sid_to_unix(idmap_ctx, "S-1-5-21-1-2-3-1000", &id);
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_sid_to_unix failed.");
-    fail_unless(id == (1000 + IDMAP_RANGE_MIN),
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_sid_to_unix failed.");
+    ck_assert_msg(id == (1000 + IDMAP_RANGE_MIN),
                 "sss_idmap_sid_to_unix returned wrong id, "
                 "got [%d], expected [%d].", id, 1000 + IDMAP_RANGE_MIN);
 
     err = sss_idmap_sid_to_unix(idmap_ctx, "S-1-5-21-1-2-3-210000", &id);
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_sid_to_unix failed.");
-    fail_unless(id == exp_id2,
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_sid_to_unix failed.");
+    ck_assert_msg(id == exp_id2,
                 "sss_idmap_sid_to_unix returned wrong id, "
                 "got [%d], expected [%d].", id, exp_id2);
 }
@@ -359,20 +359,20 @@ START_TEST(idmap_test_sid2uid_ext_sec_slices)
     const uint32_t exp_id = 351800000;
 
     err = sss_idmap_unix_to_sid(idmap_ctx, exp_id, &sid);
-    fail_unless(err == IDMAP_NO_DOMAIN, "sss_idmap_unix_to_sid did not detect "
+    ck_assert_msg(err == IDMAP_NO_DOMAIN, "sss_idmap_unix_to_sid did not detect "
                                         "id out of range");
 
     /* RID out of primary and secondary range */
     err = sss_idmap_sid_to_unix(idmap_ctx, "S-1-5-21-1-2-3-4000000", &id);
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_sid_to_unix failed.");
-    fail_unless(id == exp_id,
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_sid_to_unix failed.");
+    ck_assert_msg(id == exp_id,
                 "sss_idmap_sid_to_unix returned wrong id, "
                 "got [%d], expected [%d].", id, exp_id);
 
     /* Secondary ranges were expanded by sid_to_unix call */
     err = sss_idmap_unix_to_sid(idmap_ctx, exp_id, &sid);
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_unix_to_sid failed.");
-    fail_unless(strcmp(sid, "S-1-5-21-1-2-3-4000000") == 0,
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_unix_to_sid failed.");
+    ck_assert_msg(strcmp(sid, "S-1-5-21-1-2-3-4000000") == 0,
                 "sss_idmap_unix_to_sid returned wrong SID, "
                 "expected [%s], got [%s].", "S-1-5-21-1-2-3-4000000", sid);
     sss_idmap_free_sid(idmap_ctx, sid);
@@ -388,12 +388,12 @@ START_TEST(idmap_test_dyn_dom_store_cb_fail)
     const uint32_t exp_id = 351800000;
 
     err = sss_idmap_unix_to_sid(idmap_ctx, exp_id, &sid);
-    fail_unless(err == IDMAP_NO_DOMAIN, "sss_idmap_unix_to_sid did not detect "
+    ck_assert_msg(err == IDMAP_NO_DOMAIN, "sss_idmap_unix_to_sid did not detect "
                                         "id out of range");
 
     /* RID out of primary and secondary range */
     err = sss_idmap_sid_to_unix(idmap_ctx, "S-1-5-21-1-2-3-4000000", &id);
-    fail_unless(err == IDMAP_ERROR, "sss_idmap_sid_to_unix failed.");
+    ck_assert_msg(err == IDMAP_ERROR, "sss_idmap_sid_to_unix failed.");
 }
 END_TEST
 
@@ -406,14 +406,14 @@ START_TEST(idmap_test_dyn_dom_store_cb_ok)
     const char *exp_stored_data = "test.dom, S-1-5-21-1-2-3 S-1-5-21-1-2-3-4000000, 351800000, 351999999, 4000000";
 
     err = sss_idmap_unix_to_sid(idmap_ctx, exp_id, &sid);
-    fail_unless(err == IDMAP_NO_DOMAIN, "sss_idmap_unix_to_sid did not detect "
+    ck_assert_msg(err == IDMAP_NO_DOMAIN, "sss_idmap_unix_to_sid did not detect "
                                         "id out of range");
 
     /* RID out of primary and secondary range */
     err = sss_idmap_sid_to_unix(idmap_ctx, "S-1-5-21-1-2-3-4000000", &id);
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_sid_to_unix failed.");
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_sid_to_unix failed.");
 
-    fail_unless(strcmp(data,
+    ck_assert_msg(strcmp(data,
                        exp_stored_data) == 0,
                 "Storing dynamic domains idmapping failed: "
                 "expected [%s] but got [%s].", exp_stored_data, data);
@@ -431,24 +431,24 @@ START_TEST(idmap_test_sid2uid_additional_secondary_slices)
     unsigned int ids[max_rid + 1];
 
     tmp_ctx = talloc_new(NULL);
-    fail_unless(tmp_ctx != NULL, "Out of memory.");
+    ck_assert_msg(tmp_ctx != NULL, "Out of memory.");
 
     for (unsigned int i = 0; i < max_rid + 1; i++) {
         sids[i] = talloc_asprintf(tmp_ctx, "%s-%u", dom_prefix, i);
 
-        fail_unless(sids[i] != NULL, "Out of memory");
+        ck_assert_msg(sids[i] != NULL, "Out of memory");
 
         err = sss_idmap_sid_to_unix(idmap_ctx, sids[i], &ids[i]);
-        fail_unless(err == IDMAP_SUCCESS, "sss_idmap_sid_to_unix failed.");
+        ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_sid_to_unix failed.");
     }
 
     for (unsigned int i = 0; i < max_rid + 1; i++) {
         char *sid;
 
         err = sss_idmap_unix_to_sid(idmap_ctx, ids[i], &sid);
-        fail_unless(err == IDMAP_SUCCESS, "sss_idmap_sid_to_unix failed.");
+        ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_sid_to_unix failed.");
 
-        fail_unless(strcmp(sid, sids[i]) == 0,
+        ck_assert_msg(strcmp(sid, sids[i]) == 0,
                     "sss_idmap_unix_to_sid returned wrong sid, "
                     "got [%s], expected [%s].", sid, sids[i]);
         talloc_free(sid);
@@ -467,11 +467,11 @@ START_TEST(idmap_test_bin_sid2uid)
 
     err = sss_idmap_sid_to_bin_sid(idmap_ctx, "S-1-5-21-1-2-3-1000",
                                    &bin_sid, &length);
-    fail_unless(err == IDMAP_SUCCESS, "Failed to convert SID to binary SID");
+    ck_assert_msg(err == IDMAP_SUCCESS, "Failed to convert SID to binary SID");
 
     err = sss_idmap_bin_sid_to_unix(idmap_ctx, bin_sid, length , &id);
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_bin_sid_to_unix failed.");
-    fail_unless(id == (1000 + IDMAP_RANGE_MIN),
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_bin_sid_to_unix failed.");
+    ck_assert_msg(id == (1000 + IDMAP_RANGE_MIN),
                 "sss_idmap_bin_sid_to_unix returned wrong id, "
                 "got [%d], expected [%d].", id, 1000 + IDMAP_RANGE_MIN);
 
@@ -486,11 +486,11 @@ START_TEST(idmap_test_dom_sid2uid)
     struct sss_dom_sid *dom_sid = NULL;
 
     err = sss_idmap_sid_to_dom_sid(idmap_ctx, "S-1-5-21-1-2-3-1000", &dom_sid);
-    fail_unless(err == IDMAP_SUCCESS, "Failed to convert SID to SID structure");
+    ck_assert_msg(err == IDMAP_SUCCESS, "Failed to convert SID to SID structure");
 
     err = sss_idmap_dom_sid_to_unix(idmap_ctx, dom_sid, &id);
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_dom_sid_to_unix failed.");
-    fail_unless(id == (1000 + IDMAP_RANGE_MIN),
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_dom_sid_to_unix failed.");
+    ck_assert_msg(id == (1000 + IDMAP_RANGE_MIN),
                 "sss_idmap_dom_sid_to_unix returned wrong id, "
                 "got [%d], expected [%d].", id, 1000 + IDMAP_RANGE_MIN);
 
@@ -504,12 +504,12 @@ START_TEST(idmap_test_uid2sid)
     char *sid;
 
     err = sss_idmap_unix_to_sid(idmap_ctx, 10000, &sid);
-    fail_unless(err == IDMAP_NO_DOMAIN, "sss_idmap_unix_to_sid did not detect "
+    ck_assert_msg(err == IDMAP_NO_DOMAIN, "sss_idmap_unix_to_sid did not detect "
                                         "id out of range");
 
     err = sss_idmap_unix_to_sid(idmap_ctx, 2234, &sid);
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_unix_to_sid failed.");
-    fail_unless(strcmp(sid, "S-1-5-21-1-2-3-1000") == 0,
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_unix_to_sid failed.");
+    ck_assert_msg(strcmp(sid, "S-1-5-21-1-2-3-1000") == 0,
                 "sss_idmap_unix_to_sid returned wrong SID, "
                 "expected [%s], got [%s].", "S-1-5-21-1-2-3-1000", sid);
 
@@ -525,12 +525,12 @@ START_TEST(idmap_test_uid2sid_ss)
     err = sss_idmap_unix_to_sid(idmap_ctx,
                                 IDMAP_RANGE_MIN + idmap_ctx->idmap_opts.rangesize + 1,
                                 &sid);
-    fail_unless(err == IDMAP_NO_DOMAIN, "sss_idmap_unix_to_sid did not detect "
+    ck_assert_msg(err == IDMAP_NO_DOMAIN, "sss_idmap_unix_to_sid did not detect "
                                         "id out of range");
 
     err = sss_idmap_unix_to_sid(idmap_ctx, 2234, &sid);
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_unix_to_sid failed.");
-    fail_unless(strcmp(sid, "S-1-5-21-1-2-3-1000") == 0,
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_unix_to_sid failed.");
+    ck_assert_msg(strcmp(sid, "S-1-5-21-1-2-3-1000") == 0,
                 "sss_idmap_unix_to_sid returned wrong SID, "
                 "expected [%s], got [%s].", "S-1-5-21-1-2-3-1000", sid);
 
@@ -540,8 +540,8 @@ START_TEST(idmap_test_uid2sid_ss)
     err = sss_idmap_unix_to_sid(idmap_ctx,
                                 313800000,
                                 &sid);
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_unix_to_sid failed.");
-    fail_unless(strcmp(sid, "S-1-5-21-1-2-3-400000") == 0,
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_unix_to_sid failed.");
+    ck_assert_msg(strcmp(sid, "S-1-5-21-1-2-3-400000") == 0,
                 "sss_idmap_unix_to_sid returned wrong SID, "
                 "expected [%s], got [%s].", "S-1-5-21-1-2-3-400000", sid);
 
@@ -556,16 +556,16 @@ START_TEST(idmap_test_uid2dom_sid)
     char *sid = NULL;
 
     err = sss_idmap_unix_to_dom_sid(idmap_ctx, 10000, &dom_sid);
-    fail_unless(err == IDMAP_NO_DOMAIN, "sss_idmap_unix_to_dom_sid did not detect "
+    ck_assert_msg(err == IDMAP_NO_DOMAIN, "sss_idmap_unix_to_dom_sid did not detect "
                                         "id out of range");
 
     err = sss_idmap_unix_to_dom_sid(idmap_ctx, 2234, &dom_sid);
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_unix_to_dom_sid failed.");
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_unix_to_dom_sid failed.");
 
     err = sss_idmap_dom_sid_to_sid(idmap_ctx, dom_sid, &sid);
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_dom_sid_to_sid failed.");
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_dom_sid_to_sid failed.");
 
-    fail_unless(strcmp(sid, "S-1-5-21-1-2-3-1000") == 0,
+    ck_assert_msg(strcmp(sid, "S-1-5-21-1-2-3-1000") == 0,
                 "sss_idmap_unix_to_dom_sid returned wrong SID, "
                 "expected [%s], got [%s].", "S-1-5-21-1-2-3-1000", sid);
 
@@ -582,16 +582,16 @@ START_TEST(idmap_test_uid2bin_sid)
     char *sid = NULL;
 
     err = sss_idmap_unix_to_bin_sid(idmap_ctx, 10000, &bin_sid, &length);
-    fail_unless(err == IDMAP_NO_DOMAIN, "sss_idmap_unix_to_bin_sid did not detect "
+    ck_assert_msg(err == IDMAP_NO_DOMAIN, "sss_idmap_unix_to_bin_sid did not detect "
                                         "id out of range");
 
     err = sss_idmap_unix_to_bin_sid(idmap_ctx, 2234, &bin_sid, &length);
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_unix_to_bin_sid failed.");
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_unix_to_bin_sid failed.");
 
     err = sss_idmap_bin_sid_to_sid(idmap_ctx, bin_sid, length, &sid);
-    fail_unless(err == IDMAP_SUCCESS, "sss_idmap_bin_sid_to_sid failed.");
+    ck_assert_msg(err == IDMAP_SUCCESS, "sss_idmap_bin_sid_to_sid failed.");
 
-    fail_unless(strcmp(sid, "S-1-5-21-1-2-3-1000") == 0,
+    ck_assert_msg(strcmp(sid, "S-1-5-21-1-2-3-1000") == 0,
                 "sss_idmap_unix_to_bin_sid returned wrong SID, "
                 "expected [%s], got [%s].", "S-1-5-21-1-2-3-1000", sid);
 
@@ -610,17 +610,17 @@ START_TEST(idmap_test_bin_sid2dom_sid)
     err = sss_idmap_bin_sid_to_dom_sid(idmap_ctx, test_bin_sid,
                                        test_bin_sid_length, &dom_sid);
 
-    fail_unless(err == IDMAP_SUCCESS,
+    ck_assert_msg(err == IDMAP_SUCCESS,
                 "Failed to convert binary SID to struct sss_dom_sid.");
 
     err = sss_idmap_dom_sid_to_bin_sid(idmap_ctx, dom_sid, &new_bin_sid,
                                        &new_bin_sid_length);
-    fail_unless(err == IDMAP_SUCCESS,
+    ck_assert_msg(err == IDMAP_SUCCESS,
                 "Failed to convert struct sss_dom_sid to binary SID.");
 
-    fail_unless(new_bin_sid_length == test_bin_sid_length,
+    ck_assert_msg(new_bin_sid_length == test_bin_sid_length,
                 "Length of binary SIDs do not match.");
-    fail_unless(memcmp(test_bin_sid, new_bin_sid, test_bin_sid_length) == 0,
+    ck_assert_msg(memcmp(test_bin_sid, new_bin_sid, test_bin_sid_length) == 0,
                 "Binary SIDs do not match.");
 
     sss_idmap_free_dom_sid(idmap_ctx, dom_sid);
@@ -636,17 +636,17 @@ START_TEST(idmap_test_sid2dom_sid)
 
     err = sss_idmap_sid_to_dom_sid(idmap_ctx, "S-1-5-21-1-2-3-1000", &dom_sid);
 
-    fail_unless(err == IDMAP_SUCCESS,
+    ck_assert_msg(err == IDMAP_SUCCESS,
                 "Failed to convert SID string to struct sss_dom_sid.");
 
     err = sss_idmap_dom_sid_to_sid(idmap_ctx, dom_sid, &new_sid);
-    fail_unless(err == IDMAP_SUCCESS,
+    ck_assert_msg(err == IDMAP_SUCCESS,
                 "Failed to convert struct sss_dom_sid to SID string.");
 
-    fail_unless(new_sid != NULL, "SID string not set");
-    fail_unless(strlen("S-1-5-21-1-2-3-1000") == strlen(new_sid),
+    ck_assert_msg(new_sid != NULL, "SID string not set");
+    ck_assert_msg(strlen("S-1-5-21-1-2-3-1000") == strlen(new_sid),
                 "Length of SID strings do not match.");
-    fail_unless(strcmp("S-1-5-21-1-2-3-1000", new_sid) == 0,
+    ck_assert_msg(strcmp("S-1-5-21-1-2-3-1000", new_sid) == 0,
                 "SID strings do not match.");
 
     sss_idmap_free_dom_sid(idmap_ctx, dom_sid);
@@ -662,23 +662,23 @@ START_TEST(idmap_test_large_and_too_large_sid)
 
     err = sss_idmap_sid_to_dom_sid(idmap_ctx, large_sid, &dom_sid);
 
-    fail_unless(err == IDMAP_SUCCESS,
+    ck_assert_msg(err == IDMAP_SUCCESS,
                 "Failed to convert SID string with a UINT32_MAX component "
                 "to struct sss_dom_sid.");
 
     err = sss_idmap_dom_sid_to_sid(idmap_ctx, dom_sid, &new_sid);
-    fail_unless(err == IDMAP_SUCCESS,
+    ck_assert_msg(err == IDMAP_SUCCESS,
                 "Failed to convert struct sss_dom_sid to SID string.");
 
-    fail_unless(new_sid != NULL, "SID string not set");
-    fail_unless(strlen(large_sid) == strlen(new_sid),
+    ck_assert_msg(new_sid != NULL, "SID string not set");
+    ck_assert_msg(strlen(large_sid) == strlen(new_sid),
                 "Length of SID strings do not match.");
-    fail_unless(strcmp(large_sid, new_sid) == 0,
+    ck_assert_msg(strcmp(large_sid, new_sid) == 0,
                 "SID strings do not match, expected [%s], got [%s]",
                 large_sid, new_sid);
 
     err = sss_idmap_sid_to_dom_sid(idmap_ctx, too_large_sid, &dom_sid);
-    fail_unless(err == IDMAP_SID_INVALID,
+    ck_assert_msg(err == IDMAP_SID_INVALID,
                 "Trying to convert  a SID with a too large component "
                 "did not return IDMAP_SID_INVALID");
 
@@ -694,12 +694,12 @@ START_TEST(idmap_test_sid2bin_sid)
     uint8_t *bin_sid = NULL;
 
     err = sss_idmap_sid_to_bin_sid(idmap_ctx, test_sid, &bin_sid, &length);
-    fail_unless(err == IDMAP_SUCCESS,
+    ck_assert_msg(err == IDMAP_SUCCESS,
                 "Failed to convert SID string to binary sid.");
-    fail_unless(length == test_bin_sid_length,
+    ck_assert_msg(length == test_bin_sid_length,
                 "Size of binary SIDs do not match, got [%zu], expected [%zu]",
                 length, test_bin_sid_length);
-    fail_unless(memcmp(bin_sid, test_bin_sid, test_bin_sid_length) == 0,
+    ck_assert_msg(memcmp(bin_sid, test_bin_sid, test_bin_sid_length) == 0,
                 "Binary SIDs do not match");
 
     sss_idmap_free_bin_sid(idmap_ctx, bin_sid);
@@ -713,9 +713,9 @@ START_TEST(idmap_test_bin_sid2sid)
 
     err = sss_idmap_bin_sid_to_sid(idmap_ctx, test_bin_sid, test_bin_sid_length,
                                    &sid);
-    fail_unless(err == IDMAP_SUCCESS,
+    ck_assert_msg(err == IDMAP_SUCCESS,
                 "Failed to convert binary SID to SID string.");
-    fail_unless(strcmp(sid, test_sid) == 0, "SID strings do not match, "
+    ck_assert_msg(strcmp(sid, test_sid) == 0, "SID strings do not match, "
                                             "expected [%s], get [%s]",
                                             test_sid, sid);
 
@@ -730,14 +730,14 @@ START_TEST(idmap_test_smb_sid2dom_sid)
     struct dom_sid *new_smb_sid = NULL;
 
     err = sss_idmap_smb_sid_to_dom_sid(idmap_ctx, &test_smb_sid, &dom_sid);
-    fail_unless(err == IDMAP_SUCCESS,
+    ck_assert_msg(err == IDMAP_SUCCESS,
                 "Failed to convert samba dom_sid to struct sss_dom_sid.");
 
     err = sss_idmap_dom_sid_to_smb_sid(idmap_ctx, dom_sid, &new_smb_sid);
-    fail_unless(err == IDMAP_SUCCESS,
+    ck_assert_msg(err == IDMAP_SUCCESS,
                 "Failed to convert struct sss_dom_sid to samba dom_sid.");
 
-    fail_unless(memcmp(&test_smb_sid, new_smb_sid, sizeof(struct dom_sid)) == 0,
+    ck_assert_msg(memcmp(&test_smb_sid, new_smb_sid, sizeof(struct dom_sid)) == 0,
                 "Samba dom_sid-s do not match.");
 
     sss_idmap_free_dom_sid(idmap_ctx, dom_sid);
@@ -753,12 +753,12 @@ START_TEST(idmap_test_smb_sid2bin_sid)
 
     err = sss_idmap_smb_sid_to_bin_sid(idmap_ctx, &test_smb_sid,
                                        &bin_sid, &length);
-    fail_unless(err == IDMAP_SUCCESS,
+    ck_assert_msg(err == IDMAP_SUCCESS,
                 "Failed to convert samba dom_sid to binary sid.");
-    fail_unless(length == test_bin_sid_length,
+    ck_assert_msg(length == test_bin_sid_length,
                 "Size of binary SIDs do not match, got [%zu], expected [%zu]",
                 length, test_bin_sid_length);
-    fail_unless(memcmp(bin_sid, test_bin_sid, test_bin_sid_length) == 0,
+    ck_assert_msg(memcmp(bin_sid, test_bin_sid, test_bin_sid_length) == 0,
                 "Binary SIDs do not match.");
 
     sss_idmap_free_bin_sid(idmap_ctx, bin_sid);
@@ -772,9 +772,9 @@ START_TEST(idmap_test_bin_sid2smb_sid)
 
     err = sss_idmap_bin_sid_to_smb_sid(idmap_ctx, test_bin_sid,
                                        test_bin_sid_length, &smb_sid);
-    fail_unless(err == IDMAP_SUCCESS,
+    ck_assert_msg(err == IDMAP_SUCCESS,
                 "Failed to convert binary sid to samba dom_sid.");
-    fail_unless(memcmp(&test_smb_sid, smb_sid, sizeof(struct dom_sid)) == 0,
+    ck_assert_msg(memcmp(&test_smb_sid, smb_sid, sizeof(struct dom_sid)) == 0,
                  "Samba dom_sid structs do not match.");
 
     sss_idmap_free_smb_sid(idmap_ctx, smb_sid);
@@ -787,9 +787,9 @@ START_TEST(idmap_test_smb_sid2sid)
     char *sid = NULL;
 
     err = sss_idmap_smb_sid_to_sid(idmap_ctx, &test_smb_sid, &sid);
-    fail_unless(err == IDMAP_SUCCESS,
+    ck_assert_msg(err == IDMAP_SUCCESS,
                 "Failed to convert samba dom_sid to sid string.");
-    fail_unless(strcmp(sid, test_sid) == 0, "SID strings do not match, "
+    ck_assert_msg(strcmp(sid, test_sid) == 0, "SID strings do not match, "
                                             "expected [%s], get [%s]",
                                             test_sid, sid);
 
@@ -803,9 +803,9 @@ START_TEST(idmap_test_sid2smb_sid)
     struct dom_sid *smb_sid = NULL;
 
     err = sss_idmap_sid_to_smb_sid(idmap_ctx, test_sid, &smb_sid);
-    fail_unless(err == IDMAP_SUCCESS,
+    ck_assert_msg(err == IDMAP_SUCCESS,
                 "Failed to convert binary sid to samba dom_sid.");
-    fail_unless(memcmp(&test_smb_sid, smb_sid, sizeof(struct dom_sid)) == 0,
+    ck_assert_msg(memcmp(&test_smb_sid, smb_sid, sizeof(struct dom_sid)) == 0,
                  "Samba dom_sid structs do not match.");
 
     sss_idmap_free_smb_sid(idmap_ctx, smb_sid);

--- a/src/tests/strtonum-tests.c
+++ b/src/tests/strtonum-tests.c
@@ -32,32 +32,32 @@
  ********************/
 #define EXPECT_UNSET_ERRNO(error) \
     do { \
-        fail_unless(error == 0, "errno unexpectedly set to %d[%s]", \
+        ck_assert_msg(error == 0, "errno unexpectedly set to %d[%s]", \
                                 error, strerror(error)); \
     } while(0)
 
 #define CHECK_RESULT(expected, actual) \
     do { \
-        fail_unless(actual == expected, "Expected %jd, got %jd", \
+        ck_assert_msg(actual == expected, "Expected %jd, got %jd", \
                                         (intmax_t)expected, (intmax_t)actual); \
     } while(0)
 
 #define CHECK_ERRNO(expected, actual) \
     do { \
-        fail_unless(actual == expected, "Expected errno %d[%s], got %d[%s]", \
+        ck_assert_msg(actual == expected, "Expected errno %d[%s], got %d[%s]", \
                                         expected, strerror(expected), \
                                         actual, strerror(actual)); \
     } while(0)
 
 #define CHECK_ENDPTR(expected, actual) \
     do { \
-        fail_unless(actual == expected, "Expected endptr %p, got %p", \
+        ck_assert_msg(actual == expected, "Expected endptr %p, got %p", \
                                          expected, actual); \
     } while(0)
 
 #define CHECK_ZERO_ENDPTR(endptr) \
     do { \
-        fail_unless(endptr && *endptr == '\0', "Invalid endptr"); \
+        ck_assert_msg(endptr && *endptr == '\0', "Invalid endptr"); \
     } while(0)
 
 /******************

--- a/src/tests/sysdb-tests.c
+++ b/src/tests/sysdb-tests.c
@@ -35,7 +35,7 @@
 #include "db/sysdb_autofs.h"
 #include "db/sysdb_iphosts.h"
 #include "db/sysdb_ipnetworks.h"
-#include "tests/common.h"
+#include "tests/common_check.h"
 
 #define TESTS_PATH "tp_" BASE_FILE_STEM
 #define TEST_CONF_FILE "tests_conf.ldb"
@@ -80,13 +80,13 @@ static int _setup_sysdb_tests(struct sysdb_test_ctx **ctx, bool enumerate)
     /* (relative to current dir) */
     ret = mkdir(TESTS_PATH, 0775);
     if (ret == -1 && errno != EEXIST) {
-        fail("Could not create %s directory", TESTS_PATH);
+        ck_abort_msg("Could not create %s directory", TESTS_PATH);
         return EFAULT;
     }
 
     test_ctx = talloc_zero(NULL, struct sysdb_test_ctx);
     if (test_ctx == NULL) {
-        fail("Could not allocate memory for test context");
+        ck_abort_msg("Could not allocate memory for test context");
         return ENOMEM;
     }
 
@@ -95,14 +95,14 @@ static int _setup_sysdb_tests(struct sysdb_test_ctx **ctx, bool enumerate)
      */
     test_ctx->ev = tevent_context_init(test_ctx);
     if (test_ctx->ev == NULL) {
-        fail("Could not create event context");
+        ck_abort_msg("Could not create event context");
         talloc_free(test_ctx);
         return EIO;
     }
 
     conf_db = talloc_asprintf(test_ctx, "%s/%s", TESTS_PATH, TEST_CONF_FILE);
     if (conf_db == NULL) {
-        fail("Out of memory, aborting!");
+        ck_abort_msg("Out of memory, aborting!");
         talloc_free(test_ctx);
         return ENOMEM;
     }
@@ -111,7 +111,7 @@ static int _setup_sysdb_tests(struct sysdb_test_ctx **ctx, bool enumerate)
     /* Connect to the conf db */
     ret = confdb_init(test_ctx, &test_ctx->confdb, conf_db);
     if (ret != EOK) {
-        fail("Could not initialize connection to the confdb");
+        ck_abort_msg("Could not initialize connection to the confdb");
         talloc_free(test_ctx);
         return ret;
     }
@@ -120,7 +120,7 @@ static int _setup_sysdb_tests(struct sysdb_test_ctx **ctx, bool enumerate)
     ret = confdb_add_param(test_ctx->confdb, true,
                            "config/sssd", "domains", val);
     if (ret != EOK) {
-        fail("Could not initialize domains placeholder");
+        ck_abort_msg("Could not initialize domains placeholder");
         talloc_free(test_ctx);
         return ret;
     }
@@ -129,7 +129,7 @@ static int _setup_sysdb_tests(struct sysdb_test_ctx **ctx, bool enumerate)
     ret = confdb_add_param(test_ctx->confdb, true,
                            "config/domain/FILES", "id_provider", val);
     if (ret != EOK) {
-        fail("Could not initialize provider");
+        ck_abort_msg("Could not initialize provider");
         talloc_free(test_ctx);
         return ret;
     }
@@ -138,7 +138,7 @@ static int _setup_sysdb_tests(struct sysdb_test_ctx **ctx, bool enumerate)
     ret = confdb_add_param(test_ctx->confdb, true,
                            "config/domain/FILES", "enumerate", val);
     if (ret != EOK) {
-        fail("Could not initialize FILES domain");
+        ck_abort_msg("Could not initialize FILES domain");
         talloc_free(test_ctx);
         return ret;
     }
@@ -147,7 +147,7 @@ static int _setup_sysdb_tests(struct sysdb_test_ctx **ctx, bool enumerate)
     ret = confdb_add_param(test_ctx->confdb, true,
                            "config/domain/FILES", "cache_credentials", val);
     if (ret != EOK) {
-        fail("Could not initialize FILES domain");
+        ck_abort_msg("Could not initialize FILES domain");
         talloc_free(test_ctx);
         return ret;
     }
@@ -155,7 +155,7 @@ static int _setup_sysdb_tests(struct sysdb_test_ctx **ctx, bool enumerate)
     ret = sssd_domain_init(test_ctx, test_ctx->confdb, TEST_DOM_NAME,
                            TESTS_PATH, &test_ctx->domain);
     if (ret != EOK) {
-        fail("Could not initialize connection to the sysdb (%d)", ret);
+        ck_abort_msg("Could not initialize connection to the sysdb (%d)", ret);
         talloc_free(test_ctx);
         return ret;
     }
@@ -178,7 +178,7 @@ static void fail_if_null_ctx_leaks(struct sysdb_test_ctx *ctx)
 
     new_null_pointer_size = talloc_total_size(NULL);
     if(new_null_pointer_size != ctx->null_pointer_size) {
-        fail("NULL pointer leaked memory, was %zu, is %zu\n",
+        ck_abort_msg("NULL pointer leaked memory, was %zu, is %zu\n",
              ctx->null_pointer_size, new_null_pointer_size);
     }
 }
@@ -329,9 +329,9 @@ static int test_store_user(struct test_data *data)
     int ret;
 
     homedir = talloc_asprintf(data, "/home/testuser%d", data->uid);
-    fail_if(homedir == NULL, "OOM");
+    sss_ck_fail_if_msg(homedir == NULL, "OOM");
     gecos = talloc_asprintf(data, "Test User %d", data->uid);
-    fail_if(gecos == NULL, "OOM");
+    sss_ck_fail_if_msg(gecos == NULL, "OOM");
 
     ret = sysdb_store_user(data->ctx->domain,
                            data->username, "x",
@@ -523,7 +523,7 @@ static int test_delete_recursive(struct test_data *data)
     }
 
     ret = sysdb_delete_recursive(data->ctx->sysdb, dn, false);
-    fail_unless(ret == EOK, "sysdb_delete_recursive returned [%d]", ret);
+    ck_assert_msg(ret == EOK, "sysdb_delete_recursive returned [%d]", ret);
     return ret;
 }
 
@@ -687,37 +687,37 @@ START_TEST (test_sysdb_user_new_id)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     fqname = sss_create_internal_fqname(test_ctx,
                                         username,
                                         test_ctx->domain->name);
-    fail_if(fqname == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(fqname == NULL, "Failed to allocate memory");
 
     attrs = sysdb_new_attrs(test_ctx);
-    fail_if(attrs == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(attrs == NULL, "Failed to allocate memory");
 
     ret = sysdb_attrs_add_string(attrs, SYSDB_DESCRIPTION, desc_in);
-    fail_if(ret != EOK, "Failed to add attribute: " SYSDB_DESCRIPTION);
+    sss_ck_fail_if_msg(ret != EOK, "Failed to add attribute: " SYSDB_DESCRIPTION);
 
     ret = sysdb_add_user(test_ctx->domain, fqname,
                          1234, 1234, fqname, "/", "/bin/bash",
                          NULL, attrs, 0, 0);
-    fail_if(ret != EOK, "Could not store user %s", fqname);
+    sss_ck_fail_if_msg(ret != EOK, "Could not store user %s", fqname);
 
     ret = sysdb_search_user_by_name(test_ctx,
                                     test_ctx->domain,
                                     fqname, get_attrs, &msg);
-    fail_if(ret != EOK, "Could not retrieve user %s", fqname);
+    sss_ck_fail_if_msg(ret != EOK, "Could not retrieve user %s", fqname);
 
     desc = ldb_msg_find_attr_as_string(msg, SYSDB_DESCRIPTION, NULL);
-    fail_unless(desc != NULL, "Failed to find attribute: " SYSDB_DESCRIPTION);
+    ck_assert_msg(desc != NULL, "Failed to find attribute: " SYSDB_DESCRIPTION);
     ck_assert_str_eq(desc, desc_in);
 
     ret = sysdb_delete_user(test_ctx->domain, fqname, 0);
-    fail_unless(ret == EOK, "sysdb_delete_user error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_delete_user error [%d][%s]",
                             ret, strerror(ret));
 
     talloc_free(test_ctx);
@@ -733,16 +733,16 @@ START_TEST (test_sysdb_store_user)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_user(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     ret = test_store_user(data);
 
-    fail_if(ret != EOK, "Could not store user %s", data->username);
+    sss_ck_fail_if_msg(ret != EOK, "Could not store user %s", data->username);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -756,17 +756,17 @@ START_TEST (test_sysdb_store_user_existing)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_user(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
     data->shell = "/bin/ksh";
 
     ret = test_store_user(data);
 
-    fail_if(ret != EOK, "Could not store user %s", data->username);
+    sss_ck_fail_if_msg(ret != EOK, "Could not store user %s", data->username);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -780,16 +780,16 @@ START_TEST (test_sysdb_store_group)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "OOM");
+    sss_ck_fail_if_msg(data == NULL, "OOM");
 
     ret = test_store_group(data);
 
-    fail_if(ret != EOK, "Could not store POSIX group #%d", _i);
+    sss_ck_fail_if_msg(ret != EOK, "Could not store POSIX group #%d", _i);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -803,16 +803,16 @@ START_TEST (test_sysdb_remove_local_user)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_user(test_ctx, _i);
-    fail_if(data == NULL, "OOM");
+    sss_ck_fail_if_msg(data == NULL, "OOM");
 
     ret = test_remove_user(data);
 
-    fail_if(ret != EOK, "Could not remove user %s", data->username);
+    sss_ck_fail_if_msg(ret != EOK, "Could not remove user %s", data->username);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -826,17 +826,17 @@ START_TEST (test_sysdb_remove_local_user_by_uid)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new(test_ctx);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
     data->uid = _i;
 
     ret = test_remove_user_by_uid(data);
 
-    fail_if(ret != EOK, "Could not remove user with uid %d", _i);
+    sss_ck_fail_if_msg(ret != EOK, "Could not remove user with uid %d", _i);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -850,16 +850,16 @@ START_TEST (test_sysdb_remove_local_group)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     ret = test_remove_group(data);
 
-    fail_if(ret != EOK, "Could not remove group %s", data->groupname);
+    sss_ck_fail_if_msg(ret != EOK, "Could not remove group %s", data->groupname);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -873,18 +873,18 @@ START_TEST (test_sysdb_remove_local_group_by_gid)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     null_ctx_get_size(data->ctx);
     ret = test_remove_group_by_gid(data);
     fail_if_null_ctx_leaks(test_ctx);
 
-    fail_if(ret != EOK, "Could not remove group with gid %d", _i);
+    sss_ck_fail_if_msg(ret != EOK, "Could not remove group with gid %d", _i);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -898,16 +898,16 @@ START_TEST (test_sysdb_add_user)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_user(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     ret = test_add_user(data);
 
-    fail_if(ret != EOK, "Could not add user %s", data->username);
+    sss_ck_fail_if_msg(ret != EOK, "Could not add user %s", data->username);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -921,16 +921,16 @@ START_TEST (test_sysdb_add_group)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     ret = test_add_group(data);
 
-    fail_if(ret != EOK, "Could not add group %s", data->groupname);
+    sss_ck_fail_if_msg(ret != EOK, "Could not add group %s", data->groupname);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -946,25 +946,25 @@ START_TEST (test_sysdb_add_group_with_ghosts)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     for (j = MBO_GROUP_BASE; j < _i; j++) {
         member_fqname = test_asprintf_fqname(data, data->ctx->domain,
                                              "testghost%d", j);
         ret = sysdb_attrs_steal_string(data->attrs, SYSDB_GHOST, member_fqname);
         if (ret != EOK) {
-            fail_unless(ret == EOK, "Cannot add attr\n");
+            ck_assert_msg(ret == EOK, "Cannot add attr\n");
         }
     }
 
     ret = test_store_group(data);
 
-    fail_if(ret != EOK, "Could not add group %s", data->groupname);
+    sss_ck_fail_if_msg(ret != EOK, "Could not add group %s", data->groupname);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -978,16 +978,16 @@ START_TEST (test_sysdb_add_incomplete_group)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     ret = test_add_incomplete_group(data);
 
-    fail_if(ret != EOK, "Could not add incomplete group %s", data->groupname);
+    sss_ck_fail_if_msg(ret != EOK, "Could not add incomplete group %s", data->groupname);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -999,7 +999,7 @@ START_TEST (test_sysdb_incomplete_group_rename)
 
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
@@ -1007,21 +1007,21 @@ START_TEST (test_sysdb_incomplete_group_rename)
                                      20000, NULL,
                                      "S-1-5-21-123-456-789-111",
                                      NULL, true, 0);
-    fail_unless(ret == EOK,
+    ck_assert_msg(ret == EOK,
                 "sysdb_add_incomplete_group error [%d][%s]",
                 ret, strerror(ret));
 
     /* Adding a group with the same GID and all the other characteristics uknown should fail */
     ret = sysdb_add_incomplete_group(test_ctx->domain, "incomplete_group_new",
                                      20000, NULL, NULL, NULL, true, 0);
-    fail_unless(ret == EEXIST, "Did not caught a duplicate\n");
+    ck_assert_msg(ret == EEXIST, "Did not caught a duplicate\n");
 
     /* A different SID should also trigger a failure */
     ret = sysdb_add_incomplete_group(test_ctx->domain, "incomplete_group_new",
                                      20000, NULL,
                                      "S-1-5-21-123-456-789-222",
                                      NULL, true, 0);
-    fail_unless(ret == EEXIST, "Did not caught a duplicate\n");
+    ck_assert_msg(ret == EEXIST, "Did not caught a duplicate\n");
 
     /* But if we know based on a SID that the group is in fact the same,
      * let's just change its name
@@ -1030,7 +1030,7 @@ START_TEST (test_sysdb_incomplete_group_rename)
                                      20000, NULL,
                                      "S-1-5-21-123-456-789-111",
                                      NULL, true, 0);
-    fail_unless(ret == ERR_GID_DUPLICATED,
+    ck_assert_msg(ret == ERR_GID_DUPLICATED,
                 "Did not catch a legitimate rename. ret: %d [%s]",
                 ret, sss_strerror(ret));
 }
@@ -1048,30 +1048,30 @@ START_TEST (test_sysdb_getpwnam)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_user(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     res = test_getpwnam(data);
-    fail_if(res->count != 1,
+    sss_ck_fail_if_msg(res->count != 1,
             "Invalid number of replies. Expected 1, got %d", res->count);
 
     /* Check the user was found with the expected FQDN and UID */
     uid = ldb_msg_find_attr_as_uint(res->msgs[0], SYSDB_UIDNUM, 0);
-    fail_unless(uid == _i, "Did not find the expected UID");
+    ck_assert_msg(uid == _i, "Did not find the expected UID");
     username = ldb_msg_find_attr_as_string(res->msgs[0], SYSDB_NAME, NULL);
     ck_assert_str_eq(username, data->username);
 
     /* Search for the user with the wrong case */
     data->username = test_asprintf_fqname(data, test_ctx->domain,
                                           "TESTUSER%d", _i);
-    fail_if(data->username == NULL, "OOM");
+    sss_ck_fail_if_msg(data->username == NULL, "OOM");
 
     res = test_getpwnam(data);
-    fail_if(res->count != 0,
+    sss_ck_fail_if_msg(res->count != 0,
             "Invalid number of replies. Expected 0, got %d", res->count);
 
     talloc_free(test_ctx);
@@ -1089,7 +1089,7 @@ START_TEST(test_user_group_by_name)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
@@ -1100,16 +1100,16 @@ START_TEST(test_user_group_by_name)
     test_ctx->domain->mpg_mode = MPG_ENABLED;
 
     data = test_data_new_user(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     ret = sysdb_search_group_by_name(data,
                                      data->ctx->domain,
                                      data->username, /* we're searching for the private group */
                                      NULL,
                                      &msg);
-    fail_if(ret != EOK,
+    sss_ck_fail_if_msg(ret != EOK,
             "sysdb_search_group_by_name failed with error: %d", ret);
-    fail_if(msg == NULL, "Failed to find group: %s", data->username);
+    sss_ck_fail_if_msg(msg == NULL, "Failed to find group: %s", data->username);
 
     groupname = ldb_msg_find_attr_as_string(msg, SYSDB_NAME, NULL);
     ck_assert_str_eq(groupname, data->username);
@@ -1126,19 +1126,19 @@ START_TEST(test_user_group_by_name_local)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_user(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     ret = sysdb_search_group_by_name(data,
                                      data->ctx->domain,
                                      data->username, /* we're searching for the private group */
                                      NULL,
                                      &msg);
-    fail_if(ret != ENOENT,
+    sss_ck_fail_if_msg(ret != ENOENT,
             "sysdb_search_group_by_name must return ENOENT got: %d", ret);
 }
 END_TEST
@@ -1155,19 +1155,19 @@ START_TEST (test_sysdb_getgrnam)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     res = test_getgrnam(data);
-    fail_if(res->count != 1,
+    sss_ck_fail_if_msg(res->count != 1,
             "Invalid number of replies. Expected 1, got %d", res->count);
 
     gid = ldb_msg_find_attr_as_uint(res->msgs[0], SYSDB_GIDNUM, 0);
-    fail_unless(gid == _i,
+    ck_assert_msg(gid == _i,
                 "Did not find the expected GID (found %d expected %d)",
                 gid, _i);
     groupname = ldb_msg_find_attr_as_string(res->msgs[0], SYSDB_NAME, NULL);
@@ -1176,10 +1176,10 @@ START_TEST (test_sysdb_getgrnam)
     /* Search for the group with the wrong case */
     data->groupname = test_asprintf_fqname(data, test_ctx->domain,
                                           "TESTGROUP%d", _i);
-    fail_if(data->groupname == NULL, "OOM");
+    sss_ck_fail_if_msg(data->groupname == NULL, "OOM");
 
     res = test_getgrnam(data);
-    fail_if(res->count != 0,
+    sss_ck_fail_if_msg(res->count != 0,
             "Invalid number of replies. Expected 1, got %d", res->count);
 
     talloc_free(test_ctx);
@@ -1197,26 +1197,26 @@ START_TEST (test_sysdb_getgrgid)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "OOM");
+    sss_ck_fail_if_msg(data == NULL, "OOM");
 
     ret = sysdb_getgrgid(test_ctx,
                          test_ctx->domain,
                          data->gid, &res);
     if (ret) {
-        fail("sysdb_getgrgid failed for gid %d (%d: %s)",
+        ck_abort_msg("sysdb_getgrgid failed for gid %d (%d: %s)",
              data->gid, ret, strerror(ret));
         goto done;
     }
 
     fqname = ldb_msg_find_attr_as_string(res->msgs[0], SYSDB_NAME, 0);
-    fail_unless(fqname != NULL, "No group name?\n");
+    ck_assert_msg(fqname != NULL, "No group name?\n");
 
-    fail_unless(strcmp(fqname, data->groupname) == 0,
+    ck_assert_msg(strcmp(fqname, data->groupname) == 0,
                 "Did not find the expected groupname (found %s expected %s)",
                 fqname, data->groupname);
 done:
@@ -1236,24 +1236,24 @@ START_TEST (test_sysdb_getgrgid_attrs)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "OOM");
+    sss_ck_fail_if_msg(data == NULL, "OOM");
 
     ret = sysdb_getgrgid_attrs(test_ctx,
                                test_ctx->domain,
                                data->gid, attrs, &res);
     if (ret) {
-        fail("sysdb_getgrgid_attrs failed for gid %d (%d: %s)",
+        ck_abort_msg("sysdb_getgrgid_attrs failed for gid %d (%d: %s)",
              data->gid, ret, strerror(ret));
         goto done;
     }
 
     ctime = ldb_msg_find_attr_as_uint64(res->msgs[0], SYSDB_CREATE_TIME, 0);
-    fail_unless(ctime != 0, "Missing create time");
+    ck_assert_msg(ctime != 0, "Missing create time");
 
 done:
     talloc_free(test_ctx);
@@ -1271,16 +1271,16 @@ START_TEST (test_sysdb_search_groups)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     filter = talloc_asprintf(test_ctx, "("SYSDB_GIDNUM"=%d)", _i);
-    fail_if(filter == NULL, "OOM");
+    sss_ck_fail_if_msg(filter == NULL, "OOM");
 
     ret = sysdb_search_groups(test_ctx, test_ctx->domain,
                              filter, attrs, &count, &msgs);
     talloc_free(filter);
-    fail_if(ret != EOK, "Search failed: %d", ret);
-    fail_if(count != 1, "Did not find the expected group\n");
+    sss_ck_fail_if_msg(ret != EOK, "Search failed: %d", ret);
+    sss_ck_fail_if_msg(count != 1, "Did not find the expected group\n");
 
     talloc_free(test_ctx);
 }
@@ -1297,29 +1297,29 @@ START_TEST (test_sysdb_getpwuid)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_user(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     ret = sysdb_getpwuid(test_ctx,
                          test_ctx->domain,
                          _i, &res);
     if (ret) {
-        fail("sysdb_getpwuid failed for uid %d (%d: %s)",
+        ck_abort_msg("sysdb_getpwuid failed for uid %d (%d: %s)",
              _i, ret, strerror(ret));
         goto done;
     }
 
-    fail_unless(res->count == 1, "Expected 1 user entry, found %d\n",
+    ck_assert_msg(res->count == 1, "Expected 1 user entry, found %d\n",
                 res->count);
 
     fqname = ldb_msg_find_attr_as_string(res->msgs[0], SYSDB_NAME, 0);
-    fail_unless(fqname != NULL, "No name?\n");
+    ck_assert_msg(fqname != NULL, "No name?\n");
 
-    fail_unless(strcmp(fqname, data->username) == 0,
+    ck_assert_msg(strcmp(fqname, data->username) == 0,
                 "Did not find the expected username (found %s expected %s)",
                 fqname, data->username);
 done:
@@ -1336,7 +1336,7 @@ START_TEST (test_sysdb_enumgrent)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
@@ -1345,12 +1345,12 @@ START_TEST (test_sysdb_enumgrent)
     ret = sysdb_enumgrent(test_ctx,
                           test_ctx->domain,
                           &res);
-    fail_unless(ret == EOK,
+    ck_assert_msg(ret == EOK,
                 "sysdb_enumgrent failed (%d: %s)",
                 ret, strerror(ret));
 
     /* 10 groups + 10 users (we're MPG) */
-    fail_if(res->count != 20, "Expected 20 users, got %d", res->count);
+    sss_ck_fail_if_msg(res->count != 20, "Expected 20 users, got %d", res->count);
 
     talloc_free(test_ctx);
 }
@@ -1365,18 +1365,18 @@ START_TEST (test_sysdb_enumpwent)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     ret = sysdb_enumpwent(test_ctx,
                           test_ctx->domain,
                           &res);
-    fail_unless(ret == EOK,
+    ck_assert_msg(ret == EOK,
                 "sysdb_enumpwent failed (%d: %s)",
                 ret, strerror(ret));
 
-    fail_if(res->count != 10, "Expected 10 users, got %d", res->count);
+    sss_ck_fail_if_msg(res->count != 10, "Expected 10 users, got %d", res->count);
 
     talloc_free(test_ctx);
 }
@@ -1392,16 +1392,16 @@ START_TEST (test_sysdb_set_user_attr)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_user(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->attrs = sysdb_new_attrs(test_ctx);
     if (ret != EOK) {
-        fail("Could not create the changeset");
+        ck_abort_msg("Could not create the changeset");
         return;
     }
 
@@ -1409,13 +1409,13 @@ START_TEST (test_sysdb_set_user_attr)
                                  SYSDB_SHELL,
                                  "/bin/ksh");
     if (ret != EOK) {
-        fail("Could not create the changeset");
+        ck_abort_msg("Could not create the changeset");
         return;
     }
 
     ret = test_set_user_attr(data);
 
-    fail_if(ret != EOK, "Could not modify user %s", data->username);
+    sss_ck_fail_if_msg(ret != EOK, "Could not modify user %s", data->username);
 
     talloc_free(test_ctx);
 }
@@ -1432,18 +1432,18 @@ START_TEST (test_sysdb_search_users)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     filter = talloc_asprintf(test_ctx,
                              "(&("SYSDB_UIDNUM"=%d)("SYSDB_SHELL"=/bin/ksh))",
                              _i);
-    fail_if(filter == NULL, "OOM");
+    sss_ck_fail_if_msg(filter == NULL, "OOM");
 
     ret = sysdb_search_users(test_ctx, test_ctx->domain,
                              filter, attrs, &count, &msgs);
     talloc_free(filter);
-    fail_if(ret != EOK, "Search failed: %d", ret);
-    fail_if(count != 1, "Did not find the expected user\n");
+    sss_ck_fail_if_msg(ret != EOK, "Search failed: %d", ret);
+    sss_ck_fail_if_msg(count != 1, "Did not find the expected user\n");
 
     talloc_free(test_ctx);
 }
@@ -1459,33 +1459,33 @@ START_TEST (test_sysdb_remove_attrs)
     const char *shell;
 
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     data = test_data_new_user(test_ctx, _i);
-    fail_if(data == NULL, "OOM");
+    sss_ck_fail_if_msg(data == NULL, "OOM");
 
     ret = sysdb_getpwnam(test_ctx,
                          test_ctx->domain,
                          data->username, &res);
-    fail_if(ret != EOK, "sysdb_getpwnam failed for fqname %s (%d: %s)",
+    sss_ck_fail_if_msg(ret != EOK, "sysdb_getpwnam failed for fqname %s (%d: %s)",
                          data->username, ret, strerror(ret));
     shell = ldb_msg_find_attr_as_string(res->msgs[0], SYSDB_SHELL, NULL);
-    fail_unless(shell != NULL, "Did not find user shell before removal");
+    ck_assert_msg(shell != NULL, "Did not find user shell before removal");
 
     rmattrs[0] = discard_const(SYSDB_SHELL);
     rmattrs[1] = NULL;
 
     ret = sysdb_remove_attrs(test_ctx->domain, data->username,
                              SYSDB_MEMBER_USER, rmattrs);
-    fail_if(ret != EOK, "Removing attributes failed: %d", ret);
+    sss_ck_fail_if_msg(ret != EOK, "Removing attributes failed: %d", ret);
 
     ret = sysdb_getpwnam(test_ctx,
                          test_ctx->domain,
                          data->username, &res);
-    fail_if(ret != EOK, "sysdb_getpwnam failed for fqname %s (%d: %s)",
+    sss_ck_fail_if_msg(ret != EOK, "sysdb_getpwnam failed for fqname %s (%d: %s)",
                          data->username, ret, strerror(ret));
     shell = ldb_msg_find_attr_as_string(res->msgs[0], SYSDB_SHELL, NULL);
-    fail_unless(shell == NULL, "Found user shell after removal");
+    ck_assert_msg(shell == NULL, "Found user shell after removal");
 }
 END_TEST
 
@@ -1501,25 +1501,25 @@ START_TEST (test_sysdb_get_user_attr)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_user(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     ret = sysdb_get_user_attr(test_ctx, test_ctx->domain, data->username, attrs,
                               &res);
     if (ret) {
-        fail("Could not get attributes for user %s", data->username);
+        ck_abort_msg("Could not get attributes for user %s", data->username);
         goto done;
     }
 
-    fail_if(res->count != 1,
+    sss_ck_fail_if_msg(res->count != 1,
             "Invalid number of entries, expected 1, got %d", res->count);
 
     attrval = ldb_msg_find_attr_as_string(res->msgs[0], SYSDB_SHELL, 0);
-    fail_if(strcmp(attrval, "/bin/ksh"),
+    sss_ck_fail_if_msg(strcmp(attrval, "/bin/ksh"),
             "Got bad attribute value for user %s", data->username);
 done:
     talloc_free(test_ctx);
@@ -1539,39 +1539,39 @@ START_TEST (test_sysdb_get_user_attr_subdomain)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     /* Create subdomain */
     subdomain = new_subdomain(test_ctx, test_ctx->domain,
                               "test.sub", "TEST.SUB", "test", "S-3",
                               MPG_DISABLED, false, NULL, NULL, 0, NULL, true);
-    fail_if(subdomain == NULL, "Failed to create new subdomain.");
+    sss_ck_fail_if_msg(subdomain == NULL, "Failed to create new subdomain.");
 
     ret = sss_names_init_from_args(test_ctx,
                                    "(((?P<domain>[^\\\\]+)\\\\(?P<name>.+$))|" \
                                    "((?P<name>[^@]+)@(?P<domain>.+$))|" \
                                    "(^(?P<name>[^@\\\\]+)$))",
                                    "%1$s@%2$s", &subdomain->names);
-    fail_if(ret != EOK, "Failed to init names.");
+    sss_ck_fail_if_msg(ret != EOK, "Failed to init names.");
 
     /* Create user */
     fq_name = sss_create_internal_fqname(test_ctx, username, subdomain->name);
-    fail_if(fq_name == NULL, "Failed to create fq name.");
+    sss_ck_fail_if_msg(fq_name == NULL, "Failed to create fq name.");
 
     ret = sysdb_store_user(subdomain, fq_name, NULL, 12345, 0, "Gecos",
                            "/home/userhome", "/bin/bash", NULL, NULL, NULL,
                            -1, 0);
-    fail_if(ret != EOK, "sysdb_store_user failed.");
+    sss_ck_fail_if_msg(ret != EOK, "sysdb_store_user failed.");
 
     /* Test */
     ret = sysdb_get_user_attr(test_ctx, subdomain, fq_name,
                               attrs, &res);
-    fail_if(ret != EOK, "Could not get user attributes.");
-    fail_if(res->count != 1, "Invalid number of entries, expected 1, got %d",
+    sss_ck_fail_if_msg(ret != EOK, "Could not get user attributes.");
+    sss_ck_fail_if_msg(res->count != 1, "Invalid number of entries, expected 1, got %d",
             res->count);
 
     attrval = ldb_msg_find_attr_as_string(res->msgs[0], SYSDB_SHELL, 0);
-    fail_if(strcmp(attrval, "/bin/bash") != 0, "Got bad attribute value.");
+    sss_ck_fail_if_msg(strcmp(attrval, "/bin/bash") != 0, "Got bad attribute value.");
 
     talloc_free(test_ctx);
 }
@@ -1594,37 +1594,37 @@ START_TEST (test_sysdb_add_nonposix_user)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     /* Create user */
     fq_name = sss_create_internal_fqname(test_ctx, username, test_ctx->domain->name);
-    fail_if(fq_name == NULL, "Failed to create fq name.");
+    sss_ck_fail_if_msg(fq_name == NULL, "Failed to create fq name.");
 
     user_attrs = sysdb_new_attrs(test_ctx);
-    fail_if(user_attrs == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(user_attrs == NULL, "Failed to allocate memory");
 
     ret = sysdb_attrs_add_bool(user_attrs, SYSDB_POSIX, false);
-    fail_if(ret != EOK, "Could not add attribute");
+    sss_ck_fail_if_msg(ret != EOK, "Could not add attribute");
 
     ret = sysdb_add_user(test_ctx->domain, fq_name, 0, 0, "Gecos",
                          "/home/userhome", "/bin/bash", NULL, user_attrs, 0, 0);
-    fail_if(ret != EOK, "sysdb_add_user failed.");
+    sss_ck_fail_if_msg(ret != EOK, "sysdb_add_user failed.");
 
     /* Test */
     ret = sysdb_get_user_attr(test_ctx, test_ctx->domain, fq_name,
                               get_attrs, &res);
-    fail_if(ret != EOK, "Could not get user attributes.");
-    fail_if(res->count != 1, "Invalid number of entries, expected 1, got %d",
+    sss_ck_fail_if_msg(ret != EOK, "Could not get user attributes.");
+    sss_ck_fail_if_msg(res->count != 1, "Invalid number of entries, expected 1, got %d",
             res->count);
 
     attrval = ldb_msg_find_attr_as_string(res->msgs[0], SYSDB_POSIX, NULL);
-    fail_if(strcasecmp(attrval, "false") != 0, "Got bad attribute value.");
+    sss_ck_fail_if_msg(strcasecmp(attrval, "false") != 0, "Got bad attribute value.");
 
     id = ldb_msg_find_attr_as_uint64(res->msgs[0], SYSDB_UIDNUM, 123);
-    fail_unless(id == 0, "Wrong UID value");
+    ck_assert_msg(id == 0, "Wrong UID value");
 
     id = ldb_msg_find_attr_as_uint64(res->msgs[0], SYSDB_GIDNUM, 123);
-    fail_unless(id == 0, "Wrong GID value");
+    ck_assert_msg(id == 0, "Wrong GID value");
 
     talloc_free(test_ctx);
 }
@@ -1644,21 +1644,21 @@ static void add_nonposix_incomplete_group(struct sysdb_test_ctx *test_ctx,
 
     /* Create group */
     fq_name = sss_create_internal_fqname(test_ctx, groupname, test_ctx->domain->name);
-    fail_if(fq_name == NULL, "Failed to create fq name.");
+    sss_ck_fail_if_msg(fq_name == NULL, "Failed to create fq name.");
 
     ret = sysdb_add_incomplete_group(test_ctx->domain, fq_name, 0,
                                      NULL, NULL, NULL, false, 0);
-    fail_if(ret != EOK, "sysdb_add_group failed.");
+    sss_ck_fail_if_msg(ret != EOK, "sysdb_add_group failed.");
 
     /* Test */
     ret = sysdb_search_group_by_name(test_ctx, test_ctx->domain, fq_name, get_attrs, &msg);
-    fail_if(ret != EOK, "sysdb_search_group_by_name failed.");
+    sss_ck_fail_if_msg(ret != EOK, "sysdb_search_group_by_name failed.");
 
     attrval = ldb_msg_find_attr_as_string(msg, SYSDB_POSIX, NULL);
-    fail_if(strcasecmp(attrval, "false") != 0, "Got bad attribute value.");
+    sss_ck_fail_if_msg(strcasecmp(attrval, "false") != 0, "Got bad attribute value.");
 
     id = ldb_msg_find_attr_as_uint64(msg, SYSDB_GIDNUM, 123);
-    fail_unless(id == 0, "Wrong GID value");
+    ck_assert_msg(id == 0, "Wrong GID value");
 }
 
 START_TEST (test_sysdb_add_nonposix_group)
@@ -1668,7 +1668,7 @@ START_TEST (test_sysdb_add_nonposix_group)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     add_nonposix_incomplete_group(test_ctx, "nonposix1");
     add_nonposix_incomplete_group(test_ctx, "nonposix2");
@@ -1686,21 +1686,21 @@ START_TEST (test_sysdb_add_group_member)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->uid = _i - 1000; /* the UID of user to add */
     data->username = test_asprintf_fqname(data, test_ctx->domain,
                                           "testuser%d", data->uid);
-    fail_if(data->username == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data->username == NULL, "Failed to allocate memory");
 
     ret = test_add_group_member(data);
 
-    fail_if(ret != EOK, "Could not modify group %s", data->groupname);
+    sss_ck_fail_if_msg(ret != EOK, "Could not modify group %s", data->groupname);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -1719,37 +1719,37 @@ START_TEST (test_sysdb_initgroups)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_user(test_ctx, _i);
-    fail_if(data == NULL, "OOM\n");
+    sss_ck_fail_if_msg(data == NULL, "OOM\n");
 
     ret = sysdb_initgroups(test_ctx,
                            test_ctx->domain,
                            data->username,
                            &res);
-    fail_if(ret != EOK, "sysdb_initgroups failed\n");
+    sss_ck_fail_if_msg(ret != EOK, "sysdb_initgroups failed\n");
 
     /* result should contain 2 messages - user and his group */
-    fail_if(res->count != 2, "expected 2 groups, got %d\n", res->count);
+    sss_ck_fail_if_msg(res->count != 2, "expected 2 groups, got %d\n", res->count);
 
     /* check if it's the expected user and expected group */
     user = res->msgs[0];
     group = res->msgs[1];
 
     uid = ldb_msg_find_attr_as_uint(user, SYSDB_UIDNUM, 0);
-    fail_unless(uid == _i,
+    ck_assert_msg(uid == _i,
                 "Did not find the expected UID (found %d expected %d)",
                 uid, _i);
 
-    fail_unless(strcmp(ldb_msg_find_attr_as_string(user, SYSDB_NAME, NULL),
+    ck_assert_msg(strcmp(ldb_msg_find_attr_as_string(user, SYSDB_NAME, NULL),
                        data->username) == 0,
                 "Wrong username\n");
 
     gid = ldb_msg_find_attr_as_uint(group, SYSDB_GIDNUM, 0);
-    fail_unless(gid == _i + 1000,
+    ck_assert_msg(gid == _i + 1000,
                 "Did not find the expected GID (found %d expected %d)",
                 gid, _i);
 
@@ -1766,20 +1766,20 @@ START_TEST (test_sysdb_remove_group_member)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->uid = _i - 1000; /* the UID of user to remove */
     data->username = test_asprintf_fqname(data, test_ctx->domain,
                                           "testuser%d", data->uid);
-    fail_if(data->username == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data->username == NULL, "Failed to allocate memory");
 
     ret = test_remove_group_member(data);
-    fail_if(ret != EOK, "Remove group member failed: %d", ret);
+    sss_ck_fail_if_msg(ret != EOK, "Remove group member failed: %d", ret);
 
     talloc_free(test_ctx);
 }
@@ -1794,17 +1794,17 @@ START_TEST (test_sysdb_remove_nonexistent_user)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new(test_ctx);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
     data->uid = 12345;
 
     ret = test_remove_user_by_uid(data);
 
-    fail_if(ret != ENOENT, "Unexpected return code %d, expected ENOENT", ret);
+    sss_ck_fail_if_msg(ret != ENOENT, "Unexpected return code %d, expected ENOENT", ret);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -1818,17 +1818,17 @@ START_TEST (test_sysdb_remove_nonexistent_group)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new(test_ctx);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
     data->gid = 12345;
 
     ret = test_remove_group_by_gid(data);
 
-    fail_if(ret != ENOENT, "Unexpected return code %d, expected ENOENT", ret);
+    sss_ck_fail_if_msg(ret != ENOENT, "Unexpected return code %d, expected ENOENT", ret);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -1842,12 +1842,12 @@ START_TEST (test_sysdb_get_new_id)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Cannot setup sysdb tests\n");
+    sss_ck_fail_if_msg(ret != EOK, "Cannot setup sysdb tests\n");
 
     test_ctx->domain->provider = discard_const_p(char, "local");
     ret = sysdb_get_new_id(test_ctx->domain, &id);
-    fail_if(ret != EOK, "Cannot get new ID\n");
-    fail_if(id != test_ctx->domain->id_min);
+    sss_ck_fail_if_msg(ret != EOK, "Cannot get new ID\n");
+    sss_ck_fail_if_msg(id != test_ctx->domain->id_min);
 }
 END_TEST
 #endif
@@ -1861,17 +1861,17 @@ START_TEST (test_sysdb_store_custom)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new(test_ctx);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->uid = _i;
     data->attrs = sysdb_new_attrs(test_ctx);
     if (ret != EOK) {
-        fail("Could not create attribute list");
+        ck_abort_msg("Could not create attribute list");
         return;
     }
 
@@ -1879,13 +1879,13 @@ START_TEST (test_sysdb_store_custom)
                                  TEST_ATTR_NAME,
                                  TEST_ATTR_VALUE);
     if (ret != EOK) {
-        fail("Could not add attribute");
+        ck_abort_msg("Could not add attribute");
         return;
     }
 
     ret = test_store_custom(data);
 
-    fail_if(ret != EOK, "Could not add custom object");
+    sss_ck_fail_if_msg(ret != EOK, "Could not add custom object");
     talloc_free(test_ctx);
 }
 END_TEST
@@ -1900,20 +1900,20 @@ START_TEST (test_sysdb_search_custom_by_name)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new(test_ctx);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->attrlist = talloc_array(test_ctx, const char *, 2);
-    fail_unless(data->attrlist != NULL, "talloc_array failed");
+    ck_assert_msg(data->attrlist != NULL, "talloc_array failed");
     data->attrlist[0] = TEST_ATTR_NAME;
     data->attrlist[1] = NULL;
 
     object_name = talloc_asprintf(data, "%s_%d", CUSTOM_TEST_OBJECT, 29010);
-    fail_unless(object_name != NULL, "talloc_asprintf failed");
+    ck_assert_msg(object_name != NULL, "talloc_asprintf failed");
 
     ret = sysdb_search_custom_by_name(data,
                                       data->ctx->domain,
@@ -1923,19 +1923,19 @@ START_TEST (test_sysdb_search_custom_by_name)
                                       &data->msgs_count,
                                       &data->msgs);
 
-    fail_if(ret != EOK, "Could not search custom object");
+    sss_ck_fail_if_msg(ret != EOK, "Could not search custom object");
 
-    fail_unless(data->msgs_count == 1,
+    ck_assert_msg(data->msgs_count == 1,
                 "Wrong number of objects, expected [1] got [%zd]",
                 data->msgs_count);
-    fail_unless(data->msgs[0]->num_elements == 1,
+    ck_assert_msg(data->msgs[0]->num_elements == 1,
                 "Wrong number of results, expected [1] got [%d]",
                 data->msgs[0]->num_elements);
-    fail_unless(strcmp(data->msgs[0]->elements[0].name, TEST_ATTR_NAME) == 0,
+    ck_assert_msg(strcmp(data->msgs[0]->elements[0].name, TEST_ATTR_NAME) == 0,
                 "Wrong attribute name");
-    fail_unless(data->msgs[0]->elements[0].num_values == 1,
+    ck_assert_msg(data->msgs[0]->elements[0].num_values == 1,
                 "Wrong number of attribute values");
-    fail_unless(strncmp((const char *)data->msgs[0]->elements[0].values[0].data,
+    ck_assert_msg(strncmp((const char *)data->msgs[0]->elements[0].values[0].data,
                         TEST_ATTR_VALUE,
                         data->msgs[0]->elements[0].values[0].length) == 0,
                 "Wrong attribute value");
@@ -1953,17 +1953,17 @@ START_TEST (test_sysdb_update_custom)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new(test_ctx);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->uid = 29010;
     data->attrs = sysdb_new_attrs(test_ctx);
     if (ret != EOK) {
-        fail("Could not create attribute list");
+        ck_abort_msg("Could not create attribute list");
         return;
     }
 
@@ -1971,7 +1971,7 @@ START_TEST (test_sysdb_update_custom)
                                  TEST_ATTR_NAME,
                                  TEST_ATTR_UPDATE_VALUE);
     if (ret != EOK) {
-        fail("Could not add attribute");
+        ck_abort_msg("Could not add attribute");
         return;
     }
 
@@ -1979,13 +1979,13 @@ START_TEST (test_sysdb_update_custom)
                                  TEST_ATTR_ADD_NAME,
                                  TEST_ATTR_ADD_VALUE);
     if (ret != EOK) {
-        fail("Could not add attribute");
+        ck_abort_msg("Could not add attribute");
         return;
     }
 
     ret = test_store_custom(data);
 
-    fail_if(ret != EOK, "Could not add custom object");
+    sss_ck_fail_if_msg(ret != EOK, "Could not add custom object");
     talloc_free(test_ctx);
 }
 END_TEST
@@ -2001,21 +2001,21 @@ START_TEST (test_sysdb_search_custom_update)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new(test_ctx);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->attrlist = talloc_array(test_ctx, const char *, 3);
-    fail_unless(data->attrlist != NULL, "talloc_array failed");
+    ck_assert_msg(data->attrlist != NULL, "talloc_array failed");
     data->attrlist[0] = TEST_ATTR_NAME;
     data->attrlist[1] = TEST_ATTR_ADD_NAME;
     data->attrlist[2] = NULL;
 
     object_name = talloc_asprintf(data, "%s_%d", CUSTOM_TEST_OBJECT, 29010);
-    fail_unless(object_name != NULL, "talloc_asprintf failed");
+    ck_assert_msg(object_name != NULL, "talloc_asprintf failed");
 
     ret = sysdb_search_custom_by_name(data,
                                       data->ctx->domain,
@@ -2025,31 +2025,31 @@ START_TEST (test_sysdb_search_custom_update)
                                       &data->msgs_count,
                                       &data->msgs);
 
-    fail_if(ret != EOK, "Could not search custom object");
+    sss_ck_fail_if_msg(ret != EOK, "Could not search custom object");
 
-    fail_unless(data->msgs_count == 1,
+    ck_assert_msg(data->msgs_count == 1,
                 "Wrong number of objects, expected [1] got [%zd]",
                 data->msgs_count);
-    fail_unless(data->msgs[0]->num_elements == 2,
+    ck_assert_msg(data->msgs[0]->num_elements == 2,
                 "Wrong number of results, expected [2] got [%d]",
                 data->msgs[0]->num_elements);
 
     el = ldb_msg_find_element(data->msgs[0], TEST_ATTR_NAME);
-    fail_unless(el != NULL, "Attribute [%s] not found", TEST_ATTR_NAME);
-    fail_unless(el->num_values == 1, "Wrong number ([%d] instead of 1) "
+    ck_assert_msg(el != NULL, "Attribute [%s] not found", TEST_ATTR_NAME);
+    ck_assert_msg(el->num_values == 1, "Wrong number ([%d] instead of 1) "
                 "of attribute values for [%s]", el->num_values,
                 TEST_ATTR_NAME);
-    fail_unless(strncmp((const char *) el->values[0].data,
+    ck_assert_msg(strncmp((const char *) el->values[0].data,
                 TEST_ATTR_UPDATE_VALUE,
                 el->values[0].length) == 0,
                 "Wrong attribute value");
 
     el = ldb_msg_find_element(data->msgs[0], TEST_ATTR_ADD_NAME);
-    fail_unless(el != NULL, "Attribute [%s] not found", TEST_ATTR_ADD_NAME);
-    fail_unless(el->num_values == 1, "Wrong number ([%d] instead of 1) "
+    ck_assert_msg(el != NULL, "Attribute [%s] not found", TEST_ATTR_ADD_NAME);
+    ck_assert_msg(el->num_values == 1, "Wrong number ([%d] instead of 1) "
                 "of attribute values for [%s]", el->num_values,
                 TEST_ATTR_ADD_NAME);
-    fail_unless(strncmp((const char *) el->values[0].data,
+    ck_assert_msg(strncmp((const char *) el->values[0].data,
                 TEST_ATTR_ADD_VALUE,
                 el->values[0].length) == 0,
                 "Wrong attribute value");
@@ -2069,15 +2069,15 @@ START_TEST (test_sysdb_search_custom)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new(test_ctx);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->attrlist = talloc_array(test_ctx, const char *, 3);
-    fail_unless(data->attrlist != NULL, "talloc_array failed");
+    ck_assert_msg(data->attrlist != NULL, "talloc_array failed");
     data->attrlist[0] = TEST_ATTR_NAME;
     data->attrlist[1] = TEST_ATTR_ADD_NAME;
     data->attrlist[2] = NULL;
@@ -2088,9 +2088,9 @@ START_TEST (test_sysdb_search_custom)
                               &data->msgs_count,
                               &data->msgs);
 
-    fail_if(ret != EOK, "Could not search custom object");
+    sss_ck_fail_if_msg(ret != EOK, "Could not search custom object");
 
-    fail_unless(data->msgs_count == 10,
+    ck_assert_msg(data->msgs_count == 10,
                 "Wrong number of objects, expected [10] got [%zd]",
                 data->msgs_count);
 
@@ -2107,16 +2107,16 @@ START_TEST (test_sysdb_delete_custom)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new(test_ctx);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     ret = test_delete_custom(data);
 
-    fail_if(ret != EOK, "Could not delete custom object");
+    sss_ck_fail_if_msg(ret != EOK, "Could not delete custom object");
     talloc_free(test_ctx);
 }
 END_TEST
@@ -2129,15 +2129,15 @@ START_TEST (test_sysdb_cache_password)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_unless(ret == EOK, "Could not set up the test");
+    ck_assert_msg(ret == EOK, "Could not set up the test");
 
     data = test_data_new_user(test_ctx, _i);
-    fail_if(data == NULL, "OOM\n");
+    sss_ck_fail_if_msg(data == NULL, "OOM\n");
 
     ret = sysdb_cache_password(test_ctx->domain,
                                data->username,
                                data->username);
-    fail_unless(ret == EOK, "sysdb_cache_password request failed [%d].", ret);
+    ck_assert_msg(ret == EOK, "sysdb_cache_password request failed [%d].", ret);
 
     talloc_free(test_ctx);
 }
@@ -2155,36 +2155,36 @@ START_TEST (test_sysdb_cache_password_ex)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_unless(ret == EOK, "Could not set up the test");
+    ck_assert_msg(ret == EOK, "Could not set up the test");
 
     data = test_data_new_user(test_ctx, _i);
-    fail_if(data == NULL, "OOM\n");
+    sss_ck_fail_if_msg(data == NULL, "OOM\n");
 
     ret = sysdb_get_user_attr(test_ctx, test_ctx->domain, data->username,
                               attrs, &res);
-    fail_unless(ret == EOK, "sysdb_get_user_attr request failed [%d].", ret);
+    ck_assert_msg(ret == EOK, "sysdb_get_user_attr request failed [%d].", ret);
 
     val = ldb_msg_find_attr_as_int(res->msgs[0], SYSDB_CACHEDPWD_TYPE, 0);
-    fail_unless(val == SSS_AUTHTOK_TYPE_PASSWORD,
+    ck_assert_msg(val == SSS_AUTHTOK_TYPE_PASSWORD,
                 "Unexpected authtok type, found [%d], expected [%d].",
                 val, SSS_AUTHTOK_TYPE_PASSWORD);
 
     ret = sysdb_cache_password_ex(test_ctx->domain, data->username,
                                   data->username, SSS_AUTHTOK_TYPE_2FA, 12);
 
-    fail_unless(ret == EOK, "sysdb_cache_password request failed [%d].", ret);
+    ck_assert_msg(ret == EOK, "sysdb_cache_password request failed [%d].", ret);
 
     ret = sysdb_get_user_attr(test_ctx, test_ctx->domain, data->username,
                               attrs, &res);
-    fail_unless(ret == EOK, "sysdb_get_user_attr request failed [%d].", ret);
+    ck_assert_msg(ret == EOK, "sysdb_get_user_attr request failed [%d].", ret);
 
     val = ldb_msg_find_attr_as_int(res->msgs[0], SYSDB_CACHEDPWD_TYPE, 0);
-    fail_unless(val == SSS_AUTHTOK_TYPE_2FA,
+    ck_assert_msg(val == SSS_AUTHTOK_TYPE_2FA,
                 "Unexpected authtok type, found [%d], expected [%d].",
                 val, SSS_AUTHTOK_TYPE_2FA);
 
     val = ldb_msg_find_attr_as_int(res->msgs[0], SYSDB_CACHEDPWD_FA2_LEN, 0);
-    fail_unless(val == 12,
+    ck_assert_msg(val == 12,
                 "Unexpected second factor length, found [%d], expected [%d].",
                 val, 12);
 
@@ -2206,16 +2206,16 @@ static void cached_authentication_without_expiration(uid_t uid,
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_unless(ret == EOK, "Could not set up the test");
+    ck_assert_msg(ret == EOK, "Could not set up the test");
 
     data = test_data_new_user(test_ctx, uid);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     val[0] = "0";
     ret = confdb_add_param(test_ctx->confdb, true, CONFDB_PAM_CONF_ENTRY,
                            CONFDB_PAM_CRED_TIMEOUT, val);
     if (ret != EOK) {
-        fail("Could not initialize provider");
+        ck_abort_msg("Could not initialize provider");
         talloc_free(test_ctx);
         return;
     }
@@ -2225,14 +2225,14 @@ static void cached_authentication_without_expiration(uid_t uid,
                            test_ctx->confdb, false,
                            &expire_date, &delayed_until);
 
-    fail_unless(ret == expected_result, "sysdb_cache_auth request does not "
+    ck_assert_msg(ret == expected_result, "sysdb_cache_auth request does not "
                                         "return expected result [%d].",
                                         expected_result);
 
-    fail_unless(expire_date == 0, "Wrong expire date, expected [%d], got [%ld]",
+    ck_assert_msg(expire_date == 0, "Wrong expire date, expected [%d], got [%ld]",
                                   0, expire_date);
 
-    fail_unless(delayed_until == -1, "Wrong delay, expected [%d], got [%ld]",
+    ck_assert_msg(delayed_until == -1, "Wrong delay, expected [%d], got [%ld]",
                                   -1, delayed_until);
 
     talloc_free(test_ctx);
@@ -2254,16 +2254,16 @@ static void cached_authentication_with_expiration(uid_t uid,
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_unless(ret == EOK, "Could not set up the test");
+    ck_assert_msg(ret == EOK, "Could not set up the test");
 
     data = test_data_new_user(test_ctx, uid);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     val[0] = "1";
     ret = confdb_add_param(test_ctx->confdb, true, CONFDB_PAM_CONF_ENTRY,
                            CONFDB_PAM_CRED_TIMEOUT, val);
     if (ret != EOK) {
-        fail("Could not initialize provider");
+        ck_abort_msg("Could not initialize provider");
         talloc_free(test_ctx);
         return;
     }
@@ -2275,27 +2275,27 @@ static void cached_authentication_with_expiration(uid_t uid,
 
     data->attrs = sysdb_new_attrs(data);
     ret = sysdb_attrs_add_time_t(data->attrs, SYSDB_LAST_ONLINE_AUTH, now);
-    fail_unless(ret == EOK, "Could not add attribute "SYSDB_LAST_ONLINE_AUTH
+    ck_assert_msg(ret == EOK, "Could not add attribute "SYSDB_LAST_ONLINE_AUTH
                             ": %s", sss_strerror(ret));
 
     ret = sysdb_set_user_attr(data->ctx->domain, data->username, data->attrs,
                               SYSDB_MOD_REP);
-    fail_unless(ret == EOK, "Could not modify user %s", data->username);
+    ck_assert_msg(ret == EOK, "Could not modify user %s", data->username);
 
     ret = sysdb_cache_auth(data->ctx->domain, data->username,
                            password ? password : data->username,
                            test_ctx->confdb, false,
                            &expire_date, &delayed_until);
 
-    fail_unless(ret == expected_result,
+    ck_assert_msg(ret == expected_result,
                 "sysdb_cache_auth request does not return expected "
                 "result [%d], got [%d].", expected_result, ret);
 
-    fail_unless(expire_date == expected_expire_date,
+    ck_assert_msg(expire_date == expected_expire_date,
                 "Wrong expire date, expected [%ld], got [%ld]",
                 expected_expire_date, expire_date);
 
-    fail_unless(delayed_until == -1, "Wrong delay, expected [%d], got [%ld]",
+    ck_assert_msg(delayed_until == -1, "Wrong delay, expected [%d], got [%ld]",
                                   -1, delayed_until);
 
     talloc_free(test_ctx);
@@ -2331,21 +2331,21 @@ START_TEST (test_sysdb_prepare_asq_test_user)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->uid = ASQ_TEST_USER_UID;
     data->username = test_asprintf_fqname(data, test_ctx->domain,
                                           "testuser%u", data->uid);
-    fail_if(data->username == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data->username == NULL, "Failed to allocate memory");
 
     ret = test_add_group_member(data);
 
-    fail_if(ret != EOK, "Could not modify group %s", data->groupname);
+    sss_ck_fail_if_msg(ret != EOK, "Could not modify group %s", data->groupname);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -2364,42 +2364,42 @@ START_TEST (test_sysdb_asq_search)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_user(test_ctx, ASQ_TEST_USER_UID);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->attrlist = talloc_array(data, const char *, 2);
-    fail_unless(data->attrlist != NULL, "talloc_array failed");
+    ck_assert_msg(data->attrlist != NULL, "talloc_array failed");
     data->attrlist[0] = "gidNumber";
     data->attrlist[1] = NULL;
 
     user_dn = sysdb_user_dn(data, data->ctx->domain, data->username);
-    fail_unless(user_dn != NULL, "sysdb_user_dn failed");
+    ck_assert_msg(user_dn != NULL, "sysdb_user_dn failed");
 
     ret = sysdb_asq_search(data, test_ctx->domain,
                            user_dn, NULL, "memberof",
                            data->attrlist, &msgs_count, &msgs);
 
-    fail_if(ret != EOK, "Failed to send ASQ search request.\n");
+    sss_ck_fail_if_msg(ret != EOK, "Failed to send ASQ search request.\n");
 
-    fail_unless(msgs_count == 10, "wrong number of results, "
+    ck_assert_msg(msgs_count == 10, "wrong number of results, "
                                   "found [%zd] expected [10]", msgs_count);
 
     for (i = 0; i < msgs_count; i++) {
-        fail_unless(msgs[i]->num_elements == 1, "wrong number of elements, "
+        ck_assert_msg(msgs[i]->num_elements == 1, "wrong number of elements, "
                                      "found [%d] expected [1]",
                                      msgs[i]->num_elements);
 
-        fail_unless(msgs[i]->elements[0].num_values == 1,
+        ck_assert_msg(msgs[i]->elements[0].num_values == 1,
                     "wrong number of values, found [%d] expected [1]",
                     msgs[i]->elements[0].num_values);
 
         gid_str = talloc_asprintf(data, "%d", 28010 + i);
-        fail_unless(gid_str != NULL, "talloc_asprintf failed.");
-        fail_unless(strncmp(gid_str,
+        ck_assert_msg(gid_str != NULL, "talloc_asprintf failed.");
+        ck_assert_msg(strncmp(gid_str,
                             (const char *) msgs[i]->elements[0].values[0].data,
                             msgs[i]->elements[0].values[0].length)  == 0,
                             "wrong value, found [%.*s] expected [%s]",
@@ -2423,45 +2423,45 @@ START_TEST (test_sysdb_search_all_users)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new(test_ctx);
-    fail_unless(data != NULL, "Failed to allocate memory");
+    ck_assert_msg(data != NULL, "Failed to allocate memory");
 
     data->attrlist = talloc_array(data, const char *, 2);
-    fail_unless(data->attrlist != NULL, "talloc_array failed");
+    ck_assert_msg(data->attrlist != NULL, "talloc_array failed");
     data->attrlist[0] = "uidNumber";
     data->attrlist[1] = NULL;
 
     ret = test_search_all_users(data);
 
-    fail_if(ret != EOK, "Search failed");
+    sss_ck_fail_if_msg(ret != EOK, "Search failed");
 
-    fail_unless(data->msgs_count == 10,
+    ck_assert_msg(data->msgs_count == 10,
                 "wrong number of results, found [%zd] expected [10]",
                 data->msgs_count);
 
     for (i = 0; i < data->msgs_count; i++) {
-        fail_unless(data->msgs[i]->num_elements == 1,
+        ck_assert_msg(data->msgs[i]->num_elements == 1,
                     "wrong number of elements, found [%d] expected [1]",
                     data->msgs[i]->num_elements);
 
-        fail_unless(data->msgs[i]->elements[0].num_values == 1,
+        ck_assert_msg(data->msgs[i]->elements[0].num_values == 1,
                     "wrong number of values, found [%d] expected [1]",
                     data->msgs[i]->elements[0].num_values);
 
         for (j = 0; j < data->msgs_count; j++) {
             uid_str = talloc_asprintf(data, "%d", 27010 + j);
-            fail_unless(uid_str != NULL, "talloc_asprintf failed.");
+            ck_assert_msg(uid_str != NULL, "talloc_asprintf failed.");
             if (strncmp(uid_str,
                         (char *) data->msgs[i]->elements[0].values[0].data,
                         data->msgs[i]->elements[0].values[0].length)  == 0) {
                 break;
             }
         }
-        fail_unless(strncmp(uid_str,
+        ck_assert_msg(strncmp(uid_str,
                             (char *) data->msgs[i]->elements[0].values[0].data,
                             data->msgs[i]->elements[0].values[0].length)  == 0,
                             "wrong value, found [%.*s] expected [%s]",
@@ -2482,16 +2482,16 @@ START_TEST (test_sysdb_delete_recursive)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new(test_ctx);
-    fail_unless(data != NULL, "Failed to allocate memory");
+    ck_assert_msg(data != NULL, "Failed to allocate memory");
 
     ret = test_delete_recursive(data);
 
-    fail_if(ret != EOK, "Recursive delete failed");
+    sss_ck_fail_if_msg(ret != EOK, "Recursive delete failed");
     talloc_free(test_ctx);
 }
 END_TEST
@@ -2503,34 +2503,34 @@ START_TEST (test_sysdb_attrs_replace_name)
     int ret;
 
     attrs = sysdb_new_attrs(NULL);
-    fail_unless(attrs != NULL, "sysdb_new_attrs failed");
+    ck_assert_msg(attrs != NULL, "sysdb_new_attrs failed");
 
     ret = sysdb_attrs_add_string(attrs, "foo", "bar");
-    fail_unless(ret == EOK, "sysdb_attrs_add_string failed");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_string failed");
 
     ret = sysdb_attrs_add_string(attrs, "fool", "bool");
-    fail_unless(ret == EOK, "sysdb_attrs_add_string failed");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_string failed");
 
     ret = sysdb_attrs_add_string(attrs, "foot", "boot");
-    fail_unless(ret == EOK, "sysdb_attrs_add_string failed");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_string failed");
 
     ret = sysdb_attrs_replace_name(attrs, "foo", "foot");
-    fail_unless(ret == EEXIST,
+    ck_assert_msg(ret == EEXIST,
                 "sysdb_attrs_replace overwrites existing attribute");
 
     ret = sysdb_attrs_replace_name(attrs, "foo", "oof");
-    fail_unless(ret == EOK, "sysdb_attrs_replace failed");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_replace failed");
 
     ret = sysdb_attrs_get_el(attrs, "foo", &el);
-    fail_unless(ret == EOK, "sysdb_attrs_get_el failed");
-    fail_unless(el->num_values == 0, "Attribute foo is not empty.");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_get_el failed");
+    ck_assert_msg(el->num_values == 0, "Attribute foo is not empty.");
 
     ret = sysdb_attrs_get_el(attrs, "oof", &el);
-    fail_unless(ret == EOK, "sysdb_attrs_get_el failed");
-    fail_unless(el->num_values == 1,
+    ck_assert_msg(ret == EOK, "sysdb_attrs_get_el failed");
+    ck_assert_msg(el->num_values == 1,
                 "Wrong number of values for attribute oof, "
                 "expected [1] got [%d].", el->num_values);
-    fail_unless(strncmp("bar", (char *) el->values[0].data,
+    ck_assert_msg(strncmp("bar", (char *) el->values[0].data,
                         el->values[0].length) == 0,
                 "Wrong value, expected [bar] got [%.*s]",
                 (int)  el->values[0].length, el->values[0].data);
@@ -2548,27 +2548,27 @@ START_TEST (test_sysdb_memberof_store_group)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, MBO_GROUP_BASE + _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     if (_i == 0) {
         data->attrlist = NULL;
     } else {
         data->attrlist = talloc_array(data, const char *, 2);
-        fail_unless(data->attrlist != NULL, "talloc_array failed.");
+        ck_assert_msg(data->attrlist != NULL, "talloc_array failed.");
         data->attrlist[0] = test_asprintf_fqname(data, data->ctx->domain,
                                                  "testgroup%d", data->gid - 1);
         data->attrlist[1] = NULL;
-        fail_if(data->attrlist[0] == NULL, "Failed to allocate memory");
+        sss_ck_fail_if_msg(data->attrlist[0] == NULL, "Failed to allocate memory");
     }
 
     ret = test_memberof_store_group(data);
 
-    fail_if(ret != EOK, "Could not store POSIX group #%d", data->gid);
+    sss_ck_fail_if_msg(ret != EOK, "Could not store POSIX group #%d", data->gid);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -2582,34 +2582,34 @@ START_TEST (test_sysdb_memberof_store_group_with_ghosts)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     if (_i == 0 || _i == MBO_GROUP_BASE) {
         data->attrlist = NULL;
     } else {
         data->attrlist = talloc_array(data, const char *, 2);
-        fail_unless(data->attrlist != NULL, "talloc_array failed.");
+        ck_assert_msg(data->attrlist != NULL, "talloc_array failed.");
         data->attrlist[0] = test_asprintf_fqname(data, data->ctx->domain,
                                                  "testgroup%d", data->gid - 1);
         data->attrlist[1] = NULL;
-        fail_if(data->attrlist[0] == NULL, "Failed to allocate memory");
+        sss_ck_fail_if_msg(data->attrlist[0] == NULL, "Failed to allocate memory");
     }
 
     data->ghostlist = talloc_array(data, char *, 2);
-    fail_unless(data->ghostlist != NULL, "talloc_array failed.");
+    ck_assert_msg(data->ghostlist != NULL, "talloc_array failed.");
     data->ghostlist[0] = test_asprintf_fqname(data, data->ctx->domain,
                                              "testuser%d", data->gid);
     data->ghostlist[1] = NULL;
-    fail_if(data->ghostlist[0] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data->ghostlist[0] == NULL, "Failed to allocate memory");
 
     ret = test_memberof_store_group_with_ghosts(data);
 
-    fail_if(ret != EOK, "Could not store POSIX group #%d", data->gid);
+    sss_ck_fail_if_msg(ret != EOK, "Could not store POSIX group #%d", data->gid);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -2623,25 +2623,25 @@ START_TEST (test_sysdb_memberof_store_group_with_double_ghosts)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     if (_i == 0) {
         data->attrlist = NULL;
     } else {
         data->attrlist = talloc_array(data, const char *, 2);
-        fail_unless(data->attrlist != NULL, "talloc_array failed.");
+        ck_assert_msg(data->attrlist != NULL, "talloc_array failed.");
         data->attrlist[0] = test_asprintf_fqname(data, data->ctx->domain,
                                                  "testgroup%d", data->gid - 1);
         data->attrlist[1] = NULL;
     }
 
     data->ghostlist = talloc_array(data, char *, 3);
-    fail_unless(data->ghostlist != NULL, "talloc_array failed.");
+    ck_assert_msg(data->ghostlist != NULL, "talloc_array failed.");
     data->ghostlist[0] = test_asprintf_fqname(data, data->ctx->domain,
                                               "testusera%d", data->gid);
     data->ghostlist[1] = test_asprintf_fqname(data, data->ctx->domain,
@@ -2650,7 +2650,7 @@ START_TEST (test_sysdb_memberof_store_group_with_double_ghosts)
 
     ret = test_memberof_store_group_with_ghosts(data);
 
-    fail_if(ret != EOK, "Could not store POSIX group #%d", data->gid);
+    sss_ck_fail_if_msg(ret != EOK, "Could not store POSIX group #%d", data->gid);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -2668,22 +2668,22 @@ START_TEST (test_sysdb_memberof_mod_add)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     ghostname = test_asprintf_fqname(data, test_ctx->domain,
                                      "testghost%d", _i);
-    fail_unless(ghostname != NULL, "Out of memory\n");
+    ck_assert_msg(ghostname != NULL, "Out of memory\n");
 
     ret = sysdb_attrs_steal_string(data->attrs, SYSDB_GHOST, ghostname);
-    fail_unless(ret == EOK, "Cannot add attr\n");
+    ck_assert_msg(ret == EOK, "Cannot add attr\n");
 
     data->attrlist = talloc_array(data, const char *, 2);
-    fail_unless(data->attrlist != NULL, "talloc_array failed.");
+    ck_assert_msg(data->attrlist != NULL, "talloc_array failed.");
     data->attrlist[0] = SYSDB_GHOST;
     data->attrlist[1] = NULL;
 
@@ -2691,7 +2691,7 @@ START_TEST (test_sysdb_memberof_mod_add)
     for (itergid = data->gid ; itergid < MBO_GROUP_BASE + NUM_GHOSTS; itergid++) {
         ret = sysdb_search_group_by_gid(data, test_ctx->domain, itergid,
                                         data->attrlist, &data->msg);
-        fail_if(ret != EOK, "Cannot retrieve group %llu\n",
+        sss_ck_fail_if_msg(ret != EOK, "Cannot retrieve group %llu\n",
                 (unsigned long long) data->gid);
 
         gv.data = (uint8_t *) ghostname;
@@ -2700,19 +2700,19 @@ START_TEST (test_sysdb_memberof_mod_add)
         el = ldb_msg_find_element(data->msg, SYSDB_GHOST);
         if (data->gid > MBO_GROUP_BASE) {
             /* The first group would have the ghost attribute gone completely */
-            fail_if(el == NULL, "Cannot find ghost element\n");
+            sss_ck_fail_if_msg(el == NULL, "Cannot find ghost element\n");
             test_gv = ldb_msg_find_val(el, &gv);
-            fail_unless(test_gv == NULL,
+            ck_assert_msg(test_gv == NULL,
                         "Ghost user %s unexpectedly found\n", ghostname);
         } else {
-            fail_unless(el == NULL, "Stray values in ghost element?\n");
+            ck_assert_msg(el == NULL, "Stray values in ghost element?\n");
         }
     }
 
     /* Perform the add operation */
     ret = sysdb_set_group_attr(test_ctx->domain,
                                data->groupname, data->attrs, SYSDB_MOD_ADD);
-    fail_unless(ret == EOK, "Cannot set group attrs\n");
+    ck_assert_msg(ret == EOK, "Cannot set group attrs\n");
 
     /* Before the delete, all groups with gid >= _i have the testuser%_i
      * as a member
@@ -2720,17 +2720,17 @@ START_TEST (test_sysdb_memberof_mod_add)
     for (itergid = data->gid ; itergid < MBO_GROUP_BASE + NUM_GHOSTS; itergid++) {
         ret = sysdb_search_group_by_gid(data, test_ctx->domain, itergid,
                                         data->attrlist, &data->msg);
-        fail_if(ret != EOK, "Cannot retrieve group %llu\n",
+        sss_ck_fail_if_msg(ret != EOK, "Cannot retrieve group %llu\n",
                 (unsigned long long) data->gid);
 
         gv.data = (uint8_t *) ghostname;
         gv.length = strlen(ghostname);
 
         el = ldb_msg_find_element(data->msg, SYSDB_GHOST);
-        fail_if(el == NULL, "Cannot find ghost element\n");
+        sss_ck_fail_if_msg(el == NULL, "Cannot find ghost element\n");
 
         test_gv = ldb_msg_find_val(el, &gv);
-        fail_if(test_gv == NULL, "Cannot find ghost user %s\n", ghostname);
+        sss_ck_fail_if_msg(test_gv == NULL, "Cannot find ghost user %s\n", ghostname);
     }
     talloc_free(test_ctx);
 }
@@ -2750,27 +2750,27 @@ START_TEST (test_sysdb_memberof_mod_replace)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     /* The test replaces the testuser%i attribute with testghost%i */
     ghostname_del = test_asprintf_fqname(data, test_ctx->domain,
                                          "testuser%d", _i);
-    fail_unless(ghostname_del != NULL, "Out of memory\n");
+    ck_assert_msg(ghostname_del != NULL, "Out of memory\n");
 
     ghostname_add = test_asprintf_fqname(data, test_ctx->domain,
                                          "testuser%d", _i);
-    fail_unless(ghostname_add != NULL, "Out of memory\n");
+    ck_assert_msg(ghostname_add != NULL, "Out of memory\n");
 
     ret = sysdb_attrs_steal_string(data->attrs, SYSDB_GHOST, ghostname_add);
-    fail_unless(ret == EOK, "Cannot add attr\n");
+    ck_assert_msg(ret == EOK, "Cannot add attr\n");
 
     data->attrlist = talloc_array(data, const char *, 2);
-    fail_unless(data->attrlist != NULL, "talloc_array failed.");
+    ck_assert_msg(data->attrlist != NULL, "talloc_array failed.");
     data->attrlist[0] = SYSDB_GHOST;
     data->attrlist[1] = NULL;
 
@@ -2780,23 +2780,23 @@ START_TEST (test_sysdb_memberof_mod_replace)
     for (itergid = data->gid ; itergid < MBO_GROUP_BASE + NUM_GHOSTS; itergid++) {
         ret = sysdb_search_group_by_gid(data, test_ctx->domain, itergid,
                                         data->attrlist, &data->msg);
-        fail_if(ret != EOK, "Cannot retrieve group %llu\n",
+        sss_ck_fail_if_msg(ret != EOK, "Cannot retrieve group %llu\n",
                 (unsigned long long) data->gid);
 
         gv.data = (uint8_t *) ghostname_del;
         gv.length = strlen(ghostname_del);
 
         el = ldb_msg_find_element(data->msg, SYSDB_GHOST);
-        fail_if(el == NULL, "Cannot find ghost element\n");
+        sss_ck_fail_if_msg(el == NULL, "Cannot find ghost element\n");
 
         test_gv = ldb_msg_find_val(el, &gv);
-        fail_if(test_gv == NULL, "Cannot find ghost user %s\n", ghostname_del);
+        sss_ck_fail_if_msg(test_gv == NULL, "Cannot find ghost user %s\n", ghostname_del);
     }
 
     /* Perform the replace operation */
     ret =  sysdb_set_group_attr(test_ctx->domain,
                                 data->groupname, data->attrs, SYSDB_MOD_REP);
-    fail_unless(ret == EOK, "Cannot set group attrs\n");
+    ck_assert_msg(ret == EOK, "Cannot set group attrs\n");
 
     /* After the replace, all groups with gid >= _i have the testghost%_i
      * as a member
@@ -2804,17 +2804,17 @@ START_TEST (test_sysdb_memberof_mod_replace)
     for (itergid = data->gid ; itergid < MBO_GROUP_BASE + NUM_GHOSTS; itergid++) {
         ret = sysdb_search_group_by_gid(data, test_ctx->domain, itergid,
                                         data->attrlist, &data->msg);
-        fail_if(ret != EOK, "Cannot retrieve group %llu\n",
+        sss_ck_fail_if_msg(ret != EOK, "Cannot retrieve group %llu\n",
                 (unsigned long long) data->gid);
 
         gv.data = (uint8_t *) ghostname_add;
         gv.length = strlen(ghostname_add);
 
         el = ldb_msg_find_element(data->msg, SYSDB_GHOST);
-        fail_if(el == NULL, "Cannot find ghost element\n");
+        sss_ck_fail_if_msg(el == NULL, "Cannot find ghost element\n");
 
         test_gv = ldb_msg_find_val(el, &gv);
-        fail_if(test_gv == NULL, "Cannot find ghost user %s\n", ghostname_add);
+        sss_ck_fail_if_msg(test_gv == NULL, "Cannot find ghost user %s\n", ghostname_add);
     }
 
     talloc_free(test_ctx);
@@ -2837,12 +2837,12 @@ START_TEST (test_sysdb_memberof_mod_replace_keep)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, MBO_GROUP_BASE + 10 - _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     /* The test replaces the attributes (testusera$gid, testuserb$gid) with
      * just testusera$gid. The result should be not only testusera, but also
@@ -2850,17 +2850,17 @@ START_TEST (test_sysdb_memberof_mod_replace_keep)
      */
     ghostname_rep = test_asprintf_fqname(data, data->ctx->domain,
                                          "testusera%d", data->gid);
-    fail_unless(ghostname_rep != NULL, "Out of memory\n");
+    ck_assert_msg(ghostname_rep != NULL, "Out of memory\n");
 
     ret = sysdb_attrs_steal_string(data->attrs, SYSDB_GHOST, ghostname_rep);
-    fail_unless(ret == EOK, "Cannot add attr\n");
+    ck_assert_msg(ret == EOK, "Cannot add attr\n");
 
     ghostname_del = test_asprintf_fqname(data, data->ctx->domain,
                                          "testuserb%d", data->gid);
-    fail_unless(ghostname_del != NULL, "Out of memory\n");
+    ck_assert_msg(ghostname_del != NULL, "Out of memory\n");
 
     data->attrlist = talloc_array(data, const char *, 2);
-    fail_unless(data->attrlist != NULL, "talloc_array failed.");
+    ck_assert_msg(data->attrlist != NULL, "talloc_array failed.");
     data->attrlist[0] = SYSDB_GHOST;
     data->attrlist[1] = NULL;
 
@@ -2870,35 +2870,35 @@ START_TEST (test_sysdb_memberof_mod_replace_keep)
     for (itergid = data->gid ; itergid < MBO_GROUP_BASE + NUM_GHOSTS; itergid++) {
         ret = sysdb_search_group_by_gid(data, test_ctx->domain, itergid,
                                         data->attrlist, &data->msg);
-        fail_if(ret != EOK, "Cannot retrieve group %llu\n",
+        sss_ck_fail_if_msg(ret != EOK, "Cannot retrieve group %llu\n",
                 (unsigned long long) data->gid);
 
         gv.data = (uint8_t *) ghostname_rep;
         gv.length = strlen(ghostname_rep);
 
         el = ldb_msg_find_element(data->msg, SYSDB_GHOST);
-        fail_if(el == NULL, "Cannot find ghost element\n");
+        sss_ck_fail_if_msg(el == NULL, "Cannot find ghost element\n");
 
         test_gv = ldb_msg_find_val(el, &gv);
-        fail_if(test_gv == NULL, "Cannot find ghost user %s\n", ghostname_rep);
+        sss_ck_fail_if_msg(test_gv == NULL, "Cannot find ghost user %s\n", ghostname_rep);
 
         gv.data = (uint8_t *) ghostname_del;
         gv.length = strlen(ghostname_rep);
 
         test_gv = ldb_msg_find_val(el, &gv);
-        fail_if(test_gv == NULL, "Cannot find ghost user %s\n", ghostname_del);
+        sss_ck_fail_if_msg(test_gv == NULL, "Cannot find ghost user %s\n", ghostname_del);
 
         /* inherited users must be there */
         for (iteruid = MBO_GROUP_BASE ; iteruid < itergid ; iteruid++) {
             ghostname_check = test_asprintf_fqname(data, data->ctx->domain,
                                                    "testusera%d", iteruid);
-            fail_unless(ghostname_rep != NULL, "Out of memory\n");
+            ck_assert_msg(ghostname_rep != NULL, "Out of memory\n");
 
             gv.data = (uint8_t *) ghostname_check;
             gv.length = strlen(ghostname_check);
 
             test_gv = ldb_msg_find_val(el, &gv);
-            fail_if(test_gv == NULL, "Cannot find inherited ghost user %s\n",
+            sss_ck_fail_if_msg(test_gv == NULL, "Cannot find inherited ghost user %s\n",
                     ghostname_check);
 
             if (iteruid < data->gid) {
@@ -2909,7 +2909,7 @@ START_TEST (test_sysdb_memberof_mod_replace_keep)
                 gv.length = strlen(ghostname_check);
 
                 test_gv = ldb_msg_find_val(el, &gv);
-                fail_if(test_gv == NULL, "Cannot find inherited ghost user %s\n",
+                sss_ck_fail_if_msg(test_gv == NULL, "Cannot find inherited ghost user %s\n",
                         ghostname_check);
             }
             talloc_zfree(ghostname_check);
@@ -2919,7 +2919,7 @@ START_TEST (test_sysdb_memberof_mod_replace_keep)
     /* Perform the replace operation */
     ret = sysdb_set_group_attr(test_ctx->domain,
                                data->groupname, data->attrs, SYSDB_MOD_REP);
-    fail_unless(ret == EOK, "Cannot set group attrs\n");
+    ck_assert_msg(ret == EOK, "Cannot set group attrs\n");
 
     /* After the replace, testusera should still be there, but we also need
      * to keep ghost users inherited from other groups
@@ -2927,7 +2927,7 @@ START_TEST (test_sysdb_memberof_mod_replace_keep)
     for (itergid = data->gid ; itergid < MBO_GROUP_BASE + NUM_GHOSTS; itergid++) {
         ret = sysdb_search_group_by_gid(data, test_ctx->domain, itergid,
                                         data->attrlist, &data->msg);
-        fail_if(ret != EOK, "Cannot retrieve group %llu\n",
+        sss_ck_fail_if_msg(ret != EOK, "Cannot retrieve group %llu\n",
                 (unsigned long long) data->gid);
 
         gv.data = (uint8_t *) ghostname_rep;
@@ -2935,17 +2935,17 @@ START_TEST (test_sysdb_memberof_mod_replace_keep)
 
         /* testusera must still be there */
         el = ldb_msg_find_element(data->msg, SYSDB_GHOST);
-        fail_if(el == NULL, "Cannot find ghost element\n");
+        sss_ck_fail_if_msg(el == NULL, "Cannot find ghost element\n");
 
         test_gv = ldb_msg_find_val(el, &gv);
-        fail_if(test_gv == NULL, "Cannot find ghost user %s\n", ghostname_rep);
+        sss_ck_fail_if_msg(test_gv == NULL, "Cannot find ghost user %s\n", ghostname_rep);
 
         /* testuserb must be gone */
         gv.data = (uint8_t *) ghostname_del;
         gv.length = strlen(ghostname_rep);
 
         test_gv = ldb_msg_find_val(el, &gv);
-        fail_unless(test_gv == NULL, "Cannot find ghost user %s\n", ghostname_del);
+        ck_assert_msg(test_gv == NULL, "Cannot find ghost user %s\n", ghostname_del);
 
         /* inherited users must still be there */
         for (iteruid = MBO_GROUP_BASE ; iteruid < itergid ; iteruid++) {
@@ -2955,7 +2955,7 @@ START_TEST (test_sysdb_memberof_mod_replace_keep)
             gv.length = strlen(ghostname_check);
 
             test_gv = ldb_msg_find_val(el, &gv);
-            fail_if(test_gv == NULL, "Cannot find inherited ghost user %s\n",
+            sss_ck_fail_if_msg(test_gv == NULL, "Cannot find inherited ghost user %s\n",
                     ghostname_check);
 
             if (iteruid < data->gid) {
@@ -2966,7 +2966,7 @@ START_TEST (test_sysdb_memberof_mod_replace_keep)
                 gv.length = strlen(ghostname_check);
 
                 test_gv = ldb_msg_find_val(el, &gv);
-                fail_if(test_gv == NULL, "Cannot find inherited ghost user %s\n",
+                sss_ck_fail_if_msg(test_gv == NULL, "Cannot find inherited ghost user %s\n",
                         ghostname_check);
             }
             talloc_zfree(ghostname_check);
@@ -2986,23 +2986,23 @@ START_TEST (test_sysdb_memberof_close_loop)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, MBO_GROUP_BASE);
-    fail_if(data == NULL, "OOM");
+    sss_ck_fail_if_msg(data == NULL, "OOM");
 
     data->attrlist = talloc_array(data, const char *, 2);
-    fail_unless(data->attrlist != NULL, "talloc_array failed.");
+    ck_assert_msg(data->attrlist != NULL, "talloc_array failed.");
     data->attrlist[0] = test_asprintf_fqname(data, test_ctx->domain,
                                              "testgroup%d", data->gid + 9);
-    fail_unless(data->attrlist[0] != NULL, "talloc_array failed.");
+    ck_assert_msg(data->attrlist[0] != NULL, "talloc_array failed.");
     data->attrlist[1] = NULL;
 
     ret = test_memberof_store_group(data);
 
-    fail_if(ret != EOK, "Could not store POSIX group #%d", data->gid);
+    sss_ck_fail_if_msg(ret != EOK, "Could not store POSIX group #%d", data->gid);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -3016,15 +3016,15 @@ START_TEST (test_sysdb_memberof_store_user)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_user(test_ctx, MBO_USER_BASE + _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     ret = test_store_user(data);
-    fail_if(ret != EOK, "Could not store user %s", data->username);
+    sss_ck_fail_if_msg(ret != EOK, "Could not store user %s", data->username);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -3038,20 +3038,20 @@ START_TEST (test_sysdb_memberof_add_group_member)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, MBO_GROUP_BASE + _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->uid = MBO_USER_BASE + _i;
     data->username = test_asprintf_fqname(data, test_ctx->domain,
                                           "testuser%d", data->uid);
-    fail_if(data->username == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data->username == NULL, "Failed to allocate memory");
 
     ret = test_add_group_member(data);
-    fail_if(ret != EOK, "Could not modify group %s", data->groupname);
+    sss_ck_fail_if_msg(ret != EOK, "Could not modify group %s", data->groupname);
 
     talloc_free(test_ctx);
 }
@@ -3066,15 +3066,15 @@ START_TEST (test_sysdb_memberof_check_memberuid_without_group_5)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, MBO_GROUP_BASE + _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->attrlist = talloc_array(data, const char *, 2);
-    fail_unless(data->attrlist != NULL, "tallo_array failed.");
+    ck_assert_msg(data->attrlist != NULL, "tallo_array failed.");
     data->attrlist[0] = "memberuid";
     data->attrlist[1] = NULL;
 
@@ -3082,21 +3082,21 @@ START_TEST (test_sysdb_memberof_check_memberuid_without_group_5)
                                     data->gid, data->attrlist,
                                     &data->msg);
     if (_i == 5) {
-        fail_unless(ret == ENOENT,
+        ck_assert_msg(ret == ENOENT,
                     "sysdb_search_group_by_gid found "
                     "already deleted group");
         if (ret == ENOENT) ret = EOK;
 
-        fail_if(ret != EOK, "Could not check group %d", data->gid);
+        sss_ck_fail_if_msg(ret != EOK, "Could not check group %d", data->gid);
     } else {
-        fail_if(ret != EOK, "Could not check group %d", data->gid);
+        sss_ck_fail_if_msg(ret != EOK, "Could not check group %d", data->gid);
 
-        fail_unless(data->msg->num_elements == 1,
+        ck_assert_msg(data->msg->num_elements == 1,
                     "Wrong number of results, expected [1] got [%d]",
                     data->msg->num_elements);
-        fail_unless(strcmp(data->msg->elements[0].name, "memberuid") == 0,
+        ck_assert_msg(strcmp(data->msg->elements[0].name, "memberuid") == 0,
                     "Wrong attribute name");
-        fail_unless(data->msg->elements[0].num_values == ((_i + 1) % 6),
+        ck_assert_msg(data->msg->elements[0].num_values == ((_i + 1) % 6),
                     "Wrong number of attribute values, "
                     "expected [%d] got [%d]", ((_i + 1) % 6),
                     data->msg->elements[0].num_values);
@@ -3115,15 +3115,15 @@ START_TEST (test_sysdb_memberof_check_memberuid)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, MBO_GROUP_BASE + _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->attrlist = talloc_array(data, const char *, 2);
-    fail_unless(data->attrlist != NULL, "talloc_array failed.");
+    ck_assert_msg(data->attrlist != NULL, "talloc_array failed.");
     data->attrlist[0] = "memberuid";
     data->attrlist[1] = NULL;
 
@@ -3131,14 +3131,14 @@ START_TEST (test_sysdb_memberof_check_memberuid)
                                     data->gid, data->attrlist,
                                     &data->msg);
 
-    fail_if(ret != EOK, "Could not check group %d", data->gid);
+    sss_ck_fail_if_msg(ret != EOK, "Could not check group %d", data->gid);
 
-    fail_unless(data->msg->num_elements == 1,
+    ck_assert_msg(data->msg->num_elements == 1,
                 "Wrong number of results, expected [1] got [%d]",
                 data->msg->num_elements);
-    fail_unless(strcmp(data->msg->elements[0].name, "memberuid") == 0,
+    ck_assert_msg(strcmp(data->msg->elements[0].name, "memberuid") == 0,
                 "Wrong attribute name");
-    fail_unless(data->msg->elements[0].num_values == _i + 1,
+    ck_assert_msg(data->msg->elements[0].num_values == _i + 1,
                 "Wrong number of attribute values, expected [%d] got [%d]",
                 _i + 1, data->msg->elements[0].num_values);
 
@@ -3155,15 +3155,15 @@ START_TEST (test_sysdb_memberof_check_memberuid_loop)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i + MBO_GROUP_BASE);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->attrlist = talloc_array(data, const char *, 2);
-    fail_unless(data->attrlist != NULL, "talloc_array failed.");
+    ck_assert_msg(data->attrlist != NULL, "talloc_array failed.");
     data->attrlist[0] = "memberuid";
     data->attrlist[1] = NULL;
 
@@ -3171,14 +3171,14 @@ START_TEST (test_sysdb_memberof_check_memberuid_loop)
                                     data->gid, data->attrlist,
                                     &data->msg);
 
-    fail_if(ret != EOK, "Could not check group %d", data->gid);
+    sss_ck_fail_if_msg(ret != EOK, "Could not check group %d", data->gid);
 
-    fail_unless(data->msg->num_elements == 1,
+    ck_assert_msg(data->msg->num_elements == 1,
                 "Wrong number of results, expected [1] got [%d]",
                 data->msg->num_elements);
-    fail_unless(strcmp(data->msg->elements[0].name, "memberuid") == 0,
+    ck_assert_msg(strcmp(data->msg->elements[0].name, "memberuid") == 0,
                 "Wrong attribute name");
-    fail_unless(data->msg->elements[0].num_values == 10,
+    ck_assert_msg(data->msg->elements[0].num_values == 10,
                 "Wrong number of attribute values, expected [%d] got [%d]",
                 10, data->msg->elements[0].num_values);
 
@@ -3195,15 +3195,15 @@ START_TEST (test_sysdb_memberof_check_memberuid_loop_without_group_5)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i + MBO_GROUP_BASE);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->attrlist = talloc_array(data, const char *, 2);
-    fail_unless(data->attrlist != NULL, "tallo_array failed.");
+    ck_assert_msg(data->attrlist != NULL, "tallo_array failed.");
     data->attrlist[0] = "memberuid";
     data->attrlist[1] = NULL;
 
@@ -3212,21 +3212,21 @@ START_TEST (test_sysdb_memberof_check_memberuid_loop_without_group_5)
                                     &data->msg);
 
     if (_i == 5) {
-        fail_unless(ret == ENOENT,
+        ck_assert_msg(ret == ENOENT,
                     "sysdb_search_group_by_gid_send found "
                     "already deleted group");
         if (ret == ENOENT) ret = EOK;
 
-        fail_if(ret != EOK, "Could not check group %d", data->gid);
+        sss_ck_fail_if_msg(ret != EOK, "Could not check group %d", data->gid);
     } else {
-        fail_if(ret != EOK, "Could not check group %d", data->gid);
+        sss_ck_fail_if_msg(ret != EOK, "Could not check group %d", data->gid);
 
-        fail_unless(data->msg->num_elements == 1,
+        ck_assert_msg(data->msg->num_elements == 1,
                     "Wrong number of results, expected [1] got [%d]",
                     data->msg->num_elements);
-        fail_unless(strcmp(data->msg->elements[0].name, "memberuid") == 0,
+        ck_assert_msg(strcmp(data->msg->elements[0].name, "memberuid") == 0,
                     "Wrong attribute name");
-        fail_unless(data->msg->elements[0].num_values == ((_i + 5) % 10),
+        ck_assert_msg(data->msg->elements[0].num_values == ((_i + 5) % 10),
                     "Wrong number of attribute values, expected [%d] got [%d]",
                     ((_i + 5) % 10), data->msg->elements[0].num_values);
     }
@@ -3244,25 +3244,25 @@ START_TEST (test_sysdb_memberof_check_nested_ghosts)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->attrlist = talloc_array(data, const char *, 2);
-    fail_unless(data->attrlist != NULL, "talloc_array failed.");
+    ck_assert_msg(data->attrlist != NULL, "talloc_array failed.");
     data->attrlist[0] = SYSDB_GHOST;
     data->attrlist[1] = NULL;
 
     ret = sysdb_search_group_by_gid(data, test_ctx->domain, data->gid,
                                     data->attrlist, &data->msg);
-    fail_if(ret != EOK, "Cannot retrieve group %llu\n", (unsigned long long) data->gid);
+    sss_ck_fail_if_msg(ret != EOK, "Cannot retrieve group %llu\n", (unsigned long long) data->gid);
 
-    fail_unless(strcmp(data->msg->elements[0].name, SYSDB_GHOST) == 0,
+    ck_assert_msg(strcmp(data->msg->elements[0].name, SYSDB_GHOST) == 0,
                 "Wrong attribute name");
-    fail_unless(data->msg->elements[0].num_values == _i - MBO_GROUP_BASE + 1,
+    ck_assert_msg(data->msg->elements[0].num_values == _i - MBO_GROUP_BASE + 1,
                 "Wrong number of attribute values, expected [%d] got [%d]",
                 _i - MBO_GROUP_BASE + 1, data->msg->elements[0].num_values);
 
@@ -3279,25 +3279,25 @@ START_TEST (test_sysdb_memberof_check_nested_double_ghosts)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->attrlist = talloc_array(data, const char *, 2);
-    fail_unless(data->attrlist != NULL, "talloc_array failed.");
+    ck_assert_msg(data->attrlist != NULL, "talloc_array failed.");
     data->attrlist[0] = SYSDB_GHOST;
     data->attrlist[1] = NULL;
 
     ret = sysdb_search_group_by_gid(data, test_ctx->domain, data->gid,
                                     data->attrlist, &data->msg);
-    fail_if(ret != EOK, "Cannot retrieve group %llu\n", (unsigned long long) data->gid);
+    sss_ck_fail_if_msg(ret != EOK, "Cannot retrieve group %llu\n", (unsigned long long) data->gid);
 
-    fail_unless(strcmp(data->msg->elements[0].name, SYSDB_GHOST) == 0,
+    ck_assert_msg(strcmp(data->msg->elements[0].name, SYSDB_GHOST) == 0,
                 "Wrong attribute name");
-    fail_unless(data->msg->elements[0].num_values == (_i - MBO_GROUP_BASE + 1)*2,
+    ck_assert_msg(data->msg->elements[0].num_values == (_i - MBO_GROUP_BASE + 1)*2,
                 "Wrong number of attribute values, expected [%d] got [%d]",
                 (_i - MBO_GROUP_BASE + 1)*2,
                 data->msg->elements[0].num_values);
@@ -3316,34 +3316,34 @@ START_TEST (test_sysdb_memberof_remove_child_group_and_check_ghost)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
     delgid = data->gid - 1;
 
     data->attrlist = talloc_array(data, const char *, 2);
-    fail_unless(data->attrlist != NULL, "talloc_array failed.");
+    ck_assert_msg(data->attrlist != NULL, "talloc_array failed.");
     data->attrlist[0] = SYSDB_GHOST;
     data->attrlist[1] = NULL;
 
     ret = sysdb_search_group_by_gid(data, test_ctx->domain, data->gid,
                                     data->attrlist, &data->msg);
-    fail_if(ret != EOK, "Cannot retrieve group %llu\n", (unsigned long long) data->gid);
+    sss_ck_fail_if_msg(ret != EOK, "Cannot retrieve group %llu\n", (unsigned long long) data->gid);
 
-    fail_unless(strcmp(data->msg->elements[0].name, SYSDB_GHOST) == 0,
+    ck_assert_msg(strcmp(data->msg->elements[0].name, SYSDB_GHOST) == 0,
                 "Wrong attribute name");
 
     /* Expect our own and our parent's */
-    fail_unless(data->msg->elements[0].num_values == 2,
+    ck_assert_msg(data->msg->elements[0].num_values == 2,
                 "Wrong number of attribute values, expected [%d] got [%d]",
                 2, data->msg->elements[0].num_values);
 
     /* Remove the parent */
     ret = sysdb_delete_group(data->ctx->domain, NULL, delgid);
-    fail_if(ret != EOK, "Cannot delete group %llu [%d]: %s\n",
+    sss_ck_fail_if_msg(ret != EOK, "Cannot delete group %llu [%d]: %s\n",
             (unsigned long long) data->gid, ret, strerror(ret));
 
     talloc_free(data->msg);
@@ -3351,13 +3351,13 @@ START_TEST (test_sysdb_memberof_remove_child_group_and_check_ghost)
     /* Check the parent again. The inherited ghost user should be gone. */
     ret = sysdb_search_group_by_gid(data, test_ctx->domain, data->gid,
                                     data->attrlist, &data->msg);
-    fail_if(ret != EOK, "Cannot retrieve group %llu\n", (unsigned long long) data->gid);
+    sss_ck_fail_if_msg(ret != EOK, "Cannot retrieve group %llu\n", (unsigned long long) data->gid);
 
-    fail_unless(strcmp(data->msg->elements[0].name, SYSDB_GHOST) == 0,
+    ck_assert_msg(strcmp(data->msg->elements[0].name, SYSDB_GHOST) == 0,
                 "Wrong attribute name");
 
     /* Expect our own now only */
-    fail_unless(data->msg->elements[0].num_values == 1,
+    ck_assert_msg(data->msg->elements[0].num_values == 1,
                 "Wrong number of attribute values, expected [%d] got [%d]",
                 1, data->msg->elements[0].num_values);
 
@@ -3378,20 +3378,20 @@ START_TEST (test_sysdb_memberof_mod_del)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     ghostname = test_asprintf_fqname(data, test_ctx->domain, "testuser%d", _i);
-    fail_unless(ghostname != NULL, "Out of memory\n");
+    ck_assert_msg(ghostname != NULL, "Out of memory\n");
     ret = sysdb_attrs_steal_string(data->attrs, SYSDB_GHOST, ghostname);
-    fail_unless(ret == EOK, "Cannot add attr\n");
+    ck_assert_msg(ret == EOK, "Cannot add attr\n");
 
     data->attrlist = talloc_array(data, const char *, 2);
-    fail_unless(data->attrlist != NULL, "talloc_array failed.");
+    ck_assert_msg(data->attrlist != NULL, "talloc_array failed.");
     data->attrlist[0] = SYSDB_GHOST;
     data->attrlist[1] = NULL;
 
@@ -3401,17 +3401,17 @@ START_TEST (test_sysdb_memberof_mod_del)
     for (itergid = data->gid ; itergid < MBO_GROUP_BASE + NUM_GHOSTS; itergid++) {
         ret = sysdb_search_group_by_gid(data, test_ctx->domain, itergid,
                                         data->attrlist, &data->msg);
-        fail_if(ret != EOK, "Cannot retrieve group %llu\n",
+        sss_ck_fail_if_msg(ret != EOK, "Cannot retrieve group %llu\n",
                 (unsigned long long) data->gid);
 
         gv.data = (uint8_t *) ghostname;
         gv.length = strlen(ghostname);
 
         el = ldb_msg_find_element(data->msg, SYSDB_GHOST);
-        fail_if(el == NULL, "Cannot find ghost element\n");
+        sss_ck_fail_if_msg(el == NULL, "Cannot find ghost element\n");
 
         test_gv = ldb_msg_find_val(el, &gv);
-        fail_if(test_gv == NULL, "Cannot find ghost user %s\n", ghostname);
+        sss_ck_fail_if_msg(test_gv == NULL, "Cannot find ghost user %s\n", ghostname);
     }
 
     /* Delete the attribute */
@@ -3419,13 +3419,13 @@ START_TEST (test_sysdb_memberof_mod_del)
     ret = sysdb_set_group_attr(test_ctx->domain,
                                data->groupname, data->attrs, SYSDB_MOD_DEL);
     fail_if_null_ctx_leaks(test_ctx);
-    fail_unless(ret == EOK, "Cannot set group attrs\n");
+    ck_assert_msg(ret == EOK, "Cannot set group attrs\n");
 
     /* After the delete, we shouldn't be able to find the ghost attribute */
     for (itergid = data->gid ; itergid < MBO_GROUP_BASE + NUM_GHOSTS; itergid++) {
         ret = sysdb_search_group_by_gid(data, test_ctx->domain, itergid,
                                         data->attrlist, &data->msg);
-        fail_if(ret != EOK, "Cannot retrieve group %llu\n",
+        sss_ck_fail_if_msg(ret != EOK, "Cannot retrieve group %llu\n",
                 (unsigned long long) data->gid);
 
         gv.data = (uint8_t *) ghostname;
@@ -3434,12 +3434,12 @@ START_TEST (test_sysdb_memberof_mod_del)
         el = ldb_msg_find_element(data->msg, SYSDB_GHOST);
         if (itergid > data->gid) {
             /* The first group would have the ghost attribute gone completely */
-            fail_if(el == NULL, "Cannot find ghost element\n");
+            sss_ck_fail_if_msg(el == NULL, "Cannot find ghost element\n");
             test_gv = ldb_msg_find_val(el, &gv);
-            fail_unless(test_gv == NULL,
+            ck_assert_msg(test_gv == NULL,
                         "Ghost user %s unexpectedly found\n", ghostname);
         } else {
-            fail_unless(el == NULL, "Stray values in ghost element?\n");
+            ck_assert_msg(el == NULL, "Stray values in ghost element?\n");
         }
     }
 
@@ -3457,29 +3457,29 @@ START_TEST (test_sysdb_memberof_check_ghost)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->attrlist = talloc_array(data, const char *, 2);
-    fail_unless(data->attrlist != NULL, "talloc_array failed.");
+    ck_assert_msg(data->attrlist != NULL, "talloc_array failed.");
     data->attrlist[0] = SYSDB_GHOST;
     data->attrlist[1] = NULL;
 
     ret = sysdb_search_group_by_gid(data, test_ctx->domain, data->gid,
                                     data->attrlist, &data->msg);
 
-    fail_if(ret != EOK, "Could not check group %d", data->gid);
+    sss_ck_fail_if_msg(ret != EOK, "Could not check group %d", data->gid);
 
     if (_i > MBO_GROUP_BASE) {
         /* After the previous test, the first group (gid == MBO_GROUP_BASE)
          * has no ghost users. That's a legitimate test case we need to account
          * for now.
          */
-        fail_unless(data->msg->num_elements == 1,
+        ck_assert_msg(data->msg->num_elements == 1,
                     "Wrong number of results, expected [1] got [%d] for %d",
                     data->msg->num_elements, data->gid);
     }
@@ -3489,16 +3489,16 @@ START_TEST (test_sysdb_memberof_check_ghost)
         return;
     }
 
-    fail_unless(strcmp(data->msg->elements[0].name, SYSDB_GHOST) == 0,
+    ck_assert_msg(strcmp(data->msg->elements[0].name, SYSDB_GHOST) == 0,
                 "Wrong attribute name");
-    fail_unless(data->msg->elements[0].num_values == _i - MBO_GROUP_BASE,
+    ck_assert_msg(data->msg->elements[0].num_values == _i - MBO_GROUP_BASE,
                 "Wrong number of attribute values, expected [%d] got [%d]",
                 _i + 1, data->msg->elements[0].num_values);
 
     for (j = MBO_GROUP_BASE; j < _i; j++) {
         expected = test_asprintf_fqname(data, test_ctx->domain, "testghost%d", j);
-        fail_if(expected == NULL, "OOM\n");
-        fail_unless(strcmp(expected,
+        sss_ck_fail_if_msg(expected == NULL, "OOM\n");
+        ck_assert_msg(strcmp(expected,
                            (const char *) data->msg->elements[0].values[j-MBO_GROUP_BASE].data) == 0,
                     "Expecting: %s dot: %s", expected,
                     (const char *) data->msg->elements[0].values[j-MBO_GROUP_BASE].data);
@@ -3518,18 +3518,18 @@ START_TEST (test_sysdb_memberof_convert_to_real_users)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_user(test_ctx, _i * 2);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
     data->username = test_asprintf_fqname(data, test_ctx->domain,
                                           "testghost%d", _i);
-    fail_if(data->username == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data->username == NULL, "Failed to allocate memory");
 
     ret = test_store_user(data);
-    fail_if(ret != EOK, "Cannot add user %s\n", data->username);
+    sss_ck_fail_if_msg(ret != EOK, "Cannot add user %s\n", data->username);
 }
 END_TEST
 
@@ -3547,15 +3547,15 @@ START_TEST (test_sysdb_memberof_check_convert)
      */
     ret = _setup_sysdb_tests(&test_ctx, false);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->attrlist = talloc_array(data, const char *, 3);
-    fail_unless(data->attrlist != NULL, "talloc_array failed.");
+    ck_assert_msg(data->attrlist != NULL, "talloc_array failed.");
     data->attrlist[0] = SYSDB_GHOST;
     data->attrlist[1] = SYSDB_MEMBER;
     data->attrlist[2] = NULL;
@@ -3563,9 +3563,9 @@ START_TEST (test_sysdb_memberof_check_convert)
     ret = sysdb_search_group_by_gid(data, test_ctx->domain, data->gid,
                                     data->attrlist, &data->msg);
 
-    fail_if(ret != EOK, "Could not check group %d", data->gid);
+    sss_ck_fail_if_msg(ret != EOK, "Could not check group %d", data->gid);
 
-    fail_unless(data->msg->num_elements == (_i == MBO_GROUP_BASE) ? 0 : 1,
+    ck_assert_msg(data->msg->num_elements == (_i == MBO_GROUP_BASE) ? 0 : 1,
                 "Wrong number of results, expected [1] got [%d] for %d",
                 data->msg->num_elements, data->gid);
 
@@ -3586,10 +3586,10 @@ START_TEST (test_sysdb_memberof_check_convert)
         exp_gh = 0;
     }
 
-    fail_if(exp_mem != members->num_values,
+    sss_ck_fail_if_msg(exp_mem != members->num_values,
             "Expected %d members, found %d\n", exp_mem, members->num_values);
     if (exp_gh) {
-        fail_if(exp_gh != ghosts->num_values,
+        sss_ck_fail_if_msg(exp_gh != ghosts->num_values,
                 "Expected %d members, found %d\n", exp_gh, ghosts->num_values);
     }
 
@@ -3610,64 +3610,64 @@ START_TEST (test_sysdb_memberof_ghost_replace)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     /* The test replaces the testghost%i attribute with testuser%i */
     ghostname_del = test_asprintf_fqname(data, test_ctx->domain,
                                          "testghost%d", data->gid - 1);
-    fail_unless(ghostname_del != NULL, "Out of memory\n");
+    ck_assert_msg(ghostname_del != NULL, "Out of memory\n");
 
     ghostname_add = test_asprintf_fqname(data, test_ctx->domain,
                                          "testuser%d", data->gid - 1);
-    fail_unless(ghostname_add != NULL, "Out of memory\n");
+    ck_assert_msg(ghostname_add != NULL, "Out of memory\n");
 
     ret = sysdb_attrs_steal_string(data->attrs, SYSDB_GHOST, ghostname_add);
-    fail_unless(ret == EOK, "Cannot add attr\n");
+    ck_assert_msg(ret == EOK, "Cannot add attr\n");
 
     data->attrlist = talloc_array(data, const char *, 2);
-    fail_unless(data->attrlist != NULL, "talloc_array failed.");
+    ck_assert_msg(data->attrlist != NULL, "talloc_array failed.");
     data->attrlist[0] = SYSDB_GHOST;
     data->attrlist[1] = NULL;
 
     /* Before the replace, the group has the testghost%_i as a member */
     ret = sysdb_search_group_by_gid(data, test_ctx->domain, data->gid,
                                     data->attrlist, &data->msg);
-    fail_if(ret != EOK, "Cannot retrieve group %llu\n",
+    sss_ck_fail_if_msg(ret != EOK, "Cannot retrieve group %llu\n",
             (unsigned long long) data->gid);
 
     gv.data = (uint8_t *) ghostname_del;
     gv.length = strlen(ghostname_del);
 
     el = ldb_msg_find_element(data->msg, SYSDB_GHOST);
-    fail_if(el == NULL, "Cannot find ghost element\n");
+    sss_ck_fail_if_msg(el == NULL, "Cannot find ghost element\n");
 
     test_gv = ldb_msg_find_val(el, &gv);
-    fail_if(test_gv == NULL, "Cannot find ghost user %s\n", ghostname_del);
+    sss_ck_fail_if_msg(test_gv == NULL, "Cannot find ghost user %s\n", ghostname_del);
 
     /* Perform the replace operation */
     ret =  sysdb_set_group_attr(test_ctx->domain,
                                 data->groupname, data->attrs, SYSDB_MOD_REP);
-    fail_unless(ret == EOK, "Cannot set group attrs\n");
+    ck_assert_msg(ret == EOK, "Cannot set group attrs\n");
 
     /* After the replace, the group has the testghost%_i as a member */
     ret = sysdb_search_group_by_gid(data, test_ctx->domain, data->gid,
                                     data->attrlist, &data->msg);
-    fail_if(ret != EOK, "Cannot retrieve group %llu\n",
+    sss_ck_fail_if_msg(ret != EOK, "Cannot retrieve group %llu\n",
             (unsigned long long) data->gid);
 
     gv.data = (uint8_t *) ghostname_add;
     gv.length = strlen(ghostname_add);
 
     el = ldb_msg_find_element(data->msg, SYSDB_GHOST);
-    fail_if(el == NULL, "Cannot find ghost element\n");
+    sss_ck_fail_if_msg(el == NULL, "Cannot find ghost element\n");
 
     test_gv = ldb_msg_find_val(el, &gv);
-    fail_if(test_gv == NULL, "Cannot find ghost user %s\n", ghostname_add);
+    sss_ck_fail_if_msg(test_gv == NULL, "Cannot find ghost user %s\n", ghostname_add);
 }
 END_TEST
 
@@ -3684,64 +3684,64 @@ START_TEST (test_sysdb_memberof_ghost_replace_noop)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     /* The test replaces the testghost%i attribute with testuser%i */
     ghostname_del = test_asprintf_fqname(data, test_ctx->domain,
                                          "testuser%d", data->gid - 1);
-    fail_unless(ghostname_del != NULL, "Out of memory\n");
+    ck_assert_msg(ghostname_del != NULL, "Out of memory\n");
 
     ghostname_add = test_asprintf_fqname(data, test_ctx->domain,
                                          "testuser%d", data->gid - 1);
-    fail_unless(ghostname_add != NULL, "Out of memory\n");
+    ck_assert_msg(ghostname_add != NULL, "Out of memory\n");
 
     ret = sysdb_attrs_steal_string(data->attrs, SYSDB_GHOST, ghostname_add);
-    fail_unless(ret == EOK, "Cannot add attr\n");
+    ck_assert_msg(ret == EOK, "Cannot add attr\n");
 
     data->attrlist = talloc_array(data, const char *, 2);
-    fail_unless(data->attrlist != NULL, "talloc_array failed.");
+    ck_assert_msg(data->attrlist != NULL, "talloc_array failed.");
     data->attrlist[0] = SYSDB_GHOST;
     data->attrlist[1] = NULL;
 
     /* Before the replace, the group has the testghost%_i as a member */
     ret = sysdb_search_group_by_gid(data, test_ctx->domain, data->gid,
                                     data->attrlist, &data->msg);
-    fail_if(ret != EOK, "Cannot retrieve group %llu\n",
+    sss_ck_fail_if_msg(ret != EOK, "Cannot retrieve group %llu\n",
             (unsigned long long) data->gid);
 
     gv.data = (uint8_t *) ghostname_del;
     gv.length = strlen(ghostname_del);
 
     el = ldb_msg_find_element(data->msg, SYSDB_GHOST);
-    fail_if(el == NULL, "Cannot find ghost element\n");
+    sss_ck_fail_if_msg(el == NULL, "Cannot find ghost element\n");
 
     test_gv = ldb_msg_find_val(el, &gv);
-    fail_if(test_gv == NULL, "Cannot find ghost user %s\n", ghostname_del);
+    sss_ck_fail_if_msg(test_gv == NULL, "Cannot find ghost user %s\n", ghostname_del);
 
     /* Perform the replace operation */
     ret =  sysdb_set_group_attr(test_ctx->domain,
                                 data->groupname, data->attrs, SYSDB_MOD_REP);
-    fail_unless(ret == EOK, "Cannot set group attrs\n");
+    ck_assert_msg(ret == EOK, "Cannot set group attrs\n");
 
     /* After the replace, the group has the testghost%_i as a member */
     ret = sysdb_search_group_by_gid(data, test_ctx->domain, data->gid,
                                     data->attrlist, &data->msg);
-    fail_if(ret != EOK, "Cannot retrieve group %llu\n",
+    sss_ck_fail_if_msg(ret != EOK, "Cannot retrieve group %llu\n",
             (unsigned long long) data->gid);
 
     gv.data = (uint8_t *) ghostname_add;
     gv.length = strlen(ghostname_add);
 
     el = ldb_msg_find_element(data->msg, SYSDB_GHOST);
-    fail_if(el == NULL, "Cannot find ghost element\n");
+    sss_ck_fail_if_msg(el == NULL, "Cannot find ghost element\n");
 
     test_gv = ldb_msg_find_val(el, &gv);
-    fail_if(test_gv == NULL, "Cannot find ghost user %s\n", ghostname_add);
+    sss_ck_fail_if_msg(test_gv == NULL, "Cannot find ghost user %s\n", ghostname_add);
 }
 END_TEST
 
@@ -3754,16 +3754,16 @@ START_TEST (test_sysdb_memberof_user_cleanup)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_user(test_ctx, _i * 2);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     ret = test_remove_user_by_uid(data);
 
-    fail_if(ret != EOK, "Could not remove user with uid %d", _i);
+    sss_ck_fail_if_msg(ret != EOK, "Could not remove user with uid %d", _i);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -3779,39 +3779,39 @@ START_TEST (test_sysdb_set_get_bool)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     dn = sysdb_domain_dn(test_ctx, test_ctx->domain);
-    fail_unless(dn != NULL, "Failed to allocate memory");
+    ck_assert_msg(dn != NULL, "Failed to allocate memory");
 
     /* attribute is not created yet */
     ret = sysdb_get_bool(test_ctx->sysdb, dn, attr_val,
                          &value);
-    fail_unless(ret == ENOENT,
+    ck_assert_msg(ret == ENOENT,
                 "sysdb_get_bool returned %d:[%s], but ENOENT is expected",
                 ret, sss_strerror(ret));
 
     /* add attribute */
     ret = sysdb_set_bool(test_ctx->sysdb, dn, test_ctx->domain->name,
                          attr_val, true);
-    fail_unless(ret == EOK, "sysdb_set_bool failed with error: %d", ret);
+    ck_assert_msg(ret == EOK, "sysdb_set_bool failed with error: %d", ret);
 
     /* successfully obtain attribute */
     ret = sysdb_get_bool(test_ctx->sysdb, dn, attr_val,
                          &value);
-    fail_unless(ret == EOK, "sysdb_get_bool failed %d:[%s]",
+    ck_assert_msg(ret == EOK, "sysdb_get_bool failed %d:[%s]",
                 ret, sss_strerror(ret));
-    fail_unless(value == true, "sysdb_get_bool must return true");
+    ck_assert_msg(value == true, "sysdb_get_bool must return true");
 
     /* use non-existing DN */
     ne_dn = ldb_dn_new_fmt(test_ctx, test_ctx->sysdb->ldb, SYSDB_DOM_BASE,
                         "non-existing domain");
-    fail_unless(ne_dn != NULL, "Failed to allocate memory");
+    ck_assert_msg(ne_dn != NULL, "Failed to allocate memory");
     ret = sysdb_get_bool(test_ctx->sysdb, ne_dn, attr_val,
                          &value);
-    fail_unless(ret == ENOENT,
+    ck_assert_msg(ret == ENOENT,
                 "sysdb_get_bool returned %d:[%s], but ENOENT is expected",
                 ret, sss_strerror(ret));
 
@@ -3832,39 +3832,39 @@ START_TEST (test_sysdb_set_get_uint)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     dn = sysdb_domain_dn(test_ctx, test_ctx->domain);
-    fail_unless(dn != NULL, "Failed to allocate memory");
+    ck_assert_msg(dn != NULL, "Failed to allocate memory");
 
     /* attribute is not created yet */
     ret = sysdb_get_uint(test_ctx->sysdb, dn, attr_val,
                          &value);
-    fail_unless(ret == ENOENT,
+    ck_assert_msg(ret == ENOENT,
                 "sysdb_get_uint returned %d:[%s], but ENOENT is expected",
                 ret, sss_strerror(ret));
 
     /* add attribute */
     ret = sysdb_set_uint(test_ctx->sysdb, dn, test_ctx->domain->name,
                          attr_val, 0xCAFEBABE);
-    fail_unless(ret == EOK, "sysdb_set_uint failed with error: %d", ret);
+    ck_assert_msg(ret == EOK, "sysdb_set_uint failed with error: %d", ret);
 
     /* successfully obtain attribute */
     ret = sysdb_get_uint(test_ctx->sysdb, dn, attr_val,
                          &value);
-    fail_unless(ret == EOK, "sysdb_get_uint failed %d:[%s]",
+    ck_assert_msg(ret == EOK, "sysdb_get_uint failed %d:[%s]",
                 ret, sss_strerror(ret));
     ck_assert_int_eq(value, 0xCAFEBABE);
 
     /* use non-existing DN */
     ne_dn = ldb_dn_new_fmt(test_ctx, test_ctx->sysdb->ldb, SYSDB_DOM_BASE,
                         "non-existing domain");
-    fail_unless(ne_dn != NULL, "Failed to allocate memory");
+    ck_assert_msg(ne_dn != NULL, "Failed to allocate memory");
     ret = sysdb_get_uint(test_ctx->sysdb, ne_dn, attr_val,
                          &value);
-    fail_unless(ret == ENOENT,
+    ck_assert_msg(ret == ENOENT,
                 "sysdb_get_uint returned %d:[%s], but ENOENT is expected",
                 ret, sss_strerror(ret));
 
@@ -3883,23 +3883,23 @@ START_TEST (test_sysdb_attrs_to_list)
 
     attrs_list[0] = sysdb_new_attrs(test_ctx);
     ret = sysdb_attrs_add_string(attrs_list[0], "test_attr", "attr1");
-    fail_if(ret, "Add string failed");
+    sss_ck_fail_if_msg(ret, "Add string failed");
     attrs_list[1] = sysdb_new_attrs(test_ctx);
     ret = sysdb_attrs_add_string(attrs_list[1], "test_attr", "attr2");
-    fail_if(ret, "Add string failed");
+    sss_ck_fail_if_msg(ret, "Add string failed");
     attrs_list[2] = sysdb_new_attrs(test_ctx);
     ret = sysdb_attrs_add_string(attrs_list[2], "nottest_attr", "attr3");
-    fail_if(ret, "Add string failed");
+    sss_ck_fail_if_msg(ret, "Add string failed");
 
     ret = sysdb_attrs_to_list(test_ctx, attrs_list, 3,
                               "test_attr", &list);
-    fail_unless(ret == EOK, "sysdb_attrs_to_list failed with code %d", ret);
+    ck_assert_msg(ret == EOK, "sysdb_attrs_to_list failed with code %d", ret);
 
-    fail_unless(strcmp(list[0],"attr1") == 0, "Expected [attr1], got [%s]",
+    ck_assert_msg(strcmp(list[0],"attr1") == 0, "Expected [attr1], got [%s]",
                                               list[0]);
-    fail_unless(strcmp(list[1],"attr2") == 0, "Expected [attr2], got [%s]",
+    ck_assert_msg(strcmp(list[1],"attr2") == 0, "Expected [attr2], got [%s]",
                                               list[1]);
-    fail_unless(list[2] == NULL, "List should be NULL-terminated");
+    ck_assert_msg(list[2] == NULL, "List should be NULL-terminated");
 
     talloc_free(test_ctx);
 }
@@ -3915,59 +3915,59 @@ START_TEST(test_sysdb_get_real_name)
     char *realname;
 
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     fq_alias = sss_create_internal_fqname(test_ctx, "alias",
                                           test_ctx->domain->name);
     realname = sss_create_internal_fqname(test_ctx, "RealName",
                                           test_ctx->domain->name);
-    fail_if(fq_alias == NULL, "sss_create_internal_fqname failed");
-    fail_if(realname == NULL, "sss_create_internal_fqname failed");
+    sss_ck_fail_if_msg(fq_alias == NULL, "sss_create_internal_fqname failed");
+    sss_ck_fail_if_msg(realname == NULL, "sss_create_internal_fqname failed");
 
     user_attrs = sysdb_new_attrs(test_ctx);
-    fail_unless(user_attrs != NULL, "sysdb_new_attrs failed");
+    ck_assert_msg(user_attrs != NULL, "sysdb_new_attrs failed");
 
     ret = sysdb_attrs_add_string(user_attrs, SYSDB_NAME_ALIAS, fq_alias);
-    fail_unless(ret == EOK, "sysdb_attrs_add_string failed.");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_string failed.");
 
     ret = sysdb_attrs_add_string(user_attrs, SYSDB_UPN, "foo@bar");
-    fail_unless(ret == EOK, "sysdb_attrs_add_string failed.");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_string failed.");
 
     ret = sysdb_attrs_add_string(user_attrs, SYSDB_SID_STR,
                                  "S-1-5-21-123-456-789-111");
-    fail_unless(ret == EOK, "sysdb_attrs_add_string failed.");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_string failed.");
 
     ret = sysdb_attrs_add_string(user_attrs, SYSDB_UUID,
                                  "12345678-9012-3456-7890-123456789012");
-    fail_unless(ret == EOK, "sysdb_attrs_add_string failed.");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_string failed.");
 
     ret = sysdb_store_user(test_ctx->domain, realname,
                            NULL, 22345, 0, "gecos",
                            "/home/realname", "/bin/bash",
                            NULL, user_attrs, NULL, -1, 0);
-    fail_unless(ret == EOK, "sysdb_store_user failed.");
+    ck_assert_msg(ret == EOK, "sysdb_store_user failed.");
 
     /* Get real, uncanonicalized name as string */
     ret = sysdb_get_real_name(test_ctx, test_ctx->domain, fq_alias, &str);
-    fail_unless(ret == EOK, "sysdb_get_real_name failed.");
-    fail_unless(strcmp(str, realname) == 0, "Expected [%s], got [%s].",
+    ck_assert_msg(ret == EOK, "sysdb_get_real_name failed.");
+    ck_assert_msg(strcmp(str, realname) == 0, "Expected [%s], got [%s].",
                                               realname, str);
 
     ret = sysdb_get_real_name(test_ctx, test_ctx->domain, "foo@bar", &str);
-    fail_unless(ret == EOK, "sysdb_get_real_name failed.");
-    fail_unless(strcmp(str, realname) == 0, "Expected [%s], got [%s].",
+    ck_assert_msg(ret == EOK, "sysdb_get_real_name failed.");
+    ck_assert_msg(strcmp(str, realname) == 0, "Expected [%s], got [%s].",
                                               realname, str);
 
     ret = sysdb_get_real_name(test_ctx, test_ctx->domain,
                               "S-1-5-21-123-456-789-111", &str);
-    fail_unless(ret == EOK, "sysdb_get_real_name failed.");
-    fail_unless(strcmp(str, realname) == 0, "Expected [%s], got [%s].",
+    ck_assert_msg(ret == EOK, "sysdb_get_real_name failed.");
+    ck_assert_msg(strcmp(str, realname) == 0, "Expected [%s], got [%s].",
                                               realname, str);
 
     ret = sysdb_get_real_name(test_ctx, test_ctx->domain,
                               "12345678-9012-3456-7890-123456789012", &str);
-    fail_unless(ret == EOK, "sysdb_get_real_name failed.");
-    fail_unless(strcmp(str, realname) == 0, "Expected [%s], got [%s].",
+    ck_assert_msg(ret == EOK, "sysdb_get_real_name failed.");
+    ck_assert_msg(strcmp(str, realname) == 0, "Expected [%s], got [%s].",
                                               realname, str);
 }
 END_TEST
@@ -3985,64 +3985,64 @@ START_TEST(test_group_rename)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_unless(ret == EOK, "Could not set up the test");
+    ck_assert_msg(ret == EOK, "Could not set up the test");
 
     fromname = sss_create_internal_fqname(test_ctx, "fromgroup",
                                           test_ctx->domain->name);
-    fail_if(fromname == NULL, "sss_create_internal_fqname failed");
+    sss_ck_fail_if_msg(fromname == NULL, "sss_create_internal_fqname failed");
     toname = sss_create_internal_fqname(test_ctx, "togroup",
                                         test_ctx->domain->name);
-    fail_if(toname == NULL, "sss_create_internal_fqname failed");
+    sss_ck_fail_if_msg(toname == NULL, "sss_create_internal_fqname failed");
 
     /* Store and verify the first group */
     ret = sysdb_store_group(test_ctx->domain,
                             fromname, grgid, NULL, 0, 0);
-    fail_unless(ret == EOK, "Could not add first group");
+    ck_assert_msg(ret == EOK, "Could not add first group");
 
     ret = sysdb_getgrnam(test_ctx, test_ctx->domain, fromname, &res);
-    fail_unless(ret == EOK, "Could not retrieve the group from cache\n");
+    ck_assert_msg(ret == EOK, "Could not retrieve the group from cache\n");
     if (res->count != 1) {
-        fail("Invalid number of replies. Expected 1, got %d", res->count);
+        ck_abort_msg("Invalid number of replies. Expected 1, got %d", res->count);
         goto done;
     }
 
     gid = ldb_msg_find_attr_as_uint(res->msgs[0], SYSDB_GIDNUM, 0);
-    fail_unless(gid == grgid,
+    ck_assert_msg(gid == grgid,
                 "Did not find the expected GID (found %llu expected %llu)",
                 (unsigned long long) gid, (unsigned long long) grgid);
     name = ldb_msg_find_attr_as_string(res->msgs[0], SYSDB_NAME, NULL);
-    fail_unless(strcmp(fromname, name) == 0,
+    ck_assert_msg(strcmp(fromname, name) == 0,
                 "Did not find the expected name (found %s expected %s)",
                 name, fromname);
 
     /* Perform rename and check that GID is the same, but name changed */
     ret = sysdb_add_group(test_ctx->domain, toname, grgid, NULL, 0, 0);
-    fail_unless(ret == EEXIST, "Group renamed with a low level call?");
+    ck_assert_msg(ret == EEXIST, "Group renamed with a low level call?");
 
     ret = sysdb_store_group(test_ctx->domain,
                             toname, grgid, NULL, 0, 0);
-    fail_unless(ret == EOK, "Could not add first group");
+    ck_assert_msg(ret == EOK, "Could not add first group");
 
     ret = sysdb_getgrnam(test_ctx, test_ctx->domain, toname, &res);
-    fail_unless(ret == EOK, "Could not retrieve the group from cache\n");
+    ck_assert_msg(ret == EOK, "Could not retrieve the group from cache\n");
     if (res->count != 1) {
-        fail("Invalid number of replies. Expected 1, got %d", res->count);
+        ck_abort_msg("Invalid number of replies. Expected 1, got %d", res->count);
         goto done;
     }
 
     gid = ldb_msg_find_attr_as_uint(res->msgs[0], SYSDB_GIDNUM, 0);
-    fail_unless(gid == grgid,
+    ck_assert_msg(gid == grgid,
                 "Did not find the expected GID (found %llu expected %llu)",
                 (unsigned long long) gid, (unsigned long long) grgid);
     name = ldb_msg_find_attr_as_string(res->msgs[0], SYSDB_NAME, NULL);
-    fail_unless(strcmp(toname, name) == 0,
+    ck_assert_msg(strcmp(toname, name) == 0,
                 "Did not find the expected GID (found %s expected %s)",
                 name, toname);
 
     /* Verify the first name is gone */
     ret = sysdb_getgrnam(test_ctx, test_ctx->domain, fromname, &res);
-    fail_unless(ret == EOK, "Could not retrieve the group from cache\n");
-    fail_unless(res->count == 0, "Unexpectedly found the original user\n");
+    ck_assert_msg(ret == EOK, "Could not retrieve the group from cache\n");
+    ck_assert_msg(res->count == 0, "Unexpectedly found the original user\n");
 
 done:
     talloc_free(test_ctx);
@@ -4062,66 +4062,66 @@ START_TEST(test_user_rename)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_unless(ret == EOK, "Could not set up the test");
+    ck_assert_msg(ret == EOK, "Could not set up the test");
 
     fromname = sss_create_internal_fqname(test_ctx, "fromname", test_ctx->domain->name);
     toname = sss_create_internal_fqname(test_ctx, "toname", test_ctx->domain->name);
-    fail_if(fromname == NULL, "sss_create_internal_fqname failed");
-    fail_if(toname == NULL, "sss_create_internal_fqname failed");
+    sss_ck_fail_if_msg(fromname == NULL, "sss_create_internal_fqname failed");
+    sss_ck_fail_if_msg(toname == NULL, "sss_create_internal_fqname failed");
 
     /* Store and verify the first user */
     ret = sysdb_store_user(test_ctx->domain,
                            fromname, NULL, userid, 0,
                            fromname, "/", "/bin/sh",
                            NULL, NULL, NULL, 0, 0);
-    fail_unless(ret == EOK, "Could not add first user");
+    ck_assert_msg(ret == EOK, "Could not add first user");
 
     ret = sysdb_getpwnam(test_ctx, test_ctx->domain, fromname, &res);
-    fail_unless(ret == EOK, "Could not retrieve the user from cache\n");
+    ck_assert_msg(ret == EOK, "Could not retrieve the user from cache\n");
     if (res->count != 1) {
-        fail("Invalid number of replies. Expected 1, got %d", res->count);
+        ck_abort_msg("Invalid number of replies. Expected 1, got %d", res->count);
         goto done;
     }
 
     uid = ldb_msg_find_attr_as_uint(res->msgs[0], SYSDB_UIDNUM, 0);
-    fail_unless(uid == userid,
+    ck_assert_msg(uid == userid,
                 "Did not find the expected UID (found %llu expected %llu)",
                 (unsigned long long) uid, (unsigned long long) userid);
     name = ldb_msg_find_attr_as_string(res->msgs[0], SYSDB_NAME, NULL);
-    fail_unless(strcmp(fromname, name) == 0,
+    ck_assert_msg(strcmp(fromname, name) == 0,
                 "Did not find the expected name (found %s expected %s)",
                 name, fromname);
 
     /* Perform rename and check that GID is the same, but name changed */
     ret = sysdb_add_user(test_ctx->domain, toname, userid, 0,
                          fromname, "/", "/bin/sh", NULL, NULL, 0, 0);
-    fail_unless(ret == EEXIST, "A second user added with low level call?");
+    ck_assert_msg(ret == EEXIST, "A second user added with low level call?");
 
     ret = sysdb_store_user(test_ctx->domain, toname, NULL,
                            userid, 0, fromname, "/", "/bin/sh",
                            NULL, NULL, NULL, 0, 0);
-    fail_unless(ret == EOK, "Could not add second user");
+    ck_assert_msg(ret == EOK, "Could not add second user");
 
     ret = sysdb_getpwnam(test_ctx, test_ctx->domain, toname, &res);
-    fail_unless(ret == EOK, "Could not retrieve the user from cache\n");
+    ck_assert_msg(ret == EOK, "Could not retrieve the user from cache\n");
     if (res->count != 1) {
-        fail("Invalid number of replies. Expected 1, got %d", res->count);
+        ck_abort_msg("Invalid number of replies. Expected 1, got %d", res->count);
         goto done;
     }
 
     uid = ldb_msg_find_attr_as_uint(res->msgs[0], SYSDB_UIDNUM, 0);
-    fail_unless(uid == userid,
+    ck_assert_msg(uid == userid,
                 "Did not find the expected UID (found %llu expected %llu)",
                 (unsigned long long) uid, (unsigned long long) userid);
     name = ldb_msg_find_attr_as_string(res->msgs[0], SYSDB_NAME, NULL);
-    fail_unless(strcmp(toname, name) == 0,
+    ck_assert_msg(strcmp(toname, name) == 0,
                 "Did not find the expected name (found %s expected %s)",
                 name, fromname);
 
     /* Verify the first name is gone */
     ret = sysdb_getpwnam(test_ctx, test_ctx->domain, fromname, &res);
-    fail_unless(ret == EOK, "Could not retrieve the user from cache\n");
-    fail_unless(res->count == 0, "Unexpectedly found the original user\n");
+    ck_assert_msg(ret == EOK, "Could not retrieve the user from cache\n");
+    ck_assert_msg(res->count == 0, "Unexpectedly found the original user\n");
 
 done:
     talloc_free(test_ctx);
@@ -4142,39 +4142,39 @@ START_TEST (test_sysdb_update_members)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_unless(ret == EOK, "Could not set up the test");
+    ck_assert_msg(ret == EOK, "Could not set up the test");
 
     user_fqname = sss_create_internal_fqname(test_ctx, user,
                                              test_ctx->domain->name);
-    fail_if(user_fqname == NULL, "user_fqname returned NULL");
+    sss_ck_fail_if_msg(user_fqname == NULL, "user_fqname returned NULL");
 
     ret = sysdb_initgroups(test_ctx, test_ctx->domain, user_fqname, &res);
-    fail_if(ret != EOK, "sysdb_initgroups failed with error: %d", ret);
+    sss_ck_fail_if_msg(ret != EOK, "sysdb_initgroups failed with error: %d", ret);
     ck_assert_int_eq(res->count, 1);   /* only the user itself */
 
     /* Add a user to two groups */
     add_groups = talloc_array(test_ctx, char *, 3);
     add_groups[0] = sss_create_internal_fqname(add_groups, "testgroup28001",
                                                test_ctx->domain->name);
-    fail_if(add_groups[0] == NULL, "Failed to create internal fqname for: %s",
+    sss_ck_fail_if_msg(add_groups[0] == NULL, "Failed to create internal fqname for: %s",
                                    test_ctx->domain->name);
     add_groups[1] = sss_create_internal_fqname(add_groups, "testgroup28002",
                                                test_ctx->domain->name);
-    fail_if(add_groups[1] == NULL, "Failed to create internal fqname for: %s",
+    sss_ck_fail_if_msg(add_groups[1] == NULL, "Failed to create internal fqname for: %s",
 		                   test_ctx->domain->name);
     add_groups[2] = NULL;
 
     /* For later check */
     group_fqname = talloc_strdup(test_ctx, add_groups[1]);
-    fail_if(group_fqname == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(group_fqname == NULL, "Failed to allocate memory");
 
     ret = sysdb_update_members(test_ctx->domain, user_fqname,
                                SYSDB_MEMBER_USER,
                                (const char *const *)add_groups, NULL);
-    fail_unless(ret == EOK, "Could not add groups");
+    ck_assert_msg(ret == EOK, "Could not add groups");
 
     ret = sysdb_initgroups(test_ctx, test_ctx->domain, user_fqname, &res);
-    fail_if(ret != EOK, "sysdb_initgroups failed with error: %d", ret);
+    sss_ck_fail_if_msg(ret != EOK, "sysdb_initgroups failed with error: %d", ret);
     ck_assert_int_eq(res->count, 3);
 
     check_fqname = ldb_msg_find_attr_as_string(res->msgs[1], SYSDB_NAME, NULL);
@@ -4197,10 +4197,10 @@ START_TEST (test_sysdb_update_members)
     ret = sysdb_update_members(test_ctx->domain, user_fqname, SYSDB_MEMBER_USER,
                                (const char *const *)add_groups,
                                (const char *const *)del_groups);
-    fail_unless(ret == EOK, "Group replace failed");
+    ck_assert_msg(ret == EOK, "Group replace failed");
 
     ret = sysdb_initgroups(test_ctx, test_ctx->domain, user_fqname, &res);
-    fail_if(ret != EOK, "sysdb_initgroups failed with error: %d", ret);
+    sss_ck_fail_if_msg(ret != EOK, "sysdb_initgroups failed with error: %d", ret);
     ck_assert_int_eq(res->count, 3);
 
     check_fqname = ldb_msg_find_attr_as_string(res->msgs[1], SYSDB_NAME, NULL);
@@ -4212,7 +4212,7 @@ START_TEST (test_sysdb_update_members)
     talloc_zfree(del_groups);
 
     ret = sysdb_initgroups(test_ctx, test_ctx->domain, user_fqname, &res);
-    fail_if(ret != EOK, "sysdb_initgroups failed with error: %d", ret);
+    sss_ck_fail_if_msg(ret != EOK, "sysdb_initgroups failed with error: %d", ret);
     ck_assert_int_eq(res->count, 3);
 
     /* Remove a user from two groups */
@@ -4225,10 +4225,10 @@ START_TEST (test_sysdb_update_members)
 
     ret = sysdb_update_members(test_ctx->domain, user_fqname, SYSDB_MEMBER_USER,
                                NULL, (const char *const *)del_groups);
-    fail_unless(ret == EOK, "Could not remove groups");
+    ck_assert_msg(ret == EOK, "Could not remove groups");
 
     ret = sysdb_initgroups(test_ctx, test_ctx->domain, user_fqname, &res);
-    fail_if(ret != EOK, "sysdb_initgroups failed with error: %d", ret);
+    sss_ck_fail_if_msg(ret != EOK, "sysdb_initgroups failed with error: %d", ret);
     ck_assert_int_eq(res->count, 1);   /* only the user itself */
 
     talloc_zfree(test_ctx);
@@ -4247,21 +4247,21 @@ START_TEST (test_sysdb_group_dn_name)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new_group(test_ctx, _i);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     group_dn = sysdb_group_dn(test_ctx, test_ctx->domain, data->groupname);
-    fail_if(group_dn == NULL, "OOM");
+    sss_ck_fail_if_msg(group_dn == NULL, "OOM");
 
     ret = sysdb_group_dn_name(test_ctx->sysdb, test_ctx,
                               ldb_dn_get_linearized(group_dn), &parsed);
-    fail_if(ret != EOK, "Cannot get the group name from DN");
+    sss_ck_fail_if_msg(ret != EOK, "Cannot get the group name from DN");
 
-    fail_if(strcmp(data->groupname, parsed) != 0,
+    sss_ck_fail_if_msg(strcmp(data->groupname, parsed) != 0,
             "Names don't match (got %s)", parsed);
     talloc_free(test_ctx);
 }
@@ -4276,18 +4276,18 @@ START_TEST (test_sysdb_add_basic_netgroup)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new(test_ctx);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
     data->uid = _i;         /* This is kinda abuse of uid, though */
     data->netgrname = talloc_asprintf(data, "testnetgr%d", _i);
 
     ret = test_add_basic_netgroup(data);
 
-    fail_if(ret != EOK, "Could not add netgroup %s", data->netgrname);
+    sss_ck_fail_if_msg(ret != EOK, "Could not add netgroup %s", data->netgrname);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -4303,7 +4303,7 @@ START_TEST (test_sysdb_search_netgroup_by_name)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
@@ -4311,11 +4311,11 @@ START_TEST (test_sysdb_search_netgroup_by_name)
 
     ret = sysdb_search_netgroup_by_name(test_ctx, test_ctx->domain,
                                         netgrname, NULL, &msg);
-    fail_if(ret != EOK, "Could not find netgroup with name %s", netgrname);
+    sss_ck_fail_if_msg(ret != EOK, "Could not find netgroup with name %s", netgrname);
 
     netgroup_dn = sysdb_netgroup_dn(test_ctx, test_ctx->domain, netgrname);
-    fail_if(netgroup_dn == NULL, "Failed to allocate memory");
-    fail_if(ldb_dn_compare(msg->dn, netgroup_dn) != 0, "Found wrong netgroup!\n");
+    sss_ck_fail_if_msg(netgroup_dn == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(ldb_dn_compare(msg->dn, netgroup_dn) != 0, "Found wrong netgroup!\n");
     talloc_free(test_ctx);
 }
 END_TEST
@@ -4329,17 +4329,17 @@ START_TEST (test_sysdb_remove_netgroup_entry)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new(test_ctx);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
     data->netgrname = talloc_asprintf(data, "testnetgr%d", _i);
 
     ret = test_remove_netgroup_entry(data);
 
-    fail_if(ret != EOK, "Could not remove netgroup %s", data->netgrname);
+    sss_ck_fail_if_msg(ret != EOK, "Could not remove netgroup %s", data->netgrname);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -4353,17 +4353,17 @@ START_TEST (test_sysdb_remove_netgroup_by_name)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new(test_ctx);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
     data->netgrname = talloc_asprintf(data, "testnetgr%d", _i);
 
     ret = test_remove_netgroup_by_name(data);
 
-    fail_if(ret != EOK, "Could not remove netgroup with name %s", data->netgrname);
+    sss_ck_fail_if_msg(ret != EOK, "Could not remove netgroup with name %s", data->netgrname);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -4377,18 +4377,18 @@ START_TEST (test_sysdb_set_netgroup_attr)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = test_data_new(test_ctx);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
     data->uid = _i;         /* This is kinda abuse of uid, though */
     data->netgrname = talloc_asprintf(data, "testnetgr%d", _i);
 
     ret = test_set_netgroup_attr(data);
 
-    fail_if(ret != EOK, "Could not set netgroup attribute %s", data->netgrname);
+    sss_ck_fail_if_msg(ret != EOK, "Could not set netgroup attribute %s", data->netgrname);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -4406,7 +4406,7 @@ START_TEST (test_sysdb_get_netgroup_attr)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
@@ -4416,12 +4416,12 @@ START_TEST (test_sysdb_get_netgroup_attr)
     ret = sysdb_get_netgroup_attr(test_ctx, test_ctx->domain, netgrname,
                                   attrs, &res);
 
-    fail_if(ret != EOK, "Could not get netgroup attributes");
-    fail_if(res->count != 1,
+    sss_ck_fail_if_msg(ret != EOK, "Could not get netgroup attributes");
+    sss_ck_fail_if_msg(res->count != 1,
             "Invalid number of entries, expected 1, got %d", res->count);
 
     attrval = ldb_msg_find_attr_as_string(res->msgs[0], SYSDB_DESCRIPTION, 0);
-    fail_if(strcmp(attrval, description),
+    sss_ck_fail_if_msg(strcmp(attrval, description),
             "Got bad attribute value for netgroup %s", netgrname);
     talloc_free(test_ctx);
 }
@@ -4435,15 +4435,15 @@ START_TEST (test_netgroup_base_dn)
     const char *strdn;
 
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     base_dn = sysdb_netgroup_base_dn(test_ctx, test_ctx->domain);
-    fail_if(base_dn == NULL, "Could not get netgroup base DN");
+    sss_ck_fail_if_msg(base_dn == NULL, "Could not get netgroup base DN");
 
     strdn = ldb_dn_get_linearized(base_dn);
-    fail_if(strdn == NULL, "Could not get string netgroup base DN");
+    sss_ck_fail_if_msg(strdn == NULL, "Could not get string netgroup base DN");
 
-    fail_if(strstr(strdn, SYSDB_NETGROUP_CONTAINER) != strdn,
+    sss_ck_fail_if_msg(strstr(strdn, SYSDB_NETGROUP_CONTAINER) != strdn,
             "Malformed netgroup baseDN");
 }
 END_TEST
@@ -4533,37 +4533,37 @@ START_TEST (test_sysdb_netgr_to_entries)
     size_t netgroup_count;
 
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     ret = store_netgr(test_ctx, "simple_netgroup", &simple_netgroup);
-    fail_if(ret != EOK, "Could not store the netgr");
+    sss_ck_fail_if_msg(ret != EOK, "Could not store the netgr");
 
     ret = sysdb_getnetgr(test_ctx, test_ctx->domain, "simple_netgroup", &res);
-    fail_unless(ret == EOK, "sysdb_getnetgr error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_getnetgr error [%d][%s]",
                             ret, strerror(ret));
-    fail_unless(res->count == 1, "Received [%d] responses",
+    ck_assert_msg(res->count == 1, "Received [%d] responses",
                                  res->count);
     ret = sysdb_netgr_to_entries(test_ctx, res, &entries, &netgroup_count);
-    fail_unless(ret == EOK, "sysdb_netgr_to_entries error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_netgr_to_entries error [%d][%s]",
                             ret, strerror(ret));
-    fail_unless(netgroup_count == 1, "Received [%zd] triples", netgroup_count);
+    ck_assert_msg(netgroup_count == 1, "Received [%zd] triples", netgroup_count);
     bret = sysdb_netgr_ctx_cmp(entries[0], &simple_netgroup);
-    fail_unless(bret == true, "Netgroup triples do not match");
+    ck_assert_msg(bret == true, "Netgroup triples do not match");
 
     ret = store_netgr(test_ctx, "ws_netgroup", &ws_netgroup);
-    fail_if(ret != EOK, "Could not store the netgr");
+    sss_ck_fail_if_msg(ret != EOK, "Could not store the netgr");
 
     ret = sysdb_getnetgr(test_ctx, test_ctx->domain, "ws_netgroup", &res);
-    fail_unless(ret == EOK, "sysdb_getnetgr error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_getnetgr error [%d][%s]",
                             ret, strerror(ret));
-    fail_unless(res->count == 1, "Received [%d] responses",
+    ck_assert_msg(res->count == 1, "Received [%d] responses",
                                  res->count);
     ret = sysdb_netgr_to_entries(test_ctx, res, &entries, &netgroup_count);
-    fail_unless(ret == EOK, "sysdb_netgr_to_entries error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_netgr_to_entries error [%d][%s]",
                             ret, strerror(ret));
-    fail_unless(netgroup_count == 1, "Received [%zd] triples", netgroup_count);
+    ck_assert_msg(netgroup_count == 1, "Received [%zd] triples", netgroup_count);
     bret = sysdb_netgr_ctx_cmp(entries[0], &simple_netgroup);
-    fail_unless(bret == true, "Netgroup triples do not match");
+    ck_assert_msg(bret == true, "Netgroup triples do not match");
 }
 END_TEST
 
@@ -4589,7 +4589,7 @@ START_TEST(test_odd_characters)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
@@ -4598,31 +4598,31 @@ START_TEST(test_odd_characters)
                                                test_ctx->domain->name);
     odd_username = sss_create_internal_fqname(test_ctx, "*(odd)\\user,name",
                                               test_ctx->domain->name);
-    fail_if(odd_groupname == NULL, "sss_create_internal_fqname failed");
-    fail_if(odd_username == NULL, "sss_create_internal_fqname failed");
+    sss_ck_fail_if_msg(odd_groupname == NULL, "sss_create_internal_fqname failed");
+    sss_ck_fail_if_msg(odd_username == NULL, "sss_create_internal_fqname failed");
 
     /* ===== Groups ===== */
 
     /* Add */
     ret = sysdb_add_incomplete_group(test_ctx->domain, odd_groupname,
                                      20000, NULL, NULL, NULL, true, 0);
-    fail_unless(ret == EOK, "sysdb_add_incomplete_group error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_add_incomplete_group error [%d][%s]",
                             ret, strerror(ret));
 
     /* Retrieve */
     ret = sysdb_search_group_by_name(test_ctx, test_ctx->domain,
                                      odd_groupname, NULL, &msg);
-    fail_unless(ret == EOK, "sysdb_search_group_by_name error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_search_group_by_name error [%d][%s]",
                             ret, strerror(ret));
     talloc_zfree(msg);
 
     ret = sysdb_getgrnam(test_ctx, test_ctx->domain, odd_groupname, &res);
-    fail_unless(ret == EOK, "sysdb_getgrnam error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_getgrnam error [%d][%s]",
                             ret, strerror(ret));
-    fail_unless(res->count == 1, "Received [%d] responses",
+    ck_assert_msg(res->count == 1, "Received [%d] responses",
                                  res->count);
     received_group = ldb_msg_find_attr_as_string(res->msgs[0], SYSDB_NAME, NULL);
-    fail_unless(strcmp(received_group, odd_groupname) == 0,
+    ck_assert_msg(strcmp(received_group, odd_groupname) == 0,
                 "Expected [%s], got [%s]",
                 odd_groupname, received_group);
     talloc_free(res);
@@ -4635,17 +4635,17 @@ START_TEST(test_odd_characters)
                                odd_username,
                                10000, 10000,
                                "","","");
-    fail_unless(ret == EOK, "sysdb_add_basic_user error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_add_basic_user error [%d][%s]",
                             ret, strerror(ret));
 
     /* Retrieve */
     ret = sysdb_search_user_by_name(test_ctx,
                                     test_ctx->domain,
                                     odd_username, NULL, &msg);
-    fail_unless(ret == EOK, "sysdb_search_user_by_name error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_search_user_by_name error [%d][%s]",
                             ret, strerror(ret));
     val = ldb_dn_get_component_val(msg->dn, 0);
-    fail_unless(strcmp((char *)val->data, odd_username)==0,
+    ck_assert_msg(strcmp((char *)val->data, odd_username)==0,
                 "Expected [%s] got [%s]\n",
                 odd_username, (char *)val->data);
     talloc_zfree(msg);
@@ -4654,16 +4654,16 @@ START_TEST(test_odd_characters)
     ret = sysdb_add_group_member(test_ctx->domain,
                                  odd_groupname, odd_username,
                                  SYSDB_MEMBER_USER, false);
-    fail_unless(ret == EOK, "sysdb_add_group_member error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_add_group_member error [%d][%s]",
                             ret, strerror(ret));
 
     ret = sysdb_getpwnam(test_ctx, test_ctx->domain, odd_username, &res);
-    fail_unless(ret == EOK, "sysdb_getpwnam error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_getpwnam error [%d][%s]",
                             ret, strerror(ret));
-    fail_unless(res->count == 1, "Received [%d] responses",
+    ck_assert_msg(res->count == 1, "Received [%d] responses",
                                  res->count);
     received_user = ldb_msg_find_attr_as_string(res->msgs[0], SYSDB_NAME, NULL);
-    fail_unless(strcmp(received_user, odd_username) == 0,
+    ck_assert_msg(strcmp(received_user, odd_username) == 0,
                 "Expected [%s], got [%s]",
                 odd_username, received_user);
     talloc_zfree(res);
@@ -4671,23 +4671,23 @@ START_TEST(test_odd_characters)
     /* Attributes */
     ret = sysdb_get_user_attr(test_ctx, test_ctx->domain, odd_username,
                               user_attrs, &res);
-    fail_unless(ret == EOK, "sysdb_get_user_attr error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_get_user_attr error [%d][%s]",
                             ret, strerror(ret));
     talloc_free(res);
 
     /* Delete User */
     ret = sysdb_delete_user(test_ctx->domain, odd_username, 10000);
-    fail_unless(ret == EOK, "sysdb_delete_user error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_delete_user error [%d][%s]",
                             ret, strerror(ret));
 
     /* Delete non existing User */
     ret = sysdb_delete_user(test_ctx->domain, odd_username, 10000);
-    fail_unless(ret == ENOENT, "sysdb_delete_user error [%d][%s]",
+    ck_assert_msg(ret == ENOENT, "sysdb_delete_user error [%d][%s]",
                                ret, strerror(ret));
 
     /* Delete Group */
     ret = sysdb_delete_group(test_ctx->domain, odd_groupname, 20000);
-    fail_unless(ret == EOK, "sysdb_delete_group error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_delete_group error [%d][%s]",
                             ret, strerror(ret));
 
     /* Add */
@@ -4697,12 +4697,12 @@ START_TEST(test_odd_characters)
                          "","","",
                          odd_username_orig_dn,
                          NULL, 5400, 0);
-    fail_unless(ret == EOK, "sysdb_add_user error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_add_user error [%d][%s]",
                             ret, strerror(ret));
 
     /* Delete User */
     ret = sysdb_delete_user(test_ctx->domain, odd_username, 10000);
-    fail_unless(ret == EOK, "sysdb_delete_user error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_delete_user error [%d][%s]",
                             ret, strerror(ret));
 
     /* ===== Netgroups ===== */
@@ -4710,27 +4710,27 @@ START_TEST(test_odd_characters)
     ret = sysdb_add_netgroup(test_ctx->domain,
                              odd_netgroupname, "No description",
                              NULL, NULL, 30, 0);
-    fail_unless(ret == EOK, "sysdb_add_netgroup error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_add_netgroup error [%d][%s]",
                             ret, strerror(ret));
 
     /* Retrieve */
     ret = sysdb_getnetgr(test_ctx, test_ctx->domain, odd_netgroupname, &res);
-    fail_unless(ret == EOK, "sysdb_getnetgr error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_getnetgr error [%d][%s]",
                             ret, strerror(ret));
-    fail_unless(res->count == 1, "Received [%d] responses",
+    ck_assert_msg(res->count == 1, "Received [%d] responses",
                                  res->count);
     talloc_zfree(res);
 
     ret = sysdb_get_netgroup_attr(test_ctx, test_ctx->domain,
                                   odd_netgroupname, netgr_attrs, &res);
-    fail_unless(ret == EOK, "sysdb_get_netgroup_attr error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_get_netgroup_attr error [%d][%s]",
                             ret, strerror(ret));
-    fail_unless(res->count == 1, "Received [%d] responses",
+    ck_assert_msg(res->count == 1, "Received [%d] responses",
                                  res->count);
 
     /* Parse */
     ret = sysdb_netgr_to_entries(test_ctx, res, &entries, &netgroup_count);
-    fail_unless(ret == EOK, "sysdb_netgr_to_entries error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_netgr_to_entries error [%d][%s]",
                             ret, strerror(ret));
 
     talloc_zfree(res);
@@ -4752,7 +4752,7 @@ START_TEST(test_SSS_LDB_SEARCH)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
@@ -4760,22 +4760,22 @@ START_TEST(test_SSS_LDB_SEARCH)
 
     groupname = test_asprintf_fqname(test_ctx, test_ctx->domain,
                                      "test_group");
-    fail_if(groupname == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(groupname == NULL, "Failed to allocate memory");
     groupname_neg = test_asprintf_fqname(test_ctx, test_ctx->domain,
                                          "non_existing_test_group");
-    fail_if(groupname_neg == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(groupname_neg == NULL, "Failed to allocate memory");
 
     group_dn = sysdb_group_dn(test_ctx, test_ctx->domain, groupname);
-    fail_if(group_dn == NULL, "sysdb_group_dn failed");
+    sss_ck_fail_if_msg(group_dn == NULL, "sysdb_group_dn failed");
 
     nonexist_dn = sysdb_group_dn(test_ctx, test_ctx->domain,
                                  groupname_neg);
-    fail_if(nonexist_dn == NULL, "sysdb_group_dn failed");
+    sss_ck_fail_if_msg(nonexist_dn == NULL, "sysdb_group_dn failed");
 
     /* Add */
     ret = sysdb_add_incomplete_group(test_ctx->domain, groupname,
                                      20000, NULL, NULL, NULL, true, 0);
-    fail_unless(ret == EOK, "sysdb_add_incomplete_group error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_add_incomplete_group error [%d][%s]",
                 ret, strerror(ret));
 
     /* Retrieve */
@@ -4784,15 +4784,15 @@ START_TEST(test_SSS_LDB_SEARCH)
     SSS_LDB_SEARCH(ret, test_ctx->sysdb->ldb, test_ctx, &res, group_dn,
                    LDB_SCOPE_BASE, NULL, NULL);
 
-    fail_unless(ret == EOK, "SSS_LDB_SEARCH error [%d][%s]",
+    ck_assert_msg(ret == EOK, "SSS_LDB_SEARCH error [%d][%s]",
                 ret, strerror(ret));
 
-    fail_unless(res->count == 1, "Received [%d] responses",
+    ck_assert_msg(res->count == 1, "Received [%d] responses",
                                  res->count);
 
     received_group = ldb_msg_find_attr_as_string(res->msgs[0], SYSDB_NAME,
                                                  NULL);
-    fail_unless(strcmp(received_group, groupname) == 0,
+    ck_assert_msg(strcmp(received_group, groupname) == 0,
                 "Expected [%s], got [%s]", groupname, received_group);
 
     talloc_zfree(res);
@@ -4801,7 +4801,7 @@ START_TEST(test_SSS_LDB_SEARCH)
     SSS_LDB_SEARCH(ret, test_ctx->sysdb->ldb, test_ctx, &res, group_dn,
                    LDB_SCOPE_BASE, NULL, SYSDB_GC);
 
-    fail_unless(ret == EOK, "SSS_LDB_SEARCH error [%d][%s]",
+    ck_assert_msg(ret == EOK, "SSS_LDB_SEARCH error [%d][%s]",
                 ret, strerror(ret));
     talloc_zfree(res);
 
@@ -4810,7 +4810,7 @@ START_TEST(test_SSS_LDB_SEARCH)
                    LDB_SCOPE_BASE, NULL,
                    "objectClass=nonExistingObjectClass");
 
-    fail_unless(ret == ENOENT, "sss_ldb_search error [%d][%s]",
+    ck_assert_msg(ret == ENOENT, "sss_ldb_search error [%d][%s]",
                 ret, strerror(ret));
     talloc_zfree(res);
 
@@ -4818,7 +4818,7 @@ START_TEST(test_SSS_LDB_SEARCH)
     SSS_LDB_SEARCH(ret, test_ctx->sysdb->ldb, test_ctx, &res, nonexist_dn,
                    LDB_SCOPE_BASE, NULL, NULL);
 
-    fail_unless(ret == ENOENT, "SSS_LDB_SEARCH error [%d][%s]",
+    ck_assert_msg(ret == ENOENT, "SSS_LDB_SEARCH error [%d][%s]",
                 ret, strerror(ret));
     talloc_zfree(res);
 
@@ -4826,7 +4826,7 @@ START_TEST(test_SSS_LDB_SEARCH)
     talloc_zfree(group_dn);
     talloc_zfree(groupname);
     talloc_zfree(groupname_neg);
-    fail_unless(check_leaks_pop(test_ctx) == true, "Memory leak");
+    ck_assert_msg(check_leaks_pop(test_ctx) == true, "Memory leak");
 }
 END_TEST
 
@@ -4851,23 +4851,23 @@ void services_check_match(struct sysdb_test_ctx *test_ctx,
         /* Look up the service by name */
         ret = sysdb_getservbyname(test_ctx, test_ctx->domain, primary_name,
                                   NULL, &res);
-        fail_if(ret != EOK, "sysdb_getservbyname error [%s]\n",
+        sss_ck_fail_if_msg(ret != EOK, "sysdb_getservbyname error [%s]\n",
                              strerror(ret));
     } else {
         /* Look up the newly-added service by port */
         ret = sysdb_getservbyport(test_ctx, test_ctx->domain, port, NULL,
                                   &res);
-        fail_if(ret != EOK, "sysdb_getservbyport error [%s]\n",
+        sss_ck_fail_if_msg(ret != EOK, "sysdb_getservbyport error [%s]\n",
                              strerror(ret));
     }
-    fail_if(res == NULL, "ENOMEM");
+    sss_ck_fail_if_msg(res == NULL, "ENOMEM");
     ck_assert_int_eq(res->count, 1);
 
     /* Make sure the returned entry matches */
     msg = res->msgs[0];
     ret_name = ldb_msg_find_attr_as_string(msg, SYSDB_NAME, NULL);
-    fail_if(ret_name == NULL, "Cannot find attribute: " SYSDB_NAME);
-    fail_unless(strcmp(ret_name, primary_name) == 0,
+    sss_ck_fail_if_msg(ret_name == NULL, "Cannot find attribute: " SYSDB_NAME);
+    ck_assert_msg(strcmp(ret_name, primary_name) == 0,
                 "Wrong value returned for attribute: %s. got: %s expected: %s",
                 SYSDB_NAME, ret_name, primary_name);
 
@@ -4882,7 +4882,7 @@ void services_check_match(struct sysdb_test_ctx *test_ctx,
                 matched = true;
             }
         }
-        fail_if(!matched, "Unexpected value in LDB entry: [%s]",
+        sss_ck_fail_if_msg(!matched, "Unexpected value in LDB entry: [%s]",
                 (const char *)el->values[i].data);
     }
 
@@ -4894,7 +4894,7 @@ void services_check_match(struct sysdb_test_ctx *test_ctx,
                 matched = true;
             }
         }
-        fail_if(!matched, "Unexpected value in LDB entry: [%s]",
+        sss_ck_fail_if_msg(!matched, "Unexpected value in LDB entry: [%s]",
                 (const char *)el->values[i].data);
     }
 }
@@ -4920,41 +4920,41 @@ START_TEST(test_sysdb_add_services)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     primary_name = talloc_asprintf(test_ctx, "test_service");
-    fail_if(primary_name == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(primary_name == NULL, "Failed to allocate memory");
 
     aliases = talloc_array(test_ctx, const char *, 3);
-    fail_if(aliases == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(aliases == NULL, "Failed to allocate memory");
 
     aliases[0] = talloc_asprintf(aliases, "test_service_alias1");
-    fail_if(aliases[0] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(aliases[0] == NULL, "Failed to allocate memory");
 
     aliases[1] = talloc_asprintf(aliases, "test_service_alias2");
-    fail_if(aliases[1] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(aliases[1] == NULL, "Failed to allocate memory");
 
     aliases[2] = NULL;
 
     protocols = talloc_array(test_ctx, const char *, 3);
-    fail_if(protocols == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(protocols == NULL, "Failed to allocate memory");
 
     protocols[0] = talloc_asprintf(protocols, "tcp");
-    fail_if(protocols[0] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(protocols[0] == NULL, "Failed to allocate memory");
 
     protocols[1] = talloc_asprintf(protocols, "udp");
-    fail_if(protocols[1] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(protocols[1] == NULL, "Failed to allocate memory");
 
     protocols[2] = NULL;
 
     ret = sysdb_transaction_start(test_ctx->sysdb);
-    fail_if(ret != EOK, "[%s]", strerror(ret));
+    sss_ck_fail_if_msg(ret != EOK, "[%s]", strerror(ret));
 
     ret = sysdb_svc_add(NULL, test_ctx->domain,
                         primary_name, port,
                         aliases, protocols,
                         NULL);
-    fail_unless(ret == EOK, "sysdb_svc_add error [%s]\n", strerror(ret));
+    ck_assert_msg(ret == EOK, "sysdb_svc_add error [%s]\n", strerror(ret));
 
     /* Search by name and make sure the results match */
     services_check_match_name(test_ctx,
@@ -4967,7 +4967,7 @@ START_TEST(test_sysdb_add_services)
                               aliases, protocols);
 
     ret = sysdb_transaction_commit(test_ctx->sysdb);
-    fail_if(ret != EOK, "[%s]", strerror(ret));
+    sss_ck_fail_if_msg(ret != EOK, "[%s]", strerror(ret));
 
     /* Clean up after ourselves (and test deleting by name)
      *
@@ -4976,7 +4976,7 @@ START_TEST(test_sysdb_add_services)
      * single transaction.
      */
     ret = sysdb_svc_delete(test_ctx->domain, primary_name, 0, NULL);
-    fail_if(ret != EOK, "[%s]", strerror(ret));
+    sss_ck_fail_if_msg(ret != EOK, "[%s]", strerror(ret));
 
     talloc_free(test_ctx);
 }
@@ -4995,39 +4995,39 @@ START_TEST(test_sysdb_store_services)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     aliases = talloc_array(test_ctx, const char *, 3);
-    fail_if(aliases == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(aliases == NULL, "Failed to allocate memory");
 
     aliases[0] = talloc_asprintf(aliases, "test_service_alias1");
-    fail_if(aliases[0] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(aliases[0] == NULL, "Failed to allocate memory");
 
     aliases[1] = talloc_asprintf(aliases, "test_service_alias2");
-    fail_if(aliases[1] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(aliases[1] == NULL, "Failed to allocate memory");
 
     aliases[2] = NULL;
 
     protocols = talloc_array(test_ctx, const char *, 3);
-    fail_if(protocols == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(protocols == NULL, "Failed to allocate memory");
 
     protocols[0] = talloc_asprintf(protocols, "tcp");
-    fail_if(protocols[0] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(protocols[0] == NULL, "Failed to allocate memory");
 
     protocols[1] = talloc_asprintf(protocols, "udp");
-    fail_if(protocols[1] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(protocols[1] == NULL, "Failed to allocate memory");
 
     protocols[2] = NULL;
 
     ret = sysdb_transaction_start(test_ctx->sysdb);
-    fail_if(ret != EOK, "[%s]", strerror(ret));
+    sss_ck_fail_if_msg(ret != EOK, "[%s]", strerror(ret));
 
     /* Store this group (which will add it) */
     ret = sysdb_store_service(test_ctx->domain,
                               primary_name, port,
                               aliases, protocols,
                               NULL, NULL, 1, 1);
-    fail_if(ret != EOK, "[%s]", strerror(ret));
+    sss_ck_fail_if_msg(ret != EOK, "[%s]", strerror(ret));
 
     /* Search by name and make sure the results match */
     services_check_match_name(test_ctx,
@@ -5044,7 +5044,7 @@ START_TEST(test_sysdb_store_services)
                               alt_primary_name, port,
                               aliases, protocols,
                               NULL, NULL, 1, 1);
-    fail_if (ret != EOK, "[%s]", strerror(ret));
+    sss_ck_fail_if_msg(ret != EOK, "[%s]", strerror(ret));
 
     services_check_match_name(test_ctx,
                               alt_primary_name, port,
@@ -5061,14 +5061,14 @@ START_TEST(test_sysdb_store_services)
                               primary_name, port,
                               aliases, protocols,
                               NULL, NULL, 1, 1);
-    fail_if (ret != EOK, "[%s]", strerror(ret));
+    sss_ck_fail_if_msg(ret != EOK, "[%s]", strerror(ret));
 
     /* Change the port number */
     ret = sysdb_store_service(test_ctx->domain,
                               primary_name, altport,
                               aliases, protocols,
                               NULL, NULL, 1, 1);
-    fail_if (ret != EOK, "[%s]", strerror(ret));
+    sss_ck_fail_if_msg(ret != EOK, "[%s]", strerror(ret));
 
     /* Search by name and make sure the results match */
     services_check_match_name(test_ctx,
@@ -5083,7 +5083,7 @@ START_TEST(test_sysdb_store_services)
     /* TODO: Test changing aliases and protocols */
 
     ret = sysdb_transaction_commit(test_ctx->sysdb);
-    fail_if(ret != EOK, "[%s]", strerror(ret));
+    sss_ck_fail_if_msg(ret != EOK, "[%s]", strerror(ret));
 
     /* Clean up after ourselves (and test deleting by port)
      *
@@ -5092,7 +5092,7 @@ START_TEST(test_sysdb_store_services)
      * single transaction.
      */
     ret = sysdb_svc_delete(test_ctx->domain, NULL, altport, NULL);
-    fail_if(ret != EOK, "[%s]", strerror(ret));
+    sss_ck_fail_if_msg(ret != EOK, "[%s]", strerror(ret));
 
     talloc_free(test_ctx);
 }
@@ -5115,38 +5115,38 @@ START_TEST(test_sysdb_svc_remove_alias)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     aliases = talloc_array(test_ctx, const char *, 3);
-    fail_if(aliases == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(aliases == NULL, "Failed to allocate memory");
 
     aliases[0] = talloc_asprintf(aliases, "remove_alias_alias1");
-    fail_if(aliases[0] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(aliases[0] == NULL, "Failed to allocate memory");
 
     aliases[1] = talloc_asprintf(aliases, "remove_alias_alias2");
-    fail_if(aliases[1] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(aliases[1] == NULL, "Failed to allocate memory");
 
     aliases[2] = NULL;
 
     protocols = talloc_array(test_ctx, const char *, 3);
-    fail_if(protocols == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(protocols == NULL, "Failed to allocate memory");
 
     protocols[0] = talloc_asprintf(protocols, "tcp");
-    fail_if(protocols[0] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(protocols[0] == NULL, "Failed to allocate memory");
 
     protocols[1] = talloc_asprintf(protocols, "udp");
-    fail_if(protocols[1] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(protocols[1] == NULL, "Failed to allocate memory");
 
     protocols[2] = NULL;
 
     ret = sysdb_transaction_start(test_ctx->sysdb);
-    fail_if(ret != EOK, "[%s]", strerror(ret));
+    sss_ck_fail_if_msg(ret != EOK, "[%s]", strerror(ret));
 
     ret = sysdb_svc_add(NULL, test_ctx->domain,
                         primary_name, port,
                         aliases, protocols,
                         NULL);
-    fail_unless(ret == EOK, "sysdb_svc_add error [%s]\n", strerror(ret));
+    ck_assert_msg(ret == EOK, "sysdb_svc_add error [%s]\n", strerror(ret));
 
     /* Search by name and make sure the results match */
     services_check_match_name(test_ctx,
@@ -5160,16 +5160,16 @@ START_TEST(test_sysdb_svc_remove_alias)
 
     /* Now remove an alias */
     dn = sysdb_svc_dn(test_ctx->sysdb, test_ctx, test_ctx->domain->name, primary_name);
-    fail_if (dn == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(dn == NULL, "Failed to allocate memory");
 
     ret = sysdb_svc_remove_alias(test_ctx->sysdb, dn, aliases[1]);
-    fail_if (ret != EOK, "[%s]", strerror(ret));
+    sss_ck_fail_if_msg(ret != EOK, "[%s]", strerror(ret));
 
     ret = sysdb_transaction_commit(test_ctx->sysdb);
-    fail_if(ret != EOK, "sysdb_transaction_commit failed with error: %d", ret);
+    sss_ck_fail_if_msg(ret != EOK, "sysdb_transaction_commit failed with error: %d", ret);
 
     ret = sysdb_transaction_start(test_ctx->sysdb);
-    fail_if(ret != EOK, "sysdb_transaction_start failed with error: %d", ret);
+    sss_ck_fail_if_msg(ret != EOK, "sysdb_transaction_start failed with error: %d", ret);
 
     /* Set aliases[1] to NULL to perform validation checks */
     aliases[1] = NULL;
@@ -5185,7 +5185,7 @@ START_TEST(test_sysdb_svc_remove_alias)
                               aliases, protocols);
 
     ret = sysdb_transaction_commit(test_ctx->sysdb);
-    fail_if(ret != EOK, "[%s]", strerror(ret));
+    sss_ck_fail_if_msg(ret != EOK, "[%s]", strerror(ret));
 
     talloc_free(test_ctx);
 }
@@ -5201,17 +5201,17 @@ START_TEST(test_sysdb_attrs_add_lc_name_alias)
     const char **list = NULL;
 
     ret = sysdb_attrs_add_lc_name_alias(NULL, NULL);
-    fail_unless(ret == EINVAL, "EINVAL not returned for NULL input");
+    ck_assert_msg(ret == EINVAL, "EINVAL not returned for NULL input");
 
     attrs = sysdb_new_attrs(NULL);
-    fail_unless(attrs != NULL, "sysdb_new_attrs failed");
+    ck_assert_msg(attrs != NULL, "sysdb_new_attrs failed");
 
     ret = sysdb_attrs_add_lc_name_alias(attrs, LC_NAME_ALIAS_TEST_VAL);
-    fail_unless(ret == EOK, "sysdb_attrs_add_lc_name_alias failed");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_lc_name_alias failed");
 
     ret = sysdb_attrs_get_string(attrs, SYSDB_NAME_ALIAS, &str);
-    fail_unless(ret == EOK, "sysdb_attrs_get_string failed");
-    fail_unless(strcmp(str, LC_NAME_ALIAS_CHECK_VAL) == 0,
+    ck_assert_msg(ret == EOK, "sysdb_attrs_get_string failed");
+    ck_assert_msg(strcmp(str, LC_NAME_ALIAS_CHECK_VAL) == 0,
                 "Unexpected value, expected [%s], got [%s]",
                 LC_NAME_ALIAS_CHECK_VAL, str);
 
@@ -5219,20 +5219,20 @@ START_TEST(test_sysdb_attrs_add_lc_name_alias)
      * purpose but the test should illustrate the different to
      * sysdb_attrs_add_lc_name_alias_safe(). */
     ret = sysdb_attrs_add_lc_name_alias(attrs, LC_NAME_ALIAS_TEST_VAL);
-    fail_unless(ret == EOK, "sysdb_attrs_add_lc_name_alias failed");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_lc_name_alias failed");
 
     ret = sysdb_attrs_get_string_array(attrs, SYSDB_NAME_ALIAS, attrs, &list);
-    fail_unless(ret == EOK, "sysdb_attrs_get_string_array failed");
-    fail_unless(list != NULL, "No list returned");
-    fail_unless(list[0] != NULL, "Missing first list element");
-    fail_unless(strcmp(list[0], LC_NAME_ALIAS_CHECK_VAL) == 0,
+    ck_assert_msg(ret == EOK, "sysdb_attrs_get_string_array failed");
+    ck_assert_msg(list != NULL, "No list returned");
+    ck_assert_msg(list[0] != NULL, "Missing first list element");
+    ck_assert_msg(strcmp(list[0], LC_NAME_ALIAS_CHECK_VAL) == 0,
                 "Unexpected value, expected [%s], got [%s]",
                 LC_NAME_ALIAS_CHECK_VAL, list[0]);
-    fail_unless(list[1] != NULL, "Missing second list element");
-    fail_unless(strcmp(list[1], LC_NAME_ALIAS_CHECK_VAL) == 0,
+    ck_assert_msg(list[1] != NULL, "Missing second list element");
+    ck_assert_msg(strcmp(list[1], LC_NAME_ALIAS_CHECK_VAL) == 0,
                 "Unexpected value, expected [%s], got [%s]",
                 LC_NAME_ALIAS_CHECK_VAL, list[1]);
-    fail_unless(list[2] == NULL, "Missing list terminator");
+    ck_assert_msg(list[2] == NULL, "Missing list terminator");
 
     talloc_free(attrs);
 }
@@ -5246,50 +5246,50 @@ START_TEST(test_sysdb_attrs_add_lc_name_alias_safe)
     const char **list = NULL;
 
     ret = sysdb_attrs_add_lc_name_alias_safe(NULL, NULL);
-    fail_unless(ret == EINVAL, "EINVAL not returned for NULL input");
+    ck_assert_msg(ret == EINVAL, "EINVAL not returned for NULL input");
 
     attrs = sysdb_new_attrs(NULL);
-    fail_unless(attrs != NULL, "sysdb_new_attrs failed");
+    ck_assert_msg(attrs != NULL, "sysdb_new_attrs failed");
 
     ret = sysdb_attrs_add_lc_name_alias_safe(attrs, LC_NAME_ALIAS_TEST_VAL);
-    fail_unless(ret == EOK, "sysdb_attrs_add_lc_name_alias failed");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_lc_name_alias failed");
 
     ret = sysdb_attrs_get_string(attrs, SYSDB_NAME_ALIAS, &str);
-    fail_unless(ret == EOK, "sysdb_attrs_get_string failed");
-    fail_unless(strcmp(str, LC_NAME_ALIAS_CHECK_VAL) == 0,
+    ck_assert_msg(ret == EOK, "sysdb_attrs_get_string failed");
+    ck_assert_msg(strcmp(str, LC_NAME_ALIAS_CHECK_VAL) == 0,
                 "Unexpected value, expected [%s], got [%s]",
                 LC_NAME_ALIAS_CHECK_VAL, str);
 
     /* Adding the same value a second time should be ignored */
     ret = sysdb_attrs_add_lc_name_alias_safe(attrs, LC_NAME_ALIAS_TEST_VAL);
-    fail_unless(ret == EOK, "sysdb_attrs_add_lc_name_alias failed");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_lc_name_alias failed");
 
     ret = sysdb_attrs_get_string_array(attrs, SYSDB_NAME_ALIAS, attrs, &list);
-    fail_unless(ret == EOK, "sysdb_attrs_get_string_array failed");
-    fail_unless(list != NULL, "No list returned");
-    fail_unless(list[0] != NULL, "Missing first list element");
-    fail_unless(strcmp(list[0], LC_NAME_ALIAS_CHECK_VAL) == 0,
+    ck_assert_msg(ret == EOK, "sysdb_attrs_get_string_array failed");
+    ck_assert_msg(list != NULL, "No list returned");
+    ck_assert_msg(list[0] != NULL, "Missing first list element");
+    ck_assert_msg(strcmp(list[0], LC_NAME_ALIAS_CHECK_VAL) == 0,
                 "Unexpected value, expected [%s], got [%s]",
                 LC_NAME_ALIAS_CHECK_VAL, list[0]);
-    fail_unless(list[1] == NULL, "Missing list terminator");
+    ck_assert_msg(list[1] == NULL, "Missing list terminator");
 
     /* Adding different value */
     ret = sysdb_attrs_add_lc_name_alias_safe(attrs,
                                              "2nd_" LC_NAME_ALIAS_TEST_VAL);
-    fail_unless(ret == EOK, "sysdb_attrs_add_lc_name_alias failed");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_lc_name_alias failed");
 
     ret = sysdb_attrs_get_string_array(attrs, SYSDB_NAME_ALIAS, attrs, &list);
-    fail_unless(ret == EOK, "sysdb_attrs_get_string_array failed");
-    fail_unless(list != NULL, "No list returned");
-    fail_unless(list[0] != NULL, "Missing first list element");
-    fail_unless(strcmp(list[0], LC_NAME_ALIAS_CHECK_VAL) == 0,
+    ck_assert_msg(ret == EOK, "sysdb_attrs_get_string_array failed");
+    ck_assert_msg(list != NULL, "No list returned");
+    ck_assert_msg(list[0] != NULL, "Missing first list element");
+    ck_assert_msg(strcmp(list[0], LC_NAME_ALIAS_CHECK_VAL) == 0,
                 "Unexpected value, expected [%s], got [%s]",
                 LC_NAME_ALIAS_CHECK_VAL, list[0]);
-    fail_unless(list[1] != NULL, "Missing first list element");
-    fail_unless(strcmp(list[1], "2nd_" LC_NAME_ALIAS_CHECK_VAL) == 0,
+    ck_assert_msg(list[1] != NULL, "Missing first list element");
+    ck_assert_msg(strcmp(list[1], "2nd_" LC_NAME_ALIAS_CHECK_VAL) == 0,
                 "Unexpected value, expected [%s], got [%s]",
                 "2nd_" LC_NAME_ALIAS_CHECK_VAL, list[1]);
-    fail_unless(list[2] == NULL, "Missing list terminator");
+    ck_assert_msg(list[2] == NULL, "Missing list terminator");
 
     talloc_free(attrs);
 }
@@ -5305,37 +5305,37 @@ START_TEST(test_sysdb_attrs_get_string_array)
     struct ldb_message_element *el = NULL;
 
     tmp_ctx = talloc_new(NULL);
-    fail_unless(tmp_ctx != NULL, "talloc_new failed");
+    ck_assert_msg(tmp_ctx != NULL, "talloc_new failed");
 
     attrs = sysdb_new_attrs(NULL);
-    fail_unless(attrs != NULL, "sysdb_new_attrs failed");
+    ck_assert_msg(attrs != NULL, "sysdb_new_attrs failed");
 
     ret = sysdb_attrs_add_string(attrs, attrname, "val1");
-    fail_unless(ret == EOK, "sysdb_attrs_add_string failed");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_string failed");
     ret = sysdb_attrs_add_string(attrs, attrname, "val2");
-    fail_unless(ret == EOK, "sysdb_attrs_add_string failed");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_string failed");
 
     ret = sysdb_attrs_get_el_ext(attrs, attrname, false, &el);
-    fail_unless(ret == EOK, "sysdb_attrs_get_el_ext failed");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_get_el_ext failed");
 
     list = sss_ldb_el_to_string_list(tmp_ctx, el);
-    fail_if(list == NULL, "sss_ldb_el_to_string_list failed");
+    sss_ck_fail_if_msg(list == NULL, "sss_ldb_el_to_string_list failed");
 
     ck_assert_str_eq(list[0], "val1");
     ck_assert_str_eq(list[1], "val2");
-    fail_unless(list[2] == NULL, "Expected terminated list");
+    ck_assert_msg(list[2] == NULL, "Expected terminated list");
 
     talloc_free(list);
 
     ret = sysdb_attrs_get_string_array(attrs, attrname, tmp_ctx, &list);
-    fail_unless(ret == EOK, "sysdb_attrs_get_string_array failed");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_get_string_array failed");
 
     /* This test relies on values keeping the same order. It is the case
      * with LDB, but if we ever switch from LDB, we need to amend the test
      */
     ck_assert_str_eq(list[0], "val1");
     ck_assert_str_eq(list[1], "val2");
-    fail_unless(list[2] == NULL, "Expected terminated list");
+    ck_assert_msg(list[2] == NULL, "Expected terminated list");
 
     talloc_free(tmp_ctx);
 }
@@ -5350,26 +5350,26 @@ START_TEST(test_sysdb_attrs_add_val)
                           sizeof(TEST_ATTR_VALUE) - 1};
 
     tmp_ctx = talloc_new(NULL);
-    fail_unless(tmp_ctx != NULL, "talloc_new failed");
+    ck_assert_msg(tmp_ctx != NULL, "talloc_new failed");
 
     attrs = sysdb_new_attrs(NULL);
-    fail_unless(attrs != NULL, "sysdb_new_attrs failed");
+    ck_assert_msg(attrs != NULL, "sysdb_new_attrs failed");
 
     ret = sysdb_attrs_add_val(attrs, TEST_ATTR_NAME, &val);
-    fail_unless(ret == EOK, "sysdb_attrs_add_val failed.");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_val failed.");
 
     ret = sysdb_attrs_add_val(attrs, TEST_ATTR_NAME, &val);
-    fail_unless(ret == EOK, "sysdb_attrs_add_val failed.");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_val failed.");
 
-    fail_unless(attrs->num == 1, "Unexpected number of attributes.");
-    fail_unless(strcmp(attrs->a[0].name, TEST_ATTR_NAME) == 0,
+    ck_assert_msg(attrs->num == 1, "Unexpected number of attributes.");
+    ck_assert_msg(strcmp(attrs->a[0].name, TEST_ATTR_NAME) == 0,
                 "Unexpected attribute name.");
-    fail_unless(attrs->a[0].num_values == 2,
+    ck_assert_msg(attrs->a[0].num_values == 2,
                 "Unexpected number of attribute values.");
-    fail_unless(ldb_val_string_cmp(&attrs->a[0].values[0],
+    ck_assert_msg(ldb_val_string_cmp(&attrs->a[0].values[0],
                                    TEST_ATTR_VALUE) == 0,
                 "Unexpected attribute value.");
-    fail_unless(ldb_val_string_cmp(&attrs->a[0].values[1],
+    ck_assert_msg(ldb_val_string_cmp(&attrs->a[0].values[1],
                                    TEST_ATTR_VALUE) == 0,
                 "Unexpected attribute value.");
 
@@ -5386,23 +5386,23 @@ START_TEST(test_sysdb_attrs_add_val_safe)
                           sizeof(TEST_ATTR_VALUE) - 1};
 
     tmp_ctx = talloc_new(NULL);
-    fail_unless(tmp_ctx != NULL, "talloc_new failed");
+    ck_assert_msg(tmp_ctx != NULL, "talloc_new failed");
 
     attrs = sysdb_new_attrs(NULL);
-    fail_unless(attrs != NULL, "sysdb_new_attrs failed");
+    ck_assert_msg(attrs != NULL, "sysdb_new_attrs failed");
 
     ret = sysdb_attrs_add_val(attrs, TEST_ATTR_NAME, &val);
-    fail_unless(ret == EOK, "sysdb_attrs_add_val failed.");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_val failed.");
 
     ret = sysdb_attrs_add_val_safe(attrs, TEST_ATTR_NAME, &val);
-    fail_unless(ret == EOK, "sysdb_attrs_add_val failed.");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_val failed.");
 
-    fail_unless(attrs->num == 1, "Unexpected number of attributes.");
-    fail_unless(strcmp(attrs->a[0].name, TEST_ATTR_NAME) == 0,
+    ck_assert_msg(attrs->num == 1, "Unexpected number of attributes.");
+    ck_assert_msg(strcmp(attrs->a[0].name, TEST_ATTR_NAME) == 0,
                 "Unexpected attribute name.");
-    fail_unless(attrs->a[0].num_values == 1,
+    ck_assert_msg(attrs->a[0].num_values == 1,
                 "Unexpected number of attribute values.");
-    fail_unless(ldb_val_string_cmp(&attrs->a[0].values[0],
+    ck_assert_msg(ldb_val_string_cmp(&attrs->a[0].values[0],
                                    TEST_ATTR_VALUE) == 0,
                 "Unexpected attribute value.");
 
@@ -5417,23 +5417,23 @@ START_TEST(test_sysdb_attrs_add_string_safe)
     TALLOC_CTX *tmp_ctx;
 
     tmp_ctx = talloc_new(NULL);
-    fail_unless(tmp_ctx != NULL, "talloc_new failed");
+    ck_assert_msg(tmp_ctx != NULL, "talloc_new failed");
 
     attrs = sysdb_new_attrs(NULL);
-    fail_unless(attrs != NULL, "sysdb_new_attrs failed");
+    ck_assert_msg(attrs != NULL, "sysdb_new_attrs failed");
 
     ret = sysdb_attrs_add_string(attrs, TEST_ATTR_NAME, TEST_ATTR_VALUE);
-    fail_unless(ret == EOK, "sysdb_attrs_add_val failed.");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_val failed.");
 
     ret = sysdb_attrs_add_string_safe(attrs, TEST_ATTR_NAME, TEST_ATTR_VALUE);
-    fail_unless(ret == EOK, "sysdb_attrs_add_val failed.");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_val failed.");
 
-    fail_unless(attrs->num == 1, "Unexpected number of attributes.");
-    fail_unless(strcmp(attrs->a[0].name, TEST_ATTR_NAME) == 0,
+    ck_assert_msg(attrs->num == 1, "Unexpected number of attributes.");
+    ck_assert_msg(strcmp(attrs->a[0].name, TEST_ATTR_NAME) == 0,
                 "Unexpected attribute name.");
-    fail_unless(attrs->a[0].num_values == 1,
+    ck_assert_msg(attrs->a[0].num_values == 1,
                 "Unexpected number of attribute values.");
-    fail_unless(ldb_val_string_cmp(&attrs->a[0].values[0],
+    ck_assert_msg(ldb_val_string_cmp(&attrs->a[0].values[0],
                                    TEST_ATTR_VALUE) == 0,
                 "Unexpected attribute value.");
 
@@ -5451,77 +5451,77 @@ START_TEST(test_sysdb_attrs_copy)
     const char **array;
 
     ret = sysdb_attrs_copy(NULL, NULL);
-    fail_unless(ret == EINVAL, "Wrong return code");
+    ck_assert_msg(ret == EINVAL, "Wrong return code");
 
     tmp_ctx = talloc_new(NULL);
-    fail_unless(tmp_ctx != NULL, "talloc_new failed");
+    ck_assert_msg(tmp_ctx != NULL, "talloc_new failed");
 
     src = sysdb_new_attrs(tmp_ctx);
-    fail_unless(src != NULL, "sysdb_new_attrs failed");
+    ck_assert_msg(src != NULL, "sysdb_new_attrs failed");
 
     ret = sysdb_attrs_copy(src, NULL);
-    fail_unless(ret == EINVAL, "Wrong return code");
+    ck_assert_msg(ret == EINVAL, "Wrong return code");
 
     dst = sysdb_new_attrs(tmp_ctx);
-    fail_unless(dst != NULL, "sysdb_new_attrs failed");
+    ck_assert_msg(dst != NULL, "sysdb_new_attrs failed");
 
     ret = sysdb_attrs_copy(NULL, dst);
-    fail_unless(ret == EINVAL, "Wrong return code");
+    ck_assert_msg(ret == EINVAL, "Wrong return code");
 
     ret = sysdb_attrs_copy(src, dst);
-    fail_unless(ret == EOK, "sysdb_attrs_copy failed");
-    fail_unless(dst->num == 0, "Wrong number of elements");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_copy failed");
+    ck_assert_msg(dst->num == 0, "Wrong number of elements");
 
     ret = sysdb_attrs_add_string(src, TEST_ATTR_NAME, TEST_ATTR_VALUE);
-    fail_unless(ret == EOK, "sysdb_attrs_add_val failed.");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_val failed.");
 
     ret = sysdb_attrs_copy(src, dst);
-    fail_unless(ret == EOK, "sysdb_attrs_copy failed");
-    fail_unless(dst->num == 1, "Wrong number of elements");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_copy failed");
+    ck_assert_msg(dst->num == 1, "Wrong number of elements");
     ret = sysdb_attrs_get_string(dst, TEST_ATTR_NAME, &val);
-    fail_unless(ret == EOK, "sysdb_attrs_get_string failed.\n");
-    fail_unless(strcmp(val, TEST_ATTR_VALUE) == 0, "Wrong attribute value.");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_get_string failed.\n");
+    ck_assert_msg(strcmp(val, TEST_ATTR_VALUE) == 0, "Wrong attribute value.");
 
     /* Make sure the same entry is not copied twice */
     ret = sysdb_attrs_copy(src, dst);
-    fail_unless(ret == EOK, "sysdb_attrs_copy failed");
-    fail_unless(dst->num == 1, "Wrong number of elements");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_copy failed");
+    ck_assert_msg(dst->num == 1, "Wrong number of elements");
     ret = sysdb_attrs_get_string(dst, TEST_ATTR_NAME, &val);
-    fail_unless(ret == EOK, "sysdb_attrs_get_string failed.\n");
-    fail_unless(strcmp(val, TEST_ATTR_VALUE) == 0, "Wrong attribute value.");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_get_string failed.\n");
+    ck_assert_msg(strcmp(val, TEST_ATTR_VALUE) == 0, "Wrong attribute value.");
 
     /* Add new value to existing attribute */
     ret = sysdb_attrs_add_string(src, TEST_ATTR_NAME, TEST_ATTR_VALUE"_2nd");
-    fail_unless(ret == EOK, "sysdb_attrs_add_val failed.");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_val failed.");
 
     ret = sysdb_attrs_copy(src, dst);
-    fail_unless(ret == EOK, "sysdb_attrs_copy failed");
-    fail_unless(dst->num == 1, "Wrong number of elements");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_copy failed");
+    ck_assert_msg(dst->num == 1, "Wrong number of elements");
     ret = sysdb_attrs_get_string_array(dst, TEST_ATTR_NAME, tmp_ctx, &array);
-    fail_unless(ret == EOK, "sysdb_attrs_get_string_array failed.\n");
-    fail_unless(strcmp(array[0], TEST_ATTR_VALUE) == 0,
+    ck_assert_msg(ret == EOK, "sysdb_attrs_get_string_array failed.\n");
+    ck_assert_msg(strcmp(array[0], TEST_ATTR_VALUE) == 0,
                        "Wrong attribute value.");
-    fail_unless(strcmp(array[1], TEST_ATTR_VALUE"_2nd") == 0,
+    ck_assert_msg(strcmp(array[1], TEST_ATTR_VALUE"_2nd") == 0,
                        "Wrong attribute value.");
-    fail_unless(array[2] == NULL, "Wrong number of values.");
+    ck_assert_msg(array[2] == NULL, "Wrong number of values.");
 
     /* Add new attribute */
     ret = sysdb_attrs_add_string(src, TEST_ATTR_NAME"_2nd", TEST_ATTR_VALUE);
-    fail_unless(ret == EOK, "sysdb_attrs_add_val failed.");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_val failed.");
 
     ret = sysdb_attrs_copy(src, dst);
-    fail_unless(ret == EOK, "sysdb_attrs_copy failed");
-    fail_unless(dst->num == 2, "Wrong number of elements");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_copy failed");
+    ck_assert_msg(dst->num == 2, "Wrong number of elements");
     ret = sysdb_attrs_get_string_array(dst, TEST_ATTR_NAME, tmp_ctx, &array);
-    fail_unless(ret == EOK, "sysdb_attrs_get_string_array failed.\n");
-    fail_unless(strcmp(array[0], TEST_ATTR_VALUE) == 0,
+    ck_assert_msg(ret == EOK, "sysdb_attrs_get_string_array failed.\n");
+    ck_assert_msg(strcmp(array[0], TEST_ATTR_VALUE) == 0,
                        "Wrong attribute value.");
-    fail_unless(strcmp(array[1], TEST_ATTR_VALUE"_2nd") == 0,
+    ck_assert_msg(strcmp(array[1], TEST_ATTR_VALUE"_2nd") == 0,
                        "Wrong attribute value.");
-    fail_unless(array[2] == NULL, "Wrong number of values.");
+    ck_assert_msg(array[2] == NULL, "Wrong number of values.");
     ret = sysdb_attrs_get_string(dst, TEST_ATTR_NAME"_2nd", &val);
-    fail_unless(ret == EOK, "sysdb_attrs_get_string failed.\n");
-    fail_unless(strcmp(val, TEST_ATTR_VALUE) == 0, "Wrong attribute value.");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_get_string failed.\n");
+    ck_assert_msg(strcmp(val, TEST_ATTR_VALUE) == 0, "Wrong attribute value.");
 
     talloc_free(tmp_ctx);
 }
@@ -5541,53 +5541,53 @@ START_TEST (test_sysdb_search_return_ENOENT)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
     check_leaks_push(test_ctx);
 
     /* id mapping */
     ret = sysdb_idmap_get_mappings(test_ctx, test_ctx->domain, &res);
-    fail_unless(ret == ENOENT, "sysdb_idmap_get_mappings error [%d][%s].",
+    ck_assert_msg(ret == ENOENT, "sysdb_idmap_get_mappings error [%d][%s].",
                 ret, strerror(ret));
     talloc_zfree(res);
 
     data = test_data_new_user(test_ctx, 1234);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
     data->sid_str = "S-5-4-3-2-1";
 
     /* Search user */
     ret = sysdb_search_user_by_name(test_ctx, test_ctx->domain,
                                     data->username,
                                     NULL, &msg);
-    fail_unless(ret == ENOENT, "sysdb_search_user_by_name error [%d][%s].",
+    ck_assert_msg(ret == ENOENT, "sysdb_search_user_by_name error [%d][%s].",
                                ret, strerror(ret));
     talloc_zfree(msg);
 
     ret = sysdb_get_real_name(test_ctx, test_ctx->domain,
                               data->username, &str);
-    fail_unless(ret == ENOENT, "sysdb_get_real_name error [%d][%s].",
+    ck_assert_msg(ret == ENOENT, "sysdb_get_real_name error [%d][%s].",
                                ret, strerror(ret));
     talloc_zfree(str);
 
     ret = sysdb_search_user_by_uid(test_ctx, test_ctx->domain,
                                    data->uid, NULL, &msg);
-    fail_unless(ret == ENOENT, "sysdb_search_user_by_uid error [%d][%s].",
+    ck_assert_msg(ret == ENOENT, "sysdb_search_user_by_uid error [%d][%s].",
                                ret, strerror(ret));
     talloc_zfree(msg);
 
     ret = sysdb_search_user_by_sid_str(test_ctx, test_ctx->domain,
                                        data->sid_str, NULL, &msg);
-    fail_unless(ret == ENOENT, "sysdb_search_user_by_sid_str failed with "
+    ck_assert_msg(ret == ENOENT, "sysdb_search_user_by_sid_str failed with "
                                "[%d][%s].", ret, strerror(ret));
 
     /* General search */
     user_dn = sysdb_user_dn(test_ctx, test_ctx->domain,
                             data->username);
-    fail_if(user_dn == NULL, "sysdb_user_dn failed");
+    sss_ck_fail_if_msg(user_dn == NULL, "sysdb_user_dn failed");
 
     ret = sysdb_asq_search(test_ctx, test_ctx->domain,
                            user_dn, NULL, "memberof", NULL,
                            &count, &msgs);
-    fail_unless(ret == ENOENT, "sysdb_asq_search failed: %d, %s",
+    ck_assert_msg(ret == ENOENT, "sysdb_asq_search failed: %d, %s",
                                ret, strerror(ret));
     talloc_zfree(msgs);
 
@@ -5595,7 +5595,7 @@ START_TEST (test_sysdb_search_return_ENOENT)
                              user_dn, LDB_SCOPE_SUBTREE,
                              SYSDB_UC, NULL,
                              &count, &msgs);
-    fail_unless(ret == ENOENT, "sysdb_search_entry failed: %d, %s",
+    ck_assert_msg(ret == ENOENT, "sysdb_search_entry failed: %d, %s",
                                ret, strerror(ret));
     talloc_zfree(msgs);
     talloc_zfree(user_dn);
@@ -5603,11 +5603,11 @@ START_TEST (test_sysdb_search_return_ENOENT)
     /* SSS_LDB_SEARCH */
     user_dn = sysdb_user_dn(test_ctx, test_ctx->domain,
                             data->username);
-    fail_if(user_dn == NULL, "sysdb_user_dn failed");
+    sss_ck_fail_if_msg(user_dn == NULL, "sysdb_user_dn failed");
     SSS_LDB_SEARCH(ret, test_ctx->sysdb->ldb, test_ctx, &res, user_dn,
                    LDB_SCOPE_BASE, NULL, SYSDB_UC);
 
-    fail_unless(ret == ENOENT, "SSS_LDB_SEARCH failed: %d, %s",
+    ck_assert_msg(ret == ENOENT, "SSS_LDB_SEARCH failed: %d, %s",
                                ret, strerror(ret));
 
     talloc_zfree(res);
@@ -5616,24 +5616,24 @@ START_TEST (test_sysdb_search_return_ENOENT)
     /* Search group */
     talloc_zfree(data);
     data = test_data_new_group(test_ctx, 1234);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
     data->sid_str = "S-5-4-3-2-1";
 
     ret = sysdb_search_group_by_name(test_ctx, test_ctx->domain,
                                      data->groupname, NULL, &msg);
-    fail_unless(ret == ENOENT, "sysdb_search_group_by_name error [%d][%s].",
+    ck_assert_msg(ret == ENOENT, "sysdb_search_group_by_name error [%d][%s].",
                                ret, strerror(ret));
     talloc_zfree(msg);
 
     ret = sysdb_search_group_by_gid(test_ctx, test_ctx->domain,
                                     data->gid, NULL, &msg);
-    fail_unless(ret == ENOENT, "sysdb_search_group_by_gid error [%d][%s].",
+    ck_assert_msg(ret == ENOENT, "sysdb_search_group_by_gid error [%d][%s].",
                                ret, strerror(ret));
     talloc_zfree(msg);
 
     ret = sysdb_search_group_by_sid_str(test_ctx, test_ctx->domain,
                                         data->sid_str, NULL, &msg);
-    fail_unless(ret == ENOENT, "sysdb_search_group_by_sid_str failed with "
+    ck_assert_msg(ret == ENOENT, "sysdb_search_group_by_sid_str failed with "
                                "[%d][%s].", ret, strerror(ret));
     talloc_zfree(msg);
     talloc_zfree(data);
@@ -5641,20 +5641,20 @@ START_TEST (test_sysdb_search_return_ENOENT)
     /* Search netgroup */
     ret = sysdb_search_netgroup_by_name(test_ctx, test_ctx->domain,
                                         "nonexisting_netgroup", NULL, &msg);
-    fail_unless(ret == ENOENT, "sysdb_search_netgroup_by_name error [%d][%s].",
+    ck_assert_msg(ret == ENOENT, "sysdb_search_netgroup_by_name error [%d][%s].",
                                ret, strerror(ret));
     talloc_zfree(msg);
 
     ret = sysdb_getnetgr(test_ctx, test_ctx->domain, "nonexisting_netgroup",
                          &res);
-    fail_unless(ret == ENOENT, "sysdb_getnetgr error [%d][%s]",
+    ck_assert_msg(ret == ENOENT, "sysdb_getnetgr error [%d][%s]",
                 ret, strerror(ret));
     talloc_zfree(res);
 
     /* Search object */
     ret = sysdb_search_object_by_sid(test_ctx, test_ctx->domain,
                                      "S-5-4-3-2-1", NULL, &res);
-    fail_unless(ret == ENOENT, "sysdb_search_object_by_sid failed with "
+    ck_assert_msg(ret == ENOENT, "sysdb_search_object_by_sid failed with "
                                "[%d][%s].", ret, strerror(ret));
     talloc_zfree(res);
 
@@ -5662,21 +5662,21 @@ START_TEST (test_sysdb_search_return_ENOENT)
     ret = sysdb_search_users(test_ctx, test_ctx->domain,
                              "("SYSDB_SHELL"=/bin/nologin)", NULL,
                              &count, &msgs);
-    fail_unless(ret == ENOENT, "sysdb_search_users failed: %d, %s",
+    ck_assert_msg(ret == ENOENT, "sysdb_search_users failed: %d, %s",
                                ret, strerror(ret));
     talloc_zfree(msgs);
 
     ret = sysdb_search_groups(test_ctx, test_ctx->domain,
                               "("SYSDB_GIDNUM"=1234)", NULL,
                               &count, &msgs);
-    fail_unless(ret == ENOENT, "sysdb_search_groups failed: %d, %s",
+    ck_assert_msg(ret == ENOENT, "sysdb_search_groups failed: %d, %s",
                                ret, strerror(ret));
     talloc_zfree(msgs);
 
     ret = sysdb_search_netgroups(test_ctx, test_ctx->domain,
                                  "("SYSDB_NAME"=nonexisting)", NULL,
                                  &count, &msgs);
-    fail_unless(ret == ENOENT, "sysdb_search_netgroups failed: %d, %s",
+    ck_assert_msg(ret == ENOENT, "sysdb_search_netgroups failed: %d, %s",
                                ret, strerror(ret));
     talloc_zfree(msgs);
 
@@ -5685,7 +5685,7 @@ START_TEST (test_sysdb_search_return_ENOENT)
                               "(distinguishedName=nonexisting)",
                               CUSTOM_TEST_CONTAINER, NULL,
                               &count, &msgs);
-    fail_unless(ret == ENOENT, "sysdb_search_custom failed: %d, %s",
+    ck_assert_msg(ret == ENOENT, "sysdb_search_custom failed: %d, %s",
                                ret, strerror(ret));
     talloc_zfree(msgs);
 
@@ -5693,13 +5693,13 @@ START_TEST (test_sysdb_search_return_ENOENT)
                                      "nonexisting",
                                      CUSTOM_TEST_CONTAINER, NULL,
                                      &count, &msgs);
-    fail_unless(ret == ENOENT, "sysdb_search_custom_by_name failed: %d, %s",
+    ck_assert_msg(ret == ENOENT, "sysdb_search_custom_by_name failed: %d, %s",
                                ret, strerror(ret));
     talloc_zfree(msgs);
 
     /* TODO: test sysdb_search_selinux_config */
 
-    fail_unless(check_leaks_pop(test_ctx) == true, "Memory leak");
+    ck_assert_msg(check_leaks_pop(test_ctx) == true, "Memory leak");
     talloc_free(test_ctx);
 }
 END_TEST
@@ -5712,26 +5712,26 @@ START_TEST(test_sysdb_has_enumerated)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     ret = sysdb_has_enumerated(test_ctx->domain, SYSDB_HAS_ENUMERATED_ID,
                                &enumerated);
-    fail_if(ret != ENOENT,
+    sss_ck_fail_if_msg(ret != ENOENT,
             "Error [%d][%s] checking enumeration ENOENT is expected",
             ret, strerror(ret));
 
     ret = sysdb_set_enumerated(test_ctx->domain, SYSDB_HAS_ENUMERATED_ID,
                                true);
-    fail_if(ret != EOK, "Error [%d][%s] setting enumeration",
+    sss_ck_fail_if_msg(ret != EOK, "Error [%d][%s] setting enumeration",
                         ret, strerror(ret));
 
     /* Recheck enumeration status */
     ret = sysdb_has_enumerated(test_ctx->domain, SYSDB_HAS_ENUMERATED_ID,
                                &enumerated);
-    fail_if(ret != EOK, "Error [%d][%s] checking enumeration",
+    sss_ck_fail_if_msg(ret != EOK, "Error [%d][%s] checking enumeration",
                         ret, strerror(ret));
 
-    fail_unless(enumerated, "Enumeration should have been set to true");
+    ck_assert_msg(enumerated, "Enumeration should have been set to true");
 
     talloc_free(test_ctx);
 }
@@ -5751,28 +5751,28 @@ START_TEST(test_sysdb_original_dn_case_insensitive)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     data = test_data_new(test_ctx);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
     data->gid = 2900;
 
     data->groupname = test_asprintf_fqname(data, test_ctx->domain,
                                            "case_sensitive_group1");
-    fail_if(data->groupname == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data->groupname == NULL, "Failed to allocate memory");
 
     data->orig_dn = talloc_asprintf(data, "cn=%s,cn=example,cn=com", data->groupname);
-    fail_if(data->orig_dn == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data->orig_dn == NULL, "Failed to allocate memory");
 
     ret = test_add_incomplete_group(data);
-    fail_unless(ret == EOK, "sysdb_add_incomplete_group error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_add_incomplete_group error [%d][%s]",
                             ret, strerror(ret));
 
     /* different name and GID, original DN differs only by case */
     data->gid = 2901;
     data->groupname = test_asprintf_fqname(data, test_ctx->domain,
                                            "case_sensitive_group2");
-    fail_if(data->groupname == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data->groupname == NULL, "Failed to allocate memory");
     c = discard_const(data->orig_dn);
     while(*c != '\0') {
         *c = toupper(*c);
@@ -5780,23 +5780,23 @@ START_TEST(test_sysdb_original_dn_case_insensitive)
     }
 
     ret = test_add_incomplete_group(data);
-    fail_unless(ret == EOK, "sysdb_add_incomplete_group error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_add_incomplete_group error [%d][%s]",
                             ret, strerror(ret));
 
     /* Search by originalDN should yield 2 entries */
     filter = talloc_asprintf(test_ctx, "%s=%s",
                              SYSDB_ORIG_DN, data->orig_dn);
-    fail_if(filter == NULL, "Cannot construct filter\n");
+    sss_ck_fail_if_msg(filter == NULL, "Cannot construct filter\n");
 
     base_dn = sysdb_domain_dn(test_ctx, test_ctx->domain);
-    fail_if(base_dn == NULL, "Cannot construct basedn\n");
+    sss_ck_fail_if_msg(base_dn == NULL, "Cannot construct basedn\n");
 
     ret = sysdb_search_entry(test_ctx, test_ctx->sysdb,
                              base_dn, LDB_SCOPE_SUBTREE, filter, no_attrs,
                              &num_msgs, &msgs);
-    fail_unless(ret == EOK, "cache search error [%d][%s]",
+    ck_assert_msg(ret == EOK, "cache search error [%d][%s]",
                             ret, strerror(ret));
-    fail_unless(num_msgs == 2, "Did not find the expected number of entries using "
+    ck_assert_msg(num_msgs == 2, "Did not find the expected number of entries using "
                                "case insensitive originalDN search");
 }
 END_TEST
@@ -5812,23 +5812,23 @@ START_TEST(test_sysdb_search_groups_by_orig_dn)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     data = test_data_new_group(test_ctx, 456789);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->orig_dn = talloc_asprintf(data, "cn=%s,cn=example,cn=com", data->groupname);
-    fail_if(data->orig_dn == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data->orig_dn == NULL, "Failed to allocate memory");
 
     ret = test_add_incomplete_group(data);
-    fail_unless(ret == EOK, "sysdb_add_incomplete_group error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_add_incomplete_group error [%d][%s]",
                             ret, strerror(ret));
 
     ret = sysdb_search_groups_by_orig_dn(test_ctx, data->ctx->domain, data->orig_dn,
                                          no_attrs, &num_msgs, &msgs);
-    fail_unless(ret == EOK, "cache search error [%d][%s]",
+    ck_assert_msg(ret == EOK, "cache search error [%d][%s]",
                             ret, strerror(ret));
-    fail_unless(num_msgs == 1, "Did not find the expected number of entries using "
+    ck_assert_msg(num_msgs == 1, "Did not find the expected number of entries using "
                                "sysdb_search_groups_by_orign_dn search");
 }
 END_TEST
@@ -5844,27 +5844,27 @@ START_TEST(test_sysdb_search_users_by_orig_dn)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     data = test_data_new_user(test_ctx, 456789);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->orig_dn = talloc_asprintf(data, "cn=%s,cn=example,cn=com", data->username);
-    fail_if(data->orig_dn == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data->orig_dn == NULL, "Failed to allocate memory");
 
     ret = sysdb_attrs_add_string(data->attrs, SYSDB_ORIG_DN, data->orig_dn);
-    fail_unless(ret == EOK, "sysdb_attrs_add_string failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_string failed with [%d][%s].",
                 ret, strerror(ret));
 
     ret = test_add_user(data);
-    fail_unless(ret == EOK, "sysdb_add_user error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_add_user error [%d][%s]",
                             ret, strerror(ret));
 
     ret = sysdb_search_users_by_orig_dn(test_ctx, data->ctx->domain, data->orig_dn,
                                         no_attrs, &num_msgs, &msgs);
-    fail_unless(ret == EOK, "cache search error [%d][%s]",
+    ck_assert_msg(ret == EOK, "cache search error [%d][%s]",
                             ret, strerror(ret));
-    fail_unless(num_msgs == 1, "Did not find the expected number of entries using "
+    ck_assert_msg(num_msgs == 1, "Did not find the expected number of entries using "
                                "sysdb_search_users_by_orign_dn search");
 }
 END_TEST
@@ -5878,30 +5878,30 @@ START_TEST(test_sysdb_search_sid_str)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     data = test_data_new_group(test_ctx, 2902);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
     data->sid_str = "S-1-2-3-4";
 
     ret = test_add_incomplete_group(data);
-    fail_unless(ret == EOK, "sysdb_add_incomplete_group error [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_add_incomplete_group error [%d][%s]",
                             ret, strerror(ret));
 
     ret = sysdb_search_group_by_sid_str(test_ctx, test_ctx->domain,
                                         data->sid_str, NULL, &msg);
-    fail_unless(ret == EOK, "sysdb_search_group_by_sid_str failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_search_group_by_sid_str failed with [%d][%s].",
                 ret, strerror(ret));
 
     /* Delete the group by SID */
     ret = sysdb_delete_by_sid(test_ctx->sysdb, test_ctx->domain, data->sid_str);
-    fail_unless(ret == EOK, "sysdb_delete_by_sid failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_delete_by_sid failed with [%d][%s].",
                 ret, strerror(ret));
 
     /* Verify it's gone */
     ret = sysdb_search_group_by_sid_str(test_ctx, test_ctx->domain,
                                         data->sid_str, NULL, &msg);
-    fail_unless(ret == ENOENT,
+    ck_assert_msg(ret == ENOENT,
                 "sysdb_search_group_by_sid_str failed with [%d][%s].",
                 ret, strerror(ret));
 
@@ -5911,20 +5911,20 @@ START_TEST(test_sysdb_search_sid_str)
     talloc_zfree(data);
 
     data = test_data_new_user(test_ctx, 12345);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
     data->sid_str = "S-1-2-3-4-5";
 
     ret = sysdb_attrs_add_string(data->attrs, SYSDB_SID_STR, data->sid_str);
-    fail_unless(ret == EOK, "sysdb_attrs_add_string failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_string failed with [%d][%s].",
                 ret, strerror(ret));
 
     ret = test_add_user(data);
-    fail_unless(ret == EOK, "sysdb_add_user failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_add_user failed with [%d][%s].",
                 ret, strerror(ret));
 
     ret = sysdb_search_user_by_sid_str(test_ctx, test_ctx->domain,
                                        data->sid_str, NULL, &msg);
-    fail_unless(ret == EOK, "sysdb_search_user_by_sid_str failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_search_user_by_sid_str failed with [%d][%s].",
                 ret, strerror(ret));
 
     talloc_free(test_ctx);
@@ -5942,113 +5942,113 @@ START_TEST(test_sysdb_search_object_by_id)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     /* test for missing entry */
     ret = sysdb_search_object_by_id(test_ctx, test_ctx->domain, 111, NULL,
                                     &res);
-    fail_unless(ret == ENOENT, "sysdb_search_object_by_name failed with "
+    ck_assert_msg(ret == ENOENT, "sysdb_search_object_by_name failed with "
                                "[%d][%s].", ret, strerror(ret));
 
     /* test user search */
     data = test_data_new_user(test_ctx, id);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     ret = test_add_user(data);
-    fail_unless(ret == EOK, "sysdb_add_user failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_add_user failed with [%d][%s].",
                 ret, strerror(ret));
 
     ret = sysdb_search_object_by_id(test_ctx, test_ctx->domain, id, NULL,
                                     &res);
-    fail_unless(ret == EOK,
+    ck_assert_msg(ret == EOK,
                 "sysdb_search_object_by_id failed with [%d][%s].",
                 ret, strerror(ret));
-    fail_unless(res->count == 1, "Unexpected number of results, "
+    ck_assert_msg(res->count == 1, "Unexpected number of results, "
                                  "expected [%u], get [%u].", 1, res->count);
 
     returned_id = ldb_msg_find_attr_as_uint(res->msgs[0], SYSDB_UIDNUM, 0);
-    fail_unless(id == returned_id,
+    ck_assert_msg(id == returned_id,
                 "Unexpected object found, expected UID [%"PRIu32"], "
                 "got [%"PRIu32"].", id, returned_id);
     talloc_free(res);
 
     ret = test_remove_user(data);
-    fail_unless(ret == EOK,
+    ck_assert_msg(ret == EOK,
                 "test_remove_user failed with [%d][%s].", ret, strerror(ret));
 
     /* test group search */
     data = test_data_new_group(test_ctx, id);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     ret = test_add_group(data);
-    fail_unless(ret == EOK, "sysdb_add_group failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_add_group failed with [%d][%s].",
                 ret, strerror(ret));
 
     ret = sysdb_search_object_by_id(test_ctx, test_ctx->domain, id, NULL,
                                     &res);
-    fail_unless(ret == EOK,
+    ck_assert_msg(ret == EOK,
                 "sysdb_search_object_by_id failed with [%d][%s].",
                 ret, strerror(ret));
-    fail_unless(res->count == 1, "Unexpected number of results, "
+    ck_assert_msg(res->count == 1, "Unexpected number of results, "
                                  "expected [%u], get [%u].", 1, res->count);
 
     returned_id = ldb_msg_find_attr_as_uint(res->msgs[0], SYSDB_GIDNUM, 0);
-    fail_unless(id == returned_id,
+    ck_assert_msg(id == returned_id,
                 "Unexpected object found, expected GID [%"PRIu32"], "
                 "got [%"PRIu32"].", id, returned_id);
     talloc_free(res);
 
     ret = test_remove_group(data);
-    fail_unless(ret == EOK,
+    ck_assert_msg(ret == EOK,
                 "test_remove_group failed with [%d][%s].", ret, strerror(ret));
 
     /* test for bad search filter bug #3283 */
     data = test_data_new_group(test_ctx, id);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     ret = test_add_group(data);
-    fail_unless(ret == EOK, "sysdb_add_group failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_add_group failed with [%d][%s].",
                 ret, strerror(ret));
 
     test_ctx->domain->mpg_mode = MPG_DISABLED;
     ret = sysdb_add_user(test_ctx->domain, "user1", 4001, id,
                          "User 1", "/home/user1", "/bin/bash",
                          NULL, NULL, 0, 0);
-    fail_unless(ret == EOK, "sysdb_add_user failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_add_user failed with [%d][%s].",
                 ret, strerror(ret));
 
     ret = sysdb_add_user(test_ctx->domain, "user2", 4002, id,
                          "User 2", "/home/user2", "/bin/bash",
                          NULL, NULL, 0, 0);
-    fail_unless(ret == EOK, "sysdb_add_user failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_add_user failed with [%d][%s].",
                 ret, strerror(ret));
 
     ret = sysdb_search_object_by_id(test_ctx, test_ctx->domain, id, NULL,
                                     &res);
-    fail_unless(ret == EOK,
+    ck_assert_msg(ret == EOK,
                 "sysdb_search_object_by_id failed with [%d][%s].",
                 ret, strerror(ret));
-    fail_unless(res->count == 1, "Unexpected number of results, "
+    ck_assert_msg(res->count == 1, "Unexpected number of results, "
                                  "expected [%u], get [%u].", 1, res->count);
 
     returned_id = ldb_msg_find_attr_as_uint(res->msgs[0], SYSDB_GIDNUM, 0);
-    fail_unless(id == returned_id,
+    ck_assert_msg(id == returned_id,
                 "Unexpected object found, expected GID [%"PRIu32"], "
                 "got [%"PRIu32"].", id, returned_id);
     talloc_free(res);
 
     data->uid = 4001;
     ret = test_remove_user_by_uid(data);
-    fail_unless(ret == EOK,
+    ck_assert_msg(ret == EOK,
                 "test_remove_user_by_uid failed with error: %d", ret);
 
     data->uid = 4002;
     ret = test_remove_user_by_uid(data);
-    fail_unless(ret == EOK,
+    ck_assert_msg(ret == EOK,
                 "test_remove_user_by_uid failed with error: %d", ret);
 
     ret = test_remove_group(data);
-    fail_unless(ret == EOK, "test_remove_group failed with error: %d", ret);
+    ck_assert_msg(ret == EOK, "test_remove_group failed with error: %d", ret);
 
     talloc_free(test_ctx);
 }
@@ -6064,35 +6064,35 @@ START_TEST(test_sysdb_search_object_by_uuid)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     data = test_data_new_user(test_ctx, 123456);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     uuid = "11111111-2222-3333-4444-555555555555";
 
     ret = sysdb_attrs_add_string(data->attrs, SYSDB_UUID, uuid);
-    fail_unless(ret == EOK, "sysdb_attrs_add_string failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_string failed with [%d][%s].",
                 ret, strerror(ret));
 
     ret = test_add_user(data);
-    fail_unless(ret == EOK, "sysdb_add_user failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_add_user failed with [%d][%s].",
                 ret, strerror(ret));
 
     ret = sysdb_search_object_by_uuid(test_ctx, test_ctx->domain,
                                       "11111111-2222-3333-4444-555555555556",
                                       NULL, &res);
-    fail_unless(ret == ENOENT,
+    ck_assert_msg(ret == ENOENT,
                 "Unexpected return code from sysdb_search_object_by_uuid for "
                 "missing object, expected [%d], got [%d].", ENOENT, ret);
 
     ret = sysdb_search_object_by_uuid(test_ctx, test_ctx->domain,
                                       uuid, NULL, &res);
-    fail_unless(ret == EOK, "sysdb_search_object_by_uuid failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_search_object_by_uuid failed with [%d][%s].",
                 ret, strerror(ret));
-    fail_unless(res->count == 1, "Unexpected number of results, " \
+    ck_assert_msg(res->count == 1, "Unexpected number of results, " \
                                  "expected [%u], get [%u].", 1, res->count);
-    fail_unless(strcmp(ldb_msg_find_attr_as_string(res->msgs[0],
+    ck_assert_msg(strcmp(ldb_msg_find_attr_as_string(res->msgs[0],
                                                    SYSDB_NAME, ""),
                       data->username) == 0, "Unexpected object found, " \
                       "expected [%s], got [%s].", "UUIDuser",
@@ -6114,98 +6114,98 @@ START_TEST(test_sysdb_search_object_by_name)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     /* test for missing entry */
     ret = sysdb_search_object_by_name(test_ctx, test_ctx->domain,
                                       "nonexisting_name", NULL, &res);
-    fail_unless(ret == ENOENT, "sysdb_search_object_by_name failed with "
+    ck_assert_msg(ret == ENOENT, "sysdb_search_object_by_name failed with "
                                "[%d][%s].", ret, strerror(ret));
 
     /* test user search */
     data = test_data_new_user(test_ctx, 23456);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->username = user_name;
 
     ret = test_add_user(data);
-    fail_unless(ret == EOK, "sysdb_add_user failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_add_user failed with [%d][%s].",
                 ret, strerror(ret));
 
     ret = sysdb_search_object_by_name(test_ctx, test_ctx->domain,
                                       user_name, NULL, &res);
-    fail_unless(ret == EOK,
+    ck_assert_msg(ret == EOK,
                 "sysdb_search_object_by_name failed with [%d][%s].",
                 ret, strerror(ret));
-    fail_unless(res->count == 1, "Unexpected number of results, "
+    ck_assert_msg(res->count == 1, "Unexpected number of results, "
                                  "expected [%u], get [%u].", 1, res->count);
 
     returned_name = ldb_msg_find_attr_as_string(res->msgs[0], SYSDB_NAME, ""),
-    fail_unless(strcmp(returned_name, data->username) == 0,
+    ck_assert_msg(strcmp(returned_name, data->username) == 0,
                 "Unexpected object found, expected [%s], got [%s].",
                 user_name, returned_name);
     talloc_free(res);
 
     ret = test_remove_user(data);
-    fail_unless(ret == EOK,
+    ck_assert_msg(ret == EOK,
                 "test_remove_user failed with [%d][%s].", ret, strerror(ret));
 
     /* test group search */
     data = test_data_new_group(test_ctx, 23456);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->groupname = group_name;
 
     ret = test_add_group(data);
-    fail_unless(ret == EOK, "sysdb_add_group failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_add_group failed with [%d][%s].",
                 ret, strerror(ret));
 
     ret = sysdb_search_object_by_name(test_ctx, test_ctx->domain,
                                       group_name, NULL, &res);
-    fail_unless(ret == EOK,
+    ck_assert_msg(ret == EOK,
                 "sysdb_search_object_by_name failed with [%d][%s].",
                 ret, strerror(ret));
-    fail_unless(res->count == 1, "Unexpected number of results, "
+    ck_assert_msg(res->count == 1, "Unexpected number of results, "
                                  "expected [%u], get [%u].", 1, res->count);
 
     returned_name = ldb_msg_find_attr_as_string(res->msgs[0], SYSDB_NAME, ""),
-    fail_unless(strcmp(returned_name, data->groupname) == 0,
+    ck_assert_msg(strcmp(returned_name, data->groupname) == 0,
                 "Unexpected object found, expected [%s], got [%s].",
                 group_name, returned_name);
     talloc_free(res);
 
     ret = test_remove_group(data);
-    fail_unless(ret == EOK,
+    ck_assert_msg(ret == EOK,
                 "test_remove_group failed with [%d][%s].", ret, strerror(ret));
 
     /* test case insensitive search */
     data = test_data_new_group(test_ctx, 23456);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->groupname = group_name;
     test_ctx->domain->case_sensitive = false;
 
     data->attrs = sysdb_new_attrs(test_ctx);
-    fail_if(data->attrs == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data->attrs == NULL, "Failed to allocate memory");
 
     ret = sysdb_attrs_add_lc_name_alias(data->attrs, group_name);
-    fail_unless(ret == EOK,
+    ck_assert_msg(ret == EOK,
                 "sysdb_attrs_add_lc_name_alias failed with error: %d", ret);
 
     ret = test_add_group(data);
-    fail_unless(ret == EOK, "sysdb_add_group failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_add_group failed with [%d][%s].",
                 ret, strerror(ret));
 
     ret = sysdb_search_object_by_name(test_ctx, test_ctx->domain,
                                       lc_group_name, NULL, &res);
-    fail_unless(ret == EOK,
+    ck_assert_msg(ret == EOK,
                 "sysdb_search_object_by_name failed with [%d][%s].",
                 ret, strerror(ret));
-    fail_unless(res->count == 1, "Unexpected number of results, "
+    ck_assert_msg(res->count == 1, "Unexpected number of results, "
                                  "expected [%u], get [%u].", 1, res->count);
 
     returned_name = ldb_msg_find_attr_as_string(res->msgs[0], SYSDB_NAME, ""),
-    fail_unless(strcmp(returned_name, data->groupname) == 0,
+    ck_assert_msg(strcmp(returned_name, data->groupname) == 0,
                 "Unexpected object found, expected [%s], got [%s].",
                 group_name, returned_name);
 
@@ -6230,34 +6230,34 @@ START_TEST(test_sysdb_search_user_by_cert)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     data = test_data_new_user(test_ctx, 234567);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     val.data = sss_base64_decode(test_ctx, TEST_USER_CERT_DERB64, &val.length);
-    fail_unless(val.data != NULL, "sss_base64_decode failed.");
+    ck_assert_msg(val.data != NULL, "sss_base64_decode failed.");
 
     ret = sysdb_attrs_add_val(data->attrs, SYSDB_USER_MAPPED_CERT, &val);
-    fail_unless(ret == EOK, "sysdb_attrs_add_val failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_val failed with [%d][%s].",
                 ret, strerror(ret));
 
     ret = test_add_user(data);
-    fail_unless(ret == EOK, "sysdb_add_user failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_add_user failed with [%d][%s].",
                 ret, strerror(ret));
 
     ret = sysdb_search_user_by_cert(test_ctx, test_ctx->domain, "ABA=", &res);
-    fail_unless(ret == ENOENT,
+    ck_assert_msg(ret == ENOENT,
                 "Unexpected return code from sysdb_search_user_by_cert for "
                 "missing object, expected [%d], got [%d].", ENOENT, ret);
 
     ret = sysdb_search_user_by_cert(test_ctx, test_ctx->domain,
                                     TEST_USER_CERT_DERB64, &res);
-    fail_unless(ret == EOK, "sysdb_search_user_by_cert failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_search_user_by_cert failed with [%d][%s].",
                 ret, strerror(ret));
-    fail_unless(res->count == 1, "Unexpected number of results, " \
+    ck_assert_msg(res->count == 1, "Unexpected number of results, " \
                                  "expected [%u], get [%u].", 1, res->count);
-    fail_unless(strcmp(ldb_msg_find_attr_as_string(res->msgs[0],
+    ck_assert_msg(strcmp(ldb_msg_find_attr_as_string(res->msgs[0],
                                                    SYSDB_NAME, ""),
                       data->username) == 0, "Unexpected object found, " \
                       "expected [%s], got [%s].", data->username,
@@ -6265,27 +6265,27 @@ START_TEST(test_sysdb_search_user_by_cert)
 
     /* Add a second user with the same certificate */
     data2 = test_data_new_user(test_ctx, 2345671);
-    fail_if(data2 == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data2 == NULL, "Failed to allocate memory");
 
     ret = sysdb_attrs_add_val(data2->attrs, SYSDB_USER_MAPPED_CERT, &val);
-    fail_unless(ret == EOK, "sysdb_attrs_add_val failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_val failed with [%d][%s].",
                 ret, strerror(ret));
 
     ret = test_add_user(data2);
-    fail_unless(ret == EOK, "sysdb_add_user failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_add_user failed with [%d][%s].",
                 ret, strerror(ret));
 
     ret = sysdb_search_user_by_cert(test_ctx, test_ctx->domain,
                                     TEST_USER_CERT_DERB64, &res);
-    fail_unless(ret == EOK, "sysdb_search_user_by_cert failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_search_user_by_cert failed with [%d][%s].",
                 ret, strerror(ret));
-    fail_unless(res->count == 2, "Unexpected number of results, "
+    ck_assert_msg(res->count == 2, "Unexpected number of results, "
                                  "expected [%u], get [%u].", 2, res->count);
     name = ldb_msg_find_attr_as_string(res->msgs[0], SYSDB_NAME, "");
-    fail_unless(name != NULL, "Failed to find attribute: " SYSDB_NAME);
+    ck_assert_msg(name != NULL, "Failed to find attribute: " SYSDB_NAME);
     name2 = ldb_msg_find_attr_as_string(res->msgs[1], SYSDB_NAME, "");
-    fail_unless(name2 != NULL, "Failed to find attribute: " SYSDB_NAME);
-    fail_unless(((strcmp(name, data->username) == 0
+    ck_assert_msg(name2 != NULL, "Failed to find attribute: " SYSDB_NAME);
+    ck_assert_msg(((strcmp(name, data->username) == 0
                         && strcmp(name2, data2->username) == 0)
                     || (strcmp(name, data2->username) == 0
                         && strcmp(name2, data->username) == 0)),
@@ -6303,17 +6303,17 @@ START_TEST(test_sysdb_delete_by_sid)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     check_leaks_push(test_ctx);
 
     /* Delete the group by SID */
     ret = sysdb_delete_by_sid(test_ctx->sysdb, test_ctx->domain,
                               "S-1-2-3-4-NON_EXISTING_SID");
-    fail_unless(ret == EOK, "sysdb_delete_by_sid failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_delete_by_sid failed with [%d][%s].",
                 ret, strerror(ret));
 
-    fail_unless(check_leaks_pop(test_ctx) == true, "Memory leak");
+    ck_assert_msg(check_leaks_pop(test_ctx) == true, "Memory leak");
     talloc_free(test_ctx);
 }
 END_TEST
@@ -6334,66 +6334,66 @@ START_TEST(test_sysdb_subdomain_store_user)
     char *alias;
 
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     subdomain = new_subdomain(test_ctx, test_ctx->domain,
                               testdom[0], testdom[1], testdom[2], testdom[3],
                               MPG_DISABLED, false, NULL, NULL, 0, NULL, true);
-    fail_unless(subdomain != NULL, "Failed to create new subdomain.");
+    ck_assert_msg(subdomain != NULL, "Failed to create new subdomain.");
     ret = sysdb_subdomain_store(test_ctx->sysdb,
                                 testdom[0], testdom[1], testdom[2], testdom[3],
                                 false, false, NULL, 0, NULL);
-    fail_if(ret != EOK, "Could not set up the test (test subdom)");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test (test subdom)");
 
     ret = sysdb_update_subdomains(test_ctx->domain, NULL);
-    fail_unless(ret == EOK, "sysdb_update_subdomains failed with [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_update_subdomains failed with [%d][%s]",
                             ret, strerror(ret));
 
     data = test_data_new_user(test_ctx, 12345);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
     data->username = test_asprintf_fqname(data, subdomain, "SubDomUser");
 
     alias = test_asprintf_fqname(data, subdomain, "subdomuser");
-    fail_if(alias == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(alias == NULL, "Failed to allocate memory");
 
     ret = sysdb_attrs_add_string(data->attrs, SYSDB_NAME_ALIAS, alias);
-    fail_unless(ret == EOK, "sysdb_store_user failed.");
+    ck_assert_msg(ret == EOK, "sysdb_store_user failed.");
 
     ret = sysdb_store_user(subdomain, data->username,
                            NULL, data->uid, 0, "Sub Domain User",
                            "/home/subdomuser", "/bin/bash",
                            NULL, data->attrs, NULL, -1, 0);
-    fail_unless(ret == EOK, "sysdb_store_user failed.");
+    ck_assert_msg(ret == EOK, "sysdb_store_user failed.");
 
     base_dn =ldb_dn_new(test_ctx, test_ctx->sysdb->ldb, "cn=sysdb");
-    fail_unless(base_dn != NULL, "Failed to allocate memory");
+    ck_assert_msg(base_dn != NULL, "Failed to allocate memory");
 
     check_dn = sysdb_user_dn(data, subdomain, data->username);
-    fail_unless(check_dn != NULL, "Failed to allocate memory");
+    ck_assert_msg(check_dn != NULL, "Failed to allocate memory");
 
     ret = ldb_search(test_ctx->sysdb->ldb, test_ctx, &results, base_dn,
                      LDB_SCOPE_SUBTREE, NULL, "name=%s", data->username);
-    fail_unless(ret == EOK, "ldb_search failed.");
-    fail_unless(results->count == 1, "Unexpected number of results, "
+    ck_assert_msg(ret == EOK, "ldb_search failed.");
+    ck_assert_msg(results->count == 1, "Unexpected number of results, "
                                      "expected [%d], got [%d]",
                                      1, results->count);
-    fail_unless(ldb_dn_compare(results->msgs[0]->dn, check_dn) == 0,
+    ck_assert_msg(ldb_dn_compare(results->msgs[0]->dn, check_dn) == 0,
                 "Unexpected DN returned");
 
     /* Subdomains are case-insensitive. Test that the lowercased name
      * can be found, too */
     ret = sysdb_search_user_by_name(test_ctx, subdomain, alias,
                                     attrs, &msg);
-    fail_unless(ret == EOK, "sysdb_search_user_by_name failed.");
+    ck_assert_msg(ret == EOK, "sysdb_search_user_by_name failed.");
 
     ret = sysdb_delete_user(subdomain, alias, 0);
-    fail_unless(ret == EOK, "sysdb_delete_user failed [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_delete_user failed [%d][%s].",
                             ret, strerror(ret));
 
     ret = ldb_search(test_ctx->sysdb->ldb, test_ctx, &results, base_dn,
                      LDB_SCOPE_SUBTREE, NULL, "name=%s", alias);
-    fail_unless(ret == EOK, "ldb_search failed.");
-    fail_unless(results->count == 0, "Unexpected number of results, "
+    ck_assert_msg(ret == EOK, "ldb_search failed.");
+    ck_assert_msg(results->count == 0, "Unexpected number of results, "
                                      "expected [%d], got [%d]",
                                      0, results->count);
 }
@@ -6412,75 +6412,75 @@ START_TEST(test_sysdb_subdomain_content_delete)
     char *alias;
 
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     subdomain = new_subdomain(test_ctx, test_ctx->domain,
                               testdom[0], testdom[1], testdom[2], testdom[3],
                               MPG_DISABLED, false, NULL, NULL, 0, NULL, true);
-    fail_unless(subdomain != NULL, "Failed to create new subdomain.");
+    ck_assert_msg(subdomain != NULL, "Failed to create new subdomain.");
     ret = sysdb_subdomain_store(test_ctx->sysdb,
                                 testdom[0], testdom[1], testdom[2], testdom[3],
                                 false, false, NULL, 0, NULL);
-    fail_if(ret != EOK, "Could not set up the test (test subdom)");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test (test subdom)");
 
     ret = sysdb_update_subdomains(test_ctx->domain, NULL);
-    fail_unless(ret == EOK, "sysdb_update_subdomains failed with [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_update_subdomains failed with [%d][%s]",
                             ret, strerror(ret));
 
     data = test_data_new_user(test_ctx, 12345);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
     data->username = test_asprintf_fqname(data, subdomain, "SubDomUser");
 
     alias = test_asprintf_fqname(data, subdomain, "subdomuser");
-    fail_if(alias == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(alias == NULL, "Failed to allocate memory");
 
     ret = sysdb_attrs_add_string(data->attrs, SYSDB_NAME_ALIAS, alias);
-    fail_unless(ret == EOK, "sysdb_store_user failed.");
+    ck_assert_msg(ret == EOK, "sysdb_store_user failed.");
 
     ret = sysdb_store_user(subdomain, data->username,
                            NULL, data->uid, 0, "Sub Domain User",
                            "/home/subdomuser", "/bin/bash",
                            NULL, data->attrs, NULL, -1, 0);
-    fail_unless(ret == EOK, "sysdb_store_user failed.");
+    ck_assert_msg(ret == EOK, "sysdb_store_user failed.");
 
     base_dn =ldb_dn_new(test_ctx, test_ctx->sysdb->ldb, "cn=sysdb");
-    fail_unless(base_dn != NULL, "Failed to allocate memory");
+    ck_assert_msg(base_dn != NULL, "Failed to allocate memory");
 
     check_dn = sysdb_user_dn(data, subdomain, data->username);
-    fail_unless(check_dn != NULL, "Failed to allocate memory");
+    ck_assert_msg(check_dn != NULL, "Failed to allocate memory");
 
     ret = ldb_search(test_ctx->sysdb->ldb, test_ctx, &results, base_dn,
                      LDB_SCOPE_SUBTREE, NULL, "name=%s", data->username);
-    fail_unless(ret == EOK, "ldb_search failed.");
-    fail_unless(results->count == 1, "Unexpected number of results, "
+    ck_assert_msg(ret == EOK, "ldb_search failed.");
+    ck_assert_msg(results->count == 1, "Unexpected number of results, "
                                      "expected [%d], got [%d]",
                                      1, results->count);
-    fail_unless(ldb_dn_compare(results->msgs[0]->dn, check_dn) == 0,
+    ck_assert_msg(ldb_dn_compare(results->msgs[0]->dn, check_dn) == 0,
                 "Unexpected DN returned");
 
     ret = sysdb_subdomain_content_delete(test_ctx->sysdb, testdom[0]);
-    fail_unless(ret == EOK, "sysdb_subdomain_content_delete failed.");
+    ck_assert_msg(ret == EOK, "sysdb_subdomain_content_delete failed.");
 
     /* Check if user is removed */
     ret = ldb_search(test_ctx->sysdb->ldb, test_ctx, &results, base_dn,
                      LDB_SCOPE_SUBTREE, NULL, "name=%s", alias);
-    fail_unless(ret == EOK, "ldb_search failed.");
-    fail_unless(results->count == 0, "Unexpected number of results, "
+    ck_assert_msg(ret == EOK, "ldb_search failed.");
+    ck_assert_msg(results->count == 0, "Unexpected number of results, "
                                      "expected [%d], got [%d]",
                                      0, results->count);
 
     check_dom_dn = ldb_dn_new_fmt(test_ctx, test_ctx->sysdb->ldb,
                                   SYSDB_DOM_BASE, testdom[0]);
-    fail_unless(check_dom_dn != NULL, "ldb_dn_new_fmt failed.");
+    ck_assert_msg(check_dom_dn != NULL, "ldb_dn_new_fmt failed.");
 
     /* Check if domain object is still present */
     ret = ldb_search(test_ctx->sysdb->ldb, test_ctx, &results, base_dn,
                      LDB_SCOPE_SUBTREE, NULL, "cn=%s", testdom[0]);
-    fail_unless(ret == EOK, "ldb_search failed.");
-    fail_unless(results->count == 1, "Unexpected number of results, "
+    ck_assert_msg(ret == EOK, "ldb_search failed.");
+    ck_assert_msg(results->count == 1, "Unexpected number of results, "
                                      "expected [%d], got [%d]",
                                      1, results->count);
-    fail_unless(ldb_dn_compare(results->msgs[0]->dn, check_dom_dn) == 0,
+    ck_assert_msg(ldb_dn_compare(results->msgs[0]->dn, check_dom_dn) == 0,
                 "Unexpected DN returned");
 
 }
@@ -6500,60 +6500,60 @@ START_TEST(test_sysdb_subdomain_user_ops)
     char *dom_check;
 
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     subdomain = new_subdomain(test_ctx, test_ctx->domain,
                               testdom[0], testdom[1], testdom[2], testdom[3],
                               MPG_DISABLED, false, NULL, NULL, 0, NULL, true);
-    fail_unless(subdomain != NULL, "Failed to create new subdomain.");
+    ck_assert_msg(subdomain != NULL, "Failed to create new subdomain.");
     ret = sysdb_subdomain_store(test_ctx->sysdb,
                                 testdom[0], testdom[1], testdom[2], testdom[3],
                                 false, false, NULL, 0, NULL);
-    fail_if(ret != EOK, "Could not set up the test (test subdom)");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test (test subdom)");
 
     ret = sysdb_update_subdomains(test_ctx->domain, NULL);
-    fail_unless(ret == EOK, "sysdb_update_subdomains failed with [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_update_subdomains failed with [%d][%s]",
                             ret, strerror(ret));
 
     data = test_data_new_user(test_ctx, 12345);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     data->username = test_asprintf_fqname(data, subdomain, shortname);
-    fail_if(data->username == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data->username == NULL, "Failed to allocate memory");
 
     ret = sysdb_store_user(subdomain, data->username,
                            NULL, data->uid, 0, "Sub Domain User",
                            "/home/subdomuser", "/bin/bash",
                            NULL, NULL, NULL, -1, 0);
-    fail_unless(ret == EOK, "sysdb_store_domuser failed.");
+    ck_assert_msg(ret == EOK, "sysdb_store_domuser failed.");
 
     check_dn = sysdb_user_dn(data, subdomain, data->username);
-    fail_unless(check_dn != NULL, "Failed to allocate memory");
+    ck_assert_msg(check_dn != NULL, "Failed to allocate memory");
 
     ret = sysdb_search_user_by_name(test_ctx, subdomain,
                                     data->username, NULL,
                                     &msg);
-    fail_unless(ret == EOK, "sysdb_search_user_by_name failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_search_user_by_name failed with [%d][%s].",
                             ret, strerror(ret));
-    fail_unless(ldb_dn_compare(msg->dn, check_dn) == 0,
+    ck_assert_msg(ldb_dn_compare(msg->dn, check_dn) == 0,
                 "Unexpected DN returned");
 
     name = ldb_msg_find_attr_as_string(msg, SYSDB_NAME, NULL);
-    fail_if(name == NULL, "Failed to find attribute: " SYSDB_NAME);
+    sss_ck_fail_if_msg(name == NULL, "Failed to find attribute: " SYSDB_NAME);
 
     ret = sss_parse_internal_fqname(data, name, &short_check, &dom_check);
-    fail_if(ret != EOK, "sss_parse_internal_fqname failed with error: %d", ret);
+    sss_ck_fail_if_msg(ret != EOK, "sss_parse_internal_fqname failed with error: %d", ret);
     ck_assert_str_eq(short_check, shortname);
     ck_assert_str_eq(dom_check, subdomain->name);
 
     ret = sysdb_search_user_by_uid(test_ctx, subdomain, data->uid, NULL, &msg);
-    fail_unless(ret == EOK, "sysdb_search_domuser_by_uid failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_search_domuser_by_uid failed with [%d][%s].",
                             ret, strerror(ret));
-    fail_unless(ldb_dn_compare(msg->dn, check_dn) == 0,
+    ck_assert_msg(ldb_dn_compare(msg->dn, check_dn) == 0,
                 "Unexpected DN returned");
 
     ret = sysdb_delete_user(subdomain, data->username, data->uid);
-    fail_unless(ret == EOK, "sysdb_delete_domuser failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_delete_domuser failed with [%d][%s].",
                             ret, strerror(ret));
 }
 END_TEST
@@ -6573,43 +6573,43 @@ START_TEST(test_sysdb_subdomain_group_ops)
     char *dom_check;
 
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     subdomain = new_subdomain(test_ctx, test_ctx->domain,
                               testdom[0], testdom[1], testdom[2], testdom[3],
                               MPG_DISABLED, false, NULL, NULL, 0, NULL, true);
-    fail_unless(subdomain != NULL, "Failed to create new subdomain.");
+    ck_assert_msg(subdomain != NULL, "Failed to create new subdomain.");
     ret = sysdb_subdomain_store(test_ctx->sysdb,
                                 testdom[0], testdom[1], testdom[2], testdom[3],
                                 false, false, NULL, 0, NULL);
-    fail_if(ret != EOK, "Could not set up the test (test subdom)");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test (test subdom)");
 
     ret = sysdb_update_subdomains(test_ctx->domain, NULL);
-    fail_unless(ret == EOK, "sysdb_update_subdomains failed with [%d][%s]",
+    ck_assert_msg(ret == EOK, "sysdb_update_subdomains failed with [%d][%s]",
                             ret, strerror(ret));
 
     data = test_data_new_group(test_ctx, 12345);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
     data->groupname = test_asprintf_fqname(data, subdomain, shortname);
 
     alias = test_asprintf_fqname(data, subdomain, "subdomgroup");
-    fail_if(alias == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(alias == NULL, "Failed to allocate memory");
 
     ret = sysdb_attrs_add_string(data->attrs, SYSDB_NAME_ALIAS, alias);
-    fail_unless(ret == EOK, "sysdb_attrs_add_string failed.");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_string failed.");
 
     ret = sysdb_store_group(subdomain,
                             data->groupname, data->gid, data->attrs, -1, 0);
-    fail_unless(ret == EOK, "sysdb_store_group failed.");
+    ck_assert_msg(ret == EOK, "sysdb_store_group failed.");
 
     check_dn = sysdb_group_dn(data, subdomain, data->groupname);
-    fail_unless(check_dn != NULL, "Failed to allocate memory");
+    ck_assert_msg(check_dn != NULL, "Failed to allocate memory");
 
     ret = sysdb_search_group_by_name(test_ctx, subdomain, data->groupname, NULL,
                                      &msg);
-    fail_unless(ret == EOK, "sysdb_search_group_by_name failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_search_group_by_name failed with [%d][%s].",
                             ret, strerror(ret));
-    fail_unless(ldb_dn_compare(msg->dn, check_dn) == 0,
+    ck_assert_msg(ldb_dn_compare(msg->dn, check_dn) == 0,
                 "Unexpected DN returned");
 
     /* subdomains are case insensitive, so it should be possible to search
@@ -6617,27 +6617,27 @@ START_TEST(test_sysdb_subdomain_group_ops)
     /* Fixme - lowercase this */
     ret = sysdb_search_group_by_name(test_ctx, subdomain, data->groupname, NULL,
                                      &msg);
-    fail_unless(ret == EOK, "case-insensitive group search failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "case-insensitive group search failed with [%d][%s].",
                             ret, strerror(ret));
-    fail_unless(ldb_dn_compare(msg->dn, check_dn) == 0,
+    ck_assert_msg(ldb_dn_compare(msg->dn, check_dn) == 0,
                 "Unexpected DN returned");
 
     name = ldb_msg_find_attr_as_string(msg, SYSDB_NAME, NULL);
-    fail_if(name == NULL, "Failed to find attribute: " SYSDB_NAME);
+    sss_ck_fail_if_msg(name == NULL, "Failed to find attribute: " SYSDB_NAME);
 
     ret = sss_parse_internal_fqname(data, name, &short_check, &dom_check);
-    fail_if(ret != EOK, "sss_parse_internal_fqname failed with error: %d", ret);
+    sss_ck_fail_if_msg(ret != EOK, "sss_parse_internal_fqname failed with error: %d", ret);
     ck_assert_str_eq(short_check, shortname);
     ck_assert_str_eq(dom_check, subdomain->name);
 
     ret = sysdb_search_group_by_gid(test_ctx, subdomain, data->gid, NULL, &msg);
-    fail_unless(ret == EOK, "sysdb_search_group_by_gid failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_search_group_by_gid failed with [%d][%s].",
                             ret, strerror(ret));
-    fail_unless(ldb_dn_compare(msg->dn, check_dn) == 0,
+    ck_assert_msg(ldb_dn_compare(msg->dn, check_dn) == 0,
                 "Unexpected DN returned");
 
     ret = sysdb_delete_group(subdomain, data->groupname, data->gid);
-    fail_unless(ret == EOK, "sysdb_delete_group failed with [%d][%s].",
+    ck_assert_msg(ret == EOK, "sysdb_delete_group failed with [%d][%s].",
                             ret, strerror(ret));
 }
 END_TEST
@@ -6651,17 +6651,17 @@ START_TEST(test_autofs_create_map)
     errno_t ret;
 
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     autofsmapname = talloc_asprintf(test_ctx, "testmap%d", _i);
-    fail_if(autofsmapname == NULL, "Out of memory\n");
+    sss_ck_fail_if_msg(autofsmapname == NULL, "Out of memory\n");
 
     origdn = talloc_asprintf(test_ctx, "cn=testmap%d,dc=test", _i);
-    fail_if(origdn == NULL, "Out of memory\n");
+    sss_ck_fail_if_msg(origdn == NULL, "Out of memory\n");
 
     ret = sysdb_save_autofsmap(test_ctx->domain, autofsmapname,
                                autofsmapname, origdn, NULL, 0, 0, false);
-    fail_if(ret != EOK, "Could not store autofs map %s", autofsmapname);
+    sss_ck_fail_if_msg(ret != EOK, "Could not store autofs map %s", autofsmapname);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -6674,15 +6674,15 @@ START_TEST(test_autofs_retrieve_map)
     struct ldb_message *map = NULL;
 
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     autofsmapname = talloc_asprintf(test_ctx, "testmap%d", _i);
-    fail_if(autofsmapname == NULL, "Out of memory\n");
+    sss_ck_fail_if_msg(autofsmapname == NULL, "Out of memory\n");
 
     ret = sysdb_get_map_byname(test_ctx, test_ctx->domain,
                                autofsmapname, &map);
-    fail_if(ret != EOK, "Could not retrieve autofs map %s", autofsmapname);
-    fail_if(map == NULL, "No map retrieved?\n");
+    sss_ck_fail_if_msg(ret != EOK, "Could not retrieve autofs map %s", autofsmapname);
+    sss_ck_fail_if_msg(map == NULL, "No map retrieved?\n");
     talloc_free(test_ctx);
 }
 END_TEST
@@ -6694,13 +6694,13 @@ START_TEST(test_autofs_delete_map)
     errno_t ret;
 
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     autofsmapname = talloc_asprintf(test_ctx, "testmap%d", _i);
-    fail_if(autofsmapname == NULL, "Out of memory\n");
+    sss_ck_fail_if_msg(autofsmapname == NULL, "Out of memory\n");
 
     ret = sysdb_delete_autofsmap(test_ctx->domain, autofsmapname);
-    fail_if(ret != EOK, "Could not retrieve autofs map %s", autofsmapname);
+    sss_ck_fail_if_msg(ret != EOK, "Could not retrieve autofs map %s", autofsmapname);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -6713,15 +6713,15 @@ START_TEST(test_autofs_retrieve_map_neg)
     struct ldb_message *map = NULL;
 
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     autofsmapname = talloc_asprintf(test_ctx, "testmap%d", _i);
-    fail_if(autofsmapname == NULL, "Out of memory\n");
+    sss_ck_fail_if_msg(autofsmapname == NULL, "Out of memory\n");
 
     ret = sysdb_get_map_byname(test_ctx, test_ctx->domain,
                                autofsmapname, &map);
-    fail_if(ret != ENOENT, "Expected ENOENT, got %d instead\n", ret);
-    fail_if(map != NULL, "Unexpected map found\n");
+    sss_ck_fail_if_msg(ret != ENOENT, "Expected ENOENT, got %d instead\n", ret);
+    sss_ck_fail_if_msg(map != NULL, "Unexpected map found\n");
     talloc_free(test_ctx);
 }
 END_TEST
@@ -6737,23 +6737,23 @@ START_TEST(test_autofs_store_entry_in_map)
     const int limit = 10;
 
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     autofsmapname = talloc_asprintf(test_ctx, "testmap%d", _i);
-    fail_if(autofsmapname == NULL, "Out of memory\n");
+    sss_ck_fail_if_msg(autofsmapname == NULL, "Out of memory\n");
 
     for (ii=0; ii < limit; ii++) {
         autofskey = talloc_asprintf(test_ctx, "%s_testkey%d",
                                     autofsmapname, ii);
-        fail_if(autofskey == NULL, "Out of memory\n");
+        sss_ck_fail_if_msg(autofskey == NULL, "Out of memory\n");
 
         autofsval = talloc_asprintf(test_ctx, "testserver:/testval%d", ii);
-        fail_if(autofsval == NULL, "Out of memory\n");
+        sss_ck_fail_if_msg(autofsval == NULL, "Out of memory\n");
 
         ret = sysdb_save_autofsentry(test_ctx->domain,
                                      autofsmapname, autofskey,
                                      autofsval, NULL, 0, 0);
-        fail_if(ret != EOK, "Could not save autofs entry %s", autofskey);
+        sss_ck_fail_if_msg(ret != EOK, "Could not save autofs entry %s", autofskey);
     }
 
     talloc_free(test_ctx);
@@ -6770,16 +6770,16 @@ START_TEST(test_autofs_retrieve_keys_by_map)
     const int expected = 10;
 
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     autofsmapname = talloc_asprintf(test_ctx, "testmap%d", _i);
-    fail_if(autofsmapname == NULL, "Out of memory\n");
+    sss_ck_fail_if_msg(autofsmapname == NULL, "Out of memory\n");
 
     ret = sysdb_autofs_entries_by_map(test_ctx, test_ctx->domain,
                                       autofsmapname, &count, &entries);
-    fail_if(ret != EOK, "Cannot get autofs entries for map %s\n",
+    sss_ck_fail_if_msg(ret != EOK, "Cannot get autofs entries for map %s\n",
             autofsmapname);
-    fail_if(count != expected, "Expected to find %d entries, got %zd\n",
+    sss_ck_fail_if_msg(count != expected, "Expected to find %d entries, got %zd\n",
             expected, count);
     talloc_free(test_ctx);
 }
@@ -6794,21 +6794,21 @@ START_TEST(test_autofs_key_duplicate)
     errno_t ret;
 
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     autofsmapname = talloc_asprintf(test_ctx, "testmap%d", _i);
-    fail_if(autofsmapname == NULL, "Out of memory\n");
+    sss_ck_fail_if_msg(autofsmapname == NULL, "Out of memory\n");
 
     autofskey = talloc_asprintf(test_ctx, "testkey");
-    fail_if(autofskey == NULL, "Out of memory\n");
+    sss_ck_fail_if_msg(autofskey == NULL, "Out of memory\n");
 
     autofsval = talloc_asprintf(test_ctx, "testserver:/testval%d", _i);
-    fail_if(autofsval == NULL, "Out of memory\n");
+    sss_ck_fail_if_msg(autofsval == NULL, "Out of memory\n");
 
     ret = sysdb_save_autofsentry(test_ctx->domain,
                                  autofsmapname, autofskey,
                                  autofsval, NULL, 0, 0);
-    fail_if(ret != EOK, "Could not save autofs entry %s", autofskey);
+    sss_ck_fail_if_msg(ret != EOK, "Could not save autofs entry %s", autofskey);
     talloc_free(test_ctx);
 }
 END_TEST
@@ -6828,23 +6828,23 @@ START_TEST(test_autofs_get_duplicate_keys)
     const int expected = 10;
 
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     autofskey = talloc_asprintf(test_ctx, "testkey");
-    fail_if(autofskey == NULL, "Out of memory\n");
+    sss_ck_fail_if_msg(autofskey == NULL, "Out of memory\n");
 
     filter = talloc_asprintf(test_ctx, "(&(objectclass=%s)(%s=%s))",
                              SYSDB_AUTOFS_ENTRY_OC, SYSDB_AUTOFS_ENTRY_KEY, autofskey);
-    fail_if(filter == NULL, "Out of memory\n");
+    sss_ck_fail_if_msg(filter == NULL, "Out of memory\n");
 
     dn = ldb_dn_new_fmt(test_ctx, test_ctx->sysdb->ldb, SYSDB_TMPL_CUSTOM_SUBTREE,
                         AUTOFS_MAP_SUBDIR, test_ctx->domain->name);
-    fail_if(dn == NULL, "Out of memory\n");
+    sss_ck_fail_if_msg(dn == NULL, "Out of memory\n");
 
     ret = sysdb_search_entry(test_ctx, test_ctx->sysdb, dn, LDB_SCOPE_SUBTREE,
                              filter, attrs, &count, &msgs);
-    fail_unless(ret == EOK, "sysdb_search_entry returned [%d]", ret);
-    fail_if(count != expected, "Found %zd entries with name %s, expected %d\n",
+    ck_assert_msg(ret == EOK, "sysdb_search_entry returned [%d]", ret);
+    sss_ck_fail_if_msg(count != expected, "Found %zd entries with name %s, expected %d\n",
             count, autofskey, expected);
     talloc_free(test_ctx);
 }
@@ -6862,7 +6862,7 @@ static struct confdb_ctx *test_cdb_domains_prep(TALLOC_CTX *mem_ctx)
     /* (relative to current dir) */
     ret = mkdir(TESTS_PATH, 0775);
     if (ret == -1 && errno != EEXIST) {
-        fail("Could not create %s directory", TESTS_PATH);
+        ck_abort_msg("Could not create %s directory", TESTS_PATH);
         return NULL;
     }
 
@@ -6872,7 +6872,7 @@ static struct confdb_ctx *test_cdb_domains_prep(TALLOC_CTX *mem_ctx)
     /* Make sure the test domain does not interfere with our testing */
     ret = unlink(TESTS_PATH"/"TEST_CONF_FILE);
     if (ret != EOK && errno != ENOENT) {
-        fail("Could not remove confdb %s\n", TESTS_PATH"/"TEST_CONF_FILE);
+        ck_abort_msg("Could not remove confdb %s\n", TESTS_PATH"/"TEST_CONF_FILE);
         return NULL;
     }
 
@@ -6960,50 +6960,50 @@ START_TEST(test_upn_basic)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     attrs = sysdb_new_attrs(test_ctx);
-    fail_unless(attrs != NULL, "sysdb_new_attrs failed.\n");
+    ck_assert_msg(attrs != NULL, "sysdb_new_attrs failed.\n");
 
     ret = sysdb_attrs_add_string(attrs, SYSDB_UPN, UPN_PRINC);
-    fail_unless(ret == EOK, "sysdb_attrs_add_string failed.");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_string failed.");
 
     ret = sysdb_attrs_add_string(attrs, SYSDB_CANONICAL_UPN, UPN_CANON_PRINC);
-    fail_unless(ret == EOK, "sysdb_attrs_add_string failed.");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_string failed.");
 
     ret = sysdb_store_user(test_ctx->domain,
                            UPN_USER_NAME, "x",
                            12345, 0, "UPN USER", "/home/upn_user",
                            "/bin/bash", NULL,
                            attrs, NULL, -1, 0);
-    fail_unless(ret == EOK, "Could not store user.");
+    ck_assert_msg(ret == EOK, "Could not store user.");
 
     ret = sysdb_search_user_by_upn(test_ctx, test_ctx->domain, false,
                                    "abc@def.ghi", NULL, &msg);
-    fail_unless(ret == ENOENT,
+    ck_assert_msg(ret == ENOENT,
                 "sysdb_search_user_by_upn failed with non-existing UPN.");
 
     ret = sysdb_search_user_by_upn(test_ctx, test_ctx->domain, false,
                                    UPN_PRINC, NULL, &msg);
-    fail_unless(ret == EOK, "sysdb_search_user_by_upn failed.");
+    ck_assert_msg(ret == EOK, "sysdb_search_user_by_upn failed.");
 
     str = ldb_msg_find_attr_as_string(msg, SYSDB_NAME, NULL);
-    fail_unless(str != NULL, "ldb_msg_find_attr_as_string failed.");
-    fail_unless(strcmp(str, UPN_USER_NAME) == 0, "Expected [%s], got [%s].",
+    ck_assert_msg(str != NULL, "ldb_msg_find_attr_as_string failed.");
+    ck_assert_msg(strcmp(str, UPN_USER_NAME) == 0, "Expected [%s], got [%s].",
                                                  UPN_USER_NAME, str);
 
     str = ldb_msg_find_attr_as_string(msg, SYSDB_UPN, NULL);
-    fail_unless(str != NULL, "ldb_msg_find_attr_as_string failed.");
-    fail_unless(strcmp(str, UPN_PRINC) == 0,
+    ck_assert_msg(str != NULL, "ldb_msg_find_attr_as_string failed.");
+    ck_assert_msg(strcmp(str, UPN_PRINC) == 0,
                 "Expected [%s], got [%s].", UPN_PRINC, str);
 
     /* check if input is sanitized */
     ret = sysdb_search_user_by_upn(test_ctx, test_ctx->domain, false,
                                    "abc@def.ghi)(name="UPN_USER_NAME")(abc=xyz",
                                    NULL, &msg);
-    fail_unless(ret == ENOENT,
+    ck_assert_msg(ret == ENOENT,
                 "sysdb_search_user_by_upn failed with un-sanitized input.");
 
     talloc_free(test_ctx);
@@ -7020,22 +7020,22 @@ START_TEST(test_upn_basic_case)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     ret = sysdb_search_user_by_upn(test_ctx, test_ctx->domain, false,
                                    UPN_PRINC_WRONG_CASE, NULL, &msg);
-    fail_unless(ret == EOK, "sysdb_search_user_by_upn failed.");
+    ck_assert_msg(ret == EOK, "sysdb_search_user_by_upn failed.");
 
     str = ldb_msg_find_attr_as_string(msg, SYSDB_NAME, NULL);
-    fail_unless(str != NULL, "ldb_msg_find_attr_as_string failed.");
-    fail_unless(strcmp(str, UPN_USER_NAME) == 0, "Expected [%s], got [%s].",
+    ck_assert_msg(str != NULL, "ldb_msg_find_attr_as_string failed.");
+    ck_assert_msg(strcmp(str, UPN_USER_NAME) == 0, "Expected [%s], got [%s].",
                                                  UPN_USER_NAME, str);
 
     str = ldb_msg_find_attr_as_string(msg, SYSDB_UPN, NULL);
-    fail_unless(str != NULL, "ldb_msg_find_attr_as_string failed.");
-    fail_unless(strcmp(str, UPN_PRINC) == 0,
+    ck_assert_msg(str != NULL, "ldb_msg_find_attr_as_string failed.");
+    ck_assert_msg(strcmp(str, UPN_PRINC) == 0,
                 "Expected [%s], got [%s].", UPN_PRINC, str);
 
     talloc_free(test_ctx);
@@ -7052,27 +7052,27 @@ START_TEST(test_upn_canon)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     ret = sysdb_search_user_by_upn(test_ctx, test_ctx->domain, false,
                                    UPN_CANON_PRINC, NULL, &msg);
-    fail_unless(ret == EOK, "sysdb_search_user_by_upn failed.");
+    ck_assert_msg(ret == EOK, "sysdb_search_user_by_upn failed.");
 
     str = ldb_msg_find_attr_as_string(msg, SYSDB_NAME, NULL);
-    fail_unless(str != NULL, "ldb_msg_find_attr_as_string failed.");
-    fail_unless(strcmp(str, UPN_USER_NAME) == 0, "Expected [%s], got [%s].",
+    ck_assert_msg(str != NULL, "ldb_msg_find_attr_as_string failed.");
+    ck_assert_msg(strcmp(str, UPN_USER_NAME) == 0, "Expected [%s], got [%s].",
                                                  UPN_USER_NAME, str);
 
     str = ldb_msg_find_attr_as_string(msg, SYSDB_UPN, NULL);
-    fail_unless(str != NULL, "ldb_msg_find_attr_as_string failed.");
-    fail_unless(strcmp(str, UPN_PRINC) == 0,
+    ck_assert_msg(str != NULL, "ldb_msg_find_attr_as_string failed.");
+    ck_assert_msg(strcmp(str, UPN_PRINC) == 0,
                 "Expected [%s], got [%s].", UPN_PRINC, str);
 
     str = ldb_msg_find_attr_as_string(msg, SYSDB_CANONICAL_UPN, NULL);
-    fail_unless(str != NULL, "ldb_msg_find_attr_as_string failed.");
-    fail_unless(strcmp(str, UPN_CANON_PRINC) == 0,
+    ck_assert_msg(str != NULL, "ldb_msg_find_attr_as_string failed.");
+    ck_assert_msg(strcmp(str, UPN_CANON_PRINC) == 0,
                 "Expected [%s], got [%s].", UPN_CANON_PRINC, str);
 
     talloc_free(test_ctx);
@@ -7089,27 +7089,27 @@ START_TEST(test_upn_canon_case)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     ret = sysdb_search_user_by_upn(test_ctx, test_ctx->domain, false,
                                    UPN_CANON_PRINC_WRONG_CASE, NULL, &msg);
-    fail_unless(ret == EOK, "sysdb_search_user_by_upn failed.");
+    ck_assert_msg(ret == EOK, "sysdb_search_user_by_upn failed.");
 
     str = ldb_msg_find_attr_as_string(msg, SYSDB_NAME, NULL);
-    fail_unless(str != NULL, "ldb_msg_find_attr_as_string failed.");
-    fail_unless(strcmp(str, UPN_USER_NAME) == 0, "Expected [%s], got [%s].",
+    ck_assert_msg(str != NULL, "ldb_msg_find_attr_as_string failed.");
+    ck_assert_msg(strcmp(str, UPN_USER_NAME) == 0, "Expected [%s], got [%s].",
                                                  UPN_USER_NAME, str);
 
     str = ldb_msg_find_attr_as_string(msg, SYSDB_UPN, NULL);
-    fail_unless(str != NULL, "ldb_msg_find_attr_as_string failed.");
-    fail_unless(strcmp(str, UPN_PRINC) == 0,
+    ck_assert_msg(str != NULL, "ldb_msg_find_attr_as_string failed.");
+    ck_assert_msg(strcmp(str, UPN_PRINC) == 0,
                 "Expected [%s], got [%s].", UPN_PRINC, str);
 
     str = ldb_msg_find_attr_as_string(msg, SYSDB_CANONICAL_UPN, NULL);
-    fail_unless(str != NULL, "ldb_msg_find_attr_as_string failed.");
-    fail_unless(strcmp(str, UPN_CANON_PRINC) == 0,
+    ck_assert_msg(str != NULL, "ldb_msg_find_attr_as_string failed.");
+    ck_assert_msg(strcmp(str, UPN_CANON_PRINC) == 0,
                 "Expected [%s], got [%s].", UPN_CANON_PRINC, str);
 
     talloc_free(test_ctx);
@@ -7127,45 +7127,45 @@ START_TEST(test_upn_dup)
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     attrs = sysdb_new_attrs(test_ctx);
-    fail_unless(attrs != NULL, "sysdb_new_attrs failed.\n");
+    ck_assert_msg(attrs != NULL, "sysdb_new_attrs failed.\n");
 
     ret = sysdb_attrs_add_string(attrs, SYSDB_UPN, UPN_CANON_PRINC);
-    fail_unless(ret == EOK, "sysdb_attrs_add_string failed.");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_string failed.");
 
     ret = sysdb_store_user(test_ctx->domain,
                            UPN_USER_NAME"_dup", "x",
                            23456, 0, "UPN USER DUP", "/home/upn_user_dup",
                            "/bin/bash", NULL,
                            attrs, NULL, -1, 0);
-    fail_unless(ret == EOK, "Could not store user.");
+    ck_assert_msg(ret == EOK, "Could not store user.");
 
     ret = sysdb_search_user_by_upn(test_ctx, test_ctx->domain, false,
                                    UPN_CANON_PRINC, NULL, &msg);
-    fail_unless(ret == EINVAL,
+    ck_assert_msg(ret == EINVAL,
                 "sysdb_search_user_by_upn failed for duplicated UPN.");
 
     ret = sysdb_search_user_by_upn(test_ctx, test_ctx->domain, false,
                                    UPN_PRINC, NULL, &msg);
-    fail_unless(ret == EOK, "sysdb_search_user_by_upn failed.");
+    ck_assert_msg(ret == EOK, "sysdb_search_user_by_upn failed.");
 
     str = ldb_msg_find_attr_as_string(msg, SYSDB_NAME, NULL);
-    fail_unless(str != NULL, "ldb_msg_find_attr_as_string failed.");
-    fail_unless(strcmp(str, UPN_USER_NAME) == 0, "Expected [%s], got [%s].",
+    ck_assert_msg(str != NULL, "ldb_msg_find_attr_as_string failed.");
+    ck_assert_msg(strcmp(str, UPN_USER_NAME) == 0, "Expected [%s], got [%s].",
                                                  UPN_USER_NAME, str);
 
     str = ldb_msg_find_attr_as_string(msg, SYSDB_UPN, NULL);
-    fail_unless(str != NULL, "ldb_msg_find_attr_as_string failed.");
-    fail_unless(strcmp(str, UPN_PRINC) == 0,
+    ck_assert_msg(str != NULL, "ldb_msg_find_attr_as_string failed.");
+    ck_assert_msg(strcmp(str, UPN_PRINC) == 0,
                 "Expected [%s], got [%s].", UPN_PRINC, str);
 
     str = ldb_msg_find_attr_as_string(msg, SYSDB_CANONICAL_UPN, NULL);
-    fail_unless(str != NULL, "ldb_msg_find_attr_as_string failed.");
-    fail_unless(strcmp(str, UPN_CANON_PRINC) == 0,
+    ck_assert_msg(str != NULL, "ldb_msg_find_attr_as_string failed.");
+    ck_assert_msg(strcmp(str, UPN_CANON_PRINC) == 0,
                 "Expected [%s], got [%s].", UPN_CANON_PRINC, str);
 
     talloc_free(test_ctx);
@@ -7182,30 +7182,30 @@ START_TEST(test_gpo_store_retrieve)
     static const char *test_guid = "3610EDA5-77EF-11D2-8DC5-00C04FA31A66";
 
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     ret = sysdb_gpo_get_gpo_by_guid(test_ctx, test_ctx->domain,
                                     test_guid,
                                     &result);
-    fail_if(ret != ENOENT, "GPO present in cache before store op");
+    sss_ck_fail_if_msg(ret != ENOENT, "GPO present in cache before store op");
 
     ret = sysdb_gpo_get_gpos(test_ctx, test_ctx->domain, &result);
-    fail_if(ret != ENOENT, "GPO present in cache before store op");
+    sss_ck_fail_if_msg(ret != ENOENT, "GPO present in cache before store op");
 
     ret = sysdb_gpo_store_gpo(test_ctx->domain,
                               test_guid, 1, 5, 0);
-    fail_if(ret != EOK, "Could not store a test GPO");
+    sss_ck_fail_if_msg(ret != EOK, "Could not store a test GPO");
 
     ret = sysdb_gpo_get_gpos(test_ctx, test_ctx->domain, &result);
-    fail_if(ret != EOK, "GPOs not in cache after store op");
-    fail_if(result == NULL, "Could not get GPOs");
+    sss_ck_fail_if_msg(ret != EOK, "GPOs not in cache after store op");
+    sss_ck_fail_if_msg(result == NULL, "Could not get GPOs");
     ck_assert_int_eq(result->count, 1);
 
     result = NULL;
     ret = sysdb_gpo_get_gpo_by_guid(test_ctx, test_ctx->domain,
                                     test_guid, &result);
-    fail_if(ret != EOK, "GPO not in cache after store op");
-    fail_if(result == NULL, "Could not get GPOs by guid: %s", test_guid);
+    sss_ck_fail_if_msg(ret != EOK, "GPO not in cache after store op");
+    sss_ck_fail_if_msg(result == NULL, "Could not get GPOs by guid: %s", test_guid);
     ck_assert_int_eq(result->count, 1);
 
     guid = ldb_msg_find_attr_as_string(result->msgs[0],
@@ -7229,12 +7229,12 @@ START_TEST(test_gpo_replace)
     static const char *test_guid = "3610EDA5-77EF-11D2-8DC5-00C04FA31A66";
 
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not setup the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not setup the test");
 
     ret = sysdb_gpo_get_gpo_by_guid(test_ctx, test_ctx->domain,
                                     test_guid, &result);
-    fail_if(ret != EOK, "GPO not in cache after store op");
-    fail_if(result == NULL, "Could not get GPOs by guid: %s", test_guid);
+    sss_ck_fail_if_msg(ret != EOK, "GPO not in cache after store op");
+    sss_ck_fail_if_msg(result == NULL, "Could not get GPOs by guid: %s", test_guid);
     ck_assert_int_eq(result->count, 1);
 
     guid = ldb_msg_find_attr_as_string(result->msgs[0],
@@ -7248,12 +7248,12 @@ START_TEST(test_gpo_replace)
     /* Modify the version */
     ret = sysdb_gpo_store_gpo(test_ctx->domain,
                               test_guid, 2, 5, 0);
-    fail_if(ret != EOK, "Could not store a test GPO");
+    sss_ck_fail_if_msg(ret != EOK, "Could not store a test GPO");
 
     ret = sysdb_gpo_get_gpo_by_guid(test_ctx, test_ctx->domain,
                                     test_guid, &result);
-    fail_if(ret != EOK, "GPO not in cache after modify op");
-    fail_if(result == NULL, "Could not get GPOs by guid: %s", test_guid);
+    sss_ck_fail_if_msg(ret != EOK, "GPO not in cache after modify op");
+    sss_ck_fail_if_msg(result == NULL, "Could not get GPOs by guid: %s", test_guid);
     ck_assert_int_eq(result->count, 1);
 
     guid = ldb_msg_find_attr_as_string(result->msgs[0],
@@ -7276,7 +7276,7 @@ START_TEST(test_gpo_result)
     const char *value = NULL;
 
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not setup the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not setup the test");
 
     /* No result in cache */
     ret = sysdb_gpo_get_gpo_result_setting(test_ctx, test_ctx->domain,
@@ -7307,7 +7307,7 @@ START_TEST(test_gpo_result)
     ret = sysdb_gpo_get_gpo_result_setting(test_ctx, test_ctx->domain,
                                            deny_key, &value);
     ck_assert_int_eq(ret, EOK);
-    fail_unless(value == NULL, "Unexpected value returned for deny key "
+    ck_assert_msg(value == NULL, "Unexpected value returned for deny key "
                                "from sysdb_gpo_get_gpo_result_setting");
 
     /* Updating replaces the original value */
@@ -7328,7 +7328,7 @@ START_TEST(test_gpo_result)
     ret = sysdb_gpo_get_gpo_result_setting(test_ctx, test_ctx->domain,
                                            allow_key, &value);
     ck_assert_int_eq(ret, EOK);
-    fail_unless(value == NULL, "Unexpected value returned for allow key"
+    ck_assert_msg(value == NULL, "Unexpected value returned for allow key"
                                "from sysdb_gpo_get_gpo_result_setting" );
 
     /* Delete the result */
@@ -7406,11 +7406,11 @@ START_TEST(test_sysdb_mark_entry_as_expired_ldb_dn)
     char *filter;
 
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not setup the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not setup the test");
 
     /* Add something to database to test against */
     data = test_data_new_user(test_ctx, 2000);
-    fail_if(data == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(data == NULL, "Failed to allocate memory");
 
     ret = sysdb_transaction_start(test_ctx->sysdb);
     ck_assert_int_eq(ret, EOK);
@@ -7424,7 +7424,7 @@ START_TEST(test_sysdb_mark_entry_as_expired_ldb_dn)
     filter = talloc_asprintf(data,
                              "("SYSDB_UIDNUM"=%llu)",
                              (unsigned long long) data->uid);
-    fail_if(filter == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(filter == NULL, "Failed to allocate memory");
 
     ret = sysdb_search_users(test_ctx, test_ctx->domain,
                              filter, attrs, &count, &msgs);
@@ -7452,7 +7452,7 @@ START_TEST(test_sysdb_mark_entry_as_expired_ldb_dn)
     filter = talloc_asprintf(data,
                              "("SYSDB_UIDNUM"=%llu)",
                              (unsigned long long) data->uid);
-    fail_if(filter == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(filter == NULL, "Failed to allocate memory");
 
     ret = sysdb_search_users(test_ctx, test_ctx->domain,
                              filter, attrs, &count, &msgs);
@@ -7494,27 +7494,27 @@ void hosts_check_match(struct sysdb_test_ctx *test_ctx,
     if (by_name) {
         /* Look up the host by name */
         ret = sysdb_gethostbyname(test_ctx, test_ctx->domain, search, &res);
-        fail_if(ret != EOK, "sysdb_gethostbyname error [%s]\n",
+        sss_ck_fail_if_msg(ret != EOK, "sysdb_gethostbyname error [%s]\n",
                              strerror(ret));
     } else {
         /* Look up the host by address */
         ret = sysdb_gethostbyaddr(test_ctx, test_ctx->domain, search, &res);
-        fail_if(ret != EOK, "sysdb_gethostbyaddr error [%s]\n",
+        sss_ck_fail_if_msg(ret != EOK, "sysdb_gethostbyaddr error [%s]\n",
                              strerror(ret));
     }
-    fail_if(res == NULL, "ENOMEM");
+    sss_ck_fail_if_msg(res == NULL, "ENOMEM");
     ck_assert_int_eq(res->count, 1);
 
     /* Make sure the returned entry matches */
     msg = res->msgs[0];
     ret_name = ldb_msg_find_attr_as_string(msg, SYSDB_NAME, NULL);
-    fail_if(ret_name == NULL, "Failed to find attribute: " SYSDB_NAME);
-    fail_unless(strcmp(ret_name, primary_name) == 0,
+    sss_ck_fail_if_msg(ret_name == NULL, "Failed to find attribute: " SYSDB_NAME);
+    ck_assert_msg(strcmp(ret_name, primary_name) == 0,
                 "Wrong value returned for attribute: %s. got: %s expected: %s",
                 SYSDB_NAME, ret_name, primary_name);
 
     el = ldb_msg_find_element(msg, SYSDB_IP_HOST_ATTR_ADDRESS);
-    fail_if(el == NULL, "Failed to find elemeny: " SYSDB_IP_HOST_ATTR_ADDRESS);
+    sss_ck_fail_if_msg(el == NULL, "Failed to find elemeny: " SYSDB_IP_HOST_ATTR_ADDRESS);
 
     len = talloc_array_length(addresses);
     for (i = 0; i < el->num_values; i++) {
@@ -7523,7 +7523,7 @@ void hosts_check_match(struct sysdb_test_ctx *test_ctx,
             char *canonical_address;
             ret = sss_canonicalize_ip_address(test_ctx, addresses[j],
                                               &canonical_address);
-            fail_if(ret != EOK,
+            sss_ck_fail_if_msg(ret != EOK,
                      "sss_canonicalize_ip_address failed: %d", ret);
 
             if (strcmp(canonical_address,
@@ -7532,12 +7532,12 @@ void hosts_check_match(struct sysdb_test_ctx *test_ctx,
             }
         }
 
-        fail_if(!matched, "Unexpected value in LDB entry: [%s]",
+        sss_ck_fail_if_msg(!matched, "Unexpected value in LDB entry: [%s]",
                 (const char *)el->values[i].data);
     }
 
     el = ldb_msg_find_element(msg, SYSDB_NAME_ALIAS);
-    fail_if(el == NULL, "Failed to find element: " SYSDB_NAME_ALIAS);
+    sss_ck_fail_if_msg(el == NULL, "Failed to find element: " SYSDB_NAME_ALIAS);
 
     len = talloc_array_length(aliases);
     for (i = 0; i < el->num_values; i++) {
@@ -7547,7 +7547,7 @@ void hosts_check_match(struct sysdb_test_ctx *test_ctx,
                 matched = true;
             }
         }
-        fail_if(!matched, "Unexpected value in LDB entry: [%s]",
+        sss_ck_fail_if_msg(!matched, "Unexpected value in LDB entry: [%s]",
                 (const char *)el->values[i].data);
     }
 }
@@ -7573,49 +7573,49 @@ START_TEST(test_sysdb_add_hosts)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     primary_name = talloc_asprintf(test_ctx, "test.example.org");
-    fail_if(primary_name == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(primary_name == NULL, "Failed to allocate memory");
 
     aliases = talloc_array(test_ctx, const char *, 3);
-    fail_if(aliases == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(aliases == NULL, "Failed to allocate memory");
 
     aliases[0] = talloc_asprintf(aliases, "alias1.example.org");
-    fail_if(aliases[0] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(aliases[0] == NULL, "Failed to allocate memory");
 
     aliases[1] = talloc_asprintf(aliases, "alias2.example.org");
-    fail_if(aliases[1] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(aliases[1] == NULL, "Failed to allocate memory");
 
     aliases[2] = NULL;
 
     addresses = talloc_array(test_ctx, const char *, 6);
-    fail_if(addresses == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(addresses == NULL, "Failed to allocate memory");
 
     addresses[0] = talloc_asprintf(addresses, "1.1.2.3");
-    fail_if(addresses[0] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(addresses[0] == NULL, "Failed to allocate memory");
 
     addresses[1] = talloc_asprintf(addresses, "10.11.22.33");
-    fail_if(addresses[1] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(addresses[1] == NULL, "Failed to allocate memory");
 
     addresses[2] = talloc_asprintf(addresses, "100.123.123.123");
-    fail_if(addresses[2] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(addresses[2] == NULL, "Failed to allocate memory");
 
     addresses[3] = talloc_asprintf(addresses, "2001:0db8:85a3:0000:0000:8a2e:0370:7334");
-    fail_if(addresses[3] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(addresses[3] == NULL, "Failed to allocate memory");
 
     addresses[4] = talloc_asprintf(addresses, "2001:db8:85a3:0:1:8a2e:370:7334");
-    fail_if(addresses[4] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(addresses[4] == NULL, "Failed to allocate memory");
 
     addresses[5] = NULL;
 
     ret = sysdb_transaction_start(test_ctx->sysdb);
-    fail_if(ret != EOK, "[%s]", strerror(ret));
+    sss_ck_fail_if_msg(ret != EOK, "[%s]", strerror(ret));
 
     ret = sysdb_host_add(NULL, test_ctx->domain,
                          primary_name, aliases,
                          addresses, NULL);
-    fail_unless(ret == EOK, "sysdb_host_add error [%s]\n", strerror(ret));
+    ck_assert_msg(ret == EOK, "sysdb_host_add error [%s]\n", strerror(ret));
 
     /* Search by name and make sure the results match */
     hosts_check_match_name(test_ctx, primary_name, primary_name,
@@ -7632,7 +7632,7 @@ START_TEST(test_sysdb_add_hosts)
     }
 
     ret = sysdb_transaction_commit(test_ctx->sysdb);
-    fail_if(ret != EOK, "[%s]", strerror(ret));
+    sss_ck_fail_if_msg(ret != EOK, "[%s]", strerror(ret));
 
     /* Clean up after ourselves (and test deleting by name)
      *
@@ -7641,7 +7641,7 @@ START_TEST(test_sysdb_add_hosts)
      * single transaction.
      */
     ret = sysdb_host_delete(test_ctx->domain, primary_name, NULL);
-    fail_if(ret != EOK, "[%s]", strerror(ret));
+    sss_ck_fail_if_msg(ret != EOK, "[%s]", strerror(ret));
 
     talloc_free(test_ctx);
 }
@@ -7664,24 +7664,24 @@ void ipnetwork_check_match(struct sysdb_test_ctx *test_ctx,
     bool matched;
 
     ret = sss_canonicalize_ip_address(test_ctx, address, &c_addr);
-    fail_if(ret != EOK, "sss_canonicalize_ip_address failed: %d", ret);
+    sss_ck_fail_if_msg(ret != EOK, "sss_canonicalize_ip_address failed: %d", ret);
 
     ret_name = ldb_msg_find_attr_as_string(msg, SYSDB_NAME, NULL);
-    fail_if(ret_name == NULL, "Failed to find attribue: " SYSDB_NAME);
-    fail_unless(strcmp(ret_name, primary_name) == 0,
+    sss_ck_fail_if_msg(ret_name == NULL, "Failed to find attribue: " SYSDB_NAME);
+    ck_assert_msg(strcmp(ret_name, primary_name) == 0,
                 "Wrong value returned for attribute: %s. got: %s expected: %s",
                 SYSDB_NAME, ret_name, primary_name);
 
     ret_addr = ldb_msg_find_attr_as_string(msg, SYSDB_IP_NETWORK_ATTR_NUMBER,
                                            NULL);
-    fail_if(ret_addr == NULL,
+    sss_ck_fail_if_msg(ret_addr == NULL,
             "Failed to find attribue: " SYSDB_IP_NETWORK_ATTR_NUMBER);
-    fail_unless(strcmp(ret_addr, c_addr) == 0,
+    ck_assert_msg(strcmp(ret_addr, c_addr) == 0,
                 "Wrong value returned for attribute: %s. got: %s expected: %s",
                 SYSDB_IP_NETWORK_ATTR_NUMBER, ret_addr, c_addr);
 
     el = ldb_msg_find_element(msg, SYSDB_NAME_ALIAS);
-    fail_if(el == NULL, "Failed to find element: " SYSDB_NAME_ALIAS);
+    sss_ck_fail_if_msg(el == NULL, "Failed to find element: " SYSDB_NAME_ALIAS);
 
     len = talloc_array_length(aliases);
     for (i = 0; i < el->num_values; i++) {
@@ -7691,7 +7691,7 @@ void ipnetwork_check_match(struct sysdb_test_ctx *test_ctx,
                 matched = true;
             }
         }
-        fail_if(!matched, "Unexpected value in LDB entry: [%s]",
+        sss_ck_fail_if_msg(!matched, "Unexpected value in LDB entry: [%s]",
                 (const char *)el->values[i].data);
     }
 }
@@ -7707,9 +7707,9 @@ void ipnetwork_check_match_name(struct sysdb_test_ctx *test_ctx,
 
     ret = sysdb_getipnetworkbyname(test_ctx, test_ctx->domain,
                                    search_name, &res);
-    fail_if(ret != EOK, "sysdb_getipnetworkbyname error [%s]\n",
+    sss_ck_fail_if_msg(ret != EOK, "sysdb_getipnetworkbyname error [%s]\n",
             strerror(ret));
-    fail_if(res == NULL, "ENOMEM");
+    sss_ck_fail_if_msg(res == NULL, "ENOMEM");
     ck_assert_int_eq(res->count, 1);
 
     ipnetwork_check_match(test_ctx, res->msgs[0], primary_name, aliases,
@@ -7727,9 +7727,9 @@ void ipnetwork_check_match_addr(struct sysdb_test_ctx *test_ctx,
 
     ret = sysdb_getipnetworkbyaddr(test_ctx, test_ctx->domain,
                                    search_addr, &res);
-    fail_if(ret != EOK, "sysdb_getipnetworkbyaddr error [%s]\n",
+    sss_ck_fail_if_msg(ret != EOK, "sysdb_getipnetworkbyaddr error [%s]\n",
             strerror(ret));
-    fail_if(res == NULL, "ENOMEM");
+    sss_ck_fail_if_msg(res == NULL, "ENOMEM");
     ck_assert_int_eq(res->count, 1);
 
     ipnetwork_check_match(test_ctx, res->msgs[0], primary_name, aliases,
@@ -7747,32 +7747,32 @@ START_TEST(test_sysdb_add_ipnetworks)
 
     /* Setup */
     ret = setup_sysdb_tests(&test_ctx);
-    fail_if(ret != EOK, "Could not set up the test");
+    sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
 
     primary_name = talloc_asprintf(test_ctx, "network_1");
-    fail_if(primary_name == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(primary_name == NULL, "Failed to allocate memory");
 
     aliases = talloc_array(test_ctx, const char *, 3);
-    fail_if(aliases == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(aliases == NULL, "Failed to allocate memory");
 
     aliases[0] = talloc_asprintf(aliases, "network_1_alias_1");
-    fail_if(aliases[0] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(aliases[0] == NULL, "Failed to allocate memory");
 
     aliases[1] = talloc_asprintf(aliases, "network_1_alias_2");
-    fail_if(aliases[1] == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(aliases[1] == NULL, "Failed to allocate memory");
 
     aliases[2] = NULL;
 
     address = talloc_asprintf(test_ctx, "192.168.1.0");
-    fail_if(address == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(address == NULL, "Failed to allocate memory");
 
     ret = sysdb_transaction_start(test_ctx->sysdb);
-    fail_if(ret != EOK, "[%s]", strerror(ret));
+    sss_ck_fail_if_msg(ret != EOK, "[%s]", strerror(ret));
 
     ret = sysdb_ipnetwork_add(NULL, test_ctx->domain,
                               primary_name, aliases,
                               address, NULL);
-    fail_unless(ret == EOK, "sysdb_ipnetwork_add error [%s]\n", strerror(ret));
+    ck_assert_msg(ret == EOK, "sysdb_ipnetwork_add error [%s]\n", strerror(ret));
 
     /* Search by name and make sure the results match */
     ipnetwork_check_match_name(test_ctx, primary_name, primary_name,
@@ -7787,7 +7787,7 @@ START_TEST(test_sysdb_add_ipnetworks)
                                aliases, address);
 
     ret = sysdb_transaction_commit(test_ctx->sysdb);
-    fail_if(ret != EOK, "[%s]", strerror(ret));
+    sss_ck_fail_if_msg(ret != EOK, "[%s]", strerror(ret));
 
     /* Clean up after ourselves (and test deleting by name)
      *
@@ -7796,7 +7796,7 @@ START_TEST(test_sysdb_add_ipnetworks)
      * single transaction.
      */
     ret = sysdb_ipnetwork_delete(test_ctx->domain, primary_name, NULL);
-    fail_if(ret != EOK, "[%s]", strerror(ret));
+    sss_ck_fail_if_msg(ret != EOK, "[%s]", strerror(ret));
 
     talloc_free(test_ctx);
 }

--- a/src/tests/sysdb_ssh-tests.c
+++ b/src/tests/sysdb_ssh-tests.c
@@ -26,7 +26,7 @@
 
 
 #include "config.h"
-#include "tests/common.h"
+#include "tests/common_check.h"
 #include "util/util.h"
 #include "confdb/confdb.h"
 #include "db/sysdb.h"
@@ -57,13 +57,13 @@ static int setup_sysdb_tests(struct sysdb_test_ctx **ctx)
     /* (relative to current dir) */
     ret = mkdir(TESTS_PATH, 0775);
     if (ret == -1 && errno != EEXIST) {
-        fail("Could not create %s directory", TESTS_PATH);
+        ck_abort_msg("Could not create %s directory", TESTS_PATH);
         return EFAULT;
     }
 
     test_ctx = talloc_zero(NULL, struct sysdb_test_ctx);
     if (test_ctx == NULL) {
-        fail("Could not allocate memory for test context");
+        ck_abort_msg("Could not allocate memory for test context");
         return ENOMEM;
     }
 
@@ -72,14 +72,14 @@ static int setup_sysdb_tests(struct sysdb_test_ctx **ctx)
      */
     test_ctx->ev = tevent_context_init(test_ctx);
     if (test_ctx->ev == NULL) {
-        fail("Could not create event context");
+        ck_abort_msg("Could not create event context");
         talloc_free(test_ctx);
         return EIO;
     }
 
     conf_db = talloc_asprintf(test_ctx, "%s/%s", TESTS_PATH, TEST_CONF_FILE);
     if (conf_db == NULL) {
-        fail("Out of memory, aborting!");
+        ck_abort_msg("Out of memory, aborting!");
         talloc_free(test_ctx);
         return ENOMEM;
     }
@@ -88,7 +88,7 @@ static int setup_sysdb_tests(struct sysdb_test_ctx **ctx)
     /* Connect to the conf db */
     ret = confdb_init(test_ctx, &test_ctx->confdb, conf_db);
     if (ret != EOK) {
-        fail("Could not initialize connection to the confdb");
+        ck_abort_msg("Could not initialize connection to the confdb");
         talloc_free(test_ctx);
         return ret;
     }
@@ -97,7 +97,7 @@ static int setup_sysdb_tests(struct sysdb_test_ctx **ctx)
     ret = confdb_add_param(test_ctx->confdb, true,
                            "config/sssd", "domains", val);
     if (ret != EOK) {
-        fail("Could not initialize domains placeholder");
+        ck_abort_msg("Could not initialize domains placeholder");
         talloc_free(test_ctx);
         return ret;
     }
@@ -106,7 +106,7 @@ static int setup_sysdb_tests(struct sysdb_test_ctx **ctx)
     ret = confdb_add_param(test_ctx->confdb, true,
                            "config/domain/FILES", "id_provider", val);
     if (ret != EOK) {
-        fail("Could not initialize provider");
+        ck_abort_msg("Could not initialize provider");
         talloc_free(test_ctx);
         return ret;
     }
@@ -115,7 +115,7 @@ static int setup_sysdb_tests(struct sysdb_test_ctx **ctx)
     ret = confdb_add_param(test_ctx->confdb, true,
                            "config/domain/FILES", "enumerate", val);
     if (ret != EOK) {
-        fail("Could not initialize FILES domain");
+        ck_abort_msg("Could not initialize FILES domain");
         talloc_free(test_ctx);
         return ret;
     }
@@ -124,7 +124,7 @@ static int setup_sysdb_tests(struct sysdb_test_ctx **ctx)
     ret = confdb_add_param(test_ctx->confdb, true,
                            "config/domain/FILES", "cache_credentials", val);
     if (ret != EOK) {
-        fail("Could not initialize FILES domain");
+        ck_abort_msg("Could not initialize FILES domain");
         talloc_free(test_ctx);
         return ret;
     }
@@ -132,7 +132,7 @@ static int setup_sysdb_tests(struct sysdb_test_ctx **ctx)
     ret = sssd_domain_init(test_ctx, test_ctx->confdb, "files",
                            TESTS_PATH, &test_ctx->domain);
     if (ret != EOK) {
-        fail("Could not initialize connection to the sysdb (%d)", ret);
+        ck_abort_msg("Could not initialize connection to the sysdb (%d)", ret);
         talloc_free(test_ctx);
         return ret;
     }
@@ -252,13 +252,13 @@ START_TEST (store_one_host_test)
 
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = talloc_zero(test_ctx, struct test_data);
     if (data == NULL) {
-        fail("Out of memory!");
+        ck_abort_msg("Out of memory!");
         talloc_free(test_ctx);
         return;
     }
@@ -267,21 +267,21 @@ START_TEST (store_one_host_test)
     data->ev = test_ctx->ev;
     data->hostname = talloc_strdup(test_ctx, TEST_HOSTNAME);
     if (data->hostname == NULL) {
-        fail("Out of memory!");
+        ck_abort_msg("Out of memory!");
         talloc_free(test_ctx);
         return;
     }
 
     data->attrs = sysdb_new_attrs(test_ctx);
     if (data->attrs == NULL) {
-        fail("Out of memory!");
+        ck_abort_msg("Out of memory!");
         talloc_free(test_ctx);
         return;
     }
 
     ret = test_sysdb_store_ssh_host(data);
 
-    fail_if(ret != EOK, "Could not store host into database");
+    sss_ck_fail_if_msg(ret != EOK, "Could not store host into database");
     talloc_free(test_ctx);
 }
 END_TEST
@@ -294,13 +294,13 @@ START_TEST (delete_existing_host_test)
 
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = talloc_zero(test_ctx, struct test_data);
     if (data == NULL) {
-        fail("Out of memory!");
+        ck_abort_msg("Out of memory!");
         return;
     }
 
@@ -308,14 +308,14 @@ START_TEST (delete_existing_host_test)
     data->ev = test_ctx->ev;
     data->hostname = talloc_strdup(test_ctx, TEST_HOSTNAME);
     if (data->hostname == NULL) {
-        fail("Out of memory!");
+        ck_abort_msg("Out of memory!");
         talloc_free(test_ctx);
         return;
     }
 
     ret = test_sysdb_delete_ssh_host(data);
 
-    fail_if(ret != EOK, "Could not delete host from database");
+    sss_ck_fail_if_msg(ret != EOK, "Could not delete host from database");
     talloc_free(test_ctx);
 }
 END_TEST
@@ -328,13 +328,13 @@ START_TEST (delete_nonexistent_host_test)
 
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up the test");
+        ck_abort_msg("Could not set up the test");
         return;
     }
 
     data = talloc_zero(test_ctx, struct test_data);
     if (data == NULL) {
-        fail("Out of memory!");
+        ck_abort_msg("Out of memory!");
         talloc_free(test_ctx);
         return;
     }
@@ -343,14 +343,14 @@ START_TEST (delete_nonexistent_host_test)
     data->ev = test_ctx->ev;
     data->hostname = talloc_strdup(test_ctx, "nonexistent_host");
     if (data->hostname == NULL) {
-        fail("Out of memory!");
+        ck_abort_msg("Out of memory!");
         talloc_free(test_ctx);
         return;
     }
 
     ret = test_sysdb_delete_ssh_host(data);
 
-    fail_if(ret != EOK, "Deletion of nonexistent host returned code %d", ret);
+    sss_ck_fail_if_msg(ret != EOK, "Deletion of nonexistent host returned code %d", ret);
     talloc_free(test_ctx);
 
 }
@@ -364,13 +364,13 @@ START_TEST (sysdb_get_ssh_host_test)
 
     ret = setup_sysdb_tests(&test_ctx);
     if (ret != EOK) {
-        fail("Could not set up test");
+        ck_abort_msg("Could not set up test");
         return;
     }
 
     data = talloc_zero(test_ctx, struct test_data);
     if (data == NULL) {
-        fail("Out of memory!");
+        ck_abort_msg("Out of memory!");
         talloc_free(test_ctx);
         return;
     }
@@ -379,28 +379,28 @@ START_TEST (sysdb_get_ssh_host_test)
     data->ev = test_ctx->ev;
     data->hostname = talloc_strdup(test_ctx, TEST_HOSTNAME);
     if (data->hostname == NULL) {
-        fail("Out of memory!");
+        ck_abort_msg("Out of memory!");
         talloc_free(test_ctx);
         return;
     }
 
     data->attrs = sysdb_new_attrs(test_ctx);
     if (data->attrs == NULL) {
-        fail("Out of memory!");
+        ck_abort_msg("Out of memory!");
         talloc_free(test_ctx);
         return;
     }
 
     ret = test_sysdb_store_ssh_host(data);
     if (ret != EOK) {
-        fail("Could not store host '%s' to database", TEST_HOSTNAME);
+        ck_abort_msg("Could not store host '%s' to database", TEST_HOSTNAME);
         talloc_free(test_ctx);
         return;
     }
 
     ret = test_sysdb_get_ssh_host(data);
 
-    fail_if(ret != EOK, "Could not find host '%s'",TEST_HOSTNAME);
+    sss_ck_fail_if_msg(ret != EOK, "Could not find host '%s'",TEST_HOSTNAME);
     talloc_free(test_ctx);
 }
 END_TEST

--- a/src/tests/util-tests.c
+++ b/src/tests/util-tests.c
@@ -48,32 +48,32 @@ START_TEST(test_add_string_to_list)
     char **list = NULL;
 
     ret = add_string_to_list(NULL, NULL, NULL);
-    fail_unless(ret == EINVAL, "NULL input accepted");
+    ck_assert_msg(ret == EINVAL, "NULL input accepted");
 
     ret = add_string_to_list(global_talloc_context, "ABC", &list);
-    fail_unless(ret == EOK, "Adding string to non-existing list failed.");
-    fail_unless(list != NULL, "No new list created.");
-    fail_unless(list[0] != NULL, "String not added to new list.");
-    fail_unless(strcmp(list[0], "ABC") == 0,
+    ck_assert_msg(ret == EOK, "Adding string to non-existing list failed.");
+    ck_assert_msg(list != NULL, "No new list created.");
+    ck_assert_msg(list[0] != NULL, "String not added to new list.");
+    ck_assert_msg(strcmp(list[0], "ABC") == 0,
                 "Wrong string added to newly created list.");
-    fail_unless(list[1] == NULL,
+    ck_assert_msg(list[1] == NULL,
                 "Missing terminating NULL in newly created list.");
 
     ret = add_string_to_list(global_talloc_context, "DEF", &list);
-    fail_unless(ret == EOK, "Adding string to list failed.");
-    fail_unless(list != NULL, "No list returned.");
-    fail_unless(strcmp(list[0], "ABC") == 0, "Wrong first string in new list.");
-    fail_unless(strcmp(list[1], "DEF") == 0, "Wrong string added to list.");
-    fail_unless(list[2] == NULL, "Missing terminating NULL.");
+    ck_assert_msg(ret == EOK, "Adding string to list failed.");
+    ck_assert_msg(list != NULL, "No list returned.");
+    ck_assert_msg(strcmp(list[0], "ABC") == 0, "Wrong first string in new list.");
+    ck_assert_msg(strcmp(list[1], "DEF") == 0, "Wrong string added to list.");
+    ck_assert_msg(list[2] == NULL, "Missing terminating NULL.");
 
     list[0] = NULL;
     ret = add_string_to_list(global_talloc_context, "ABC", &list);
-    fail_unless(ret == EOK, "Adding string to empty list failed.");
-    fail_unless(list != NULL, "No list returned.");
-    fail_unless(list[0] != NULL, "String not added to empty list.");
-    fail_unless(strcmp(list[0], "ABC") == 0,
+    ck_assert_msg(ret == EOK, "Adding string to empty list failed.");
+    ck_assert_msg(list != NULL, "No list returned.");
+    ck_assert_msg(list[0] != NULL, "String not added to empty list.");
+    ck_assert_msg(strcmp(list[0], "ABC") == 0,
                 "Wrong string added to empty list.");
-    fail_unless(list[1] == NULL,
+    ck_assert_msg(list[1] == NULL,
                 "Missing terminating NULL in newly created list.");
 
     talloc_free(list);
@@ -90,31 +90,31 @@ START_TEST(test_string_in_list)
                     NULL};
 
     is_in = string_in_list(NULL, NULL, false);
-    fail_unless(!is_in, "NULL string is in NULL list.");
+    ck_assert_msg(!is_in, "NULL string is in NULL list.");
 
     is_in = string_in_list(NULL, empty_list, false);
-    fail_unless(!is_in, "NULL string is in empty list.");
+    ck_assert_msg(!is_in, "NULL string is in empty list.");
 
     is_in = string_in_list(NULL, list, false);
-    fail_unless(!is_in, "NULL string is in list.");
+    ck_assert_msg(!is_in, "NULL string is in list.");
 
     is_in = string_in_list("ABC", NULL, false);
-    fail_unless(!is_in, "String is in NULL list.");
+    ck_assert_msg(!is_in, "String is in NULL list.");
 
     is_in = string_in_list("ABC", empty_list, false);
-    fail_unless(!is_in, "String is in empty list.");
+    ck_assert_msg(!is_in, "String is in empty list.");
 
     is_in = string_in_list("ABC", list, false);
-    fail_unless(is_in, "String is not list.");
+    ck_assert_msg(is_in, "String is not list.");
 
     is_in = string_in_list("abc", list, false);
-    fail_unless(is_in, "String is not case in-sensitive list.");
+    ck_assert_msg(is_in, "String is not case in-sensitive list.");
 
     is_in = string_in_list("abc", list, true);
-    fail_unless(!is_in, "Wrong string found in case sensitive list.");
+    ck_assert_msg(!is_in, "Wrong string found in case sensitive list.");
 
     is_in = string_in_list("123", list, false);
-    fail_unless(!is_in, "Wrong string found in list.");
+    ck_assert_msg(!is_in, "Wrong string found in list.");
 
 }
 END_TEST
@@ -168,15 +168,15 @@ START_TEST(test_parse_args)
 
     for (i=0; tc[i].argstr != NULL; i++) {
         parsed = parse_args(tc[i].argstr);
-        fail_if(parsed == NULL && tc[i].parsed != NULL,
+        sss_ck_fail_if_msg(parsed == NULL && tc[i].parsed != NULL,
                 "Could not parse correct %d argument string '%s'\n",
                 i, tc[i].argstr);
 
         ret = diff_string_lists(test_ctx, parsed, discard_const(tc[i].parsed),
                                 &only_ret, &only_exp, &both);
-        fail_unless(ret == EOK, "diff_string_lists returned error [%d]", ret);
-        fail_unless(only_ret[0] == NULL, "The parser returned more data than expected\n");
-        fail_unless(only_exp[0] == NULL, "The parser returned less data than expected\n");
+        ck_assert_msg(ret == EOK, "diff_string_lists returned error [%d]", ret);
+        ck_assert_msg(only_ret[0] == NULL, "The parser returned more data than expected\n");
+        ck_assert_msg(only_exp[0] == NULL, "The parser returned less data than expected\n");
 
         if (parsed) {
             int parsed_len;
@@ -185,7 +185,7 @@ START_TEST(test_parse_args)
             for (parsed_len=0; parsed[parsed_len]; ++parsed_len);
             for (expected_len=0; tc[i].parsed[expected_len]; ++expected_len);
 
-            fail_unless(parsed_len == expected_len,
+            ck_assert_msg(parsed_len == expected_len,
                         "Test %d: length of 1st array [%d] != length of 2nd "
                         "array[%d]\n", i, parsed_len, expected_len);
 
@@ -228,14 +228,14 @@ START_TEST(test_diff_string_lists)
                             l1, l2,
                             &only_l1, &only_l2, &both);
 
-    fail_unless(ret == EOK, "diff_string_lists returned error [%d]", ret);
-    fail_unless(strcmp(only_l1[0], "a") == 0, "Missing \"a\" from only_l1");
-    fail_unless(only_l1[1] == NULL, "only_l1 not NULL-terminated");
-    fail_unless(strcmp(only_l2[0], "d") == 0, "Missing \"d\" from only_l2");
-    fail_unless(only_l2[1] == NULL, "only_l2 not NULL-terminated");
-    fail_unless(strcmp(both[0], "c") == 0, "Missing \"c\" from both");
-    fail_unless(strcmp(both[1], "b") == 0, "Missing \"b\" from both");
-    fail_unless(both[2] == NULL, "both not NULL-terminated");
+    ck_assert_msg(ret == EOK, "diff_string_lists returned error [%d]", ret);
+    ck_assert_msg(strcmp(only_l1[0], "a") == 0, "Missing \"a\" from only_l1");
+    ck_assert_msg(only_l1[1] == NULL, "only_l1 not NULL-terminated");
+    ck_assert_msg(strcmp(only_l2[0], "d") == 0, "Missing \"d\" from only_l2");
+    ck_assert_msg(only_l2[1] == NULL, "only_l2 not NULL-terminated");
+    ck_assert_msg(strcmp(both[0], "c") == 0, "Missing \"c\" from both");
+    ck_assert_msg(strcmp(both[1], "b") == 0, "Missing \"b\" from both");
+    ck_assert_msg(both[2] == NULL, "both not NULL-terminated");
 
     talloc_zfree(only_l1);
     talloc_zfree(only_l2);
@@ -246,12 +246,12 @@ START_TEST(test_diff_string_lists)
                             l1, l2,
                             &only_l1, &only_l2, NULL);
 
-    fail_unless(ret == EOK, "diff_string_lists returned error [%d]", ret);
-    fail_unless(strcmp(only_l1[0], "a") == 0, "Missing \"a\" from only_l1");
-    fail_unless(only_l1[1] == NULL, "only_l1 not NULL-terminated");
-    fail_unless(strcmp(only_l2[0], "d") == 0, "Missing \"d\" from only_l2");
-    fail_unless(only_l2[1] == NULL, "only_l2 not NULL-terminated");
-    fail_unless(both == NULL, "Nothing returned to both");
+    ck_assert_msg(ret == EOK, "diff_string_lists returned error [%d]", ret);
+    ck_assert_msg(strcmp(only_l1[0], "a") == 0, "Missing \"a\" from only_l1");
+    ck_assert_msg(only_l1[1] == NULL, "only_l1 not NULL-terminated");
+    ck_assert_msg(strcmp(only_l2[0], "d") == 0, "Missing \"d\" from only_l2");
+    ck_assert_msg(only_l2[1] == NULL, "only_l2 not NULL-terminated");
+    ck_assert_msg(both == NULL, "Nothing returned to both");
 
     talloc_zfree(only_l1);
     talloc_zfree(only_l2);
@@ -261,11 +261,11 @@ START_TEST(test_diff_string_lists)
                             l1, l2,
                             &only_l1, NULL, NULL);
 
-    fail_unless(ret == EOK, "diff_string_lists returned error [%d]", ret);
-    fail_unless(strcmp(only_l1[0], "a") == 0, "Missing \"a\" from only_l1");
-    fail_unless(only_l1[1] == NULL, "only_l1 not NULL-terminated");
-    fail_unless(only_l2 == NULL, "Nothing returned to only_l2");
-    fail_unless(both == NULL, "Nothing returned to both");
+    ck_assert_msg(ret == EOK, "diff_string_lists returned error [%d]", ret);
+    ck_assert_msg(strcmp(only_l1[0], "a") == 0, "Missing \"a\" from only_l1");
+    ck_assert_msg(only_l1[1] == NULL, "only_l1 not NULL-terminated");
+    ck_assert_msg(only_l2 == NULL, "Nothing returned to only_l2");
+    ck_assert_msg(both == NULL, "Nothing returned to both");
 
     talloc_zfree(only_l1);
     talloc_zfree(only_l2);
@@ -275,11 +275,11 @@ START_TEST(test_diff_string_lists)
                             l1, l2,
                             NULL, &only_l2, NULL);
 
-    fail_unless(ret == EOK, "diff_string_lists returned error [%d]", ret);
-    fail_unless(strcmp(only_l2[0], "d") == 0, "Missing \"d\" from only_l2");
-    fail_unless(only_l2[1] == NULL, "only_l2 not NULL-terminated");
-    fail_unless(only_l1 == NULL, "Nothing returned to only_l1");
-    fail_unless(both == NULL, "Nothing returned to both");
+    ck_assert_msg(ret == EOK, "diff_string_lists returned error [%d]", ret);
+    ck_assert_msg(strcmp(only_l2[0], "d") == 0, "Missing \"d\" from only_l2");
+    ck_assert_msg(only_l2[1] == NULL, "only_l2 not NULL-terminated");
+    ck_assert_msg(only_l1 == NULL, "Nothing returned to only_l1");
+    ck_assert_msg(both == NULL, "Nothing returned to both");
 
     talloc_zfree(only_l1);
     talloc_zfree(only_l2);
@@ -296,16 +296,16 @@ START_TEST(test_diff_string_lists)
                             l1, l3,
                             &only_l1, &only_l2, &both);
 
-    fail_unless(ret == EOK, "diff_string_lists returned error [%d]", ret);
-    fail_unless(strcmp(only_l1[0], "a") == 0, "Missing \"a\" from only_l1");
-    fail_unless(strcmp(only_l1[1], "b") == 0, "Missing \"b\" from only_l1");
-    fail_unless(strcmp(only_l1[2], "c") == 0, "Missing \"c\" from only_l1");
-    fail_unless(only_l1[3] == NULL, "only_l1 not NULL-terminated");
-    fail_unless(strcmp(only_l2[0], "d") == 0, "Missing \"f\" from only_l2");
-    fail_unless(strcmp(only_l2[1], "e") == 0, "Missing \"e\" from only_l2");
-    fail_unless(strcmp(only_l2[2], "f") == 0, "Missing \"d\" from only_l2");
-    fail_unless(only_l2[3] == NULL, "only_l2 not NULL-terminated");
-    fail_unless(both[0] == NULL, "both should have zero entries");
+    ck_assert_msg(ret == EOK, "diff_string_lists returned error [%d]", ret);
+    ck_assert_msg(strcmp(only_l1[0], "a") == 0, "Missing \"a\" from only_l1");
+    ck_assert_msg(strcmp(only_l1[1], "b") == 0, "Missing \"b\" from only_l1");
+    ck_assert_msg(strcmp(only_l1[2], "c") == 0, "Missing \"c\" from only_l1");
+    ck_assert_msg(only_l1[3] == NULL, "only_l1 not NULL-terminated");
+    ck_assert_msg(strcmp(only_l2[0], "d") == 0, "Missing \"f\" from only_l2");
+    ck_assert_msg(strcmp(only_l2[1], "e") == 0, "Missing \"e\" from only_l2");
+    ck_assert_msg(strcmp(only_l2[2], "f") == 0, "Missing \"d\" from only_l2");
+    ck_assert_msg(only_l2[3] == NULL, "only_l2 not NULL-terminated");
+    ck_assert_msg(both[0] == NULL, "both should have zero entries");
 
     talloc_zfree(only_l1);
     talloc_zfree(only_l2);
@@ -316,13 +316,13 @@ START_TEST(test_diff_string_lists)
                             l1, l1,
                             &only_l1, &only_l2, &both);
 
-    fail_unless(ret == EOK, "diff_string_lists returned error [%d]", ret);
-    fail_unless(only_l1[0] == NULL, "only_l1 should have zero entries");
-    fail_unless(only_l2[0] == NULL, "only_l2 should have zero entries");
-    fail_unless(strcmp(both[0], "a") == 0, "Missing \"a\" from both");
-    fail_unless(strcmp(both[1], "b") == 0, "Missing \"b\" from both");
-    fail_unless(strcmp(both[2], "c") == 0, "Missing \"c\" from both");
-    fail_unless(both[3] == NULL, "both is not NULL-terminated");
+    ck_assert_msg(ret == EOK, "diff_string_lists returned error [%d]", ret);
+    ck_assert_msg(only_l1[0] == NULL, "only_l1 should have zero entries");
+    ck_assert_msg(only_l2[0] == NULL, "only_l2 should have zero entries");
+    ck_assert_msg(strcmp(both[0], "a") == 0, "Missing \"a\" from both");
+    ck_assert_msg(strcmp(both[1], "b") == 0, "Missing \"b\" from both");
+    ck_assert_msg(strcmp(both[2], "c") == 0, "Missing \"c\" from both");
+    ck_assert_msg(both[3] == NULL, "both is not NULL-terminated");
 
     talloc_zfree(only_l1);
     talloc_zfree(only_l2);
@@ -333,13 +333,13 @@ START_TEST(test_diff_string_lists)
                             l1, NULL,
                             &only_l1, &only_l2, &both);
 
-    fail_unless(ret == EOK, "diff_string_lists returned error [%d]", ret);
-    fail_unless(strcmp(only_l1[0], "a") == 0, "Missing \"a\" from only_l1");
-    fail_unless(strcmp(only_l1[1], "b") == 0, "Missing \"b\" from only_l1");
-    fail_unless(strcmp(only_l1[2], "c") == 0, "Missing \"c\" from only_l1");
-    fail_unless(only_l1[3] == NULL, "only_l1 not NULL-terminated");
-    fail_unless(only_l2[0] == NULL, "only_l2 should have zero entries");
-    fail_unless(both[0] == NULL, "both should have zero entries");
+    ck_assert_msg(ret == EOK, "diff_string_lists returned error [%d]", ret);
+    ck_assert_msg(strcmp(only_l1[0], "a") == 0, "Missing \"a\" from only_l1");
+    ck_assert_msg(strcmp(only_l1[1], "b") == 0, "Missing \"b\" from only_l1");
+    ck_assert_msg(strcmp(only_l1[2], "c") == 0, "Missing \"c\" from only_l1");
+    ck_assert_msg(only_l1[3] == NULL, "only_l1 not NULL-terminated");
+    ck_assert_msg(only_l2[0] == NULL, "only_l2 should have zero entries");
+    ck_assert_msg(both[0] == NULL, "both should have zero entries");
 
     talloc_free(test_ctx);
 }
@@ -352,85 +352,85 @@ START_TEST(test_sss_filter_sanitize)
     char *sanitized = NULL;
 
     TALLOC_CTX *test_ctx = talloc_new(NULL);
-    fail_if (test_ctx == NULL, "Out of memory");
+    sss_ck_fail_if_msg(test_ctx == NULL, "Out of memory");
 
     const char no_specials[] = "username";
     ret = sss_filter_sanitize(test_ctx, no_specials, &sanitized);
-    fail_unless(ret == EOK, "no_specials error [%d][%s]",
+    ck_assert_msg(ret == EOK, "no_specials error [%d][%s]",
                 ret, strerror(ret));
-    fail_unless(strcmp(no_specials, sanitized)==0,
+    ck_assert_msg(strcmp(no_specials, sanitized)==0,
                 "Expected [%s], got [%s]",
                 no_specials, sanitized);
 
     const char has_asterisk[] = "*username";
     const char has_asterisk_expected[] = "\\2ausername";
     ret = sss_filter_sanitize(test_ctx, has_asterisk, &sanitized);
-    fail_unless(ret == EOK, "has_asterisk error [%d][%s]",
+    ck_assert_msg(ret == EOK, "has_asterisk error [%d][%s]",
                 ret, strerror(ret));
-    fail_unless(strcmp(has_asterisk_expected, sanitized)==0,
+    ck_assert_msg(strcmp(has_asterisk_expected, sanitized)==0,
                 "Expected [%s], got [%s]",
                 has_asterisk_expected, sanitized);
 
     const char has_lparen[] = "user(name";
     const char has_lparen_expected[] = "user\\28name";
     ret = sss_filter_sanitize(test_ctx, has_lparen, &sanitized);
-    fail_unless(ret == EOK, "has_lparen error [%d][%s]",
+    ck_assert_msg(ret == EOK, "has_lparen error [%d][%s]",
                 ret, strerror(ret));
-    fail_unless(strcmp(has_lparen_expected, sanitized)==0,
+    ck_assert_msg(strcmp(has_lparen_expected, sanitized)==0,
                 "Expected [%s], got [%s]",
                 has_lparen_expected, sanitized);
 
     const char has_rparen[] = "user)name";
     const char has_rparen_expected[] = "user\\29name";
     ret = sss_filter_sanitize(test_ctx, has_rparen, &sanitized);
-    fail_unless(ret == EOK, "has_rparen error [%d][%s]",
+    ck_assert_msg(ret == EOK, "has_rparen error [%d][%s]",
                 ret, strerror(ret));
-    fail_unless(strcmp(has_rparen_expected, sanitized)==0,
+    ck_assert_msg(strcmp(has_rparen_expected, sanitized)==0,
                 "Expected [%s], got [%s]",
                 has_rparen_expected, sanitized);
 
     const char has_backslash[] = "username\\";
     const char has_backslash_expected[] = "username\\5c";
     ret = sss_filter_sanitize(test_ctx, has_backslash, &sanitized);
-    fail_unless(ret == EOK, "has_backslash error [%d][%s]",
+    ck_assert_msg(ret == EOK, "has_backslash error [%d][%s]",
                 ret, strerror(ret));
-    fail_unless(strcmp(has_backslash_expected, sanitized)==0,
+    ck_assert_msg(strcmp(has_backslash_expected, sanitized)==0,
                 "Expected [%s], got [%s]",
                 has_backslash_expected, sanitized);
 
     const char has_all[] = "\\(user)*name";
     const char has_all_expected[] = "\\5c\\28user\\29\\2aname";
     ret = sss_filter_sanitize(test_ctx, has_all, &sanitized);
-    fail_unless(ret == EOK, "has_all error [%d][%s]",
+    ck_assert_msg(ret == EOK, "has_all error [%d][%s]",
                 ret, strerror(ret));
-    fail_unless(strcmp(has_all_expected, sanitized)==0,
+    ck_assert_msg(strcmp(has_all_expected, sanitized)==0,
                 "Expected [%s], got [%s]",
                 has_all_expected, sanitized);
 
     /* Input is reused from previous test - "\\(user)*name" */
     const char has_all_allow_asterisk_expected[] = "\\5c\\28user\\29*name";
     ret = sss_filter_sanitize_ex(test_ctx, has_all, &sanitized, "*");
-    fail_unless(ret == EOK, "has_all error [%d][%s]",
+    ck_assert_msg(ret == EOK, "has_all error [%d][%s]",
                 ret, strerror(ret));
-    fail_unless(strcmp(has_all_allow_asterisk_expected, sanitized)==0,
+    ck_assert_msg(strcmp(has_all_allow_asterisk_expected, sanitized)==0,
                 "Expected [%s], got [%s]",
                 has_all_expected, sanitized);
 
     const char has_new_line[] = "user\nname";
     const char has_new_line_expected[] = "user\\0aname";
     ret = sss_filter_sanitize(test_ctx, has_new_line, &sanitized);
-    fail_unless(ret == EOK, "has_new_line error [%d][%s]",
+    ck_assert_msg(ret == EOK, "has_new_line error [%d][%s]",
                 ret, strerror(ret));
-    fail_unless(strcmp(has_new_line_expected, sanitized) == 0,
+    ck_assert_msg(strcmp(has_new_line_expected, sanitized) == 0,
                 "Expected [%s], got [%s]",
                 has_new_line_expected, sanitized);
 
     const char has_carriage_ret[] = "user\rname";
     const char has_carriage_ret_expected[] = "user\\0dname";
     ret = sss_filter_sanitize(test_ctx, has_carriage_ret, &sanitized);
-    fail_unless(ret == EOK, "has_carriage_ret error [%d][%s]",
+    ck_assert_msg(ret == EOK, "has_carriage_ret error [%d][%s]",
                 ret, strerror(ret));
-    fail_unless(strcmp(has_carriage_ret_expected, sanitized) == 0,
+    ck_assert_msg(strcmp(has_carriage_ret_expected, sanitized) == 0,
                 "Expected [%s], got [%s]",
                 has_carriage_ret_expected, sanitized);
 
@@ -445,17 +445,17 @@ START_TEST(test_fd_nonblocking)
     errno_t ret;
 
     fd = open("/dev/null", O_RDONLY);
-    fail_unless(fd > 0,
+    ck_assert_msg(fd > 0,
                 "open failed with errno: %d", errno);
 
     flags = fcntl(fd, F_GETFL, 0);
-    fail_if(flags & O_NONBLOCK,
+    sss_ck_fail_if_msg(flags & O_NONBLOCK,
             "Unexpected flag O_NONBLOCK[%x] in [%x]", O_NONBLOCK, flags);
 
     ret = sss_fd_nonblocking(fd);
-    fail_unless(ret == EOK, "sss_fd_nonblocking failed with error: %d", ret);
+    ck_assert_msg(ret == EOK, "sss_fd_nonblocking failed with error: %d", ret);
     flags = fcntl(fd, F_GETFL, 0);
-    fail_unless(flags & O_NONBLOCK,
+    ck_assert_msg(flags & O_NONBLOCK,
                 "Flag O_NONBLOCK[%x] is missing in [%x]", O_NONBLOCK, flags);
     close(fd);
 }
@@ -463,15 +463,15 @@ END_TEST
 
 START_TEST(test_size_t_overflow)
 {
-    fail_unless(!SIZE_T_OVERFLOW(1, 1), "unexpected overflow");
-    fail_unless(!SIZE_T_OVERFLOW(SIZE_MAX, 0), "unexpected overflow");
-    fail_unless(!SIZE_T_OVERFLOW(SIZE_MAX-10, 10), "unexpected overflow");
-    fail_unless(SIZE_T_OVERFLOW(SIZE_MAX, 1), "overflow not detected");
-    fail_unless(SIZE_T_OVERFLOW(SIZE_MAX, SIZE_MAX),
+    ck_assert_msg(!SIZE_T_OVERFLOW(1, 1), "unexpected overflow");
+    ck_assert_msg(!SIZE_T_OVERFLOW(SIZE_MAX, 0), "unexpected overflow");
+    ck_assert_msg(!SIZE_T_OVERFLOW(SIZE_MAX-10, 10), "unexpected overflow");
+    ck_assert_msg(SIZE_T_OVERFLOW(SIZE_MAX, 1), "overflow not detected");
+    ck_assert_msg(SIZE_T_OVERFLOW(SIZE_MAX, SIZE_MAX),
                 "overflow not detected");
-    fail_unless(SIZE_T_OVERFLOW(SIZE_MAX, ULLONG_MAX),
+    ck_assert_msg(SIZE_T_OVERFLOW(SIZE_MAX, ULLONG_MAX),
                 "overflow not detected");
-    fail_unless(SIZE_T_OVERFLOW(SIZE_MAX, -10), "overflow not detected");
+    ck_assert_msg(SIZE_T_OVERFLOW(SIZE_MAX, -10), "overflow not detected");
 }
 END_TEST
 
@@ -483,10 +483,10 @@ START_TEST(test_utf8_talloc_str_lowercase)
 
     TALLOC_CTX *test_ctx;
     test_ctx = talloc_new(NULL);
-    fail_if(test_ctx == NULL, "Failed to allocate memory");
+    sss_ck_fail_if_msg(test_ctx == NULL, "Failed to allocate memory");
 
     lcase = sss_tc_utf8_str_tolower(test_ctx, munchen_utf8_upcase);
-    fail_if(memcmp(lcase, munchen_utf8_lowcase, strlen(lcase)),
+    sss_ck_fail_if_msg(memcmp(lcase, munchen_utf8_lowcase, strlen(lcase)),
             "Unexpected binary values");
     talloc_free(test_ctx);
 }
@@ -502,13 +502,13 @@ START_TEST(test_utf8_caseeq)
     errno_t ret;
 
     ret = sss_utf8_case_eq(munchen_utf8_upcase, munchen_utf8_lowcase);
-    fail_unless(ret == EOK, "Latin 1 Supplement comparison failed\n");
+    ck_assert_msg(ret == EOK, "Latin 1 Supplement comparison failed\n");
 
     ret = sss_utf8_case_eq(czech_utf8_upcase, czech_utf8_lowcase);
-    fail_unless(ret == EOK, "Latin Extended A comparison failed\n");
+    ck_assert_msg(ret == EOK, "Latin Extended A comparison failed\n");
 
     ret = sss_utf8_case_eq(czech_utf8_upcase, czech_utf8_lowcase_neg);
-    fail_if(ret == EOK, "Negative test succeeded\n");
+    sss_ck_fail_if_msg(ret == EOK, "Negative test succeeded\n");
 }
 END_TEST
 
@@ -519,10 +519,10 @@ START_TEST(test_utf8_check)
     bool ret;
 
     ret = sss_utf8_check(valid, strlen((const char *) valid));
-    fail_unless(ret == true, "Positive test failed\n");
+    ck_assert_msg(ret == true, "Positive test failed\n");
 
     ret = sss_utf8_check((const uint8_t *) invalid, strlen(invalid));
-    fail_unless(ret == false, "Negative test succeeded\n");
+    ck_assert_msg(ret == false, "Negative test succeeded\n");
 }
 END_TEST
 
@@ -538,7 +538,7 @@ START_TEST(test_murmurhash3_check)
                                  strlen(tests[i]),
                                  0xdeadbeef);
         for (j = 0; j < i; j++) {
-            fail_if(results[i] == results[j],
+            sss_ck_fail_if_msg(results[i] == results[j],
                     "Values have to be different. '%"PRIu32"' == '%"PRIu32"'",
                     results[i], results[j]);
         }
@@ -580,13 +580,13 @@ void setup_atomicio(void)
     mode_t old_umask;
 
     filename = strdup(FILENAME_TEMPLATE);
-    fail_unless(filename != NULL, "strdup failed");
+    ck_assert_msg(filename != NULL, "strdup failed");
 
     atio_fd = -1;
     old_umask = umask(SSS_DFL_UMASK);
     ret = mkstemp(filename);
     umask(old_umask);
-    fail_unless(ret != -1, "mkstemp failed [%d][%s]", errno, strerror(errno));
+    ck_assert_msg(ret != -1, "mkstemp failed [%d][%s]", errno, strerror(errno));
     atio_fd = ret;
 }
 
@@ -596,13 +596,13 @@ void teardown_atomicio(void)
 
     if (atio_fd != -1) {
         ret = close(atio_fd);
-        fail_unless(ret == 0, "close failed [%d][%s]", errno, strerror(errno));
+        ck_assert_msg(ret == 0, "close failed [%d][%s]", errno, strerror(errno));
     }
 
-    fail_unless(filename != NULL, "unknown filename");
+    ck_assert_msg(filename != NULL, "unknown filename");
     ret = unlink(filename);
     free(filename);
-    fail_unless(ret == 0, "unlink failed [%d][%s]", errno, strerror(errno));
+    ck_assert_msg(ret == 0, "unlink failed [%d][%s]", errno, strerror(errno));
 }
 
 START_TEST(test_atomicio_read_from_file)
@@ -614,14 +614,14 @@ START_TEST(test_atomicio_read_from_file)
     errno_t ret;
 
     fd = open("/dev/zero", O_RDONLY);
-    fail_if(fd == -1, "Cannot open /dev/zero");
+    sss_ck_fail_if_msg(fd == -1, "Cannot open /dev/zero");
 
     errno = 0;
     numread = sss_atomic_read_s(fd, buf, bufsize);
     ret = errno;
 
-    fail_unless(ret == 0, "Error %d while reading\n", ret);
-    fail_unless(numread == bufsize,
+    ck_assert_msg(ret == 0, "Error %d while reading\n", ret);
+    ck_assert_msg(numread == bufsize,
                 "Read %zd bytes expected %zd\n", numread, bufsize);
     close(fd);
 }
@@ -636,14 +636,14 @@ START_TEST(test_atomicio_read_from_small_file)
     ssize_t numread;
     errno_t ret;
 
-    fail_if(atio_fd < 0, "No fd to test?\n");
+    sss_ck_fail_if_msg(atio_fd < 0, "No fd to test?\n");
 
     errno = 0;
     numwritten = sss_atomic_write_s(atio_fd, wbuf, wsize);
     ret = errno;
 
-    fail_unless(ret == 0, "Error %d while writing\n", ret);
-    fail_unless(numwritten == wsize,
+    ck_assert_msg(ret == 0, "Error %d while writing\n", ret);
+    ck_assert_msg(numwritten == wsize,
                 "Wrote %zd bytes expected %zd\n", numwritten, wsize);
 
     fsync(atio_fd);
@@ -653,8 +653,8 @@ START_TEST(test_atomicio_read_from_small_file)
     numread = sss_atomic_read_s(atio_fd, rbuf, 64);
     ret = errno;
 
-    fail_unless(ret == 0, "Error %d while reading\n", ret);
-    fail_unless(numread == numwritten,
+    ck_assert_msg(ret == 0, "Error %d while reading\n", ret);
+    ck_assert_msg(numread == numwritten,
                 "Read %zd bytes expected %zd\n", numread, numwritten);
 }
 END_TEST
@@ -669,14 +669,14 @@ START_TEST(test_atomicio_read_from_large_file)
     ssize_t total;
     errno_t ret;
 
-    fail_if(atio_fd < 0, "No fd to test?\n");
+    sss_ck_fail_if_msg(atio_fd < 0, "No fd to test?\n");
 
     errno = 0;
     numwritten = sss_atomic_write_s(atio_fd, wbuf, wsize);
     ret = errno;
 
-    fail_unless(ret == 0, "Error %d while writing\n", ret);
-    fail_unless(numwritten == wsize,
+    ck_assert_msg(ret == 0, "Error %d while writing\n", ret);
+    ck_assert_msg(numwritten == wsize,
                 "Wrote %zd bytes expected %zd\n", numwritten, wsize);
 
     fsync(atio_fd);
@@ -688,12 +688,12 @@ START_TEST(test_atomicio_read_from_large_file)
         numread = sss_atomic_read_s(atio_fd, rbuf, 8);
         ret = errno;
 
-        fail_if(numread == -1, "Read error %d: %s\n", ret, strerror(ret));
+        sss_ck_fail_if_msg(numread == -1, "Read error %d: %s\n", ret, strerror(ret));
         total += numread;
     } while (numread != 0);
 
-    fail_unless(ret == 0, "Error %d while reading\n", ret);
-    fail_unless(total == numwritten,
+    ck_assert_msg(ret == 0, "Error %d while reading\n", ret);
+    ck_assert_msg(total == numwritten,
                 "Read %zd bytes expected %zd\n", numread, numwritten);
 }
 END_TEST
@@ -707,14 +707,14 @@ START_TEST(test_atomicio_read_exact_sized_file)
     ssize_t numread;
     errno_t ret;
 
-    fail_if(atio_fd < 0, "No fd to test?\n");
+    sss_ck_fail_if_msg(atio_fd < 0, "No fd to test?\n");
 
     errno = 0;
     numwritten = sss_atomic_write_s(atio_fd, wbuf, wsize);
     ret = errno;
 
-    fail_unless(ret == 0, "Error %d while writing\n", ret);
-    fail_unless(numwritten == wsize,
+    ck_assert_msg(ret == 0, "Error %d while writing\n", ret);
+    ck_assert_msg(numwritten == wsize,
                 "Wrote %zd bytes expected %zd\n", numwritten, wsize);
 
     fsync(atio_fd);
@@ -724,20 +724,20 @@ START_TEST(test_atomicio_read_exact_sized_file)
     numread = sss_atomic_read_s(atio_fd, rbuf, 9);
     ret = errno;
 
-    fail_unless(ret == 0, "Error %d while reading\n", ret);
-    fail_unless(numread == numwritten,
+    ck_assert_msg(ret == 0, "Error %d while reading\n", ret);
+    ck_assert_msg(numread == numwritten,
                 "Read %zd bytes expected %zd\n", numread, numwritten);
 
-    fail_unless(rbuf[8] == '\0', "String not NULL terminated?");
-    fail_unless(strcmp(wbuf, rbuf) == 0, "Read something else than wrote?");
+    ck_assert_msg(rbuf[8] == '\0', "String not NULL terminated?");
+    ck_assert_msg(strcmp(wbuf, rbuf) == 0, "Read something else than wrote?");
 
     /* We've reached end-of-file, next read must return 0 */
     errno = 0;
     numread = sss_atomic_read_s(atio_fd, rbuf, 9);
     ret = errno;
 
-    fail_unless(ret == 0, "Error %d while reading\n", ret);
-    fail_unless(numread == 0, "More data to read?");
+    ck_assert_msg(ret == 0, "Error %d while reading\n", ret);
+    ck_assert_msg(numread == 0, "More data to read?");
 }
 END_TEST
 
@@ -749,14 +749,14 @@ START_TEST(test_atomicio_read_from_empty_file)
     errno_t ret;
 
     fd = open("/dev/null", O_RDONLY);
-    fail_if(fd == -1, "Cannot open /dev/null");
+    sss_ck_fail_if_msg(fd == -1, "Cannot open /dev/null");
 
     errno = 0;
     numread = sss_atomic_read_s(fd, buf, 64);
     ret = errno;
 
-    fail_unless(ret == 0, "Error %d while reading\n", ret);
-    fail_unless(numread == 0,
+    ck_assert_msg(ret == 0, "Error %d while reading\n", ret);
+    ck_assert_msg(numread == 0,
                 "Read %zd bytes expected 0\n", numread);
     close(fd);
 }
@@ -833,17 +833,17 @@ START_TEST(test_split_on_separator)
         ret = split_on_separator(mem, sts[a].input, ',', sts[a].trim,
                                  sts[a].skip_empty, &list, &size);
 
-        fail_unless(ret == sts[a].expected_ret,
+        ck_assert_msg(ret == sts[a].expected_ret,
                     "split_on_separator failed [%d]: %s\n", ret,
                     strerror(ret));
         if (ret) {
             continue;
         }
-        fail_unless(size == sts[a].expected_size, "Returned wrong size %d "
+        ck_assert_msg(size == sts[a].expected_size, "Returned wrong size %d "
                     "(expected %d).\n", size, sts[a].expected_size);
 
         for (i = 0; str_ref = sts[a].expected_list[i], str_out = list[i]; i++) {
-            fail_unless(strcmp(str_ref, str_out) == 0,
+            ck_assert_msg(strcmp(str_ref, str_out) == 0,
                         "Expected:%s Got:%s\n", str_ref, str_out);
         }
         talloc_free(list);
@@ -914,10 +914,10 @@ START_TEST(test_check_ipv4_addr)
         /* fill sockaddr_in structure */
 
         ret = inet_pton(AF_INET, tst_data[a].str_ipaddr, &addr);
-        fail_if(ret != 1, "inet_pton failed.");
+        sss_ck_fail_if_msg(ret != 1, "inet_pton failed.");
 
         bret = check_ipv4_addr(&addr, tst_data[a].flags);
-        fail_unless(bret == tst_data[a].expected_ret,
+        ck_assert_msg(bret == tst_data[a].expected_ret,
                     "check_ipv4_addr failed (iteration %d)", a);
     }
 }
@@ -964,10 +964,10 @@ START_TEST(test_check_ipv6_addr)
         /* fill sockaddr_in structure */
 
         ret = inet_pton(AF_INET6, tst_data[a].str_ipaddr, &addr);
-        fail_if(ret != 1, "inet_pton failed.");
+        sss_ck_fail_if_msg(ret != 1, "inet_pton failed.");
 
         bret = check_ipv6_addr(&addr, tst_data[a].flags);
-        fail_unless(bret == tst_data[a].expected_ret,
+        ck_assert_msg(bret == tst_data[a].expected_ret,
                     "check_ipv6_addr failed (iteration %d)", a);
 
     }
@@ -994,7 +994,7 @@ START_TEST(test_is_host_in_domain)
 
     for (i = 0; data[i].host != NULL; i++) {
         ret = is_host_in_domain(data[i].host, data[i].domain);
-        fail_if(ret != data[i].expected, "Host: %s, Domain: %s, Expected: %d, "
+        sss_ck_fail_if_msg(ret != data[i].expected, "Host: %s, Domain: %s, Expected: %d, "
                 "Got: %d\n", data[i].host, data[i].domain,
                 data[i].expected, ret);
     }
@@ -1035,7 +1035,7 @@ static void convert_time_tz(const char* tz)
 
     if (tz) {
         ret = setenv("TZ", tz, 1);
-        fail_if(ret == -1,
+        sss_ck_fail_if_msg(ret == -1,
                 "setenv failed with errno: %d", errno);
     }
 
@@ -1044,10 +1044,10 @@ static void convert_time_tz(const char* tz)
     /* restore */
     if (orig_tz != NULL) {
         ret2 = setenv("TZ", orig_tz, 1);
-        fail_if(ret2 == -1,
+        sss_ck_fail_if_msg(ret2 == -1,
                 "setenv failed with errno: %d", errno);
     }
-    fail_unless(ret == EOK && difftime(1406894262, unix_time) == 0,
+    ck_assert_msg(ret == EOK && difftime(1406894262, unix_time) == 0,
                 "Expecting 1406894262 got: ret[%d] unix_time[%ld]",
                 ret, unix_time);
 }
@@ -1059,14 +1059,14 @@ START_TEST(test_convert_time)
     errno_t ret;
 
     ret = sss_utc_to_time_t("20150127133540P", format, &unix_time);
-    fail_unless(ret == ERR_TIMESPEC_NOT_SUPPORTED,
+    ck_assert_msg(ret == ERR_TIMESPEC_NOT_SUPPORTED,
                 "sss_utc_to_time_t must fail with %d. got: %d",
                 ERR_TIMESPEC_NOT_SUPPORTED, ret);
     ret = sss_utc_to_time_t("0Z", format, &unix_time);
-    fail_unless(ret == EINVAL,
+    ck_assert_msg(ret == EINVAL,
                 "sss_utc_to_time_t must fail with EINVAL. got: %d", ret);
     ret = sss_utc_to_time_t("000001010000Z", format, &unix_time);
-    fail_unless(ret == EINVAL,
+    ck_assert_msg(ret == EINVAL,
                 "sss_utc_to_time_t must fail with EINVAL. got: %d", ret);
 
     /* test that results are still same no matter what timezone is set */
@@ -1093,13 +1093,13 @@ START_TEST(test_sss_strerror_string_validation)
 
     for (idx = ERR_BASE; idx < ERR_LAST; ++idx) {
         error = sss_strerror(idx);
-        fail_if(error == NULL, "sss_strerror returned NULL for valid index");
+        sss_ck_fail_if_msg(error == NULL, "sss_strerror returned NULL for valid index");
 
         len = strlen(error);
-        fail_if(len == 0, "sss_strerror returned empty string");
+        sss_ck_fail_if_msg(len == 0, "sss_strerror returned empty string");
 
         last_character = error[len - 1];
-        fail_if(isalpha(last_character) == 0 && last_character != ')',
+        sss_ck_fail_if_msg(isalpha(last_character) == 0 && last_character != ')',
                 "Error string [%s] must finish with alphabetic character\n",
                 error);
     }


### PR DESCRIPTION
The fail* macros are deprecated by libcheck some time ago. Recently a fix
for a different issue in those macros cause a 'too many arguments for
format' compiler warning which won't be fixed on the libckeck side since
the macros are deprecated.

This patch replaces the deprecated macros with the new ones:

 - fail -> ck_abort_msg
- fail_unless -> ck_assert_msg
- fail_if -> sss_ck_fail_if_msg

The fail_if macro does not have a corresponding new version and I added a
local replacement sss_ck_fail_if_msg which is based on ck_assert_msg.