### PR TITLE
README: Dead social media link remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,6 @@ Make sure to follow the [guide on reporting SSSD bugs](https://sssd.io/docs/user
 ## Licensing
 Please see the file called [COPYING](COPYING).
 
-## Social networks
-We maintain our presence on [Twitter](https://twitter.com/SysSecSvcDaemon).
-
 ## Contacts
 There are several ways to contact us:
 


### PR DESCRIPTION
Back in 2011 SSSD started using twitter account to broadcast releases.
Last time it happened 13.06.2019 so this account can be considered as
dead. This PR removes link to it from main README.

Resolves: https://github.com/SSSD/sssd/issues/5649