### PR TITLE
pam: change default for pam_response_filter

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -1405,10 +1405,22 @@ fallback_homedir = /home/%u
                             </variablelist>
                         </para>
                         <para>
-                            Default: not set
+                            The list of strings can either be the list of
+                            filters which would set this list of filters and
+                            overwrite the defaults. Or each element of the list
+                            can be prefixed by a '+' or '-' character which
+                            would add the filter to the existing default or
+                            remove it from the defaults, respectively. Please
+                            note that either all list elements must have a '+'
+                            or '-' prefix or none. It is considered as an error
+                            to mix both styles.
                         </para>
                         <para>
-                            Example: ENV:KRB5CCNAME:sudo-i
+                            Default: ENV:KRB5CCNAME:sudo, ENV:KRB5CCNAME:sudo-i
+                        </para>
+                        <para>
+                            Example: -ENV:KRB5CCNAME:sudo-i will remove the
+                            filter from the default list
                         </para>
                     </listitem>
                 </varlistentry>

--- a/src/responder/pam/pamsrv.h
+++ b/src/responder/pam/pamsrv.h
@@ -58,6 +58,9 @@ struct pam_ctx {
     struct sss_certmap_ctx *sss_certmap_ctx;
     char **smartcard_services;
 
+    /* parsed list of pam_response_filter option */
+    char **pam_filter_opts;
+
     char **prompting_config_sections;
     int num_prompting_config_sections;
 

--- a/src/responder/pam/pamsrv.h
+++ b/src/responder/pam/pamsrv.h
@@ -139,7 +139,7 @@ pam_set_last_online_auth_with_curr_token(struct sss_domain_info *domain,
                                          const char *username,
                                          uint64_t value);
 
-errno_t filter_responses(struct confdb_ctx *cdb,
+errno_t filter_responses(struct pam_ctx *pctx,
                          struct response_data *resp_list,
                          struct pam_data *pd);
 

--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -593,7 +593,7 @@ static errno_t filter_responses_env(struct response_data *resp,
     return EOK;
 }
 
-errno_t filter_responses(struct confdb_ctx *cdb,
+errno_t filter_responses(struct pam_ctx *pctx,
                          struct response_data *resp_list,
                          struct pam_data *pd)
 {
@@ -604,7 +604,7 @@ errno_t filter_responses(struct confdb_ctx *cdb,
     int pam_verbosity = DEFAULT_PAM_VERBOSITY;
     char **pam_filter_opts = NULL;
 
-    ret = confdb_get_int(cdb, CONFDB_PAM_CONF_ENTRY,
+    ret = confdb_get_int(pctx->rctx->cdb, CONFDB_PAM_CONF_ENTRY,
                          CONFDB_PAM_VERBOSITY, DEFAULT_PAM_VERBOSITY,
                          &pam_verbosity);
     if (ret != EOK) {
@@ -613,7 +613,7 @@ errno_t filter_responses(struct confdb_ctx *cdb,
         pam_verbosity = DEFAULT_PAM_VERBOSITY;
     }
 
-    ret = confdb_get_string_as_list(cdb, pd, CONFDB_PAM_CONF_ENTRY,
+    ret = confdb_get_string_as_list(pctx->rctx->cdb, pd, CONFDB_PAM_CONF_ENTRY,
                                     CONFDB_PAM_RESPONSE_FILTER,
                                     &pam_filter_opts);
     if (ret != EOK) {
@@ -1036,7 +1036,7 @@ static void pam_reply(struct pam_auth_req *preq)
         inform_user(pd, pam_account_locked_message);
     }
 
-    ret = filter_responses(pctx->rctx->cdb, pd->resp_list, pd);
+    ret = filter_responses(pctx, pd->resp_list, pd);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "filter_responses failed, not fatal.\n");
     }

--- a/src/tests/cmocka/test_pam_srv.c
+++ b/src/tests/cmocka/test_pam_srv.c
@@ -3220,6 +3220,7 @@ void test_filter_response(void **state)
     assert_false(pd->resp_list->next->do_not_send_to_client);
 
     /* Test CONFDB_PAM_RESPONSE_FILTER option */
+    talloc_zfree(pam_test_ctx->pctx->pam_filter_opts);
     pam_params[1].value = "NoSuchOption";
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
@@ -3229,6 +3230,7 @@ void test_filter_response(void **state)
     assert_true(pd->resp_list->do_not_send_to_client);
     assert_false(pd->resp_list->next->do_not_send_to_client);
 
+    talloc_zfree(pam_test_ctx->pctx->pam_filter_opts);
     pam_params[1].value = "ENV"; /* filter all environment variables */
                                  /* for all services */
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
@@ -3239,6 +3241,7 @@ void test_filter_response(void **state)
     assert_true(pd->resp_list->do_not_send_to_client);
     assert_true(pd->resp_list->next->do_not_send_to_client);
 
+    talloc_zfree(pam_test_ctx->pctx->pam_filter_opts);
     pam_params[1].value = "ENV:"; /* filter all environment variables */
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
@@ -3248,6 +3251,7 @@ void test_filter_response(void **state)
     assert_true(pd->resp_list->do_not_send_to_client);
     assert_true(pd->resp_list->next->do_not_send_to_client);
 
+    talloc_zfree(pam_test_ctx->pctx->pam_filter_opts);
     pam_params[1].value = "ENV::"; /* filter all environment variables */
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
@@ -3257,6 +3261,7 @@ void test_filter_response(void **state)
     assert_true(pd->resp_list->do_not_send_to_client);
     assert_true(pd->resp_list->next->do_not_send_to_client);
 
+    talloc_zfree(pam_test_ctx->pctx->pam_filter_opts);
     pam_params[1].value = "ENV:abc:"; /* variable name does not match */
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
@@ -3266,6 +3271,7 @@ void test_filter_response(void **state)
     assert_true(pd->resp_list->do_not_send_to_client);
     assert_false(pd->resp_list->next->do_not_send_to_client);
 
+    talloc_zfree(pam_test_ctx->pctx->pam_filter_opts);
     pam_params[1].value = "ENV:abc:MyService"; /* variable name does not match */
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
@@ -3275,6 +3281,7 @@ void test_filter_response(void **state)
     assert_true(pd->resp_list->do_not_send_to_client);
     assert_false(pd->resp_list->next->do_not_send_to_client);
 
+    talloc_zfree(pam_test_ctx->pctx->pam_filter_opts);
     pam_params[1].value = "ENV::abc"; /* service name does not match */
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
@@ -3285,6 +3292,7 @@ void test_filter_response(void **state)
     assert_false(pd->resp_list->next->do_not_send_to_client);
 
     /* service name does not match */
+    talloc_zfree(pam_test_ctx->pctx->pam_filter_opts);
     pam_params[1].value = "ENV:MyEnv:abc";
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
@@ -3294,6 +3302,7 @@ void test_filter_response(void **state)
     assert_true(pd->resp_list->do_not_send_to_client);
     assert_false(pd->resp_list->next->do_not_send_to_client);
 
+    talloc_zfree(pam_test_ctx->pctx->pam_filter_opts);
     pam_params[1].value = "ENV:MyEnv"; /* match */
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
@@ -3303,6 +3312,7 @@ void test_filter_response(void **state)
     assert_true(pd->resp_list->do_not_send_to_client);
     assert_true(pd->resp_list->next->do_not_send_to_client);
 
+    talloc_zfree(pam_test_ctx->pctx->pam_filter_opts);
     pam_params[1].value = "ENV:MyEnv:"; /* match */
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
@@ -3312,6 +3322,7 @@ void test_filter_response(void **state)
     assert_true(pd->resp_list->do_not_send_to_client);
     assert_true(pd->resp_list->next->do_not_send_to_client);
 
+    talloc_zfree(pam_test_ctx->pctx->pam_filter_opts);
     pam_params[1].value = "ENV:MyEnv:MyService"; /* match */
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
@@ -3322,6 +3333,7 @@ void test_filter_response(void **state)
     assert_true(pd->resp_list->next->do_not_send_to_client);
 
     /* multiple rules with a match */
+    talloc_zfree(pam_test_ctx->pctx->pam_filter_opts);
     pam_params[1].value = "ENV:abc:def, "
                           "ENV:MyEnv:MyService, "
                           "ENV:stu:xyz";

--- a/src/tests/cmocka/test_pam_srv.c
+++ b/src/tests/cmocka/test_pam_srv.c
@@ -3191,9 +3191,10 @@ void test_filter_response(void **state)
     /* pd->resp_list points to the SSS_PAM_USER_INFO and pd->resp_list->next
      * to the SSS_PAM_ENV_ITEM message. */
 
+    pam_test_ctx->pctx->rctx = pam_test_ctx->rctx;
 
     /* Test CONFDB_PAM_VERBOSITY option */
-    ret = filter_responses(pam_test_ctx->rctx->cdb, pd->resp_list, pd);
+    ret = filter_responses(pam_test_ctx->pctx, pd->resp_list, pd);
     assert_int_equal(ret, EOK);
     assert_true(pd->resp_list->do_not_send_to_client);
     assert_false(pd->resp_list->next->do_not_send_to_client);
@@ -3204,7 +3205,7 @@ void test_filter_response(void **state)
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
 
-    ret = filter_responses(pam_test_ctx->rctx->cdb, pd->resp_list, pd);
+    ret = filter_responses(pam_test_ctx->pctx, pd->resp_list, pd);
     assert_int_equal(ret, EOK);
     assert_false(pd->resp_list->do_not_send_to_client);
     assert_false(pd->resp_list->next->do_not_send_to_client);
@@ -3213,7 +3214,7 @@ void test_filter_response(void **state)
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
 
-    ret = filter_responses(pam_test_ctx->rctx->cdb, pd->resp_list, pd);
+    ret = filter_responses(pam_test_ctx->pctx, pd->resp_list, pd);
     assert_int_equal(ret, EOK);
     assert_true(pd->resp_list->do_not_send_to_client);
     assert_false(pd->resp_list->next->do_not_send_to_client);
@@ -3223,7 +3224,7 @@ void test_filter_response(void **state)
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
 
-    ret = filter_responses(pam_test_ctx->rctx->cdb, pd->resp_list, pd);
+    ret = filter_responses(pam_test_ctx->pctx, pd->resp_list, pd);
     assert_int_equal(ret, EOK);
     assert_true(pd->resp_list->do_not_send_to_client);
     assert_false(pd->resp_list->next->do_not_send_to_client);
@@ -3233,7 +3234,7 @@ void test_filter_response(void **state)
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
 
-    ret = filter_responses(pam_test_ctx->rctx->cdb, pd->resp_list, pd);
+    ret = filter_responses(pam_test_ctx->pctx, pd->resp_list, pd);
     assert_int_equal(ret, EOK);
     assert_true(pd->resp_list->do_not_send_to_client);
     assert_true(pd->resp_list->next->do_not_send_to_client);
@@ -3242,7 +3243,7 @@ void test_filter_response(void **state)
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
 
-    ret = filter_responses(pam_test_ctx->rctx->cdb, pd->resp_list, pd);
+    ret = filter_responses(pam_test_ctx->pctx, pd->resp_list, pd);
     assert_int_equal(ret, EOK);
     assert_true(pd->resp_list->do_not_send_to_client);
     assert_true(pd->resp_list->next->do_not_send_to_client);
@@ -3251,7 +3252,7 @@ void test_filter_response(void **state)
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
 
-    ret = filter_responses(pam_test_ctx->rctx->cdb, pd->resp_list, pd);
+    ret = filter_responses(pam_test_ctx->pctx, pd->resp_list, pd);
     assert_int_equal(ret, EOK);
     assert_true(pd->resp_list->do_not_send_to_client);
     assert_true(pd->resp_list->next->do_not_send_to_client);
@@ -3260,7 +3261,7 @@ void test_filter_response(void **state)
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
 
-    ret = filter_responses(pam_test_ctx->rctx->cdb, pd->resp_list, pd);
+    ret = filter_responses(pam_test_ctx->pctx, pd->resp_list, pd);
     assert_int_equal(ret, EOK);
     assert_true(pd->resp_list->do_not_send_to_client);
     assert_false(pd->resp_list->next->do_not_send_to_client);
@@ -3269,7 +3270,7 @@ void test_filter_response(void **state)
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
 
-    ret = filter_responses(pam_test_ctx->rctx->cdb, pd->resp_list, pd);
+    ret = filter_responses(pam_test_ctx->pctx, pd->resp_list, pd);
     assert_int_equal(ret, EOK);
     assert_true(pd->resp_list->do_not_send_to_client);
     assert_false(pd->resp_list->next->do_not_send_to_client);
@@ -3278,7 +3279,7 @@ void test_filter_response(void **state)
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
 
-    ret = filter_responses(pam_test_ctx->rctx->cdb, pd->resp_list, pd);
+    ret = filter_responses(pam_test_ctx->pctx, pd->resp_list, pd);
     assert_int_equal(ret, EOK);
     assert_true(pd->resp_list->do_not_send_to_client);
     assert_false(pd->resp_list->next->do_not_send_to_client);
@@ -3288,7 +3289,7 @@ void test_filter_response(void **state)
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
 
-    ret = filter_responses(pam_test_ctx->rctx->cdb, pd->resp_list, pd);
+    ret = filter_responses(pam_test_ctx->pctx, pd->resp_list, pd);
     assert_int_equal(ret, EOK);
     assert_true(pd->resp_list->do_not_send_to_client);
     assert_false(pd->resp_list->next->do_not_send_to_client);
@@ -3297,7 +3298,7 @@ void test_filter_response(void **state)
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
 
-    ret = filter_responses(pam_test_ctx->rctx->cdb, pd->resp_list, pd);
+    ret = filter_responses(pam_test_ctx->pctx, pd->resp_list, pd);
     assert_int_equal(ret, EOK);
     assert_true(pd->resp_list->do_not_send_to_client);
     assert_true(pd->resp_list->next->do_not_send_to_client);
@@ -3306,7 +3307,7 @@ void test_filter_response(void **state)
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
 
-    ret = filter_responses(pam_test_ctx->rctx->cdb, pd->resp_list, pd);
+    ret = filter_responses(pam_test_ctx->pctx, pd->resp_list, pd);
     assert_int_equal(ret, EOK);
     assert_true(pd->resp_list->do_not_send_to_client);
     assert_true(pd->resp_list->next->do_not_send_to_client);
@@ -3315,7 +3316,7 @@ void test_filter_response(void **state)
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
 
-    ret = filter_responses(pam_test_ctx->rctx->cdb, pd->resp_list, pd);
+    ret = filter_responses(pam_test_ctx->pctx, pd->resp_list, pd);
     assert_int_equal(ret, EOK);
     assert_true(pd->resp_list->do_not_send_to_client);
     assert_true(pd->resp_list->next->do_not_send_to_client);
@@ -3327,7 +3328,7 @@ void test_filter_response(void **state)
     ret = add_pam_params(pam_params, pam_test_ctx->rctx->cdb);
     assert_int_equal(ret, EOK);
 
-    ret = filter_responses(pam_test_ctx->rctx->cdb, pd->resp_list, pd);
+    ret = filter_responses(pam_test_ctx->pctx, pd->resp_list, pd);
     assert_int_equal(ret, EOK);
     assert_true(pd->resp_list->do_not_send_to_client);
     assert_true(pd->resp_list->next->do_not_send_to_client);

--- a/src/tests/cmocka/test_utils.c
+++ b/src/tests/cmocka/test_utils.c
@@ -2173,6 +2173,9 @@ int main(int argc, const char *argv[])
         cmocka_unit_test_setup_teardown(test_sss_filter_sanitize_dn,
                                         setup_leak_tests,
                                         teardown_leak_tests),
+        cmocka_unit_test_setup_teardown(test_mod_defaults_list,
+                                        setup_leak_tests,
+                                        teardown_leak_tests),
     };
 
     /* Set debug level to invalid value so we can decide if -d 0 was used. */

--- a/src/tests/cmocka/test_utils.h
+++ b/src/tests/cmocka/test_utils.h
@@ -32,6 +32,7 @@ void test_reverse_replace_whitespaces(void **state);
 void test_guid_blob_to_string_buf(void **state);
 void test_get_last_x_chars(void **state);
 void test_concatenate_string_array(void **state);
+void test_mod_defaults_list(void **state);
 
 /* from src/tests/cmocka/test_sss_ptr_hash.c */
 void test_sss_ptr_hash_with_free_cb(void **state);

--- a/src/util/string_utils.c
+++ b/src/util/string_utils.c
@@ -146,3 +146,107 @@ char **concatenate_string_array(TALLOC_CTX *mem_ctx,
 
     return string_array;
 }
+
+errno_t mod_defaults_list(TALLOC_CTX *mem_ctx, const char **defaults_list,
+                          char **mod_list, char ***_list)
+{
+    TALLOC_CTX *tmp_ctx;
+    errno_t ret;
+    size_t mod_list_size;
+    const char **add_list;
+    const char **remove_list;
+    size_t c;
+    size_t ai = 0;
+    size_t ri = 0;
+    size_t j = 0;
+    char **list;
+    size_t expected_list_size = 0;
+    size_t defaults_list_size = 0;
+
+    for (defaults_list_size = 0;
+            defaults_list != NULL && defaults_list[defaults_list_size] != NULL;
+            defaults_list_size++);
+
+    for (mod_list_size = 0;
+            mod_list != NULL && mod_list[mod_list_size] != NULL;
+            mod_list_size++);
+
+    tmp_ctx = talloc_new(mem_ctx);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    add_list = talloc_zero_array(tmp_ctx, const char *, mod_list_size + 1);
+    remove_list = talloc_zero_array(tmp_ctx, const char *, mod_list_size + 1);
+
+    if (add_list == NULL || remove_list == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    for (c = 0; mod_list != NULL && mod_list[c] != NULL; c++) {
+        switch (mod_list[c][0]) {
+        case '+':
+            add_list[ai] = mod_list[c] + 1;
+            ++ai;
+            break;
+        case '-':
+            remove_list[ri] = mod_list[c] + 1;
+            ++ri;
+            break;
+        default:
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "The option "CONFDB_PAM_P11_ALLOWED_SERVICES" must start"
+                  "with either '+' (for adding service) or '-' (for "
+                  "removing service) got '%s'\n", mod_list[c]);
+            ret = EINVAL;
+            goto done;
+        }
+    }
+
+    expected_list_size = defaults_list_size + ai + 1;
+
+    list = talloc_zero_array(tmp_ctx, char *, expected_list_size);
+    if (list == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    for (c = 0; add_list[c] != NULL; ++c) {
+        if (string_in_list(add_list[c], discard_const(remove_list), false)) {
+            continue;
+        }
+
+        list[j] = talloc_strdup(list, add_list[c]);
+        if (list[j] == NULL) {
+            ret = ENOMEM;
+            goto done;
+        }
+        j++;
+    }
+
+    for (c = 0; defaults_list != NULL && defaults_list[c] != NULL; ++c) {
+        if (string_in_list(defaults_list[c],
+                           discard_const(remove_list), false)) {
+            continue;
+        }
+
+        list[j] = talloc_strdup(list, defaults_list[c]);
+        if (list[j] == NULL) {
+            ret = ENOMEM;
+            goto done;
+        }
+        j++;
+    }
+
+    if (_list != NULL) {
+        *_list = talloc_steal(mem_ctx, list);
+    }
+
+    ret = EOK;
+
+done:
+    talloc_zfree(tmp_ctx);
+
+    return ret;
+}

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -701,6 +701,9 @@ char **concatenate_string_array(TALLOC_CTX *mem_ctx,
                                 char **arr1, size_t len1,
                                 char **arr2, size_t len2);
 
+errno_t mod_defaults_list(TALLOC_CTX *mem_ctx, const char **defaults_list,
+                          char **mod_list, char ***_list);
+
 /* from become_user.c */
 errno_t become_user(uid_t uid, gid_t gid);
 struct sss_creds;


### PR DESCRIPTION
So far pam_response_filter didn't had any default. It turned out that it
would be useful to filter the environment variable KRB5CCANME by default
for sudo. The reason is the e.g. in contrast to su the calling user is
authenticated and hence only the Kerberos credentials of the calling user
are available. But this causes a couple of inconsistencies. E.g. depending
on the credential cache type the target user might not have access to the
credential cache and even if the credential cache can be accessed it will
contain credentials which different privileges than the target user. As a
result  it seems better to not make KRB5CCANME in the environment of the
target user and let him pick the matching default credential cache.

Resolves: https://github.com/SSSD/sssd/issues/5660