### PR TITLE
debug: add support for tevent chain id

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -697,6 +697,7 @@ dist_noinst_HEADERS = \
     src/util/session_recording.h \
     src/util/strtonum.h \
     src/util/sss_cli_cmd.h \
+    src/util/sss_chain_id.h \
     src/util/sss_ptr_hash.h \
     src/util/sss_ptr_list.h \
     src/util/sss_endian.h \
@@ -1069,6 +1070,7 @@ libsss_sbus_la_SOURCES = \
     src/util/check_and_open.c \
     src/util/debug.c \
     src/util/debug_backtrace.c \
+    src/util/sss_chain_id.c \
     src/util/sss_ptr_hash.c \
     src/util/sss_ptr_list.c \
     src/util/sss_utf8.c \
@@ -1280,6 +1282,7 @@ libsss_util_la_SOURCES = \
     src/util/files.c \
     src/util/selinux.c \
     src/util/sss_regexp.c \
+    src/util/sss_chain_id.c \
     $(NULL)
 libsss_util_la_CFLAGS = \
     $(AM_CFLAGS) \

--- a/src/external/libtevent.m4
+++ b/src/external/libtevent.m4
@@ -13,3 +13,32 @@ AS_IF([test x"$found_tevent" != xyes],
                       [-L$sss_extra_libdir -ltalloc])],
         [AC_MSG_ERROR([tevent header files are not installed])])]
 )
+
+SAVE_CFLAGS=$CFLAGS
+SAVE_LIBS=$LIBS
+CFLAGS="$CFLAGS $TEVENT_CFLAGS"
+LIBS="$LIBS $TEVENT_LIBS"
+build_chain_id=yes
+AC_CHECK_FUNCS([tevent_set_trace_fd_callback \
+                tevent_set_trace_signal_callback \
+                tevent_set_trace_timer_callback \
+                tevent_set_trace_immediate_callback \
+                tevent_fd_set_tag \
+                tevent_fd_get_tag \
+                tevent_signal_set_tag \
+                tevent_signal_get_tag \
+                tevent_timer_set_tag \
+                tevent_timer_get_tag \
+                tevent_immediate_set_tag \
+                tevent_immediate_get_tag],
+               [],
+               [build_chain_id=no])
+CFLAGS=$SAVE_CFLAGS
+LIBS=$SAVE_LIBS
+
+if test x$build_chain_id = xyes
+then
+    AC_DEFINE(BUILD_CHAIN_ID, 1, [Build chain id])
+else
+    AC_MSG_NOTICE([Chain id support is disabled due to missing dependencies in tevent])
+fi

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -47,6 +47,7 @@
 #include "util/child_common.h"
 #include "resolv/async_resolv.h"
 #include "sss_iface/sss_iface_async.h"
+#include "util/sss_chain_id.h"
 
 #define ONLINE_CB_RETRY 3
 #define ONLINE_CB_RETRY_MAX_DELAY 4
@@ -775,6 +776,8 @@ int main(int argc, const char *argv[])
         DEBUG(SSSDBG_FATAL_FAILURE, "Could not set up mainloop [%d]\n", ret);
         return 2;
     }
+
+    sss_chain_id_setup(main_ctx->event_ctx);
 
     ret = setenv(SSS_DOM_ENV, be_domain, 1);
     if (ret != 0) {

--- a/src/providers/ldap/sdap.h
+++ b/src/providers/ldap/sdap.h
@@ -42,6 +42,7 @@ struct sdap_handle;
 struct sdap_op {
     struct sdap_op *prev, *next;
     struct sdap_handle *sh;
+    uint64_t chain_id;
 
     int msgid;
     bool done;

--- a/src/tests/cmocka/data_provider/test_dp_request.c
+++ b/src/tests/cmocka/data_provider/test_dp_request.c
@@ -231,7 +231,7 @@ static void test_get_name_by_uid(void **state)
                       SENDER_NAME, DPT_ID, DPM_ACCOUNT_HANDLER, 0, req_data,
                       &req_name);
     assert_non_null(req);
-    assert_string_equal(req_name, REQ_NAME" #0");
+    assert_string_equal(req_name, REQ_NAME" #1");
     talloc_zfree(req_name);
 
     /* Send request #2 */
@@ -239,7 +239,7 @@ static void test_get_name_by_uid(void **state)
                        SENDER_NAME, DPT_ID, DPM_ACCOUNT_HANDLER, 0, req_data2,
                        &req_name);
     assert_non_null(req2);
-    assert_string_equal(req_name, REQ_NAME" #1");
+    assert_string_equal(req_name, REQ_NAME" #2");
     talloc_zfree(req_name);
 
     /* Send request #3 */
@@ -247,7 +247,7 @@ static void test_get_name_by_uid(void **state)
                        SENDER_NAME, DPT_ID, DPM_ACCOUNT_HANDLER, 0, req_data3,
                        &req_name);
     assert_non_null(req3);
-    assert_string_equal(req_name, REQ_NAME" #2");
+    assert_string_equal(req_name, REQ_NAME" #3");
     talloc_zfree(req_name);
 
     tevent_loop_wait(test_ctx->tctx->ev);
@@ -305,7 +305,7 @@ static void test_type_mismatch(void **state)
     req = dp_req_send(test_ctx, test_ctx->provider, NULL, REQ_NAME, CID,
                       SENDER_NAME, DPT_ID, DPM_ACCOUNT_HANDLER, 0, req_data, &req_name);
     assert_non_null(req);
-    assert_string_equal(req_name, REQ_NAME" #0");
+    assert_string_equal(req_name, REQ_NAME" #1");
     talloc_zfree(req_name);
 
     tevent_loop_wait(test_ctx->tctx->ev);

--- a/src/util/debug.c
+++ b/src/util/debug.c
@@ -50,6 +50,7 @@ int debug_microseconds = SSSDBG_MICROSECONDS_UNRESOLVED;
 enum sss_logger_t sss_logger = STDERR_LOGGER;
 const char *debug_log_file = "sssd";
 FILE *_sss_debug_file;
+uint64_t debug_chain_id;
 
 const char *sss_logger_str[] = {
         [STDERR_LOGGER] = "stderr",
@@ -323,7 +324,12 @@ void sss_vdebug_fn(const char *file,
     sss_debug_backtrace_printf(level, "[%s] [%s] (%#.4x): ",
                                debug_prg_name, function, level);
 
+    if (debug_chain_id > 0) {
+        sss_debug_backtrace_printf(level, "[RID#%lu] ", debug_chain_id);
+    }
+
     sss_debug_backtrace_vprintf(level, format, ap);
+
     if (flags & APPEND_LINE_FEED) {
         sss_debug_backtrace_printf(level, "\n");
     }

--- a/src/util/sss_chain_id.c
+++ b/src/util/sss_chain_id.c
@@ -135,7 +135,7 @@ uint64_t sss_chain_id_set(uint64_t id)
     return old_id;
 }
 
-uint64_t sss_chain_id_get()
+uint64_t sss_chain_id_get(void)
 {
     return debug_chain_id;
 }

--- a/src/util/sss_chain_id.c
+++ b/src/util/sss_chain_id.c
@@ -1,0 +1,160 @@
+/*
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2021 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <tevent.h>
+
+#ifdef BUILD_CHAIN_ID
+extern uint64_t debug_chain_id;
+
+static void sss_chain_id_trace_fde(struct tevent_fd *fde,
+                                   enum tevent_event_trace_point point,
+                                   void *private_data)
+{
+    switch (point) {
+    case TEVENT_EVENT_TRACE_ATTACH:
+        /* Assign the current chain id when the event is created. */
+        tevent_fd_set_tag(fde, debug_chain_id);
+        break;
+    case TEVENT_EVENT_TRACE_BEFORE_HANDLER:
+        /* Set the chain id when a handler is being called. */
+        debug_chain_id = tevent_fd_get_tag(fde);
+        break;
+    default:
+        /* Do nothing. */
+        break;
+    }
+}
+
+static void sss_chain_id_trace_signal(struct tevent_signal *se,
+                                      enum tevent_event_trace_point point,
+                                      void *private_data)
+{
+    switch (point) {
+    case TEVENT_EVENT_TRACE_ATTACH:
+        /* Assign the current chain id when the event is created. */
+        tevent_signal_set_tag(se, debug_chain_id);
+        break;
+    case TEVENT_EVENT_TRACE_BEFORE_HANDLER:
+        /* Set the chain id when a handler is being called. */
+        debug_chain_id = tevent_signal_get_tag(se);
+        break;
+    default:
+        /* Do nothing. */
+        break;
+    }
+}
+
+static void sss_chain_id_trace_timer(struct tevent_timer *timer,
+                                     enum tevent_event_trace_point point,
+                                     void *private_data)
+{
+    switch (point) {
+    case TEVENT_EVENT_TRACE_ATTACH:
+        /* Assign the current chain id when the event is created. */
+        tevent_timer_set_tag(timer, debug_chain_id);
+        break;
+    case TEVENT_EVENT_TRACE_BEFORE_HANDLER:
+        /* Set the chain id when a handler is being called. */
+        debug_chain_id = tevent_timer_get_tag(timer);
+        break;
+    default:
+        /* Do nothing. */
+        break;
+    }
+}
+
+static void sss_chain_id_trace_immediate(struct tevent_immediate *im,
+                                         enum tevent_event_trace_point point,
+                                         void *private_data)
+{
+    switch (point) {
+    case TEVENT_EVENT_TRACE_ATTACH:
+        /* Assign the current chain id when the event is created. */
+        tevent_immediate_set_tag(im, debug_chain_id);
+        break;
+    case TEVENT_EVENT_TRACE_BEFORE_HANDLER:
+        /* Set the chain id when a handler is being called. */
+        debug_chain_id = tevent_immediate_get_tag(im);
+        break;
+    default:
+        /* Do nothing. */
+        break;
+    }
+}
+
+static void sss_chain_id_trace_loop(enum tevent_trace_point point,
+                                    void *private_data)
+{
+    switch (point) {
+    case TEVENT_TRACE_AFTER_LOOP_ONCE:
+        /* Reset chain id when we got back to the loop. An event handler
+         * that set chain id was fired. This tracepoint represents a place
+         * after the event handler was finished, we need to restore chain
+         * id to 0 (out of request).
+         */
+        debug_chain_id = 0;
+        break;
+    default:
+        /* Do nothing. */
+        break;
+    }
+}
+
+void sss_chain_id_setup(struct tevent_context *ev)
+{
+    tevent_set_trace_callback(ev, sss_chain_id_trace_loop, NULL);
+    tevent_set_trace_fd_callback(ev, sss_chain_id_trace_fde, NULL);
+    tevent_set_trace_signal_callback(ev, sss_chain_id_trace_signal, NULL);
+    tevent_set_trace_timer_callback(ev, sss_chain_id_trace_timer, NULL);
+    tevent_set_trace_immediate_callback(ev, sss_chain_id_trace_immediate, NULL);
+}
+
+uint64_t sss_chain_id_set(uint64_t id)
+{
+    uint64_t old_id = debug_chain_id;
+    debug_chain_id = id;
+    return old_id;
+}
+
+uint64_t sss_chain_id_get()
+{
+    return debug_chain_id;
+}
+
+#else /* BUILD_CHAIN_ID not defined */
+
+void sss_chain_id_setup(struct tevent_context *ev)
+{
+    return;
+}
+
+uint64_t sss_chain_id_set(uint64_t id)
+{
+    return 0;
+}
+
+uint64_t sss_chain_id_get(void)
+{
+    return 0;
+}
+
+#endif /* BUILD_CHAIN_ID */

--- a/src/util/sss_chain_id.h
+++ b/src/util/sss_chain_id.h
@@ -1,0 +1,35 @@
+/*
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2021 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _SSS_CHAIN_ID_
+#define _SSS_CHAIN_ID_
+
+#include <tevent.h>
+
+/* Setup chain id tracking on tevent context. */
+void sss_chain_id_setup(struct tevent_context *ev);
+
+/* Explicitly set new chain id. The old id is returned. */
+uint64_t sss_chain_id_set(uint64_t id);
+
+/* Get the current chain id. */
+uint64_t sss_chain_id_get(void);
+
+#endif /* _SSS_CHAIN_ID_ */


### PR DESCRIPTION
This PR adds a unique identifier to the log messages of each data provider requests
so we are able to track the request form its beginning to the end.

Note: this requires functionality from https://gitlab.com/samba-team/samba/-/merge_requests/1988