### PR TITLE
sudo: disable ldap_sudo_random_offset by default

### DIFF
--- a/src/man/sssd-ldap.5.xml
+++ b/src/man/sssd-ldap.5.xml
@@ -1587,11 +1587,17 @@ ldap_access_filter = (employeeType=admin)
                             seconds.
                         </para>
                         <para>
+                            Note that this random offset is also applied on the
+                            first SSSD start which delays the first sudo rules
+                            refresh. This prolongs the time when the sudo rules
+                            are not available for use.
+                        </para>
+                        <para>
                             You can disable this offset by setting the value to
                             0.
                         </para>
                         <para>
-                            Default: 30
+                            Default: 0 (disabled)
                         </para>
                     </listitem>
                 </varlistentry>

--- a/src/providers/ad/ad_opts.c
+++ b/src/providers/ad/ad_opts.c
@@ -85,7 +85,7 @@ struct dp_option ad_def_ldap_opts[] = {
     { "ldap_sudo_search_base", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "ldap_sudo_full_refresh_interval", DP_OPT_NUMBER, { .number = 21600 }, NULL_NUMBER }, /* 360 mins */
     { "ldap_sudo_smart_refresh_interval", DP_OPT_NUMBER, { .number = 900 }, NULL_NUMBER }, /* 15 mins */
-    { "ldap_sudo_random_offset", DP_OPT_NUMBER, { .number = 30 }, NULL_NUMBER }, /* 30 seconds */
+    { "ldap_sudo_random_offset", DP_OPT_NUMBER, { .number = 0 }, NULL_NUMBER }, /* disabled */
     { "ldap_sudo_use_host_filter", DP_OPT_BOOL, BOOL_TRUE, BOOL_TRUE },
     { "ldap_sudo_hostnames", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "ldap_sudo_ip", DP_OPT_STRING, NULL_STRING, NULL_STRING },

--- a/src/providers/ipa/ipa_opts.c
+++ b/src/providers/ipa/ipa_opts.c
@@ -91,7 +91,7 @@ struct dp_option ipa_def_ldap_opts[] = {
     { "ldap_sudo_search_base", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "ldap_sudo_full_refresh_interval", DP_OPT_NUMBER, { .number = 21600 }, NULL_NUMBER },
     { "ldap_sudo_smart_refresh_interval", DP_OPT_NUMBER, { .number = 900 }, NULL_NUMBER }, /* 15 mins */
-    { "ldap_sudo_random_offset", DP_OPT_NUMBER, { .number = 30 }, NULL_NUMBER }, /* 30 seconds */
+    { "ldap_sudo_random_offset", DP_OPT_NUMBER, { .number = 0 }, NULL_NUMBER }, /* disabled */
     { "ldap_sudo_use_host_filter", DP_OPT_BOOL, BOOL_TRUE, BOOL_TRUE },
     { "ldap_sudo_hostnames", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "ldap_sudo_ip", DP_OPT_STRING, NULL_STRING, NULL_STRING },

--- a/src/providers/ldap/ldap_opts.c
+++ b/src/providers/ldap/ldap_opts.c
@@ -52,7 +52,7 @@ struct dp_option default_basic_opts[] = {
     { "ldap_sudo_search_base", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "ldap_sudo_full_refresh_interval", DP_OPT_NUMBER, { .number = 21600 }, NULL_NUMBER }, /* 360 mins */
     { "ldap_sudo_smart_refresh_interval", DP_OPT_NUMBER, { .number = 900 }, NULL_NUMBER }, /* 15 mins */
-    { "ldap_sudo_random_offset", DP_OPT_NUMBER, { .number = 30 }, NULL_NUMBER }, /* 30 seconds */
+    { "ldap_sudo_random_offset", DP_OPT_NUMBER, { .number = 0 }, NULL_NUMBER }, /* disabled */
     { "ldap_sudo_use_host_filter", DP_OPT_BOOL, BOOL_TRUE, BOOL_TRUE },
     { "ldap_sudo_hostnames", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "ldap_sudo_ip", DP_OPT_STRING, NULL_STRING, NULL_STRING },


### PR DESCRIPTION
Resolves: https://github.com/SSSD/sssd/issues/5609

:config: Default value of `ldap_sudo_random_offset` changed to 0 (disabled). This
  makes sure that sudo rules are available as soon as possible after SSSD start
  in default configuration.