### PR TITLE
src/conf_macros.m4: set default value /run for pidpath

### DIFF
--- a/src/conf_macros.m4
+++ b/src/conf_macros.m4
@@ -35,12 +35,12 @@ AC_DEFUN([WITH_PLUGIN_PATH],
 AC_DEFUN([WITH_PID_PATH],
   [ AC_ARG_WITH([pid-path],
                 [AC_HELP_STRING([--with-pid-path=PATH],
-                                [Where to store pid files for the SSSD [/var/run]]
+                                [Where to store pid files for the SSSD [/run]]
                                )
                 ]
                )
-    config_pidpath="\"VARDIR\"/run"
-    pidpath="${localstatedir}/run"
+    config_pidpath="/run"
+    pidpath="/run"
     if test x"$with_pid_path" != x; then
         config_pidpath=$with_pid_path
         pidpath=$with_pid_path


### PR DESCRIPTION
/var/run is deprecated, so replace /var/run with /run as the default
value of variable pidpath.

Signed-off-by: Kai Kang <kai.kang@windriver.com>