### PR TITLE
kcm: terminate client on bad message

### DIFF
--- a/src/responder/kcm/kcmsrv_cmd.c
+++ b/src/responder/kcm/kcmsrv_cmd.c
@@ -548,7 +548,8 @@ static void kcm_recv(struct cli_ctx *cctx)
         DEBUG(SSSDBG_FATAL_FAILURE,
             "Failed to parse data (%d, %s), aborting client\n",
             ret, sss_strerror(ret));
-        goto fail;
+        talloc_free(cctx);
+        return;
     }
 
     /* do not read anymore, client is done sending */
@@ -559,15 +560,13 @@ static void kcm_recv(struct cli_ctx *cctx)
         DEBUG(SSSDBG_FATAL_FAILURE,
               "Failed to dispatch KCM operation [%d]: %s\n",
               ret, sss_strerror(ret));
-        goto fail;
+        /* Fail with reply */
+        kcm_reply_error(cctx, ret, &req->repbuf);
+        return;
     }
 
     /* Dispatched request resumes in kcm_cmd_request_done */
     return;
-
-fail:
-    /* Fail with reply */
-    kcm_reply_error(cctx, ret, &req->repbuf);
 }
 
 static int kcm_send_data(struct cli_ctx *cctx)


### PR DESCRIPTION
The debug message clearly says that the original intention was to
abort the client, not send an error message.

We may end up in a state where we get into an infinit loop, fo example
when the client send an message that indicates 0 lenght, but there is
actually more data written. In this case, we never read the rest of the
message but the file descriptor is still readable so the fd handler gets
fired again and again.

More information can be seen in relevant FreeIPA ticket:
https://pagure.io/freeipa/issue/8877