### PR TITLE
KCM: removed unneeded assignment

### DIFF
--- a/src/responder/kcm/kcm_renew.c
+++ b/src/responder/kcm/kcm_renew.c
@@ -478,7 +478,6 @@ static void kcm_renew_tgt(struct tevent_context *ev,
 
     ctx = talloc_zero(auth_data, struct kcm_renew_auth_ctx);
     if (ctx == NULL) {
-        ret = ENOMEM;
         DEBUG(SSSDBG_FATAL_FAILURE, "Failed to allocate renew auth ctx\n");
         return;
     }


### PR DESCRIPTION
Fixes following warning:
```
Error: CLANG_WARNING:
sssd-2.5.1/src/responder/kcm/kcm_renew.c:481:9: warning[deadcode.DeadStores]: Value stored to 'ret' is never read
 #  479|       ctx = talloc_zero(auth_data, struct kcm_renew_auth_ctx);
 #  480|       if (ctx == NULL) {
 #  481|->         ret = ENOMEM;
 #  482|           DEBUG(SSSDBG_FATAL_FAILURE, "Failed to allocate renew auth ctx\n");
 #  483|           return;
```