### PR TITLE
CACHE_REQ: fixed covscan issues

### DIFF
--- a/src/responder/common/cache_req/cache_req_data.c
+++ b/src/responder/common/cache_req/cache_req_data.c
@@ -157,7 +157,7 @@ cache_req_data_create(TALLOC_CTX *mem_ctx,
     case CACHE_REQ_ENUM_IP_NETWORK:
         break;
     case CACHE_REQ_SVC_BY_NAME:
-        if (input->svc.name->input == NULL) {
+        if ((input->svc.name == NULL) || (input->svc.name->input == NULL)) {
             DEBUG(SSSDBG_CRIT_FAILURE, "Bug: name cannot be NULL!\n");
             ret = ERR_INTERNAL;
             goto done;


### PR DESCRIPTION
Fixed following warning:
```
Error: GCC_ANALYZER_WARNING (CWE-476):
sssd-2.5.1/src/responder/common/cache_req/cache_req_data.c: scope_hint: In function 'cache_req_data_create'
sssd-2.5.1/src/responder/common/cache_req/cache_req_data.c:160:28: warning[-Wanalyzer-null-dereference]: dereference of NULL '0'
 #  158|           break;
 #  159|       case CACHE_REQ_SVC_BY_NAME:
 #  160|->         if (input->svc.name->input == NULL) {
 #  161|               DEBUG(SSSDBG_CRIT_FAILURE, "Bug: name cannot be NULL!\n");
 #  162|               ret = ERR_INTERNAL;
```