### PR TITLE
p11_child: do_card partially fix loop exit condition

### DIFF
--- a/src/p11_child/p11_child_openssl.c
+++ b/src/p11_child/p11_child_openssl.c
@@ -1745,7 +1745,7 @@ errno_t do_card(TALLOC_CTX *mem_ctx, struct p11_ctx *p11_ctx,
 
                 }
 
-                if ((info.flags & CKF_REMOVABLE_DEVICE)) {
+                if ((info.flags & CKF_REMOVABLE_DEVICE) && (info.flags & CKF_TOKEN_PRESENT)) {
                     break;
                 }
             }


### PR DESCRIPTION
This commit fixes the exit condition when searching for a token in p11_child/do_card, specifically in case a token is present in a slot, but there are empty slots before it.

This commit fixes issue #5025, thanks to this comment by @sumit-bose: https://github.com/SSSD/sssd/issues/5025#issuecomment-801842175 