### PR TITLE
multihost: fix whitespace issues

### DIFF
--- a/src/tests/multihost/ad/conftest.py
+++ b/src/tests/multihost/ad/conftest.py
@@ -554,13 +554,12 @@ def sudorules(session_multihost, request):
     sudo_identity = 'sudo_usera'
     sudo_options = ["!requiretty", "!authenticate"]
     win_ldap.add_sudo_rule(rule1_dn, 'ALL', sudo_cmd,
-                          sudo_identity, sudo_options)
+                           sudo_identity, sudo_options)
     user1 = 'sudo_idmuser1'
     extra_sudo_user = [(ldap.MOD_ADD, 'sudoRunAs',
                         user1.encode('utf-8'))]
     (ret, _) = win_ldap.modify_ldap(rule1_dn, extra_sudo_user)
     assert ret == 'Success'
-
 
     def delete_sudorule():
         """ Delete sudo rule """

--- a/src/tests/multihost/ad/test_sudo.py
+++ b/src/tests/multihost/ad/test_sudo.py
@@ -216,7 +216,6 @@ class TestSudo(object):
                     assert '/usr/bin/head\n' in result
         client.sssd_conf('sudo', params, action='delete')
 
-
     @classmethod
     def class_teardown(cls, multihost):
         """ Remove sudo provider from Domain section """

--- a/src/tests/multihost/ipa/add-groups.ps1
+++ b/src/tests/multihost/ipa/add-groups.ps1
@@ -66,3 +66,4 @@ foreach ($nestedgroup in $nestedgroups) {
                 }
         }
 }
+

--- a/src/tests/multihost/ipa/nestedgroups.csv
+++ b/src/tests/multihost/ipa/nestedgroups.csv
@@ -19,3 +19,4 @@ nested_group17
 nested_group18
 nested_group19
 nested_group20
+


### PR DESCRIPTION
whitespace test fails with:

```
Missing new line at the eof: src/tests/multihost/ipa/add-groups.ps1
Missing new line at the eof: src/tests/multihost/ipa/nestedgroups.csv
```