### PR TITLE
TESTS: Make test_kcm_renewals idempotent

### DIFF
--- a/src/tests/cmocka/test_kcm_renewals.c
+++ b/src/tests/cmocka/test_kcm_renewals.c
@@ -175,6 +175,7 @@ static int teardown_kcm_renewals(void **state)
     struct test_ctx *tctx = talloc_get_type(*state, struct test_ctx);
 
     unlink(TEST_DB_FULL_PATH);
+    unlink(TEST_MKEY_FULL_PATH);
 
     rmdir(TESTS_PATH);
     talloc_free(tctx);


### PR DESCRIPTION
Fix an issue where test directory cleanup was failing, causing `make check` to fail when run twice in a row