### PR TITLE
General: Hardeninig getenv() usage

### DIFF
--- a/src/providers/files/files_init.c
+++ b/src/providers/files/files_init.c
@@ -51,29 +51,37 @@ static errno_t files_init_file_sources(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    dfl_passwd_files = getenv("SSS_FILES_PASSWD");
-    if (dfl_passwd_files) {
+    ret = sss_getenv(tmp_ctx, "SSS_FILES_PASSWD", &dfl_passwd_files);
+    if (ret == EOK) {
         sss_log(SSS_LOG_ALERT,
                 "Defaulting to %s for the passwd file, "
                 "this should only be used for testing!\n",
                 dfl_passwd_files);
-    } else {
+    } else if (ret == ENOENT) {
         dfl_passwd_files = DEFAULT_PASSWD_FILE;
+    } else {
+        sss_log(SSS_LOG_ALERT, "sss_getenv() failed");
+        goto done;
     }
     DEBUG(SSSDBG_TRACE_FUNC,
-          "Using default passwd file: [%s].\n", dfl_passwd_files);
+          "Using passwd file: [%s].\n",
+          dfl_passwd_files);
 
-    env_group_files = getenv("SSS_FILES_GROUP");
-    if (env_group_files) {
+    ret = sss_getenv(tmp_ctx, "SSS_FILES_GROUP", &env_group_files);
+    if (ret == EOK) {
         sss_log(SSS_LOG_ALERT,
                 "Defaulting to %s for the group file, "
                 "this should only be used for testing!\n",
                 env_group_files);
-    } else {
+    } else if (ret == ENOENT) {
         env_group_files = DEFAULT_GROUP_FILE;
+    } else {
+        sss_log(SSS_LOG_ALERT, "sss_getenv() failed");
+        goto done;
     }
     DEBUG(SSSDBG_TRACE_FUNC,
-          "Using default group file: [%s].\n", DEFAULT_GROUP_FILE);
+          "Using group file: [%s].\n",
+          env_group_files);
 
     ret = confdb_get_string(be_ctx->cdb, tmp_ctx, be_ctx->conf_path,
                             CONFDB_FILES_PASSWD, dfl_passwd_files,

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -1066,3 +1066,18 @@ bool is_valid_domain_name(const char *domain)
 
     return true;
 }
+
+errno_t sss_getenv(TALLOC_CTX *mem_ctx, const char *variable_name, char **_value)
+{
+    char *value = getenv(variable_name);
+    if (value == NULL) {
+        return ENOENT;
+    }
+
+    *_value = talloc_strdup(mem_ctx, value);
+    if (*_value == NULL) {
+        return ENOMEM;
+    }
+
+    return EOK;
+}

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -803,4 +803,6 @@ errno_t create_preauth_indicator(void);
 #define N_ELEMENTS(arr) (sizeof(arr) / sizeof(arr[0]))
 #endif
 
+errno_t sss_getenv(TALLOC_CTX *mem_ctx, const char *variable_name, char **_value);
+
 #endif /* __SSSD_UTIL_H__ */


### PR DESCRIPTION
Pointer returned by getenv() should be cached locally before
it is passed down to sub functions.

This PR fixes this for:
* pam_sm_authenticate()
* sysdb_ldb_connect()
* files_init_file_sources()

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1977830