### PR TITLE
SYSDB: Add search index "originalADgidNumber"

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -176,6 +176,8 @@
 #define OVERRIDE_PREFIX "override"
 #define SYSDB_DEFAULT_OVERRIDE_NAME "defaultOverrideName"
 
+#define SYSDB_ORIG_AD_GID_NUMBER "originalADgidNumber"
+
 #define SYSDB_AD_ACCOUNT_EXPIRES "adAccountExpires"
 #define SYSDB_AD_USER_ACCOUNT_CONTROL "adUserAccountControl"
 

--- a/src/db/sysdb_init.c
+++ b/src/db/sysdb_init.c
@@ -566,6 +566,13 @@ static errno_t sysdb_domain_cache_upgrade(TALLOC_CTX *mem_ctx,
     }
 
 
+    if (strcmp(version, SYSDB_VERSION_0_21) == 0) {
+        ret = sysdb_upgrade_21(sysdb, &version);
+        if (ret != EOK) {
+            goto done;
+        }
+    }
+
     ret = EOK;
 done:
     sysdb->ldb = save_ldb;

--- a/src/db/sysdb_private.h
+++ b/src/db/sysdb_private.h
@@ -23,6 +23,7 @@
 #ifndef __INT_SYS_DB_H__
 #define __INT_SYS_DB_H__
 
+#define SYSDB_VERSION_0_22 "0.22"
 #define SYSDB_VERSION_0_21 "0.21"
 #define SYSDB_VERSION_0_20 "0.20"
 #define SYSDB_VERSION_0_19 "0.19"
@@ -45,7 +46,7 @@
 #define SYSDB_VERSION_0_2 "0.2"
 #define SYSDB_VERSION_0_1 "0.1"
 
-#define SYSDB_VERSION SYSDB_VERSION_0_21
+#define SYSDB_VERSION SYSDB_VERSION_0_22
 
 #define SYSDB_BASE_LDIF \
      "dn: @ATTRIBUTES\n" \
@@ -81,6 +82,7 @@
      "@IDXATTR: mail\n" \
      "@IDXATTR: userMappedCertificate\n" \
      "@IDXATTR: ccacheFile\n" \
+     "@IDXATTR: originalADgidNumber\n" \
      "\n" \
      "dn: @MODULES\n" \
      "@LIST: asq,memberof\n" \
@@ -174,6 +176,7 @@ int sysdb_upgrade_17(struct sysdb_ctx *sysdb,
 int sysdb_upgrade_18(struct sysdb_ctx *sysdb, const char **ver);
 int sysdb_upgrade_19(struct sysdb_ctx *sysdb, const char **ver);
 int sysdb_upgrade_20(struct sysdb_ctx *sysdb, const char **ver);
+int sysdb_upgrade_21(struct sysdb_ctx *sysdb, const char **ver);
 
 int sysdb_ts_upgrade_01(struct sysdb_ctx *sysdb, const char **ver);
 

--- a/src/db/sysdb_upgrade.c
+++ b/src/db/sysdb_upgrade.c
@@ -2553,6 +2553,58 @@ done:
     return ret;
 }
 
+int sysdb_upgrade_21(struct sysdb_ctx *sysdb, const char **ver)
+{
+    struct upgrade_ctx *ctx;
+    errno_t ret;
+    struct ldb_message *msg = NULL;
+
+    ret = commence_upgrade(sysdb, sysdb->ldb, SYSDB_VERSION_0_22, &ctx);
+    if (ret) {
+        return ret;
+    }
+
+    /* Add missing indices */
+    msg = ldb_msg_new(ctx);
+    if (msg == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    msg->dn = ldb_dn_new(msg, sysdb->ldb, "@INDEXLIST");
+    if (msg->dn == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = ldb_msg_add_empty(msg, "@IDXATTR", LDB_FLAG_MOD_ADD, NULL);
+    if (ret != LDB_SUCCESS) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = ldb_msg_add_string(msg, "@IDXATTR", SYSDB_ORIG_AD_GID_NUMBER);
+    if (ret != LDB_SUCCESS) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = ldb_modify(sysdb->ldb, msg);
+    if (ret != LDB_SUCCESS) {
+        ret = sysdb_error_to_errno(ret);
+        goto done;
+    }
+
+    talloc_free(msg);
+
+    /* conversion done, update version number */
+    ret = update_version(ctx);
+
+done:
+    ret = finish_upgrade(ret, &ctx, ver);
+    return ret;
+}
+
 int sysdb_ts_upgrade_01(struct sysdb_ctx *sysdb, const char **ver)
 {
     struct upgrade_ctx *ctx;


### PR DESCRIPTION
Commit 03bc962 introduced a change which can result in
unindexed search in some scenarios. The result is performance
drop comparing to older SSSD version.

This PR adds missing search index: originalADgidNumber

:relnote: Add search index "originalADgidNumber" to SYSDB

Resolves: https://github.com/SSSD/sssd/issues/5430