### PR TITLE
ad: fallback to ldap if cldap is not available in libldap

### DIFF
--- a/src/external/ldap.m4
+++ b/src/external/ldap.m4
@@ -67,7 +67,8 @@ LIBS="$LIBS $OPENLDAP_LIBS"
 AC_CHECK_FUNCS([ldap_control_create ldap_init_fd \
                 ldap_create_deref_control_value  \
                 ldap_parse_derefresponse_control \
-                ldap_derefresponse_free])
+                ldap_derefresponse_free \
+                ldap_is_ldapc_url])
 AC_CHECK_MEMBERS([struct ldap_conncb.lc_arg],
                  [AC_RUN_IFELSE(
                    [AC_LANG_PROGRAM(

--- a/src/providers/ad/ad_cldap_ping.c
+++ b/src/providers/ad/ad_cldap_ping.c
@@ -36,6 +36,12 @@
 #include "providers/ldap/sdap_async.h"
 #include "db/sysdb.h"
 
+#ifdef HAVE_LDAP_IS_LDAPC_URL
+#define AD_PING_PROTOCOL "cldap"
+#else
+#define AD_PING_PROTOCOL "ldap"
+#endif
+
 struct ad_cldap_ping_dc_state {
     struct tevent_context *ev;
     struct sdap_options *opts;
@@ -76,8 +82,9 @@ static struct tevent_req *ad_cldap_ping_dc_send(TALLOC_CTX *mem_ctx,
     state->ad_domain = ad_domain;
 
     subreq = sdap_connect_host_send(state, ev, opts, be_res->resolv,
-                                    be_res->family_order, host_db, "cldap",
-                                    dc->host, dc->port, false);
+                                    be_res->family_order, host_db,
+                                    AD_PING_PROTOCOL, dc->host, dc->port,
+                                    false);
     if (subreq == NULL) {
         ret = ENOMEM;
         goto done;


### PR DESCRIPTION
Some distributions do not have cldap support available in libldap. Now
we fallback to ad ping over ldap conditionally during build time.

Resolves: https://github.com/SSSD/sssd/issues/5720

```
:fixes: AD ping is now sent over `ldap` if `cldap` support is not available
  during build. This helps to build SSSD on distributions without `cldap`
  support in `libldap`.
```