### PR TITLE
general: Fix compilation warnings

### DIFF
--- a/src/providers/files/files_init.c
+++ b/src/providers/files/files_init.c
@@ -40,8 +40,8 @@ static errno_t files_init_file_sources(TALLOC_CTX *mem_ctx,
     int num_group_files = 0;
     const char **passwd_files = NULL;
     const char **group_files = NULL;
-    const char *dfl_passwd_files = NULL;
-    const char *env_group_files = NULL;
+    char *dfl_passwd_files = NULL;
+    char *env_group_files = NULL;
     int i;
     errno_t ret;
 

--- a/src/sss_client/pam_sss_gss.c
+++ b/src/sss_client/pam_sss_gss.c
@@ -510,7 +510,7 @@ int pam_sm_authenticate(pam_handle_t *pamh,
 {
     const char *pam_service = NULL;
     const char *pam_user = NULL;
-    const char *ccache = NULL;
+    char *ccache = NULL;
     char *username = NULL;
     char *domain = NULL;
     char *target = NULL;


### PR DESCRIPTION
Commit 44525a9995c775ac284a6203d0e505dc4bf0d459 introduced
compilation warnings related to type casting.
This commit fixes this by align types of pointer used in code.