### PR TITLE
TOOLS: replace system() with execvp()

### DIFF
--- a/src/tools/sssctl/sssctl.h
+++ b/src/tools/sssctl/sssctl.h
@@ -47,7 +47,7 @@ enum sssctl_prompt_result
 sssctl_prompt(const char *message,
               enum sssctl_prompt_result defval);
 
-errno_t sssctl_run_command(const char *command);
+errno_t sssctl_run_command(const char *const argv[]); /* argv[0] - command */
 bool sssctl_start_sssd(bool force);
 bool sssctl_stop_sssd(bool force);
 bool sssctl_restart_sssd(bool force);


### PR DESCRIPTION
to avoid execution of user supplied command

A flaw was found in SSSD, where the sssctl command was vulnerable
to shell command injection via the logs-fetch and cache-expire
subcommands. This flaw allows an attacker to trick the root user
into running a specially crafted sssctl command, such as via sudo,
to gain root access. The highest threat from this vulnerability is
to confidentiality, integrity, as well as system availability.

:fixes: CVE-2021-3621