### PR TITLE
CI: unset DEBUGINFOD_URLS

### DIFF
--- a/contrib/ci/run
+++ b/contrib/ci/run
@@ -184,6 +184,7 @@ function build_debug()
 
     status=0
     CK_FORK=no \
+    DEBUGINFOD_URLS="" \
         stage make-check-valgrind \
                 make -j $CPU_NUM check \
                      LOG_COMPILER=libtool \


### PR DESCRIPTION
Fedora 35 adds support to automatically fetch debuginfo, this
causes slowness in valgrind and leads to timeouts/systemd-oomd
invoked on the CI make check valgrind step.

https://fedoraproject.org/wiki/Changes/DebuginfodByDefault