### PR TITLE
configure: do not unset PYTHON_PREFIX and PYTHON_EXEC_PREFIX

### DIFF
--- a/src/external/python.m4
+++ b/src/external/python.m4
@@ -73,7 +73,7 @@ AC_DEFUN([SSS_CLEAN_PYTHON_VARIABLES],
 [
     unset pyexecdir pkgpyexecdir pythondir pgkpythondir
     unset PYTHON PYTHON_CFLAGS PYTHON_LIBS PYTHON_INCLUDES
-    unset PYTHON_PREFIX PYTHON_EXEC_PREFIX PYTHON_VERSION PYTHON_CONFIG
+    unset PYTHON_VERSION PYTHON_CONFIG
 
     dnl removed cached variables, required for reusing of AM_PATH_PYTHON
     unset am_cv_pathless_PYTHON ac_cv_path_PYTHON am_cv_python_version


### PR DESCRIPTION
Recent changes in autoconf changed location of directories from:

```
checking for /usr/bin/python3 script directory... ${prefix}/lib/python3.9/site-packages
checking for /usr/bin/python3 extension module directory... ${exec_prefix}/lib64/python3.9/site-packages
```

to

```
checking for /usr/bin/python3 script directory... ${PYTHON_PREFIX}/lib/python3.10/site-packages
checking for /usr/bin/python3 extension module directory... ${PYTHON_EXEC_PREFIX}/lib64/python3.10/site-packages
```

However, we unset these variables in SSS_CLEAN_PYTHON_VARIABLES and
therefore the correct prefix is not applied anymore during installation.

---

The variables are unset because we support both python2 and python3 (look for `AM_PATH_PYTHON` in configure.ac). 

Perhaps there is a better solution? But honestly, I don't think that the exec prefix will ever be different for python2 and python3, additionally the world is stepping away from python2.