### PR TITLE
kcm: replace existing credentials to avoid unnecessary ccache growth

### DIFF
--- a/src/responder/kcm/kcmsrv_ccache.c
+++ b/src/responder/kcm/kcmsrv_ccache.c
@@ -333,12 +333,7 @@ krb5_creds **kcm_cc_unmarshal(TALLOC_CTX *mem_ctx,
     cred_list = talloc_zero_array(tmp_ctx, krb5_creds *, count + 1);
 
     for (cred = kcm_cc_get_cred(cc); cred != NULL; cred = kcm_cc_next_cred(cred), i++) {
-        ret = get_krb5_data_from_cred(tmp_ctx, cred->cred_blob, &cred_data);
-        if (ret != EOK) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "Failed to convert cred to krb5_data"
-                                       "[%d]: %s\n", ret, sss_strerror(ret));
-            goto done;
-        }
+        get_krb5_data_from_cred(cred->cred_blob, &cred_data);
 
         kerr = krb5_unmarshal_credentials(krb_context, &cred_data,
                                           &cred_list[i]);

--- a/src/util/sss_krb5.c
+++ b/src/util/sss_krb5.c
@@ -1375,3 +1375,16 @@ krb5_error_code sss_krb5_init_context(krb5_context *context)
 
     return kerr;
 }
+
+bool sss_krb5_creds_compare(krb5_context kctx, krb5_creds *a, krb5_creds *b)
+{
+    if (!krb5_principal_compare(kctx, a->client, b->client)) {
+        return false;
+    }
+
+    if (!krb5_principal_compare(kctx, a->server, b->server)) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/util/sss_krb5.c
+++ b/src/util/sss_krb5.c
@@ -1211,14 +1211,10 @@ static errno_t iobuf_get_len_bytes(TALLOC_CTX *mem_ctx,
     return EOK;
 }
 
-errno_t get_krb5_data_from_cred(TALLOC_CTX *mem_ctx,
-                                struct sss_iobuf *iobuf,
-                                krb5_data *k5data)
+void get_krb5_data_from_cred(struct sss_iobuf *iobuf, krb5_data *k5data)
 {
     k5data->data = (char *) sss_iobuf_get_data(iobuf);
     k5data->length = sss_iobuf_get_size(iobuf);
-
-    return EOK;
 }
 
 static errno_t get_krb5_data(TALLOC_CTX *mem_ctx,

--- a/src/util/sss_krb5.h
+++ b/src/util/sss_krb5.h
@@ -201,4 +201,6 @@ krb5_error_code sss_krb5_init_context(krb5_context *context);
 
 void get_krb5_data_from_cred(struct sss_iobuf *iobuf, krb5_data *k5data);
 
+bool sss_krb5_creds_compare(krb5_context kctx, krb5_creds *a, krb5_creds *b);
+
 #endif /* __SSS_KRB5_H__ */

--- a/src/util/sss_krb5.h
+++ b/src/util/sss_krb5.h
@@ -199,8 +199,6 @@ krb5_error_code sss_krb5_unmarshal_princ(TALLOC_CTX *mem_ctx,
 
 krb5_error_code sss_krb5_init_context(krb5_context *context);
 
-errno_t get_krb5_data_from_cred(TALLOC_CTX *mem_ctx,
-                                struct sss_iobuf *iobuf,
-                                krb5_data *k5data);
+void get_krb5_data_from_cred(struct sss_iobuf *iobuf, krb5_data *k5data);
 
 #endif /* __SSS_KRB5_H__ */


### PR DESCRIPTION
Currently, we just append input credential to the ccache. This however make
the ccache grow over time as credentials expires and more control 
credentials are stored.

Now we remove or credentials that are the same and overwrite them with the
input credential.

Resolves: https://github.com/SSSD/sssd/issues/5775

:fixes: KCM now replace the old credential with new one when storing
 an update credential that is however already present in the ccache
 to avoid unnecessary growth of the ccache.