### PR TITLE
krb5: fix ccache ownership for offline Smartcard authentication

### DIFF
--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -3430,8 +3430,11 @@ int main(int argc, const char *argv[])
      * default and the 'sssd' user is allowed with the help of the
      * sssd-pcsc.rules policy-kit rule. So those IDs are a suitable choice. We
      * can only call switch_creds() because after the TGT is returned we have
-     * to switch to the IDs of the user to store the TGT. */
-    if (IS_SC_AUTHTOK(kr->pd->authtok)) {
+     * to switch to the IDs of the user to store the TGT.
+     * If we are offline we have to switch to the user's credentials directly
+     * to make sure the empty ccache is created with the expected
+     * ownership. */
+    if (IS_SC_AUTHTOK(kr->pd->authtok) && !offline) {
         kerr = switch_creds(kr, kr->fast_uid, kr->fast_gid, 0, NULL,
                             &kr->pcsc_saved_creds);
     } else {


### PR DESCRIPTION
During Smartcard authentication/PKINIT the krb5_child process is running
as privileged user for some time to make sure pcscd allows access to the
Smartcard. If SSSD is offline those privileges are currently not dropped
before creating an empty ccache and as a result file based ccaches might
have a wrong ownership. With the patch the privileges are dropped is
SSSD is offline and the ccache is created with the expected ownership.

Resolves: https://github.com/SSSD/sssd/issues/5785

:fixes: ccache files are created with the right ownership during offline
  Smartcard authentication