### PR TITLE
debug: suppress backtrace if GetAccountDomain() is not supported

### DIFF
--- a/src/responder/common/cache_req/plugins/cache_req_common.c
+++ b/src/responder/common/cache_req/plugins/cache_req_common.c
@@ -140,7 +140,7 @@ cache_req_common_process_dp_reply(struct cache_req *cr,
     }
 
     if (err_maj) {
-        CACHE_REQ_DEBUG(SSSDBG_OP_FAILURE, cr,
+        CACHE_REQ_DEBUG(SSSDBG_IMPORTANT_INFO, cr,
                         "Data Provider Error: %u, %u, %s\n",
                         (unsigned int)err_maj, (unsigned int)err_min, err_msg);
         CACHE_REQ_DEBUG(SSSDBG_TRACE_FUNC, cr,

--- a/src/responder/common/responder_get_domains.c
+++ b/src/responder/common/responder_get_domains.c
@@ -795,8 +795,11 @@ static void sss_dp_get_account_domain_done(struct tevent_req *subreq)
     }
 
     if (state->dp_error != DP_ERR_OK) {
-        DEBUG(SSSDBG_OP_FAILURE, "Data Provider Error: %u, %u\n",
-              (unsigned int)state->dp_error, (unsigned int)state->error);
+        DEBUG(state->error == ERR_GET_ACCT_DOM_NOT_SUPPORTED ? SSSDBG_TRACE_INTERNAL
+                                                             : SSSDBG_IMPORTANT_INFO,
+              "Data Provider Error: %u, %u [%s]\n",
+              (unsigned int)state->dp_error, (unsigned int)state->error,
+              sss_strerror(state->error));
         tevent_req_error(req, state->error ? state->error : EIO);
         return;
     }


### PR DESCRIPTION
The return code ERR_GET_ACCT_DOM_NOT_SUPPORTED is an expected return code
if the backend does not support the GetAccountDomain() request and there is
no need to trigger a backtrace in the logs in this case.