### PR TITLE
Include sys/types.h in debug.h

### DIFF
--- a/src/util/debug.h
+++ b/src/util/debug.h
@@ -25,6 +25,7 @@
 
 #include <stdio.h>
 #include <stdbool.h>
+#include <sys/types.h>
 
 #include "util/util_errors.h"
 


### PR DESCRIPTION
Hi, I’m getting compile errors without this (on Debian 10):

    In file included from ./src/util/sss_pam_data.h:33,
                     from src/util/sss_pam_data.c:27:
    ./src/util/debug.h:92:44: error: unknown type name ‘uid_t’; did you mean ‘uint_t’?
     int chown_debug_file(const char *filename, uid_t uid, gid_t gid);
                                                ^~~~~
                                                uint_t
    ./src/util/debug.h:92:55: error: unknown type name ‘gid_t’
     int chown_debug_file(const char *filename, uid_t uid, gid_t gid);
                                                           ^~~~~

Thanks!