### PR TITLE
debug: fix unused variable warnings

### DIFF
--- a/src/util/debug.c
+++ b/src/util/debug.c
@@ -269,9 +269,6 @@ void sss_vdebug_fn(const char *file,
                    const char *format,
                    va_list ap)
 {
-    char chain_id_fmt_fixed[256];
-    char *chain_id_fmt_dyn = NULL;
-    char *result_fmt;
     static time_t last_time;
     static char last_time_str[128];
     struct timeval tv;
@@ -279,6 +276,9 @@ void sss_vdebug_fn(const char *file,
     time_t t;
 
 #ifdef WITH_JOURNALD
+    char chain_id_fmt_fixed[256];
+    char *chain_id_fmt_dyn = NULL;
+    char *result_fmt;
     errno_t ret;
     va_list ap_fallback;
 


### PR DESCRIPTION
```
/home/pbrezina/workspace/sssd/src/util/debug.c: In function ‘sss_vdebug_fn’:
/home/pbrezina/workspace/sssd/src/util/debug.c:274:11: error: unused variable ‘result_fmt’ [-Werror=unused-variable]
  274 |     char *result_fmt;
      |           ^~~~~~~~~~
/home/pbrezina/workspace/sssd/src/util/debug.c:273:11: error: unused variable ‘chain_id_fmt_dyn’ [-Werror=unused-variable]
  273 |     char *chain_id_fmt_dyn = NULL;
      |           ^~~~~~~~~~~~~~~~
/home/pbrezina/workspace/sssd/src/util/debug.c:272:10: error: unused variable ‘chain_id_fmt_fixed’ [-Werror=unused-variable]
  272 |     char chain_id_fmt_fixed[256];

```

Introduced in: 3d8dd1282ffb7d0188e36d0109340ce622745717