### PR TITLE
monitor: fix unused variable warning

### DIFF
--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -895,7 +895,6 @@ static int get_service_user(struct mt_ctx *ctx)
 static int get_monitor_config(struct mt_ctx *ctx)
 {
     int ret;
-    int timeout_seconds;
     char *badsrv = NULL;
     int i;
 


### PR DESCRIPTION
```
src/monitor/monitor.c: In function ‘get_monitor_config’:
src/monitor/monitor.c:898:9: error: unused variable ‘timeout_seconds’ [-Werror=unused-variable]
  898 |     int timeout_seconds;
```

Introduced in c4c0fd690d82f9a8a714784ad4e036a39e1017fc.