### PR TITLE
krb5_child: fixed incorrect checks on length value

### DIFF
--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -2380,7 +2380,7 @@ static errno_t unpack_authtok(struct sss_auth_token *tok,
 
     SAFEALIGN_COPY_UINT32_CHECK(&auth_token_type, buf + *p, size, p);
     SAFEALIGN_COPY_UINT32_CHECK(&auth_token_length, buf + *p, size, p);
-    if ((*p + auth_token_length) > size) {
+    if (auth_token_length > (size - *p)) {
         return EINVAL;
     }
     switch (auth_token_type) {


### PR DESCRIPTION
It is safer to isolate the checked (unknown/untrusted) value on
the left hand side in the conditions to avoid overflows/underflows.

(addition to 9f0bffebd070115ab47a92eadc6890a721c7b78d)

Resolves: https://github.com/SSSD/sssd/issues/2739