### PR TITLE
krb5: use hidden file when creating config snippets

### DIFF
--- a/src/tests/cmocka/test_utils.c
+++ b/src/tests/cmocka/test_utils.c
@@ -1513,6 +1513,26 @@ void test_sss_write_krb5_conf_snippet(void **state)
     free(path);
 }
 
+void test_get_hidden_path(void **state)
+{
+    char *s;
+
+    assert_null(get_hidden_tmp_path(NULL, NULL));
+    assert_null(get_hidden_tmp_path(NULL, "/"));
+    assert_null(get_hidden_tmp_path(NULL, "/abc/"));
+
+    s = get_hidden_tmp_path(NULL, "abc");
+    assert_string_equal(s, ".abcXXXXXX");
+    talloc_free(s);
+
+    s = get_hidden_tmp_path(NULL, "/abc");
+    assert_string_equal(s, "/.abcXXXXXX");
+    talloc_free(s);
+
+    s = get_hidden_tmp_path(NULL, "/xyz/xyz/xyz//abc");
+    assert_string_equal(s, "/xyz/xyz/xyz//.abcXXXXXX");
+    talloc_free(s);
+}
 
 struct unique_file_test_ctx {
     char *filename;
@@ -2127,6 +2147,7 @@ int main(int argc, const char *argv[])
                                         setup_leak_tests,
                                         teardown_leak_tests),
         cmocka_unit_test(test_sss_write_krb5_conf_snippet),
+        cmocka_unit_test(test_get_hidden_path),
         cmocka_unit_test_setup_teardown(test_sss_unique_file,
                                         unique_file_test_setup,
                                         unique_file_test_teardown),

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -637,6 +637,8 @@ errno_t sss_get_domain_mappings_content(TALLOC_CTX *mem_ctx,
 
 errno_t sss_write_domain_mappings(struct sss_domain_info *domain);
 
+char *get_hidden_tmp_path(TALLOC_CTX *mem_ctx, const char *path);
+
 errno_t sss_write_krb5_conf_snippet(const char *path, bool canonicalize,
                                     bool udp_limit);
 


### PR DESCRIPTION
When creating config snippets fir libkrb5 SSSD first creates a temporary
file with a random suffix and renames this file after all content is
written. If this temporary file is not properly removed or renamed dur
to an error it might confuse libkrb5.

To avoid this confusion with this patch the temporary files are created
as hidden files, the name will start with a '.', which are ignored by
libkrb5.

Resolves: https://github.com/SSSD/sssd/issues/5824