### PR TITLE
DEBUG: fix missing "va_end"

### DIFF
--- a/src/util/debug.c
+++ b/src/util/debug.c
@@ -297,11 +297,13 @@ void sss_vdebug_fn(const char *file,
             ret = snprintf(chain_id_fmt_fixed, sizeof(chain_id_fmt_fixed),
                            DEBUG_CHAIN_ID_FMT"%s", debug_chain_id, format);
             if (ret < 0) {
+                va_end(ap_fallback);
                 return;
             } else if (ret >= sizeof(chain_id_fmt_fixed)) {
                 ret = asprintf(&chain_id_fmt_dyn, DEBUG_CHAIN_ID_FMT"%s",
                                debug_chain_id, format);
                 if (ret < 0) {
+                    va_end(ap_fallback);
                     return;
                 }
                 result_fmt = chain_id_fmt_dyn;


### PR DESCRIPTION
Fixes following warning:
```
Error: VARARGS (CWE-237):
sssd-2.6.0/src/util/debug.c:294: va_init: Initializing va_list "ap_fallback".
sssd-2.6.0/src/util/debug.c:305: missing_va_end: "va_end" was not called for "ap_fallback".
 #  303|                                  debug_chain_id, format);
 #  304|                   if (ret < 0) {
 #  305|->                     return;
 #  306|                   }
 #  307|                   result_fmt = chain_id_fmt_dyn;
```