### PR TITLE
cache_req: return success for autofs when ENOENT is returned from provider

### DIFF
--- a/src/responder/common/cache_req/plugins/cache_req_autofs_entry_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_autofs_entry_by_name.c
@@ -97,7 +97,7 @@ cache_req_autofs_entry_by_name_dp_recv(struct tevent_req *subreq,
 
     ret = sbus_call_dp_autofs_GetEntry_recv(subreq);
 
-    if (ret == ERR_MISSING_DP_TARGET) {
+    if (ret == ERR_MISSING_DP_TARGET || ret == ENOENT) {
         ret = EOK;
     }
 

--- a/src/responder/common/cache_req/plugins/cache_req_autofs_map_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_autofs_map_by_name.c
@@ -93,7 +93,7 @@ cache_req_autofs_map_by_name_dp_recv(struct tevent_req *subreq,
 
     ret = sbus_call_dp_autofs_GetMap_recv(subreq);
 
-    if (ret == ERR_MISSING_DP_TARGET) {
+    if (ret == ERR_MISSING_DP_TARGET || ret == ENOENT) {
         ret = EOK;
     }
 

--- a/src/responder/common/cache_req/plugins/cache_req_autofs_map_entries.c
+++ b/src/responder/common/cache_req/plugins/cache_req_autofs_map_entries.c
@@ -125,7 +125,7 @@ cache_req_autofs_map_entries_dp_recv(struct tevent_req *subreq,
 
     ret = sbus_call_dp_autofs_Enumerate_recv(subreq);
 
-    if (ret == ERR_MISSING_DP_TARGET) {
+    if (ret == ERR_MISSING_DP_TARGET || ret == ENOENT) {
         ret = EOK;
     }
 


### PR DESCRIPTION
The receive function should return true if data provider lookup was
successfull and false if there was an error. "Not found" result is
considered a successful lookup, only failure to perform a search
should result in false return code.

Resolves: https://github.com/SSSD/sssd/issues/5832