### PR TITLE
Tests: Fix warning about deprecated res_randomid()

### DIFF
--- a/src/tests/cmocka/test_resolv_fake.c
+++ b/src/tests/cmocka/test_resolv_fake.c
@@ -59,10 +59,10 @@ static ssize_t dns_header(unsigned char **buf, size_t ancount)
     memset(hb, 0, NS_HFIXEDSZ);
     memset(&h, 0, sizeof(h));
 
-    h.id = res_randomid();     /* random query ID */
-    h.qr = 1;                  /* response flag */
-    h.rd = 1;                  /* recursion desired */
-    h.ra = 1;                  /* recursion available */
+    h.id = 0xFFFF & sss_rand();  /* random query ID */
+    h.qr = 1;                    /* response flag */
+    h.rd = 1;                    /* recursion desired */
+    h.ra = 1;                    /* recursion available */
 
     h.qdcount = htons(1);          /* no. of questions */
     h.ancount = htons(ancount);    /* no. of answers */


### PR DESCRIPTION
Warning on fedora rawhide

~~~
../src/tests/cmocka/test_resolv_fake.c: In function ‘dns_header’:
../src/tests/cmocka/test_resolv_fake.c:62:5: error: ‘__res_randomid’ is deprecated: use getentropy instead [-Werror=deprecated-declarations]
   62 |     h.id = res_randomid();     /* random query ID */
      |     ^
In file included from ../src/tests/cmocka/test_resolv_fake.c:33:
/usr/include/resolv.h:275:17: note: declared here
  275 | unsigned int    res_randomid (void) __THROW
      |                 ^~~~~~~~~~~~
~~~