### PR TITLE
sss-analyze: Fix self imports

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1919,7 +1919,6 @@ sssctl_LDADD = \
     $(NULL)
 sssctl_CFLAGS = \
     $(AM_CFLAGS) \
-    -DPYTHONDIR_PATH=\"$(python3dir)/sssd\" \
     $(NULL)
 
 if BUILD_SUDO

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -537,7 +537,7 @@ autoreconf -ivf
 
 %make_build all docs runstatedir=%{_rundir}
 
-%py3_shebang_fix src/tools/analyzer/sss_analyze.py
+%py3_shebang_fix src/tools/analyzer/sss_analyze
 sed -i -e 's:/usr/bin/python:/usr/bin/python3:' src/tools/sss_obfuscate
 
 %check
@@ -877,6 +877,7 @@ done
 %{_sbindir}/sss_debuglevel
 %{_sbindir}/sss_seed
 %{_sbindir}/sssctl
+%{_libexecdir}/%{servicename}/sss_analyze
 %{python3_sitelib}/sssd/
 %{_mandir}/man8/sss_obfuscate.8*
 %{_mandir}/man8/sss_override.8*

--- a/src/tools/analyzer/Makefile.am
+++ b/src/tools/analyzer/Makefile.am
@@ -1,16 +1,21 @@
-pkgpythondir = $(python3dir)/sssd
+sss_analyze_pythondir = $(libexecdir)/sssd
 
-dist_pkgpython_SCRIPTS = \
-    sss_analyze.py \
+dist_sss_analyze_python_SCRIPTS = \
+    sss_analyze \
     $(NULL)
 
+pkgpythondir = $(python3dir)/sssd
+
 dist_pkgpython_DATA = \
+    __init__.py \
     source_files.py \
     source_journald.py \
     source_reader.py \
+    sss_analyze.py \
     $(NULL)
 
 modulesdir = $(pkgpythondir)/modules
 dist_modules_DATA = \
+    modules/__init__.py \
     modules/request.py \
     $(NULL)

--- a/src/tools/analyzer/modules/request.py
+++ b/src/tools/analyzer/modules/request.py
@@ -1,11 +1,8 @@
 import re
-import copy
 import logging
-import argparse
 
-from enum import Enum
-from source_files import Files
-from source_journald import Journald
+from sssd.source_files import Files
+from sssd.source_journald import Journald
 from sssd.sss_analyze import SubparsersAction
 from sssd.sss_analyze import Option
 from sssd.sss_analyze import Analyzer
@@ -82,7 +79,6 @@ class RequestAnalyzer:
             Instantiated source object
         """
         if args.source == "journald":
-            import source_journald
             source = Journald()
         else:
             source = Files(args.logdir)

--- a/src/tools/analyzer/source_files.py
+++ b/src/tools/analyzer/source_files.py
@@ -1,11 +1,7 @@
-from enum import Enum
-import configparser
-from os import listdir
-from os.path import isfile, join
 import glob
 import logging
 
-from source_reader import Reader
+from sssd.source_reader import Reader
 
 logger = logging.getLogger()
 

--- a/src/tools/analyzer/source_journald.py
+++ b/src/tools/analyzer/source_journald.py
@@ -1,7 +1,6 @@
 from systemd import journal
-from source_reader import Reader
 
-from enum import Enum
+from sssd.source_reader import Reader
 
 _EXE_PREFIX = "/usr/libexec/sssd/"
 _NSS_MATCH = _EXE_PREFIX + "sssd_nss"

--- a/src/tools/analyzer/sss_analyze
+++ b/src/tools/analyzer/sss_analyze
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+from sssd import sss_analyze
+
+sss_analyze.run()

--- a/src/tools/analyzer/sss_analyze.py
+++ b/src/tools/analyzer/sss_analyze.py
@@ -1,10 +1,4 @@
-#!/usr/bin/env python
-
 import argparse
-
-import source_files
-
-from modules import request
 
 
 # Based on patch from https://bugs.python.org/issue9341
@@ -116,6 +110,9 @@ class Analyzer:
                 additional parsers attached.
         """
         # Currently only the 'request' module exists
+
+        # delayed import: the modules should be reorganized
+        from sssd.modules import request
         req = request.RequestAnalyzer()
 
         module_parser = req.setup_args(parser_grp)
@@ -160,6 +157,6 @@ class Analyzer:
         args.func(args)
 
 
-if __name__ == '__main__':
+def run():
     analyzer = Analyzer()
     analyzer.main()

--- a/src/tools/sssctl/sssctl_logs.c
+++ b/src/tools/sssctl/sssctl_logs.c
@@ -41,7 +41,7 @@
 
 #define LOG_FILE(file) " " LOG_PATH "/" file
 #define LOG_FILES LOG_FILE("*.log")
-#define SSS_ANALYZE PYTHONDIR_PATH"/sss_analyze.py"
+#define SSS_ANALYZE SSSD_LIBEXEC_PATH"/sss_analyze"
 
 #define CHECK(expr, done, msg) do { \
     if (expr) { \


### PR DESCRIPTION
- fixed self imports to allow any other Python stuff use the analyzer
  Python package

- tranformed analyzer Python package from namespaced to regular one

- moved the executable and Python code out to libexec directory
  (intended only for internal usage so far)
    
Resolves: https://github.com/SSSD/sssd/issues/5842