### PR TITLE
SSH: changed default value of `ssh_hash_known_hosts` to false

### DIFF
--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -165,7 +165,7 @@
 /* SSH */
 #define CONFDB_SSH_CONF_ENTRY "config/ssh"
 #define CONFDB_SSH_HASH_KNOWN_HOSTS "ssh_hash_known_hosts"
-#define CONFDB_DEFAULT_SSH_HASH_KNOWN_HOSTS true
+#define CONFDB_DEFAULT_SSH_HASH_KNOWN_HOSTS false
 #define CONFDB_SSH_KNOWN_HOSTS_TIMEOUT "ssh_known_hosts_timeout"
 #define CONFDB_DEFAULT_SSH_KNOWN_HOSTS_TIMEOUT 180
 #define CONFDB_SSH_CA_DB "ca_db"

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2030,7 +2030,7 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                             the managed known_hosts file.
                         </para>
                         <para>
-                            Default: true
+                            Default: false
                         </para>
                     </listitem>
                 </varlistentry>


### PR DESCRIPTION
:config: Default value of `ssh_hash_known_hosts` setting was changed
to false for the sake of consistency with OpenSSH that does not hash
host names by default.

Typical use case of this feature in general is FreeIPA where this is
configured and automatically used. Since by default any IPA user can
read the list of all hosts and the public host keys from LDAP directly,
the content of the file can be considered as public information anyway.

Resolves: https://github.com/SSSD/sssd/issues/5848