### PR TITLE
ifp: new interface to validate a certificate

### DIFF
--- a/src/responder/ifp/ifp_iface/ifp_iface.c
+++ b/src/responder/ifp/ifp_iface/ifp_iface.c
@@ -153,7 +153,8 @@ ifp_register_sbus_interface(struct sbus_connection *conn,
             SBUS_ASYNC(METHOD, org_freedesktop_sssd_infopipe_Users, ListByCertificate, ifp_users_list_by_cert_send, ifp_users_list_by_cert_recv, ctx),
             SBUS_ASYNC(METHOD, org_freedesktop_sssd_infopipe_Users, FindByNameAndCertificate, ifp_users_find_by_name_and_cert_send, ifp_users_find_by_name_and_cert_recv, ctx),
             SBUS_ASYNC(METHOD, org_freedesktop_sssd_infopipe_Users, ListByName, ifp_users_list_by_name_send, ifp_users_list_by_name_recv, ctx),
-            SBUS_ASYNC(METHOD, org_freedesktop_sssd_infopipe_Users, ListByDomainAndName, ifp_users_list_by_domain_and_name_send, ifp_users_list_by_domain_and_name_recv, ctx)
+            SBUS_ASYNC(METHOD, org_freedesktop_sssd_infopipe_Users, ListByDomainAndName, ifp_users_list_by_domain_and_name_send, ifp_users_list_by_domain_and_name_recv, ctx),
+            SBUS_ASYNC(METHOD, org_freedesktop_sssd_infopipe_Users, FindByValidCertificate, ifp_users_find_by_valid_cert_send, ifp_users_find_by_valid_cert_recv, ctx)
         ),
         SBUS_SIGNALS(SBUS_NO_SIGNALS),
         SBUS_PROPERTIES(SBUS_NO_PROPERTIES)

--- a/src/responder/ifp/ifp_iface/ifp_iface.xml
+++ b/src/responder/ifp/ifp_iface/ifp_iface.xml
@@ -182,6 +182,10 @@
             <arg name="limit" type="u" direction="in" key="3" />
             <arg name="result" type="ao" direction="out"/>
         </method>
+        <method name="FindByValidCertificate">
+            <arg name="pem_cert" type="s" direction="in" />
+            <arg name="result" type="o" direction="out" />
+        </method>
     </interface>
 
     <interface name="org.freedesktop.sssd.infopipe.Users.User">

--- a/src/responder/ifp/ifp_iface/sbus_ifp_client_sync.c
+++ b/src/responder/ifp/ifp_iface/sbus_ifp_client_sync.c
@@ -1162,6 +1162,20 @@ sbus_call_ifp_users_FindByNameAndCertificate
 }
 
 errno_t
+sbus_call_ifp_users_FindByValidCertificate
+    (TALLOC_CTX *mem_ctx,
+     struct sbus_sync_connection *conn,
+     const char *busname,
+     const char *object_path,
+     const char * arg_pem_cert,
+     const char ** _arg_result)
+{
+     return sbus_method_in_s_out_o(mem_ctx, conn,
+          busname, object_path, "org.freedesktop.sssd.infopipe.Users", "FindByValidCertificate", arg_pem_cert,
+          _arg_result);
+}
+
+errno_t
 sbus_call_ifp_users_ListByCertificate
     (TALLOC_CTX *mem_ctx,
      struct sbus_sync_connection *conn,

--- a/src/responder/ifp/ifp_iface/sbus_ifp_client_sync.h
+++ b/src/responder/ifp/ifp_iface/sbus_ifp_client_sync.h
@@ -276,6 +276,15 @@ sbus_call_ifp_users_FindByNameAndCertificate
      const char ** _arg_result);
 
 errno_t
+sbus_call_ifp_users_FindByValidCertificate
+    (TALLOC_CTX *mem_ctx,
+     struct sbus_sync_connection *conn,
+     const char *busname,
+     const char *object_path,
+     const char * arg_pem_cert,
+     const char ** _arg_result);
+
+errno_t
 sbus_call_ifp_users_ListByCertificate
     (TALLOC_CTX *mem_ctx,
      struct sbus_sync_connection *conn,

--- a/src/responder/ifp/ifp_iface/sbus_ifp_interface.h
+++ b/src/responder/ifp/ifp_iface/sbus_ifp_interface.h
@@ -1557,6 +1557,28 @@
         (handler_send), (handler_recv), (data)); \
 })
 
+/* Method: org.freedesktop.sssd.infopipe.Users.FindByValidCertificate */
+#define SBUS_METHOD_SYNC_org_freedesktop_sssd_infopipe_Users_FindByValidCertificate(handler, data) ({ \
+    SBUS_CHECK_SYNC((handler), (data), const char *, const char **); \
+    sbus_method_sync("FindByValidCertificate", \
+        &_sbus_ifp_args_org_freedesktop_sssd_infopipe_Users_FindByValidCertificate, \
+        NULL, \
+        _sbus_ifp_invoke_in_s_out_o_send, \
+        NULL, \
+        (handler), (data)); \
+})
+
+#define SBUS_METHOD_ASYNC_org_freedesktop_sssd_infopipe_Users_FindByValidCertificate(handler_send, handler_recv, data) ({ \
+    SBUS_CHECK_SEND((handler_send), (data), const char *); \
+    SBUS_CHECK_RECV((handler_recv), const char **); \
+    sbus_method_async("FindByValidCertificate", \
+        &_sbus_ifp_args_org_freedesktop_sssd_infopipe_Users_FindByValidCertificate, \
+        NULL, \
+        _sbus_ifp_invoke_in_s_out_o_send, \
+        NULL, \
+        (handler_send), (handler_recv), (data)); \
+})
+
 /* Method: org.freedesktop.sssd.infopipe.Users.ListByCertificate */
 #define SBUS_METHOD_SYNC_org_freedesktop_sssd_infopipe_Users_ListByCertificate(handler, data) ({ \
     SBUS_CHECK_SYNC((handler), (data), const char *, uint32_t, const char ***); \

--- a/src/responder/ifp/ifp_iface/sbus_ifp_symbols.c
+++ b/src/responder/ifp/ifp_iface/sbus_ifp_symbols.c
@@ -360,6 +360,18 @@ _sbus_ifp_args_org_freedesktop_sssd_infopipe_Users_FindByNameAndCertificate = {
 };
 
 const struct sbus_method_arguments
+_sbus_ifp_args_org_freedesktop_sssd_infopipe_Users_FindByValidCertificate = {
+    .input = (const struct sbus_argument[]){
+        {.type = "s", .name = "pem_cert"},
+        {NULL}
+    },
+    .output = (const struct sbus_argument[]){
+        {.type = "o", .name = "result"},
+        {NULL}
+    }
+};
+
+const struct sbus_method_arguments
 _sbus_ifp_args_org_freedesktop_sssd_infopipe_Users_ListByCertificate = {
     .input = (const struct sbus_argument[]){
         {.type = "s", .name = "pem_cert"},

--- a/src/responder/ifp/ifp_iface/sbus_ifp_symbols.h
+++ b/src/responder/ifp/ifp_iface/sbus_ifp_symbols.h
@@ -110,6 +110,9 @@ extern const struct sbus_method_arguments
 _sbus_ifp_args_org_freedesktop_sssd_infopipe_Users_FindByNameAndCertificate;
 
 extern const struct sbus_method_arguments
+_sbus_ifp_args_org_freedesktop_sssd_infopipe_Users_FindByValidCertificate;
+
+extern const struct sbus_method_arguments
 _sbus_ifp_args_org_freedesktop_sssd_infopipe_Users_ListByCertificate;
 
 extern const struct sbus_method_arguments

--- a/src/responder/ifp/ifp_users.h
+++ b/src/responder/ifp/ifp_users.h
@@ -120,6 +120,18 @@ ifp_users_list_by_domain_and_name_recv(TALLOC_CTX *mem_ctx,
                                        struct tevent_req *req,
                                        const char ***_paths);
 
+struct tevent_req *
+ifp_users_find_by_valid_cert_send(TALLOC_CTX *mem_ctx,
+                                  struct tevent_context *ev,
+                                  struct sbus_request *sbus_req,
+                                  struct ifp_ctx *ctx,
+                                  const char *pem_cert);
+
+errno_t
+ifp_users_find_by_valid_cert_recv(TALLOC_CTX *mem_ctx,
+                                  struct tevent_req *req,
+                                  const char **_path);
+
 /* org.freedesktop.sssd.infopipe.Users.User */
 
 struct tevent_req *

--- a/src/tests/intg/Makefile.am
+++ b/src/tests/intg/Makefile.am
@@ -31,6 +31,7 @@ dist_noinst_DATA = \
     test_pac_responder.py \
     data/ad_data.ldif \
     data/ad_schema.ldif \
+    data/cert_schema.ldif \
     data/sudo_schema.ldif \
     test_pysss_nss_idmap.py \
     test_infopipe.py \
@@ -208,6 +209,7 @@ intgcheck-installed: config.py passwd group pam_sss_service pam_sss_alt_service 
 	PAM_WRAPPER_SERVICE_DIR="$(abs_builddir)/$(PAM_SERVICE_DIR)" \
 	PAM_WRAPPER_PATH=$$(pkg-config --libs pam_wrapper) \
 	PAM_CERT_DB_PATH=$(PAM_CERT_DB_PATH) \
+	ABS_SRCDIR=$(abs_srcdir) \
 	SOFTHSM2_CONF=$(SOFTHSM2_CONF) \
 	KCM_RENEW=$(KCM_RENEW) \
 	DBUS_SOCK_DIR="$(DESTDIR)$(runstatedir)/dbus/" \

--- a/src/tests/intg/data/cert_schema.ldif
+++ b/src/tests/intg/data/cert_schema.ldif
@@ -1,0 +1,11 @@
+dn: cn=cert,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: cert
+olcAttributeTypes: ( 1.2.840.113556.1.4.645 NAME 'userCert'
+  DESC 'MANDATORY: X.509 user certificate'
+  EQUALITY octetStringMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 )
+olcObjectClasses: ( 1.2.840.113556.1.3.46 NAME 'mailRecipient' SUP top AUXILIARY
+  DESC 'MANDATORY: X.509 objectclass'
+  MAY ( userCert $ uid )
+  )

--- a/src/tests/intg/ds_openldap.py
+++ b/src/tests/intg/ds_openldap.py
@@ -199,6 +199,12 @@ class DSOpenLDAP(DS):
              "-l", "data/sudo_schema.ldif"],
         )
 
+        # Import cert schema
+        subprocess.check_call(
+            ["slapadd", "-F", self.conf_slapd_d_dir, "-b", "cn=config",
+             "-l", "data/cert_schema.ldif"],
+        )
+
     def _start_daemon(self):
         """Start the instance."""
         if subprocess.call(["slapd", "-F", self.conf_slapd_d_dir,

--- a/src/tests/intg/ldap_ent.py
+++ b/src/tests/intg/ldap_ent.py
@@ -36,7 +36,7 @@ def user(base_dn, uid, uidNumber, gidNumber,
     user = (
         "uid=" + uid + ",ou=Users," + base_dn,
         [
-            ('objectClass', [b'top', b'inetOrgPerson',
+            ('objectClass', [b'top', b'inetOrgPerson', b'mailRecipient',
                              b'posixAccount', b'ldapPublicKey']),
             ('cn', [uidNumber if cn is None else cn.encode('utf-8')]),
             ('sn', [b'User' if sn is None else sn.encode('utf-8')]),

--- a/src/tests/test_CA/SSSD_test_cert_0001.config
+++ b/src/tests/test_CA/SSSD_test_cert_0001.config
@@ -1,6 +1,7 @@
 # This certificate is used in
 # - src/tests/cmocka/test_cert_utils.c
 # - src/tests/cmocka/test_pam_srv.c
+# - src/tests/intg/test_infopipe.py
 [ req ]
 distinguished_name = req_distinguished_name
 prompt = no


### PR DESCRIPTION
New interface to validate a certificate. The input is the certificate to validate and the output the user path.

It also contains the integration test to check the interface that validates the user certificate.

Resolves: https://github.com/SSSD/sssd/issues/5224