### PR TITLE
CKM_RSA_PKCS support.

### DIFF
--- a/src/tests/cmocka/test_pam_srv.c
+++ b/src/tests/cmocka/test_pam_srv.c
@@ -329,6 +329,24 @@ static int pam_test_setup_no_verification(void **state)
     pam_test_setup_common();
     return 0;
 }
+
+static int pam_test_setup_mech_rsa_pkcs(void **state)
+{
+    int rc = pam_test_setup_no_verification(state);
+    if (rc != 0) {
+        return rc;
+    }
+    return putenv(discard_const("SOFTHSM2_CONF=" ABS_BUILD_DIR "/src/tests/test_CA/softhsm2_mech_rsa_pkcs.conf"));
+}
+
+static int pam_test_setup_mech_rsa_sha384_pkcs(void **state)
+{
+    int rc = pam_test_setup_no_verification(state);
+    if (rc != 0) {
+        return rc;
+    }
+    return putenv(discard_const("SOFTHSM2_CONF=" ABS_BUILD_DIR "/src/tests/test_CA/softhsm2_mech_rsa_sha384_pkcs.conf"));
+}
 #endif /* HAVE_TEST_CA */
 
 static int pam_cached_test_setup(void **state)
@@ -3662,6 +3680,12 @@ int main(int argc, const char *argv[])
                                         pam_test_setup, pam_test_teardown),
         cmocka_unit_test_setup_teardown(test_pam_cert_auth,
                                         pam_test_setup_no_verification,
+                                        pam_test_teardown),
+        cmocka_unit_test_setup_teardown(test_pam_cert_auth,
+                                        pam_test_setup_mech_rsa_pkcs,
+                                        pam_test_teardown),
+        cmocka_unit_test_setup_teardown(test_pam_cert_auth,
+                                        pam_test_setup_mech_rsa_sha384_pkcs,
                                         pam_test_teardown),
         cmocka_unit_test_setup_teardown(test_pam_pss_cert_auth,
                                         pam_test_setup, pam_test_teardown),

--- a/src/tests/test_CA/Makefile.am
+++ b/src/tests/test_CA/Makefile.am
@@ -108,7 +108,7 @@ softhsm2_none.conf:
 	@echo "objectstore.backend = file" >> $@
 	@echo "slots.removable = true" >> $@
 
-softhsm2_one: softhsm2_one.conf
+softhsm2_one: softhsm2_one.conf softhsm2_mech_rsa_pkcs.conf softhsm2_mech_rsa_sha384_pkcs.conf
 	mkdir $@
 	SOFTHSM2_CONF=./$< $(SOFTHSM2_UTIL) --init-token  --label "SSSD Test Token" --pin 123456 --so-pin 123456 --free
 	GNUTLS_PIN=123456 SOFTHSM2_CONF=./$< $(P11TOOL) --provider=$(SOFTHSM2_PATH) --write --no-mark-private --load-certificate=SSSD_test_cert_x509_0001.pem --login  --label 'SSSD test cert 0001' --id 'C554C9F82C2A9D58B70921C143304153A8A42F17'
@@ -118,6 +118,18 @@ softhsm2_one.conf:
 	@echo "directories.tokendir = "$(abs_top_builddir)"/src/tests/test_CA/softhsm2_one" > $@
 	@echo "objectstore.backend = file" >> $@
 	@echo "slots.removable = true" >> $@
+
+softhsm2_mech_rsa_pkcs.conf:
+	@echo "directories.tokendir = "$(abs_top_builddir)"/src/tests/test_CA/softhsm2_one" > $@
+	@echo "objectstore.backend = file" >> $@
+	@echo "slots.removable = true" >> $@
+	@echo "slots.mechanisms = CKM_RSA_PKCS" >> $@
+
+softhsm2_mech_rsa_sha384_pkcs.conf:
+	@echo "directories.tokendir = "$(abs_top_builddir)"/src/tests/test_CA/softhsm2_one" > $@
+	@echo "objectstore.backend = file" >> $@
+	@echo "slots.removable = true" >> $@
+	@echo "slots.mechanisms = CKM_SHA384_RSA_PKCS" >> $@
 
 #Export cert from softhsm2 via p11tool, should produce the same as openssl
 SSSD_test_cert_x509_0001.der: softhsm2_one.conf


### PR DESCRIPTION
First patch is mostly cosmetic and I don't insist on its inclusion. But IMO it makes code a little bit more readable (matter of taste though) and handling of error conditions more accurate.

The "laziest" way to test 2nd patch is to reorder `prefs` in `get_preferred_rsa_mechanism()` putting `CKM_RSA_PKCS` first.
In this case existing `pam-srv-tests` will use this mechanism:
```
(2021-10-30 20:48:44:135177): [p11_child[3211403]] [get_preferred_rsa_mechanism] (0x0200): Using PKCS#11 mechanism [1][CKM_RSA_PKCS] with message digest [-none-].
(2021-10-30 20:48:44:135183): [p11_child[3211403]] [sign_data] (0x4000): Found RSA key using mechanism [1].
(2021-10-30 20:48:44:136646): [p11_child[3211403]] [do_card] (0x4000): Certificate verified and validated.
```