### PR TITLE
[monitor] Fix untranslated string

### DIFF
--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -2398,7 +2398,7 @@ int main(int argc, const char *argv[])
 
     uid = getuid();
     if (uid != 0) {
-        ERROR("Running under %"SPRIuid", must be root\n", uid);
+        ERROR("Running under %"PRIu64", must be root\n", (uint64_t) uid);
         sss_log(SSS_LOG_ALERT, "sssd must be run as root");
         return 8;
     }


### PR DESCRIPTION
Promote format string to gettext's PRIu64 instead of using SSSD's
SPRIuid which is not recognized. This caused the original string to be
truncated in the translation files.

How to test:

Apply patch and run:

make -C po/ update-pot

Translations should contain the full string now:

msgid "Running under %<PRIu64>, must be root\n"

Resolves: #5738