### PR TITLE
Responder and Child process tevent chain id improvements

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4627,6 +4627,7 @@ p11_child_SOURCES = \
     src/util/atomic_io.c \
     src/util/util.c \
     src/util/util_ext.c \
+    src/util/sss_chain_id.c \
     $(NULL)
 p11_child_SOURCES += src/p11_child/p11_child_openssl.c
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -4589,7 +4589,8 @@ gpo_child_SOURCES = \
     src/util/atomic_io.c \
     src/util/util.c \
     src/util/util_ext.c \
-    src/util/signal.c
+    src/util/signal.c \
+    src/util/sss_chain_id.c
 gpo_child_CFLAGS = \
     $(AM_CFLAGS) \
     $(POPT_CFLAGS) \

--- a/Makefile.am
+++ b/Makefile.am
@@ -1921,7 +1921,6 @@ sssctl_LDADD = \
     $(NULL)
 sssctl_CFLAGS = \
     $(AM_CFLAGS) \
-    -DPYTHONDIR_PATH=\"$(python3dir)/sssd\" \
     $(NULL)
 
 if BUILD_SUDO

--- a/Makefile.am
+++ b/Makefile.am
@@ -4565,6 +4565,7 @@ if BUILD_SEMANAGE
 selinux_child_SOURCES = \
     src/providers/ipa/selinux_child.c \
     src/util/sss_semanage.c \
+    src/util/sss_chain_id.c \
     src/util/atomic_io.c \
     src/util/util.c \
     src/util/util_ext.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -4513,6 +4513,7 @@ krb5_child_SOURCES = \
     src/util/util.c \
     src/util/util_ext.c \
     src/util/signal.c \
+    src/util/sss_chain_id.c \
     src/util/strtonum.c \
     src/util/become_user.c \
     src/util/util_errors.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -685,6 +685,7 @@ dist_noinst_HEADERS = \
     src/util/session_recording.h \
     src/util/strtonum.h \
     src/util/sss_cli_cmd.h \
+    src/util/sss_chain_id_tevent.h \
     src/util/sss_chain_id.h \
     src/util/sss_ptr_hash.h \
     src/util/sss_ptr_list.h \
@@ -1266,6 +1267,7 @@ libsss_util_la_SOURCES = \
     src/util/files.c \
     src/util/selinux.c \
     src/util/sss_regexp.c \
+    src/util/sss_chain_id_tevent.c \
     src/util/sss_chain_id.c \
     src/util/nss_dl_load.c \
     src/util/nss_dl_load_extra.c \

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -537,7 +537,7 @@ autoreconf -ivf
 
 %make_build all docs runstatedir=%{_rundir}
 
-%py3_shebang_fix src/tools/analyzer/sss_analyze.py
+%py3_shebang_fix src/tools/analyzer/sss_analyze
 sed -i -e 's:/usr/bin/python:/usr/bin/python3:' src/tools/sss_obfuscate
 
 %check
@@ -877,6 +877,7 @@ done
 %{_sbindir}/sss_debuglevel
 %{_sbindir}/sss_seed
 %{_sbindir}/sssctl
+%{_libexecdir}/%{servicename}/sss_analyze
 %{python3_sitelib}/sssd/
 %{_mandir}/man8/sss_obfuscate.8*
 %{_mandir}/man8/sss_override.8*

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -2550,7 +2550,7 @@ int main(int argc, const char *argv[])
     ret = close(STDIN_FILENO);
     if (ret != EOK) return 6;
 
-    ret = server_setup(SSSD_MONITOR_NAME, flags, 0, 0,
+    ret = server_setup(SSSD_MONITOR_NAME, false, flags, 0, 0,
                        monitor->conf_path, &main_ctx);
     if (ret != EOK) return 2;
 

--- a/src/p11_child/p11_child_common.c
+++ b/src/p11_child/p11_child_common.c
@@ -33,6 +33,7 @@
 #include "providers/backend.h"
 #include "util/crypto/sss_crypto.h"
 #include "util/cert.h"
+#include "util/sss_chain_id.h"
 #include "p11_child/p11_child.h"
 
 static const char *op_mode_str(enum op_mode mode)
@@ -161,6 +162,7 @@ int main(int argc, const char *argv[])
     char *key_id = NULL;
     char *label = NULL;
     char *cert_b64 = NULL;
+    uint64_t chain_id = 0;
     bool wait_for_card = false;
     char *uri = NULL;
 
@@ -194,6 +196,8 @@ int main(int argc, const char *argv[])
          _("certificate to verify, base64 encoded"), NULL},
         {"uri", 0, POPT_ARG_STRING, &uri, 0,
          _("PKCS#11 URI to restrict selection"), NULL},
+        {"chain-id", 0, POPT_ARG_LONG, &chain_id,
+         0, _("Tevent chain ID used for logging purposes"), NULL},
         POPT_TABLEEND
     };
 
@@ -312,6 +316,9 @@ int main(int argc, const char *argv[])
             ERROR("set_debug_file_from_fd failed.\n");
         }
     }
+
+    sss_chain_id_set_format(DEBUG_CHAIN_ID_FMT_CID);
+    sss_chain_id_set(chain_id);
 
     DEBUG_INIT(debug_level, opt_logger);
 

--- a/src/providers/ad/ad_gpo_child.c
+++ b/src/providers/ad/ad_gpo_child.c
@@ -33,6 +33,7 @@
 
 #include "util/util.h"
 #include "util/child_common.h"
+#include "util/sss_chain_id.h"
 #include "providers/backend.h"
 #include "providers/ad/ad_gpo.h"
 #include "sss_cli.h"
@@ -724,6 +725,7 @@ main(int argc, const char *argv[])
     int opt;
     poptContext pc;
     int debug_fd = -1;
+    uint64_t chain_id;
     const char *opt_logger = NULL;
     errno_t ret;
     int sysvol_gpt_version;
@@ -740,6 +742,8 @@ main(int argc, const char *argv[])
         SSSD_DEBUG_OPTS
         {"debug-fd", 0, POPT_ARG_INT, &debug_fd, 0,
          _("An open file descriptor for the debug logs"), NULL},
+        {"chain-id", 0, POPT_ARG_LONG, &chain_id,
+         0, _("Tevent chain ID used for logging purposes"), NULL},
         SSSD_LOGGER_OPTS
         POPT_TABLEEND
     };
@@ -774,6 +778,9 @@ main(int argc, const char *argv[])
             ERROR("set_debug_file_from_fd failed.\n");
         }
     }
+
+    sss_chain_id_set_format(DEBUG_CHAIN_ID_FMT_RID);
+    sss_chain_id_set(chain_id);
 
     DEBUG_INIT(debug_level, opt_logger);
 

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -47,6 +47,7 @@
 #include "util/child_common.h"
 #include "resolv/async_resolv.h"
 #include "sss_iface/sss_iface_async.h"
+#include "util/sss_chain_id_tevent.h"
 #include "util/sss_chain_id.h"
 
 #define ONLINE_CB_RETRY 3

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -47,8 +47,6 @@
 #include "util/child_common.h"
 #include "resolv/async_resolv.h"
 #include "sss_iface/sss_iface_async.h"
-#include "util/sss_chain_id_tevent.h"
-#include "util/sss_chain_id.h"
 
 #define ONLINE_CB_RETRY 3
 #define ONLINE_CB_RETRY_MAX_DELAY 4
@@ -772,13 +770,11 @@ int main(int argc, const char *argv[])
     confdb_path = talloc_asprintf(NULL, CONFDB_DOMAIN_PATH_TMPL, be_domain);
     if (!confdb_path) return 2;
 
-    ret = server_setup(srv_name, 0, 0, 0, confdb_path, &main_ctx);
+    ret = server_setup(srv_name, false, 0, 0, 0, confdb_path, &main_ctx);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Could not set up mainloop [%d]\n", ret);
         return 2;
     }
-
-    sss_chain_id_setup(main_ctx->event_ctx);
 
     ret = setenv(SSS_DOM_ENV, be_domain, 1);
     if (ret != 0) {

--- a/src/providers/ipa/selinux_child.c
+++ b/src/providers/ipa/selinux_child.c
@@ -30,6 +30,7 @@
 
 #include "util/util.h"
 #include "util/child_common.h"
+#include "util/sss_chain_id.h"
 #include "providers/backend.h"
 
 struct input_buffer {
@@ -217,12 +218,15 @@ int main(int argc, const char *argv[])
     bool needs_update;
     const char *username;
     const char *opt_logger = NULL;
+    uint64_t chain_id;
 
     struct poptOption long_options[] = {
         POPT_AUTOHELP
         SSSD_DEBUG_OPTS
         {"debug-fd", 0, POPT_ARG_INT, &debug_fd, 0,
          _("An open file descriptor for the debug logs"), NULL},
+        {"chain-id", 0, POPT_ARG_LONG, &chain_id,
+         0, _("Tevent chain ID used for logging purposes"), NULL},
         SSSD_LOGGER_OPTS
         POPT_TABLEEND
     };
@@ -257,6 +261,9 @@ int main(int argc, const char *argv[])
             ERROR("set_debug_file_from_fd failed.\n");
         }
     }
+
+    sss_chain_id_set_format(DEBUG_CHAIN_ID_FMT_RID);
+    sss_chain_id_set(chain_id);
 
     DEBUG_INIT(debug_level, opt_logger);
 

--- a/src/providers/krb5/krb5_auth.h
+++ b/src/providers/krb5/krb5_auth.h
@@ -47,6 +47,7 @@
 #define CHILD_OPT_FAST_PRINCIPAL "fast-principal"
 #define CHILD_OPT_CANONICALIZE "canonicalize"
 #define CHILD_OPT_SSS_CREDS_PASSWORD "sss-creds-password"
+#define CHILD_OPT_CHAIN_ID "chain-id"
 
 struct krb5child_req {
     struct pam_data *pd;

--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -36,6 +36,7 @@
 #include "util/user_info_msg.h"
 #include "util/child_common.h"
 #include "util/find_uid.h"
+#include "util/sss_chain_id.h"
 #include "src/util/util_errors.h"
 #include "providers/backend.h"
 #include "providers/krb5/krb5_auth.h"
@@ -3317,6 +3318,7 @@ int main(int argc, const char *argv[])
     krb5_error_code kerr;
     uid_t fast_uid = 0;
     gid_t fast_gid = 0;
+    uint64_t chain_id = 0;
     struct cli_opts cli_opts = { 0 };
     int sss_creds_password = 0;
 
@@ -3345,6 +3347,8 @@ int main(int argc, const char *argv[])
          _("Requests canonicalization of the principal name"), NULL},
         {CHILD_OPT_SSS_CREDS_PASSWORD, 0, POPT_ARG_NONE, &sss_creds_password,
          0, _("Use custom version of krb5_get_init_creds_password"), NULL},
+        {CHILD_OPT_CHAIN_ID, 0, POPT_ARG_LONG, &chain_id,
+         0, _("Tevent chain ID used for logging purposes"), NULL},
         POPT_TABLEEND
     };
 
@@ -3385,6 +3389,9 @@ int main(int argc, const char *argv[])
             ERROR("set_debug_file_from_fd failed.\n");
         }
     }
+
+    sss_chain_id_set_format(DEBUG_CHAIN_ID_FMT_RID);
+    sss_chain_id_set(chain_id);
 
     DEBUG_INIT(debug_level, opt_logger);
 

--- a/src/providers/krb5/krb5_child_handler.c
+++ b/src/providers/krb5/krb5_child_handler.c
@@ -26,6 +26,7 @@
 
 #include "util/util.h"
 #include "util/child_common.h"
+#include "util/sss_chain_id.h"
 #include "providers/krb5/krb5_common.h"
 #include "providers/krb5/krb5_auth.h"
 #include "src/providers/krb5/krb5_utils.h"
@@ -301,6 +302,7 @@ errno_t set_extra_args(TALLOC_CTX *mem_ctx, struct krb5_ctx *krb5_ctx,
 {
     const char **extra_args;
     const char *krb5_realm;
+    uint64_t chain_id;
     size_t c = 0;
     int ret;
 
@@ -417,6 +419,17 @@ errno_t set_extra_args(TALLOC_CTX *mem_ctx, struct krb5_ctx *krb5_ctx,
         }
         c++;
     }
+
+    chain_id = sss_chain_id_get();
+    extra_args[c] = talloc_asprintf(extra_args,
+                                    "--"CHILD_OPT_CHAIN_ID"=%lu",
+                                    chain_id);
+    if (extra_args[c] == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "talloc_asprintf failed.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+    c++;
 
     extra_args[c] = NULL;
 

--- a/src/providers/proxy/proxy_auth.c
+++ b/src/providers/proxy/proxy_auth.c
@@ -26,6 +26,7 @@
 
 #include "providers/proxy/proxy.h"
 #include "sss_iface/sss_iface_async.h"
+#include "util/sss_chain_id.h"
 
 struct pc_init_ctx;
 
@@ -178,11 +179,12 @@ static struct tevent_req *proxy_child_init_send(TALLOC_CTX *mem_ctx,
 
     state->command = talloc_asprintf(req,
             "%s/proxy_child -d %#.4x --debug-timestamps=%d "
-            "--debug-microseconds=%d --logger=%s --domain %s --id %d",
+            "--debug-microseconds=%d --logger=%s --domain %s --id %d "
+            "--chain-id=%lu",
             SSSD_LIBEXEC_PATH, debug_level, debug_timestamps,
             debug_microseconds, sss_logger_str[sss_logger],
             auth_ctx->be->domain->name,
-            child_ctx->id);
+            child_ctx->id, sss_chain_id_get());
     if (state->command == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "talloc_asprintf failed.\n");
         return NULL;

--- a/src/providers/proxy/proxy_child.c
+++ b/src/providers/proxy/proxy_child.c
@@ -556,7 +556,7 @@ int main(int argc, const char *argv[])
     conf_entry = talloc_asprintf(NULL, CONFDB_DOMAIN_PATH_TMPL, domain);
     if (!conf_entry) return 2;
 
-    ret = server_setup(srv_name, 0, 0, 0, conf_entry, &main_ctx);
+    ret = server_setup(srv_name, false, 0, 0, 0, conf_entry, &main_ctx);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Could not set up mainloop [%d]\n", ret);
         return 2;

--- a/src/providers/proxy/proxy_child.c
+++ b/src/providers/proxy/proxy_child.c
@@ -43,6 +43,7 @@
 #include "confdb/confdb.h"
 #include "providers/proxy/proxy.h"
 #include "sss_iface/sss_iface_async.h"
+#include "util/sss_chain_id.h"
 
 #include "providers/backend.h"
 
@@ -480,6 +481,7 @@ int main(int argc, const char *argv[])
     struct main_context *main_ctx;
     int ret;
     long id = 0;
+    long chain_id;
     char *pam_target = NULL;
     uid_t uid;
     gid_t gid;
@@ -493,6 +495,8 @@ int main(int argc, const char *argv[])
          _("Domain of the information provider (mandatory)"), NULL },
         {"id", 0, POPT_ARG_LONG, &id, 0,
          _("Child identifier (mandatory)"), NULL },
+        {"chain-id", 0, POPT_ARG_LONG, &chain_id, 0,
+         _("Tevent chain ID used for logging purposes"), NULL },
         POPT_TABLEEND
     };
 
@@ -547,6 +551,8 @@ int main(int argc, const char *argv[])
     /* set up things like debug, signals, daemonization, etc. */
     debug_log_file = talloc_asprintf(NULL, "proxy_child_%s", domain);
     if (!debug_log_file) return 2;
+
+    sss_chain_id_set(chain_id);
 
     DEBUG_INIT(debug_level, opt_logger);
 

--- a/src/responder/autofs/autofssrv.c
+++ b/src/responder/autofs/autofssrv.c
@@ -213,7 +213,7 @@ int main(int argc, const char *argv[])
     debug_log_file = "sssd_autofs";
     DEBUG_INIT(debug_level, opt_logger);
 
-    ret = server_setup("autofs", 0, uid, gid,
+    ret = server_setup("autofs", true, 0, uid, gid,
                        CONFDB_AUTOFS_CONF_ENTRY, &main_ctx);
     if (ret != EOK) {
         return 2;

--- a/src/responder/common/responder.h
+++ b/src/responder/common/responder.h
@@ -165,6 +165,7 @@ struct cli_ctx {
 
     struct cli_creds *creds;
     char *cmd_line;
+    uint64_t old_chain_id;
 
     void *protocol_ctx;
     void *state_ctx;

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -42,6 +42,8 @@
 #include "providers/data_provider.h"
 #include "util/util_creds.h"
 #include "sss_iface/sss_iface_async.h"
+#include "util/sss_chain_id_tevent.h"
+#include "util/sss_chain_id.h"
 
 #ifdef HAVE_SYSTEMD
 #include <systemd/sd-daemon.h>
@@ -85,6 +87,8 @@ static void client_close_fn(struct tevent_context *ev,
               "Failed to close fd [%d]: [%s]\n",
                ctx->cfd, strerror(ret));
     }
+    /* Restore the original chain id  */
+    sss_chain_id_set(ctx->old_chain_id);
 
     DEBUG(SSSDBG_TRACE_INTERNAL,
           "Terminated client [%p][%d]\n",
@@ -521,6 +525,8 @@ static void accept_fd_handler(struct tevent_context *ev,
     int ret;
     int fd = accept_ctx->is_private ? rctx->priv_lfd : rctx->lfd;
 
+    rctx->client_id_num++;
+
     if (accept_ctx->is_private) {
         ret = stat(rctx->priv_sock_name, &stat_buf);
         if (ret == -1) {
@@ -637,7 +643,6 @@ static void accept_fd_handler(struct tevent_context *ev,
         /* Non-fatal, continue */
     }
 
-    rctx->client_id_num++;
     DEBUG(SSSDBG_TRACE_FUNC,
           "[CID#%u] Client [cmd %s][uid %u][%p][%d] connected%s!\n",
           rctx->client_id_num, cctx->cmd_line, cli_creds_get_uid(cctx->creds),
@@ -1099,6 +1104,9 @@ void sss_client_fd_handler(void *ptr,
         /* Non-fatal, continue */
     }
 
+    /* Set the chain id */
+    cctx->old_chain_id = sss_chain_id_set(cctx->rctx->client_id_num);
+
     if (flags & TEVENT_FD_READ) {
         recv_fn(cctx);
         return;
@@ -1310,6 +1318,8 @@ int sss_process_init(TALLOC_CTX *mem_ctx,
               CONFDB_RESPONDER_CLI_IDLE_TIMEOUT, ret, strerror(ret));
         goto fail;
     }
+
+    sss_chain_id_setup(rctx->ev);
 
     /* Ensure that the client timeout is at least ten seconds */
     if (rctx->client_idle_timeout < 10) {

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -639,7 +639,7 @@ static void accept_fd_handler(struct tevent_context *ev,
 
     rctx->client_id_num++;
     DEBUG(SSSDBG_TRACE_FUNC,
-          "Client [CID #%u][cmd %s][uid %u][%p][%d] connected%s!\n",
+          "[CID#%u] Client [cmd %s][uid %u][%p][%d] connected%s!\n",
           rctx->client_id_num, cctx->cmd_line, cli_creds_get_uid(cctx->creds),
           cctx, cctx->cfd, accept_ctx->is_private ? " to privileged pipe" : "");
 

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -1319,8 +1319,6 @@ int sss_process_init(TALLOC_CTX *mem_ctx,
         goto fail;
     }
 
-    sss_chain_id_setup(rctx->ev);
-
     /* Ensure that the client timeout is at least ten seconds */
     if (rctx->client_idle_timeout < 10) {
         rctx->client_idle_timeout = 10;

--- a/src/responder/ifp/ifpsrv.c
+++ b/src/responder/ifp/ifpsrv.c
@@ -339,7 +339,7 @@ int main(int argc, const char *argv[])
     debug_log_file = "sssd_ifp";
     DEBUG_INIT(debug_level, opt_logger);
 
-    ret = server_setup("ifp", 0, 0, 0,
+    ret = server_setup("ifp", true, 0, 0, 0,
                        CONFDB_IFP_CONF_ENTRY, &main_ctx);
     if (ret != EOK) return 2;
 

--- a/src/responder/kcm/kcm.c
+++ b/src/responder/kcm/kcm.c
@@ -357,7 +357,7 @@ int main(int argc, const char *argv[])
     debug_log_file = "sssd_kcm";
     DEBUG_INIT(debug_level, opt_logger);
 
-    ret = server_setup("kcm", 0, uid, gid, CONFDB_KCM_CONF_ENTRY,
+    ret = server_setup("kcm", true, 0, uid, gid, CONFDB_KCM_CONF_ENTRY,
                        &main_ctx);
     if (ret != EOK) return 2;
 

--- a/src/responder/nss/nss_get_object.c
+++ b/src/responder/nss/nss_get_object.c
@@ -309,9 +309,8 @@ nss_get_object_send(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    DEBUG(SSSDBG_TRACE_FUNC, "Client [%p][%d][CID #%u]: sent cache request #%u\n",
-          cli_ctx, cli_ctx->cfd, cli_ctx->rctx->client_id_num,
-          cache_req_get_reqid(subreq));
+    DEBUG(SSSDBG_TRACE_FUNC, "Client [%p][%d]: sent cache request #%u\n",
+          cli_ctx, cli_ctx->cfd, cache_req_get_reqid(subreq));
 
     tevent_req_set_callback(subreq, nss_get_object_done, req);
 

--- a/src/responder/nss/nsssrv.c
+++ b/src/responder/nss/nsssrv.c
@@ -664,7 +664,7 @@ int main(int argc, const char *argv[])
     debug_log_file = "sssd_nss";
     DEBUG_INIT(debug_level, opt_logger);
 
-    ret = server_setup("nss", 0, uid, gid, CONFDB_NSS_CONF_ENTRY,
+    ret = server_setup("nss", true, 0, uid, gid, CONFDB_NSS_CONF_ENTRY,
                        &main_ctx);
     if (ret != EOK) return 2;
 

--- a/src/responder/pac/pacsrv.c
+++ b/src/responder/pac/pacsrv.c
@@ -202,7 +202,7 @@ int main(int argc, const char *argv[])
     debug_log_file = "sssd_pac";
     DEBUG_INIT(debug_level, opt_logger);
 
-    ret = server_setup("pac", 0, uid, gid,
+    ret = server_setup("pac", true, 0, uid, gid,
                        CONFDB_PAC_CONF_ENTRY, &main_ctx);
     if (ret != EOK) return 2;
 

--- a/src/responder/pam/pamsrv.c
+++ b/src/responder/pam/pamsrv.c
@@ -489,7 +489,7 @@ int main(int argc, const char *argv[])
               "debugging might not work!\n");
     }
 
-    ret = server_setup("pam", 0, uid, gid, CONFDB_PAM_CONF_ENTRY, &main_ctx);
+    ret = server_setup("pam", true, 0, uid, gid, CONFDB_PAM_CONF_ENTRY, &main_ctx);
     if (ret != EOK) return 2;
 
     ret = die_if_parent_died();

--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -1154,8 +1154,8 @@ static void pam_reply(struct pam_auth_req *preq)
     }
 
 done:
-    DEBUG(SSSDBG_FUNC_DATA, "Returning [%d]: %s to the client [CID #%u]\n",
-          pd->pam_status, pam_strerror(NULL, pd->pam_status), pd->client_id_num);
+    DEBUG(SSSDBG_FUNC_DATA, "Returning [%d]: %s to the client\n",
+          pd->pam_status, pam_strerror(NULL, pd->pam_status));
     sss_cmd_done(cctx, preq);
 }
 

--- a/src/responder/pam/pamsrv_dp.c
+++ b/src/responder/pam/pamsrv_dp.c
@@ -47,8 +47,7 @@ pam_dp_send_req(struct pam_auth_req *preq)
         return EIO;
     }
 
-    DEBUG(SSSDBG_CONF_SETTINGS, "Sending request [CID #%u] with the following data:\n",
-                                preq->client_id_num);
+    DEBUG(SSSDBG_CONF_SETTINGS, "Sending request with the following data:\n");
     DEBUG_PAM_DATA(SSSDBG_CONF_SETTINGS, preq->pd);
 
     subreq = sbus_call_dp_dp_pamHandler_send(preq, be_conn->conn,
@@ -85,11 +84,10 @@ pam_dp_send_req_done(struct tevent_req *subreq)
     preq->pd->pam_status = pam_response->pam_status;
     preq->pd->account_locked = pam_response->account_locked;
 
-    DEBUG(SSSDBG_FUNC_DATA, "received: [%d (%s)][%s][CID #%u]\n",
+    DEBUG(SSSDBG_FUNC_DATA, "received: [%d (%s)][%s]\n",
           pam_response->pam_status,
           pam_strerror(NULL, pam_response->pam_status),
-          preq->pd->domain,
-          preq->pd->client_id_num);
+          preq->pd->domain);
 
     for (resp = pam_response->resp_list; resp != NULL; resp = resp->next) {
         talloc_steal(preq->pd, resp);

--- a/src/responder/pam/pamsrv_p11.c
+++ b/src/responder/pam/pamsrv_p11.c
@@ -29,6 +29,7 @@
 #include "responder/pam/pam_helpers.h"
 #include "lib/certmap/sss_certmap.h"
 #include "util/crypto/sss_crypto.h"
+#include "util/sss_chain_id.h"
 #include "db/sysdb.h"
 
 
@@ -718,10 +719,11 @@ struct tevent_req *pam_check_cert_send(TALLOC_CTX *mem_ctx,
     struct timeval tv;
     int pipefd_to_child[2] = PIPE_INIT;
     int pipefd_from_child[2] = PIPE_INIT;
-    const char *extra_args[16] = { NULL };
+    const char *extra_args[18] = { NULL };
     uint8_t *write_buf = NULL;
     size_t write_buf_len = 0;
     size_t arg_c;
+    uint64_t chain_id;
     const char *module_name = NULL;
     const char *token_name = NULL;
     const char *key_id = NULL;
@@ -746,6 +748,12 @@ struct tevent_req *pam_check_cert_send(TALLOC_CTX *mem_ctx,
 
     /* extra_args are added in revers order */
     arg_c = 0;
+
+    chain_id = sss_chain_id_get();
+
+    extra_args[arg_c++] = talloc_asprintf(mem_ctx, "%lu", chain_id);
+    extra_args[arg_c++] = "--chain-id";
+
     if (uri != NULL) {
         DEBUG(SSSDBG_TRACE_ALL, "Adding PKCS#11 URI [%s].\n", uri);
         extra_args[arg_c++] = uri;

--- a/src/responder/ssh/sshsrv.c
+++ b/src/responder/ssh/sshsrv.c
@@ -208,7 +208,7 @@ int main(int argc, const char *argv[])
               "debugging might not work!\n");
     }
 
-    ret = server_setup("ssh", 0, uid, gid,
+    ret = server_setup("ssh", true, 0, uid, gid,
                        CONFDB_SSH_CONF_ENTRY, &main_ctx);
     if (ret != EOK) {
         return 2;

--- a/src/responder/sudo/sudosrv.c
+++ b/src/responder/sudo/sudosrv.c
@@ -196,7 +196,7 @@ int main(int argc, const char *argv[])
         }
     }
 
-    ret = server_setup("sudo", 0, uid, gid, CONFDB_SUDO_CONF_ENTRY,
+    ret = server_setup("sudo", true, 0, uid, gid, CONFDB_SUDO_CONF_ENTRY,
                        &main_ctx);
     if (ret != EOK) {
         return 2;

--- a/src/tests/cmocka/test_krb5_common.c
+++ b/src/tests/cmocka/test_krb5_common.c
@@ -103,7 +103,8 @@ void test_set_extra_args(void **state)
     assert_int_equal(ret, EOK);
     assert_string_equal(krb5_child_extra_args[0], uid_opt);
     assert_string_equal(krb5_child_extra_args[1], gid_opt);
-    assert_null(krb5_child_extra_args[2]);
+    assert_string_equal(krb5_child_extra_args[2], "--chain-id=0");
+    assert_null(krb5_child_extra_args[3]);
     talloc_free(krb5_child_extra_args);
 
     krb5_ctx->canonicalize = true;
@@ -113,7 +114,8 @@ void test_set_extra_args(void **state)
     assert_string_equal(krb5_child_extra_args[0], uid_opt);
     assert_string_equal(krb5_child_extra_args[1], gid_opt);
     assert_string_equal(krb5_child_extra_args[2], "--canonicalize");
-    assert_null(krb5_child_extra_args[3]);
+    assert_string_equal(krb5_child_extra_args[3], "--chain-id=0");
+    assert_null(krb5_child_extra_args[4]);
     talloc_free(krb5_child_extra_args);
 
     krb5_ctx->realm = discard_const(TEST_REALM);
@@ -124,7 +126,8 @@ void test_set_extra_args(void **state)
     assert_string_equal(krb5_child_extra_args[1], gid_opt);
     assert_string_equal(krb5_child_extra_args[2], "--realm=" TEST_REALM);
     assert_string_equal(krb5_child_extra_args[3], "--canonicalize");
-    assert_null(krb5_child_extra_args[4]);
+    assert_string_equal(krb5_child_extra_args[4], "--chain-id=0");
+    assert_null(krb5_child_extra_args[5]);
     talloc_free(krb5_child_extra_args);
 
     /* --fast-principal will be only set if FAST is used */
@@ -136,7 +139,8 @@ void test_set_extra_args(void **state)
     assert_string_equal(krb5_child_extra_args[1], gid_opt);
     assert_string_equal(krb5_child_extra_args[2], "--realm=" TEST_REALM);
     assert_string_equal(krb5_child_extra_args[3], "--canonicalize");
-    assert_null(krb5_child_extra_args[4]);
+    assert_string_equal(krb5_child_extra_args[4], "--chain-id=0");
+    assert_null(krb5_child_extra_args[5]);
     talloc_free(krb5_child_extra_args);
 
     krb5_ctx->use_fast_str = discard_const(TEST_FAST_STR);
@@ -150,7 +154,8 @@ void test_set_extra_args(void **state)
     assert_string_equal(krb5_child_extra_args[4],
                         "--fast-principal=" TEST_FAST_PRINC);
     assert_string_equal(krb5_child_extra_args[5], "--canonicalize");
-    assert_null(krb5_child_extra_args[6]);
+    assert_string_equal(krb5_child_extra_args[6], "--chain-id=0");
+    assert_null(krb5_child_extra_args[7]);
     talloc_free(krb5_child_extra_args);
 
     krb5_ctx->lifetime_str = discard_const(TEST_LIFE_STR);
@@ -168,7 +173,8 @@ void test_set_extra_args(void **state)
     assert_string_equal(krb5_child_extra_args[6],
                         "--fast-principal=" TEST_FAST_PRINC);
     assert_string_equal(krb5_child_extra_args[7], "--canonicalize");
-    assert_null(krb5_child_extra_args[8]);
+    assert_string_equal(krb5_child_extra_args[8], "--chain-id=0");
+    assert_null(krb5_child_extra_args[9]);
     talloc_free(krb5_child_extra_args);
 
     talloc_free(krb5_ctx);

--- a/src/tests/cwrap/test_server.c
+++ b/src/tests/cwrap/test_server.c
@@ -101,7 +101,7 @@ void test_run_as_root_fg(void **state)
 
     pid = fork();
     if (pid == 0) {
-        ret = server_setup(__FUNCTION__, 0, 0, 0,
+        ret = server_setup(__FUNCTION__, false, 0, 0, 0,
                            __FUNCTION__, &main_ctx);
         assert_int_equal(ret, 0);
         exit(0);
@@ -124,7 +124,7 @@ void test_run_as_sssd_fg(void **state)
 
     pid = fork();
     if (pid == 0) {
-        ret = server_setup(__FUNCTION__, 0, sssd->pw_uid, sssd->pw_gid,
+        ret = server_setup(__FUNCTION__, false, 0, sssd->pw_uid, sssd->pw_gid,
                            __FUNCTION__, &main_ctx);
         assert_int_equal(ret, 0);
         exit(0);
@@ -149,7 +149,7 @@ void test_run_as_root_daemon(void **state)
 
     pid = fork();
     if (pid == 0) {
-        ret = server_setup(__FUNCTION__, FLAGS_PID_FILE,
+        ret = server_setup(__FUNCTION__, false, FLAGS_PID_FILE,
                            0, 0, __FUNCTION__, &main_ctx);
         assert_int_equal(ret, 0);
 

--- a/src/tools/analyzer/Makefile.am
+++ b/src/tools/analyzer/Makefile.am
@@ -11,6 +11,7 @@ dist_pkgpython_DATA = \
     source_files.py \
     source_journald.py \
     source_reader.py \
+    parser.py \
     sss_analyze.py \
     $(NULL)
 

--- a/src/tools/analyzer/Makefile.am
+++ b/src/tools/analyzer/Makefile.am
@@ -1,16 +1,21 @@
-pkgpythondir = $(python3dir)/sssd
+sss_analyze_pythondir = $(libexecdir)/sssd
 
-dist_pkgpython_SCRIPTS = \
-    sss_analyze.py \
+dist_sss_analyze_python_SCRIPTS = \
+    sss_analyze \
     $(NULL)
 
+pkgpythondir = $(python3dir)/sssd
+
 dist_pkgpython_DATA = \
+    __init__.py \
     source_files.py \
     source_journald.py \
     source_reader.py \
+    sss_analyze.py \
     $(NULL)
 
 modulesdir = $(pkgpythondir)/modules
 dist_modules_DATA = \
+    modules/__init__.py \
     modules/request.py \
     $(NULL)

--- a/src/tools/analyzer/modules/request.py
+++ b/src/tools/analyzer/modules/request.py
@@ -250,13 +250,11 @@ class RequestAnalyzer:
         component = source.Component.NSS
         resp = "nss"
         pattern = [f'REQ_TRACE.*\[CID #{cid}\\]']
-        pattern.append(f"\[CID #{cid}\\].*connected")
+        pattern.append(f"\[CID#{cid}\\]")
 
         if args.pam:
             component = source.Component.PAM
             resp = "pam"
-            pam_data_regex = f'pam.*\[CID#{cid}\]'
-            pattern.append(pam_data_regex)
 
         logger.info(f"******** Checking {resp} responder for Client ID"
                     f" {cid} *******")

--- a/src/tools/analyzer/modules/request.py
+++ b/src/tools/analyzer/modules/request.py
@@ -171,8 +171,8 @@ class RequestAnalyzer:
         if line.startswith('   *  '):
             return
         fields = line.split("[")
-        cr_field = fields[2].split(":")[1]
-        cr = cr_field[5:]
+        cr_field = fields[3][7:]
+        cr = cr_field.split(":")[0][4:]
         if "refreshed" in line:
             return
         # CR Plugin name
@@ -189,7 +189,7 @@ class RequestAnalyzer:
             ts = line.split(")")[0]
             ts = ts[1:]
             fields = line.split("[")
-            cid = fields[3][5:-1]
+            cid = fields[3][4:-9]
             cmd = fields[4][4:-1]
             uid = fields[5][4:-1]
             if not uid.isnumeric():
@@ -218,10 +218,11 @@ class RequestAnalyzer:
         source = self.load(args)
         component = source.Component.NSS
         resp = "nss"
+        # Log messages matching the following regex patterns contain
+        # the useful info we need to produce list output
         patterns = ['\[cmd']
         patterns.append("(cache_req_send|cache_req_process_input|"
                         "cache_req_search_send)")
-        consume = True
         if args.pam:
             component = source.Component.PAM
             resp = "pam"
@@ -229,7 +230,6 @@ class RequestAnalyzer:
         logger.info(f"******** Listing {resp} client requests ********")
         source.set_component(component)
         self.done = ""
-        # For each CID
         for line in self.matched_line(source, patterns):
             if isinstance(source, Journald):
                 print(line)
@@ -255,7 +255,8 @@ class RequestAnalyzer:
         if args.pam:
             component = source.Component.PAM
             resp = "pam"
-            pam_data_regex = f'pam_print_data.*\[CID #{cid}\]'
+            pam_data_regex = f'pam.*\[CID#{cid}\]'
+            pattern.append(pam_data_regex)
 
         logger.info(f"******** Checking {resp} responder for Client ID"
                     f" {cid} *******")

--- a/src/tools/analyzer/modules/request.py
+++ b/src/tools/analyzer/modules/request.py
@@ -1,11 +1,8 @@
 import re
-import copy
 import logging
-import argparse
 
-from enum import Enum
-from source_files import Files
-from source_journald import Journald
+from sssd.source_files import Files
+from sssd.source_journald import Journald
 from sssd.sss_analyze import SubparsersAction
 from sssd.sss_analyze import Option
 from sssd.sss_analyze import Analyzer
@@ -82,7 +79,6 @@ class RequestAnalyzer:
             Instantiated source object
         """
         if args.source == "journald":
-            import source_journald
             source = Journald()
         else:
             source = Files(args.logdir)

--- a/src/tools/analyzer/modules/request.py
+++ b/src/tools/analyzer/modules/request.py
@@ -3,9 +3,8 @@ import logging
 
 from sssd.source_files import Files
 from sssd.source_journald import Journald
-from sssd.sss_analyze import SubparsersAction
-from sssd.sss_analyze import Option
-from sssd.sss_analyze import Analyzer
+from sssd.parser import SubparsersAction
+from sssd.parser import Option
 
 logger = logging.getLogger()
 
@@ -39,7 +38,7 @@ class RequestAnalyzer:
         """
         self.module_parser.print_help()
 
-    def setup_args(self, parser_grp):
+    def setup_args(self, parser_grp, cli):
         """
         Setup module parser, subcommands, and options
 
@@ -57,7 +56,6 @@ class RequestAnalyzer:
                                                       action=SubparsersAction,
                                                       metavar='COMMANDS')
 
-        cli = Analyzer()
         subcmd_grp = subparser.add_parser_group('Operation Modes')
         cli.add_subcommand(subcmd_grp, 'list', 'List recent requests',
                            self.list_requests, self.list_opts)

--- a/src/tools/analyzer/parser.py
+++ b/src/tools/analyzer/parser.py
@@ -1,0 +1,60 @@
+import argparse
+
+
+# Based on patch from https://bugs.python.org/issue9341
+class SubparsersAction(argparse._SubParsersAction):
+    """
+    Provide a subparser action that can create subparsers with ability of
+    grouping arguments.
+
+    It is based on the patch from:
+
+        - https://bugs.python.org/issue9341
+    """
+
+    class _PseudoGroup(argparse.Action):
+        def __init__(self, container, title):
+            super().__init__(option_strings=[], dest=title)
+            self.container = container
+            self._choices_actions = []
+
+        def add_parser(self, name, **kwargs):
+            # add the parser to the main Action, but move the pseudo action
+            # in the group's own list
+            parser = self.container.add_parser(name, **kwargs)
+            choice_action = self.container._choices_actions.pop()
+            self._choices_actions.append(choice_action)
+            return parser
+
+        def _get_subactions(self):
+            return self._choices_actions
+
+        def add_parser_group(self, title):
+            # the formatter can handle recursive subgroups
+            grp = SubparsersAction._PseudoGroup(self, title)
+            self._choices_actions.append(grp)
+            return grp
+
+    def add_parser_group(self, title):
+        """
+        Add new parser group.
+
+        :param title: Title.
+        :type title: str
+        :return: Parser group that can have additional parsers attached.
+        :rtype: ``argparse.Action`` extended with ``add_parser`` method
+        """
+        grp = self._PseudoGroup(self, title)
+        self._choices_actions.append(grp)
+        return grp
+
+
+class Option:
+    """
+    Group option attributes for command/subcommand options
+    """
+    def __init__(self, name, help_msg, opt_type, short_opt=None):
+        self.name = name
+        self.short_opt = short_opt
+        self.help_msg = help_msg
+        self.opt_type = opt_type

--- a/src/tools/analyzer/source_files.py
+++ b/src/tools/analyzer/source_files.py
@@ -1,11 +1,7 @@
-from enum import Enum
-import configparser
-from os import listdir
-from os.path import isfile, join
 import glob
 import logging
 
-from source_reader import Reader
+from sssd.source_reader import Reader
 
 logger = logging.getLogger()
 

--- a/src/tools/analyzer/source_files.py
+++ b/src/tools/analyzer/source_files.py
@@ -46,19 +46,22 @@ class Files(Reader):
         else:
             return path + "/"
 
-    def get_domain_logfiles(self):
+    def get_domain_logfiles(self, child=False):
         """ Retrieve list of SSSD log files, exclude rotated (.gz) files """
         domain_files = []
         exclude_list = ["ifp", "nss", "pam", "sudo", "autofs",
                         "ssh", "pac", "kcm", ".gz"]
-        file_list = glob.glob(self.path + "sssd_*")
+        if child:
+            file_list = glob.glob(self.path + "*.log")
+        else:
+            file_list = glob.glob(self.path + "sssd_*")
         for file in file_list:
             if not any(s in file for s in exclude_list):
                 domain_files.append(file)
 
         return domain_files
 
-    def set_component(self, component):
+    def set_component(self, component, child):
         """
         Switch the reader to interact with a certain SSSD component
         NSS, PAM, BE
@@ -69,8 +72,9 @@ class Files(Reader):
         elif component == self.Component.PAM:
             self.log_files.append(self.path + "sssd_pam.log")
         elif component == self.Component.BE:
-            if not self.domains:
+            domains = self.get_domain_logfiles(child)
+            if not domains:
                 raise IOError
             # error: No domains found?
-            for dom in self.domains:
+            for dom in domains:
                 self.log_files.append(dom)

--- a/src/tools/analyzer/source_journald.py
+++ b/src/tools/analyzer/source_journald.py
@@ -1,7 +1,6 @@
 from systemd import journal
-from source_reader import Reader
 
-from enum import Enum
+from sssd.source_reader import Reader
 
 _EXE_PREFIX = "/usr/libexec/sssd/"
 _NSS_MATCH = _EXE_PREFIX + "sssd_nss"

--- a/src/tools/analyzer/source_journald.py
+++ b/src/tools/analyzer/source_journald.py
@@ -33,7 +33,7 @@ class Journald(Reader):
             else:
                 yield msg
 
-    def set_component(self, component):
+    def set_component(self, component, child):
         """
         Switch the reader to interact with a certain SSSD component
         NSS, PAM, BE

--- a/src/tools/analyzer/sss_analyze
+++ b/src/tools/analyzer/sss_analyze
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+from sssd import sss_analyze
+
+sss_analyze.run()

--- a/src/tools/analyzer/sss_analyze.py
+++ b/src/tools/analyzer/sss_analyze.py
@@ -1,10 +1,4 @@
-#!/usr/bin/env python
-
 import argparse
-
-import source_files
-
-from modules import request
 
 
 # Based on patch from https://bugs.python.org/issue9341
@@ -116,6 +110,9 @@ class Analyzer:
                 additional parsers attached.
         """
         # Currently only the 'request' module exists
+
+        # delayed import: the modules should be reorganized
+        from sssd.modules import request
         req = request.RequestAnalyzer()
 
         module_parser = req.setup_args(parser_grp)
@@ -160,6 +157,6 @@ class Analyzer:
         args.func(args)
 
 
-if __name__ == '__main__':
+def run():
     analyzer = Analyzer()
     analyzer.main()

--- a/src/tools/analyzer/sss_analyze.py
+++ b/src/tools/analyzer/sss_analyze.py
@@ -1,63 +1,7 @@
 import argparse
 
-
-# Based on patch from https://bugs.python.org/issue9341
-class SubparsersAction(argparse._SubParsersAction):
-    """
-    Provide a subparser action that can create subparsers with ability of
-    grouping arguments.
-
-    It is based on the patch from:
-
-        - https://bugs.python.org/issue9341
-    """
-
-    class _PseudoGroup(argparse.Action):
-        def __init__(self, container, title):
-            super().__init__(option_strings=[], dest=title)
-            self.container = container
-            self._choices_actions = []
-
-        def add_parser(self, name, **kwargs):
-            # add the parser to the main Action, but move the pseudo action
-            # in the group's own list
-            parser = self.container.add_parser(name, **kwargs)
-            choice_action = self.container._choices_actions.pop()
-            self._choices_actions.append(choice_action)
-            return parser
-
-        def _get_subactions(self):
-            return self._choices_actions
-
-        def add_parser_group(self, title):
-            # the formatter can handle recursive subgroups
-            grp = SubparsersAction._PseudoGroup(self, title)
-            self._choices_actions.append(grp)
-            return grp
-
-    def add_parser_group(self, title):
-        """
-        Add new parser group.
-
-        :param title: Title.
-        :type title: str
-        :return: Parser group that can have additional parsers attached.
-        :rtype: ``argparse.Action`` extended with ``add_parser`` method
-        """
-        grp = self._PseudoGroup(self, title)
-        self._choices_actions.append(grp)
-        return grp
-
-
-class Option:
-    """
-    Group option attributes for command/subcommand options
-    """
-    def __init__(self, name, help_msg, opt_type, short_opt=None):
-        self.name = name
-        self.short_opt = short_opt
-        self.help_msg = help_msg
-        self.opt_type = opt_type
+from sssd.modules import request
+from sssd.parser import SubparsersAction
 
 
 class Analyzer:
@@ -110,12 +54,10 @@ class Analyzer:
                 additional parsers attached.
         """
         # Currently only the 'request' module exists
-
-        # delayed import: the modules should be reorganized
-        from sssd.modules import request
         req = request.RequestAnalyzer()
+        cli = Analyzer()
 
-        module_parser = req.setup_args(parser_grp)
+        module_parser = req.setup_args(parser_grp, cli)
 
     def setup_args(self):
         """

--- a/src/tools/sssctl/sssctl_logs.c
+++ b/src/tools/sssctl/sssctl_logs.c
@@ -394,13 +394,12 @@ errno_t sssctl_analyze(struct sss_cmdline *cmdline,
                        struct sss_tool_ctx *tool_ctx,
                        void *pvt)
 {
+#ifndef BUILD_CHAIN_ID
+    PRINT("ERROR: Tevent chain ID support missing, log analyzer is unsupported.\n");
+    return EOK;
+#endif
     errno_t ret;
 
-#ifndef BUILD_CHAIN_ID
-    PRINT("NOTE: Tevent chain ID support missing, request analysis will be limited.\n");
-    PRINT("It is recommended to use the --logdir option against tevent chain ID "
-          "supported SSSD logs.\n");
-#endif
     const char **args = talloc_array_size(tool_ctx,
                                           sizeof(char *),
                                           cmdline->argc + 2);

--- a/src/tools/sssctl/sssctl_logs.c
+++ b/src/tools/sssctl/sssctl_logs.c
@@ -41,7 +41,7 @@
 
 #define LOG_FILE(file) " " LOG_PATH "/" file
 #define LOG_FILES LOG_FILE("*.log")
-#define SSS_ANALYZE PYTHONDIR_PATH"/sss_analyze.py"
+#define SSS_ANALYZE SSSD_LIBEXEC_PATH"/sss_analyze"
 
 #define CHECK(expr, done, msg) do { \
     if (expr) { \

--- a/src/util/sss_chain_id.c
+++ b/src/util/sss_chain_id.c
@@ -18,8 +18,16 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <stdint.h>
 #include "util/sss_chain_id.h"
+#include "config.h"
+
+extern const char *debug_chain_id_fmt;
+
+#ifdef BUILD_CHAIN_ID
+void sss_chain_id_set_format(const char *fmt)
+{
+    debug_chain_id_fmt = fmt;
+}
 
 uint64_t sss_chain_id_set(uint64_t id)
 {
@@ -32,3 +40,21 @@ uint64_t sss_chain_id_get(void)
 {
     return debug_chain_id;
 }
+#else /* BUILD_CHAIN_ID not defined */
+
+void sss_chain_id_set_format(const char *fmt)
+{
+    return;
+}
+
+uint64_t sss_chain_id_set(uint64_t id)
+{
+    return 0;
+}
+
+uint64_t sss_chain_id_get(void)
+{
+    return 0;
+}
+
+#endif /* BUILD_CHAIN_ID */

--- a/src/util/sss_chain_id.h
+++ b/src/util/sss_chain_id.h
@@ -31,4 +31,7 @@ uint64_t sss_chain_id_set(uint64_t id);
 /* Get the current chain id. */
 uint64_t sss_chain_id_get(void);
 
+/* Set new debug chain id logging format. */
+void sss_chain_id_set_format(const char *fmt);
+
 #endif /* _SSS_CHAIN_ID_ */

--- a/src/util/sss_chain_id.h
+++ b/src/util/sss_chain_id.h
@@ -1,6 +1,6 @@
 /*
     Authors:
-        Pavel Březina <pbrezina@redhat.com>
+        Justin Stephenson <jstephen@redhat.com>
 
     Copyright (C) 2021 Red Hat
 
@@ -21,10 +21,9 @@
 #ifndef _SSS_CHAIN_ID_
 #define _SSS_CHAIN_ID_
 
-#include <tevent.h>
+#include <stdint.h>
 
-/* Setup chain id tracking on tevent context. */
-void sss_chain_id_setup(struct tevent_context *ev);
+extern uint64_t debug_chain_id;
 
 /* Explicitly set new chain id. The old id is returned. */
 uint64_t sss_chain_id_set(uint64_t id);

--- a/src/util/sss_chain_id_tevent.c
+++ b/src/util/sss_chain_id_tevent.c
@@ -1,0 +1,138 @@
+/*
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2021 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+#include "util/sss_chain_id.h"
+
+#include <tevent.h>
+
+#ifdef BUILD_CHAIN_ID
+
+static void sss_chain_id_trace_fde(struct tevent_fd *fde,
+                                   enum tevent_event_trace_point point,
+                                   void *private_data)
+{
+    switch (point) {
+    case TEVENT_EVENT_TRACE_ATTACH:
+        /* Assign the current chain id when the event is created. */
+        tevent_fd_set_tag(fde, debug_chain_id);
+        break;
+    case TEVENT_EVENT_TRACE_BEFORE_HANDLER:
+        /* Set the chain id when a handler is being called. */
+        debug_chain_id = tevent_fd_get_tag(fde);
+        break;
+    default:
+        /* Do nothing. */
+        break;
+    }
+}
+
+static void sss_chain_id_trace_signal(struct tevent_signal *se,
+                                      enum tevent_event_trace_point point,
+                                      void *private_data)
+{
+    switch (point) {
+    case TEVENT_EVENT_TRACE_ATTACH:
+        /* Assign the current chain id when the event is created. */
+        tevent_signal_set_tag(se, debug_chain_id);
+        break;
+    case TEVENT_EVENT_TRACE_BEFORE_HANDLER:
+        /* Set the chain id when a handler is being called. */
+        debug_chain_id = tevent_signal_get_tag(se);
+        break;
+    default:
+        /* Do nothing. */
+        break;
+    }
+}
+
+static void sss_chain_id_trace_timer(struct tevent_timer *timer,
+                                     enum tevent_event_trace_point point,
+                                     void *private_data)
+{
+    switch (point) {
+    case TEVENT_EVENT_TRACE_ATTACH:
+        /* Assign the current chain id when the event is created. */
+        tevent_timer_set_tag(timer, debug_chain_id);
+        break;
+    case TEVENT_EVENT_TRACE_BEFORE_HANDLER:
+        /* Set the chain id when a handler is being called. */
+        debug_chain_id = tevent_timer_get_tag(timer);
+        break;
+    default:
+        /* Do nothing. */
+        break;
+    }
+}
+
+static void sss_chain_id_trace_immediate(struct tevent_immediate *im,
+                                         enum tevent_event_trace_point point,
+                                         void *private_data)
+{
+    switch (point) {
+    case TEVENT_EVENT_TRACE_ATTACH:
+        /* Assign the current chain id when the event is created. */
+        tevent_immediate_set_tag(im, debug_chain_id);
+        break;
+    case TEVENT_EVENT_TRACE_BEFORE_HANDLER:
+        /* Set the chain id when a handler is being called. */
+        debug_chain_id = tevent_immediate_get_tag(im);
+        break;
+    default:
+        /* Do nothing. */
+        break;
+    }
+}
+
+static void sss_chain_id_trace_loop(enum tevent_trace_point point,
+                                    void *private_data)
+{
+    switch (point) {
+    case TEVENT_TRACE_AFTER_LOOP_ONCE:
+        /* Reset chain id when we got back to the loop. An event handler
+         * that set chain id was fired. This tracepoint represents a place
+         * after the event handler was finished, we need to restore chain
+         * id to 0 (out of request).
+         */
+        debug_chain_id = 0;
+        break;
+    default:
+        /* Do nothing. */
+        break;
+    }
+}
+
+void sss_chain_id_setup(struct tevent_context *ev)
+{
+    tevent_set_trace_callback(ev, sss_chain_id_trace_loop, NULL);
+    tevent_set_trace_fd_callback(ev, sss_chain_id_trace_fde, NULL);
+    tevent_set_trace_signal_callback(ev, sss_chain_id_trace_signal, NULL);
+    tevent_set_trace_timer_callback(ev, sss_chain_id_trace_timer, NULL);
+    tevent_set_trace_immediate_callback(ev, sss_chain_id_trace_immediate, NULL);
+}
+
+#else /* BUILD_CHAIN_ID not defined */
+
+void sss_chain_id_setup(struct tevent_context *ev)
+{
+    return;
+}
+
+#endif /* BUILD_CHAIN_ID */

--- a/src/util/sss_chain_id_tevent.h
+++ b/src/util/sss_chain_id_tevent.h
@@ -18,17 +18,12 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <stdint.h>
-#include "util/sss_chain_id.h"
+#ifndef _SSS_CHAIN_ID_TEVENT_
+#define _SSS_CHAIN_ID_TEVENT_
 
-uint64_t sss_chain_id_set(uint64_t id)
-{
-    uint64_t old_id = debug_chain_id;
-    debug_chain_id = id;
-    return old_id;
-}
+#include <tevent.h>
 
-uint64_t sss_chain_id_get(void)
-{
-    return debug_chain_id;
-}
+/* Setup chain id tracking on tevent context. */
+void sss_chain_id_setup(struct tevent_context *ev);
+
+#endif /* _SSS_CHAIN_ID_TEVENT_ */

--- a/src/util/sss_pam_data.c
+++ b/src/util/sss_pam_data.c
@@ -165,25 +165,23 @@ failed:
 
 void pam_print_data(int l, struct pam_data *pd)
 {
-    DEBUG(l, "[CID #%u] command: %s\n", pd->client_id_num, sss_cmd2str(pd->cmd));
-    DEBUG(l, "[CID #%u] domain: %s\n", pd->client_id_num, PAM_SAFE_ITEM(pd->domain));
-    DEBUG(l, "[CID #%u] user: %s\n", pd->client_id_num, PAM_SAFE_ITEM(pd->user));
-    DEBUG(l, "[CID #%u] service: %s\n", pd->client_id_num, PAM_SAFE_ITEM(pd->service));
-    DEBUG(l, "[CID #%u] tty: %s\n", pd->client_id_num, PAM_SAFE_ITEM(pd->tty));
-    DEBUG(l, "[CID #%u] ruser: %s\n", pd->client_id_num, PAM_SAFE_ITEM(pd->ruser));
-    DEBUG(l, "[CID #%u] rhost: %s\n", pd->client_id_num, PAM_SAFE_ITEM(pd->rhost));
-    DEBUG(l, "[CID #%u] authtok type: %d (%s)\n",
-          pd->client_id_num,
+    DEBUG(l, "command: %s\n", sss_cmd2str(pd->cmd));
+    DEBUG(l, "domain: %s\n", PAM_SAFE_ITEM(pd->domain));
+    DEBUG(l, "user: %s\n", PAM_SAFE_ITEM(pd->user));
+    DEBUG(l, "service: %s\n", PAM_SAFE_ITEM(pd->service));
+    DEBUG(l, "tty: %s\n", PAM_SAFE_ITEM(pd->tty));
+    DEBUG(l, "ruser: %s\n", PAM_SAFE_ITEM(pd->ruser));
+    DEBUG(l, "rhost: %s\n", PAM_SAFE_ITEM(pd->rhost));
+    DEBUG(l, "authtok type: %d (%s)\n",
           sss_authtok_get_type(pd->authtok),
           sss_authtok_type_to_str(sss_authtok_get_type(pd->authtok)));
-    DEBUG(l, "[CID #%u] newauthtok type: %d (%s)\n",
-          pd->client_id_num,
+    DEBUG(l, "newauthtok type: %d (%s)\n",
           sss_authtok_get_type(pd->newauthtok),
           sss_authtok_type_to_str(sss_authtok_get_type(pd->newauthtok)));
-    DEBUG(l, "[CID #%u] priv: %d\n", pd->client_id_num, pd->priv);
-    DEBUG(l, "[CID #%u] cli_pid: %d\n", pd->client_id_num, pd->cli_pid);
-    DEBUG(l, "[CID #%u] logon name: %s\n", pd->client_id_num, PAM_SAFE_ITEM(pd->logon_name));
-    DEBUG(l, "[CID #%u] flags: %d\n", pd->client_id_num, pd->cli_flags);
+    DEBUG(l, "priv: %d\n", pd->priv);
+    DEBUG(l, "cli_pid: %d\n", pd->cli_pid);
+    DEBUG(l, "logon name: %s\n", PAM_SAFE_ITEM(pd->logon_name));
+    DEBUG(l, "flags: %d\n", pd->cli_flags);
 }
 
 int pam_add_response(struct pam_data *pd, enum response_type type,

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -186,6 +186,9 @@ void sss_log(int priority, const char *format, ...) SSS_ATTRIBUTE_PRINTF(2, 3);
 void sss_log_ext(int priority, int facility, const char *format, ...) SSS_ATTRIBUTE_PRINTF(3, 4);
 
 /* from server.c */
+#define DEBUG_CHAIN_ID_FMT_RID "[RID#%lu] %s"
+#define DEBUG_CHAIN_ID_FMT_CID "[CID#%lu] %s"
+
 struct main_context {
     struct tevent_context *event_ctx;
     struct confdb_ctx *confdb_ctx;
@@ -197,7 +200,8 @@ errno_t server_common_rotate_logs(struct confdb_ctx *confdb,
 int die_if_parent_died(void);
 int check_pidfile(const char *file);
 int pidfile(const char *file);
-int server_setup(const char *name, int flags,
+int server_setup(const char *name, bool is_responder,
+                 int flags,
                  uid_t uid, gid_t gid,
                  const char *conf_entry,
                  struct main_context **main_ctx);


### PR DESCRIPTION
This PR adds the following tevent chain ID functionality:

* Add tevent chain ID logic into responders (log messages with tag [CID #])
* Add ability to parse child log files by passing the backend request ID  into child processes and setting the chain ID inside the child.

sss_chain_id getter/setter functions moved into their own source file (remove dependency to tevent), and some small changes to analyzer are needed.

I skipped LDAP, nsupdate, ad renewal, ipa-getkeytab child processes, as they are not tied to a user request and would not benefit from request tracking as far as I know:


