### PR TITLE
usertools: force local user for sssd process user

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -884,6 +884,7 @@ dist_noinst_HEADERS = \
     src/tests/cmocka/test_expire_common.h \
     src/tests/cmocka/test_sdap_access.h \
     src/tests/cmocka/data_provider/mock_dp.h \
+    src/tests/cwrap/common_mock_nss_dl_load.h \
     src/sss_client/pam_message.h \
     src/sss_client/ssh/sss_ssh_client.h \
     src/sss_client/sudo/sss_sudo.h \
@@ -1265,6 +1266,8 @@ libsss_util_la_SOURCES = \
     src/util/selinux.c \
     src/util/sss_regexp.c \
     src/util/sss_chain_id.c \
+    src/util/nss_dl_load.c \
+    src/util/nss_dl_load_extra.c \
     $(NULL)
 libsss_util_la_CFLAGS = \
     $(AM_CFLAGS) \

--- a/src/man/sssd-ifp.5.xml
+++ b/src/man/sssd-ifp.5.xml
@@ -56,6 +56,11 @@
                             startup.
                         </para>
                         <para>
+                            Local user names are required, i.e. accessible via
+                            <quote>files</quote> service of
+                            <filename>nsswitch.conf</filename>.
+                        </para>
+                        <para>
                             Default: 0 (only the root user is allowed to access
                             the InfoPipe responder)
                         </para>

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -424,6 +424,12 @@
                                 </phrase>
                             </para>
                             <para>
+                                Both a user name and a uid can be used but the
+                                user should be a local one, i.e. accessible via
+                                <quote>files</quote> service of
+                                <filename>nsswitch.conf</filename>.
+                            </para>
+                            <para>
                                 Default: not set, process will run as root
                             </para>
                         </listitem>
@@ -2161,6 +2167,11 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                             user names that are allowed to access the PAC
                             responder. User names are resolved to UIDs at
                             startup.
+                        </para>
+                        <para>
+                            Local user names are required, i.e. accessible via
+                            <quote>files</quote> service of
+                            <filename>nsswitch.conf</filename>.
                         </para>
                         <para>
                             Default: 0 (only the root user is allowed to access

--- a/src/tests/cwrap/Makefile.am
+++ b/src/tests/cwrap/Makefile.am
@@ -141,15 +141,17 @@ endif
 
 usertools_tests_SOURCES = \
     test_usertools.c \
+    common_mock_nss_dl_load.c \
+    ../../../src/util/usertools.c \
     $(NULL)
 usertools_tests_CFLAGS = \
     $(AM_CFLAGS) \
     $(NULL)
 usertools_tests_LDADD = \
+    $(LIBADD_DL) \
     $(CMOCKA_LIBS) \
     $(POPT_LIBS) \
     $(TALLOC_LIBS) \
-    $(abs_top_builddir)/libsss_util.la \
     $(abs_top_builddir)/libsss_debug.la \
     $(abs_top_builddir)/libsss_test_common.la \
     $(NULL)
@@ -159,9 +161,10 @@ endif
 
 responder_common_tests_SOURCES =\
     test_responder_common.c \
+    common_mock_nss_dl_load.c \
     $(SSSD_RESPONDER_IFACE_OBJ) \
     ../../../src/responder/common/negcache_files.c \
-    ../../../src/util/nss_dl_load.c \
+    ../../../src/util/usertools.c \
     ../../../src/responder/common/negcache.c \
     ../../../src/responder/common/responder_common.c \
     ../../../src/responder/common/responder_packet.c \
@@ -179,7 +182,6 @@ responder_common_tests_LDADD = \
     $(SSSD_LIBS) \
     $(SELINUX_LIBS) \
     $(SYSTEMD_DAEMON_LIBS) \
-    $(abs_top_builddir)/libsss_util.la \
     $(abs_top_builddir)/libsss_debug.la \
     $(abs_top_builddir)/libsss_test_common.la \
     $(abs_top_builddir)/libsss_iface.la \

--- a/src/tests/cwrap/common_mock_nss_dl_load.c
+++ b/src/tests/cwrap/common_mock_nss_dl_load.c
@@ -1,0 +1,77 @@
+/*
+    Authors:
+        Iker Pedrosa <ipedrosa@redhat.com>
+
+    Copyright (C) 2021 Red Hat
+
+    SSSD tests: Fake nss dl load
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <stddef.h>
+
+#include "common_mock_nss_dl_load.h"
+
+
+static enum nss_status
+mock_getpwnam_r(const char *name, struct passwd *result,
+                char *buffer, size_t buflen, int *errnop)
+{
+    void *pwd_pointer = NULL;
+    int rc;
+
+    rc = getpwnam_r(name, result, buffer, buflen, (struct passwd **)&pwd_pointer);
+    if (rc == 0 && pwd_pointer == result) {
+        *errnop = 0;
+        return NSS_STATUS_SUCCESS;
+    } else if (rc == 0 && (pwd_pointer == NULL)) {
+        *errnop = ENOENT;
+        return NSS_STATUS_NOTFOUND;
+    } else {
+        *errnop = rc;
+        return NSS_STATUS_UNAVAIL;
+    }
+}
+
+static enum nss_status
+mock_getpwuid_r(uid_t uid, struct passwd *result,
+                char *buffer, size_t buflen, int *errnop)
+{
+    void *pwd_pointer = NULL;
+    int rc;
+
+    rc = getpwuid_r(uid, result, buffer, buflen, (struct passwd **)&pwd_pointer);
+    if (rc == 0 && pwd_pointer == result) {
+        *errnop = 0;
+        return NSS_STATUS_SUCCESS;
+    } else if (rc == 0 && (pwd_pointer == NULL)) {
+        *errnop = ENOENT;
+        return NSS_STATUS_NOTFOUND;
+    } else {
+        *errnop = rc;
+        return NSS_STATUS_UNAVAIL;
+    }
+}
+
+errno_t mock_sss_load_nss_pw_symbols(struct sss_nss_ops *ops)
+{
+    ops->getpwnam_r = mock_getpwnam_r;
+    ops->getpwuid_r = mock_getpwuid_r;
+
+    return EOK;
+}

--- a/src/tests/cwrap/common_mock_nss_dl_load.h
+++ b/src/tests/cwrap/common_mock_nss_dl_load.h
@@ -1,0 +1,30 @@
+/*
+    Authors:
+        Iker Pedrosa <ipedrosa@redhat.com>
+
+    Copyright (C) 2021 Red Hat
+
+    SSSD tests: Fake nss dl load
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __COMMON_MOCK_NSS_DL_LOAD_H_
+#define __COMMON_MOCK_NSS_DL_LOAD_H_
+
+#include "util/nss_dl_load.h"
+
+errno_t mock_sss_load_nss_pw_symbols(struct sss_nss_ops *ops);
+
+#endif /* __COMMON_MOCK_NSS_DL_LOAD_H_ */

--- a/src/tests/cwrap/test_responder_common.c
+++ b/src/tests/cwrap/test_responder_common.c
@@ -29,6 +29,13 @@
 #include "util/util.h"
 #include "responder/common/responder.h"
 #include "tests/cmocka/common_mock.h"
+#include "tests/cwrap/common_mock_nss_dl_load.h"
+
+
+errno_t sss_load_nss_pw_symbols(struct sss_nss_ops *ops)
+{
+    return mock_sss_load_nss_pw_symbols(ops);
+}
 
 /* Just to satisfy dependencies */
 struct cli_protocol_version *register_cli_protocol_version(void)

--- a/src/tests/cwrap/test_usertools.c
+++ b/src/tests/cwrap/test_usertools.c
@@ -27,6 +27,12 @@
 #include <popt.h>
 #include "util/util.h"
 #include "tests/cmocka/common_mock.h"
+#include "tests/cwrap/common_mock_nss_dl_load.h"
+
+errno_t sss_load_nss_pw_symbols(struct sss_nss_ops *ops)
+{
+    return mock_sss_load_nss_pw_symbols(ops);
+}
 
 void test_get_user_num(void **state)
 {

--- a/src/util/nss_dl_load.h
+++ b/src/util/nss_dl_load.h
@@ -23,6 +23,8 @@
 #include <pwd.h>
 #include <grp.h>
 #include <netdb.h>
+#include <stdbool.h>
+
 #include "util/util_errors.h"
 #include "sss_client/nss_compat.h"
 
@@ -118,5 +120,6 @@ struct sss_nss_symbols {
 errno_t sss_load_nss_symbols(struct sss_nss_ops *ops, const char *libname,
                              struct sss_nss_symbols *syms, size_t nsyms);
 
+errno_t sss_load_nss_pw_symbols(struct sss_nss_ops *ops);
 
 #endif /* __SSSD_NSS_DL_LOAD_H__ */

--- a/src/util/nss_dl_load_extra.c
+++ b/src/util/nss_dl_load_extra.c
@@ -1,0 +1,40 @@
+/*
+    SSSD
+
+    nss_dl_load_extra.c
+
+    Authors:
+        Sumit Bose <sbose@redhat.com>
+        Iker Pedrosa <ipedrosa@redhat.com>
+
+    Copyright (C) 2021 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "util/nss_dl_load.h"
+
+errno_t sss_load_nss_pw_symbols(struct sss_nss_ops *ops)
+{
+    errno_t ret;
+    struct sss_nss_symbols syms[] = {
+        {(void*)&ops->getpwnam_r, true, "getpwnam_r" },
+        {(void*)&ops->getpwuid_r, true, "getpwuid_r" }
+    };
+    size_t nsyms = sizeof(syms) / sizeof(struct sss_nss_symbols);
+
+    ret = sss_load_nss_symbols(ops, "files", syms, nsyms);
+
+    return ret;
+}


### PR DESCRIPTION
System hardening by forcing the sssd user to be loaded from a local database (/etc/passwd) instead of using any remote user. This could happen in very special conditions and might change the owner of the sssd databases and generate a denial of service.

Moreover, clarify user option in sssd.conf, as it accepts both the user name and the id as input. The only constraint is that the user should be present in the local database (/etc/passwd).