### PR TITLE
p11_child: Fixes for authentication

### DIFF
--- a/src/p11_child/p11_child.h
+++ b/src/p11_child/p11_child.h
@@ -28,9 +28,6 @@
 /* for CK_MECHANISM_TYPE */
 #include <p11-kit/pkcs11.h>
 
-/* Time to wait during a C_Finalize C_Initialize cycle to discover
- * new slots. */
-#define PKCS11_FINIALIZE_INITIALIZE_WAIT_TIME 3
 /* Time to wait for new slot events. */
 #define PKCS11_SLOT_EVENT_WAIT_TIME 1
 struct p11_ctx;

--- a/src/p11_child/p11_child.h
+++ b/src/p11_child/p11_child.h
@@ -31,6 +31,8 @@
 /* Time to wait during a C_Finalize C_Initialize cycle to discover
  * new slots. */
 #define PKCS11_FINIALIZE_INITIALIZE_WAIT_TIME 3
+/* Time to wait for new slot events. */
+#define PKCS11_SLOT_EVENT_WAIT_TIME 1
 struct p11_ctx;
 
 struct cert_verify_opts {

--- a/src/p11_child/p11_child_openssl.c
+++ b/src/p11_child/p11_child_openssl.c
@@ -1605,7 +1605,8 @@ static errno_t wait_for_card(CK_FUNCTION_LIST *module, CK_SLOT_ID *slot_id,
 
         rv = module->C_GetSlotInfo(*slot_id, info);
         if (rv != CKR_OK) {
-            DEBUG(SSSDBG_OP_FAILURE, "C_GetSlotInfo failed\n");
+            DEBUG(SSSDBG_OP_FAILURE, "C_GetSlotInfo failed [%lu][%s].\n",
+                                     rv, p11_kit_strerror(rv));
             return EIO;
         }
         DEBUG(SSSDBG_TRACE_ALL,
@@ -1706,7 +1707,8 @@ errno_t do_card(TALLOC_CTX *mem_ctx, struct p11_ctx *p11_ctx,
                 memset(&module_info, 0, sizeof(CK_INFO));
                 rv = modules[c]->C_GetInfo(&module_info);
                 if (rv != CKR_OK) {
-                    DEBUG(SSSDBG_OP_FAILURE, "C_GetInfo failed.\n");
+                    DEBUG(SSSDBG_OP_FAILURE, "C_GetInfo failed [%lu][%s].\n",
+                                             rv, p11_kit_strerror(rv));
                     ret = EIO;
                     goto done;
                 }
@@ -1722,7 +1724,8 @@ errno_t do_card(TALLOC_CTX *mem_ctx, struct p11_ctx *p11_ctx,
             num_slots = MAX_SLOTS;
             rv = modules[c]->C_GetSlotList(CK_FALSE, slots, &num_slots);
             if (rv != CKR_OK) {
-                DEBUG(SSSDBG_OP_FAILURE, "C_GetSlotList failed.\n");
+                DEBUG(SSSDBG_OP_FAILURE, "C_GetSlotList failed [%lu][%s].\n",
+                                         rv, p11_kit_strerror(rv));
                 ret = EIO;
                 goto done;
             }
@@ -1730,7 +1733,9 @@ errno_t do_card(TALLOC_CTX *mem_ctx, struct p11_ctx *p11_ctx,
             for (s = 0; s < num_slots; s++) {
                 rv = modules[c]->C_GetSlotInfo(slots[s], &info);
                 if (rv != CKR_OK) {
-                    DEBUG(SSSDBG_OP_FAILURE, "C_GetSlotInfo failed\n");
+                    DEBUG(SSSDBG_OP_FAILURE,
+                          "C_GetSlotInfo failed [%lu][%s].\n",
+                          rv, p11_kit_strerror(rv));
                     ret = EIO;
                     goto done;
                 }
@@ -1761,7 +1766,9 @@ errno_t do_card(TALLOC_CTX *mem_ctx, struct p11_ctx *p11_ctx,
                 if ((info.flags & CKF_TOKEN_PRESENT) && uri != NULL) {
                     rv = modules[c]->C_GetTokenInfo(slots[s], &token_info);
                     if (rv != CKR_OK) {
-                        DEBUG(SSSDBG_OP_FAILURE, "C_GetTokenInfo failed.\n");
+                        DEBUG(SSSDBG_OP_FAILURE,
+                              "C_GetTokenInfo failed [%lu][%s].\n",
+                              rv, p11_kit_strerror(rv));
                         ret = EIO;
                         goto done;
                     }
@@ -1833,7 +1840,8 @@ errno_t do_card(TALLOC_CTX *mem_ctx, struct p11_ctx *p11_ctx,
 
     rv = module->C_GetTokenInfo(slot_id, &token_info);
     if (rv != CKR_OK) {
-        DEBUG(SSSDBG_OP_FAILURE, "C_GetTokenInfo failed.\n");
+        DEBUG(SSSDBG_OP_FAILURE, "C_GetTokenInfo failed [%lu][%s].\n",
+                                 rv, p11_kit_strerror(rv));
         ret = EIO;
         goto done;
     }

--- a/src/p11_child/p11_child_openssl.c
+++ b/src/p11_child/p11_child_openssl.c
@@ -1609,9 +1609,14 @@ static errno_t wait_for_card(CK_FUNCTION_LIST *module, CK_SLOT_ID *slot_id,
             return EIO;
         }
         DEBUG(SSSDBG_TRACE_ALL,
-              "Description [%s] Manufacturer [%s] flags [%lu] "
+              "Description [%.*s] Manufacturer [%.*s] flags [%lu] "
               "removable [%s] token present [%s].\n",
-              info->slotDescription, info->manufacturerID, info->flags,
+              (int) p11_kit_space_strlen(info->slotDescription,
+                                         sizeof(info->slotDescription)),
+              info->slotDescription,
+              (int) p11_kit_space_strlen(info->manufacturerID,
+                                         sizeof(info->manufacturerID)),
+              info->manufacturerID, info->flags,
               (info->flags & CKF_REMOVABLE_DEVICE) ? "true": "false",
               (info->flags & CKF_TOKEN_PRESENT) ? "true": "false");
 


### PR DESCRIPTION
This addresses several issues when searching for a token for (pre-)authentication, in particular when `--wait_for_card` is used. It includes a partial fix for #5025 (RHBZ 1989996), so that tokens for authentication may be inserted into any slot on a single PKCS #‎ 11 module.

This also includes fixes for possible memory leaks and unhandled error conditions in this part of the code.