### PR TITLE
CONFDB: check the return values

### DIFF
--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -685,7 +685,11 @@ int confdb_init(TALLOC_CTX *mem_ctx,
     old_umask = umask(SSS_DFL_UMASK);
     /* file may exists and could be owned by root from previous version */
     sss_sssd_user_uid_and_gid(&sssd_uid, &sssd_gid);
-    chown(confdb_location, sssd_uid, sssd_gid);
+    ret = chown(confdb_location, sssd_uid, sssd_gid);
+    if (ret != EOK && errno != ENOENT) {
+        DEBUG(SSSDBG_MINOR_FAILURE, "Unable to chown config database [%s]: %s\n",
+              confdb_location, sss_strerror(errno));
+    }
     sss_set_sssd_user_eid();
 
     ret = ldb_connect(cdb->ldb, confdb_location, 0, NULL);

--- a/src/util/usertools.c
+++ b/src/util/usertools.c
@@ -863,17 +863,34 @@ void sss_set_sssd_user_eid(void)
     uid_t uid;
     gid_t gid;
 
+
     if (geteuid() == 0) {
         sss_sssd_user_uid_and_gid(&uid, &gid);
-        seteuid(uid);
-        setegid(gid);
+        if (seteuid(uid) != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "Failed to set euid to %"SPRIuid": %s\n",
+                  uid, sss_strerror(errno));
+        }
+        if (setegid(gid) != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "Failed to set egid to %"SPRIgid": %s\n",
+                  gid, sss_strerror(errno));
+        }
     }
 }
 
 void sss_restore_sssd_user_eid(void)
 {
     if (getuid() == 0) {
-        seteuid(getuid());
-        setegid(getgid());
+        if (seteuid(getuid()) != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "Failed to restore euid: %s\n",
+                  sss_strerror(errno));
+        }
+        if (setegid(getgid()) != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "Failed to restore egid: %s\n",
+                  sss_strerror(errno));
+        }
     }
 }


### PR DESCRIPTION
Covscan pointed out that return value of chown and sete[ug]id is
not checked in some cases. There is not much we can do
in case of failure so only minor failure is logged.

Resolves: https://github.com/SSSD/sssd/issues/5876