### PR TITLE
LDAP: expire accounts when today >= shadowExpire

### DIFF
--- a/src/providers/ldap/ldap_auth.c
+++ b/src/providers/ldap/ldap_auth.c
@@ -146,7 +146,7 @@ static errno_t check_pwexpire_shadow(struct spwd *spwd, time_t now,
         return EOK;
     }
 
-    if ((spwd->sp_expire != -1 && today > spwd->sp_expire) ||
+    if ((spwd->sp_expire != -1 && today >= spwd->sp_expire) ||
         (spwd->sp_max != -1 && spwd->sp_inact != -1 &&
          password_age > spwd->sp_max + spwd->sp_inact))
     {

--- a/src/providers/ldap/sdap_access.c
+++ b/src/providers/ldap/sdap_access.c
@@ -412,7 +412,7 @@ static errno_t sdap_account_expired_shadow(struct pam_data *pd,
     }
 
     today = (long) (time(NULL) / (60 * 60 * 24));
-    if (sp_expire > 0 && today > sp_expire) {
+    if (sp_expire > 0 && today >= sp_expire) {
 
         ret = pam_add_response(pd, SSS_PAM_SYSTEM_INFO,
                                sizeof(SHADOW_EXPIRE_MSG),


### PR DESCRIPTION
This brings the behavior of SSSD with regards to account expiry based on
shadow attributes in line with other projects.

Resolves: https://github.com/SSSD/sssd/issues/5873