### PR TITLE
TEST: Add missing polarion requirements to tests

### DIFF
--- a/src/tests/multihost/alltests/test_krb5.py
+++ b/src/tests/multihost/alltests/test_krb5.py
@@ -74,6 +74,7 @@ class TestKrbWithLogin(object):
          queries in a very large environment
         :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1772513
         :id: 74a60320-e48b-11eb-ba19-845cf3eff344
+        :requirement: IDM-SSSD-REQ : LDAP Provider
         :steps:
           1. Start SSSD with any configuration
           2. Call 'getent passwd username@domain'

--- a/src/tests/multihost/ipa/test_subid_ranges.py
+++ b/src/tests/multihost/ipa/test_subid_ranges.py
@@ -1,4 +1,10 @@
-""" Automation of IPA bugs """
+""" Automation of IPA subid feature bugs
+
+:requirement: IDM-IPA-REQ: ipa subid range
+:casecomponent: sssd
+:subsystemteam: sst_idm_sssd
+:upstream: yes
+"""
 
 import pytest
 import subprocess


### PR DESCRIPTION
Some tests were not linked to polarion requirements
The subid tests added recently is linked to
"IDM-IPA-REQ: ipa subid range" in this PR