### PR TITLE
contrib: sssd krb5 configuration snippet

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,6 +57,7 @@ sssdconfdir = $(sysconfdir)/sssd
 sssddatadir = $(datadir)/sssd
 sssdapiplugindir = $(sssddatadir)/sssd.api.d
 sssdtapscriptdir = $(sssddatadir)/systemtap
+krb5snippetsdir = $(sssddatadir)/krb5-snippets
 dbuspolicydir = $(sysconfdir)/dbus-1/system.d
 dbusservicedir = $(datadir)/dbus-1/system-services
 sss_statedir = $(localstatedir)/lib/sss
@@ -4693,6 +4694,8 @@ sssd_krb5_localauth_plugin_la_LDFLAGS = \
     -avoid-version \
     -module
 endif
+
+dist_krb5snippets_DATA = contrib/enable_sssd_conf_dir
 
 sssd_pac_plugin_la_SOURCES = \
     src/sss_client/sssd_pac.c \

--- a/contrib/enable_sssd_conf_dir
+++ b/contrib/enable_sssd_conf_dir
@@ -1,0 +1,5 @@
+# This file should normally be installed by your distribution into a
+# directory that is included from the Kerberos configuration file (/etc/krb5.conf)
+# On Fedora/RHEL/CentOS, this is /etc/krb5.conf.d/
+
+includedir /var/lib/sss/pubconf/krb5.include.d/

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -566,6 +566,10 @@ mkdir -p $RPM_BUILD_ROOT/%{_sysconfdir}/krb5.conf.d
 cp $RPM_BUILD_ROOT/%{_datadir}/sssd-kcm/kcm_default_ccache \
    $RPM_BUILD_ROOT/%{_sysconfdir}/krb5.conf.d/kcm_default_ccache
 
+# krb5 configuration snippet
+cp $RPM_BUILD_ROOT/%{_datadir}/sssd/krb5-snippets/enable_sssd_conf_dir \
+   $RPM_BUILD_ROOT/%{_sysconfdir}/krb5.conf.d/enable_sssd_conf_dir
+
 # Create directory for cifs-idmap alternative
 # Otherwise this directory could not be owned by sssd-client
 mkdir -p $RPM_BUILD_ROOT/%{_sysconfdir}/cifs-utils
@@ -792,6 +796,9 @@ done
 %license COPYING
 %{_libdir}/%{name}/libsss_krb5.so
 %{_mandir}/man5/sssd-krb5.5*
+%config(noreplace) %{_sysconfdir}/krb5.conf.d/enable_sssd_conf_dir
+%dir %{_datadir}/sssd/krb5-snippets
+%{_datadir}/sssd/krb5-snippets/enable_sssd_conf_dir
 
 %files common-pac
 %license COPYING


### PR DESCRIPTION
Add a configuration snippet for krb5 that points to the folder where the
sssd configuration for this service is located. This will enable
passwordless (GSSAPI) ssh to work without any sssd configuration change.

Resolves: https://github.com/SSSD/sssd/issues/5893