### PR TITLE
Monitor: reduce log severity and add error

### DIFF
--- a/src/monitor/monitor_netlink.c
+++ b/src/monitor/monitor_netlink.c
@@ -776,7 +776,8 @@ static void netlink_fd_handler(struct tevent_context *ev, struct tevent_fd *fde,
 
     ret = nl_recvmsgs_default(nlctx->nlp);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Error while reading from netlink fd\n");
+        DEBUG(SSSDBG_OP_FAILURE, "Error while reading from netlink fd: %s\n",
+              nlw_geterror(ret));
         return;
     }
 }


### PR DESCRIPTION
text in case of fail to read from netlink fd.