### PR TITLE
Adding multidomain test cases for bz2013297 and bz2018432

### DIFF
--- a/src/tests/multihost/admultidomain/conftest.py
+++ b/src/tests/multihost/admultidomain/conftest.py
@@ -1,0 +1,164 @@
+
+""" Common AD Fixtures """
+from __future__ import print_function
+import random
+import subprocess
+import time
+import pytest
+import ldap
+import os
+import posixpath
+import pathlib
+# pylint: disable=unused-import
+from sssd.testlib.common.paths import SSSD_DEFAULT_CONF, NSSWITCH_DEFAULT_CONF
+from sssd.testlib.common.qe_class import session_multihost
+from sssd.testlib.common.qe_class import create_testdir
+from sssd.testlib.common.exceptions import SSSDException
+from sssd.testlib.common.utils import ADOperations
+from sssd.testlib.common.exceptions import LdapException
+from sssd.testlib.common.samba import sambaTools
+from sssd.testlib.common.utils import sssdTools
+
+
+def pytest_configure():
+    """ Namespace hook, Adds below dict to pytest namespace """
+    pytest.num_masters = 0
+    pytest.num_ad = 4
+    pytest.num_atomic = 0
+    pytest.num_replicas = 0
+    pytest.num_clients = 1
+    pytest.num_others = 0
+
+
+# ######## Function scoped Fixtures ####################
+@pytest.fixture(scope="function")
+def adjoin(session_multihost, request):
+    """ Join to AD using net ads command """
+    ad_realm = session_multihost.ad[0].realm
+    ad_ip = session_multihost.ad[0].ip
+    ad_host = session_multihost.ad[0].sys_hostname
+    client_ad = sssdTools(session_multihost.client[0], session_multihost.ad[0])
+    client_ad.update_resolv_conf(session_multihost.ad[0])
+    client_ad.systemsssdauth(ad_realm, ad_host)
+    client_ad.disjoin_ad()
+    client_ad.create_kdcinfo(ad_realm, ad_ip)
+    kinit = f'kinit Administrator@{ad_realm}'
+    ad_password = session_multihost.ad[0].ssh_password
+    try:
+        session_multihost.client[0].run_command(kinit, stdin_text=ad_password)
+    except subprocess.CalledProcessError:
+        pytest.fail("kinit failed")
+
+    def _join(membersw=None):
+        """ Join AD """
+        if membersw == 'samba':
+            client_ad.join_ad(ad_realm, ad_password, mem_sw='samba')
+        else:
+            client_ad.join_ad(ad_realm, ad_password)
+
+    def adleave():
+        """ Disjoin AD """
+        client_ad.disjoin_ad()
+        remove_keytab = 'rm -f /etc/krb5.keytab'
+        kdestroy_cmd = 'kdestroy -A'
+        session_multihost.client[0].run_command(kdestroy_cmd)
+        session_multihost.client[0].run_command(remove_keytab)
+    request.addfinalizer(adleave)
+    return _join
+
+
+@pytest.fixture(scope="function")
+def adchildjoin(session_multihost, request):
+    """ Join to AD using net ads command """
+    ad_realm = session_multihost.ad[1].realm
+    ad_ip = session_multihost.ad[1].ip
+    client_ad = sssdTools(session_multihost.client[0], session_multihost.ad[1])
+    client_ad.disjoin_ad()
+    client_ad.create_kdcinfo(ad_realm, ad_ip)
+    kinit = "kinit Administrator@%s" % ad_realm
+    ad_password = session_multihost.ad[1].ssh_password
+    try:
+        session_multihost.client[0].run_command(kinit, stdin_text=ad_password)
+    except subprocess.CalledProcessError:
+        pytest.fail("kinit failed")
+
+    def _join(membersw=None):
+        """ Join AD """
+        if membersw == 'samba':
+            client_ad.join_ad(ad_realm, ad_password, mem_sw='samba')
+        else:
+            client_ad.join_ad(ad_realm, ad_password)
+
+    def adleave():
+        """ Disjoin AD """
+        client_ad.disjoin_ad()
+        remove_keytab = 'rm -f /etc/krb5.keytab'
+        kdestroy_cmd = 'kdestroy -A'
+        session_multihost.client[0].run_command(kdestroy_cmd)
+        session_multihost.client[0].run_command(remove_keytab)
+    request.addfinalizer(adleave)
+    return _join
+
+
+@pytest.fixture(scope='function')
+def backupsssdconf(session_multihost, request):
+    """ Backup and restore sssd.conf """
+    bkup = 'cp -f %s %s.orig' % (SSSD_DEFAULT_CONF,
+                                 SSSD_DEFAULT_CONF)
+    session_multihost.client[0].run_command(bkup)
+    session_multihost.client[0].service_sssd('stop')
+
+    def restoresssdconf():
+        """ Restore sssd.conf """
+        restore = 'cp -f %s.orig %s' % (SSSD_DEFAULT_CONF, SSSD_DEFAULT_CONF)
+        session_multihost.client[0].run_command(restore)
+    request.addfinalizer(restoresssdconf)
+
+
+# ############## class scoped Fixtures ##############################
+@pytest.fixture(scope="class")
+def multihost(session_multihost, request):
+    """ Multihost fixture to be used by tests
+    :param obj session_multihost: multihost object
+    :return obj session_multihost: return multihost object
+    :Exceptions: None
+    """
+    if hasattr(request.cls(), 'class_setup'):
+        request.cls().class_setup(session_multihost)
+        request.addfinalizer(
+            lambda: request.cls().class_teardown(session_multihost))
+    return session_multihost
+
+
+@pytest.fixture(scope="class")
+def clear_sssd_cache(session_multihost):
+    """ Clear sssd cache """
+    client = sssdTools(session_multihost.client[0])
+    client.clear_sssd_cache()
+
+
+# ################### Session scoped fixtures #########################
+@pytest.fixture(scope="session", autouse=True)
+def setup_session(request, session_multihost):
+    """ Setup Session """
+    client = sssdTools(session_multihost.client[0])
+    realm = session_multihost.ad[1].realm
+    ad_host = session_multihost.ad[1].sys_hostname
+    try:
+        master = sssdTools(session_multihost.master[0])
+    except IndexError:
+        pass
+    else:
+        master.server_install_pkgs()
+        master.update_resolv_conf(session_multihost.ad[1].ip)
+    client.client_install_pkgs()
+    client.update_resolv_conf(session_multihost.ad[1].ip)
+    client.clear_sssd_cache()
+    client.systemsssdauth(realm, ad_host)
+
+    def teardown_session():
+        """ Teardown session """
+        session_multihost.client[0].service_sssd('stop')
+        remove_sssd_conf = 'rm -f /etc/sssd/sssd.conf'
+        session_multihost.client[0].run_command(remove_sssd_conf)
+    request.addfinalizer(teardown_session)

--- a/src/tests/multihost/admultidomain/pytest.ini
+++ b/src/tests/multihost/admultidomain/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+markers =
+   admultidomain: Multidomain tests with multiple domains
+   tier1: All tier1 test cases
+   tier2: All tier2 test cases
+   tier3: All tier3 test cases

--- a/src/tests/multihost/admultidomain/readme.rst
+++ b/src/tests/multihost/admultidomain/readme.rst
@@ -1,0 +1,45 @@
+AD Multidomain Provider Test Suite
+======================
+
+This directory contains automation for SSSD AD Provider
+Multi-domain tests.
+
+Fixtures
+========
+
+
+session
+*******
+
+* setup_session: This fixtures does the following tasks:
+
+
+  * Install common required packages like
+  * Updated /etc/resolv.conf with Windows IP Address
+  * Clear sssd cache
+  * Configure system to use sssd authentication
+
+
+* teardown_session: This is not a fixtures but a teardown of ``setup_session``
+
+  * Restores resolv.conf
+  * Stop sssd service
+  * remove sssd.conf
+
+
+class
+*****
+
+* multihost: This fixture returns multihost object. Also using builtin request
+  fixture we pass ``class_setup`` and ``class_teardown``.  If the test suite defines
+  class_setup and class_teardown functions, multihost object will be available
+  to execute any remote functions.
+
+* clear_sssd_cache: Stops sssd service. Removes cache files from
+  ``/var/lib/sss/db`` and starts sssd service. Sleeps for 10 seconds.
+
+* joinad: Join the system to Windows AD using realm with membercli-software
+  being adcli.
+
+* joinad: Join the system to Windows AD using realm with membercli-software
+  being adcli.

--- a/src/tests/multihost/admultidomain/test_multidomain.py
+++ b/src/tests/multihost/admultidomain/test_multidomain.py
@@ -1,0 +1,174 @@
+""" AD-Provider AD Parameters tests ported from bash
+
+:requirement: ad_parameters
+:casecomponent: sssd
+:subsystemteam: sst_idm_sssd
+:upstream: yes
+"""
+import tempfile
+import pytest
+
+from sssd.testlib.common.utils import sssdTools
+from sssd.testlib.common.utils import SSSDException
+from sssd.testlib.common.utils import ADOperations
+
+
+@pytest.fixture(scope="class")
+def change_client_hostname(session_multihost, request):
+    """ Change client hostname to a truncated version in the AD domain"""
+    cmd = session_multihost.client[0].run_command(
+        'hostname', raiseonerr=False)
+    old_hostname = cmd.stdout_text.rstrip()
+    ad_domain = session_multihost.ad[0].domainname
+    session_multihost.client[0].run_command(
+        f'hostname client.{ad_domain}', raiseonerr=False)
+
+    def restore():
+        """ Restore hostname """
+        session_multihost.client[0].run_command(
+            f'hostname {old_hostname}',
+            raiseonerr=False
+        )
+    request.addfinalizer(restore)
+
+
+@pytest.mark.tier1
+@pytest.mark.admultidomain
+@pytest.mark.usefixtures("change_client_hostname")
+class TestADMultiDomain(object):
+
+    @staticmethod
+    def test_0001_bz2013297(multihost, adchildjoin):
+        """
+        :title: IDM-SSSD-TC: ad_provider: forests: disabled root ad domain
+        causes subdomains to be marked offline
+        :id:
+        :setup:
+          1. Configure parent and child domain
+          2. Join client to child domain
+          3. ad_enabled_domains is not configured
+          4. ad_enabled_domains to contain only the child domain
+        :steps:
+          1. Lookup user from child domain
+          2. Lookup user from parent domain
+          3. Change  ad_enabled_domains parameter
+          4. Lookup user from child domain
+          5. Lookup user from parent domain
+        :expectedresults:
+          1. Parent user is found
+          2. Child user is found
+          3. Parent user is not found
+          4. Child user is found
+        :customerscenario: True
+        """
+        adchildjoin(membersw='adcli')
+        ad_domain = multihost.ad[0].domainname
+        ad_child_domain = multihost.ad[1].domainname
+
+        # Configure sssd
+        multihost.client[0].service_sssd('stop')
+        client = sssdTools(multihost.client[0], multihost.ad[1])
+        client.backup_sssd_conf()
+        dom_section = f'domain/{client.get_domain_section_name()}'
+        sssd_params = {
+            'ad_domain': ad_child_domain,
+            'debug_level': '9',
+            'use_fully_qualified_names': 'True',
+            'cache_credentials': 'True',
+        }
+        client.sssd_conf(dom_section, sssd_params)
+        client.clear_sssd_cache()
+
+        # Search for the user in root domain
+        parent_cmd = multihost.client[0].run_command(
+            f'getent passwd user1@{ad_domain}',
+            raiseonerr=False
+        )
+        # Search for the user in child domain
+        child_cmd = multihost.client[0].run_command(
+            f'getent passwd child_user1@{ad_child_domain}',
+            raiseonerr=False
+        )
+
+        client.restore_sssd_conf()
+        client.clear_sssd_cache()
+
+        # Evaluate test results
+        assert parent_cmd.returncode == 0
+        assert child_cmd.returncode == 0
+
+        dom_section = f'domain/{client.get_domain_section_name()}'
+        sssd_params = {
+            'ad_domain': ad_child_domain,
+            'debug_level': '9',
+            'use_fully_qualified_names': 'True',
+            'cache_credentials': 'True',
+            'ad_enabled_domains': ad_child_domain
+        }
+        client.sssd_conf(dom_section, sssd_params)
+        client.clear_sssd_cache()
+
+        # Search for the user in root domain
+        parent_cmd = multihost.client[0].run_command(
+            f'getent passwd user1@{ad_domain}',
+            raiseonerr=False
+        )
+        # Search for the user in child domain
+        child_cmd = multihost.client[0].run_command(
+            f'getent passwd child_user1@{ad_child_domain}',
+            raiseonerr=False
+        )
+
+        client.restore_sssd_conf()
+        client.clear_sssd_cache()
+
+        # Evaluate test results
+        assert parent_cmd.returncode == 2
+        assert child_cmd.returncode == 0
+
+    @staticmethod
+    def test_0002_bz2018432(multihost, adjoin):
+        """
+        :title: IDM-SSSD-TC: ad_provider: forests:  based SSSD adds more AD
+        domains than it should based on the configuration file
+        :id:
+        :setup:
+          1. Configure several domains, this suite contains 4 trusted domains
+          2. Join client to parent domain
+        :steps:
+          1. Perform sssctl domain-list
+        :expectedresults:
+          1. Only trusted domains listed
+        :customerscenario: True
+        """
+        adjoin(membersw='adcli')
+        ad_domain = multihost.ad[0].domainname
+        ad_child_domain = multihost.ad[1].domainname
+        ad_child1_domain = multihost.ad[2].domainname
+        ad_tree_domain = multihost.ad[3].domainname
+
+        # Configure sssd
+        multihost.client[0].service_sssd('stop')
+        client = sssdTools(multihost.client[0], multihost.ad[0])
+        client.backup_sssd_conf()
+        dom_section = f'domain/{client.get_domain_section_name()}'
+        sssd_params = {
+            'ad_domain': ad_domain,
+            'debug_level': '9',
+            'use_fully_qualified_names': 'True',
+            'cache_credentials': 'True'
+        }
+        client.sssd_conf(dom_section, sssd_params)
+        client.clear_sssd_cache()
+        # List domains
+        domain_list_cmd = multihost.client[0].run_command(
+            'sssctl domain-list', raiseonerr=False)
+        ad_count = len(multihost.ad)
+
+        assert str(ad_domain) \
+               and str(ad_child_domain) \
+               and str(ad_child1_domain) \
+               and str(ad_tree_domain) \
+               in domain_list_cmd.stdout_text
+
+        assert (len(domain_list_cmd.stdout_text.split('\n'))-1) == ad_count

--- a/src/tests/multihost/sssd/testlib/common/qe_class.py
+++ b/src/tests/multihost/sssd/testlib/common/qe_class.py
@@ -54,6 +54,13 @@ class QeConfig(pytest_multihost.config.Config):
             log.addHandler(handler)
         return log
 
+    def filter(self, descriptions):
+        """
+        Override default behavior to not filter hosts, so that it can work
+        with dynamic topologies.
+        """
+        return
+
 
 class QeBaseHost(pytest_multihost.host.BaseHost):
     """QeBaseHost subclass of multihost plugin BaseHost class."""
@@ -338,8 +345,11 @@ def session_multihost(request):
     mh.others = mh.domain.hosts_by_role('other')
 
     if pytest.num_ad > 0:
-        mh.domain_ad = mh.config.domains[1]
-        mh.ad = mh.domain_ad.hosts_by_role('ad')
+        mh.ad = []
+        for i in range(1, pytest.num_ad+1):
+            print(i)
+            print(mh.config.domains[i].hosts_by_role('ad'))
+            mh.ad.extend(mh.config.domains[i].hosts_by_role('ad'))
 
     yield mh
 


### PR DESCRIPTION
Created multidomain pytest test suite
- test cases to for bz2013297 and bz2018432 has been added
- testsuite will provision a parent and tree domain and two childs
- qeclass had to be modified to count AD servers outside of a single
      domain for allow pytest-multihost to work.
    
    Signed-off-by: Dan Lavu <dlavu@redhat.com>
