### PR TITLE
Tests: add docstring in intg/test_infopipe.py

### DIFF
--- a/src/tests/intg/test_infopipe.py
+++ b/src/tests/intg/test_infopipe.py
@@ -718,6 +718,13 @@ def test_update_member_list_and_get_all(dbus_system_bus,
 def test_find_by_valid_certificate(dbus_system_bus,
                                    ldap_conn,
                                    add_user_with_cert):
+    """test_find_by_valid_certificate
+
+    :id: 3f212e6e-00ce-44ac-95d4-59925cb5a14a
+    :title: SSSD-TC: Infopipe: Find by valid certificate
+    :casecomponent: sssd
+    :subsystemteam: sst_idm_sssd
+    """
     users_obj = dbus_system_bus.get_object(
         'org.freedesktop.sssd.infopipe',
         '/org/freedesktop/sssd/infopipe/Users')


### PR DESCRIPTION
Adding docstring to test_find_by_valid_certificate to define some
metadata for tracking the test case.

Minimal content needed is:
- :id: <generated UUID>
- :title: SSSD-TC: <Feature or functional area>: <Title of test>
- :casecompoent: sssd
- :subsystemteam: sst_idm_sssd

The first two will differ per tests going forward but, the last two are
defaults needed.

Command used to generate UUID:
python3 -c 'import uuid; print(uuid.uuid4())'