### PR TITLE
intg: remove unused is_secrets_socket()

### DIFF
--- a/src/tests/intg/getsockopt_wrapper.c
+++ b/src/tests/intg/getsockopt_wrapper.c
@@ -28,23 +28,6 @@ static bool is_dbus_socket(int fd)
     return NULL != strstr(unix_socket->sun_path, "system_bus_socket");
 }
 
-static bool is_secrets_socket(int fd)
-{
-    int ret;
-    struct sockaddr_storage addr = { 0 };
-    socklen_t addrlen = sizeof(addr);
-    struct sockaddr_un *unix_socket;
-
-    ret = getsockname(fd, (struct sockaddr *)&addr, &addrlen);
-    if (ret != 0) return false;
-
-    if (addr.ss_family != AF_UNIX) return false;
-
-    unix_socket = (struct sockaddr_un *)&addr;
-
-    return NULL != strstr(unix_socket->sun_path, "secrets.socket");
-}
-
 static bool peer_is_private_pam(int fd)
 {
     int ret;


### PR DESCRIPTION
Use of this function was removed in:
10069b1d39e671b7502c5211883c94ceaa91aebb

```
sssd/build/../src/tests/intg/getsockopt_wrapper.c:31:13: error: ‘is_secrets_socket’ defined but not used [-Werror=unused-function]
   31 | static bool is_secrets_socket(int fd)
```