### PR TITLE
Client ca validation error

### DIFF
--- a/src/man/sssd-ifp.5.xml
+++ b/src/man/sssd-ifp.5.xml
@@ -38,6 +38,22 @@
             to query information about remote users and groups over the
             system bus.
         </para>
+
+    <refsect2 id='valid_certificate'>
+        <title>FIND BY VALID CERTIFICATE</title>
+        <para>
+            The following options can be used to control how the certificates
+            are validated when using the FindByValidCertificate() API:
+            <itemizedlist>
+                <listitem><para>ca_db</para></listitem>
+                <listitem><para>p11_child_timeout</para></listitem>
+                <listitem><para>certificate_verification</para></listitem>
+            </itemizedlist>
+            For more details about the options see
+            <citerefentry><refentrytitle>sssd.conf</refentrytitle>
+            <manvolnum>5</manvolnum></citerefentry>.
+        </para>
+    </refsect2>
     </refsect1>
 
     <refsect1 id='configuration-options'>

--- a/src/p11_child/p11_child_common.c
+++ b/src/p11_child/p11_child_common.c
@@ -147,7 +147,7 @@ int main(int argc, const char *argv[])
     poptContext pc;
     int debug_fd = -1;
     const char *opt_logger = NULL;
-    errno_t ret;
+    errno_t ret = 0;
     TALLOC_CTX *main_ctx = NULL;
     enum op_mode mode = OP_NONE;
     enum pin_mode pin_mode = PIN_NONE;
@@ -382,5 +382,10 @@ fail:
     DEBUG(SSSDBG_CRIT_FAILURE, "p11_child failed!\n");
     close(STDOUT_FILENO);
     talloc_free(main_ctx);
-    return EXIT_FAILURE;
+
+    if (ret == ERR_CA_DB_NOT_FOUND) {
+        return CA_DB_NOT_FOUND_EXIT_CODE;
+    } else {
+        return EXIT_FAILURE;
+    }
 }

--- a/src/p11_child/p11_child_openssl.c
+++ b/src/p11_child/p11_child_openssl.c
@@ -667,9 +667,17 @@ errno_t init_verification(struct p11_ctx *p11_ctx,
 
     if (!X509_LOOKUP_load_file(lookup, p11_ctx->ca_db, X509_FILETYPE_PEM)) {
         err = ERR_get_error();
-        DEBUG(SSSDBG_OP_FAILURE, "X509_LOOKUP_load_file failed [%lu][%s].\n",
-                                 err, ERR_error_string(err, NULL));
-        ret = EIO;
+        DEBUG(SSSDBG_OP_FAILURE,
+              "X509_LOOKUP_load_file [%s] failed [%lu][%s].\n",
+              p11_ctx->ca_db, err, ERR_error_string(err, NULL));
+
+        if (ERR_GET_LIB(err) == ERR_LIB_SYS &&
+            ERR_GET_REASON(err) == ENOENT) {
+            ret = ERR_CA_DB_NOT_FOUND;
+        } else {
+            ret = EIO;
+        }
+
         goto done;
     }
 

--- a/src/sbus/sbus_errors.c
+++ b/src/sbus/sbus_errors.c
@@ -34,6 +34,7 @@ static const struct {
     { SBUS_ERROR_INTERNAL,          ERR_INTERNAL },
     { SBUS_ERROR_NOT_FOUND,         ENOENT },
     { SBUS_ERROR_KILLED,            ERR_SBUS_KILL_CONNECTION },
+    { SBUS_ERROR_NO_CA,             ERR_CA_DB_NOT_FOUND},
 
     /* D-Bus standard errors. Some errno values may overlap, but when
      * finding its D-Bus pair the first match is returned. */

--- a/src/sbus/sbus_errors.h
+++ b/src/sbus/sbus_errors.h
@@ -31,6 +31,7 @@
 #define SBUS_ERROR_INTERNAL         "sbus.Error.Internal"
 #define SBUS_ERROR_NOT_FOUND        "sbus.Error.NotFound"
 #define SBUS_ERROR_KILLED           "sbus.Error.ConnectionKilled"
+#define SBUS_ERROR_NO_CA            "sbus.Error.NoCA"
 #define SBUS_ERROR_ERRNO            "sbus.Error.Errno"
 
 errno_t sbus_error_to_errno(DBusError *error);

--- a/src/util/child_common.h
+++ b/src/util/child_common.h
@@ -36,7 +36,6 @@
 #define CHILD_MSG_CHUNK     256
 
 #define SIGTERM_TO_SIGKILL_TIME 2
-#define CHILD_TIMEOUT_EXIT_CODE 7
 
 struct response {
     uint8_t *buf;

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -114,7 +114,11 @@ extern int dbus_activated;
 #define FLAGS_GEN_CONF 0x0008
 #define FLAGS_NO_WATCHDOG 0x0010
 
-#define SSS_WATCHDOG_EXIT_CODE 70 /* to match EX_SOFTWARE in sysexits.h */
+enum sssd_exit_status {
+    CHILD_TIMEOUT_EXIT_CODE = 7,
+    CA_DB_NOT_FOUND_EXIT_CODE = 50,
+    SSS_WATCHDOG_EXIT_CODE = 70 /* to match EX_SOFTWARE in sysexits.h */
+};
 
 #define PIPE_INIT { -1, -1 }
 

--- a/src/util/util_errors.c
+++ b/src/util/util_errors.c
@@ -146,6 +146,8 @@ struct err_string error_to_str[] = {
 
     { "TLS handshake was interrupted"}, /* ERR_TLS_HANDSHAKE_INTERRUPTED */
 
+    { "Certificate authority file not found"}, /* ERR_CA_DB_NOT_FOUND */
+
     { "ERR_LAST" } /* ERR_LAST */
 };
 

--- a/src/util/util_errors.h
+++ b/src/util/util_errors.h
@@ -167,6 +167,8 @@ enum sssd_errors {
 
     ERR_TLS_HANDSHAKE_INTERRUPTED,
 
+    ERR_CA_DB_NOT_FOUND,
+
     ERR_LAST            /* ALWAYS LAST */
 };
 


### PR DESCRIPTION
Improve the error handling for FindByValidCertificate() by returning a
specific exception ID when the certificate authority file is missing.
Moreover, the log lines have been changed to point to p11_child logs
when an unknown error happens.

Moreover, a new test case has been created for the certificate authority
file missing situation.

Finally, include a reference to ca_db, p11_child_timeout and
certificate_verification in sssd-ifp man page. These options can used be
to control how the certificates are validated with
FindByValidCertificate() API.

Resolves: https://github.com/SSSD/sssd/issues/5911