### PR TITLE
test: fix pep8 complaint

### DIFF
--- a/src/tests/multihost/admultidomain/test_multidomain.py
+++ b/src/tests/multihost/admultidomain/test_multidomain.py
@@ -166,9 +166,9 @@ class TestADMultiDomain(object):
         ad_count = len(multihost.ad)
 
         assert str(ad_domain) \
-               and str(ad_child_domain) \
-               and str(ad_child1_domain) \
-               and str(ad_tree_domain) \
-               in domain_list_cmd.stdout_text
+            and str(ad_child_domain) \
+            and str(ad_child1_domain) \
+            and str(ad_tree_domain) \
+            in domain_list_cmd.stdout_text
 
         assert (len(domain_list_cmd.stdout_text.split('\n'))-1) == ad_count


### PR DESCRIPTION
Fix pep8 complaint about over-indentation in test_multidomain.py file. I
guess this is only happening in RHEL8 and Debian because the tool was
forked to pycodestyle, only it is being updated and pycodestyle isn't
available for those distributions from the package manager.