### PR TITLE
ad: add required 'cn' attribute to subdomain object

### DIFF
--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -1646,6 +1646,13 @@ static void ad_check_root_domain_done(struct tevent_req *subreq)
         goto done;
     }
 
+    ret = sysdb_attrs_add_string(state->reply[0], AD_AT_DOMAIN_NAME,
+                                 state->forest);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sysdb_attrs_add_string() failed.\n");
+        goto done;
+    }
+
     err = sss_idmap_sid_to_bin_sid(state->idmap_ctx->map, id,
                                    &id_val.data, &id_val.length);
     if (err != IDMAP_SUCCESS) {


### PR DESCRIPTION
If the forest root is not part of the return trusted domain objects
from the local domain controller we generate an object for further
processing. During this processing it is expected that the 'cn'
attribute is set and contains the name of the forest root. So far this
attribute was missing and it is now added by this patch.

Resolves: https://github.com/SSSD/sssd/issues/5926