### PR TITLE
Fix for test bz1294670

### DIFF
--- a/src/tests/multihost/alltests/test_sudo.py
+++ b/src/tests/multihost/alltests/test_sudo.py
@@ -56,7 +56,7 @@ class TestSudo(object):
                 ssh = SSHClient(multihost.client[0].sys_hostname,
                                 username=user, password='Secret123')
             except paramiko.ssh_exception.AuthenticationException:
-                pytest.fail("Authentication Failed as user %s" % (localuser))
+                pytest.fail("Authentication Failed as user %s" % (user))
             else:
                 for count in range(1, 10):
                     sudo_cmd = 'sudo fdisk -l'

--- a/src/tests/multihost/alltests/test_sudo.py
+++ b/src/tests/multihost/alltests/test_sudo.py
@@ -63,7 +63,7 @@ class TestSudo(object):
                     (_, _, _) = ssh.execute_cmd(args=sudo_cmd)
                     sudo_cmd = 'sudo ls -l /usr/sbin/'
                     (_, _, _) = ssh.execute_cmd(args=sudo_cmd)
-            ssh.close()
+                ssh.close()
         pkill = 'pkill tcpdump'
         multihost.client[0].run_command(pkill)
         for user in localusers.keys():


### PR DESCRIPTION
test_bz1294670 in src/tests/multihost/alltests/test_sudo.py had 2 problems:

1) Wrong variable used in line 59 where there does not exist any variable named 'localuser', it should be 'user' from line 48.
2) Wrong indentation of ssh.close() on line 66, should be aligned with the indentation of 'ssh' variable declaration on line 56.