### PR TITLE
ipa: fix reply socket of selinux_child

### DIFF
--- a/src/providers/ipa/ipa_selinux.c
+++ b/src/providers/ipa/ipa_selinux.c
@@ -714,7 +714,7 @@ static errno_t selinux_fork_child(struct selinux_child_state *state)
     if (pid == 0) { /* child */
         exec_child_ex(state, pipefd_to_child, pipefd_from_child,
                       SELINUX_CHILD, SELINUX_CHILD_LOG_FILE, extra_args,
-                      false, STDIN_FILENO, STDERR_FILENO);
+                      false, STDIN_FILENO, STDOUT_FILENO);
         DEBUG(SSSDBG_CRIT_FAILURE, "Could not exec selinux_child: [%d][%s].\n",
               ret, sss_strerror(ret));
         return ret;


### PR DESCRIPTION
Commit c92d39a30fa0162d4efdfbe5883c8ea9911a2249 accidentally switched
the reply socket of selinux_child from stdout to stderr while switching
from exec_child to exec_child_ex. This patch returns the original
behavior.

Resolves: https://github.com/SSSD/sssd/issues/5939