### PR TITLE
INTG: Restrict smartcard in sc auth tests

### DIFF
--- a/src/responder/pam/pamsrv_p11.c
+++ b/src/responder/pam/pamsrv_p11.c
@@ -719,7 +719,7 @@ struct tevent_req *pam_check_cert_send(TALLOC_CTX *mem_ctx,
     struct timeval tv;
     int pipefd_to_child[2] = PIPE_INIT;
     int pipefd_from_child[2] = PIPE_INIT;
-    const char *extra_args[18] = { NULL };
+    const char *extra_args[19] = { NULL };
     uint8_t *write_buf = NULL;
     size_t write_buf_len = 0;
     size_t arg_c;

--- a/src/tests/cmocka/test_pam_srv.c
+++ b/src/tests/cmocka/test_pam_srv.c
@@ -289,6 +289,7 @@ static int pam_test_setup(void **state)
     };
 
     struct sss_test_conf_param pam_params[] = {
+        { CONFDB_PAM_P11_URI, "pkcs11:manufacturer=SoftHSM%20project" },
         { "p11_child_timeout", "30" },
         { "pam_cert_verification", NULL },
         { NULL, NULL },             /* Sentinel */
@@ -3105,7 +3106,7 @@ void test_pam_preauth_ocsp_no_ocsp(void **state)
     };
 
     struct sss_test_conf_param pam_params[] = {
-        { CONFDB_PAM_P11_URI, NULL },
+        { CONFDB_PAM_P11_URI, "pkcs11:manufacturer=SoftHSM%20project" },
         { NULL, NULL },             /* Sentinel */
     };
 

--- a/src/tests/intg/test_pam_responder.py
+++ b/src/tests/intg/test_pam_responder.py
@@ -134,6 +134,8 @@ def format_pam_cert_auth_conf(config):
         pam_p11_allowed_services = +pam_sss_service, +pam_sss_sc_required, \
                                    +pam_sss_try_sc, +pam_sss_allow_missing_name
         pam_cert_db_path = {config.PAM_CERT_DB_PATH}
+        p11_uri = pkcs11:manufacturer=SoftHSM%20project; \
+                  token=SSSD%20Test%20Token
         p11_child_timeout = 5
         p11_wait_for_card_timeout = 5
         debug_level = 10
@@ -164,6 +166,8 @@ def format_pam_cert_auth_conf_name_format(config):
         pam_p11_allowed_services = +pam_sss_service, +pam_sss_sc_required, \
                                    +pam_sss_try_sc, +pam_sss_allow_missing_name
         pam_cert_db_path = {config.PAM_CERT_DB_PATH}
+        p11_uri = pkcs11:manufacturer=SoftHSM%20project; \
+                  token=SSSD%20Test%20Token
         p11_child_timeout = 5
         p11_wait_for_card_timeout = 5
         debug_level = 10


### PR DESCRIPTION
Smartcard auth related tests can fail when integration tests are run on a machine(F34) with a yubikey inserted. Add a `p11_uri` option to filter only the softhsm2-used integration test cards.