### PR TITLE
ad: do not write kdc info file for GC lookup

### DIFF
--- a/src/providers/ad/ad_common.c
+++ b/src/providers/ad/ad_common.c
@@ -1084,7 +1084,8 @@ ad_resolve_callback(void *private_data, struct fo_server *server)
         goto done;
     }
 
-    if (service->krb5_service->write_kdcinfo) {
+    if (service->krb5_service->write_kdcinfo && !(sdata != NULL && sdata->gc)) {
+        /* write KDC info file only if this is not GC lookup */
         ret = write_krb5info_file_from_fo_server(service->krb5_service,
                                                  server,
                                                  true,


### PR DESCRIPTION
:fixes: When authenticating AD users, backtrace was triggered even
though everything was working correctly. This was caused by a search
in the global catalog. Servers from the global catalog are filtered
out of the list before writing the KDC info file. With this fix,
SSSD does not attempt to write to the KDC info file when performing
a GC lookup.

Resolves: https://github.com/SSSD/sssd/issues/5956