### PR TITLE
sdap: record time needed for a sdap operation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1271,6 +1271,7 @@ libsss_util_la_SOURCES = \
     src/util/sss_chain_id.c \
     src/util/nss_dl_load.c \
     src/util/nss_dl_load_extra.c \
+    src/util/sss_time.c \
     $(NULL)
 libsss_util_la_CFLAGS = \
     $(AM_CFLAGS) \

--- a/src/man/include/debug_levels.xml
+++ b/src/man/include/debug_levels.xml
@@ -78,6 +78,13 @@
          <emphasis>0x4000</emphasis>: Extremely low-level tracing information.
     </para>
     <para>
+         <emphasis>9</emphasis>,
+         <emphasis>0x20000</emphasis>: Performance and statistical data,
+         please note that due to the way requests are processed internally the
+         logged execution time of a request might be longer than it actually
+	 was.
+    </para>
+    <para>
          <emphasis>10</emphasis>,
          <emphasis>0x10000</emphasis>: Even more low-level libldb tracing
          information. Almost never really required.

--- a/src/providers/data_provider/dp_request.c
+++ b/src/providers/data_provider/dp_request.c
@@ -40,6 +40,7 @@ struct dp_req {
     struct dp_method *execute;
     const char *name;
     uint32_t num;
+    uint64_t start_time;
 
     struct tevent_req *req;
     struct tevent_req *handler_req;
@@ -189,6 +190,8 @@ dp_req_new(TALLOC_CTX *mem_ctx,
         talloc_free(dp_req);
         return ret;
     }
+
+    dp_req->start_time = get_start_time();
 
     /* Now the request is created. We will return it even in case of error
      * so we can get better debug messages. */
@@ -396,6 +399,9 @@ static void dp_req_done(struct tevent_req *subreq)
 
     DP_REQ_DEBUG(SSSDBG_TRACE_FUNC, state->dp_req->name,
                  "Request handler finished [%d]: %s", ret, sss_strerror(ret));
+    DP_REQ_DEBUG(SSSDBG_PERF_STAT, state->dp_req->name,
+                 "Handling request took %s.",
+                 sss_format_time(get_spend_time_us(state->dp_req->start_time)));
 
     if (ret != EOK) {
         tevent_req_error(req, ret);

--- a/src/providers/ipa/ipa_s2n_exop.c
+++ b/src/providers/ipa/ipa_s2n_exop.c
@@ -181,7 +181,7 @@ static struct tevent_req *ipa_s2n_exop_send(TALLOC_CTX *mem_ctx,
                                   msgid);
 
     stat_info = talloc_asprintf(state, "server: [%s] %s",
-                                sdap_get_server_ip_str(state->sh),
+                                sdap_get_server_ip_str_safe(state->sh),
                                 stat_info_in != NULL ? stat_info_in
                                                      : "IPA EXOP");
     if (stat_info == NULL) {

--- a/src/providers/ipa/ipa_s2n_exop.c
+++ b/src/providers/ipa/ipa_s2n_exop.c
@@ -162,7 +162,7 @@ static struct tevent_req *ipa_s2n_exop_send(TALLOC_CTX *mem_ctx,
     DEBUG(SSSDBG_TRACE_INTERNAL, "ldap_extended_operation sent, msgid = %d\n",
                                   msgid);
 
-    ret = sdap_op_add(state, ev, state->sh, msgid, ipa_s2n_exop_done, req,
+    ret = sdap_op_add(state, ev, state->sh, msgid, NULL, ipa_s2n_exop_done, req,
                       timeout, &state->op);
     if (ret) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Failed to set up operation!\n");

--- a/src/providers/ipa/ipa_s2n_exop.c
+++ b/src/providers/ipa/ipa_s2n_exop.c
@@ -227,7 +227,7 @@ static void ipa_s2n_exop_done(struct sdap_op *op,
                             NULL, 0);
     if (ret != LDAP_SUCCESS) {
         DEBUG(SSSDBG_OP_FAILURE, "ldap_parse_result failed (%d)\n",
-                                 state->op->msgid);
+                                 sdap_op_get_msgid(state->op));
         ret = ERR_NETWORK_IO;
         goto done;
     }

--- a/src/providers/ldap/sdap.h
+++ b/src/providers/ldap/sdap.h
@@ -45,6 +45,7 @@ struct sdap_op {
     uint64_t chain_id;
 
     int msgid;
+    char *stat_info;
     uint64_t start_time;
     bool done;
 

--- a/src/providers/ldap/sdap.h
+++ b/src/providers/ldap/sdap.h
@@ -39,25 +39,6 @@ typedef void (sdap_op_callback_t)(struct sdap_op *op,
 
 struct sdap_handle;
 
-struct sdap_op {
-    struct sdap_op *prev, *next;
-    struct sdap_handle *sh;
-    uint64_t chain_id;
-
-    int msgid;
-    char *stat_info;
-    uint64_t start_time;
-    int timeout;
-    bool done;
-
-    sdap_op_callback_t *callback;
-    void *data;
-
-    struct tevent_context *ev;
-    struct sdap_msg *list;
-    struct sdap_msg *last;
-};
-
 struct fd_event_item {
     struct fd_event_item *prev;
     struct fd_event_item *next;

--- a/src/providers/ldap/sdap.h
+++ b/src/providers/ldap/sdap.h
@@ -45,6 +45,7 @@ struct sdap_op {
     uint64_t chain_id;
 
     int msgid;
+    uint64_t start_time;
     bool done;
 
     sdap_op_callback_t *callback;

--- a/src/providers/ldap/sdap.h
+++ b/src/providers/ldap/sdap.h
@@ -47,6 +47,7 @@ struct sdap_op {
     int msgid;
     char *stat_info;
     uint64_t start_time;
+    int timeout;
     bool done;
 
     sdap_op_callback_t *callback;

--- a/src/providers/ldap/sdap_async.c
+++ b/src/providers/ldap/sdap_async.c
@@ -29,6 +29,30 @@
 
 #define REPLY_REALLOC_INCREMENT 10
 
+struct sdap_op {
+    struct sdap_op *prev, *next;
+    struct sdap_handle *sh;
+    uint64_t chain_id;
+
+    int msgid;
+    char *stat_info;
+    uint64_t start_time;
+    int timeout;
+    bool done;
+
+    sdap_op_callback_t *callback;
+    void *data;
+
+    struct tevent_context *ev;
+    struct sdap_msg *list;
+    struct sdap_msg *last;
+};
+
+int sdap_op_get_msgid(struct sdap_op *op)
+{
+    return op != NULL ? op->msgid : 0;
+}
+
 /* ==LDAP-Memory-Handling================================================= */
 
 static int lmsg_destructor(void *mem)

--- a/src/providers/ldap/sdap_async.c
+++ b/src/providers/ldap/sdap_async.c
@@ -677,7 +677,8 @@ struct tevent_req *sdap_exop_modify_passwd_send(TALLOC_CTX *memctx,
           "ldap_extended_operation sent, msgid = %d\n", msgid);
 
     stat_info = talloc_asprintf(state, "server: [%s] modify passwd dn: [%s]",
-                                sdap_get_server_ip_str(state->sh), user_dn);
+                                sdap_get_server_ip_str_safe(state->sh),
+                                user_dn);
     if (stat_info == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to create info string, ignored.\n");
     }
@@ -848,7 +849,8 @@ sdap_modify_send(TALLOC_CTX *mem_ctx,
     }
 
     stat_info = talloc_asprintf(state, "server: [%s] modify dn: [%s] attr: [%s]",
-                                sdap_get_server_ip_str(state->sh), dn, attr);
+                                sdap_get_server_ip_str_safe(state->sh), dn,
+                                attr);
     if (stat_info == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to create info string, ignored.\n");
     }
@@ -1387,6 +1389,12 @@ const char *sdap_get_server_ip_str(struct sdap_handle *sh)
     return out;
 }
 
+const char *sdap_get_server_ip_str_safe(struct sdap_handle *sh)
+{
+    const char *ip = sdap_get_server_ip_str(sh);
+    return ip != NULL ? ip : "- IP not available -";
+}
+
 static void sdap_print_server(struct sdap_handle *sh)
 {
     const char *ip;
@@ -1650,7 +1658,7 @@ static errno_t sdap_get_generic_ext_step(struct tevent_req *req)
     DEBUG(SSSDBG_TRACE_INTERNAL, "ldap_search_ext called, msgid = %d\n", msgid);
 
     stat_info = talloc_asprintf(state, "server: [%s] filter: [%s] base: [%s]",
-                                sdap_get_server_ip_str(state->sh),
+                                sdap_get_server_ip_str_safe(state->sh),
                                 state->filter, state->search_base);
     if (stat_info == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to create info string, ignored.\n");

--- a/src/providers/ldap/sdap_async_connection.c
+++ b/src/providers/ldap/sdap_async_connection.c
@@ -339,7 +339,7 @@ static void sdap_sys_connect_done(struct tevent_req *subreq)
     }
 
     stat_info = talloc_asprintf(state, "server: [%s] START TLS",
-                                sdap_get_server_ip_str(state->sh));
+                                sdap_get_server_ip_str_safe(state->sh));
     if (stat_info == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to create info string, ignored.\n");
     }
@@ -721,7 +721,7 @@ static struct tevent_req *simple_bind_send(TALLOC_CTX *memctx,
     }
 
     stat_info = talloc_asprintf(state, "server: [%s] simple bind: [%s]",
-                                sdap_get_server_ip_str(state->sh),
+                                sdap_get_server_ip_str_safe(state->sh),
                                 state->user_dn);
     if (stat_info == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to create info string, ignored.\n");

--- a/src/providers/ldap/sdap_async_connection.c
+++ b/src/providers/ldap/sdap_async_connection.c
@@ -394,7 +394,7 @@ static void sdap_connect_done(struct sdap_op *op,
                             &state->result, NULL, &errmsg, NULL, NULL, 0);
     if (ret != LDAP_SUCCESS) {
         DEBUG(SSSDBG_OP_FAILURE,
-              "ldap_parse_result failed (%d)\n", state->op->msgid);
+              "ldap_parse_result failed (%d)\n", sdap_op_get_msgid(state->op));
         tevent_req_error(req, EIO);
         return;
     }
@@ -777,7 +777,7 @@ static void simple_bind_done(struct sdap_op *op,
                             &response_controls, 0);
     if (lret != LDAP_SUCCESS) {
         DEBUG(SSSDBG_MINOR_FAILURE,
-              "ldap_parse_result failed (%d)\n", state->op->msgid);
+              "ldap_parse_result failed (%d)\n", sdap_op_get_msgid(state->op));
         ret = ERR_INTERNAL;
         goto done;
     }

--- a/src/providers/ldap/sdap_async_connection.c
+++ b/src/providers/ldap/sdap_async_connection.c
@@ -340,7 +340,7 @@ static void sdap_sys_connect_done(struct tevent_req *subreq)
     ret = sdap_set_connected(state->sh, state->ev);
     if (ret) goto fail;
 
-    ret = sdap_op_add(state, state->ev, state->sh, msgid,
+    ret = sdap_op_add(state, state->ev, state->sh, msgid, NULL,
                       sdap_connect_done, req,
                       dp_opt_get_int(state->opts->basic, SDAP_OPT_TIMEOUT),
                       &state->op);
@@ -712,7 +712,7 @@ static struct tevent_req *simple_bind_send(TALLOC_CTX *memctx,
         if (ret) goto fail;
     }
 
-    ret = sdap_op_add(state, ev, sh, msgid,
+    ret = sdap_op_add(state, ev, sh, msgid, NULL,
                       simple_bind_done, req, timeout, &state->op);
     if (ret) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Failed to set up operation!\n");

--- a/src/providers/ldap/sdap_async_private.h
+++ b/src/providers/ldap/sdap_async_private.h
@@ -73,7 +73,12 @@ int sdap_get_rootdse_recv(struct tevent_req *req,
 
 errno_t deref_string_to_val(const char *str, int *val);
 
+/* Extract server IP from sdap_handle and return it as string or NULL in case
+ * of an error */
 const char *sdap_get_server_ip_str(struct sdap_handle *sh);
+
+/* Same as sdap_get_server_ip_str() but always returns a strings */
+const char *sdap_get_server_ip_str_safe(struct sdap_handle *sh);
 
 /* from sdap_child_helpers.c */
 

--- a/src/providers/ldap/sdap_async_private.h
+++ b/src/providers/ldap/sdap_async_private.h
@@ -57,7 +57,7 @@ errno_t sdap_set_connected(struct sdap_handle *sh, struct tevent_context *ev);
 errno_t sdap_call_conn_cb(const char *uri,int fd, struct sdap_handle *sh);
 
 int sdap_op_add(TALLOC_CTX *memctx, struct tevent_context *ev,
-                struct sdap_handle *sh, int msgid,
+                struct sdap_handle *sh, int msgid, const char *stat_info,
                 sdap_op_callback_t *callback, void *data,
                 int timeout, struct sdap_op **_op);
 

--- a/src/providers/ldap/sdap_async_private.h
+++ b/src/providers/ldap/sdap_async_private.h
@@ -56,6 +56,8 @@ errno_t sdap_set_connected(struct sdap_handle *sh, struct tevent_context *ev);
 
 errno_t sdap_call_conn_cb(const char *uri,int fd, struct sdap_handle *sh);
 
+int sdap_op_get_msgid(struct sdap_op *op);
+
 int sdap_op_add(TALLOC_CTX *memctx, struct tevent_context *ev,
                 struct sdap_handle *sh, int msgid, const char *stat_info,
                 sdap_op_callback_t *callback, void *data,

--- a/src/providers/ldap/sdap_async_private.h
+++ b/src/providers/ldap/sdap_async_private.h
@@ -71,6 +71,8 @@ int sdap_get_rootdse_recv(struct tevent_req *req,
 
 errno_t deref_string_to_val(const char *str, int *val);
 
+const char *sdap_get_server_ip_str(struct sdap_handle *sh);
+
 /* from sdap_child_helpers.c */
 
 struct tevent_req *sdap_get_tgt_send(TALLOC_CTX *mem_ctx,

--- a/src/tests/debug-tests.c
+++ b/src/tests/debug-tests.c
@@ -50,7 +50,7 @@ START_TEST(test_debug_convert_old_level_old_format)
         SSSDBG_TRACE_FUNC,
         SSSDBG_TRACE_LIBS,
         SSSDBG_TRACE_INTERNAL,
-        SSSDBG_TRACE_ALL | SSSDBG_BE_FO,
+        SSSDBG_TRACE_ALL | SSSDBG_BE_FO | SSSDBG_PERF_STAT,
         SSSDBG_TRACE_LDB
     };
 

--- a/src/util/debug.c
+++ b/src/util/debug.c
@@ -191,7 +191,7 @@ int debug_convert_old_level(int old_level)
         new_level |= SSSDBG_TRACE_INTERNAL;
 
     if (old_level >= 9)
-        new_level |= SSSDBG_TRACE_ALL | SSSDBG_BE_FO;
+        new_level |= SSSDBG_TRACE_ALL | SSSDBG_BE_FO | SSSDBG_PERF_STAT;
 
     if (old_level >= 10)
         new_level |= SSSDBG_TRACE_LDB;

--- a/src/util/debug.h
+++ b/src/util/debug.h
@@ -112,13 +112,14 @@ int rotate_debug_files(void);
 #define SSSDBG_TRACE_ALL      0x4000   /* level 9 */
 #define SSSDBG_BE_FO          0x8000   /* level 9 */
 #define SSSDBG_TRACE_LDB     0x10000   /* level 10 */
+#define SSSDBG_PERF_STAT     0x20000   /* level 9 */
 
 /* IMPORTANT_INFO will be logged if any of bits >=  OP_FAILURE are on: */
 #define SSSDBG_IMPORTANT_INFO (SSSDBG_OP_FAILURE|SSSDBG_MINOR_FAILURE|\
                                SSSDBG_CONF_SETTINGS|SSSDBG_FUNC_DATA|\
                                SSSDBG_TRACE_FUNC|SSSDBG_TRACE_LIBS|\
                                SSSDBG_TRACE_INTERNAL|SSSDBG_TRACE_ALL|\
-                               SSSDBG_BE_FO|SSSDBG_TRACE_LDB)
+                               SSSDBG_BE_FO|SSSDBG_TRACE_LDB|SSSDBG_PERF_STAT)
 
 #define SSSDBG_INVALID        -1
 #define SSSDBG_UNRESOLVED      0

--- a/src/util/sss_time.c
+++ b/src/util/sss_time.c
@@ -1,0 +1,76 @@
+/*
+   SSSD - time utils
+
+   Copyright (C) Sumit Bose <sbose@redhat.com> 2021
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "util/util.h"
+
+#define TV_TO_US(tv) ((tv).tv_sec * 1000000 + (tv).tv_usec)
+
+uint64_t get_start_time()
+{
+    struct timeval tv;
+
+    if (gettimeofday(&tv, NULL) != 0) {
+        DEBUG(SSSDBG_OP_FAILURE, "gettimeofday failed.\n");
+        return 0;
+    }
+
+    return TV_TO_US(tv);
+}
+
+const char *sss_format_time(uint64_t us)
+{
+    static char out[128];
+    int ret;
+
+    if (us == 0) {
+        return "[- unavailable -]";
+    }
+
+    ret = snprintf(out, sizeof(out), "[%.3f] milliseconds", (double) us/1000);
+    if (ret < 0 || ret >= sizeof(out)) {
+        return "[- formatting error -]";
+    }
+
+    return out;
+}
+
+uint64_t get_spend_time_us(uint64_t st)
+{
+    struct timeval tv;
+    uint64_t time_now;
+
+    if (st == 0) {
+        DEBUG(SSSDBG_OP_FAILURE, "Missing start time.\n");
+        return 0;
+    }
+
+    if (gettimeofday(&tv, NULL) != 0) {
+        DEBUG(SSSDBG_OP_FAILURE, "gettimeofday failed.\n");
+        return 0;
+    }
+
+    time_now = TV_TO_US(tv);
+
+    if (st > time_now) {
+        DEBUG(SSSDBG_OP_FAILURE, "Start time in future.\n");
+        return 0;
+    }
+
+    return time_now - st;
+}

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -794,4 +794,10 @@ errno_t sss_getenv(TALLOC_CTX *mem_ctx,
                    const char *default_value,
                    char **_value);
 
+/* from sss_time.c */
+uint64_t get_start_time(void);
+
+const char *sss_format_time(uint64_t us);
+uint64_t get_spend_time_us(uint64_t st);
+
 #endif /* __SSSD_UTIL_H__ */


### PR DESCRIPTION
The start time of an sdap operation is stored to calculate the spend time
when the operation finished. This spend time is an upper limit for the time
the underlying LDAP operation took. The actual time of the LDAP operation
might be shorter. This might happen is many sdap operations are running in
parallel and the given operation has to wait for processing due to the
asynchronous handling of the operations.

To easy identify LDAP request which are running longer than expected all 
requests needing 80% of there timeout are recorded wit h log level 
SSSDBG_IMPORTANT_INFO.

The threshold of 80% is currently hard-coded.

Please note that due to the asynchronous processing in the backend some 
requests might be logged with a long execution time not because they need
the recorded time but because their processing is delayed by another
request which was processed before.

Resolves: https://github.com/SSSD/sssd/issues/5967