### PR TITLE
ci: build pull requests in copr

### DIFF
--- a/.github/actions/build-sssd-srpm/action.yml
+++ b/.github/actions/build-sssd-srpm/action.yml
@@ -1,0 +1,38 @@
+name: Build SSSD's source rpm
+inputs:
+  version:
+    description: Package version.
+    required: true
+  release:
+    description: Package release.
+    required: false
+    default: '${{ github.run_number }}'
+outputs:
+  file:
+    description: Source rpm file name.
+    value: ${{ steps.srpm.outputs.file }}
+  path:
+    description: Path to the source rpm.
+    value: ${{ steps.srpm.outputs.path }}
+runs:
+  using: 'composite'
+  steps:
+  - name: Generate tarball and spec file
+    shell: bash
+    run: |
+      version="${{ inputs.version }}"
+      release="${{ inputs.release }}"
+      name="sssd-$version"
+      tar -cvzf "$name.tar.gz" --transform "s,^,$name/," *
+
+      cp contrib/sssd.spec.in ./sssd.spec
+
+      sed -iE "s/@PACKAGE_NAME@/sssd/g" ./sssd.spec
+      sed -iE "s/@PACKAGE_VERSION@/$version/g" ./sssd.spec
+      sed -iE "s/@PRERELEASE_VERSION@/$release/g" ./sssd.spec
+  - name: Build source rpm
+    id: srpm
+    uses: SSSD/action-build-srpm@master
+    with:
+      tarball: sssd-${{ inputs.version }}.tar.gz
+      specfile: sssd.spec

--- a/.github/workflows/copr_build.yml
+++ b/.github/workflows/copr_build.yml
@@ -1,0 +1,126 @@
+# Build project in Fedora copr with multiple chroots.
+#
+# The project is build for each pull request and it will be availale in copr as
+# @sssd/pr#number. If the build is successful, it can be then installed with:
+# dnf copr enable @sssd/pr#number.
+#
+# The project is automatically deleted after 60 days or after the pull request
+# is closed, whatever happens first. It is rebuild with each pull request
+# update.
+#
+# The source rpm used to build the project in copr is attached as an artifact to
+# this check.
+#
+# Simplified flow:
+# - build srpm (rvn == sssd-pr#number-#runid) and upload it as an artifact
+# - obtain list of desired chroots
+# - create copr project @sssd/pr#number
+# - cancel previous pending builds
+# - build project - there is one job (and one commit status) per chroot
+
+name: copr
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+env:
+  COPR_ACCOUNT: '@sssd'
+  COPR_PROJECT: pr${{ github.event.pull_request.number }}
+  PR_ID: ${{ github.event.pull_request.number }}
+  PR_URL: ${{ github.event.pull_request.html_url }}
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      srpm: ${{ steps.srpm.outputs.file }}
+      chroots_json: ${{ steps.chroots.outputs.json }}
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+    - name: Build source rpm
+      id: srpm
+      uses: ./.github/actions/build-sssd-srpm
+      with:
+        version: ${{ env.COPR_PROJECT }}
+
+    - name: Upload source rpm as an artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ steps.srpm.outputs.file }}
+        path: ${{ steps.srpm.outputs.path }}
+
+    - name: Initialize copr actions
+      id: copr
+      uses: SSSD/action-copr/init@master
+      with:
+        token: ${{ secrets.COPR_SECRETS }}
+
+    - name: Get copr chroots
+      id: chroots
+      uses: SSSD/action-copr/filter-chroots@master
+      with:
+        coprcfg: ${{ secrets.COPR_SECRETS }}
+        filter: "fedora-.+-x86_64|centos-stream-9-x86_64"
+        exclude: "fedora-eln-.+"
+
+    - name: Create copr project
+      uses: SSSD/action-copr/create-project@master
+      with:
+        coprcfg: ${{ steps.copr.outputs.coprcfg }}
+        chroots: ${{ steps.chroots.outputs.list }}
+        project: ${{ env.COPR_PROJECT }}
+        account: ${{ env.COPR_ACCOUNT }}
+        description: 'Development package for [sssd pull request #${{ env.PR_ID }}](${{ env.PR_URL }}).'
+        instructions: 'Use this for test purpose only. Do not use this in production.'
+
+    - name: Cancel pending builds
+      uses: SSSD/action-copr/cancel-builds@master
+      with:
+        coprcfg: ${{ steps.copr.outputs.coprcfg }}
+        project: ${{ env.COPR_PROJECT }}
+        account: ${{ env.COPR_ACCOUNT }}
+
+    - name: Add buildroot repository to CentOS Stream
+      env:
+        coprcfg: ${{ steps.copr.outputs.coprcfg }}
+      run: |
+        copr-cli --config "$coprcfg" edit-chroot                                                  \
+          --repos 'https://kojihub.stream.centos.org/kojifiles/repos/c9s-build/latest/$basearch/' \
+          $COPR_ACCOUNT/$COPR_PROJECT/centos-stream-9-x86_64
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [prepare]
+    strategy:
+      matrix:
+        chroot: ${{ fromJson(needs.prepare.outputs.chroots_json) }}
+      fail-fast: false
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v2
+
+    - name: Downlooad source rpm
+      uses: actions/download-artifact@v2
+      with:
+        name: ${{ needs.prepare.outputs.srpm }}
+        path: .
+
+    - name: Initialize copr actions
+      id: copr
+      uses: SSSD/action-copr/init@master
+      with:
+        token: ${{ secrets.COPR_SECRETS }}
+
+    - name: Build srpm in copr for ${{ matrix.chroot }}
+      uses: SSSD/action-copr/submit-build@master
+      with:
+        coprcfg: ${{ steps.copr.outputs.coprcfg }}
+        srpm: ${{ needs.prepare.outputs.srpm }}
+        chroots: ${{ matrix.chroot }}
+        project: ${{ env.COPR_PROJECT }}
+        account: ${{ env.COPR_ACCOUNT }}

--- a/.github/workflows/copr_cleanup.yml
+++ b/.github/workflows/copr_cleanup.yml
@@ -1,0 +1,21 @@
+name: copr cleanup
+on:
+  pull_request_target:
+    types: [closed]
+jobs:
+  delete:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.action == 'closed' }}
+    steps:
+    - name: Initialize copr actions
+      id: copr
+      uses: SSSD/action-copr/init@master
+      with:
+        token: ${{ secrets.COPR_SECRETS }}
+
+    - name: Delete copr project
+      uses: SSSD/action-copr/delete-project@master
+      with:
+        coprcfg: ${{ steps.copr.outputs.coprcfg }}
+        project: 'pr${{ github.event.pull_request.number }}'
+        account: '@sssd'


### PR DESCRIPTION
New copr project will be created for each pull request under the sssd
group. The project will be automatically deleted after 60 days or after
the pull request is closed.

The workflow also produces comment on the pull request, there may
be a little race condition between the time where the comment is
already visible and the time when the project is created, but it is
not long. The reason for this is that the comment is created before
the project is built in order for it to be always on the top.

The workflow works like this:
- submit comment to the pull request
- build tarball and spec file (rvn is sssd-pr#prid-#runid)
- build srpm
- upload srpm as an artifact to the job
- create copr project @sssd/pr#prid if not exist
- cancel previous pending/running builds if there are any
- build package in centos-* and fedora-*

The workflow fails if build in any chroot fails.
The workflow succeeds if all chroots are successful.

---

You may want to disable running all or selected actions in your forks to prevent workflows run in your repository.