### PR TITLE
util: fix rawhide compilation problem

### DIFF
--- a/src/util/sss_krb5.h
+++ b/src/util/sss_krb5.h
@@ -88,10 +88,11 @@ errno_t select_principal_from_keytab(TALLOC_CTX *mem_ctx,
                                      char **_realm);
 
 #ifndef HAVE_KRB5_GET_INIT_CREDS_OPT_SET_EXPIRE_CALLBACK
-typedef void krb5_expire_callback_func(krb5_context context, void *data,
-                                             krb5_timestamp password_expiration,
-                                             krb5_timestamp account_expiration,
-                                             krb5_boolean is_last_req);
+typedef void
+(KRB5_CALLCONV *krb5_expire_callback_func)(krb5_context context, void *data,
+                                           krb5_timestamp password_expiration,
+                                           krb5_timestamp account_expiration,
+                                           krb5_boolean is_last_req);
 #endif
 krb5_error_code KRB5_CALLCONV sss_krb5_get_init_creds_opt_set_expire_callback(
                                                    krb5_context context,


### PR DESCRIPTION
The signature for krb5_expire_callback_func() changed in
https://github.com/krb5/krb5/commit/aedd1fea8405d857c072fb41f2d38db9df31c70d
but it wasn't updated in sssd. That was causing a compilation issue in
rawhide that this commit fixes. The change only updates the sssd
signature to match the one provided by krb5.