### PR TITLE
TEST: fix long line pep8 error

### DIFF
--- a/src/tests/multihost/ipa/test_misc.py
+++ b/src/tests/multihost/ipa/test_misc.py
@@ -360,5 +360,6 @@ class Testipabz(object):
         file_name = 'domain_list_' + str(time.time())
         (_, _, _) = ssh2.execute_cmd(f"sudo -S /usr/sbin/sssctl domain-list > "
                                      f"/tmp/{file_name}", stdin=test_password)
-        result = multihost.client[0].run_command(f"cat /tmp/{file_name}").stdout_text
+        result = multihost.client[0].run_command(f"cat /tmp/{file_name}"
+                                                 ).stdout_text
         assert domain_name in result


### PR DESCRIPTION
Was introduced by c0f767c5513183048a3abae447881ded505cce47