### PR TITLE
CI: enable CodeQL analysis

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -1,0 +1,10 @@
+name: 'Install dependencies'
+description: 'Install dependencies to build sssd'
+runs:
+  using: "composite"
+  steps:
+  - shell: bash
+    run: |
+      cd contrib/ci/
+      . deps.sh
+      deps_install

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -1,0 +1,42 @@
+name: "Static code analysis"
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # Everyday at midnight
+    - cron: '0 0 * * *'
+
+jobs:
+  codeql:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Install dependencies
+      id: dependencies
+      uses: ./.github/actions/install-dependencies
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        queries: +security-and-quality
+
+    - name: Compile sssd
+      run: |
+        source contrib/fedora/bashrc_sssd
+        cd contrib/ci/
+        . configure.sh
+        cd ../..
+        reconfig "${CONFIGURE_ARG_LIST[@]}"
+        PROCESSORS=$(/usr/bin/getconf _NPROCESSORS_ONLN)
+        make -j$PROCESSORS
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1
+      with:
+        languages: cpp, python

--- a/contrib/ci/deps.sh
+++ b/contrib/ci/deps.sh
@@ -155,9 +155,6 @@ if [[ "$DISTRO_BRANCH" == -debian-* ]]; then
         libuid-wrapper
         libpam-wrapper
         python-pytest
-        python-ldap
-        python-ldb
-        python-requests
         python-psutil
         ldap-utils
         slapd
@@ -177,6 +174,21 @@ if [[ "$DISTRO_BRANCH" == -debian-* ]]; then
         libp11-kit-dev
         libunistring-dev
     )
+
+    if [[ "$DISTRO_BRANCH" == -debian-ubuntu-* ]]; then
+        DEPS_LIST+=(
+            python3-ldap
+            python3-ldb
+            python3-requests
+        )
+    else
+        DEPS_LIST+=(
+            python-ldap
+            python-ldb
+            python-requests
+        )
+    fi
+
     DEPS_INTGCHECK_SATISFIED=true
 fi
 

--- a/src/db/sysdb_services.c
+++ b/src/db/sysdb_services.c
@@ -49,7 +49,7 @@ sysdb_getservbyname(TALLOC_CTX *mem_ctx,
     TALLOC_CTX *tmp_ctx;
     static const char *attrs[] = SYSDB_SVC_ATTRS;
     char *sanitized_name;
-    char *sanitized_proto;
+    char *sanitized_proto = NULL;
     char *subfilter;
     struct ldb_result *res = NULL;
     struct ldb_message **msgs;

--- a/src/db/sysdb_upgrade.c
+++ b/src/db/sysdb_upgrade.c
@@ -1076,6 +1076,11 @@ int sysdb_upgrade_10(struct sysdb_ctx *sysdb, struct sss_domain_info *domain,
     for (i = 0; i < res->count; i++) {
         user = res->msgs[i];
         memberof_el = ldb_msg_find_element(user, "memberof");
+        if (memberof_el == NULL) {
+            ret = EINVAL;
+            goto done;
+        }
+
         name = ldb_msg_find_attr_as_string(user, "name", NULL);
         if (name == NULL) {
             ret = EIO;

--- a/src/ldb_modules/memberof.c
+++ b/src/ldb_modules/memberof.c
@@ -1710,6 +1710,9 @@ static int mbof_del_cleanup_children(struct mbof_del_ctx *del_ctx)
     ldb = ldb_module_get_ctx(ctx->module);
 
     el = ldb_msg_find_element(first->entry, DB_MEMBER);
+    if (el == NULL) {
+        return EINVAL;
+    }
 
     /* prepare del sets */
     for (i = 0; i < el->num_values; i++) {

--- a/src/lib/sifp/sss_sifp_attrs.c
+++ b/src/lib/sifp/sss_sifp_attrs.c
@@ -304,7 +304,7 @@ sss_sifp_find_attr_as_string_array(sss_sifp_attr **attrs,
                                    const char * const **_value)
 {
     sss_sifp_error ret = SSS_SIFP_ATTR_MISSING;
-    char **value;
+    char **value = NULL;
 
     GET_ATTR_ARRAY(attrs, name, SSS_SIFP_ATTR_TYPE_STRING, str,
                    *_num_values, value, ret);

--- a/src/lib/sifp/sss_sifp_parser.c
+++ b/src/lib/sifp/sss_sifp_parser.c
@@ -434,7 +434,7 @@ done:
     if (ret != SSS_SIFP_OK) {
         if (attr->type == SSS_SIFP_ATTR_TYPE_STRING && attr->data.str != NULL) {
             for (unsigned int i = 0;
-                 attr->data.str[i] != NULL && i < attr->num_values;
+                 (i < attr->num_values) && (attr->data.str[i] != NULL);
                  i++) {
                 _free(ctx, attr->data.str[i]);
             }

--- a/src/providers/ad/ad_gpo_ndr.c
+++ b/src/providers/ad/ad_gpo_ndr.c
@@ -199,7 +199,7 @@ ndr_pull_security_ace_object_ctr(struct ndr_pull *ndr,
                                  int ndr_flags,
                                  union security_ace_object_ctr *r)
 {
-    uint32_t level;
+    uint32_t level = 0;
     NDR_PULL_CHECK_FLAGS(ndr, ndr_flags);
     if (ndr_flags & NDR_SCALARS) {
         /* This token is not used again (except perhaps below in the NDR_BUFFERS case) */

--- a/src/providers/ad/ad_pac.c
+++ b/src/providers/ad/ad_pac.c
@@ -255,7 +255,7 @@ errno_t ad_get_sids_from_pac(TALLOC_CTX *mem_ctx,
     char *user_sid_str = NULL;
     char *primary_group_sid_str = NULL;
     size_t c;
-    size_t num_sids;
+    size_t num_sids = 0;
     char **sid_list = NULL;
     struct hash_iter_context_t *iter = NULL;
     hash_entry_t *entry;

--- a/src/providers/files/files_ops.c
+++ b/src/providers/files/files_ops.c
@@ -458,7 +458,7 @@ static errno_t sf_enum_users(struct files_id_ctx *id_ctx, struct passwd **users,
     errno_t ret;
     size_t i;
 
-    for (i = start; users[i] != NULL && i < (start + size); i++) {
+    for (i = start; i < (start + size) && users[i] != NULL; i++) {
         ret = save_file_user(id_ctx, users[i]);
         if (ret != EOK) {
             DEBUG(SSSDBG_MINOR_FAILURE,
@@ -676,7 +676,7 @@ static errno_t sf_enum_groups(struct files_id_ctx *id_ctx,
         goto done;
     }
 
-    for (i = start; groups[i] != NULL && i < (start + size); i++) {
+    for (i = start; i < (start + size) && groups[i] != NULL; i++) {
         ret = save_file_group(id_ctx, groups[i], cached_users);
         if (ret != EOK) {
             DEBUG(SSSDBG_MINOR_FAILURE,

--- a/src/providers/ipa/ipa_subdomains.c
+++ b/src/providers/ipa/ipa_subdomains.c
@@ -2489,8 +2489,8 @@ static void ipa_subdomains_write_kdcinfo_domain_done(struct tevent_req *subreq)
                 tevent_req_data(req,
                                 struct ipa_subdomains_write_kdcinfo_state);
     struct sss_domain_info *next_domain;
-    struct resolv_hostport_addr **rhp_addrs;
-    size_t rhp_len;
+    struct resolv_hostport_addr **rhp_addrs = NULL;
+    size_t rhp_len = 0;
 
     if (state->pdctx->servers != NULL) {
         ret = kdcinfo_from_server_list_recv(state->pdctx, subreq,

--- a/src/providers/ipa/ipa_sudo_conversion.c
+++ b/src/providers/ipa/ipa_sudo_conversion.c
@@ -661,7 +661,7 @@ build_filter(TALLOC_CTX *mem_ctx,
     hash_key_t *keys;
     unsigned long int count;
     unsigned long int i;
-    char *filter;
+    char *filter = NULL;
     char *rdn_val;
     const char *rdn_attr;
     char *safe_rdn;

--- a/src/providers/krb5/krb5_utils.c
+++ b/src/providers/krb5/krb5_utils.c
@@ -527,7 +527,7 @@ parse_krb5_map_user(TALLOC_CTX *mem_ctx,
                     struct map_id_name_to_krb_primary **_name_to_primary)
 {
     int size;
-    char **map;
+    char **map = NULL;
     errno_t ret;
     TALLOC_CTX *tmp_ctx;
     struct map_id_name_to_krb_primary *name_to_primary;

--- a/src/providers/ldap/ldap_auth.c
+++ b/src/providers/ldap/ldap_auth.c
@@ -516,11 +516,11 @@ int get_user_dn(TALLOC_CTX *memctx,
                        void **user_pw_expire_data)
 {
     TALLOC_CTX *tmpctx;
-    enum pwexpire pw_expire_type;
+    enum pwexpire pw_expire_type = PWEXPIRE_NONE;
     void *pw_expire_data;
     struct ldb_result *res;
     const char **attrs;
-    const char *dn;
+    const char *dn = NULL;
     int ret;
 
     tmpctx = talloc_new(memctx);

--- a/src/providers/ldap/ldap_id.c
+++ b/src/providers/ldap/ldap_id.c
@@ -534,7 +534,7 @@ static void users_get_done(struct tevent_req *subreq)
     struct users_get_state *state = tevent_req_data(req,
                                                      struct users_get_state);
     char *endptr;
-    uid_t uid;
+    uid_t uid = 0;
     int dp_error = DP_ERR_FATAL;
     int ret;
 

--- a/src/providers/ldap/sdap.c
+++ b/src/providers/ldap/sdap.c
@@ -661,7 +661,7 @@ errno_t sdap_parse_deref(TALLOC_CTX *mem_ctx,
     const char *orig_dn;
     const char **ocs;
     struct sdap_attr_map *map;
-    int num_attrs;
+    int num_attrs = 0;
     int ret, i, a, mi;
     const char *name;
     size_t len;

--- a/src/providers/ldap/sdap_async.c
+++ b/src/providers/ldap/sdap_async.c
@@ -2737,7 +2737,7 @@ static errno_t sdap_asq_search_parse_entry(struct sdap_handle *sh,
     struct berval **vals;
     int i, mi;
     struct sdap_attr_map *map;
-    int num_attrs;
+    int num_attrs = 0;
     struct sdap_deref_attrs **res;
     char *tmp;
     char *dn = NULL;

--- a/src/providers/ldap/sdap_async_connection.c
+++ b/src/providers/ldap/sdap_async_connection.c
@@ -136,7 +136,7 @@ static void sdap_sys_connect_done(struct tevent_req *subreq)
                                                      struct sdap_connect_state);
     struct timeval tv;
     int ver;
-    int lret;
+    int lret = 0;
     int optret;
     int ret = EOK;
     int msgid;

--- a/src/providers/ldap/sdap_async_groups.c
+++ b/src/providers/ldap/sdap_async_groups.c
@@ -504,7 +504,7 @@ static int sdap_save_group(TALLOC_CTX *memctx,
     struct ldb_message_element *el;
     struct sysdb_attrs *group_attrs;
     const char *group_name = NULL;
-    gid_t gid;
+    gid_t gid = 0;
     errno_t ret;
     char *usn_value = NULL;
     TALLOC_CTX *tmpctx = NULL;

--- a/src/providers/ldap/sdap_async_nested_groups.c
+++ b/src/providers/ldap/sdap_async_nested_groups.c
@@ -264,7 +264,7 @@ sdap_nested_group_hash_group(struct sdap_nested_group_ctx *group_ctx,
                              struct sysdb_attrs *group)
 {
     struct sdap_attr_map *map = group_ctx->opts->group_map;
-    gid_t gid;
+    gid_t gid = 0;
     errno_t ret;
     bool posix_group = true;
     bool use_id_mapping;

--- a/src/providers/ldap/sdap_async_resolver_enum.h
+++ b/src/providers/ldap/sdap_async_resolver_enum.h
@@ -20,8 +20,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef _SDAP_ASYNC_ENUM_H_
-#define _SDAP_ASYNC_ENUM_H_
+#ifndef _SDAP_ASYNC_RESOLVER_ENUM_H_
+#define _SDAP_ASYNC_RESOLVER_ENUM_H_
 
 struct tevent_req *
 sdap_dom_resolver_enum_send(TALLOC_CTX *memctx,
@@ -33,4 +33,4 @@ sdap_dom_resolver_enum_send(TALLOC_CTX *memctx,
 
 errno_t sdap_dom_resolver_enum_recv(struct tevent_req *req);
 
-#endif /* _SDAP_ASYNC_ENUM_H_ */
+#endif /* _SDAP_ASYNC_RESOLVER_ENUM_H_ */

--- a/src/providers/ldap/sdap_async_services.c
+++ b/src/providers/ldap/sdap_async_services.c
@@ -353,7 +353,7 @@ sdap_save_service(TALLOC_CTX *mem_ctx,
     const char *name = NULL;
     const char **aliases;
     const char **protocols;
-    const char **cased_protocols;
+    const char **cased_protocols = NULL;
     const char **store_protocols;
     char **missing;
     uint16_t port;

--- a/src/providers/proxy/proxy_auth.c
+++ b/src/providers/proxy/proxy_auth.c
@@ -660,9 +660,9 @@ static void run_proxy_child_queue(struct tevent_context *ev,
     struct proxy_auth_ctx *auth_ctx;
     struct hash_iter_context_t *iter;
     struct hash_entry_t *entry;
-    struct tevent_req *req;
+    struct tevent_req *req = NULL;
     struct tevent_req *subreq;
-    struct proxy_child_ctx *state;
+    struct proxy_child_ctx *state = NULL;
 
     auth_ctx = talloc_get_type(pvt, struct proxy_auth_ctx);
 

--- a/src/providers/proxy/proxy_auth.c
+++ b/src/providers/proxy/proxy_auth.c
@@ -668,6 +668,11 @@ static void run_proxy_child_queue(struct tevent_context *ev,
 
     /* Launch next queued request */
     iter = new_hash_iter_context(auth_ctx->request_table);
+    if (iter == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "new_hash_iter_context failed.\n");
+        return;
+    }
+
     while ((entry = iter->next(iter)) != NULL) {
         req = talloc_get_type(entry->value.ptr, struct tevent_req);
         state = tevent_req_data(req, struct proxy_child_ctx);

--- a/src/responder/ifp/ifp_iface/ifp_iface_types.c
+++ b/src/responder/ifp/ifp_iface/ifp_iface_types.c
@@ -154,6 +154,12 @@ errno_t sbus_iterator_write_ifp_extra(DBusMessageIter *iterator,
     }
 
     table_iter = new_hash_iter_context(table);
+    if (table_iter == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "new_hash_iter_context failed.\n");
+        ret = EINVAL;
+        goto done;
+    }
+
     while ((entry = table_iter->next(table_iter)) != NULL) {
         if (entry->key.type != HASH_KEY_STRING || entry->key.str == NULL
                 || entry->value.type != HASH_VALUE_PTR
@@ -211,6 +217,9 @@ done:
         }
     }
 
-    talloc_free(table_iter);
+    if (table_iter != NULL) {
+        talloc_free(table_iter);
+    }
+
     return ret;
 }

--- a/src/responder/ifp/ifp_iface/ifp_iface_types.h
+++ b/src/responder/ifp/ifp_iface/ifp_iface_types.h
@@ -18,8 +18,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef _SSS_IFACE_CUSTOM_TYPES_H_
-#define _SSS_IFACE_CUSTOM_TYPES_H_
+#ifndef _IFP_IFACE_CUSTOM_TYPES_H_
+#define _IFP_IFACE_CUSTOM_TYPES_H_
 
 #include <talloc.h>
 #include <dhash.h>
@@ -32,4 +32,4 @@ errno_t sbus_iterator_read_ifp_extra(TALLOC_CTX *mem_ctx,
 errno_t sbus_iterator_write_ifp_extra(DBusMessageIter *iterator,
                                       hash_table_t *table);
 
-#endif /* _SBUS_ITERATOR_READERS_H_ */
+#endif /* _IFP_IFACE_CUSTOM_TYPES_H_ */

--- a/src/responder/nss/nss_protocol_svcent.c
+++ b/src/responder/nss/nss_protocol_svcent.c
@@ -72,7 +72,7 @@ nss_get_svcent(TALLOC_CTX *mem_ctx,
         protocol = requested_protocol;
     } else {
         el = ldb_msg_find_element(msg, SYSDB_SVC_PROTO);
-        if (el->num_values == 0) {
+        if (el == NULL || el->num_values == 0) {
             ret = EINVAL;
             goto done;
         }

--- a/src/responder/nss/nsssrv_mmap_cache.c
+++ b/src/responder/nss/nsssrv_mmap_cache.c
@@ -529,7 +529,7 @@ static errno_t sss_mc_get_strs_len(struct sss_mc_ctx *mcc,
 static struct sss_mc_rec *sss_mc_find_record(struct sss_mc_ctx *mcc,
                                              struct sized_string *key)
 {
-    struct sss_mc_rec *rec;
+    struct sss_mc_rec *rec = NULL;
     uint32_t hash;
     uint32_t slot;
     rel_ptr_t name_ptr;
@@ -803,7 +803,7 @@ errno_t sss_mmap_cache_pw_invalidate(struct sss_mc_ctx *mcc,
 
 errno_t sss_mmap_cache_pw_invalidate_uid(struct sss_mc_ctx *mcc, uid_t uid)
 {
-    struct sss_mc_rec *rec;
+    struct sss_mc_rec *rec = NULL;
     struct sss_mc_pwd_data *data;
     uint32_t hash;
     uint32_t slot;
@@ -941,7 +941,7 @@ errno_t sss_mmap_cache_gr_invalidate(struct sss_mc_ctx *mcc,
 
 errno_t sss_mmap_cache_gr_invalidate_gid(struct sss_mc_ctx *mcc, gid_t gid)
 {
-    struct sss_mc_rec *rec;
+    struct sss_mc_rec *rec = NULL;
     struct sss_mc_grp_data *data;
     uint32_t hash;
     uint32_t slot;

--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -2176,7 +2176,7 @@ static errno_t pam_is_last_online_login_fresh(struct sss_domain_info *domain,
                                               bool *_result)
 {
     errno_t ret;
-    bool result;
+    bool result = true;
     uint64_t last_login;
 
     ret = pam_get_last_online_auth_with_curr_token(domain, user, &last_login);
@@ -2515,7 +2515,7 @@ pam_get_last_online_auth_with_curr_token(struct sss_domain_info *domain,
     TALLOC_CTX *tmp_ctx = NULL;
     const char *attrs[] = { SYSDB_LAST_ONLINE_AUTH_WITH_CURR_TOKEN, NULL };
     struct ldb_message *ldb_msg;
-    uint64_t value;
+    uint64_t value = 0;
     errno_t ret;
 
     if (name == NULL || *name == '\0') {

--- a/src/responder/sudo/sudosrv_get_sudorules.c
+++ b/src/responder/sudo/sudosrv_get_sudorules.c
@@ -520,7 +520,7 @@ static errno_t sudosrv_fetch_rules(TALLOC_CTX *mem_ctx,
                                    struct sysdb_attrs ***_rules,
                                    uint32_t *_num_rules)
 {
-    struct sysdb_attrs **rules;
+    struct sysdb_attrs **rules = NULL;
     const char *debug_name = "unknown";
     uint32_t num_rules;
     errno_t ret;

--- a/src/sbus/interface/sbus_iterator_readers.c
+++ b/src/sbus/interface/sbus_iterator_readers.c
@@ -68,7 +68,7 @@ _sbus_iterator_read_basic_array(TALLOC_CTX *mem_ctx,
 {
     DBusMessageIter subiter;
     uint8_t *arrayptr;
-    void *array;
+    void *array = NULL;
     int arg_type;
     int count;
     errno_t ret;

--- a/src/sbus/interface/sbus_iterator_readers.c
+++ b/src/sbus/interface/sbus_iterator_readers.c
@@ -87,7 +87,7 @@ _sbus_iterator_read_basic_array(TALLOC_CTX *mem_ctx,
     switch (dbus_type) {
     case DBUS_TYPE_STRING:
     case DBUS_TYPE_OBJECT_PATH:
-        array = talloc_zero_size(mem_ctx, (count + 1) * element_size);
+        array = talloc_zero_size(mem_ctx, (size_t)(count + 1) * element_size);
         if (array == NULL) {
             ret = ENOMEM;
             goto done;
@@ -106,7 +106,7 @@ _sbus_iterator_read_basic_array(TALLOC_CTX *mem_ctx,
             goto done;
         }
 
-        array = talloc_zero_size(mem_ctx, count * element_size);
+        array = talloc_zero_size(mem_ctx, (size_t)count * element_size);
         if (array == NULL) {
             ret = ENOMEM;
             goto done;

--- a/src/sbus/router/sbus_router.c
+++ b/src/sbus/router/sbus_router.c
@@ -109,6 +109,10 @@ sbus_router_signal_parse(TALLOC_CTX *mem_ctx,
 
     /* Split the duplicate into interface and signal name parts. */
     dot = strrchr(dup, '.');
+    if (dot == NULL) {
+        talloc_free(dup);
+        return EINVAL;
+    }
     *dot = '\0';
 
     signal_name = talloc_strdup(mem_ctx, dot + 1);

--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -2140,7 +2140,7 @@ static void eval_argv(pam_handle_t *pamh, int argc, const char **argv,
 static int prompt_by_config(pam_handle_t *pamh, struct pam_items *pi)
 {
     size_t c;
-    int ret;
+    int ret = PAM_SUCCESS;
 
     if (pi->pc == NULL || *pi->pc == NULL) {
         return PAM_SYSTEM_ERR;

--- a/src/sss_iface/sss_iface_types.h
+++ b/src/sss_iface/sss_iface_types.h
@@ -40,4 +40,4 @@ errno_t sbus_iterator_read_pam_response(TALLOC_CTX *mem_ctx,
 errno_t sbus_iterator_write_pam_response(DBusMessageIter *iterator,
                                          struct pam_data *pd);
 
-#endif /* _SBUS_ITERATOR_READERS_H_ */
+#endif /* _SSS_IFACE_CUSTOM_TYPES_H_ */

--- a/src/tools/sss_cache.c
+++ b/src/tools/sss_cache.c
@@ -453,7 +453,7 @@ static bool invalidate_entries(TALLOC_CTX *ctx,
                                const char *filter, const char *name)
 {
     const char *attrs[] = {SYSDB_NAME, NULL};
-    size_t msg_count;
+    size_t msg_count = 0;
     struct ldb_message **msgs;
     const char *type_string = "unknown";
     errno_t ret = EINVAL;

--- a/src/tools/sss_override.c
+++ b/src/tools/sss_override.c
@@ -454,7 +454,7 @@ get_object_domain(enum sysdb_member_type type,
                   struct sss_domain_info *domains)
 {
     TALLOC_CTX *tmp_ctx;
-    struct sss_domain_info *dom;
+    struct sss_domain_info *dom = NULL;
     struct ldb_result *res;
     const char *strtype;
     char *sysname;
@@ -1119,7 +1119,7 @@ list_user_overrides(TALLOC_CTX *mem_ctx,
                     const char *filter)
 {
     TALLOC_CTX *tmp_ctx;
-    struct override_user *objs;
+    struct override_user *objs = NULL;
     struct ldb_message **msgs;
     size_t count;
     size_t i;
@@ -1210,7 +1210,7 @@ list_group_overrides(TALLOC_CTX *mem_ctx,
                      const char *filter)
 {
     TALLOC_CTX *tmp_ctx;
-    struct override_group *objs;
+    struct override_group *objs = NULL;
     struct ldb_message **msgs;
     size_t count;
     size_t i;

--- a/src/util/util_lock.c
+++ b/src/util/util_lock.c
@@ -31,7 +31,7 @@
 errno_t sss_br_lock_file(int fd, size_t start, size_t len,
                          int num_tries, useconds_t wait)
 {
-    int ret;
+    int ret = EAGAIN;
     struct flock lock;
     int retries_left;
 


### PR DESCRIPTION
Enable the CodeQL analysis on the master branch for push, pull-request
and nightly.

Moreover, fixed two types of issues reported by the aforementioned tool:
* **Time-of-check time-of-use filesystem race condition.** Separately checking
the state of a file before operating on it may allow an attacker to modify the
file between the two operations. To reduce the probability of this happening
change the order in which chmod() and rename() are executed.
* **Multiplication result converted to larger type.** A multiplication result that is
converted to a larger type can be a sign that the result can overflow the type
converted from. Using a cast to the target type (size_t) to avoid overflow.