### PR TITLE
Tests: Add sleep before collecting logs in flaky ad parameters tests.

### DIFF
--- a/src/tests/multihost/ad/test_adparameters_ported.py
+++ b/src/tests/multihost/ad/test_adparameters_ported.py
@@ -1789,6 +1789,11 @@ class TestADParamsPorted:
         time.sleep(10)
         # Run su
         su_result = client.su_success(aduser, password='NewPass1_123')
+
+        # We need to wait for the event to be written to the log,
+        # otherwise test randomly fails.
+        time.sleep(30)
+
         # Download log
         log_str = multihost.client[0].get_file_contents(
                 "/var/log/secure").decode('utf-8')
@@ -1864,6 +1869,10 @@ class TestADParamsPorted:
         second_login_result = client.auth_from_client_key(aduser)
 
         password_login_res = client.auth_from_client(aduser, 'Secret123') == 3
+
+        # We need to wait for the event to be written to the log,
+        # otherwise test randomly fails.
+        time.sleep(30)
 
         # Download log
         log_str = multihost.client[0].get_file_contents(
@@ -1942,6 +1951,10 @@ class TestADParamsPorted:
         client.clear_sssd_cache()
         second_login_result = client.auth_from_client_key(aduser)
         password_login_res = client.auth_from_client(aduser, 'Secret123') == 3
+
+        # We need to wait for the event to be written to the log,
+        # otherwise test randomly fails.
+        time.sleep(30)
 
         # Download log
         log_str = multihost.client[0].get_file_contents(


### PR DESCRIPTION
The tests in TestADParamsPorted:
test_0021_ad_parameters_ssh_change_password_logon
test_0022_ad_parameters_account_disabled
test_0023_ad_parameters_account_expired
collected log immediately after event but when cloud is under load
they were randomly failing as the log was not written yet.