### PR TITLE
CI: Add internal covscan workflow to Jenkins 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ class Notification {
    *
    * There are two types of notifications:
    * a) Summary (i.e. sssd-ci: Success. details: @details_url)
-   * b) Single build (i.e. sssd-ci/fedora28: Success. details: @aws_url)
+   * b) Single build (i.e. sssd-ci/fedora35: Success. details: @aws_url)
    */
   Notification(pipeline, context, details_url, aws_url, on_demand) {
     this.pipeline = pipeline
@@ -87,8 +87,16 @@ class Test {
     this.target = pipeline.env.CHANGE_TARGET
   }
 
+  def handleCmdError(rc) {
+    if (rc == 255) {
+      this.pipeline.error "Timeout reached."
+    } else if (rc != 0) {
+      this.pipeline.error "Some tests failed."
+    }
+  }
+
   /* Test entry point. */
-  def run() {
+  def run(command=null) {
     /* These needs to be set here in order to get correct workspace. */
     this.artifactsdir = "${this.pipeline.env.WORKSPACE}/artifacts/${this.system}"
     this.codedir = "${this.pipeline.env.WORKSPACE}/sssd"
@@ -109,20 +117,18 @@ class Test {
 
       this.pipeline.echo "Executing tests, started at ${this.getCurrentTime()}"
 
-      def command = String.format(
-        '%s/sssd-test-suite -c "%s" run --sssd "%s" --artifacts "%s" --update --prune',
-        "${this.basedir}/sssd-test-suite",
-        "${this.basedir}/configs/${this.system}.json",
-        this.codedir,
-        this.artifactsdir
-      )
+      if (command == null) {
+        command = String.format(
+          '%s/sssd-test-suite -c "%s" run --sssd "%s" --artifacts "%s" --update --prune',
+          "${this.basedir}/sssd-test-suite",
+          "${this.basedir}/configs/${this.system}.json",
+          this.codedir,
+          this.artifactsdir
+        )
+      }
 
       def rc = this.pipeline.sh script: command, returnStatus: true
-      if (rc == 255) {
-        this.pipeline.error "Timeout reached."
-      } else if (rc != 0) {
-        this.pipeline.error "Some tests failed."
-      }
+      this.handleCmdError(rc)
 
       this.pipeline.echo "Finished at ${this.getCurrentTime()}"
       this.notify('SUCCESS', 'Success.')
@@ -217,6 +223,10 @@ class OnDemandTest extends Test {
     this.branch = branch
   }
 
+  def handleCmdError(rc) {
+    super.handleCmdError(rc)
+  }
+
   def run() {
     this.pipeline.echo "Repository: ${this.repo}"
     this.pipeline.echo "Branch: ${this.branch}"
@@ -245,7 +255,116 @@ class OnDemandTest extends Test {
   }
 }
 
+/* Manage test run for internal covscan test.
+ * Can be triggered for PRs, ondemand and branch runs */
+class Covscan extends Test {
+  String repo
+  String branch
+  String basedir
+  String pr_number
+  boolean on_demand
+  String artifactsdir
+
+  /* @param pipeline Jenkins pipeline context.
+   * @param notification Notification object.
+   * @param repo Repository fetch URL.
+   * @param branch Branch to checkout.
+   * @param pr_number Pull Request Number, null if not inside a PR.
+   * @param on_demand true for on_demand runs, false otherwise.
+   */
+  Covscan(pipeline, notification, repo, branch, pr_number, on_demand) {
+    super(pipeline, "covscan", notification)
+
+    this.repo = repo
+    this.branch = branch
+    this.pr_number = pr_number
+    this.basedir = "/home/fedora"
+    this.on_demand = on_demand
+  }
+
+  /* Errors returned from covscan.sh */
+  def handleCmdError(rc) {
+    if (rc == 0) { return }
+
+    switch (rc) {
+      case 1:
+        this.pipeline.error "Covscan diff shows new errors!"
+        break
+      case 2:
+        this.pipeline.error "Covscan task FAILED"
+        break
+      case 3:
+        this.pipeline.error "Covscan task INTERRUPTED"
+        break
+      case 4:
+        this.pipeline.error "Covscan task CANCELLED"
+        break
+      case 255:
+        this.pipeline.error "Timeout reached."
+        break
+      default:
+        this.pipeline.error "Generic Failure, unknown return code"
+        break
+    }
+  }
+
+  def run() {
+    def version = this.pr_number ? this.pr_number : this.branch.trim()
+    this.pipeline.echo "Executing covscan script with version: ${version}_${this.pipeline.env.BUILD_ID}"
+
+    def command = String.format(
+      '%s/scripts/covscan.sh "%s%s_%s" "%s"',
+      this.basedir,
+      this.pr_number ? "pr" : "",
+      version,
+      this.pipeline.env.BUILD_ID,
+      this.pipeline.env.WORKSPACE,
+    )
+
+    super.run(command)
+  }
+
+  def checkout() {
+    if (on_demand) {
+      this.pipeline.echo "Checkout ${this.branch}"
+
+      this.pipeline.dir('sssd') {
+        this.pipeline.git branch: this.branch, url: this.repo
+      }
+    } else {
+      this.pipeline.dir('sssd') {
+        this.pipeline.checkout this.pipeline.scm
+      }
+    }
+  }
+
+  def rebase() {
+    super.rebase()
+  }
+
+  def archive() {
+    if (on_demand) {
+      this.pipeline.echo 'On demand run. Artifacts are not stored in the cloud.'
+      this.pipeline.echo 'They are accessible only from Jenkins.'
+      this.pipeline.echo "${this.pipeline.env.BUILD_URL}/artifact/artifacts/${this.system}"
+      this.pipeline.archiveArtifacts artifacts: "artifacts/**",
+        allowEmptyArchive: true
+
+      this.pipeline.sh "rm -fr ${this.artifactsdir}"
+    } else {
+      super.archive()
+    }
+  }
+
+  def notify(status, message) {
+    this.notification.notify(status, message, "covscan")
+  }
+}
+
 def systems = []
+def pr_labels = []
+def with_tests_label = false
+def with_tests_title = false
 def on_demand = params.ON_DEMAND ? true : false
 def notification = new Notification(
   this, 'sssd-ci',
@@ -300,9 +419,29 @@ try {
             python -c "import sys, json; print(json.load(sys.stdin).get('title'))"
           """
           currentBuild.description = "PR ${env.CHANGE_ID}: ${title}"
+          if (title.toLowerCase().contains('tests: ')) {
+            with_tests_title = true
+          }
         } else {
           /* Branch: name */
           currentBuild.description = "Branch: ${env.BRANCH_NAME}"
+        }
+      }
+    }
+  }
+
+  stage('Retrieve labels') {
+    node('master') {
+      if (env.CHANGE_TARGET) {
+        def labels = sh returnStdout: true, script: """
+          curl -s https://api.github.com/repos/SSSD/sssd/pulls/${env.CHANGE_ID}
+        """
+        def props = readJSON text: labels
+        props['labels'].each { key, value ->
+          pr_labels.add(key['name'])
+          if (key['name'] == 'Tests') {
+              with_tests_label = true
+          }
         }
       }
     }
@@ -314,6 +453,9 @@ try {
     /* Notify that all systems are pending. */
     for (system in systems) {
       notification.notify('PENDING', 'Awaiting executor', system)
+    }
+    if ((with_tests_label == false) && (with_tests_title == false)) {
+      notification.notify('PENDING', 'Pending.', "covscan")
     }
   }
 
@@ -338,6 +480,19 @@ try {
         }
       })
     }
+
+    /* Run covscan against non-test related PRs */
+    if ((with_tests_label == false) && (with_tests_title == false)) {
+      stages.put("covscan", {
+        node("sssd-ci") {
+          stage("covscan") {
+            covscan = new Covscan(this, notification, params.REPO_URL, params.REPO_BRANCH, env.CHANGE_ID, on_demand)
+            covscan.run()
+          }
+        }
+      })
+    }
+
     parallel(stages)
   }
   stage('Report results') {

--- a/contrib/fedora/make_srpm.sh
+++ b/contrib/fedora/make_srpm.sh
@@ -27,6 +27,7 @@ usage(){
     echo -e "\t-c, --clean        Remove directory rpmbuild and exit."
     echo -e "\t-P, --patches      Requires list of patches for SRPM."
     echo -e "\t-o, --output       Moves the created srpm to a specific output directory."
+    echo -e "\t-v, --version      Provide package version to set in spec file."
     echo -e "\t-h, --help         Print this help and exit."
     echo -e "\t-?, --usage"
 
@@ -92,6 +93,11 @@ case $i in
     OUTPUT=("$@")
     break
     ;;
+    -v|--version)
+    shift
+    VERSION=("$@")
+    break
+    ;;
     -h|--help|-\?|--usage)
     usage
     ;;
@@ -134,6 +140,9 @@ fi
 
 PACKAGE_VERSION=$(grep "\[VERSION_NUMBER\]" $VERSION_FILE \
                   | sed -e 's/.*\[//' -e 's/\]).*$//')
+if [ -n "$VERSION" ]; then
+    PACKAGE_VERSION="$VERSION"
+fi
 if [ "x$PACKAGE_VERSION" = x ]; then
     echo "Fatal: Could parse version from file:$VERSION_FILE!"
     exit 1;


### PR DESCRIPTION
This PR relies on sssd-ci support being added first, which I submitted a MR for.

Jenkinsfile changes in this PR implement:
* add covscan stage for on_demand, branch, and PR runs. Covscan will be skipped for PR with 'Tests' label, or if PR title.lowercased() contains 'tests: '
* Execute scripts/covscan.sh, job will fail if covscan version-diff output 'added.err' file contains any content. Job will also fail if covscan task state is cancelled, interrupted, or failed. 
* sssd-ci/covscan github notify message will indicate the above return code status. If a new covscan error is present, it will require checking Jenkins build job, or covscan hub to see diff output
* covscan VersionDiffBuild task can be found on the covscan hub in the format:
    * PRs: sssd-pr$prnumber_$build_id-0.fc34.src.rpm
    * OnDemand or branch: sssd-$branch_$build_id-0.fc34.src.rpm