### PR TITLE
Tests: Update KeytabRotation tests in AD tier 2

### DIFF
--- a/src/tests/multihost/ad/conftest.py
+++ b/src/tests/multihost/ad/conftest.py
@@ -306,7 +306,8 @@ def keytab_sssd_conf(session_multihost, request, adjoin):
                    'debug_level': '9'}
     domain_name = client.get_domain_section_name()
     domain_section = 'domain/{}'.format(domain_name)
-    client.sssd_conf(domain_section, sssd_params,)
+    client.sssd_conf(domain_section, sssd_params)
+    client.clear_sssd_cache()
 
     def restore_sssd_conf():
         """ Restore original sssd.conf """

--- a/src/tests/multihost/ad/test_hostkeytabrotation.py
+++ b/src/tests/multihost/ad/test_hostkeytabrotation.py
@@ -14,7 +14,6 @@ from sssd.testlib.common.utils import sssdTools
 from sssd.testlib.common.samba import sambaTools
 
 
-@pytest.mark.usefixtures('clear_sssd_cache')
 @pytest.mark.keytabrotation
 class TestHostKeytabRotation(object):
     """ Keytab Rotation Test cases
@@ -55,6 +54,8 @@ class TestHostKeytabRotation(object):
         try:
             multihost.client[0].run_command(restart_sssd)
         except subprocess.CalledProcessError:
+            multihost.client[0].multihost.client[0].run_command(
+                'journalctl -x -n 50 --no-pager -u sssd', raiseonerr=False)
             pytest.fail("Cannot restart sssd service")
         time.sleep(30)
         ls = 'ls -l /etc/krb5.keytab'
@@ -100,6 +101,8 @@ class TestHostKeytabRotation(object):
         try:
             multihost.client[0].run_command(restart_sssd)
         except subprocess.CalledProcessError:
+            multihost.client[0].multihost.client[0].run_command(
+                'journalctl -x -n 50 --no-pager -u sssd', raiseonerr=False)
             pytest.fail("Cannot restart sssd service")
         time.sleep(30)
         domain_basedn_entry = multihost.ad[0].domain_basedn_entry
@@ -175,6 +178,8 @@ class TestHostKeytabRotation(object):
         try:
             multihost.client[0].run_command(restart_sssd)
         except subprocess.CalledProcessError:
+            multihost.client[0].multihost.client[0].run_command(
+                'journalctl -x -n 50 --no-pager -u sssd', raiseonerr=False)
             pytest.fail("Cannot restart sssd service")
         time.sleep(60)
         cmd = multihost.client[0].run_command(klist_cmd, raiseonerr=False)
@@ -238,6 +243,8 @@ class TestHostKeytabRotation(object):
         try:
             multihost.client[0].run_command(restart_sssd)
         except subprocess.CalledProcessError:
+            multihost.client[0].multihost.client[0].run_command(
+                'journalctl -x -n 50 --no-pager -u sssd', raiseonerr=False)
             pytest.fail("Cannot restart sssd service")
         time.sleep(45)
         cmd = multihost.client[0].run_command(klist_cmd, raiseonerr=False)
@@ -291,6 +298,8 @@ class TestHostKeytabRotation(object):
         try:
             multihost.client[0].run_command(restart_sssd)
         except subprocess.CalledProcessError:
+            multihost.client[0].multihost.client[0].run_command(
+                'journalctl -x -n 50 --no-pager -u sssd', raiseonerr=False)
             pytest.fail("Cannot restart sssd service")
         time.sleep(45)
         cmd = multihost.client[0].run_command(klist_cmd, raiseonerr=False)

--- a/src/tests/multihost/ad/test_samba_data.py
+++ b/src/tests/multihost/ad/test_samba_data.py
@@ -40,7 +40,8 @@ class Testsmbsecretrotation(object):
                        'debug_level': '9'}
         domain_name = client.get_domain_section_name()
         domain_section = 'domain/{}'.format(domain_name)
-        client.sssd_conf(domain_section, sssd_params,)
+        client.sssd_conf(domain_section, sssd_params)
+        client.clear_sssd_cache()
         client.reset_machine_password()
         client_hostname = multihost.client[0].sys_hostname.split('.')[0]
         if len(client_hostname) > 15:
@@ -54,6 +55,8 @@ class Testsmbsecretrotation(object):
         try:
             multihost.client[0].run_command(restart_sssd)
         except subprocess.CalledProcessError:
+            multihost.client[0].multihost.client[0].run_command(
+                'journalctl -x -n 50 --no-pager -u sssd', raiseonerr=False)
             pytest.fail("Cannot restart sssd service")
         time.sleep(30)
         ls = 'cat /etc/sssd/sssd.conf'


### PR DESCRIPTION
Remove class fixture clear_sssd_cache from TestHostKeytabRotation.
In the case that the environment is not tainted the tests fail to
restart sssd in setup because it is not configured yet resulting in ERROR.
Clearing cache and restart of sssd added in keytab_sssd_conf fixture,
where it is actually needed.
Added extra debug information when sssd fails to start.
The test Testsmbsecretrotation::test_0001_rotation needs to restart
sssd so the changed configuration is properly applied.