### PR TITLE
systemtap: Hard-coded path instead of @libdir@

### DIFF
--- a/src/systemtap/sssd.stp.in
+++ b/src/systemtap/sssd.stp.in
@@ -61,13 +61,13 @@ probe sdap_search_recv = process("@libdir@/sssd/libsss_ldap_common.so").mark("sd
                        base, scope, filter);
 }
 
-probe sdap_parse_entry = process("/usr/lib64/sssd/libsss_ldap_common.so").mark("sdap_parse_entry")
+probe sdap_parse_entry = process("@libdir@/sssd/libsss_ldap_common.so").mark("sdap_parse_entry")
 {
     attr = user_string($arg1);
     value = user_string_n($arg2, $arg3);
 }
 
-probe sdap_parse_entry_done = process("/usr/lib64/sssd/libsss_ldap_common.so").mark("sdap_parse_entry_done")
+probe sdap_parse_entry_done = process("@libdir@/sssd/libsss_ldap_common.so").mark("sdap_parse_entry_done")
 {
    # No arguments
 }


### PR DESCRIPTION
There were hard-coded paths in the sssd.stp.in file. The probes did not
work on another platforms or if SSSD was compiled with different prefix
like /usr/local.