### PR TITLE
AD/IPA: ignore 'ldap_default_authtok_type' conf setting

### DIFF
--- a/src/providers/ad/ad_common.c
+++ b/src/providers/ad/ad_common.c
@@ -165,6 +165,14 @@ ad_create_sdap_options(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
+    /* sssd-ad can't use simple bind, ignore option that potentially can be set
+     * for sssd-ldap in the same domain
+     */
+    ret = dp_opt_set_string(id_opts->basic, SDAP_DEFAULT_AUTHTOK_TYPE, NULL);
+    if (ret != EOK) {
+        goto done;
+    }
+
     /* Get sdap option maps */
 
     /* General Attribute Map */

--- a/src/providers/ad/ad_opts.c
+++ b/src/providers/ad/ad_opts.c
@@ -67,7 +67,7 @@ struct dp_option ad_def_ldap_opts[] = {
     { "ldap_backup_uri", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "ldap_search_base", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "ldap_default_bind_dn", DP_OPT_STRING, NULL_STRING, NULL_STRING },
-    { "ldap_default_authtok_type", DP_OPT_STRING, { "password" }, NULL_STRING},
+    { "ldap_default_authtok_type", DP_OPT_STRING, NULL_STRING, NULL_STRING},
     { "ldap_default_authtok", DP_OPT_BLOB, NULL_BLOB, NULL_BLOB },
     { "ldap_search_timeout", DP_OPT_NUMBER, { .number = 6 }, NULL_NUMBER },
     { "ldap_network_timeout", DP_OPT_NUMBER, { .number = 6 }, NULL_NUMBER },

--- a/src/providers/ipa/ipa_common.c
+++ b/src/providers/ipa/ipa_common.c
@@ -213,6 +213,15 @@ int ipa_get_id_options(struct ipa_options *ipa_opts,
         goto done;
     }
 
+    /* sssd-ipa can't use simple bind, ignore option that potentially can be set
+     * for sssd-ldap in the same domain
+     */
+    ret = dp_opt_set_string(ipa_opts->id->basic,
+                            SDAP_DEFAULT_AUTHTOK_TYPE, NULL);
+    if (ret != EOK) {
+        goto done;
+    }
+
     ret = domain_to_basedn(tmpctx,
                            dp_opt_get_string(ipa_opts->basic, IPA_KRB5_REALM),
                            &basedn);

--- a/src/tests/ipa_ldap_opt-tests.c
+++ b/src/tests/ipa_ldap_opt-tests.c
@@ -172,25 +172,25 @@ END_TEST
 static void fail_unless_dp_opt_is_terminator(struct dp_option *o)
 {
     ck_assert_msg(o->opt_name == NULL,
-                "Unexpected NULL for opt_name in dp_option");
+                "Unexpected non-NULL for opt_name in dp_option");
     ck_assert_msg(o->type == 0,
-                "Unexpected 0 for type in dp_option");
+                "Unexpected non-zero for type in dp_option");
     ck_assert_msg(o->def_val.string == NULL,
-                "Unexpected NULL for def_val.string in dp_option");
+                "Unexpected non-NULL for def_val.string in dp_option");
     ck_assert_msg(o->val.string == NULL,
-                "Unexpected NULL for val.string in dp_option");
+                "Unexpected non-NULL for val.string in dp_option");
 }
 
 static void fail_unless_sdap_opt_is_terminator(struct sdap_attr_map *m)
 {
     ck_assert_msg(m->name == NULL,
-                "Unexpected NULL for name in sdap_attr_map");
+                "Unexpected non-NULL for name in sdap_attr_map");
     ck_assert_msg(m->def_name == NULL,
-                "Unexpected NULL for def_name in sdap_attr_map");
+                "Unexpected non-NULL for def_name in sdap_attr_map");
     ck_assert_msg(m->sys_name == NULL,
-                "Unexpected NULL for sys_name in sdap_attr_map");
+                "Unexpected non-NULL for sys_name in sdap_attr_map");
     ck_assert_msg(m->opt_name == NULL,
-                "Unexpected NULL for opt_name in sdap_attr_map");
+                "Unexpected non-NULL for opt_name in sdap_attr_map");
 }
 
 START_TEST(test_dp_opt_sentinel)


### PR DESCRIPTION
AD/IPA providers can't use simple bind, but this option
can be set in case AD/IPA and LDAP provider types are mixed
in the same domain, causing issues during `sdap_cli_auth_step()`

Resolves: https://github.com/SSSD/sssd/issues/5998