### PR TITLE
ci: move languages parameter to codeql init

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -24,6 +24,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:
+        languages: cpp, python
         queries: +security-and-quality
 
     - name: Compile sssd
@@ -38,5 +39,3 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
-      with:
-        languages: cpp, python


### PR DESCRIPTION
codeql analyze does not have this parameter:

```
Warning: Unexpected input(s) 'languages', valid inputs are ['check_name', 'output', 'upload', 'cleanup-level', 'ram', 'add-snippets', 'skip-queries', 'threads', 'checkout_path', 'ref', 'sha', 'category', 'upload-database', 'wait-for-processing', 'token', 'matrix']
```