### PR TITLE
Codeql fixes

### DIFF
--- a/src/providers/ad/ad_gpo_ndr.c
+++ b/src/providers/ad/ad_gpo_ndr.c
@@ -58,8 +58,7 @@ ndr_pull_GUID(struct ndr_pull *ndr,
         NDR_CHECK(ndr_pull_array_uint8(ndr, NDR_SCALARS, r->node, size_node_0));
         NDR_CHECK(ndr_pull_trailer_align(ndr, 4));
     }
-    if (ndr_flags & NDR_BUFFERS) {
-    }
+
     return NDR_ERR_SUCCESS;
 }
 

--- a/src/providers/data_provider/dp.c
+++ b/src/providers/data_provider/dp.c
@@ -199,10 +199,7 @@ dp_init_send(TALLOC_CTX *mem_ctx,
     ret = EAGAIN;
 
 done:
-    if (ret == EOK) {
-        tevent_req_done(req);
-        tevent_req_post(req, ev);
-    } else if (ret != EAGAIN) {
+    if (ret != EAGAIN) {
         tevent_req_error(req, ret);
         tevent_req_post(req, ev);
     }

--- a/src/providers/ipa/ipa_subdomains.c
+++ b/src/providers/ipa/ipa_subdomains.c
@@ -1923,20 +1923,11 @@ ipa_domain_resolution_order_send(TALLOC_CTX *mem_ctx,
                                  state->domain->name, attrs);
     if (subreq == NULL) {
         ret = ENOMEM;
-        goto immediately;
-    }
-
-    tevent_req_set_callback(subreq, ipa_domain_resolution_order_done, req);
-
-    return req;
-
-immediately:
-    if (ret == EOK) {
-        tevent_req_done(req);
-    } else {
         tevent_req_error(req, ret);
+        tevent_req_post(req, ev);
+    } else {
+        tevent_req_set_callback(subreq, ipa_domain_resolution_order_done, req);
     }
-    tevent_req_post(req, ev);
 
     return req;
 }
@@ -2189,11 +2180,7 @@ kdcinfo_from_site_send(TALLOC_CTX *mem_ctx,
     return req;
 
 immediately:
-    if (ret != EOK) {
-        tevent_req_error(req, ret);
-    } else {
-        tevent_req_done(req);
-    }
+    tevent_req_error(req, ret);
     tevent_req_post(req, ev);
     return req;
 }

--- a/src/providers/ipa/ipa_sudo_refresh.c
+++ b/src/providers/ipa/ipa_sudo_refresh.c
@@ -79,11 +79,7 @@ ipa_sudo_full_refresh_send(TALLOC_CTX *mem_ctx,
     return req;
 
 immediately:
-    if (ret == EOK) {
-        tevent_req_done(req);
-    } else {
-        tevent_req_error(req, ret);
-    }
+    tevent_req_error(req, ret);
     tevent_req_post(req, ev);
 
     return req;
@@ -205,11 +201,7 @@ ipa_sudo_smart_refresh_send(TALLOC_CTX *mem_ctx,
     return req;
 
 immediately:
-    if (ret == EOK) {
-        tevent_req_done(req);
-    } else {
-        tevent_req_error(req, ret);
-    }
+    tevent_req_error(req, ret);
     tevent_req_post(req, ev);
 
     return req;

--- a/src/providers/ldap/sdap_async_connection.c
+++ b/src/providers/ldap/sdap_async_connection.c
@@ -527,11 +527,7 @@ struct tevent_req *sdap_connect_host_send(TALLOC_CTX *mem_ctx,
     return req;
 
 immediately:
-    if (ret == EOK) {
-        tevent_req_done(req);
-    } else {
-        tevent_req_error(req, ret);
-    }
+    tevent_req_error(req, ret);
     tevent_req_post(req, ev);
 
     return req;

--- a/src/providers/ldap/sdap_async_initgroups.c
+++ b/src/providers/ldap/sdap_async_initgroups.c
@@ -3057,7 +3057,7 @@ static void sdap_get_initgr_user(struct tevent_req *subreq)
         }
     } else if (count == 1) {
         state->orig_user = usr_attrs[0];
-    } else if (count != 1) {
+    } else {
         DEBUG(SSSDBG_FUNC_DATA,
               "The search returned %zu entries, need to match the correct one\n",
               count);

--- a/src/providers/ldap/sdap_async_initgroups_ad.c
+++ b/src/providers/ldap/sdap_async_initgroups_ad.c
@@ -83,11 +83,7 @@ sdap_get_ad_tokengroups_send(TALLOC_CTX *mem_ctx,
     return req;
 
 immediately:
-    if (ret == EOK) {
-        tevent_req_done(req);
-    } else {
-        tevent_req_error(req, ret);
-    }
+    tevent_req_error(req, ret);
     tevent_req_post(req, ev);
 
     return req;
@@ -1631,20 +1627,11 @@ sdap_ad_tokengroups_initgroups_send(TALLOC_CTX *mem_ctx,
     }
     if (subreq == NULL) {
         ret = ENOMEM;
-        goto immediately;
-    }
-
-    tevent_req_set_callback(subreq, sdap_ad_tokengroups_initgroups_done, req);
-
-    return req;
-
-immediately:
-    if (ret == EOK) {
-        tevent_req_done(req);
-    } else {
         tevent_req_error(req, ret);
+        tevent_req_post(req, ev);
+    } else {
+        tevent_req_set_callback(subreq, sdap_ad_tokengroups_initgroups_done, req);
     }
-    tevent_req_post(req, ev);
 
     return req;
 }

--- a/src/providers/ldap/sdap_async_nested_groups.c
+++ b/src/providers/ldap/sdap_async_nested_groups.c
@@ -2072,21 +2072,13 @@ sdap_nested_group_lookup_unknown_send(TALLOC_CTX *mem_ctx,
                                                 state->member);
     if (subreq == NULL) {
         ret = ENOMEM;
-        goto immediately;
-    }
-
-    tevent_req_set_callback(subreq, sdap_nested_group_lookup_unknown_user_done,
-                            req);
-
-    return req;
-
-immediately:
-    if (ret == EOK) {
-        tevent_req_done(req);
-    } else {
         tevent_req_error(req, ret);
+        tevent_req_post(req, ev);
+    } else {
+        tevent_req_set_callback(subreq,
+                                sdap_nested_group_lookup_unknown_user_done,
+                                req);
     }
-    tevent_req_post(req, ev);
 
     return req;
 }

--- a/src/providers/ldap/sdap_online_check.c
+++ b/src/providers/ldap/sdap_online_check.c
@@ -57,20 +57,11 @@ static struct tevent_req *sdap_online_check_send(TALLOC_CTX *mem_ctx,
                                    CON_TLS_DFL, false);
     if (subreq == NULL) {
         ret = ENOMEM;
-        goto immediately;
-    }
-
-    tevent_req_set_callback(subreq, sdap_online_check_connect_done, req);
-
-    return req;
-
-immediately:
-    if (ret == EOK) {
-        tevent_req_done(req);
-    } else {
         tevent_req_error(req, ret);
+        tevent_req_post(req, be_ctx->ev);
+    } else {
+        tevent_req_set_callback(subreq, sdap_online_check_connect_done, req);
     }
-    tevent_req_post(req, be_ctx->ev);
 
     return req;
 }

--- a/src/providers/ldap/sdap_sudo_refresh.c
+++ b/src/providers/ldap/sdap_sudo_refresh.c
@@ -91,11 +91,7 @@ struct tevent_req *sdap_sudo_full_refresh_send(TALLOC_CTX *mem_ctx,
     return req;
 
 immediately:
-    if (ret == EOK) {
-        tevent_req_done(req);
-    } else {
-        tevent_req_error(req, ret);
-    }
+    tevent_req_error(req, ret);
     tevent_req_post(req, id_ctx->be->ev);
 
     return req;
@@ -221,11 +217,7 @@ struct tevent_req *sdap_sudo_smart_refresh_send(TALLOC_CTX *mem_ctx,
     return req;
 
 immediately:
-    if (ret == EOK) {
-        tevent_req_done(req);
-    } else {
-        tevent_req_error(req, ret);
-    }
+    tevent_req_error(req, ret);
     tevent_req_post(req, id_ctx->be->ev);
 
     return req;

--- a/src/providers/proxy/proxy.h
+++ b/src/providers/proxy/proxy.h
@@ -99,8 +99,6 @@ struct pc_init_ctx {
     struct sbus_connection *conn;
 };
 
-//int proxy_client_init(struct sbus_connection *conn, void *data);
-
 #define PROXY_CHILD_PIPE "private/proxy_child"
 #define DEFAULT_BUFSIZE 4096
 #define MAX_BUF_SIZE 1024*1024 /* max 1MiB */

--- a/src/responder/common/cache_req/cache_req_search.c
+++ b/src/responder/common/cache_req/cache_req_search.c
@@ -601,11 +601,7 @@ struct tevent_req *cache_req_locate_domain_send(TALLOC_CTX *mem_ctx,
     return req;
 
 immediate:
-    if (ret == EOK) {
-        tevent_req_done(req);
-    } else {
-        tevent_req_error(req, ret);
-    }
+    tevent_req_error(req, ret);
     tevent_req_post(req, ev);
     return req;
 }

--- a/src/responder/common/responder_dp.c
+++ b/src/responder/common/responder_dp.c
@@ -418,10 +418,7 @@ sss_dp_resolver_get_send(TALLOC_CTX *mem_ctx,
     ret = EAGAIN;
 
 done:
-    if (ret == EOK) {
-        tevent_req_done(req);
-        tevent_req_post(req, rctx->ev);
-    } else if (ret != EAGAIN) {
+    if (ret != EAGAIN) {
         tevent_req_error(req, ret);
         tevent_req_post(req, rctx->ev);
     }

--- a/src/responder/common/responder_get_domains.c
+++ b/src/responder/common/responder_get_domains.c
@@ -763,10 +763,7 @@ sss_dp_get_account_domain_send(TALLOC_CTX *mem_ctx,
     ret = EAGAIN;
 
 done:
-    if (ret == EOK) {
-        tevent_req_done(req);
-        tevent_req_post(req, rctx->ev);
-    } else if (ret != EAGAIN) {
+    if (ret != EAGAIN) {
         tevent_req_error(req, ret);
         tevent_req_post(req, rctx->ev);
     }

--- a/src/responder/sudo/sudosrv_get_sudorules.c
+++ b/src/responder/sudo/sudosrv_get_sudorules.c
@@ -775,20 +775,11 @@ struct tevent_req *sudosrv_get_rules_send(TALLOC_CTX *mem_ctx,
                                            username);
     if (subreq == NULL) {
         ret = ENOMEM;
-        goto immediately;
-    }
-
-    tevent_req_set_callback(subreq, sudosrv_get_rules_initgr_done, req);
-
-    return req;
-
-immediately:
-    if (ret == EOK) {
-        tevent_req_done(req);
-    } else {
         tevent_req_error(req, ret);
+        tevent_req_post(req, ev);
+    } else {
+        tevent_req_set_callback(subreq, sudosrv_get_rules_initgr_done, req);
     }
-    tevent_req_post(req, ev);
 
     return req;
 }

--- a/src/sbus/connection/sbus_connection_connect.c
+++ b/src/sbus/connection/sbus_connection_connect.c
@@ -380,10 +380,7 @@ sbus_server_create_and_connect_send(TALLOC_CTX *mem_ctx,
     ret = EAGAIN;
 
 done:
-    if (ret == EOK) {
-        tevent_req_done(req);
-        tevent_req_post(req, ev);
-    } else if (ret != EAGAIN) {
+    if (ret != EAGAIN) {
         tevent_req_error(req, ret);
         tevent_req_post(req, ev);
     }

--- a/src/sss_client/sss_cli.h
+++ b/src/sss_client/sss_cli.h
@@ -127,7 +127,6 @@ enum sss_cli_command {
     SSS_NSS_SETNETGRENT    = 0x0061,
     SSS_NSS_GETNETGRENT    = 0x0062,
     SSS_NSS_ENDNETGRENT    = 0x0063,
-    /* SSS_NSS_INNETGR     = 0x0064, */
 
 /* networks */
 

--- a/src/tests/intg/ldap_local_override_test.py
+++ b/src/tests/intg/ldap_local_override_test.py
@@ -622,9 +622,9 @@ def test_find_user_override(ldap_conn, env_find_user_override):
     out = check_output(['sss_override', 'user-find']).decode('utf-8')
 
     # Expected override of users
-    exp_usr_ovrd = ['user1@LDAP:ov_user1:10010:20010:Overriden User 1:'
+    exp_usr_ovrd = ['user1@LDAP:ov_user1:10010:20010:Overriden User 1:' +
                     '/home/ov/user1:/bin/ov_user1_shell:',
-                    'user2@LDAP:ov_user2:10020:20020:Overriden User 2:'
+                    'user2@LDAP:ov_user2:10020:20020:Overriden User 2:' +
                     '/home/ov/user2:/bin/ov_user2_shell:']
 
     assert set(out.splitlines()) == set(exp_usr_ovrd)

--- a/src/tests/multihost/alltests/conftest.py
+++ b/src/tests/multihost/alltests/conftest.py
@@ -963,13 +963,14 @@ def create_posix_usersgroups_failover(session_multihost):
                                   group_info)
         except LdapException:
             assert False
-            group_dn = 'cn=ldapusers,ou=Groups,dc=example,dc=test'
-            for i in range(1, 10):
-                user_dn = 'uid=foo%d,ou=People,dc=example,dc=test' % i
-                add_member = [(ldap.MOD_ADD, 'uniqueMember',
-                               user_dn.encode('utf-8'))]
-                (ret, _) = ldap_inst.modify_ldap(group_dn, add_member)
-                assert ret == 'Success'
+
+        group_dn = 'cn=ldapusers,ou=Groups,dc=example,dc=test'
+        for i in range(1, 10):
+            user_dn = 'uid=foo%d,ou=People,dc=example,dc=test' % i
+            add_member = [(ldap.MOD_ADD, 'uniqueMember',
+                           user_dn.encode('utf-8'))]
+            (ret, _) = ldap_inst.modify_ldap(group_dn, add_member)
+            assert ret == 'Success'
 
 
 @pytest.fixture(scope='class')

--- a/src/tests/multihost/alltests/test_krb_ldap_connection.py
+++ b/src/tests/multihost/alltests/test_krb_ldap_connection.py
@@ -210,8 +210,8 @@ class TestKrbLdapConnectionTimeout(object):
         """
         cmd_mod_user = ["kadmin.local", "-q", "modprinc -maxlife 2mins foo1"]
         multihost.master[0].run_command(cmd_mod_user)
-        cmd_mod = ["kadmin.local", "-q", "modprinc -maxlife 2mins "
-                   "krbtgt/EXAMPLE.TEST"]
+        cmd_mod = ["kadmin.local", "-q",
+                   "modprinc -maxlife 2mins krbtgt/EXAMPLE.TEST"]
         multihost.master[0].run_command(cmd_mod)
         multihost.client[0].log.info(
             '\n\n\nTesting for the case where timeout value is'

--- a/src/tests/multihost/alltests/test_ns_account_lock.py
+++ b/src/tests/multihost/alltests/test_ns_account_lock.py
@@ -288,9 +288,9 @@ class TestNsAccountLock(object):
                                      b'nsRoleDefinition',
                                      b'nsComplexRoleDefinition',
                                      b'nsNestedRoleDefinition'],
-                     'nsRoleDN': [b'cn=filtered,ou=people,'
+                     'nsRoleDN': [b'cn=filtered,ou=people,' +
                                   b'dc=example,dc=test',
-                                  b'cn=managed,ou=people,'
+                                  b'cn=managed,ou=people,' +
                                   b'dc=example,dc=test']}
         user_dn = 'cn=nested,ou=People,dc=example,dc=test'
         (_, _) = ldap_inst.add_entry(user_info, user_dn)

--- a/src/tests/multihost/basic/test_sudo.py
+++ b/src/tests/multihost/basic/test_sudo.py
@@ -62,8 +62,4 @@ class TestSanitySudo(object):
             (_, _, exit_status) = ssh.execute_cmd('sudo -l')
             assert exit_status == 0
             time.sleep(30)
-            if exit_status != 0:
-                journalctl_cmd = 'journalctl -x -n 100 --no-pager'
-                multihost.master[0].run_command(journalctl_cmd)
-                pytest.fail("%s cmd failed for user %s" % ('sudo -l', 'foo1'))
             ssh.close()

--- a/src/util/sss_cli_cmd.c
+++ b/src/util/sss_cli_cmd.c
@@ -105,9 +105,6 @@ const char *sss_cmd2str(enum sss_cli_command cmd)
         return "SSS_NSS_GETNETGRENT";
     case SSS_NSS_ENDNETGRENT:
         return "SSS_NSS_ENDNETGRENT";
-    /* SSS_NSS_INNETGR:
-        return "SSS_NSS_INNETGR";
-        break; */
 
     /* networks */
     case SSS_NSS_GETNETBYNAME:


### PR DESCRIPTION
There are five error types: Unreachable code, Comparison result is always the same, Empty branch of conditional, Commented-out code and Implicit string concatenation in a list. The first four were resolved by removing unused code and cleaning up the remaining code. For the last one I made clear which strings are being concatenated.