### PR TITLE
CI: Use proper branch name variable in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -490,7 +490,7 @@ try {
       stages.put("covscan", {
         node("sssd-ci") {
           stage("covscan") {
-            covscan = new Covscan(this, notification, params.REPO_URL, params.REPO_BRANCH, env.CHANGE_ID, on_demand)
+            covscan = new Covscan(this, notification, params.REPO_URL, env.BRANCH_NAME, env.CHANGE_ID, on_demand)
             covscan.run()
           }
         }


### PR DESCRIPTION
This is a fix for Covscan master branch run in Jenkins.

I could only test PR and OnDemand jenkins builds for my covscan workflow addition. it appears `params. REPO_BRANCH` is null when job runs against sssd master push.

~~~
java.lang.NullPointerException: Cannot invoke method trim() on null
object
        at org.codehaus.groovy.runtime.NullObject.invokeMethod(NullObject.java:91)
        at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:48)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
        at org.codehaus.groovy.runtime.callsite.NullCallSite.call(NullCallSite.java:35)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
        at org.kohsuke.groovy.sandbox.impl.Checker$1.call(Checker.java:163)
        at org.kohsuke.groovy.sandbox.impl.Checker.checkedCall(Checker.java:165)
        at com.cloudbees.groovy.cps.sandbox.SandboxInvoker.methodCall(SandboxInvoker.java:17)
        at Covscan.run(WorkflowScript:312)
~~~