### PR TITLE
sifp: fix coverity issue

### DIFF
--- a/src/lib/sifp/sss_sifp_parser.c
+++ b/src/lib/sifp/sss_sifp_parser.c
@@ -132,7 +132,7 @@ sss_sifp_parse_dict(sss_sifp_ctx *ctx,
     DBusMessageIter dict_iter;
     DBusMessageIter array_iter;
     sss_sifp_error ret;
-    hash_key_t table_key;
+    hash_key_t table_key = {0};
     hash_value_t table_value;
     const char *key = NULL;
     const char *value = NULL;


### PR DESCRIPTION
```
Error: GCC_ANALYZER_WARNING (CWE-457):
sssd-pr5762_14/src/lib/sifp/sss_sifp_parser.c: scope_hint: In function 'sss_sifp_parse_dict'
sssd-pr5762_14/src/lib/sifp/sss_sifp_parser.c:233:18: warning[-Wanalyzer-use-of-uninitialized-value]: use of uninitialized value 'table_key.<U7260>.str'
sssd-pr5762_14/src/lib/sifp/sss_sifp_parser.c:461:5: note: in expansion of macro 'check_dbus_arg'
sssd-pr5762_14/src/lib/sifp/sss_sifp_parser.c:147:5: note: in expansion of macro 'check_dbus_arg'
  231|
  232|   done:
  233|->     if (table_key.str != NULL) {
  234|           _free(ctx, table_key.str);
  235|       }
```