### PR TITLE
test: increase timeout for dlopen-tests

### DIFF
--- a/contrib/ci/sssd.supp
+++ b/contrib/ci/sssd.supp
@@ -236,3 +236,23 @@
    ...
    fun:main
 }
+
+# Suppress https://bugzilla.redhat.com/show_bug.cgi?id=2065675
+{
+   dlopen-tests
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:UnknownInlinedFun
+   fun:_dl_find_object_update
+   fun:dl_open_worker_begin
+   fun:_dl_catch_exception
+   fun:dl_open_worker
+   fun:_dl_catch_exception
+   fun:_dl_open
+   fun:dlopen_doit
+   fun:_dl_catch_exception
+   fun:_dl_catch_error
+   fun:_dlerror_run
+   fun:dlopen@@GLIBC_2.34
+}

--- a/src/tests/intg/ds_openldap.py
+++ b/src/tests/intg/ds_openldap.py
@@ -133,18 +133,18 @@ class DSOpenLDAP(DS):
             objectClass: olcModuleList
             cn: module{{0}}
             olcModulePath: {dist_lib_dir}
-            olcModuleLoad: back_hdb
+            olcModuleLoad: back_mdb
 
             # Set defaults for the backend
-            dn: olcBackend=hdb,cn=config
+            dn: olcBackend=mdb,cn=config
             objectClass: olcBackendConfig
-            olcBackend: hdb
+            olcBackend: mdb
 
             # The database definition.
-            dn: olcDatabase=hdb,cn=config
+            dn: olcDatabase=mdb,cn=config
             objectClass: olcDatabaseConfig
-            objectClass: olcHdbConfig
-            olcDatabase: hdb
+            objectClass: olcMdbConfig
+            olcDatabase: mdb
             olcDbCheckpoint: 512 30
             olcLastMod: TRUE
             olcSuffix: {self.base_dn}


### PR DESCRIPTION
Recently CI runs failed while running the dlopen-tests under valgrind
because ti run for more that 10s. Since single runs took about 30s this
patch increases the timeout to 60s.