### PR TITLE
CI: Add warnings enabled build and make check

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -5,6 +5,4 @@ runs:
   steps:
   - shell: bash
     run: |
-      cd contrib/ci/
-      . deps.sh
-      deps_install
+      sudo ./contrib/ci/run --deps-only

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,57 @@
+name: "Build"
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  make-check:
+    runs-on: ubuntu-latest
+    container: fedora:latest
+    permissions:
+      security-events: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Install container pre-requisites
+      run: |
+        dnf -y install util-linux
+
+    - name: Install dependencies
+      id: dependencies
+      uses: ./.github/actions/install-dependencies
+
+    - name: Configure sssd
+      uses: ./.github/actions/configure
+
+    - name: make
+      shell: bash
+      working-directory: x86_64
+      run: |
+        source ../contrib/fedora/bashrc_sssd
+        make CFLAGS+="$SSS_WARNINGS -Werror"
+
+    - name: make check
+      shell: bash
+      working-directory: x86_64
+      run: |
+        source ../contrib/fedora/bashrc_sssd
+        make CFLAGS+="$SSS_WARNINGS -Werror" check
+
+    - name: make distcheck
+      shell: bash
+      working-directory: x86_64
+      run: |
+        source ../contrib/fedora/bashrc_sssd
+        AUX_DISTCHECK_CONFIGURE_FLAGS+=--with-smb-idmap-interface-version=5 make distcheck
+
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: configure-artifacts
+        path: |
+          x86_64/config.log
+          x86_64/config.h
+        if-no-files-found: error

--- a/contrib/ci/distro.sh
+++ b/contrib/ci/distro.sh
@@ -35,9 +35,10 @@ else
 fi
 declare -r DISTRO_FAMILY
 
-DISTRO_ID=`lsb_release --id | sed -e 's/^[^:]*:\s*\(.*\)$/\L\1\E/'`
+. /etc/os-release
+DISTRO_ID=$ID
 declare -r DISTRO_ID
-DISTRO_RELEASE=`lsb_release --release | sed -e 's/^[^:]*:\s*\(.*\)$/\L\1\E/'`
+DISTRO_RELEASE=$VERSION_ID
 declare -r DISTRO_RELEASE
 
 # Distribution branch (lowercase)

--- a/contrib/ci/rpm-spec-builddeps
+++ b/contrib/ci/rpm-spec-builddeps
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Extract build dependencies from an RPM .spec file.
 #

--- a/contrib/ci/run
+++ b/contrib/ci/run
@@ -55,6 +55,7 @@ declare PEP8_IGNORE="--ignore=E121,E123,E126,E226,E24,E704,W503,W504,W605"
 declare PEP8_MAX_LENGTH="--max-line-length=119"
 declare BASE_PFX=""
 declare DEPS=true
+declare DEPS_ONLY=false
 declare BASE_DIR=`pwd`
 declare MODERATE=false
 declare RIGOROUS=false
@@ -83,6 +84,7 @@ Options:
     -p, --prefix=STRING Use STRING as the prefix to prepend to file and
                         directory paths in output.
     -n, --no-deps       Don't attempt to install dependencies.
+    -d, --deps-only     Only install dependencies, don't run tests.
     -e, --essential     Run the essential subset of tests.
     -m, --moderate      Run the moderate subset of tests.
     -r, --rigorous,
@@ -320,8 +322,8 @@ function run_build()
 #
 declare args_expr
 args_expr=`getopt --name \`basename "\$0"\` \
-                  --options hp:nemrf \
-                  --longoptions help,prefix:,no-deps \
+                  --options hp:dnemrf \
+                  --longoptions help,prefix:,no-deps,deps-only \
                   --longoptions essential,moderate,rigorous,full \
                   -- "$@"`
 eval set -- "$args_expr"
@@ -332,6 +334,8 @@ while true; do
             usage;          exit 0;;
         -p|--prefix)
             BASE_PFX="$2";  shift 2;;
+        -d|--deps-only)
+            DEPS_ONLY=true; shift;;
         -n|--no-deps)
             DEPS=false;     shift;;
         -e|--essential)
@@ -360,6 +364,13 @@ export V=1
 if "$DEPS"; then
     stage install-deps  deps_install
 fi
+
+if "$DEPS_ONLY"; then
+    unset V
+    trap - EXIT
+    exit
+fi
+
 if [[ "$DISTRO_BRANCH" != redhat-* ]]; then
     # Ignore "E722 do not use bare except" exceptions
     # that are only raised on debian_testing machines.

--- a/contrib/fedora/bashrc_sssd
+++ b/contrib/fedora/bashrc_sssd
@@ -73,6 +73,8 @@ SSS_WARNINGS='-Wall \
               -Wextra \
               -Wno-unused-parameter \
               -Wno-sign-compare \
+              -Wshadow \
+              -Wunused-variable \
               -Wformat-security'
 
 # Build (or finish building) all objects and then run the build-tests against


### PR DESCRIPTION
Build and runs make check with `-Werror` and the following flags enabled: 
~~~
SSS_WARNINGS='-Wall \
              -Wextra \
              -Wno-unused-parameter \
              -Wno-sign-compare \
              -Wformat-security'
...


chmake()
{
    make V=0 \
         CFLAGS+="-ggdb3 $SSS_WARNINGS ${SSS_WERROR-} -O0 -Wp,-U_FORTIFY_SOURCE" \
         -j$PROCESSORS check "$@"
}
~~~
