### PR TITLE
Tests: fix python linter issues 1

### DIFF
--- a/src/config/SSSDConfig/__init__.py.in
+++ b/src/config/SSSDConfig/__init__.py.in
@@ -1001,7 +1001,7 @@ class SSSDConfig(SSSDChangeConf):
         with open(configfile, 'r') as fd:
             try:
                 self.readfp(fd)
-            except:
+            except Exception:
                 raise ParsingError
 
         self.configfile = configfile

--- a/src/config/SSSDConfig/ipachangeconf.py
+++ b/src/config/SSSDConfig/ipachangeconf.py
@@ -75,7 +75,7 @@ class IPAChangeConf(object):
         elif type(indent) is str:
             self.indent = (indent, )
         else:
-           raise ValueError('Indent must be a list of strings')
+            raise ValueError('Indent must be a list of strings')
 
     def setOptionAssignment(self, assign):
         if type(assign) is tuple:
@@ -275,8 +275,8 @@ class IPAChangeConf(object):
                 raise SyntaxError('Unknown action: ['+no['action']+']')
 
             if o['type'] == "comment" or o['type'] == "empty":
-                 opts.append(o)
-                 continue
+                opts.append(o)
+                continue
 
             if o['type'] == "option":
                 (num, no) = self.findOpts(newopts, 'option', o['name'], True)
@@ -288,8 +288,8 @@ class IPAChangeConf(object):
                         opts.append(o)
                         continue
                     if no['action'] == 'comment':
-                       opts.append({'name':'comment', 'type':'comment',
-                                    'value':self.dcomment+o['name']+self.dassign+o['value']})
+                        opts.append({'name':'comment', 'type':'comment',
+                                     'value':self.dcomment+o['name']+self.dassign+o['value']})
                     continue
                 if no['action'] == 'set':
                     opts.append(no)

--- a/src/config/SSSDConfig/ipachangeconf.py
+++ b/src/config/SSSDConfig/ipachangeconf.py
@@ -284,7 +284,7 @@ class IPAChangeConf(object):
                     opts.append(o)
                     continue
                 if no['action'] == 'comment' or no['action'] == 'remove':
-                    if no['value'] != None and o['value'] != no['value']:
+                    if no['value'] is not None and o['value'] != no['value']:
                         opts.append(o)
                         continue
                     if no['action'] == 'comment':
@@ -571,7 +571,7 @@ class SSSDChangeConf(IPAChangeConf):
 
     def has_option(self, section, name):
         index, item = self.get_option_index(section, name)
-        if index != -1 and item != None:
+        if index != -1 and item is not None:
             return True
         return False
 

--- a/src/config/SSSDConfigTest.py
+++ b/src/config/SSSDConfigTest.py
@@ -176,7 +176,7 @@ class SSSDConfigTestValid(unittest.TestCase):
         #Ensure the output file doesn't exist
         try:
             os.unlink(of)
-        except:
+        except OSError:
             pass
 
         #Write out the file
@@ -228,7 +228,7 @@ class SSSDConfigTestValid(unittest.TestCase):
         #Ensure the output file doesn't exist
         try:
             os.unlink(of)
-        except:
+        except OSError:
             pass
 
         #Write out the file
@@ -1909,7 +1909,7 @@ class SSSDConfigTestSSSDConfig(unittest.TestCase):
         #Ensure the output file doesn't exist
         try:
             os.unlink(of)
-        except:
+        except OSError:
             pass
 
         #Write out the file

--- a/src/config/SSSDConfigTest.py
+++ b/src/config/SSSDConfigTest.py
@@ -377,12 +377,12 @@ class SSSDConfigTestSSSDService(unittest.TestCase):
                         "list_options is requiring a %s" %
                         options['reconnection_retries'][0])
 
-        self.assertTrue(options['reconnection_retries'][1] == None,
+        self.assertTrue(options['reconnection_retries'][1] is None,
                         "reconnection_retries should not require a subtype. " +
                         "list_options is requiring a %s" %
                         options['reconnection_retries'][1])
 
-        self.assertTrue(options['reconnection_retries'][3] == None,
+        self.assertTrue(options['reconnection_retries'][3] is None,
                         "reconnection_retries should have no default")
 
         self.assertTrue(type(options['services']) == tuple,
@@ -638,7 +638,7 @@ class SSSDConfigTestSSSDDomain(unittest.TestCase):
                         "list_options is requiring a %s" %
                         options['max_id'][0])
 
-        self.assertTrue(options['max_id'][1] == None,
+        self.assertTrue(options['max_id'][1] is None,
                         "max_id should not require a subtype. " +
                         "list_options is requiring a %s" %
                         options['max_id'][1])
@@ -993,7 +993,7 @@ class SSSDConfigTestSSSDDomain(unittest.TestCase):
                         "list_options is requiring a %s" %
                         options['max_id'][0])
 
-        self.assertTrue(options['max_id'][1] == None,
+        self.assertTrue(options['max_id'][1] is None,
                         "config_file_version should not require a subtype. " +
                         "list_options is requiring a %s" %
                         options['max_id'][1])

--- a/src/config/SSSDConfigTest.py
+++ b/src/config/SSSDConfigTest.py
@@ -85,8 +85,8 @@ class SSSDConfigTestValid(unittest.TestCase):
                                      srcdir + "/etc/sssd.api.d")
         sssdconfig.new_config()
         sssdconfig.delete_service('sssd')
-        new_sssd_service = sssdconfig.new_service('sssd');
-        new_options = new_sssd_service.list_options();
+        new_sssd_service = sssdconfig.new_service('sssd')
+        new_options = new_sssd_service.list_options()
 
         self.assertTrue('debug_level' in new_options)
         self.assertEqual(new_options['debug_level'][0], int)
@@ -1156,7 +1156,7 @@ class SSSDConfigTestSSSDDomain(unittest.TestCase):
         domain = SSSDConfig.SSSDDomain('sssd', self.schema)
 
         # Positive test - Change the name once
-        domain.set_name('sssd2');
+        domain.set_name('sssd2')
         self.assertEqual(domain.get_name(), 'sssd2')
         self.assertEqual(domain.oldname, 'sssd')
 

--- a/src/tests/intg/ldap_local_override_test.py
+++ b/src/tests/intg/ldap_local_override_test.py
@@ -61,7 +61,7 @@ def ds_inst(request):
         "cn=admin", "Secret123")
     try:
         ds_inst.setup()
-    except:
+    except Exception:
         ds_inst.teardown()
         raise
     request.addfinalizer(lambda: ds_inst.teardown())
@@ -104,7 +104,7 @@ def stop_sssd():
     while True:
         try:
             os.kill(pid, signal.SIGCONT)
-        except:
+        except OSError:
             break
         time.sleep(1)
 
@@ -128,7 +128,7 @@ def create_sssd_fixture(request):
     def teardown():
         try:
             stop_sssd()
-        except:
+        except Exception:
             pass
         for path in os.listdir(config.DB_PATH):
             os.unlink(config.DB_PATH + "/" + path)
@@ -174,7 +174,7 @@ def prepare_sssd(request, ldap_conn, use_fully_qualified_names=False,
         # remove user export file
         try:
             os.unlink(OVERRIDE_FILENAME)
-        except:
+        except OSError:
             pass
     request.addfinalizer(teardown)
 

--- a/src/tests/intg/test_enumeration.py
+++ b/src/tests/intg/test_enumeration.py
@@ -58,7 +58,7 @@ def ds_inst(request):
 
     try:
         ds_inst.setup()
-    except:
+    except Exception:
         ds_inst.teardown()
         raise
     request.addfinalizer(lambda: ds_inst.teardown())
@@ -208,10 +208,10 @@ def cleanup_sssd_process():
         while True:
             try:
                 os.kill(pid, signal.SIGCONT)
-            except:
+            except OSError:
                 break
             time.sleep(1)
-    except:
+    except OSError:
         pass
     for path in os.listdir(config.DB_PATH):
         os.unlink(config.DB_PATH + "/" + path)

--- a/src/tests/intg/test_files_provider.py
+++ b/src/tests/intg/test_files_provider.py
@@ -107,7 +107,7 @@ def stop_sssd():
     while True:
         try:
             os.kill(pid, signal.SIGCONT)
-        except:
+        except OSError:
             break
         time.sleep(1)
 
@@ -132,7 +132,7 @@ def create_sssd_fixture(request):
     def teardown():
         try:
             stop_sssd()
-        except:
+        except Exception:
             pass
         for path in os.listdir(config.DB_PATH):
             os.unlink(config.DB_PATH + "/" + path)

--- a/src/tests/intg/test_infopipe.py
+++ b/src/tests/intg/test_infopipe.py
@@ -94,10 +94,10 @@ class DbusDaemon(object):
                 while True:
                     try:
                         os.kill(self.pid, signal.SIGCONT)
-                    except:
+                    except OSError:
                         break
                     time.sleep(.1)
-            except:
+            except OSError:
                 pass
 
         # clean pid so we can start service one more time
@@ -133,7 +133,7 @@ def ds_inst(request):
 
     try:
         ds_inst.setup()
-    except:
+    except Exception:
         ds_inst.teardown()
         raise
     request.addfinalizer(ds_inst.teardown)
@@ -277,10 +277,10 @@ def cleanup_sssd_process():
         while True:
             try:
                 os.kill(pid, signal.SIGCONT)
-            except:
+            except OSError:
                 break
             time.sleep(1)
-    except:
+    except OSError:
         pass
     for path in os.listdir(config.DB_PATH):
         os.unlink(config.DB_PATH + "/" + path)

--- a/src/tests/intg/test_kcm.py
+++ b/src/tests/intg/test_kcm.py
@@ -70,7 +70,7 @@ def kdc_instance(request):
     try:
         kdc_instance.set_up()
         kdc_instance.start_kdc()
-    except:
+    except Exception:
         kdc_instance.teardown()
         raise
     request.addfinalizer(kdc_instance.teardown)
@@ -110,7 +110,7 @@ def create_sssd_kcm_fixture(sock_path, krb5_conf_path, request):
         for _ in range(1, 100):
             try:
                 sck.connect(abs_sock_path)
-            except:
+            except Exception:
                 time.sleep(0.1)
             else:
                 break

--- a/src/tests/intg/test_ldap.py
+++ b/src/tests/intg/test_ldap.py
@@ -54,7 +54,7 @@ def ds_inst(request):
 
     try:
         ds_inst.setup()
-    except:
+    except Exception:
         ds_inst.teardown()
         raise
     request.addfinalizer(ds_inst.teardown)
@@ -210,10 +210,10 @@ def cleanup_sssd_process():
         while True:
             try:
                 os.kill(pid, signal.SIGCONT)
-            except:
+            except OSError:
                 break
             time.sleep(1)
-    except:
+    except OSError:
         pass
     for path in os.listdir(config.DB_PATH):
         os.unlink(config.DB_PATH + "/" + path)

--- a/src/tests/intg/test_memory_cache.py
+++ b/src/tests/intg/test_memory_cache.py
@@ -48,7 +48,7 @@ def ds_inst(request):
         "cn=admin", "Secret123")
     try:
         ds_inst.setup()
-    except:
+    except Exception:
         ds_inst.teardown()
         raise
     request.addfinalizer(lambda: ds_inst.teardown())
@@ -91,7 +91,7 @@ def stop_sssd():
     while True:
         try:
             os.kill(pid, signal.SIGCONT)
-        except:
+        except OSError:
             break
         time.sleep(1)
 
@@ -104,7 +104,7 @@ def create_sssd_fixture(request):
     def teardown():
         try:
             stop_sssd()
-        except:
+        except Exception:
             pass
         for path in os.listdir(config.DB_PATH):
             os.unlink(config.DB_PATH + "/" + path)

--- a/src/tests/intg/test_netgroup.py
+++ b/src/tests/intg/test_netgroup.py
@@ -47,7 +47,7 @@ def ds_inst(request):
 
     try:
         ds_inst.setup()
-    except:
+    except Exception:
         ds_inst.teardown()
         raise
     request.addfinalizer(ds_inst.teardown)
@@ -167,10 +167,10 @@ def cleanup_sssd_process():
         while True:
             try:
                 os.kill(pid, signal.SIGCONT)
-            except:
+            except OSError:
                 break
             time.sleep(1)
-    except:
+    except OSError:
         pass
     for path in os.listdir(config.DB_PATH):
         os.unlink(config.DB_PATH + "/" + path)

--- a/src/tests/intg/test_pac_responder.py
+++ b/src/tests/intg/test_pac_responder.py
@@ -40,7 +40,7 @@ def stop_sssd():
     while True:
         try:
             os.kill(pid, signal.SIGCONT)
-        except:
+        except OSError:
             break
         time.sleep(1)
 
@@ -62,7 +62,7 @@ def create_sssd_fixture(request):
     def teardown():
         try:
             stop_sssd()
-        except:
+        except Exception:
             pass
         for path in os.listdir(config.DB_PATH):
             os.unlink(config.DB_PATH + "/" + path)
@@ -116,7 +116,7 @@ def test_multithreaded_pac_client(files_domain_only, sssd_pac_test_client):
 
     try:
         subprocess.check_call(sssd_pac_test_client)
-    except:
+    except Exception:
         # cancel alarm
         signal.alarm(0)
         raise Exception("sssd_pac_test_client failed")

--- a/src/tests/intg/test_pam_responder.py
+++ b/src/tests/intg/test_pam_responder.py
@@ -51,7 +51,7 @@ def ad_inst(request):
 
     try:
         instance.setup()
-    except:
+    except Exception:
         instance.teardown()
         raise
     request.addfinalizer(instance.teardown)
@@ -398,7 +398,7 @@ def test_password_prompting_config_global(ldap_conn, pam_prompting_config,
 
     try:
         out, err = sssctl.communicate(input="111")
-    except:
+    except Exception:
         sssctl.kill()
         out, err = sssctl.communicate()
 
@@ -424,7 +424,7 @@ def test_password_prompting_config_srv(ldap_conn, pam_prompting_config,
 
     try:
         out, err = sssctl.communicate(input="111")
-    except:
+    except Exception:
         sssctl.kill()
         out, err = sssctl.communicate()
 
@@ -462,7 +462,7 @@ def test_sc_auth_wrong_pin(simple_pam_cert_auth, env_for_sssctl):
 
     try:
         out, err = sssctl.communicate(input="111")
-    except:
+    except Exception:
         sssctl.kill()
         out, err = sssctl.communicate()
 
@@ -486,7 +486,7 @@ def test_sc_auth(simple_pam_cert_auth, env_for_sssctl):
 
     try:
         out, err = sssctl.communicate(input="123456")
-    except:
+    except Exception:
         sssctl.kill()
         out, err = sssctl.communicate()
 
@@ -510,7 +510,7 @@ def test_require_sc_auth(simple_pam_cert_auth, env_for_sssctl):
 
     try:
         out, err = sssctl.communicate(input="123456")
-    except:
+    except Exception:
         sssctl.kill()
         out, err = sssctl.communicate()
 
@@ -539,7 +539,7 @@ def test_require_sc_auth_no_cert(simple_pam_cert_auth_no_cert, env_for_sssctl):
 
     try:
         out, err = sssctl.communicate(input="123456")
-    except:
+    except Exception:
         sssctl.kill()
         out, err = sssctl.communicate()
 
@@ -569,7 +569,7 @@ def test_try_sc_auth_no_map(simple_pam_cert_auth, env_for_sssctl):
 
     try:
         out, err = sssctl.communicate(input="123456")
-    except:
+    except Exception:
         sssctl.kill()
         out, err = sssctl.communicate()
 
@@ -594,7 +594,7 @@ def test_try_sc_auth(simple_pam_cert_auth, env_for_sssctl):
 
     try:
         out, err = sssctl.communicate(input="123456")
-    except:
+    except Exception:
         sssctl.kill()
         out, err = sssctl.communicate()
 
@@ -621,7 +621,7 @@ def test_try_sc_auth_root(simple_pam_cert_auth, env_for_sssctl):
 
     try:
         out, err = sssctl.communicate(input="123456")
-    except:
+    except Exception:
         sssctl.kill()
         out, err = sssctl.communicate()
 
@@ -649,7 +649,7 @@ def test_sc_auth_missing_name(simple_pam_cert_auth, env_for_sssctl):
 
     try:
         out, err = sssctl.communicate(input="123456")
-    except:
+    except Exception:
         sssctl.kill()
         out, err = sssctl.communicate()
 
@@ -676,7 +676,7 @@ def test_sc_auth_missing_name_whitespace(simple_pam_cert_auth, env_for_sssctl):
 
     try:
         out, err = sssctl.communicate(input="123456")
-    except:
+    except Exception:
         sssctl.kill()
         out, err = sssctl.communicate()
 
@@ -704,7 +704,7 @@ def test_sc_auth_name_format(simple_pam_cert_auth_name_format, env_for_sssctl):
 
     try:
         out, err = sssctl.communicate(input="123456")
-    except:
+    except Exception:
         sssctl.kill()
         out, err = sssctl.communicate()
 
@@ -725,7 +725,7 @@ def kdc_instance(request):
     try:
         kdc_instance.set_up()
         kdc_instance.start_kdc()
-    except:
+    except Exception:
         kdc_instance.teardown()
         raise
     request.addfinalizer(kdc_instance.teardown)
@@ -763,7 +763,7 @@ def test_krb5_auth(setup_krb5, env_for_sssctl):
 
     try:
         out, err = sssctl.communicate(input="Secret123User1")
-    except:
+    except Exception:
         sssctl.kill()
         out, err = sssctl.communicate()
 
@@ -784,7 +784,7 @@ def test_krb5_auth(setup_krb5, env_for_sssctl):
 
     try:
         out, err = sssctl.communicate(input="Secret123User1")
-    except:
+    except Exception:
         sssctl.kill()
         out, err = sssctl.communicate()
 
@@ -830,7 +830,7 @@ def test_krb5_auth_domains(setup_krb5_domains, env_for_sssctl):
 
     try:
         out, err = sssctl.communicate(input="Secret123User1")
-    except:
+    except Exception:
         sssctl.kill()
         out, err = sssctl.communicate()
 

--- a/src/tests/intg/test_pysss_nss_idmap.py
+++ b/src/tests/intg/test_pysss_nss_idmap.py
@@ -46,7 +46,7 @@ def ad_inst(request):
 
     try:
         instance.setup()
-    except:
+    except Exception:
         instance.teardown()
         raise
     request.addfinalizer(instance.teardown)
@@ -138,10 +138,10 @@ def cleanup_sssd_process():
         while True:
             try:
                 os.kill(pid, signal.SIGCONT)
-            except:
+            except OSError:
                 break
             time.sleep(1)
-    except:
+    except OSError:
         pass
     for path in os.listdir(config.DB_PATH):
         os.unlink(config.DB_PATH + "/" + path)

--- a/src/tests/intg/test_resolver.py
+++ b/src/tests/intg/test_resolver.py
@@ -49,7 +49,7 @@ def ds_inst(request):
 
     try:
         ds_inst.setup()
-    except:
+    except Exception:
         ds_inst.teardown()
         raise
     request.addfinalizer(ds_inst.teardown)
@@ -181,10 +181,10 @@ def cleanup_sssd_process():
         while True:
             try:
                 os.kill(pid, signal.SIGCONT)
-            except:
+            except OSError:
                 break
             time.sleep(1)
-    except:
+    except OSError:
         pass
     for path in os.listdir(config.DB_PATH):
         os.unlink(config.DB_PATH + "/" + path)

--- a/src/tests/intg/test_session_recording.py
+++ b/src/tests/intg/test_session_recording.py
@@ -42,7 +42,7 @@ def stop_sssd():
     while True:
         try:
             os.kill(pid, signal.SIGCONT)
-        except:
+        except OSError:
             break
         time.sleep(1)
 
@@ -69,7 +69,7 @@ def ds_inst(request):
 
     try:
         ds_inst.setup()
-    except:
+    except Exception:
         ds_inst.teardown()
         raise
     request.addfinalizer(lambda: ds_inst.teardown())
@@ -201,10 +201,10 @@ def cleanup_sssd_process():
         while True:
             try:
                 os.kill(pid, signal.SIGCONT)
-            except:
+            except OSError:
                 break
             time.sleep(1)
-    except:
+    except OSError:
         pass
     for path in os.listdir(config.DB_PATH):
         os.unlink(config.DB_PATH + "/" + path)

--- a/src/tests/intg/test_ssh_pubkey.py
+++ b/src/tests/intg/test_ssh_pubkey.py
@@ -64,7 +64,7 @@ def ds_inst(request):
 
     try:
         ds_inst.setup()
-    except:
+    except Exception:
         ds_inst.teardown()
         raise
     request.addfinalizer(ds_inst.teardown)
@@ -192,10 +192,10 @@ def cleanup_sssd_process():
         while True:
             try:
                 os.kill(pid, signal.SIGCONT)
-            except:
+            except OSError:
                 break
             time.sleep(1)
-    except:
+    except OSError:
         pass
     for path in os.listdir(config.DB_PATH):
         os.unlink(config.DB_PATH + "/" + path)

--- a/src/tests/intg/test_sssctl.py
+++ b/src/tests/intg/test_sssctl.py
@@ -43,7 +43,7 @@ def ds_inst(request):
         "cn=admin", "Secret123")
     try:
         ds_inst.setup()
-    except:
+    except Exception:
         ds_inst.teardown()
         raise
     request.addfinalizer(lambda: ds_inst.teardown())
@@ -93,7 +93,7 @@ def stop_sssd():
     while True:
         try:
             os.kill(pid, signal.SIGCONT)
-        except:
+        except OSError:
             break
         time.sleep(1)
 
@@ -106,7 +106,7 @@ def create_sssd_fixture(request):
     def teardown():
         try:
             stop_sssd()
-        except:
+        except Exception:
             pass
         for path in os.listdir(config.DB_PATH):
             os.unlink(config.DB_PATH + "/" + path)

--- a/src/tests/intg/test_sudo.py
+++ b/src/tests/intg/test_sudo.py
@@ -62,7 +62,7 @@ def ds_inst(request):
 
     try:
         ds_inst.setup()
-    except:
+    except Exception:
         ds_inst.teardown()
         raise
     request.addfinalizer(ds_inst.teardown)
@@ -186,10 +186,10 @@ def cleanup_sssd_process():
         while True:
             try:
                 os.kill(pid, signal.SIGCONT)
-            except:
+            except OSError:
                 break
             time.sleep(1)
-    except:
+    except OSError:
         pass
     for path in os.listdir(config.DB_PATH):
         os.unlink(config.DB_PATH + "/" + path)

--- a/src/tests/intg/test_ts_cache.py
+++ b/src/tests/intg/test_ts_cache.py
@@ -52,7 +52,7 @@ def ds_inst(request):
         "cn=admin", "Secret123")
     try:
         ds_inst.setup()
-    except:
+    except Exception:
         ds_inst.teardown()
         raise
     request.addfinalizer(lambda: ds_inst.teardown())
@@ -100,7 +100,7 @@ def stop_sssd():
     while True:
         try:
             os.kill(pid, signal.SIGCONT)
-        except:
+        except OSError:
             break
         time.sleep(1)
 
@@ -113,7 +113,7 @@ def create_sssd_fixture(request):
     def teardown():
         try:
             stop_sssd()
-        except:
+        except Exception:
             pass
         for path in os.listdir(config.DB_PATH):
             os.unlink(config.DB_PATH + "/" + path)


### PR DESCRIPTION
flake8 has detected several hundred issues in the python code and having all the fixes in a single PR is complex and difficult to review. That's why I'm creating a set of PRs as a spin-off of [the flake8 enabling PR](https://github.com/SSSD/sssd/pull/6006).

This set of patches fixes indentation issues (E111 and E117), end semicolons (E703), incorrect comparisons with "==" (E711) and bare 'except' usage (E722).