### PR TITLE
Tests: fix python linter issues 2

### DIFF
--- a/src/config/SSSDConfigTest.py
+++ b/src/config/SSSDConfigTest.py
@@ -44,8 +44,8 @@ def create_temp_dir():
     return tempfile.mkdtemp(dir=test_dir)
 
 
-def striplist(l):
-    return([x.strip() for x in l])
+def striplist(the_list):
+    return([x.strip() for x in the_list])
 
 
 class SSSDConfigTestValid(unittest.TestCase):

--- a/src/tests/intg/test_files_provider.py
+++ b/src/tests/intg/test_files_provider.py
@@ -853,8 +853,8 @@ def test_getgrnam_no_members(add_group_nomem_with_canary, files_domain_only):
 
 
 def groupadd_list(grp_ops, groups):
-    for grp in groups:
-        grp_ops.groupadd(**grp)
+    for group in groups:
+        grp_ops.groupadd(**group)
 
 
 def useradd_list(pwd_ops, users):

--- a/src/tests/multihost/alltests/conftest.py
+++ b/src/tests/multihost/alltests/conftest.py
@@ -1302,18 +1302,17 @@ def enable_sssd_hostmap(session_multihost, request):
     """ Enables sssd for network and host database in nsswitch.conf """
     tools = sssdTools(session_multihost.client[0])
     nsswitch_file = '/etc/authselect/user-nsswitch.conf'
-    bkup = f'cp -vf %s %s_bkp' % (nsswitch_file, nsswitch_file)
+    bkup = f'cp -vf {nsswitch_file} {nsswitch_file}_bkp'
     cmd = session_multihost.client[0].run_command(bkup)
 
     for value in ['hosts', 'networks']:
-        update_nsswitch = f"sed -i 's/%s:/%s: sss/' %s" % (value, value,
-                                                           nsswitch_file)
+        update_nsswitch = f"sed -i 's/{value}:/{value}: sss/' {nsswitch_file}"
         cmd = session_multihost.client[0].run_command(update_nsswitch)
     authselect = 'authselect select sssd'
     session_multihost.client[0].run_command(authselect)
 
     def restore_nsswitch():
-        restore = f"cp -vf %s_bkp %s" % (nsswitch_file, nsswitch_file)
+        restore = f"cp -vf {nsswitch_file}_bkp {nsswitch_file}"
         cmd = session_multihost.client[0].run_command(restore)
         session_multihost.client[0].run_command(authselect)
         tools.clear_sssd_cache()

--- a/src/tests/multihost/alltests/test_config_merging.py
+++ b/src/tests/multihost/alltests/test_config_merging.py
@@ -246,7 +246,7 @@ class TestConfigMerge(object):
         tools.remove_sss_cache('/var/log/sssd')
         start_sssd = 'systemctl start sssd'
         start = multihost.client[0].run_command(start_sssd, raiseonerr=False)
-        assert start.returncode is not 0
+        assert start.returncode != 0
         cmd_rm = 'rm -f /etc/sssd/conf.d/01_snippet.conf'
         multihost.client[0].run_command(cmd_rm, raiseonerr=False)
 

--- a/src/tests/multihost/alltests/test_krb5.py
+++ b/src/tests/multihost/alltests/test_krb5.py
@@ -29,9 +29,8 @@ class TestKrbWithLogin(object):
         :bugzilla:
          https://bugzilla.redhat.com/show_bug.cgi?id=1734094
         """
-        multihost.client[0].run_command(f'authselect '
-                                        f'select sssd '
-                                        f'with-files-access-provider')
+        multihost.client[0].run_command('authselect select sssd '
+                                        'with-files-access-provider')
         multihost.client[0].service_sssd('stop')
         client_tool = sssdTools(multihost.client[0])
         domain_params = {'id_provider': 'files',

--- a/src/tests/multihost/alltests/test_sudo.py
+++ b/src/tests/multihost/alltests/test_sudo.py
@@ -222,8 +222,8 @@ class TestSudo(object):
         multihost.client[0].service_sssd('start')
         time.sleep(40)
         logfile = f'/var/log/sssd/sssd_{ds_instance_name}.log'
-        tmout_ptrn = f'(SUDO.*Refresh.*executing)'
-        rschdl_ptrn = f'(SUDO.*Refresh.*rescheduling)'
+        tmout_ptrn = '(SUDO.*Refresh.*executing)'
+        rschdl_ptrn = '(SUDO.*Refresh.*rescheduling)'
         regex_tmout = re.compile(f'{tmout_ptrn}')
         rgx_rs_tstmp = re.compile(f'{rschdl_ptrn}')
         full_rfsh_tstmp = []

--- a/src/tests/multihost/ipa/conftest.py
+++ b/src/tests/multihost/ipa/conftest.py
@@ -213,7 +213,7 @@ def environment_setup(session_multihost, request):
     client.run_command("yum install -y gcc")
     client.run_command("yum install -y podman")
     with pytest.raises(subprocess.CalledProcessError):
-        client.run_command(f"grep subid /etc/nsswitch.conf")
+        client.run_command("grep subid /etc/nsswitch.conf")
     file_location = "/src/tests/multihost/ipa/data/list_subid_ranges.c"
     client.transport.put_file(os.getcwd() +
                               file_location,

--- a/src/tests/multihost/ipa/test_adtrust.py
+++ b/src/tests/multihost/ipa/test_adtrust.py
@@ -86,7 +86,7 @@ class TestADTrust(object):
             multihost.client[0].run_command(cmd, raiseonerr=False)
         cmd = f'echo "{fq_aduser} ALL=(ALL) ALL" >> /etc/sudoers'
         multihost.client[0].run_command(cmd, raiseonerr=False)
-        log = re.compile(f'.*System.*error.*Broken.*pipe.*')
+        log = re.compile('.*System.*error.*Broken.*pipe.*')
         try:
             ssh = SSHClient(multihost.client[0].ip,
                             username=f'{fq_aduser}',
@@ -111,7 +111,7 @@ class TestADTrust(object):
         for pam_file in "/etc/pam.d/sudo-i", "/etc/pam.d/sudo":
             cmd = f'sed -i "1d" {pam_file}'
             multihost.client[0].run_command(cmd, raiseonerr=False)
-        cmd = f'sed -i "$ d" /etc/sudoers'
+        cmd = 'sed -i "$ d" /etc/sudoers'
         multihost.client[0].run_command(cmd, raiseonerr=False)
         cmd = f'mv {bk_krbkcm} {krbkcm}'
         multihost.client[0].run_command(cmd, raiseonerr=False)

--- a/src/tests/multihost/sssd/testlib/common/libkrb5.py
+++ b/src/tests/multihost/sssd/testlib/common/libkrb5.py
@@ -169,7 +169,7 @@ class krb5srv(object):
         if service is None:
             service = 'host'
 
-        if p_type is 'user':
+        if p_type == 'user':
             add_principal = "add_principal -clearpolicy"\
                             " -pw %s %s@%s" % (password, principal,
                                                self.krb_realm)
@@ -180,7 +180,7 @@ class krb5srv(object):
                                                          self.krb_realm)
             kadmin_local_cmd = ['kadmin.local', '-r',
                                 self.krb_realm, '-q', add_principal]
-        elif p_type is 'admin':
+        elif p_type == 'admin':
             add_principal = "add_principal -clearpolicy"\
                             " -pw %s %s/%s" % (password, service, 'admin')
             kadmin_local_cmd = ['kadmin.local', '-r', self.krb_realm,


### PR DESCRIPTION
flake8 has detected several hundred issues in the python code and having all the fixes in a single PR is complex and difficult to review. That's why I'm creating a set of PRs as a spin-off of [the flake8 enabling PR](https://github.com/SSSD/sssd/pull/6006).

This set of patches fixes ambiguous variable names (E741), shadowed variables (F402), f-strings usage (F541) and comparison symbols (F632).

As a final note, f-string is a new and improved way of formatting strings in python. It is commonly used to concatenate strings. The code that I have changed was either not concatenating a string so a simple string would have been enough, or concatenating f-strings in the old way.

For more information check https://realpython.com/python-f-strings/