### PR TITLE
CI: Update apt cache

### DIFF
--- a/contrib/ci/distro.sh
+++ b/contrib/ci/distro.sh
@@ -74,6 +74,9 @@ function distro_pkg_install()
                  END {exit s}'
     elif [[ "$DISTRO_BRANCH" == -debian-* ]]; then
         [ $# != 0 ] && DEBIAN_FRONTEND=noninteractive \
+                       # Ensure updated apt cache
+                       sudo -p "$prompt" apt-get --yes update \
+                    && DEBIAN_FRONTEND=noninteractive \
                        sudo -p "$prompt" apt-get --yes install -- "$@"
     else
         echo "Cannot install packages on $DISTRO_BRANCH" >&2


### PR DESCRIPTION
Fixes error on runners in GH Action workflows when installing packages
~~~
Fetched 46.1 MB in 13s (3596 kB/s)
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/g/glibc/libc6-dbg_2.31-0ubuntu9.2_amd64.deb
404  Not Found [IP: 40.81.13.82 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
~~~

For example: https://github.com/SSSD/sssd/runs/5397444035?check_suite_focus=true