### PR TITLE
nss: add sss_nss_getorigbyusername and sss_nss_getorigbygroupname

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1393,7 +1393,7 @@ libsss_nss_idmap_la_LIBADD = \
     $(NULL)
 libsss_nss_idmap_la_LDFLAGS = \
     -Wl,--version-script,$(srcdir)/src/sss_client/idmap/sss_nss_idmap.exports \
-    -version-info 5:0:5
+    -version-info 6:0:6
 
 dist_noinst_DATA += src/sss_client/idmap/sss_nss_idmap.exports
 

--- a/src/responder/nss/nss_cmd.c
+++ b/src/responder/nss/nss_cmd.c
@@ -1185,7 +1185,8 @@ static errno_t nss_cmd_getidbysid(struct cli_ctx *cli_ctx)
                          nss_protocol_fill_id);
 }
 
-static errno_t nss_cmd_getorigbyname(struct cli_ctx *cli_ctx)
+static errno_t nss_cmd_getorigbyname_common(struct cli_ctx *cli_ctx,
+                                            enum cache_req_type type)
 {
     errno_t ret;
     struct nss_ctx *nss_ctx;
@@ -1224,9 +1225,25 @@ static errno_t nss_cmd_getorigbyname(struct cli_ctx *cli_ctx)
         attrs = defattrs;
     }
 
-    return nss_getby_name(cli_ctx, false, CACHE_REQ_OBJECT_BY_NAME, attrs,
+    return nss_getby_name(cli_ctx, false, type, attrs,
                           SSS_MC_NONE, nss_protocol_fill_orig);
 }
+
+static errno_t nss_cmd_getorigbyname(struct cli_ctx *cli_ctx)
+{
+    return nss_cmd_getorigbyname_common(cli_ctx, CACHE_REQ_OBJECT_BY_NAME);
+}
+
+static errno_t nss_cmd_getorigbyusername(struct cli_ctx *cli_ctx)
+{
+    return nss_cmd_getorigbyname_common(cli_ctx, CACHE_REQ_USER_BY_NAME);
+}
+
+static errno_t nss_cmd_getorigbygroupname(struct cli_ctx *cli_ctx)
+{
+    return nss_cmd_getorigbyname_common(cli_ctx, CACHE_REQ_GROUP_BY_NAME);
+}
+
 
 static errno_t nss_cmd_getnamebycert(struct cli_ctx *cli_ctx)
 {
@@ -1367,6 +1384,8 @@ struct sss_cmd_table *get_nss_cmds(void)
         { SSS_NSS_GETNAMEBYSID, nss_cmd_getnamebysid },
         { SSS_NSS_GETIDBYSID, nss_cmd_getidbysid },
         { SSS_NSS_GETORIGBYNAME, nss_cmd_getorigbyname },
+        { SSS_NSS_GETORIGBYUSERNAME, nss_cmd_getorigbyusername },
+        { SSS_NSS_GETORIGBYGROUPNAME, nss_cmd_getorigbygroupname },
         { SSS_NSS_GETNAMEBYCERT, nss_cmd_getnamebycert },
         { SSS_NSS_GETLISTBYCERT, nss_cmd_getlistbycert },
         { SSS_NSS_GETPWNAM_EX, nss_cmd_getpwnam_ex },

--- a/src/sss_client/idmap/sss_nss_idmap.c
+++ b/src/sss_client/idmap/sss_nss_idmap.c
@@ -225,6 +225,8 @@ static int sss_nss_getyyybyxxx(union input inp, enum sss_cli_command cmd,
     case SSS_NSS_GETNAMEBYSID:
     case SSS_NSS_GETIDBYSID:
     case SSS_NSS_GETORIGBYNAME:
+    case SSS_NSS_GETORIGBYUSERNAME:
+    case SSS_NSS_GETORIGBYGROUPNAME:
         ret = sss_strnlen(inp.str, 2048, &inp_len);
         if (ret != EOK) {
             return EINVAL;
@@ -339,6 +341,8 @@ static int sss_nss_getyyybyxxx(union input inp, enum sss_cli_command cmd,
 
         break;
     case SSS_NSS_GETORIGBYNAME:
+    case SSS_NSS_GETORIGBYUSERNAME:
+    case SSS_NSS_GETORIGBYGROUPNAME:
         ret = buf_to_kv_list(repbuf + DATA_START, data_len, &kv_list);
         if (ret != EOK) {
             goto done;
@@ -528,9 +532,11 @@ int sss_nss_getidbysid(const char *sid, uint32_t *id, enum sss_id_type *id_type)
     return sss_nss_getidbysid_timeout(sid, NO_TIMEOUT, id, id_type);
 }
 
-int sss_nss_getorigbyname_timeout(const char *fq_name, unsigned int timeout,
-                                  struct sss_nss_kv **kv_list,
-                                  enum sss_id_type *type)
+int sss_nss_getorigbyname_timeout_common(const char *fq_name,
+                                         unsigned int timeout,
+                                         enum sss_cli_command cmd,
+                                         struct sss_nss_kv **kv_list,
+                                         enum sss_id_type *type)
 {
     int ret;
     union input inp;
@@ -542,7 +548,7 @@ int sss_nss_getorigbyname_timeout(const char *fq_name, unsigned int timeout,
 
     inp.str = fq_name;
 
-    ret = sss_nss_getyyybyxxx(inp, SSS_NSS_GETORIGBYNAME, timeout, &out);
+    ret = sss_nss_getyyybyxxx(inp, cmd, timeout, &out);
     if (ret == EOK) {
         *kv_list = out.d.kv_list;
         *type = out.type;
@@ -551,10 +557,49 @@ int sss_nss_getorigbyname_timeout(const char *fq_name, unsigned int timeout,
     return ret;
 }
 
+int sss_nss_getorigbyname_timeout(const char *fq_name, unsigned int timeout,
+                                  struct sss_nss_kv **kv_list,
+                                  enum sss_id_type *type)
+{
+    return sss_nss_getorigbyname_timeout_common(fq_name, timeout,
+                                                SSS_NSS_GETORIGBYNAME, kv_list,
+                                                type);
+}
+
 int sss_nss_getorigbyname(const char *fq_name, struct sss_nss_kv **kv_list,
                           enum sss_id_type *type)
 {
     return sss_nss_getorigbyname_timeout(fq_name, NO_TIMEOUT, kv_list, type);
+}
+
+int sss_nss_getorigbyusername_timeout(const char *fq_name, unsigned int timeout,
+                                      struct sss_nss_kv **kv_list,
+                                      enum sss_id_type *type)
+{
+    return sss_nss_getorigbyname_timeout_common(fq_name, timeout,
+                                                SSS_NSS_GETORIGBYUSERNAME,
+                                                kv_list, type);
+}
+
+int sss_nss_getorigbyusername(const char *fq_name, struct sss_nss_kv **kv_list,
+                             enum sss_id_type *type)
+{
+    return sss_nss_getorigbyusername_timeout(fq_name, NO_TIMEOUT, kv_list, type);
+}
+
+int sss_nss_getorigbygroupname_timeout(const char *fq_name, unsigned int timeout,
+                                       struct sss_nss_kv **kv_list,
+                                       enum sss_id_type *type)
+{
+    return sss_nss_getorigbyname_timeout_common(fq_name, timeout,
+                                                SSS_NSS_GETORIGBYGROUPNAME,
+                                                kv_list, type);
+}
+
+int sss_nss_getorigbygroupname(const char *fq_name, struct sss_nss_kv **kv_list,
+                             enum sss_id_type *type)
+{
+    return sss_nss_getorigbygroupname_timeout(fq_name, NO_TIMEOUT, kv_list, type);
 }
 
 int sss_nss_getnamebycert_timeout(const char *cert, unsigned int timeout,

--- a/src/sss_client/idmap/sss_nss_idmap.exports
+++ b/src/sss_client/idmap/sss_nss_idmap.exports
@@ -57,3 +57,12 @@ SSS_NSS_IDMAP_0.5.0 {
         sss_nss_getsidbygid;
         sss_nss_getsidbygid_timeout;
 } SSS_NSS_IDMAP_0.4.0;
+
+SSS_NSS_IDMAP_0.6.0 {
+    # public functions
+    global:
+        sss_nss_getorigbyusername;
+        sss_nss_getorigbyusername_timeout;
+        sss_nss_getorigbygroupname;
+        sss_nss_getorigbygroupname_timeout;
+} SSS_NSS_IDMAP_0.5.0;

--- a/src/sss_client/idmap/sss_nss_idmap.h
+++ b/src/sss_client/idmap/sss_nss_idmap.h
@@ -153,6 +153,48 @@ int sss_nss_getorigbyname(const char *fq_name, struct sss_nss_kv **kv_list,
                           enum sss_id_type *type);
 
 /**
+ * @brief Find original data by fully qualified user name
+ *
+ * @param[in] fq_name  Fully qualified name of a user
+ * @param[out] kv_list A NULL terminate list of key-value pairs where the key
+ *                     is the attribute name in the cache of SSSD,
+ *                     must be freed by the caller with sss_nss_free_kv()
+ * @param[out] type    Type of the object related to the given name
+ *
+ * @return
+ *  - 0 (EOK): success
+ *  - ENOENT: requested user was not found in the domain extracted from the given name
+ *  - ENETUNREACH: SSSD does not know how to handle the domain extracted from the given name
+ *  - ENOSYS: this call is not supported by the configured provider
+ *  - EINVAL: input cannot be parsed
+ *  - EIO: remote servers cannot be reached
+ *  - EFAULT: any other error
+ */
+int sss_nss_getorigbyusername(const char *fq_name, struct sss_nss_kv **kv_list,
+                              enum sss_id_type *type);
+
+/**
+ * @brief Find original data by fully qualified group name
+ *
+ * @param[in] fq_name  Fully qualified name of a group
+ * @param[out] kv_list A NULL terminate list of key-value pairs where the key
+ *                     is the attribute name in the cache of SSSD,
+ *                     must be freed by the caller with sss_nss_free_kv()
+ * @param[out] type    Type of the object related to the given name
+ *
+ * @return
+ *  - 0 (EOK): success
+ *  - ENOENT: requested group was not found in the domain extracted from the given name
+ *  - ENETUNREACH: SSSD does not know how to handle the domain extracted from the given name
+ *  - ENOSYS: this call is not supported by the configured provider
+ *  - EINVAL: input cannot be parsed
+ *  - EIO: remote servers cannot be reached
+ *  - EFAULT: any other error
+ */
+int sss_nss_getorigbygroupname(const char *fq_name, struct sss_nss_kv **kv_list,
+                               enum sss_id_type *type);
+
+/**
  * @brief Return the fully qualified name for the given base64 encoded
  * X.509 certificate in DER format
  *
@@ -183,9 +225,10 @@ int sss_nss_getlistbycert(const char *cert, char ***fq_name,
                           enum sss_id_type **type);
 
 /**
- * @brief Free key-value list returned by sss_nss_getorigbyname()
+ * @brief Free key-value list returned by sss_nss_getorigbyXYZ()
  *
- * @param[in] kv_list Key-value list returned by sss_nss_getorigbyname().
+ * @param[in] kv_list Key-value list returned by sss_nss_getorigbyname() and
+ *                    similar calls.
  */
 void sss_nss_free_kv(struct sss_nss_kv *kv_list);
 
@@ -450,6 +493,56 @@ int sss_nss_getidbysid_timeout(const char *sid, unsigned int timeout,
 int sss_nss_getorigbyname_timeout(const char *fq_name, unsigned int timeout,
                                   struct sss_nss_kv **kv_list,
                                   enum sss_id_type *type);
+
+/**
+ * @brief Find original data by fully qualified user name with timeout
+ *
+ * @param[in] fq_name  Fully qualified name of a user
+ * @param[in] timeout  timeout in milliseconds
+ * @param[out] kv_list A NULL terminate list of key-value pairs where the key
+ *                     is the attribute name in the cache of SSSD,
+ *                     must be freed by the caller with sss_nss_free_kv()
+ * @param[out] type    Type of the object related to the given name
+ *
+ * @return
+ *  - 0 (EOK): success
+ *  - ENOENT: requested user was not found in the domain extracted from the given name
+ *  - ENETUNREACH: SSSD does not know how to handle the domain extracted from the given name
+ *  - ENOSYS: this call is not supported by the configured provider
+ *  - EINVAL: input cannot be parsed
+ *  - EIO: remote servers cannot be reached
+ *  - EFAULT: any other error
+ *  - ETIME:     request timed out but was send to SSSD
+ *  - ETIMEDOUT: request timed out but was not send to SSSD
+ */
+int sss_nss_getorigbyusername_timeout(const char *fq_name, unsigned int timeout,
+                                      struct sss_nss_kv **kv_list,
+                                      enum sss_id_type *type);
+
+/**
+ * @brief Find original data by fully qualified group name with timeout
+ *
+ * @param[in] fq_name  Fully qualified name of a group
+ * @param[in] timeout  timeout in milliseconds
+ * @param[out] kv_list A NULL terminate list of key-value pairs where the key
+ *                     is the attribute name in the cache of SSSD,
+ *                     must be freed by the caller with sss_nss_free_kv()
+ * @param[out] type    Type of the object related to the given name
+ *
+ * @return
+ *  - 0 (EOK): success
+ *  - ENOENT: requested group was not found in the domain extracted from the given name
+ *  - ENETUNREACH: SSSD does not know how to handle the domain extracted from the given name
+ *  - ENOSYS: this call is not supported by the configured provider
+ *  - EINVAL: input cannot be parsed
+ *  - EIO: remote servers cannot be reached
+ *  - EFAULT: any other error
+ *  - ETIME:     request timed out but was send to SSSD
+ *  - ETIMEDOUT: request timed out but was not send to SSSD
+ */
+int sss_nss_getorigbygroupname_timeout(const char *fq_name, unsigned int timeout,
+                                       struct sss_nss_kv **kv_list,
+                                       enum sss_id_type *type);
 
 /**
  * @brief Return the fully qualified name for the given base64 encoded

--- a/src/sss_client/sss_cli.h
+++ b/src/sss_client/sss_cli.h
@@ -283,6 +283,20 @@ SSS_NSS_GETSIDBYGID   = 0x0119, /**< Takes an unsigned 32bit integer (POSIX GID)
                                      and return the zero terminated string
                                      representation of the SID of the object
                                      with the given UID. */
+SSS_NSS_GETORIGBYUSERNAME = 0x011A, /**< Takes a zero terminated fully qualified
+                                     user name and returns a list of zero
+                                     terminated strings with key-value pairs
+                                     where the first string is the key and
+                                     second the value. Hence the list should
+                                     have an even number of strings, if not
+                                     the whole list is invalid. */
+SSS_NSS_GETORIGBYGROUPNAME = 0x011B, /**< Takes a zero terminated fully qualified
+                                     group name and returns a list of zero
+                                     terminated strings with key-value pairs
+                                     where the first string is the key and
+                                     second the value. Hence the list should
+                                     have an even number of strings, if not
+                                     the whole list is invalid. */
 
 /* subid */
     SSS_NSS_GET_SUBID_RANGES = 0x0130, /**< Requests both subuid and subgid ranges

--- a/src/util/sss_cli_cmd.c
+++ b/src/util/sss_cli_cmd.c
@@ -227,6 +227,10 @@ const char *sss_cmd2str(enum sss_cli_command cmd)
         return "SSS_NSS_GETIDBYSID";
     case SSS_NSS_GETORIGBYNAME:
         return "SSS_NSS_GETORIGBYNAME";
+    case SSS_NSS_GETORIGBYUSERNAME:
+        return "SSS_NSS_GETORIGBYUSERNAME";
+    case SSS_NSS_GETORIGBYGROUPNAME:
+        return "SSS_NSS_GETORIGBYGROUPNAME";
 
     /* SUBID ranges */
     case SSS_NSS_GET_SUBID_RANGES:


### PR DESCRIPTION
Since the user and group namespaces are independent in POSIX/Linux it is
important to be able to indicate if a user or a group is search by name.
Currently the sss_nss_getorigbyname() call does not allow this and this
patches adds two new calls to fix this.

Resolves: https://github.com/SSSD/sssd/issues/6042