### PR TITLE
usertools: better default for IPA/AD re_expression

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -3313,7 +3313,7 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                         </para>
                         <para>
                             Default for the AD and IPA provider:
-                            <quote>(((?P&lt;domain&gt;[^\\]+)\\(?P&lt;name&gt;.+$))|((?P&lt;name&gt;[^@]+)@(?P&lt;domain&gt;.+$))|(^(?P&lt;name&gt;[^@\\]+)$))</quote>
+                            <quote>(((?P&lt;domain&gt;[^\\]+)\\(?P&lt;name&gt;.+$))|((?P&lt;name&gt;.+)@(?P&lt;domain&gt;[^@]+$))|(^(?P&lt;name&gt;[^@\\]+)$))</quote>
                             which allows three different styles for user names:
                             <itemizedlist>
                                 <listitem>
@@ -3335,15 +3335,6 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                             which translates to "the name is everything up to
                             the <quote>@</quote> sign, the domain everything
                             after that"
-                        </para>
-                        <para>
-                            NOTE: Some Active Directory groups, typically
-                            those used for MS Exchange contain an
-                            <quote>@</quote> sign in the name, which
-                            clashes with the default re_expression value for
-                            the AD and IPA providers. To support these groups,
-                            consider changing the re_expression value to:
-                            <quote>((?P&lt;name&gt;.+)@(?P&lt;domain&gt;[^@]+$))</quote>.
                         </para>
                     </listitem>
                 </varlistentry>

--- a/src/util/usertools.c
+++ b/src/util/usertools.c
@@ -58,7 +58,7 @@ char *get_uppercase_realm(TALLOC_CTX *memctx, const char *name)
 
 
 #define IPA_AD_DEFAULT_RE "(((?P<domain>[^\\\\]+)\\\\(?P<name>.+$))|" \
-                         "((?P<name>[^@]+)@(?P<domain>.+$))|" \
+                         "((?P<name>.+)@(?P<domain>[^@]+$))|" \
                          "(^(?P<name>[^@\\\\]+)$))"
 
 static errno_t get_id_provider_default_re(TALLOC_CTX *mem_ctx,

--- a/src/util/usertools.c
+++ b/src/util/usertools.c
@@ -56,11 +56,6 @@ char *get_uppercase_realm(TALLOC_CTX *memctx, const char *name)
     return realm;
 }
 
-
-#define IPA_AD_DEFAULT_RE "(((?P<domain>[^\\\\]+)\\\\(?P<name>.+$))|" \
-                         "((?P<name>.+)@(?P<domain>[^@]+$))|" \
-                         "(^(?P<name>[^@\\\\]+)$))"
-
 static errno_t get_id_provider_default_re(TALLOC_CTX *mem_ctx,
                                           struct confdb_ctx *cdb,
                                           const char *conf_path,
@@ -73,8 +68,8 @@ static errno_t get_id_provider_default_re(TALLOC_CTX *mem_ctx,
     struct provider_default_re {
         const char *name;
         const char *re;
-    } provider_default_re[] = {{"ipa", IPA_AD_DEFAULT_RE},
-                               {"ad", IPA_AD_DEFAULT_RE},
+    } provider_default_re[] = {{"ipa", SSS_IPA_AD_DEFAULT_RE},
+                               {"ad", SSS_IPA_AD_DEFAULT_RE},
                                {NULL, NULL}};
 
     ret = confdb_get_string(cdb, mem_ctx, conf_path, CONFDB_DOMAIN_ID_PROVIDER,
@@ -224,8 +219,7 @@ int sss_names_init(TALLOC_CTX *mem_ctx, struct confdb_ctx *cdb,
     }
 
     if (!re_pattern) {
-        re_pattern = talloc_strdup(tmpctx,
-                                   "(?P<name>[^@]+)@?(?P<domain>[^@]*$)");
+        re_pattern = talloc_strdup(tmpctx, SSS_DEFAULT_RE);
         if (!re_pattern) {
             ret = ENOMEM;
             goto done;
@@ -263,7 +257,7 @@ done:
 int sss_ad_default_names_ctx(TALLOC_CTX *mem_ctx,
                              struct sss_names_ctx **_out)
 {
-    return sss_names_init_from_args(mem_ctx, IPA_AD_DEFAULT_RE,
+    return sss_names_init_from_args(mem_ctx, SSS_IPA_AD_DEFAULT_RE,
                                     CONFDB_DEFAULT_FULL_NAME_FORMAT,
                                     _out);
 }

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -239,6 +239,12 @@ struct sss_names_ctx {
     sss_regexp_t *re;
 };
 
+#define SSS_DEFAULT_RE "(?P<name>[^@]+)@?(?P<domain>[^@]*$)"
+
+#define SSS_IPA_AD_DEFAULT_RE "(((?P<domain>[^\\\\]+)\\\\(?P<name>.+$))|" \
+                              "((?P<name>.+)@(?P<domain>[^@]+$))|" \
+                              "(^(?P<name>[^@\\\\]+)$))"
+
 /* initialize sss_names_ctx directly from arguments */
 int sss_names_init_from_args(TALLOC_CTX *mem_ctx,
                              const char *re_pattern,


### PR DESCRIPTION
Some Active Directory groups, typically those used for MS Exchange
contain an “@” sign in the name. New IPA and AD re_expression
default handles it correctly, considering that the domain is everything
that follows the last '@'.

:relnote: Better default for IPA/AD re_expression. Tunning for group names containing '@' is no
longer needed.
