### PR TITLE
Tests: fix python linter issues 7

### DIFF
--- a/src/config/SSSDConfig/ipachangeconf.py
+++ b/src/config/SSSDConfig/ipachangeconf.py
@@ -25,6 +25,7 @@ import time
 import shutil
 import re
 
+
 def openLocked(filename, perms, create=True):
     fd = -1
 
@@ -329,7 +330,6 @@ class IPAChangeConf(object):
 
             raise SyntaxError('Unknown type: ['+no['type']+']')
 
-
     def merge(self, oldopts, newopts):
 
         #Use a two pass strategy
@@ -466,6 +466,7 @@ class IPAChangeConf(object):
             except IOError:
                 pass
         return True
+
 
 # An SSSD-specific subclass of IPAChangeConf
 class SSSDChangeConf(IPAChangeConf):

--- a/src/config/SSSDConfig/ipachangeconf.py
+++ b/src/config/SSSDConfig/ipachangeconf.py
@@ -589,4 +589,3 @@ class SSSDChangeConf(IPAChangeConf):
         else:
             subtree = self.opts
         return self.findOpts(subtree, type, name)
-

--- a/src/config/SSSDConfig/sssdoptions.py
+++ b/src/config/SSSDConfig/sssdoptions.py
@@ -71,9 +71,12 @@ class SSSDOptions(object):
         'shell_fallback': _('If a shell stored in central directory is allowed but not available, use this fallback'),
         'default_shell': _('Shell to use if the provider does not list one'),
         'memcache_timeout': _('How long will be in-memory cache records valid'),
-        'memcache_size_passwd': _('Size (in megabytes) of the data table allocated inside fast in-memory cache for passwd requests'),
-        'memcache_size_group': _('Size (in megabytes) of the data table allocated inside fast in-memory cache for group requests'),
-        'memcache_size_initgroups': _('Size (in megabytes) of the data table allocated inside fast in-memory cache for initgroups requests'),
+        'memcache_size_passwd': _(
+            'Size (in megabytes) of the data table allocated inside fast in-memory cache for passwd requests'),
+        'memcache_size_group': _(
+            'Size (in megabytes) of the data table allocated inside fast in-memory cache for group requests'),
+        'memcache_size_initgroups': _(
+            'Size (in megabytes) of the data table allocated inside fast in-memory cache for initgroups requests'),
         'homedir_substring': _('The value of this option will be used in the expansion of the override_homedir option '
                                'if the template contains the format string %H.'),
         'get_domains_timeout': _('Specifies time in seconds for which the list of subdomains will be considered '

--- a/src/config/SSSDConfigTest.py
+++ b/src/config/SSSDConfigTest.py
@@ -70,7 +70,6 @@ class SSSDConfigTestValid(unittest.TestCase):
         sssd_service = sssdconfig.get_service('sssd')
         service_opts = sssd_service.list_options()
 
-
         self.assertTrue('services' in service_opts.keys())
         service_list = sssd_service.get_option('services')
         self.assertTrue('nss' in service_list)
@@ -197,7 +196,6 @@ class SSSDConfigTestValid(unittest.TestCase):
         #Remove the output file
         os.unlink(of)
 
-
     def testModifyExistingConfig(self):
         sssdconfig = SSSDConfig.SSSDConfig(srcdir + "/etc/sssd.api.conf",
                                            srcdir + "/etc/sssd.api.d")
@@ -281,6 +279,7 @@ class SSSDConfigTestValid(unittest.TestCase):
         self.assertEqual(ldap_domain.get_option('auth_provider'), 'ldap')
         self.assertEqual(ldap_domain.get_option('id_provider'), 'ldap')
 
+
 class SSSDConfigTestInvalid(unittest.TestCase):
     def setUp(self):
         pass
@@ -294,6 +293,7 @@ class SSSDConfigTestInvalid(unittest.TestCase):
         sssdconfig.import_config(srcdir + "/testconfigs/sssd-invalid-badbool.conf")
         self.assertRaises(TypeError,
                           sssdconfig.get_domain, 'IPA')
+
 
 class SSSDConfigTestSSSDService(unittest.TestCase):
     def setUp(self):
@@ -497,6 +497,7 @@ class SSSDConfigTestSSSDService(unittest.TestCase):
         # Positive test - Remove an option that doesn't exist
         self.assertRaises(SSSDConfig.NoOptionError, service.get_option, 'nosuchentry')
         service.remove_option('nosuchentry')
+
 
 class SSSDConfigTestSSSDDomain(unittest.TestCase):
     def setUp(self):
@@ -1168,6 +1169,7 @@ class SSSDConfigTestSSSDDomain(unittest.TestCase):
         # Negative test - try setting the name to a non-string
         self.assertRaises(TypeError,
                           domain.set_name, 4)
+
 
 class SSSDConfigTestSSSDConfig(unittest.TestCase):
     def setUp(self):
@@ -1925,7 +1927,6 @@ class SSSDConfigTestSSSDConfig(unittest.TestCase):
         #Remove the output file
         os.unlink(of)
 
-
         domain2 = sssdconfig.get_domain('example.com2')
         self.assertTrue(domain2.get_option('ldap_krb5_init_creds'))
         self.assertFalse(domain2.get_option('ldap_id_use_start_tls'))
@@ -2110,7 +2111,6 @@ class SSSDConfigTestSSSDConfig(unittest.TestCase):
         for domain in control_list:
             self.assertTrue(domain in sssdconfig.list_inactive_domains(),
                             "Domain [domain/%s] should be disabled" % domain)
-
 
 
 if __name__ == "__main__":

--- a/src/config/SSSDConfigTest.py
+++ b/src/config/SSSDConfigTest.py
@@ -1251,7 +1251,9 @@ class SSSDConfigTestSSSDConfig(unittest.TestCase):
         # Negative Test - Invalid config file version
         sssdconfig = SSSDConfig.SSSDConfig(srcdir + "/etc/sssd.api.conf",
                                            srcdir + "/etc/sssd.api.d")
-        self.assertRaises(SSSDConfig.ParsingError, sssdconfig.import_config, srcdir + "/testconfigs/sssd-badversion.conf")
+        self.assertRaises(SSSDConfig.ParsingError,
+                          sssdconfig.import_config,
+                          srcdir + "/testconfigs/sssd-badversion.conf")
 
         # Negative Test - Already initialized
         sssdconfig = SSSDConfig.SSSDConfig(srcdir + "/etc/sssd.api.conf",

--- a/src/tests/multihost/alltests/conftest.py
+++ b/src/tests/multihost/alltests/conftest.py
@@ -1151,7 +1151,6 @@ def krb_connection_timeout(
         session_multihost,
         create_host_user,
         request):
-
     """ Create necessary principals and keytabs for the test.
     :param obj session_multihost: multihost object
     :param obj create_host_user: to create user for SASL with GSSAPI


### PR DESCRIPTION
flake8 has detected several hundred issues in the python code and having all the fixes in a single PR is complex and difficult to review. That's why I'm creating a set of PRs as a spin-off of [the flake8 enabling PR](https://github.com/SSSD/sssd/pull/6006).

This set of patches fixes the blank lines (E302, E303 and W391) and the lines too long (E501).