### PR TITLE
NSS: change default value of 'cache_first' to 'true'

### DIFF
--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -98,6 +98,12 @@
 #define CONFDB_RESPONDER_IDLE_TIMEOUT "responder_idle_timeout"
 #define CONFDB_RESPONDER_IDLE_DEFAULT_TIMEOUT 300
 #define CONFDB_RESPONDER_CACHE_FIRST "cache_first"
+#ifdef BUILD_FILES_PROVIDER
+/* There is a subtile issue with this option when 'files' + another domain is enabled */
+#define CONFDB_RESPONDER_CACHE_FIRST_DEFAILT false
+#else
+#define CONFDB_RESPONDER_CACHE_FIRST_DEFAILT true
+#endif
 
 /* NSS */
 #define CONFDB_NSS_CONF_ENTRY "config/nss"

--- a/src/man/Makefile.am
+++ b/src/man/Makefile.am
@@ -52,6 +52,8 @@ PASSKEY_CONDS = ;build_passkey
 endif
 if BUILD_FILES_PROVIDER
 FILES_PROVIDER_CONDS = ;with_files_provider
+else
+FILES_PROVIDER_CONDS = ;without_files_provider
 endif
 
 

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -945,8 +945,11 @@
                             This option specifies whether the responder should
                             query all caches before querying the Data Providers.
                         </para>
-                        <para>
+                        <para condition="with_files_provider">
                             Default: false
+                        </para>
+                        <para condition="without_files_provider">
+                            Default: true
                         </para>
                     </listitem>
                 </varlistentry>

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -1341,7 +1341,8 @@ int sss_process_init(TALLOC_CTX *mem_ctx,
 
     ret = confdb_get_bool(rctx->cdb, rctx->confdb_service_path,
                           CONFDB_RESPONDER_CACHE_FIRST,
-                          false, &rctx->cache_first);
+                          CONFDB_RESPONDER_CACHE_FIRST_DEFAILT,
+                          &rctx->cache_first);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
               "Cannot get \"cache_first_option\".\n"


### PR DESCRIPTION
Having 'cache_first' as 'false' is a performance degradation without a reason
in the multi-(sub)domains enviroments (typical case when AD is involved).

:config: Default value of 'cache_first' option was changed to 'true'