### PR TITLE
Tests: fix continuation line under-indented (E128)

### DIFF
--- a/src/tests/multihost/ad/test_adparameters.py
+++ b/src/tests/multihost/ad/test_adparameters.py
@@ -555,7 +555,7 @@ class TestBugzillaAutomation(object):
         multihost.client[0].service_sssd('stop')
         userlist = f'root, {aduser2}'
         params2 = {'filter_users': userlist,
-                  'filter_groups': 'root'}
+                   'filter_groups': 'root'}
         client.sssd_conf('nss', params2)
         client.remove_sss_cache('/var/lib/sss/db')
         client.remove_sss_cache('/var/lib/sss/mc')


### PR DESCRIPTION
Commit 1b24149eeb0489b8a2d35629ff41c085dbf2c538 introduced a linter
issue that makes all CI runs to fail. Fix it by adding an additional
whitespace.