### PR TITLE
Tests: Fix under-intended line in test_adparameters

### DIFF
--- a/src/tests/multihost/ad/test_adparameters.py
+++ b/src/tests/multihost/ad/test_adparameters.py
@@ -555,7 +555,7 @@ class TestBugzillaAutomation(object):
         multihost.client[0].service_sssd('stop')
         userlist = f'root, {aduser2}'
         params2 = {'filter_users': userlist,
-                  'filter_groups': 'root'}
+                   'filter_groups': 'root'}
         client.sssd_conf('nss', params2)
         client.remove_sss_cache('/var/lib/sss/db')
         client.remove_sss_cache('/var/lib/sss/mc')


### PR DESCRIPTION
Issue reported by pycodestyle and causing PR CI to fail.

./src/tests/multihost/ad/test_adparameters.py:558:19: E128 continuation
line under-indented for visual indent