### PR TITLE
ci: fix dlopen-tests on Fedora 36

### DIFF
--- a/contrib/ci/sssd.supp
+++ b/contrib/ci/sssd.supp
@@ -236,3 +236,24 @@
    ...
    fun:main
 }
+
+# Fedora 36 https://bugzilla.redhat.com/show_bug.cgi?id=2065675
+{
+   glibc-dlopen
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:UnknownInlinedFun
+   fun:_dl_find_object_update
+   fun:dl_open_worker_begin
+   fun:_dl_catch_exception
+   fun:dl_open_worker
+   fun:_dl_catch_exception
+   fun:_dl_open
+   fun:dlopen_doit
+   fun:_dl_catch_exception
+   fun:_dl_catch_error
+   fun:_dlerror_run
+   fun:dlopen_implementation
+   fun:dlopen@@GLIBC_2.34
+}


### PR DESCRIPTION
This should fix dlopen tests under valgrind on Fedora 36 and 37. I opened bug against glibc https://bugzilla.redhat.com/show_bug.cgi?id=2065675

Fedora 37 still fails on inotify tests, valgrind found there some "conditional jump depends on uninitialized  variable"- It looks like false positive, but I need to take a closer look.