### PR TITLE
Tests: 2 fixes for tests failures

### DIFF
--- a/src/tests/multihost/alltests/conftest.py
+++ b/src/tests/multihost/alltests/conftest.py
@@ -437,7 +437,7 @@ def sssd_sudo_conf(session_multihost, request):
               'sudo_provider': 'ldap'}
     domain_section = f'domain/{ds_instance_name}'
     tools.sssd_conf(domain_section, params, action='update')
-    multihost.client[0].service_sssd('start')
+    session_multihost.client[0].service_sssd('start')
 
     def restore_sssd_conf():
         """ Restore sssd.conf """

--- a/src/tests/multihost/ipa/conftest.py
+++ b/src/tests/multihost/ipa/conftest.py
@@ -204,7 +204,7 @@ def environment_setup(session_multihost, request):
     """
     client = session_multihost.client[0]
     client.run_command("yum "
-                       "--enablerepo=rhel-CRB install"
+                       "--enablerepo=*-CRB install"
                        " -y shadow-utils*")
     client.run_command("yum install -y gcc")
     client.run_command("yum install -y podman")


### PR DESCRIPTION
Recently the flake8 fixes introduced an issue deleting string 'session_' from the command and internally the CRB repo was renamed