### PR TITLE
UTILS: fixes CWE-394 like:

### DIFF
--- a/src/util/util_lock.c
+++ b/src/util/util_lock.c
@@ -63,8 +63,9 @@ errno_t sss_br_lock_file(int fd, size_t start, size_t len,
                 if (retries_left - 1 > 0) {
                     ret = usleep(wait);
                     if (ret == -1) {
+                        ret = errno;
                         DEBUG(SSSDBG_MINOR_FAILURE,
-                              "usleep() failed -> ignoring\n");
+                              "usleep() failed with %d -> ignoring\n", ret);
                     }
                 }
             } else {
@@ -76,6 +77,9 @@ errno_t sss_br_lock_file(int fd, size_t start, size_t len,
         } else if (ret == 0) {
             /* File successfully locked */
             break;
+        } else {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "Unexpected fcntl() return code: %d\n", ret);
         }
     }
     if (retries_left == 0) {


### PR DESCRIPTION
```
src/responder/nss/nsssrv.c:339: negative_return_fn: Function "sss_mmap_cache_init(nctx, "passwd", nctx->mc_uid, nctx->mc_gid, SSS_MC_PASSWD, mc_size_passwd * 26214UL, (time_t)memcache_timeout, &nctx->pwd_mc_ctx)" returns a negative number.
src/responder/nss/nsssrv.c:339: assign: Assigning: "ret" = "sss_mmap_cache_init(nctx, "passwd", nctx->mc_uid, nctx->mc_gid, SSS_MC_PASSWD, mc_size_passwd * 26214UL, (time_t)memcache_timeout, &nctx->pwd_mc_ctx)".
src/responder/nss/nsssrv.c:346: negative_returns: "ret" is passed to a parameter that cannot be negative.
 #  344|                                 &nctx->pwd_mc_ctx);
 #  345|       if (ret) {
 #  346|->         DEBUG(SSSDBG_CRIT_FAILURE,
 #  347|                 "Failed to initialize passwd mmap cache: '%s'\n",
 #  348|                 sss_strerror(ret));
```