### PR TITLE
systemd: only relaunch after crashes and do not retry forever

### DIFF
--- a/src/sysv/systemd/sssd.service.in
+++ b/src/sysv/systemd/sssd.service.in
@@ -3,6 +3,8 @@ Description=System Security Services Daemon
 # SSSD must be running before we permit user sessions
 Before=systemd-user-sessions.service nss-user-lookup.target
 Wants=nss-user-lookup.target
+StartLimitIntervalSec=50s
+StartLimitBurst=5
 @condconfigexists@
 
 [Service]
@@ -13,7 +15,7 @@ Type=notify
 NotifyAccess=main
 PIDFile=@pidpath@/sssd.pid
 CapabilityBoundingSet= @additional_caps@ CAP_IPC_LOCK CAP_CHOWN CAP_DAC_READ_SEARCH CAP_KILL CAP_NET_ADMIN CAP_SYS_NICE CAP_FOWNER CAP_SETGID CAP_SETUID CAP_SYS_ADMIN CAP_SYS_RESOURCE CAP_BLOCK_SUSPEND
-Restart=on-failure
+Restart=on-abnormal
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
As proposed by Sumit, set `Relaunch=on-abnormal`  to only relaunch after a crash. `systemd` will not try to relaunch `sssd` if it returned with an error code, for instance, on an invalid configuration.
Use `StartLimitIntevalSec=50s` and `StartLimitBurst=5` to limit the number of times it is relaunched to avoid blocking the boot process. With these values, if `sssd` crashes, `systemd` will relaunch it as long as it is not launched more than 5 times during a 50s interval, which will delay the boot process by 50 seconds at most.
These are compromise values, as there are no one-size-fits-all values.
I reproduced the problem described by the user and it took 6 seconds for `sssd` to exit, giving it 4 more seconds seems a good compromise. We could give it more time, for instance 15 seconds, but that could delay the boot process for 5*15=75 seconds. We could retry less than 5 times, but this value seems correct and is the same value used by `systemd` by default.
