### PR TITLE
ccpcheck: fix issues

### DIFF
--- a/src/lib/idmap/sss_idmap.c
+++ b/src/lib/idmap/sss_idmap.c
@@ -31,7 +31,7 @@
 #include "lib/idmap/sss_idmap_private.h"
 #include "shared/murmurhash3.h"
 
-#define SID_FMT "%s-%d"
+#define SID_FMT "%s-%"PRIu32
 #define SID_STR_MAX_LEN 1024
 
 /* Hold all parameters for unix<->sid mapping relevant for

--- a/src/responder/ifp/ifp_iface_nodes.c
+++ b/src/responder/ifp/ifp_iface_nodes.c
@@ -138,7 +138,7 @@ nodes_domains(TALLOC_CTX *mem_ctx,
     domain = ctx->rctx->domains;
     do {
         nodes[count] = sbus_opath_escape(nodes, domain->name);
-        if (nodes == NULL) {
+        if (nodes[count] == NULL) {
             DEBUG(SSSDBG_CRIT_FAILURE, "sbus_opath_escape_part() failed\n");
             talloc_free(nodes);
             return ENOMEM;

--- a/src/sss_client/autofs/autofs_test_client.c
+++ b/src/sss_client/autofs/autofs_test_client.c
@@ -76,7 +76,7 @@ int main(int argc, const char *argv[])
     requested_protocol = pc_protocol;
     protocol = _sss_auto_protocol_version(requested_protocol);
     if (protocol != requested_protocol) {
-        fprintf(stderr, "Unsupported protocol version: %d -> %d\n",
+        fprintf(stderr, "Unsupported protocol version: %u -> %u\n",
                 requested_protocol, protocol);
         exit(EXIT_FAILURE);
     }

--- a/src/sss_client/sudo_testcli/sudo_testcli.c
+++ b/src/sss_client/sudo_testcli/sudo_testcli.c
@@ -78,7 +78,7 @@ int main(int argc, char **argv)
     printf("[\n");
     printf("\t{\n");
     printf("\t\t\"type\": \"default\",\n");
-    printf("\t\t\"retval\": %d,\n", error);
+    printf("\t\t\"retval\": %u,\n", error);
     if (error == SSS_SUDO_ERROR_OK) {
         print_sss_result(result);
     }
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
 
     printf("\t{\n");
     printf("\t\t\"type\": \"rules\",\n");
-    printf("\t\t\"retval\": %d,\n", error);
+    printf("\t\t\"retval\": %u,\n", error);
     if (error == SSS_SUDO_ERROR_OK) {
         print_sss_result(result);
     }

--- a/src/util/usertools.c
+++ b/src/util/usertools.c
@@ -732,7 +732,7 @@ char **sss_create_internal_fqname_list(TALLOC_CTX *mem_ctx,
         fqname_list[i] = sss_create_internal_fqname(fqname_list,
                                                     shortname_list[i],
                                                     dom_name);
-        if (fqname_list == NULL) {
+        if (fqname_list[i] == NULL) {
             talloc_free(fqname_list);
             return NULL;
         }


### PR DESCRIPTION
The issues fixed fall in the following categories: invalid printf
argument type and redundant check for a pointer.

The whole output from the cppcheck for the issues:
```
<error id="invalidPrintfArgType_sint" severity="warning" msg="%d in format string (no. 2) requires &apos;int&apos; but the argument type is &apos;unsigned int&apos;." verbose="%d in format string (no. 2) requires &apos;int&apos; but the argument type is &apos;unsigned int&apos;." cwe="686" file0="src/lib/idmap/sss_idmap.c">
    <location file="src/lib/idmap/sss_idmap.c" line="1186" column="11"/>
</error>
<error id="invalidPrintfArgType_sint" severity="warning" msg="%d in format string (no. 2) requires &apos;int&apos; but the argument type is &apos;unsigned int&apos;." verbose="%d in format string (no. 2) requires &apos;int&apos; but the argument type is &apos;unsigned int&apos;." cwe="686" file0="src/lib/idmap/sss_idmap.c">
    <location file="src/lib/idmap/sss_idmap.c" line="1196" column="11"/>
</error>
<error id="nullPointerRedundantCheck" severity="warning" msg="Either the condition &apos;nodes==NULL&apos; is redundant or there is possible null pointer dereference: nodes." verbose="Either the condition &apos;nodes==NULL&apos; is redundant or there is possible null pointer dereference: nodes." cwe="476" file0="src/responder/ifp/ifp_iface_nodes.c">
    <location file="src/responder/ifp/ifp_iface_nodes.c" line="140" column="9" info="Null pointer dereference"/>
    <location file="src/responder/ifp/ifp_iface_nodes.c" line="141" column="19" info="Assuming that condition &apos;nodes==NULL&apos; is not redundant"/>
    <symbol>nodes</symbol>
</error>
<error id="invalidPrintfArgType_sint" severity="warning" msg="%d in format string (no. 1) requires &apos;int&apos; but the argument type is &apos;unsigned int&apos;." verbose="%d in format string (no. 1) requires &apos;int&apos; but the argument type is &apos;unsigned int&apos;." cwe="686" file0="src/sss_client/autofs/autofs_test_client.c">
    <location file="src/sss_client/autofs/autofs_test_client.c" line="79" column="9"/>
</error>
<error id="invalidPrintfArgType_sint" severity="warning" msg="%d in format string (no. 1) requires &apos;int&apos; but the argument type is &apos;unsigned int&apos;." verbose="%d in format string (no. 1) requires &apos;int&apos; but the argument type is &apos;unsigned int&apos;." cwe="686" file0="src/sss_client/sudo_testcli/sudo_testcli.c">
    <location file="src/sss_client/sudo_testcli/sudo_testcli.c" line="81" column="5"/>
</error>
<error id="invalidPrintfArgType_sint" severity="warning" msg="%d in format string (no. 1) requires &apos;int&apos; but the argument type is &apos;unsigned int&apos;." verbose="%d in format string (no. 1) requires &apos;int&apos; but the argument type is &apos;unsigned int&apos;." cwe="686" file0="src/sss_client/sudo_testcli/sudo_testcli.c">
    <location file="src/sss_client/sudo_testcli/sudo_testcli.c" line="100" column="5"/>
</error>
<error id="nullPointerRedundantCheck" severity="warning" msg="Either the condition &apos;fqname_list==NULL&apos; is redundant or there is possible null pointer dereference: fqname_list." verbose="Either the condition &apos;fqname_list==NULL&apos; is redundant or there is possible null pointer dereference: fqname_list." cwe="476" file0="src/util/usertools.c">
    <location file="src/util/usertools.c" line="732" column="9" info="Null pointer dereference"/>
    <location file="src/util/usertools.c" line="735" column="25" info="Assuming that condition &apos;fqname_list==NULL&apos; is not redundant"/>
    <symbol>fqname_list</symbol>
</error>
```