### PR TITLE
SID MC

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1379,6 +1379,7 @@ libsss_nss_idmap_la_SOURCES = \
     src/sss_client/common.c \
     src/sss_client/idmap/common_ex.c \
     src/sss_client/nss_mc_passwd.c \
+    src/sss_client/nss_mc_sid.c \
     src/sss_client/nss_passwd.c \
     src/sss_client/nss_mc_group.c \
     src/sss_client/nss_group.c \

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -116,6 +116,7 @@
 #define CONFDB_NSS_MEMCACHE_SIZE_PASSWD "memcache_size_passwd"
 #define CONFDB_NSS_MEMCACHE_SIZE_GROUP "memcache_size_group"
 #define CONFDB_NSS_MEMCACHE_SIZE_INITGROUPS "memcache_size_initgroups"
+#define CONFDB_NSS_MEMCACHE_SIZE_SID "memcache_size_sid"
 #define CONFDB_NSS_HOMEDIR_SUBSTRING "homedir_substring"
 #define CONFDB_DEFAULT_HOMEDIR_SUBSTRING "/home"
 

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -1240,6 +1240,33 @@ fallback_homedir = /home/%u
                     </listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term>memcache_size_sid (integer)</term>
+                    <listitem>
+                        <para>
+                            Size (in megabytes) of the data table allocated inside
+                            fast in-memory cache for SID related requests.
+                            Only SID-by-ID and ID-by-SID requests are currently
+                            cached in fast in-memory cache.
+                            Setting the size to 0 will disable the SID
+                            in-memory cache.
+                        </para>
+                        <para>
+                            Default: 6
+                        </para>
+                        <para>
+                            WARNING: Disabled or too small in-memory cache can
+                            have significant negative impact on SSSD's
+                            performance.
+                        </para>
+                        <para>
+                            NOTE: If the environment variable
+                            SSS_NSS_USE_MEMCACHE is set to "NO", client
+                            applications will not use the fast in-memory
+                            cache.
+                        </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
                     <term>user_attributes (string)</term>
                     <listitem>
                         <para>

--- a/src/responder/nss/nss_cmd.c
+++ b/src/responder/nss/nss_cmd.c
@@ -533,7 +533,9 @@ static errno_t invalidate_cache(struct nss_cmd_ctx *cmd_ctx,
         is_user = false;
         break;
     default:
-        /* nothing to do */
+        /* nothing to do -
+         * other requests don't support SSS_NSS_EX_FLAG_INVALIDATE_CACHE
+         */
         return EOK;
     }
 
@@ -1151,26 +1153,29 @@ static errno_t nss_cmd_getsidbyname(struct cli_ctx *cli_ctx)
 
 static errno_t nss_cmd_getsidbyid(struct cli_ctx *cli_ctx)
 {
-    const char *attrs[] = { SYSDB_SID_STR, NULL };
+    const char *attrs[] = { SYSDB_SID_STR, SYSDB_UIDNUM, SYSDB_GIDNUM,
+                            SYSDB_OBJECTCATEGORY, NULL };
 
     return nss_getby_id(cli_ctx, false, CACHE_REQ_OBJECT_BY_ID, attrs,
-                        SSS_MC_NONE, nss_protocol_fill_sid);
+                        SSS_MC_SID, nss_protocol_fill_sid);
 }
 
 static errno_t nss_cmd_getsidbyuid(struct cli_ctx *cli_ctx)
 {
-    const char *attrs[] = { SYSDB_SID_STR, NULL };
+    const char *attrs[] = { SYSDB_SID_STR, SYSDB_UIDNUM, SYSDB_GIDNUM,
+                            SYSDB_OBJECTCATEGORY, NULL };
 
     return nss_getby_id(cli_ctx, false, CACHE_REQ_USER_BY_ID, attrs,
-                        SSS_MC_NONE, nss_protocol_fill_sid);
+                        SSS_MC_SID, nss_protocol_fill_sid);
 }
 
 static errno_t nss_cmd_getsidbygid(struct cli_ctx *cli_ctx)
 {
-    const char *attrs[] = { SYSDB_SID_STR, NULL };
+    const char *attrs[] = { SYSDB_SID_STR, SYSDB_UIDNUM, SYSDB_GIDNUM,
+                            SYSDB_OBJECTCATEGORY, NULL };
 
     return nss_getby_id(cli_ctx, false, CACHE_REQ_GROUP_BY_ID, attrs,
-                        SSS_MC_NONE, nss_protocol_fill_sid);
+                        SSS_MC_SID, nss_protocol_fill_sid);
 }
 
 static errno_t nss_cmd_getnamebysid(struct cli_ctx *cli_ctx)

--- a/src/responder/nss/nss_private.h
+++ b/src/responder/nss/nss_private.h
@@ -91,6 +91,7 @@ struct nss_ctx {
     struct sss_mc_ctx *pwd_mc_ctx;
     struct sss_mc_ctx *grp_mc_ctx;
     struct sss_mc_ctx *initgr_mc_ctx;
+    struct sss_mc_ctx *sid_mc_ctx;
     uid_t mc_uid;
     gid_t mc_gid;
 };

--- a/src/responder/nss/nss_protocol_sid.c
+++ b/src/responder/nss/nss_protocol_sid.c
@@ -126,12 +126,13 @@ nss_get_sid_id_type(struct nss_cmd_ctx *cmd_ctx,
             continue;
         }
 
+        tmp = ldb_msg_find_attr_as_string(result->msgs[c],
+                                           SYSDB_SID_STR, NULL);
+        if (tmp == NULL) {
+            continue;
+        }
+
         if (ltype == SSS_ID_TYPE_GID) {
-            tmp = ldb_msg_find_attr_as_string(result->msgs[c],
-                                               SYSDB_SID_STR, NULL);
-            if (tmp == NULL) {
-                continue;
-            }
             if (tmp != NULL && group_sid != NULL) {
                 DEBUG(SSSDBG_OP_FAILURE,
                       "Search for SID found multiple groups with SIDs: %s, %s;"
@@ -142,11 +143,6 @@ nss_get_sid_id_type(struct nss_cmd_ctx *cmd_ctx,
             group_gid = ldb_msg_find_attr_as_uint64(result->msgs[c],
                                                     SYSDB_GIDNUM, 0);
         } else {
-            tmp = ldb_msg_find_attr_as_string(result->msgs[c],
-                                              SYSDB_SID_STR, NULL);
-            if (tmp == NULL) {
-                continue;
-            }
             if (tmp != NULL && user_sid != NULL) {
                 DEBUG(SSSDBG_OP_FAILURE,
                       "Search for SID found multiple users with SIDs: %s, %s; "

--- a/src/responder/nss/nss_protocol_sid.c
+++ b/src/responder/nss/nss_protocol_sid.c
@@ -134,8 +134,8 @@ nss_get_sid_id_type(struct nss_cmd_ctx *cmd_ctx,
             }
             if (tmp != NULL && group_sid != NULL) {
                 DEBUG(SSSDBG_OP_FAILURE,
-                      "Search for SID found multiple users with a SID, "
-                      "request failed.\n");
+                      "Search for SID found multiple groups with SIDs: %s, %s;"
+                      " request failed.\n", tmp, group_sid);
                 return EINVAL;
             }
             group_sid = tmp;
@@ -149,8 +149,8 @@ nss_get_sid_id_type(struct nss_cmd_ctx *cmd_ctx,
             }
             if (tmp != NULL && user_sid != NULL) {
                 DEBUG(SSSDBG_OP_FAILURE,
-                      "Search for SID found multiple users with a SID, "
-                      "request failed.\n");
+                      "Search for SID found multiple users with SIDs: %s, %s; "
+                      "request failed.\n", tmp, user_sid);
                 return EINVAL;
             }
             user_sid = tmp;

--- a/src/responder/nss/nss_protocol_sid.c
+++ b/src/responder/nss/nss_protocol_sid.c
@@ -239,7 +239,8 @@ nss_protocol_fill_sid(struct nss_ctx *nss_ctx,
             return EOK;
         }
         ret = sss_mmap_cache_sid_store(&nss_ctx->sid_mc_ctx, &sz_sid,
-                                       (uint32_t)id, id_type);
+                                       (uint32_t)id, id_type,
+                                       cmd_ctx->type != CACHE_REQ_OBJECT_BY_ID);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE,
                   "Failed to store SID='%s' / ID=%lu in mmap cache [%d]: %s!\n",
@@ -636,7 +637,8 @@ nss_protocol_fill_id(struct nss_ctx *nss_ctx,
             return EOK;
         }
         to_sized_string(&sid_key, sid);
-        ret = sss_mmap_cache_sid_store(&nss_ctx->sid_mc_ctx, &sid_key, id, id_type);
+        ret = sss_mmap_cache_sid_store(&nss_ctx->sid_mc_ctx, &sid_key, id, id_type,
+                                       cmd_ctx->type != CACHE_REQ_OBJECT_BY_ID);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE,
                   "Failed to store SID='%s' / ID=%d in mmap cache [%d]: %s!\n",

--- a/src/responder/nss/nss_protocol_sid.c
+++ b/src/responder/nss/nss_protocol_sid.c
@@ -65,11 +65,6 @@ nss_get_id_type(struct nss_cmd_ctx *cmd_ctx,
     errno_t ret;
     bool mpg;
 
-    if (cmd_ctx->sid_id_type != SSS_ID_TYPE_NOT_SPECIFIED) {
-        *_type = cmd_ctx->sid_id_type;
-        return EOK;
-    }
-
     /* Well known objects are always groups. */
     if (result->well_known_object) {
         *_type = SSS_ID_TYPE_GID;

--- a/src/responder/nss/nsssrv_mmap_cache.c
+++ b/src/responder/nss/nsssrv_mmap_cache.c
@@ -1084,7 +1084,8 @@ errno_t sss_mmap_cache_initgr_invalidate(struct sss_mc_ctx *mcc,
 errno_t sss_mmap_cache_sid_store(struct sss_mc_ctx **_mcc,
                                  const struct sized_string *sid,
                                  uint32_t id,
-                                 uint32_t type)
+                                 uint32_t type,
+                                 bool explicit_lookup)
 {
     struct sss_mc_ctx *mcc = *_mcc;
     struct sss_mc_rec *rec;
@@ -1122,6 +1123,7 @@ errno_t sss_mmap_cache_sid_store(struct sss_mc_ctx **_mcc,
     data->name = MC_PTR_DIFF(data->sid, data);
     data->type = type;
     data->id = id;
+    data->populated_by = (explicit_lookup ? 1 : 0);
     data->sid_len = sid->len;
     memcpy(data->sid, sid->str, sid->len);
 

--- a/src/responder/nss/nsssrv_mmap_cache.c
+++ b/src/responder/nss/nsssrv_mmap_cache.c
@@ -380,6 +380,8 @@ static const char *mc_type_to_str(enum sss_mc_type type)
         return "GROUP";
     case SSS_MC_INITGROUPS:
         return "INITGROUPS";
+    case SSS_MC_SID:
+        return "SID";
     default:
         return "-UNKNOWN-";
     }

--- a/src/responder/nss/nsssrv_mmap_cache.c
+++ b/src/responder/nss/nsssrv_mmap_cache.c
@@ -1273,7 +1273,7 @@ errno_t sss_mmap_cache_init(TALLOC_CTX *mem_ctx, const char *name,
                             enum sss_mc_type type, size_t n_elem,
                             time_t timeout, struct sss_mc_ctx **mcc)
 {
-    /* sss_mc_header alone occupies whole slot,
+    /* sss_mc_rec alone occupies whole slot,
      * so each entry takes 2 slots at the very least
      */
     static const int PAYLOAD_FACTOR = 2;

--- a/src/responder/nss/nsssrv_mmap_cache.c
+++ b/src/responder/nss/nsssrv_mmap_cache.c
@@ -535,7 +535,7 @@ static errno_t sss_mc_get_strs_len(struct sss_mc_ctx *mcc,
 }
 
 static struct sss_mc_rec *sss_mc_find_record(struct sss_mc_ctx *mcc,
-                                             struct sized_string *key)
+                                             const struct sized_string *key)
 {
     struct sss_mc_rec *rec = NULL;
     uint32_t hash;
@@ -619,7 +619,7 @@ static struct sss_mc_rec *sss_mc_find_record(struct sss_mc_ctx *mcc,
 
 static errno_t sss_mc_get_record(struct sss_mc_ctx **_mcc,
                                  size_t rec_len,
-                                 struct sized_string *key,
+                                 const struct sized_string *key,
                                  struct sss_mc_rec **_rec)
 {
     struct sss_mc_ctx *mcc = *_mcc;
@@ -705,7 +705,7 @@ static inline void sss_mmap_chain_in_rec(struct sss_mc_ctx *mcc,
  ***************************************************************************/
 
 static errno_t sss_mmap_cache_invalidate(struct sss_mc_ctx *mcc,
-                                         struct sized_string *key)
+                                         const struct sized_string *key)
 {
     struct sss_mc_rec *rec;
 
@@ -730,12 +730,12 @@ static errno_t sss_mmap_cache_invalidate(struct sss_mc_ctx *mcc,
  ***************************************************************************/
 
 errno_t sss_mmap_cache_pw_store(struct sss_mc_ctx **_mcc,
-                                struct sized_string *name,
-                                struct sized_string *pw,
+                                const struct sized_string *name,
+                                const struct sized_string *pw,
                                 uid_t uid, gid_t gid,
-                                struct sized_string *gecos,
-                                struct sized_string *homedir,
-                                struct sized_string *shell)
+                                const struct sized_string *gecos,
+                                const struct sized_string *homedir,
+                                const struct sized_string *shell)
 {
     struct sss_mc_ctx *mcc = *_mcc;
     struct sss_mc_rec *rec;
@@ -804,7 +804,7 @@ errno_t sss_mmap_cache_pw_store(struct sss_mc_ctx **_mcc,
 }
 
 errno_t sss_mmap_cache_pw_invalidate(struct sss_mc_ctx *mcc,
-                                     struct sized_string *name)
+                                     const struct sized_string *name)
 {
     return sss_mmap_cache_invalidate(mcc, name);
 }
@@ -874,10 +874,10 @@ done:
  ***************************************************************************/
 
 int sss_mmap_cache_gr_store(struct sss_mc_ctx **_mcc,
-                            struct sized_string *name,
-                            struct sized_string *pw,
+                            const struct sized_string *name,
+                            const struct sized_string *pw,
                             gid_t gid, size_t memnum,
-                            char *membuf, size_t memsize)
+                            const char *membuf, size_t memsize)
 {
     struct sss_mc_ctx *mcc = *_mcc;
     struct sss_mc_rec *rec;
@@ -942,7 +942,7 @@ int sss_mmap_cache_gr_store(struct sss_mc_ctx **_mcc,
 }
 
 errno_t sss_mmap_cache_gr_invalidate(struct sss_mc_ctx *mcc,
-                                     struct sized_string *name)
+                                     const struct sized_string *name)
 {
     return sss_mmap_cache_invalidate(mcc, name);
 }
@@ -1008,10 +1008,10 @@ done:
 }
 
 errno_t sss_mmap_cache_initgr_store(struct sss_mc_ctx **_mcc,
-                                    struct sized_string *name,
-                                    struct sized_string *unique_name,
+                                    const struct sized_string *name,
+                                    const struct sized_string *unique_name,
                                     uint32_t num_groups,
-                                    uint8_t *gids_buf)
+                                    const uint8_t *gids_buf)
 {
     struct sss_mc_ctx *mcc = *_mcc;
     struct sss_mc_rec *rec;
@@ -1075,13 +1075,13 @@ errno_t sss_mmap_cache_initgr_store(struct sss_mc_ctx **_mcc,
 }
 
 errno_t sss_mmap_cache_initgr_invalidate(struct sss_mc_ctx *mcc,
-                                         struct sized_string *name)
+                                         const struct sized_string *name)
 {
     return sss_mmap_cache_invalidate(mcc, name);
 }
 
 errno_t sss_mmap_cache_sid_store(struct sss_mc_ctx **_mcc,
-                                 struct sized_string *sid,
+                                 const struct sized_string *sid,
                                  uint32_t id,
                                  uint32_t type)
 {

--- a/src/responder/nss/nsssrv_mmap_cache.c
+++ b/src/responder/nss/nsssrv_mmap_cache.c
@@ -25,6 +25,7 @@
 #include <sys/mman.h>
 #include <fcntl.h>
 #include "util/mmap_cache.h"
+#include "sss_client/idmap/sss_nss_idmap.h"
 #include "responder/nss/nss_private.h"
 #include "responder/nss/nsssrv_mmap_cache.h"
 
@@ -1096,7 +1097,9 @@ errno_t sss_mmap_cache_sid_store(struct sss_mc_ctx **_mcc,
         return EINVAL;
     }
 
-    ret = snprintf(idkey, sizeof(idkey), "%u-%ld", type, (long)id);
+    ret = snprintf(idkey, sizeof(idkey), "%d-%ld",
+                   (type == SSS_ID_TYPE_GID) ? SSS_ID_TYPE_GID : SSS_ID_TYPE_UID,
+                   (long)id);
     if (ret > (sizeof(idkey) - 1)) {
         return EINVAL;
     }

--- a/src/responder/nss/nsssrv_mmap_cache.h
+++ b/src/responder/nss/nsssrv_mmap_cache.h
@@ -60,7 +60,8 @@ errno_t sss_mmap_cache_initgr_store(struct sss_mc_ctx **_mcc,
 errno_t sss_mmap_cache_sid_store(struct sss_mc_ctx **_mcc,
                                  const struct sized_string *sid,
                                  uint32_t id,
-                                 uint32_t type);  /* enum sss_id_type*/
+                                 uint32_t type,          /* enum sss_id_type*/
+                                 bool explicit_lookup);  /* false ~ by_id(), true ~ by_uid/gid() */
 
 errno_t sss_mmap_cache_pw_invalidate(struct sss_mc_ctx *mcc,
                                      const struct sized_string *name);

--- a/src/responder/nss/nsssrv_mmap_cache.h
+++ b/src/responder/nss/nsssrv_mmap_cache.h
@@ -57,6 +57,11 @@ errno_t sss_mmap_cache_initgr_store(struct sss_mc_ctx **_mcc,
                                     uint32_t num_groups,
                                     uint8_t *gids_buf);
 
+errno_t sss_mmap_cache_sid_store(struct sss_mc_ctx **_mcc,
+                                 struct sized_string *sid,
+                                 uint32_t id,
+                                 uint32_t type);  /* enum sss_id_type*/
+
 errno_t sss_mmap_cache_pw_invalidate(struct sss_mc_ctx *mcc,
                                      struct sized_string *name);
 

--- a/src/responder/nss/nsssrv_mmap_cache.h
+++ b/src/responder/nss/nsssrv_mmap_cache.h
@@ -29,6 +29,7 @@ enum sss_mc_type {
     SSS_MC_PASSWD,
     SSS_MC_GROUP,
     SSS_MC_INITGROUPS,
+    SSS_MC_SID,
 };
 
 errno_t sss_mmap_cache_init(TALLOC_CTX *mem_ctx, const char *name,

--- a/src/responder/nss/nsssrv_mmap_cache.h
+++ b/src/responder/nss/nsssrv_mmap_cache.h
@@ -38,42 +38,42 @@ errno_t sss_mmap_cache_init(TALLOC_CTX *mem_ctx, const char *name,
                             time_t valid_time, struct sss_mc_ctx **mcc);
 
 errno_t sss_mmap_cache_pw_store(struct sss_mc_ctx **_mcc,
-                                struct sized_string *name,
-                                struct sized_string *pw,
+                                const struct sized_string *name,
+                                const struct sized_string *pw,
                                 uid_t uid, gid_t gid,
-                                struct sized_string *gecos,
-                                struct sized_string *homedir,
-                                struct sized_string *shell);
+                                const struct sized_string *gecos,
+                                const struct sized_string *homedir,
+                                const struct sized_string *shell);
 
 errno_t sss_mmap_cache_gr_store(struct sss_mc_ctx **_mcc,
-                                struct sized_string *name,
-                                struct sized_string *pw,
+                                const struct sized_string *name,
+                                const struct sized_string *pw,
                                 gid_t gid, size_t memnum,
-                                char *membuf, size_t memsize);
+                                const char *membuf, size_t memsize);
 
 errno_t sss_mmap_cache_initgr_store(struct sss_mc_ctx **_mcc,
-                                    struct sized_string *name,
-                                    struct sized_string *unique_name,
+                                    const struct sized_string *name,
+                                    const struct sized_string *unique_name,
                                     uint32_t num_groups,
-                                    uint8_t *gids_buf);
+                                    const uint8_t *gids_buf);
 
 errno_t sss_mmap_cache_sid_store(struct sss_mc_ctx **_mcc,
-                                 struct sized_string *sid,
+                                 const struct sized_string *sid,
                                  uint32_t id,
                                  uint32_t type);  /* enum sss_id_type*/
 
 errno_t sss_mmap_cache_pw_invalidate(struct sss_mc_ctx *mcc,
-                                     struct sized_string *name);
+                                     const struct sized_string *name);
 
 errno_t sss_mmap_cache_pw_invalidate_uid(struct sss_mc_ctx *mcc, uid_t uid);
 
 errno_t sss_mmap_cache_gr_invalidate(struct sss_mc_ctx *mcc,
-                                     struct sized_string *name);
+                                     const struct sized_string *name);
 
 errno_t sss_mmap_cache_gr_invalidate_gid(struct sss_mc_ctx *mcc, gid_t gid);
 
 errno_t sss_mmap_cache_initgr_invalidate(struct sss_mc_ctx *mcc,
-                                         struct sized_string *name);
+                                         const struct sized_string *name);
 
 errno_t sss_mmap_cache_reinit(TALLOC_CTX *mem_ctx,
                               uid_t uid, gid_t gid,

--- a/src/sss_client/idmap/sss_nss_ex.c
+++ b/src/sss_client/idmap/sss_nss_ex.c
@@ -57,7 +57,7 @@ struct nss_input {
     } result;
 };
 
-errno_t sss_nss_mc_get(struct nss_input *inp)
+static errno_t sss_nss_mc_get(struct nss_input *inp)
 {
     switch(inp->cmd) {
     case SSS_NSS_GETPWNAM:

--- a/src/sss_client/idmap/sss_nss_ex.c
+++ b/src/sss_client/idmap/sss_nss_ex.c
@@ -166,7 +166,8 @@ static int check_flags(struct nss_input *inp, uint32_t flags,
     return 0;
 }
 
-int sss_get_ex(struct nss_input *inp, uint32_t flags, unsigned int timeout)
+static int sss_get_ex(struct nss_input *inp, uint32_t flags,
+                      unsigned int timeout)
 {
     uint8_t *repbuf = NULL;
     size_t replen;

--- a/src/sss_client/nss_mc.h
+++ b/src/sss_client/nss_mc.h
@@ -90,4 +90,10 @@ errno_t sss_nss_mc_initgroups_dyn(const char *name, size_t name_len,
                                   gid_t group, long int *start, long int *size,
                                   gid_t **groups, long int limit);
 
+/* SID db */
+errno_t sss_nss_mc_get_sid_by_id(uint32_t id, char **sid, uint32_t *type);
+errno_t sss_nss_mc_get_sid_by_uid(uint32_t id, char **sid, uint32_t *type);
+errno_t sss_nss_mc_get_sid_by_gid(uint32_t id, char **sid, uint32_t *type);
+errno_t sss_nss_mc_get_id_by_sid(const char *sid, uint32_t *id, uint32_t *type);
+
 #endif /* _NSS_MC_H_ */

--- a/src/sss_client/nss_mc_sid.c
+++ b/src/sss_client/nss_mc_sid.c
@@ -1,0 +1,181 @@
+/*
+ * System Security Services Daemon. NSS client interface
+ *
+ * Copyright (C) 2022 Red Hat
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* SID database NSS interface using mmap cache */
+
+#include <stddef.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include "nss_mc.h"
+#include "util/mmap_cache.h"
+#include "idmap/sss_nss_idmap.h"
+
+static struct sss_cli_mc_ctx sid_mc_ctx = { UNINITIALIZED, -1, 0, NULL, 0, NULL, 0,
+                                            NULL, 0, 0 };
+
+static errno_t mc_get_sid_by_typed_id(uint32_t id, enum sss_id_type lookup_type,
+                                      char **sid, uint32_t *type)
+{
+    int ret;
+    char key[16];
+    int key_len;
+    uint32_t hash;
+    uint32_t slot;
+    struct sss_mc_rec *rec = NULL;
+    const struct sss_mc_sid_data *data = NULL;
+
+    key_len = snprintf(key, sizeof(key), "%u-%ld", lookup_type, (long)id);
+    if (key_len > (sizeof(key) - 1)) {
+        return EINVAL;
+    }
+
+    ret = sss_nss_mc_get_ctx("sid", &sid_mc_ctx);
+    if (ret) {
+        return ret;
+    }
+
+    hash = sss_nss_mc_hash(&sid_mc_ctx, key, key_len + 1);
+    slot = sid_mc_ctx.hash_table[hash];
+
+    while (MC_SLOT_WITHIN_BOUNDS(slot, sid_mc_ctx.dt_size)) {
+        free(rec); /* free record from previous iteration */
+        rec = NULL;
+
+        ret = sss_nss_mc_get_record(&sid_mc_ctx, slot, &rec);
+        if (ret) {
+            goto done;
+        }
+        if (hash != rec->hash2) {
+            ret = EINVAL;
+            goto done;
+        }
+
+        data = (struct sss_mc_sid_data *)rec->data;
+        if (id == data->id) {
+            if (rec->expire < time(NULL)) {
+                ret = EINVAL;
+                goto done;
+            }
+            *type = data->type;
+            *sid = strdup(data->sid);
+            if (!*sid) {
+                ret = ENOMEM;
+            }
+            goto done;
+        }
+
+        slot = sss_nss_mc_next_slot_with_hash(rec, hash);
+    }
+
+    ret = ENOENT;
+
+done:
+    free(rec);
+    __sync_sub_and_fetch(&sid_mc_ctx.active_threads, 1);
+    return ret;
+}
+
+errno_t sss_nss_mc_get_sid_by_uid(uint32_t id, char **sid, uint32_t *type)
+{
+    return mc_get_sid_by_typed_id(id, SSS_ID_TYPE_UID, sid, type);
+}
+
+errno_t sss_nss_mc_get_sid_by_gid(uint32_t id, char **sid, uint32_t *type)
+{
+    return mc_get_sid_by_typed_id(id, SSS_ID_TYPE_GID, sid, type);
+}
+
+errno_t sss_nss_mc_get_sid_by_id(uint32_t id, char **sid, uint32_t *type)
+{
+    errno_t ret;
+
+    /* MC should behave the same way sssd_nss does.
+     * If user object exists sssd_nss would always return this user object.
+     */
+    ret = sss_nss_mc_get_sid_by_uid(id, sid, type);
+    if (ret != ENOENT) {
+        return ret; /* found or fatal error */
+    }
+
+    /* This is where things get tricky.
+     * Consider a case of manually created user private group:
+     * since MC could be primed via explicit by-gid() lookup,
+     * missing user object doesn't mean sssd_nss wouldn't return
+     * it, hence request should go to sssd_nss.
+     */
+    return ENOENT;
+}
+
+errno_t sss_nss_mc_get_id_by_sid(const char *sid, uint32_t *id, uint32_t *type)
+{
+    int ret;
+    int key_len;
+    uint32_t hash;
+    uint32_t slot;
+    struct sss_mc_rec *rec = NULL;
+    const struct sss_mc_sid_data *data = NULL;
+
+    key_len = strlen(sid) + 1;
+
+    ret = sss_nss_mc_get_ctx("sid", &sid_mc_ctx);
+    if (ret) {
+        return ret;
+    }
+
+    hash = sss_nss_mc_hash(&sid_mc_ctx, sid, key_len);
+    slot = sid_mc_ctx.hash_table[hash];
+
+    while (MC_SLOT_WITHIN_BOUNDS(slot, sid_mc_ctx.dt_size)) {
+        free(rec); /* free record from previous iteration */
+        rec = NULL;
+
+        ret = sss_nss_mc_get_record(&sid_mc_ctx, slot, &rec);
+        if (ret) {
+            goto done;
+        }
+        if (hash != rec->hash1) {
+            ret = EINVAL;
+            goto done;
+        }
+
+        data = (struct sss_mc_sid_data *)rec->data;
+        if (strcmp(sid, data->sid) == 0) {
+            if (rec->expire < time(NULL)) {
+                ret = EINVAL;
+                goto done;
+            }
+            *type = data->type;
+            *id = data->id;
+            goto done; /* ret == 0 */
+        }
+
+        slot = sss_nss_mc_next_slot_with_hash(rec, hash);
+    }
+
+    ret = ENOENT;
+
+done:
+    free(rec);
+    __sync_sub_and_fetch(&sid_mc_ctx.active_threads, 1);
+    return ret;
+}

--- a/src/util/mmap_cache.h
+++ b/src/util/mmap_cache.h
@@ -150,6 +150,7 @@ struct sss_mc_sid_data {
     rel_ptr_t name;         /* ptr to SID string, rel. to struct base addr */
     uint32_t type;          /* enum sss_id_type */
     uint32_t id;            /* gid or uid */
+    uint32_t populated_by;  /* 0 - by_id(), 1 - by_uid/gid() lookup */
     uint32_t sid_len;       /* length of sid */
     char sid[0];
 };

--- a/src/util/mmap_cache.h
+++ b/src/util/mmap_cache.h
@@ -146,6 +146,14 @@ struct sss_mc_initgr_data {
                              * after gids */
 };
 
+struct sss_mc_sid_data {
+    rel_ptr_t name;         /* ptr to SID string, rel. to struct base addr */
+    uint32_t type;          /* enum sss_id_type */
+    uint32_t id;            /* gid or uid */
+    uint32_t sid_len;       /* length of sid */
+    char sid[0];
+};
+
 #pragma pack()
 
 


### PR DESCRIPTION
This PR aims to add mem-cache support for `sid-by-*id()` and `id-by-sid()` lookups.

Things left to do (at least) are:
 - to add a patch that will support reading group objects by `sid_by_id()` lookup (I plan to store type of a lookup function that was used to populate mem-cache to overcome issue currently described in the comment inside `sss_nss_mc_get_sid_by_id()`)
 - to actually test it
 -  to update https://sssd.io/contrib/mmap_cache.html

But I make this public to receive a preliminary feedback to avoid investing more capacity if approach will be deemed unreasonable.
@sumit-bose, could you please take a glance?