### PR TITLE
pam: fix section parsing issue

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2573,6 +2573,7 @@ EXTRA_pam_srv_tests_DEPENDENCIES += p11_child
 pam_srv_tests_SOURCES = \
     $(TEST_MOCK_RESP_OBJ) \
     src/tests/cmocka/test_pam_srv.c \
+    src/tests/cmocka/common_utils.c \
     src/sss_client/pam_message.c \
     src/responder/pam/pamsrv_cmd.c \
     src/responder/pam/pamsrv_p11.c \

--- a/src/responder/pam/pam_prompting_config.c
+++ b/src/responder/pam/pam_prompting_config.c
@@ -124,7 +124,7 @@ static errno_t pam_set_prompting_options(struct confdb_ctx *cdb,
     dummy = talloc_asprintf(tmp_ctx, "%s/%s", section_path,
                                               service_name);
     for (c = 0; c < num_sections; c++) {
-        if (strcmp(sections[c], CONFDB_PC_TYPE_PASSWORD) == 0) {
+        if (strcmp(sections[c], section_path) == 0) {
             global = true;
         }
         if (dummy != NULL && strcmp(sections[c], dummy) == 0) {

--- a/src/tests/cmocka/common_mock.h
+++ b/src/tests/cmocka/common_mock.h
@@ -53,4 +53,10 @@ enum sss_test_wrapper_call {
     WRAP_CALL_REAL
 };
 
+void list_tests(FILE *file, const char *pref,
+                const struct CMUnitTest tests[], size_t test_count);
+
+int sss_cmocka_run_group_tests(const struct CMUnitTest * const tests,
+                               const size_t num_tests,
+                               const char *single);
 #endif /* __COMMON_MOCK_H_ */

--- a/src/tests/cmocka/common_utils.c
+++ b/src/tests/cmocka/common_utils.c
@@ -1,0 +1,66 @@
+/*
+    Authors:
+        Sumit Bose <sbose@redhat.com>
+
+    Copyright (C) 2022 Red Hat
+
+    SSSD tests: common helpers
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "tests/cmocka/common_mock.h"
+
+static struct CMUnitTest select_test(const struct CMUnitTest tests[],
+                                     size_t test_count, const char *name)
+{
+    size_t c;
+    struct CMUnitTest empty = { 0 };
+
+    for (c = 0; c < test_count; c++) {
+        if (strcmp(tests[c].name, name) == 0) {
+            return tests[c];
+        }
+    }
+
+    return empty;
+}
+
+void list_tests(FILE *file, const char *pref,
+                const struct CMUnitTest tests[], size_t test_count)
+{
+    size_t c;
+    for (c = 0; c < test_count; c++) {
+        fprintf(file, "%s %s\n", pref == NULL ? "" : pref, tests[c].name);
+    }
+}
+
+int sss_cmocka_run_group_tests(const struct CMUnitTest * const tests,
+                               const size_t num_tests,
+                               const char *single)
+{
+    struct CMUnitTest single_test[1];
+
+    if (single != NULL) {
+        single_test[0] = select_test(tests, num_tests, single);
+        if (single_test[0].name == NULL) {
+            fprintf(stderr, "\nTest [%s] not available.\n\n", single);
+            return ENOENT;
+        }
+
+        return _cmocka_run_group_tests("single_test", single_test, 1,
+                                      NULL, NULL);
+    }
+    return _cmocka_run_group_tests("tests", tests, num_tests, NULL, NULL);
+}


### PR DESCRIPTION
Due to a typo it was always necessary to have a `[prompting/password]`
section in sssd.conf to enable the other `prompting` section.

This patch fixes this and adds some unit test to cover that part of the
code.

Resolves: https://github.com/SSSD/sssd/issues/6081