### PR TITLE
ci: integrate covscan to github actions

### DIFF
--- a/.github/actions/build-sssd-srpm/action.yml
+++ b/.github/actions/build-sssd-srpm/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: Package release.
     required: false
     default: '${{ github.run_number }}'
+  working-directory:
+    description: Working directory.
+    required: false
+    default: '.'
 outputs:
   file:
     description: Source rpm file name.
@@ -20,6 +24,7 @@ runs:
   - name: Generate tarball and spec file
     shell: bash
     run: |
+      pushd '${{ inputs.working-directory }}'
       version="${{ inputs.version }}"
       release="${{ inputs.release }}"
       name="sssd-$version"
@@ -30,9 +35,10 @@ runs:
       sed -iE "s/@PACKAGE_NAME@/sssd/g" ./sssd.spec
       sed -iE "s/@PACKAGE_VERSION@/$version/g" ./sssd.spec
       sed -iE "s/@PRERELEASE_VERSION@/$release/g" ./sssd.spec
+      popd
   - name: Build source rpm
     id: srpm
     uses: SSSD/action-build-srpm@master
     with:
-      tarball: sssd-${{ inputs.version }}.tar.gz
-      specfile: sssd.spec
+      tarball: ${{ inputs.working-directory }}/sssd-${{ inputs.version }}.tar.gz
+      specfile: ${{ inputs.working-directory }}/sssd.spec

--- a/.github/actions/build-sssd-srpm/action.yml
+++ b/.github/actions/build-sssd-srpm/action.yml
@@ -38,7 +38,7 @@ runs:
       popd
   - name: Build source rpm
     id: srpm
-    uses: SSSD/action-build-srpm@master
+    uses: next-actions/build-srpm@master
     with:
       tarball: ${{ inputs.working-directory }}/sssd-${{ inputs.version }}.tar.gz
       specfile: ${{ inputs.working-directory }}/sssd.spec

--- a/.github/workflows/analyze-target.yml
+++ b/.github/workflows/analyze-target.yml
@@ -3,7 +3,7 @@ on:
   pull_request_target:
     branches: [master]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 jobs:
   cppcheck:

--- a/.github/workflows/analyze-target.yml
+++ b/.github/workflows/analyze-target.yml
@@ -2,7 +2,9 @@ name: "Analyze (target)"
 on:
   pull_request_target:
     branches: [master]
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   cppcheck:
     runs-on: ubuntu-latest
@@ -25,3 +27,56 @@ jobs:
         pull_request_id: ${{ github.event.pull_request.number }}
         allow_approve: false
         enable_checks: "warning,unusedFunction,missingInclude"
+
+  covscan:
+    runs-on: covscan
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout target branch
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.base_ref }}
+        path: target
+
+    - name: Checkout pull request branch
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.head_ref }}
+        path: pr
+
+    - name: Build source rpm - ${{ github.base_ref }}
+      id: target
+      uses: ./target/.github/actions/build-sssd-srpm
+      with:
+        working-directory: target
+        version: ${{ github.base_ref }}
+
+    - name: Build source rpm - pr${{ github.event.pull_request.number }}
+      id: pr
+      uses: ./target/.github/actions/build-sssd-srpm
+      with:
+        working-directory: pr
+        version: pr${{ github.event.pull_request.number }}
+
+    - name: Run covscan
+      run: |
+        run-covscan --base-srpm "${{ steps.target.outputs.path }}" --srpm "${{ steps.pr.outputs.path }}" --output-dir logs
+
+    - name: Print result
+      uses: next-actions/print-logs@master
+      if: always()
+      with:
+        working-directory: logs
+        files: |
+          added.err
+          *.err
+
+    - name: Upload artifacts
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        if-no-files-found: ignore
+        name: covscan
+        path: |
+          ./logs/*.err

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,26 +102,15 @@ jobs:
         working-directory: /sssd
         script: ./contrib/ci/run --moderate
 
-    - name: Print make check result
+    - name: Print logs
+      uses: next-actions/print-logs@master
       if: always()
-      run: |
-        if [ -f ./sssd/ci-build-debug/test-suite.log ]; then
-          cat ./sssd/ci-build-debug/test-suite.log
-        fi
-
-    - name: Print make intgcheck result
-      if: always()
-      run: |
-        if [ -f ./sssd/ci-build-debug/ci-make-intgcheck.log ]; then
-          cat ./sssd/ci-build-debug/ci-make-intgcheck.log
-        fi
-
-    - name: Print make distcheck result
-      if: always()
-      run: |
-        if [ -f ./sssd/ci-build-debug/ci-make-distcheck.log ]; then
-          cat ./sssd/ci-build-debug/ci-make-distcheck.log
-        fi
+      with:
+        working-directory: ./sssd/ci-build-debug
+        files: |
+          test-suite.log
+          ci-make-intgcheck.log
+          ci-make-distcheck.log
 
     - name: Upload main artifacts
       if: always()

--- a/.github/workflows/copr_build.yml
+++ b/.github/workflows/copr_build.yml
@@ -59,20 +59,20 @@ jobs:
 
     - name: Initialize copr actions
       id: copr
-      uses: SSSD/action-copr/init@master
+      uses: next-actions/copr/init@master
       with:
         token: ${{ secrets.COPR_SECRETS }}
 
     - name: Get copr chroots
       id: chroots
-      uses: SSSD/action-copr/filter-chroots@master
+      uses: next-actions/copr/filter-chroots@master
       with:
         coprcfg: ${{ secrets.COPR_SECRETS }}
         filter: "fedora-.+-x86_64|centos-stream-9-x86_64"
         exclude: "fedora-eln-.+"
 
     - name: Create copr project
-      uses: SSSD/action-copr/create-project@master
+      uses: next-actions/copr/create-project@master
       with:
         coprcfg: ${{ steps.copr.outputs.coprcfg }}
         chroots: ${{ steps.chroots.outputs.list }}
@@ -82,7 +82,7 @@ jobs:
         instructions: 'Use this for test purpose only. Do not use this in production.'
 
     - name: Cancel pending builds
-      uses: SSSD/action-copr/cancel-builds@master
+      uses: next-actions/copr/cancel-builds@master
       with:
         coprcfg: ${{ steps.copr.outputs.coprcfg }}
         project: ${{ env.COPR_PROJECT }}
@@ -115,12 +115,12 @@ jobs:
 
     - name: Initialize copr actions
       id: copr
-      uses: SSSD/action-copr/init@master
+      uses: next-actions/copr/init@master
       with:
         token: ${{ secrets.COPR_SECRETS }}
 
     - name: Build srpm in copr for ${{ matrix.chroot }}
-      uses: SSSD/action-copr/submit-build@master
+      uses: next-actions/copr/submit-build@master
       with:
         coprcfg: ${{ steps.copr.outputs.coprcfg }}
         srpm: ${{ needs.prepare.outputs.srpm }}

--- a/.github/workflows/copr_cleanup.yml
+++ b/.github/workflows/copr_cleanup.yml
@@ -12,12 +12,12 @@ jobs:
     steps:
     - name: Initialize copr actions
       id: copr
-      uses: SSSD/action-copr/init@master
+      uses: next-actions/copr/init@master
       with:
         token: ${{ secrets.COPR_SECRETS }}
 
     - name: Delete copr project
-      uses: SSSD/action-copr/delete-project@master
+      uses: next-actions/copr/delete-project@master
       with:
         coprcfg: ${{ steps.copr.outputs.coprcfg }}
         project: 'pr${{ github.event.pull_request.number }}'


### PR DESCRIPTION
This integrates covscan to github actions using a custom runner
that runs in internal openshift. It parses the covscan output and
converts it into annotations to closely integrate it into a code.

The annotations are visible when viewing commit via github web ui
and in check run summary.

I will publish the runner in SSSD's private repository soon.

Example:
https://github.com/pbrezina/sssd/runs/5832137540?check_suite_focus=true