### PR TITLE
ci: disable fedora-review for copr pr builds

### DIFF
--- a/.github/workflows/copr_build.yml
+++ b/.github/workflows/copr_build.yml
@@ -78,6 +78,7 @@ jobs:
         chroots: ${{ steps.chroots.outputs.list }}
         project: ${{ env.COPR_PROJECT }}
         account: ${{ env.COPR_ACCOUNT }}
+        fedora-review: off
         description: 'Development package for [sssd pull request #${{ env.PR_ID }}](${{ env.PR_URL }}).'
         instructions: 'Use this for test purpose only. Do not use this in production.'
 


### PR DESCRIPTION
fedora-review tool started to fail, this commit disables
fedora-review for pull request builds. If it gets fixed,
we may re-enable it later.

https://pagure.io/copr/copr/issue/2040