### PR TITLE
p11_child: enable more than one CRL PEM file

### DIFF
--- a/src/p11_child/p11_child.h
+++ b/src/p11_child/p11_child.h
@@ -38,7 +38,8 @@ struct cert_verify_opts {
     bool verification_partial_chain;
     char *ocsp_default_responder;
     char *ocsp_default_responder_signing_cert;
-    char *crl_file;
+    char **crl_files;
+    int num_files;
     CK_MECHANISM_TYPE ocsp_dgst;
     bool soft_ocsp;
     bool soft_crl;

--- a/src/tests/cmocka/test_utils.c
+++ b/src/tests/cmocka/test_utils.c
@@ -1764,7 +1764,7 @@ static void test_parse_cert_verify_opts(void **state)
     assert_true(cv_opts->do_ocsp);
     assert_null(cv_opts->ocsp_default_responder);
     assert_null(cv_opts->ocsp_default_responder_signing_cert);
-    assert_null(cv_opts->crl_file);
+    assert_null(cv_opts->crl_files);
     talloc_free(cv_opts);
 
     ret = parse_cert_verify_opts(global_talloc_context, "wedfkwefjk", &cv_opts);
@@ -1774,7 +1774,7 @@ static void test_parse_cert_verify_opts(void **state)
     assert_true(cv_opts->do_ocsp);
     assert_null(cv_opts->ocsp_default_responder);
     assert_null(cv_opts->ocsp_default_responder_signing_cert);
-    assert_null(cv_opts->crl_file);
+    assert_null(cv_opts->crl_files);
     talloc_free(cv_opts);
 
     ret = parse_cert_verify_opts(global_talloc_context, "no_ocsp", &cv_opts);
@@ -1784,7 +1784,7 @@ static void test_parse_cert_verify_opts(void **state)
     assert_false(cv_opts->do_ocsp);
     assert_null(cv_opts->ocsp_default_responder);
     assert_null(cv_opts->ocsp_default_responder_signing_cert);
-    assert_null(cv_opts->crl_file);
+    assert_null(cv_opts->crl_files);
     talloc_free(cv_opts);
 
     ret = parse_cert_verify_opts(global_talloc_context, "no_verification",
@@ -1795,7 +1795,7 @@ static void test_parse_cert_verify_opts(void **state)
     assert_true(cv_opts->do_ocsp);
     assert_null(cv_opts->ocsp_default_responder);
     assert_null(cv_opts->ocsp_default_responder_signing_cert);
-    assert_null(cv_opts->crl_file);
+    assert_null(cv_opts->crl_files);
     talloc_free(cv_opts);
 
     ret = parse_cert_verify_opts(global_talloc_context,
@@ -1806,7 +1806,7 @@ static void test_parse_cert_verify_opts(void **state)
     assert_false(cv_opts->do_ocsp);
     assert_null(cv_opts->ocsp_default_responder);
     assert_null(cv_opts->ocsp_default_responder_signing_cert);
-    assert_null(cv_opts->crl_file);
+    assert_null(cv_opts->crl_files);
     talloc_free(cv_opts);
 
     ret = parse_cert_verify_opts(global_talloc_context,
@@ -1828,7 +1828,7 @@ static void test_parse_cert_verify_opts(void **state)
     assert_true(cv_opts->do_ocsp);
     assert_string_equal(cv_opts->ocsp_default_responder, "abc");
     assert_string_equal(cv_opts->ocsp_default_responder_signing_cert, "def");
-    assert_null(cv_opts->crl_file);
+    assert_null(cv_opts->crl_files);
     talloc_free(cv_opts);
 
     ret = parse_cert_verify_opts(global_talloc_context, "crl_file=hij",
@@ -1839,7 +1839,20 @@ static void test_parse_cert_verify_opts(void **state)
     assert_true(cv_opts->do_ocsp);
     assert_null(cv_opts->ocsp_default_responder);
     assert_null(cv_opts->ocsp_default_responder_signing_cert);
-    assert_string_equal(cv_opts->crl_file, "hij");
+    assert_string_equal(cv_opts->crl_files[0], "hij");
+    talloc_free(cv_opts);
+
+    ret = parse_cert_verify_opts(global_talloc_context,
+                                 "crl_file=file1.pem,crl_file=file2.pem",
+                                 &cv_opts);
+    assert_int_equal(ret, EOK);
+    assert_true(cv_opts->do_verification);
+    assert_false(cv_opts->verification_partial_chain);
+    assert_true(cv_opts->do_ocsp);
+    assert_null(cv_opts->ocsp_default_responder);
+    assert_null(cv_opts->ocsp_default_responder_signing_cert);
+    assert_string_equal(cv_opts->crl_files[0], "file1.pem");
+    assert_string_equal(cv_opts->crl_files[1], "file2.pem");
     talloc_free(cv_opts);
 
     ret = parse_cert_verify_opts(global_talloc_context, "partial_chain", &cv_opts);
@@ -1849,7 +1862,7 @@ static void test_parse_cert_verify_opts(void **state)
     assert_true(cv_opts->do_ocsp);
     assert_null(cv_opts->ocsp_default_responder);
     assert_null(cv_opts->ocsp_default_responder_signing_cert);
-    assert_null(cv_opts->crl_file);
+    assert_null(cv_opts->crl_files);
     talloc_free(cv_opts);
 }
 

--- a/src/tests/test_CA/Makefile.am
+++ b/src/tests/test_CA/Makefile.am
@@ -30,6 +30,7 @@ pkcs12 = $(addprefix SSSD_test_cert_pkcs12_,$(addsuffix .pem,$(ids)))
 
 
 extra = softhsm2_none softhsm2_one softhsm2_two softhsm2_2tokens softhsm2_ocsp softhsm2_2certs_same_id softhsm2_pss_one SSSD_test_cert_x509_0001.der SSSD_test_cert_x509_0007.der
+extra += SSSD_test_CA_crl.pem
 if HAVE_FAKETIME
 extra += SSSD_test_CA_expired_crl.pem
 endif
@@ -37,7 +38,7 @@ endif
 # If openssl is run in parallel there might be conflicts with the serial
 .NOTPARALLEL:
 
-ca_all: clean serial SSSD_test_CA.pem $(certs) $(certs_h) $(pubkeys) $(pubkeys_h) $(pkcs12) $(extra)
+ca_all: clean serial SSSD_test_CA.pem SSSD_test_CA_crl.pem $(certs) $(certs_h) $(pubkeys) $(pubkeys_h) $(pkcs12) $(extra)
 
 $(pwdfile):
 	@echo "123456" > $@
@@ -96,6 +97,9 @@ SSSD_test_cert_pubsshkey_%.h: SSSD_test_cert_pubsshkey_%.pub
 
 SSSD_test_CA_expired_crl.pem:
 	$(FAKETIME) -f '-7d' $(OPENSSL) ca -gencrl -out $@ -keyfile $(openssl_ca_key) -config ${openssl_ca_config} -crlhours 1
+
+SSSD_test_CA_crl.pem: $(openssl_ca_key) SSSD_test_CA.pem
+	$(OPENSSL) ca -gencrl -out $@ -keyfile $(openssl_ca_key) -config $(openssl_ca_config) -crldays 99999
 
 # The softhsm2 PKCS#11 setups are used in
 # - src/tests/cmocka/test_pam_srv.c
@@ -206,6 +210,7 @@ CLEANFILES = \
     index.txt.attr.old  index.txt.old \
     serial  serial.old  \
     SSSD_test_CA.pem $(pwdfile) SSSD_test_CA_expired_crl.pem \
+    SSSD_test_CA_crl.pem \
     $(certs) $(certs_h) $(pubkeys) $(pubkeys_h) $(pkcs12) \
     softhsm2_*.conf \
     SSSD_test_*.der \

--- a/src/tests/test_ECC_CA/Makefile.am
+++ b/src/tests/test_ECC_CA/Makefile.am
@@ -16,12 +16,12 @@ pubkeys = $(addprefix SSSD_test_ECC_cert_pubsshkey_,$(addsuffix .pub,$(ids)))
 pubkeys_h = $(addprefix SSSD_test_ECC_cert_pubsshkey_,$(addsuffix .h,$(ids)))
 pkcs12 = $(addprefix SSSD_test_ECC_cert_pkcs12_,$(addsuffix .pem,$(ids)))
 
-extra = softhsm2_ecc_one
+extra = softhsm2_ecc_one SSSD_test_ECC_crl.pem
 
 # If openssl is run in parallel there might be conflicts with the serial
 .NOTPARALLEL:
 
-ca_all: clean serial SSSD_test_ECC_CA.pem $(certs) $(certs_h) $(pubkeys) $(pubkeys_h) $(pkcs12) $(extra)
+ca_all: clean serial SSSD_test_ECC_crl.pem $(certs) $(certs_h) $(pubkeys) $(pubkeys_h) $(pkcs12) $(extra)
 
 $(pwdfile):
 	@echo "123456" > $@
@@ -51,6 +51,9 @@ SSSD_test_ECC_cert_x509_%.h: SSSD_test_ECC_cert_x509_%.pem
 SSSD_test_ECC_cert_pubsshkey_%.h: SSSD_test_ECC_cert_pubsshkey_%.pub
 	@echo "#define SSSD_TEST_ECC_CERT_SSH_KEY_$* \""$(shell cut -d' ' -f2 $<)"\"" > $@
 
+SSSD_test_ECC_crl.pem: $(openssl_ecc_ca_key) SSSD_test_ECC_CA.pem
+	$(OPENSSL) ca -gencrl -out $@ -keyfile $(openssl_ecc_ca_key) -config $(openssl_ecc_ca_config) -crldays 99999
+
 
 softhsm2_ecc_one: softhsm2_ecc_one.conf
 	mkdir $@
@@ -67,7 +70,7 @@ CLEANFILES = \
     index.txt  index.txt.attr \
     index.txt.attr.old  index.txt.old \
     serial  serial.old  \
-    SSSD_test_ECC_CA.pem $(pwdfile) \
+    SSSD_test_ECC_CA.pem SSSD_test_ECC_crl.pem $(pwdfile) \
     $(certs) $(certs_h) $(pubkeys) $(pubkeys_h) $(pkcs12) \
     softhsm2_*.conf \
     $(NULL)


### PR DESCRIPTION
Enable support for more than one CRL PEM file. p11_child parses the
crl_file list passed as argument, loads all the files and makes the
validation.

Finally, add a new test case in test_utils to check that the p11_child
crl_file argument has been parsed correctly. Add another three test
cases in test_oam_srv to check the validation process.

Resolves: https://github.com/SSSD/sssd/issues/6086