### PR TITLE
sssctl: Get and Set per-Component Debug-Level

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1921,6 +1921,7 @@ sssctl_LDADD = \
     $(LIBADD_DL) \
     libsss_certmap.la \
     libifp_iface_sync.la \
+    libsss_iface.la \
     libsss_iface_sync.la \
     libsss_sbus_sync.la \
     $(NULL)

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -2018,17 +2018,27 @@ static void monitor_sbus_connected(struct tevent_req *req)
         goto done;
     }
 
-    SBUS_INTERFACE(iface,
+    SBUS_INTERFACE(iface_monitor,
         sssd_monitor,
         SBUS_METHODS(
             SBUS_SYNC(METHOD, sssd_monitor, RegisterService, monitor_sbus_RegisterService, ctx)
         ),
         SBUS_SIGNALS(SBUS_NO_SIGNALS),
-        SBUS_PROPERTIES(SBUS_NO_PROPERTIES)
+        SBUS_PROPERTIES(
+            SBUS_NO_PROPERTIES)
+    );
+    SBUS_INTERFACE(iface_service,
+        sssd_service,
+        SBUS_METHODS(SBUS_NO_METHODS),
+        SBUS_SIGNALS(SBUS_NO_SIGNALS),
+        SBUS_PROPERTIES(
+            SBUS_SYNC(GETTER, sssd_service, debug_level, generic_get_debug_level, NULL)
+        )
     );
 
     struct sbus_path paths[] = {
-        {SSS_BUS_PATH, &iface},
+        {SSS_BUS_PATH, &iface_monitor},
+        {SSS_BUS_PATH, &iface_service},
         {NULL, NULL}
     };
 

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -2032,7 +2032,8 @@ static void monitor_sbus_connected(struct tevent_req *req)
         SBUS_METHODS(SBUS_NO_METHODS),
         SBUS_SIGNALS(SBUS_NO_SIGNALS),
         SBUS_PROPERTIES(
-            SBUS_SYNC(GETTER, sssd_service, debug_level, generic_get_debug_level, NULL)
+            SBUS_SYNC(GETTER, sssd_service, debug_level, generic_get_debug_level, NULL),
+            SBUS_SYNC(SETTER, sssd_service, debug_level, generic_set_debug_level, NULL)
         )
     );
 

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -484,7 +484,9 @@ be_register_monitor_iface(struct sbus_connection *conn, struct be_ctx *be_ctx)
             SBUS_SYNC(METHOD, sssd_service, rotateLogs, data_provider_logrotate, be_ctx)
         ),
         SBUS_SIGNALS(SBUS_NO_SIGNALS),
-        SBUS_PROPERTIES(SBUS_NO_PROPERTIES)
+        SBUS_PROPERTIES(
+            SBUS_SYNC(GETTER, sssd_service, debug_level, generic_get_debug_level, NULL)
+        )
     );
 
     struct sbus_path paths[] = {

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -485,7 +485,8 @@ be_register_monitor_iface(struct sbus_connection *conn, struct be_ctx *be_ctx)
         ),
         SBUS_SIGNALS(SBUS_NO_SIGNALS),
         SBUS_PROPERTIES(
-            SBUS_SYNC(GETTER, sssd_service, debug_level, generic_get_debug_level, NULL)
+            SBUS_SYNC(GETTER, sssd_service, debug_level, generic_get_debug_level, NULL),
+            SBUS_SYNC(SETTER, sssd_service, debug_level, generic_set_debug_level, NULL)
         )
     );
 

--- a/src/responder/autofs/autofssrv.c
+++ b/src/responder/autofs/autofssrv.c
@@ -80,7 +80,9 @@ autofs_register_service_iface(struct autofs_ctx *autofs_ctx,
             SBUS_SYNC(METHOD, sssd_service, clearEnumCache, autofs_clean_hash_table, autofs_ctx)
         ),
         SBUS_SIGNALS(SBUS_NO_SIGNALS),
-        SBUS_PROPERTIES(SBUS_NO_PROPERTIES)
+        SBUS_PROPERTIES(
+            SBUS_SYNC(GETTER, sssd_service, debug_level, generic_get_debug_level, NULL)
+        )
     );
 
     ret = sbus_connection_add_path(rctx->mon_conn, SSS_BUS_PATH, &iface_svc);

--- a/src/responder/autofs/autofssrv.c
+++ b/src/responder/autofs/autofssrv.c
@@ -81,7 +81,8 @@ autofs_register_service_iface(struct autofs_ctx *autofs_ctx,
         ),
         SBUS_SIGNALS(SBUS_NO_SIGNALS),
         SBUS_PROPERTIES(
-            SBUS_SYNC(GETTER, sssd_service, debug_level, generic_get_debug_level, NULL)
+            SBUS_SYNC(GETTER, sssd_service, debug_level, generic_get_debug_level, NULL),
+            SBUS_SYNC(SETTER, sssd_service, debug_level, generic_set_debug_level, NULL)
         )
     );
 

--- a/src/responder/common/responder_iface.c
+++ b/src/responder/common/responder_iface.c
@@ -146,7 +146,9 @@ sss_resp_register_service_iface(struct resp_ctx *rctx)
             SBUS_SYNC(METHOD, sssd_service, rotateLogs, responder_logrotate, rctx)
         ),
         SBUS_SIGNALS(SBUS_NO_SIGNALS),
-        SBUS_PROPERTIES(SBUS_NO_PROPERTIES)
+        SBUS_PROPERTIES(
+            SBUS_SYNC(GETTER, sssd_service, debug_level, generic_get_debug_level, NULL)
+        )
     );
 
     ret = sbus_connection_add_path(rctx->mon_conn, SSS_BUS_PATH, &iface_svc);

--- a/src/responder/common/responder_iface.c
+++ b/src/responder/common/responder_iface.c
@@ -147,7 +147,8 @@ sss_resp_register_service_iface(struct resp_ctx *rctx)
         ),
         SBUS_SIGNALS(SBUS_NO_SIGNALS),
         SBUS_PROPERTIES(
-            SBUS_SYNC(GETTER, sssd_service, debug_level, generic_get_debug_level, NULL)
+            SBUS_SYNC(GETTER, sssd_service, debug_level, generic_get_debug_level, NULL),
+            SBUS_SYNC(SETTER, sssd_service, debug_level, generic_set_debug_level, NULL)
         )
     );
 

--- a/src/responder/ifp/ifpsrv.c
+++ b/src/responder/ifp/ifpsrv.c
@@ -143,7 +143,9 @@ ifp_register_service_iface(struct ifp_ctx *ifp_ctx,
             SBUS_SYNC(METHOD, sssd_service, sysbusReconnect, ifp_sysbus_reconnect, ifp_ctx)
         ),
         SBUS_SIGNALS(SBUS_NO_SIGNALS),
-        SBUS_PROPERTIES(SBUS_NO_PROPERTIES)
+        SBUS_PROPERTIES(
+            SBUS_SYNC(GETTER, sssd_service, debug_level, generic_get_debug_level, NULL)
+        )
     );
 
     ret = sbus_connection_add_path(rctx->mon_conn, SSS_BUS_PATH, &iface_svc);

--- a/src/responder/ifp/ifpsrv.c
+++ b/src/responder/ifp/ifpsrv.c
@@ -144,7 +144,8 @@ ifp_register_service_iface(struct ifp_ctx *ifp_ctx,
         ),
         SBUS_SIGNALS(SBUS_NO_SIGNALS),
         SBUS_PROPERTIES(
-            SBUS_SYNC(GETTER, sssd_service, debug_level, generic_get_debug_level, NULL)
+            SBUS_SYNC(GETTER, sssd_service, debug_level, generic_get_debug_level, NULL),
+            SBUS_SYNC(SETTER, sssd_service, debug_level, generic_set_debug_level, NULL)
         )
     );
 

--- a/src/responder/nss/nsssrv.c
+++ b/src/responder/nss/nsssrv.c
@@ -403,7 +403,9 @@ nss_register_service_iface(struct nss_ctx *nss_ctx,
             SBUS_SYNC(METHOD, sssd_service, clearNegcache, nss_clear_negcache, nss_ctx)
         ),
         SBUS_SIGNALS(SBUS_NO_SIGNALS),
-        SBUS_PROPERTIES(SBUS_NO_PROPERTIES)
+        SBUS_PROPERTIES(
+            SBUS_SYNC(GETTER, sssd_service, debug_level, generic_get_debug_level, NULL)
+        )
     );
 
     ret = sbus_connection_add_path(rctx->mon_conn, SSS_BUS_PATH, &iface_svc);

--- a/src/responder/nss/nsssrv.c
+++ b/src/responder/nss/nsssrv.c
@@ -404,7 +404,8 @@ nss_register_service_iface(struct nss_ctx *nss_ctx,
         ),
         SBUS_SIGNALS(SBUS_NO_SIGNALS),
         SBUS_PROPERTIES(
-            SBUS_SYNC(GETTER, sssd_service, debug_level, generic_get_debug_level, NULL)
+            SBUS_SYNC(GETTER, sssd_service, debug_level, generic_get_debug_level, NULL),
+            SBUS_SYNC(SETTER, sssd_service, debug_level, generic_set_debug_level, NULL)
         )
     );
 

--- a/src/sss_iface/sbus_sss_client_properties.h
+++ b/src/sss_iface/sbus_sss_client_properties.h
@@ -25,4 +25,11 @@
 
 #include "sss_iface/sss_iface_types.h"
 
+struct sbus_all_service {
+    struct {
+        bool is_set;
+        uint32_t value;
+    } debug_level;
+};
+
 #endif /* _SBUS_SSS_CLIENT_PROPERTIES_H_ */

--- a/src/sss_iface/sbus_sss_client_sync.c
+++ b/src/sss_iface/sbus_sss_client_sync.c
@@ -184,6 +184,50 @@ done:
     return ret;
 }
 
+static errno_t
+sbus_set_u
+    (struct sbus_sync_connection *conn,
+     const char *bus,
+     const char *path,
+     const char *iface,
+     const char *property,
+     uint32_t value)
+{
+    TALLOC_CTX *tmp_ctx;
+    struct _sbus_sss_invoker_args_u in;
+    DBusMessage *raw_message;
+    errno_t ret;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Out of memory!\n");
+        return ENOMEM;
+    }
+
+    in.arg0 = value;
+
+    raw_message = sbus_create_set_call(tmp_ctx,
+                      (sbus_invoker_writer_fn)_sbus_sss_invoker_write_u,
+                      bus, path, iface, property,
+                      "u", &in);
+    if (raw_message == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = sbus_call_DBusProperties_Set(conn, raw_message);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    ret = EOK;
+
+done:
+    talloc_free(tmp_ctx);
+
+    return ret;
+}
+
 errno_t
 sbus_get_service_debug_level
     (struct sbus_sync_connection *conn,
@@ -193,6 +237,17 @@ sbus_get_service_debug_level
 {
     return sbus_get_u(conn, busname, object_path,
                 "sssd.service", "debug_level", _value);
+}
+
+errno_t
+sbus_set_service_debug_level
+    (struct sbus_sync_connection *conn,
+     const char *busname,
+     const char *object_path,
+     uint32_t value)
+{
+    return sbus_set_u(conn, busname, object_path,
+               "sssd.service", "debug_level", value);
 }
 
 errno_t

--- a/src/sss_iface/sbus_sss_client_sync.c
+++ b/src/sss_iface/sbus_sss_client_sync.c
@@ -131,3 +131,119 @@ sbus_call_systemd_StopUnit
           _arg_job);
 }
 
+static errno_t
+sbus_get_u
+    (struct sbus_sync_connection *conn,
+     const char *bus,
+     const char *path,
+     const char *iface,
+     const char *property,
+     uint32_t* _value)
+{
+    TALLOC_CTX *tmp_ctx;
+    struct _sbus_sss_invoker_args_u *out;
+    sbus_value_reader_fn reader;
+    sbus_value_reader_talloc_fn reader_talloc;
+    DBusMessage *reply;
+    errno_t ret;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Out of memory!\n");
+        return ENOMEM;
+    }
+
+    out = talloc_zero(tmp_ctx, struct _sbus_sss_invoker_args_u);
+    if (out == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Unable to allocate space for output parameters!\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = sbus_call_DBusProperties_Get(tmp_ctx, conn,
+              bus, path, iface, property, &reply);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    reader = (sbus_value_reader_fn)sbus_iterator_read_u;
+    reader_talloc = NULL;
+    ret = sbus_parse_get_message(out, reader, reader_talloc, reply, &out->arg0);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    *_value = out->arg0;
+
+    ret = EOK;
+
+done:
+    talloc_free(tmp_ctx);
+
+    return ret;
+}
+
+errno_t
+sbus_get_service_debug_level
+    (struct sbus_sync_connection *conn,
+     const char *busname,
+     const char *object_path,
+     uint32_t* _value)
+{
+    return sbus_get_u(conn, busname, object_path,
+                "sssd.service", "debug_level", _value);
+}
+
+errno_t
+sbus_getall_service
+    (TALLOC_CTX *mem_ctx,
+     struct sbus_sync_connection *conn,
+     const char *busname,
+     const char *object_path,
+     struct sbus_all_service **_properties)
+{
+    TALLOC_CTX *tmp_ctx;
+    struct sbus_all_service *properties;
+    DBusMessage *reply;
+    errno_t ret;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Out of memory!\n");
+        return ENOMEM;
+    }
+
+    properties = talloc_zero(tmp_ctx, struct sbus_all_service);
+    if (properties == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    struct sbus_parse_getall_table table[] = {
+        {"debug_level", (sbus_value_reader_fn)sbus_iterator_read_u, NULL,
+         &properties->debug_level.value, &properties->debug_level.is_set},
+        {NULL, NULL, NULL, NULL, NULL}
+    };
+
+    ret = sbus_call_DBusProperties_GetAll(tmp_ctx, conn,
+              busname, object_path, "sssd.service", &reply);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    ret = sbus_parse_getall_message(properties, table, reply);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    *_properties = talloc_steal(mem_ctx, properties);
+
+    ret = EOK;
+
+done:
+    talloc_free(tmp_ctx);
+
+    return ret;
+}
+

--- a/src/sss_iface/sbus_sss_client_sync.h
+++ b/src/sss_iface/sbus_sss_client_sync.h
@@ -58,4 +58,19 @@ sbus_call_systemd_StopUnit
      const char * arg_mode,
      const char ** _arg_job);
 
+errno_t
+sbus_get_service_debug_level
+    (struct sbus_sync_connection *conn,
+     const char *busname,
+     const char *object_path,
+     uint32_t* _value);
+
+errno_t
+sbus_getall_service
+    (TALLOC_CTX *mem_ctx,
+     struct sbus_sync_connection *conn,
+     const char *busname,
+     const char *object_path,
+     struct sbus_all_service **_properties);
+
 #endif /* _SBUS_SSS_CLIENT_SYNC_H_ */

--- a/src/sss_iface/sbus_sss_client_sync.h
+++ b/src/sss_iface/sbus_sss_client_sync.h
@@ -66,6 +66,13 @@ sbus_get_service_debug_level
      uint32_t* _value);
 
 errno_t
+sbus_set_service_debug_level
+    (struct sbus_sync_connection *conn,
+     const char *busname,
+     const char *object_path,
+     uint32_t value);
+
+errno_t
 sbus_getall_service
     (TALLOC_CTX *mem_ctx,
      struct sbus_sync_connection *conn,

--- a/src/sss_iface/sbus_sss_interface.h
+++ b/src/sss_iface/sbus_sss_interface.h
@@ -995,4 +995,39 @@
         (handler_send), (handler_recv), (data)); \
 })
 
+/* Property: sssd.service.debug_level */
+#define SBUS_GETTER_SYNC_sssd_service_debug_level(handler, data) ({ \
+    SBUS_CHECK_SYNC((handler), (data), uint32_t*); \
+    sbus_property_sync("debug_level", "u", SBUS_PROPERTY_READABLE, \
+       NULL, \
+       _sbus_sss_invoke_in__out_u_send, \
+       (handler), (data)); \
+})
+
+#define SBUS_GETTER_ASYNC_sssd_service_debug_level(handler_send, handler_recv, data) ({ \
+    SBUS_CHECK_SEND((handler_send), (data)); \
+    SBUS_CHECK_RECV((handler_recv), uint32_t*); \
+    sbus_property_async("debug_level", "u", SBUS_PROPERTY_READABLE, \
+       NULL, \
+       _sbus_sss_invoke_in__out_u_send, \
+       (handler_send), (handler_recv), (data)); \
+})
+
+#define SBUS_SETTER_SYNC_sssd_service_debug_level(handler, data) ({\
+    SBUS_CHECK_SYNC((handler), (data)); \
+    sbus_property_sync("debug_level", "u", SBUS_PROPERTY_WRITABLE, \
+       NULL, \
+       _sbus_sss_invoke_in__out__send, \
+       (handler), (data)); \
+})
+
+#define SBUS_SETTER_ASYNC_sssd_service_debug_level(handler_send, handler_recv, data) ({ \
+    SBUS_CHECK_SEND((handler_send), (data)); \
+    SBUS_CHECK_RECV((handler_recv)); \
+    sbus_property_async("debug_level", "u", SBUS_PROPERTY_WRITABLE, \
+       NULL, \
+       _sbus_sss_invoke_in__out__send, \
+       (handler_send), (handler_recv), (data)); \
+})
+
 #endif /* _SBUS_SSS_INTERFACE_H_ */

--- a/src/sss_iface/sbus_sss_interface.h
+++ b/src/sss_iface/sbus_sss_interface.h
@@ -1014,19 +1014,19 @@
 })
 
 #define SBUS_SETTER_SYNC_sssd_service_debug_level(handler, data) ({\
-    SBUS_CHECK_SYNC((handler), (data)); \
+    SBUS_CHECK_SYNC((handler), (data), uint32_t); \
     sbus_property_sync("debug_level", "u", SBUS_PROPERTY_WRITABLE, \
        NULL, \
-       _sbus_sss_invoke_in__out__send, \
+       _sbus_sss_invoke_in_u_out__send, \
        (handler), (data)); \
 })
 
 #define SBUS_SETTER_ASYNC_sssd_service_debug_level(handler_send, handler_recv, data) ({ \
-    SBUS_CHECK_SEND((handler_send), (data)); \
+    SBUS_CHECK_SEND((handler_send), (data), uint32_t); \
     SBUS_CHECK_RECV((handler_recv)); \
     sbus_property_async("debug_level", "u", SBUS_PROPERTY_WRITABLE, \
        NULL, \
-       _sbus_sss_invoke_in__out__send, \
+       _sbus_sss_invoke_in_u_out__send, \
        (handler_send), (handler_recv), (data)); \
 })
 

--- a/src/sss_iface/sbus_sss_invokers.h
+++ b/src/sss_iface/sbus_sss_invokers.h
@@ -40,6 +40,7 @@
          const char **_key)
 
 _sbus_sss_declare_invoker(, );
+_sbus_sss_declare_invoker(, u);
 _sbus_sss_declare_invoker(pam_data, pam_response);
 _sbus_sss_declare_invoker(raw, qus);
 _sbus_sss_declare_invoker(s, );

--- a/src/sss_iface/sss_iface.xml
+++ b/src/sss_iface/sss_iface.xml
@@ -23,6 +23,10 @@
         <method name="clearNegcache" />
         <method name="clearEnumCache" />
         <method name="sysbusReconnect" />
+        <property name="debug_level" type="u" access="read">
+            <annotation name="codegen.SyncCaller" value="true" />
+            <annotation name="codegen.AsyncCaller" value="false" />
+        </property>
     </interface>
 
     <interface name="sssd.ProxyChild.Client">

--- a/src/sss_iface/sss_iface.xml
+++ b/src/sss_iface/sss_iface.xml
@@ -23,7 +23,7 @@
         <method name="clearNegcache" />
         <method name="clearEnumCache" />
         <method name="sysbusReconnect" />
-        <property name="debug_level" type="u" access="read">
+        <property name="debug_level" type="u" access="readwrite">
             <annotation name="codegen.SyncCaller" value="true" />
             <annotation name="codegen.AsyncCaller" value="false" />
         </property>

--- a/src/tests/intg/util.py
+++ b/src/tests/intg/util.py
@@ -20,6 +20,7 @@
 
 import re
 import os
+import sys
 import subprocess
 import config
 import shutil
@@ -81,8 +82,19 @@ def restore_envvar_file(name):
     os.rename(backup_path, path)
 
 
-def get_call_output(cmd, stderr_output=subprocess.PIPE):
-    process = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                               stderr=stderr_output)
-    output, ret = process.communicate()
-    return output.decode('utf-8')
+def get_call_output(cmd, stderr_output=subprocess.PIPE, check=False):
+    """
+        Executes the provided command.
+        When check is set to True, this function will throw an exception
+        if the command returns with a non-zero value.
+    """
+
+    if (sys.version_info.major < 3
+            or (sys.version_info.major == 3 and sys.version_info.minor < 7)):
+        output = subprocess.check_output(cmd, universal_newlines=True,
+                                         stderr=stderr_output)
+        return output
+
+    process = subprocess.run(cmd, check=check, text=True,
+                             stdout=subprocess.PIPE, stderr=stderr_output)
+    return process.stdout

--- a/src/tools/common/sss_tools.h
+++ b/src/tools/common/sss_tools.h
@@ -91,6 +91,7 @@ errno_t sss_tool_popt_ex(struct sss_cmdline *cmdline,
                          void *popt_fn_pvt,
                          const char *fopt_name,
                          const char *fopt_help,
+                         enum sss_tool_opt fopt_require,
                          const char **_fopt,
                          bool *_opt_set);
 

--- a/src/tools/sss_override.c
+++ b/src/tools/sss_override.c
@@ -71,7 +71,7 @@ static errno_t parse_cmdline(struct sss_cmdline *cmdline,
 
     ret = sss_tool_popt_ex(cmdline, options, require,
                            NULL, NULL, "NAME", _("Specify name."),
-                           &input_name, NULL);
+                           SSS_TOOL_OPT_REQUIRED, &input_name, NULL);
     if (ret != EXIT_SUCCESS) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse command arguments\n");
         return ret;
@@ -170,7 +170,8 @@ static errno_t parse_cmdline_find(struct sss_cmdline *cmdline,
     };
 
     ret = sss_tool_popt_ex(cmdline, options, SSS_TOOL_OPT_OPTIONAL,
-                           NULL, NULL, NULL, NULL, NULL, NULL);
+                           NULL, NULL, NULL, NULL, SSS_TOOL_OPT_REQUIRED,
+                           NULL, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse command arguments\n");
         return ret;
@@ -200,7 +201,7 @@ static errno_t parse_cmdline_import(struct sss_cmdline *cmdline,
 
     ret = sss_tool_popt_ex(cmdline, NULL, SSS_TOOL_OPT_OPTIONAL,
                            NULL, NULL, "FILE", "File to import the data from.",
-                           _file, NULL);
+                           SSS_TOOL_OPT_REQUIRED, _file, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse command arguments\n");
         return ret;
@@ -216,7 +217,7 @@ static errno_t parse_cmdline_export(struct sss_cmdline *cmdline,
 
     ret = sss_tool_popt_ex(cmdline, NULL, SSS_TOOL_OPT_OPTIONAL,
                            NULL, NULL, "FILE", "File to export the data to.",
-                           _file, NULL);
+                           SSS_TOOL_OPT_REQUIRED, _file, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse command arguments\n");
         return ret;

--- a/src/tools/sssctl/sssctl.c
+++ b/src/tools/sssctl/sssctl.c
@@ -295,7 +295,7 @@ int main(int argc, const char **argv)
         SSS_TOOL_DELIMITER("Log files tools:"),
         SSS_TOOL_COMMAND("logs-remove", "Remove existing SSSD log files", 0, sssctl_logs_remove),
         SSS_TOOL_COMMAND("logs-fetch", "Archive SSSD log files in tarball", 0, sssctl_logs_fetch),
-        SSS_TOOL_COMMAND("debug-level", "Change SSSD debug level", 0, sssctl_debug_level),
+        SSS_TOOL_COMMAND("debug-level", "Change or print information about SSSD debug level", 0, sssctl_debug_level),
         SSS_TOOL_COMMAND("analyze", "Analyze logged data", 0, sssctl_analyze),
 #ifdef HAVE_LIBINI_CONFIG_V1_3
         SSS_TOOL_DELIMITER("Configuration files tools:"),

--- a/src/tools/sssctl/sssctl_access_report.c
+++ b/src/tools/sssctl/sssctl_access_report.c
@@ -393,7 +393,7 @@ errno_t sssctl_access_report(struct sss_cmdline *cmdline,
 
     ret = sss_tool_popt_ex(cmdline, NULL, SSS_TOOL_OPT_OPTIONAL,
                            NULL, NULL, "DOMAIN", _("Specify domain name."),
-                           &domname, NULL);
+                           SSS_TOOL_OPT_REQUIRED, &domname, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse command arguments\n");
         return ret;

--- a/src/tools/sssctl/sssctl_cache.c
+++ b/src/tools/sssctl/sssctl_cache.c
@@ -564,7 +564,7 @@ static errno_t parse_cmdline(struct sss_cmdline *cmdline,
 
     ret = sss_tool_popt_ex(cmdline, options, SSS_TOOL_OPT_OPTIONAL,
                            NULL, NULL, "NAME", _("Specify name."),
-                           &input_name, NULL);
+                           SSS_TOOL_OPT_REQUIRED, &input_name, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse command arguments\n");
         return ret;

--- a/src/tools/sssctl/sssctl_cert.c
+++ b/src/tools/sssctl/sssctl_cert.c
@@ -55,7 +55,7 @@ errno_t sssctl_cert_show(struct sss_cmdline *cmdline,
     ret = sss_tool_popt_ex(cmdline, options, SSS_TOOL_OPT_OPTIONAL,
                            NULL, NULL, "CERTIFICATE-BASE64-ENCODED",
                            _("Specify base64 encoded certificate."),
-                           &cert_b64, NULL);
+                           SSS_TOOL_OPT_REQUIRED, &cert_b64, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse command arguments\n");
         return ret;
@@ -112,7 +112,7 @@ errno_t sssctl_cert_map(struct sss_cmdline *cmdline,
     ret = sss_tool_popt_ex(cmdline, options, SSS_TOOL_OPT_OPTIONAL,
                            NULL, NULL, "CERTIFICATE-BASE64-ENCODED",
                            _("Specify base64 encoded certificate."),
-                           &cert_b64, NULL);
+                           SSS_TOOL_OPT_REQUIRED, &cert_b64, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse command arguments\n");
         return ret;

--- a/src/tools/sssctl/sssctl_domains.c
+++ b/src/tools/sssctl/sssctl_domains.c
@@ -331,7 +331,7 @@ errno_t sssctl_domain_status(struct sss_cmdline *cmdline,
 
     ret = sss_tool_popt_ex(cmdline, options, SSS_TOOL_OPT_OPTIONAL,
                            NULL, NULL, "DOMAIN", _("Specify domain name."),
-                           &opts.domain, &opt_set);
+                           SSS_TOOL_OPT_REQUIRED, &opts.domain, &opt_set);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse command arguments\n");
         return ret;

--- a/src/tools/sssctl/sssctl_logs.c
+++ b/src/tools/sssctl/sssctl_logs.c
@@ -289,7 +289,8 @@ errno_t sssctl_logs_fetch(struct sss_cmdline *cmdline,
 
     /* Parse command line. */
     ret = sss_tool_popt_ex(cmdline, NULL, SSS_TOOL_OPT_OPTIONAL, NULL, NULL,
-                           "FILE", "Output file", &file, NULL);
+                           "FILE", "Output file", SSS_TOOL_OPT_REQUIRED,
+                           &file, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse command arguments\n");
         return ret;
@@ -335,7 +336,7 @@ errno_t sssctl_debug_level(struct sss_cmdline *cmdline,
     ret = sss_tool_popt_ex(cmdline, long_options, SSS_TOOL_OPT_OPTIONAL, NULL,
                            NULL, "DEBUG_LEVEL_TO_SET",
                            _("Specify debug level you want to set"),
-                           &debug_as_string, NULL);
+                           SSS_TOOL_OPT_REQUIRED, &debug_as_string, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse command arguments\n");
         return ret;

--- a/src/tools/sssctl/sssctl_logs.c
+++ b/src/tools/sssctl/sssctl_logs.c
@@ -38,6 +38,8 @@
 #include "tools/sssctl/sssctl.h"
 #include "tools/tools_util.h"
 #include "confdb/confdb.h"
+#include "sss_iface/sss_iface_sync.h"
+#include "responder/ifp/ifp_iface/ifp_iface_sync.h"
 
 #define LOG_FILE(file) " " LOG_PATH "/" file
 #define LOG_FILES LOG_FILE("*.log")
@@ -50,6 +52,22 @@
     } \
 } while(0)
 
+#define POPT_SERV_OPTION(NAME, VAR) {services[SERV_ ## NAME].name, \
+                                     '\0', POPT_BIT_SET, &VAR, \
+                                     services[SERV_ ## NAME].mask, \
+                                     _("Target the " #NAME " service"), NULL}
+
+#define STARTS_WITH(s, p)     (strncmp((s), (p), strlen(p)) == 0)
+#define REMOVE_PREFIX(s, p)   (STARTS_WITH(s, p) ? (s) + strlen(p) : (s))
+#define IS_DOMAIN(c)          STARTS_WITH((c), "domain/")
+#define DOMAIN_NAME(c)        REMOVE_PREFIX((c), "domain/")
+#define EMPTY_TARGETS(t)      ((t)[0] == NULL)
+
+enum debug_level_action {
+    ACTION_SET,
+    ACTION_GET
+};
+
 struct debuglevel_tool_ctx {
     struct confdb_ctx *confdb;
     char **sections;
@@ -60,13 +78,83 @@ struct sssctl_logs_opts {
     int archived;
 };
 
-errno_t set_debug_level(struct debuglevel_tool_ctx *tool_ctx,
-                        int debug_to_set, const char *config_file)
+struct sssctl_service_desc {
+    const char *name;
+    int mask;
+};
+
+enum serv_idx {
+    SERV_SSSD,
+    SERV_NSS,
+    SERV_PAM,
+    SERV_SUDO,
+    SERV_AUTOFS,
+    SERV_SSH,
+    SERV_PAC,
+    SERV_IFP,
+    SERV_COUNT
+};
+
+struct sssctl_service_desc services[] = {
+    { "sssd",   1U << SERV_SSSD  },
+    { "nss",    1U << SERV_NSS   },
+    { "pam",    1U << SERV_PAM   },
+    { "sudo",   1U << SERV_SUDO  },
+    { "autofs", 1U << SERV_AUTOFS},
+    { "ssh",    1U << SERV_SSH   },
+    { "pac",    1U << SERV_PAC   },
+    { "ifp",    1U << SERV_IFP   }
+};
+
+static struct sbus_sync_connection *connect_to_sbus(TALLOC_CTX *mem_ctx)
 {
-    int ret;
-    int err;
-    const char *values[2];
-    char **section = NULL;
+    struct sbus_sync_connection *conn;
+
+    conn = sbus_sync_connect_private(mem_ctx, SSS_MONITOR_ADDRESS, NULL);
+    if (conn == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Failed to connect to the sbus monitor\n");
+    }
+
+    return conn;
+}
+
+static const char *get_busname(TALLOC_CTX *mem_ctx, struct confdb_ctx *confdb,
+                               const char *component)
+{
+    errno_t ret;
+    const char *busname;
+    struct sss_domain_info *domain;
+
+    if (strcmp(component, "sssd") == 0) {
+        busname = talloc_strdup(mem_ctx, SSS_BUS_MONITOR);
+    } else if (IS_DOMAIN(component)) {
+        ret = confdb_get_domain(confdb, DOMAIN_NAME(component), &domain);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "Unknown domain: %s\n", component);
+            busname = NULL;
+            goto done;
+        }
+
+        busname = sss_iface_domain_bus(mem_ctx, domain);
+    } else {
+        busname = talloc_asprintf(mem_ctx, "sssd.%s", component);
+    }
+
+done:
+    return busname;
+}
+
+/* in_out_value is an input argument when action is ACTION_SET; it is an output
+ * argument when action is ACTION_GET. */
+static errno_t do_debug_level(enum debug_level_action action,
+                                  struct sbus_sync_connection *conn,
+                                  struct confdb_ctx *confdb,
+                                  const char *component,
+                                  uint32_t *in_out_value)
+{
+    errno_t ret;
+    uint32_t value;
+    const char *busname;
     TALLOC_CTX *tmp_ctx = talloc_new(NULL);
 
     if (tmp_ctx == NULL) {
@@ -74,37 +162,101 @@ errno_t set_debug_level(struct debuglevel_tool_ctx *tool_ctx,
         return ENOMEM;
     }
 
-    /* convert debug_to_set to string */
-    values[0] = talloc_asprintf(tmp_ctx, "0x%.4x", debug_to_set);
-    if (values[0] == NULL) {
-        ret = ENOMEM;
-        goto done;
+    busname = get_busname(tmp_ctx, confdb, component);
+    if (busname == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Failed to create the bus name for %s\n",
+              component);
     }
-    values[1] = NULL;
 
-    /* write to confdb */
-    for (section = tool_ctx->sections; *section != NULL; section++) {
-        ret = confdb_add_param(tool_ctx->confdb, 1, *section,
-                               CONFDB_SERVICE_DEBUG_LEVEL, values);
+    if (action == ACTION_GET) {
+        ret = sbus_get_service_debug_level(conn, busname, SSS_BUS_PATH, &value);
         if (ret != EOK) {
+            ret = ENOENT;
+            goto done;
+        }
+
+        *in_out_value = value;
+    } else {
+        ret = sbus_set_service_debug_level(conn, busname, SSS_BUS_PATH,
+                                           *in_out_value);
+        if (ret != EOK) {
+            ret = ENOENT;
             goto done;
         }
     }
-
-    /*
-     * Change atime and mtime of sssd.conf,
-     * so the configuration can be restored on next start.
-     */
-    errno = 0;
-    if (utime(config_file, NULL) == -1) {
-        err = errno;
-        DEBUG(SSSDBG_MINOR_FAILURE, "Unable to change mtime of \"%s\": %s\n",
-              config_file, strerror(err));
-    }
-
     ret = EOK;
 
 done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+static errno_t sssctl_do_debug_level(enum debug_level_action action,
+                                         struct debuglevel_tool_ctx *tool_ctx,
+                                         const char **targets,
+                                         uint32_t debug_to_set)
+{
+    bool all_targets = EMPTY_TARGETS(targets);
+    errno_t ret = EOK;
+    errno_t final_ret = EOK;
+    uint32_t current_level = SSSDBG_INVALID;
+    TALLOC_CTX *tmp_ctx = talloc_new(NULL);
+    const char *stripped_target;
+    const char **curr_target;
+    struct sbus_sync_connection *conn;
+
+    if (tmp_ctx == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "talloc_new() failed\n");
+        return ENOMEM;
+    }
+
+    conn = connect_to_sbus(tmp_ctx);
+    if (conn == NULL) {
+        ERROR("SSSD is not running.\n");
+        ret = EIO;
+        goto fini;
+    }
+
+    curr_target = (all_targets ?
+                   discard_const_p(const char *, tool_ctx->sections) : targets);
+    while (*curr_target != NULL) {
+        stripped_target = REMOVE_PREFIX(*curr_target, "config/");
+
+        if (action == ACTION_GET) {
+            ret = do_debug_level(ACTION_GET, conn, tool_ctx->confdb,
+                                 stripped_target, &current_level);
+            CHECK(ret != EOK && ret != ENOENT, fini,
+                  "Could not read the debug level.");
+
+            if (ret == EOK) {
+                PRINT(_("%1$-25s %2$#.4x\n"), stripped_target, current_level);
+            } else {
+               if (!all_targets) {
+                    if (IS_DOMAIN(stripped_target)) {
+                        PRINT(_("%1$-25s Unknown domain\n"), stripped_target);
+                    } else {
+                        PRINT(_("%1$-25s Unreachable service\n"), stripped_target);
+                    }
+                    final_ret = ENOENT;
+                }
+            }
+        } else {
+            ret = do_debug_level(ACTION_SET, conn, tool_ctx->confdb,
+                                 stripped_target, &debug_to_set);
+            CHECK(ret != EOK && ret != ENOENT, fini,
+                  "Could not set the debug level.");
+            if (ret == ENOENT && !all_targets) {
+                final_ret = ret;
+            }
+        }
+        curr_target++;
+    }
+
+    if (ret == EOK) {
+        ret = final_ret;
+    }
+
+fini:
     talloc_free(tmp_ctx);
     return ret;
 }
@@ -210,6 +362,68 @@ errno_t get_confdb_sections(TALLOC_CTX *ctx, struct confdb_ctx *confdb,
 fail:
     talloc_free(tmp_ctx);
     return ret;
+}
+
+static const char **get_targets(TALLOC_CTX *mem_ctx, int services_mask,
+                                const char **domainv)
+{
+    int i;
+    int count = 1;
+    const char **targets = NULL;
+    TALLOC_CTX *tmp_ctx = talloc_new(NULL);
+
+    if (tmp_ctx == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "talloc_new() failed\n");
+        return NULL;
+    }
+
+    targets = talloc_zero_array(tmp_ctx, const char *, count);
+    if (targets == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Could not allocate memory for the list of targets\n");
+        goto done;
+    }
+
+    if (services_mask != 0) {
+        for (i = 0; i < SERV_COUNT; i++) {
+            if (services_mask == 0 || (services_mask & services[i].mask) != 0) {
+                targets = talloc_realloc(tmp_ctx, targets, const char *, count + 1);
+                if (targets == NULL) {
+                    DEBUG(SSSDBG_CRIT_FAILURE,
+                          "Could not allocate memory for the list of targets\n");
+                    goto done;
+                }
+                targets[count - 1] = talloc_strdup(tmp_ctx, services[i].name);
+                targets[count++] = NULL;
+            }
+        }
+    }
+
+    if (domainv != NULL) {
+        for (; *domainv != NULL; domainv++) {
+            targets = talloc_realloc(tmp_ctx, targets, const char *, count + 1);
+            if (targets == NULL) {
+                DEBUG(SSSDBG_CRIT_FAILURE,
+                      "Could not allocate memory for the list of targets\n");
+                goto done;
+            }
+            if (IS_DOMAIN(*domainv)) {
+                targets[count - 1] = talloc_strdup(tmp_ctx, *domainv);
+            } else {
+                targets[count - 1] = talloc_asprintf(tmp_ctx, "domain/%s", *domainv);
+            }
+            targets[count++] = NULL;
+        }
+    }
+
+    targets = talloc_steal(mem_ctx, targets);
+    for (i = 0; i < count; i++) {
+        targets[i] = talloc_steal(mem_ctx, targets[i]);
+    }
+
+done:
+    talloc_free(tmp_ctx);
+    return targets;
 }
 
 int parse_debug_level(const char *strlevel)
@@ -322,52 +536,54 @@ errno_t sssctl_debug_level(struct sss_cmdline *cmdline,
                            void *pvt)
 {
     int ret;
-    int debug_to_set = SSSDBG_INVALID;
+    int pc_services = 0;
+    uint32_t debug_to_set = SSSDBG_INVALID;
+    const char **pc_domains = NULL;
+    const char **targets = NULL;
     const char *debug_as_string = NULL;
-    const char *config_file = NULL;
-    const char *pc_config_file = NULL;
+
     struct debuglevel_tool_ctx *ctx = NULL;
     struct poptOption long_options[] = {
-        {"config", 'c', POPT_ARG_STRING, &pc_config_file,
-            0, _("Specify a non-default config file"), NULL},
+        {"domain", '\0', POPT_ARG_ARGV, &pc_domains,
+            0, _("Target a specific domain"), NULL},
+        POPT_SERV_OPTION(SSSD, pc_services),
+        POPT_SERV_OPTION(NSS, pc_services),
+        POPT_SERV_OPTION(PAM, pc_services),
+        POPT_SERV_OPTION(SUDO, pc_services),
+        POPT_SERV_OPTION(AUTOFS, pc_services),
+        POPT_SERV_OPTION(SSH, pc_services),
+        POPT_SERV_OPTION(PAC, pc_services),
+        POPT_SERV_OPTION(IFP, pc_services),
         POPT_TABLEEND
     };
-
-    ret = sss_tool_popt_ex(cmdline, long_options, SSS_TOOL_OPT_OPTIONAL, NULL,
-                           NULL, "DEBUG_LEVEL_TO_SET",
-                           _("Specify debug level you want to set"),
-                           SSS_TOOL_OPT_REQUIRED, &debug_as_string, NULL);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse command arguments\n");
-        return ret;
-    }
-
-    /* get config file */
-    if (pc_config_file) {
-        config_file = talloc_strdup(ctx, pc_config_file);
-    } else {
-        config_file = talloc_strdup(ctx, SSSD_CONFIG_FILE);
-    }
-
-    if (config_file == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "talloc_strdup() failed\n");
-        ret = ENOMEM;
-        goto fini;
-    }
-
-    CHECK_ROOT(ret, debug_prg_name);
-
-    debug_to_set = parse_debug_level(debug_as_string);
-    CHECK(debug_to_set == SSSDBG_INVALID, fini, "Invalid debug level.");
 
     /* allocate context */
     ctx = talloc_zero(NULL, struct debuglevel_tool_ctx);
     if (ctx == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Could not allocate memory for tools context\n");
-        ret = ENOMEM;
+        return ENOMEM;
+    }
+
+    ret = sss_tool_popt_ex(cmdline, long_options, SSS_TOOL_OPT_OPTIONAL, NULL,
+                           NULL, "DEBUG_LEVEL_TO_SET",
+                           _("Specify debug level you want to set"),
+                           SSS_TOOL_OPT_OPTIONAL, &debug_as_string, NULL);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse command arguments\n");
         goto fini;
     }
+
+    CHECK_ROOT(ret, debug_prg_name);
+
+    if (debug_as_string != NULL) {
+        debug_to_set = (uint32_t) parse_debug_level(debug_as_string);
+        CHECK(debug_to_set == SSSDBG_INVALID, fini, "Invalid debug level.");
+    }
+
+    /* Create a list with all the target names (services + domains) */
+    targets = get_targets(ctx, pc_services, pc_domains);
+    CHECK(targets == NULL, fini, "Could not allocate memory.");
 
     ret = connect_to_confdb(ctx, &ctx->confdb);
     CHECK(ret != EOK, fini, "Could not connect to configuration database.");
@@ -375,20 +591,21 @@ errno_t sssctl_debug_level(struct sss_cmdline *cmdline,
     ret = get_confdb_sections(ctx, ctx->confdb, &ctx->sections);
     CHECK(ret != EOK, fini, "Could not get all configuration sections.");
 
-    ret = set_debug_level(ctx, debug_to_set, config_file);
-    CHECK(ret != EOK, fini, "Could not set debug level.");
+    if (debug_as_string == NULL) {
+        ret = sssctl_do_debug_level(ACTION_GET, ctx, targets, 0);
+    } else {
+        ret = sssctl_do_debug_level(ACTION_SET, ctx, targets, debug_to_set);
+    }
 
-    ret = sss_signal(SIGHUP);
-    CHECK(ret != EOK, fini,
-          "Could not force sssd processes to reload configuration. "
-          "Is sssd running?");
+    /* Only report missing components that the user requested,
+       except for the monitor (sssd not running) */
+    if (ret != ENOENT && ret != EIO && EMPTY_TARGETS(targets)) {
+        ret = EOK;
+    }
 
 fini:
     talloc_free(ctx);
-    /* pc_config_file is allocated by popt using malloc().
-     * debug_as_string is not allocated but points to the command line. */
-    free(discard_const(pc_config_file));
-
+    /* debug_as_string is not allocated but points to the command line. */
     return ret;
 }
 

--- a/src/tools/sssctl/sssctl_logs.c
+++ b/src/tools/sssctl/sssctl_logs.c
@@ -356,9 +356,6 @@ errno_t sssctl_debug_level(struct sss_cmdline *cmdline,
 
     CHECK_ROOT(ret, debug_prg_name);
 
-    /* free pc_config_file? */
-    /* free debug_as_string? */
-
     debug_to_set = parse_debug_level(debug_as_string);
     CHECK(debug_to_set == SSSDBG_INVALID, fini, "Invalid debug level.");
 
@@ -387,6 +384,10 @@ errno_t sssctl_debug_level(struct sss_cmdline *cmdline,
 
 fini:
     talloc_free(ctx);
+    /* pc_config_file is allocated by popt using malloc().
+     * debug_as_string is not allocated but points to the command line. */
+    free(discard_const(pc_config_file));
+
     return ret;
 }
 

--- a/src/tools/sssctl/sssctl_user_checks.c
+++ b/src/tools/sssctl/sssctl_user_checks.c
@@ -238,7 +238,7 @@ errno_t sssctl_user_checks(struct sss_cmdline *cmdline,
 
     ret = sss_tool_popt_ex(cmdline, options, SSS_TOOL_OPT_OPTIONAL,
                            NULL, NULL, "USERNAME", _("Specify user name."),
-                           &user, NULL);
+                           SSS_TOOL_OPT_REQUIRED, &user, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse command arguments\n");
         return ret;

--- a/src/util/server.c
+++ b/src/util/server.c
@@ -436,6 +436,15 @@ errno_t generic_get_debug_level(TALLOC_CTX *mem_ctx,
     return EOK;
 }
 
+errno_t generic_set_debug_level(TALLOC_CTX *mem_ctx,
+                                struct sbus_request *sbus_req,
+                                void *pvt_data,
+                                uint32_t new_debug_level)
+{
+    debug_level = new_debug_level;
+    return EOK;
+}
+
 static const char *get_db_path(void)
 {
 #ifdef UNIT_TESTING

--- a/src/util/server.c
+++ b/src/util/server.c
@@ -427,6 +427,15 @@ errno_t server_common_rotate_logs(struct confdb_ctx *confdb,
     return EOK;
 }
 
+errno_t generic_get_debug_level(TALLOC_CTX *mem_ctx,
+                                struct sbus_request *sbus_req,
+                                void *pvt_data,
+                                uint32_t *_debug_level)
+{
+    *_debug_level = debug_level;
+    return EOK;
+}
+
 static const char *get_db_path(void)
 {
 #ifdef UNIT_TESTING

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -195,8 +195,14 @@ struct main_context {
     pid_t parent_pid;
 };
 
+struct sbus_request;
+
 errno_t server_common_rotate_logs(struct confdb_ctx *confdb,
                                   const char *conf_entry);
+errno_t generic_get_debug_level(TALLOC_CTX *mem_ctx,
+                                struct sbus_request *sbus_req,
+                                void *pvt_data,
+                                uint32_t *_debug_level);
 int die_if_parent_died(void);
 int check_pidfile(const char *file);
 int pidfile(const char *file);

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -203,6 +203,10 @@ errno_t generic_get_debug_level(TALLOC_CTX *mem_ctx,
                                 struct sbus_request *sbus_req,
                                 void *pvt_data,
                                 uint32_t *_debug_level);
+errno_t generic_set_debug_level(TALLOC_CTX *mem_ctx,
+                                struct sbus_request *sbus_req,
+                                void *pvt_data,
+                                uint32_t new_debug_level);
 int die_if_parent_died(void);
 int check_pidfile(const char *file);
 int pidfile(const char *file);


### PR DESCRIPTION
First commit frees a variable which is allocated by ``popt`` using ``malloc`` and has to be manually freed. As it is a ``const char *``, we need to bypass the ``const`` modifier.

Seconds to fifth commits are related to [issue 6019](https://github.com/SSSD/sssd/issues/6019).

One implements a modification to function ``sss_tool_popt_ex()`` to let the caller decide whether the free option is mandatory. This is done with a new argument called ``fopt_require``. Although this modification is needed by the fifth commit, is it actually a separate thing.

Third and fourth commits are the server-side code for the new S-Bus property ``debug_level`` provided by the ``sssd.service`` interface. Third is the getter and fourth the setter.

Fifth commit modifies ``sssctl debug-level``'s behavior to show the current debug level if the caller doesn't provide one. In addition, it is possible to target each component separately. The design page is still under review: https://github.com/SSSD/sssd.io/pull/55

Please notice that the ``-c/--config`` option is no longer used by ``sssctl debug-level`` so I removed it.
