### PR TITLE
NSS: fix initgroups mem-cache invalidation

### DIFF
--- a/src/responder/nss/nss_cmd.c
+++ b/src/responder/nss/nss_cmd.c
@@ -512,7 +512,6 @@ static errno_t invalidate_cache(struct sss_nss_cmd_ctx *cmd_ctx,
     int ret;
     enum sss_mc_type memcache_type;
     const char *name;
-    char *output_name = NULL;
     bool is_user;
     struct sysdb_attrs *attrs = NULL;
 
@@ -539,28 +538,20 @@ static errno_t invalidate_cache(struct sss_nss_cmd_ctx *cmd_ctx,
         return EOK;
     }
 
-    /* Find output name to invalidate memory cache entry*/
+    /* Find output name to invalidate memory cache entry */
     name = sss_get_name_from_msg(result->domain, result->msgs[0]);
     if (name == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Found object has no name.\n");
         return EINVAL;
     }
-    ret = sss_output_fqname(cmd_ctx, result->domain, name,
-                            cmd_ctx->nss_ctx->rctx->override_space,
-                            &output_name);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "sss_output_fqname failed.\n");
-        return ret;
-    }
 
     memcache_delete_entry(cmd_ctx->nss_ctx, cmd_ctx->nss_ctx->rctx, NULL,
-                          output_name, 0, memcache_type);
+                          name, 0, memcache_type);
     if (memcache_type == SSS_MC_INITGROUPS) {
         /* Invalidate the passwd data as well */
         memcache_delete_entry(cmd_ctx->nss_ctx, cmd_ctx->nss_ctx->rctx,
-                              result->domain, output_name, 0, SSS_MC_PASSWD);
+                              result->domain, name, 0, SSS_MC_PASSWD);
     }
-    talloc_free(output_name);
 
     /* Use sysdb name to invalidate disk cache entry */
     name = ldb_msg_find_attr_as_string(result->msgs[0], SYSDB_NAME, NULL);

--- a/src/responder/nss/nss_get_object.c
+++ b/src/responder/nss/nss_get_object.c
@@ -363,37 +363,12 @@ static void sss_nss_get_object_finish_req(struct tevent_req *req,
 
     state = tevent_req_data(req, struct sss_nss_get_object_state);
 
-    /*  - SIDs are unique between domains, so there are no other entries
-     *    to delete in 'EOK' case.
-     *  - Since request hits nss-responder, there is already no valid entry
-     *    in the mem-cache to delete (*) in 'ENOENT' case.
-     *    (*) This is possible in theory:
-     *      - entry is valid in the mem-cache and
-     *      - entry is expired in ldb-cache and
-     *      - object was deleted on the server and
-     *      - SSS_NSS_USE_MEMCACHE=NO is used by the client,
-     *      but it is so unrealistic that it's not worth bothering.
-     */
-     if (state->memcache == SSS_MC_SID) {
-         (ret == EOK) ? tevent_req_done(req) : tevent_req_error(req, ret);
-         return;
-     }
-
     switch (ret) {
     case EOK:
-        if (state->memcache != SSS_MC_NONE) {
-            /* Delete entry from all domains but the one that was found. */
-            memcache_delete_entry(state->nss_ctx, state->rctx,
-                                  state->result->domain,
-                                  state->input_name,
-                                  state->input_id,
-                                  state->memcache);
-        }
-
         tevent_req_done(req);
         break;
     case ENOENT:
-        if (state->memcache != SSS_MC_NONE) {
+        if ((state->memcache != SSS_MC_NONE) && (state->memcache != SSS_MC_SID)) {
             /* Delete entry from all domains. */
             memcache_delete_entry(state->nss_ctx, state->rctx, NULL,
                                   state->input_name, state->input_id,

--- a/src/responder/nss/nss_protocol_grent.c
+++ b/src/responder/nss/nss_protocol_grent.c
@@ -367,7 +367,7 @@ sss_nss_protocol_fill_initgr(struct sss_nss_ctx *nss_ctx,
     struct ldb_message *primary_group_msg;
     const char *posix;
     struct sized_string rawname;
-    struct sized_string unique_name;
+    struct sized_string canonical_name;
     uint32_t num_results;
     uint8_t *body;
     size_t body_len;
@@ -464,10 +464,10 @@ sss_nss_protocol_fill_initgr(struct sss_nss_ctx *nss_ctx,
                 && ((cmd_ctx->flags & SSS_NSS_EX_FLAG_INVALIDATE_CACHE) == 0)
                 && (nss_ctx->initgr_mc_ctx != NULL)) {
         to_sized_string(&rawname, cmd_ctx->rawname);
-        to_sized_string(&unique_name, result->lookup_name);
+        to_sized_string(&canonical_name, sss_get_name_from_msg(domain, user));
 
         ret = sss_mmap_cache_initgr_store(&nss_ctx->initgr_mc_ctx, &rawname,
-                                          &unique_name, num_results,
+                                          &canonical_name, num_results,
                                           body + 2 * sizeof(uint32_t));
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE,

--- a/src/responder/nss/nsssrv_mmap_cache.c
+++ b/src/responder/nss/nsssrv_mmap_cache.c
@@ -605,17 +605,13 @@ static struct sss_mc_rec *sss_mc_find_record(struct sss_mc_ctx *mcc,
         }
 
         if (strcmp(key->str, t_key) == 0) {
-            break;
+            return rec;
         }
 
         slot = sss_mc_next_slot_with_hash(rec, hash);
     }
 
-    if (slot == MC_INVALID_VAL) {
-        return NULL;
-    }
-
-    return rec;
+    return NULL;
 }
 
 static errno_t sss_mc_get_record(struct sss_mc_ctx **_mcc,

--- a/src/responder/nss/nsssrv_mmap_cache.c
+++ b/src/responder/nss/nsssrv_mmap_cache.c
@@ -1046,9 +1046,6 @@ errno_t sss_mmap_cache_initgr_store(struct sss_mc_ctx **_mcc,
 
     MC_RAISE_BARRIER(rec);
 
-    /* We cannot use two keys for searching in initgroups cache.
-     * Use the first key twice.
-     */
     sss_mmap_set_rec_header(mcc, rec, rec_len, mcc->valid_time_slot,
                             name->str, name->len,
                             unique_name->str, unique_name->len);


### PR DESCRIPTION
Initgroups MC uses 'lookup_name' as a primary key, not output format.

Based on proposal by Jakub Hrozek in #558

Missing part in that patch was fix of `nss_get_object_finish_req()`
But it's tricky to fix for `ENOENT` case because we don't have `lookup_name` for every domain at hand.
Frankly, I'm not sure it's worth fixing.
