### PR TITLE
SPEC: python egg info format change

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5375,9 +5375,12 @@ if BUILD_PYTHON2_BINDINGS
 		rm -f $(builddir)/src/config/SSSDConfig/sssdoptions.py ; \
 	fi
 
-	rm -f $(builddir)/src/config/SSSDConfig/*.pyc
-
 	cd $(builddir)/src/config; $(PYTHON2) setup.py build --build-base $(abs_builddir)/src/config clean --all
+
+	rm -fr "$(builddir)/src/config/dist"
+	rm -fr "$(builddir)/src/config/SSSDConfig.egg-info"
+	rm -fr "$(builddir)/src/config/SSSDConfig/__pycache__"
+	find "$(builddir)/src/config/SSSDConfig" -name "*.py[co]" -delete
 endif
 if BUILD_PYTHON3_BINDINGS
 	if [ ! $(srcdir)/src/config/SSSDConfig/ipachangeconf.py -ef $(builddir)/src/config/SSSDConfig/ipachangeconf.py ]; then \
@@ -5388,9 +5391,12 @@ if BUILD_PYTHON3_BINDINGS
 		rm -f $(builddir)/src/config/SSSDConfig/sssdoptions.py ; \
 	fi
 
-	rm -f $(builddir)/src/config/SSSDConfig/__pycache__/*.pyc
-
 	cd $(builddir)/src/config; $(PYTHON3) setup.py build --build-base $(abs_builddir)/src/config clean --all
+
+	rm -fr "$(builddir)/src/config/dist"
+	rm -fr "$(builddir)/src/config/SSSDConfig.egg-info"
+	rm -fr "$(builddir)/src/config/SSSDConfig/__pycache__"
+	find "$(builddir)/src/config/SSSDConfig" -name "*.py[co]" -delete
 endif
 	for doc in $(SSSD_DOCS); do \
 		rm -Rf $$doc; \

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -598,7 +598,7 @@ rm -Rf ${RPM_BUILD_ROOT}/%{_docdir}/%{name}
 
 # Older versions of rpmbuild can only handle one -f option
 # So we need to append to the sssd*.lang file
-for file in `ls $RPM_BUILD_ROOT/%{python3_sitelib}/*.egg-info 2> /dev/null`
+for file in `find $RPM_BUILD_ROOT/%{python3_sitelib} -maxdepth 1 -name "*.egg-info" 2> /dev/null`
 do
     echo %{python3_sitelib}/`basename $file` >> python3_sssdconfig.lang
 done


### PR DESCRIPTION
In the new python egg-info changed from a file to a folder with
several files.

This patch fixes the SPEC file to handle it correctly in both cases.