### PR TITLE
SDAP: sdap_nested_group_deref_direct_process():

### DIFF
--- a/src/tools/sssctl/sssctl_cache.c
+++ b/src/tools/sssctl/sssctl_cache.c
@@ -112,7 +112,7 @@ static errno_t get_attr_name(TALLOC_CTX *mem_ctx,
         outname = sss_tc_fqname(mem_ctx, dom->names, dom, tmp_name);
         talloc_free(tmp_name);
         if (outname == NULL) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "sss_replace_space failed\n");
+            DEBUG(SSSDBG_CRIT_FAILURE, "sss_tc_fqname() failed\n");
             return ENOMEM;
         }
     } else {


### PR DESCRIPTION
store 'state->members' in a hash table to reduce computational complexity during "new member" check.
    
Resolves: https://github.com/SSSD/sssd/issues/5134
