### PR TITLE
Monitor: Set _SSS_LOOPS conditionally at monitor startup

### DIFF
--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -2551,7 +2551,7 @@ int main(int argc, const char *argv[])
     if (ret != EOK) return 6;
 
     ret = server_setup(SSSD_MONITOR_NAME, false, flags, 0, 0,
-                       monitor->conf_path, &main_ctx);
+                       monitor->conf_path, &main_ctx, false);
     if (ret != EOK) return 2;
 
     /* Use confd initialized in server_setup. ldb_tdb module (1.4.0) check PID

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -770,7 +770,7 @@ int main(int argc, const char *argv[])
     confdb_path = talloc_asprintf(NULL, CONFDB_DOMAIN_PATH_TMPL, be_domain);
     if (!confdb_path) return 2;
 
-    ret = server_setup(srv_name, false, 0, 0, 0, confdb_path, &main_ctx);
+    ret = server_setup(srv_name, false, 0, 0, 0, confdb_path, &main_ctx, false);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Could not set up mainloop [%d]\n", ret);
         return 2;

--- a/src/providers/proxy/proxy_child.c
+++ b/src/providers/proxy/proxy_child.c
@@ -562,7 +562,7 @@ int main(int argc, const char *argv[])
     conf_entry = talloc_asprintf(NULL, CONFDB_DOMAIN_PATH_TMPL, domain);
     if (!conf_entry) return 2;
 
-    ret = server_setup(srv_name, false, 0, 0, 0, conf_entry, &main_ctx);
+    ret = server_setup(srv_name, false, 0, 0, 0, conf_entry, &main_ctx, true);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Could not set up mainloop [%d]\n", ret);
         return 2;

--- a/src/responder/autofs/autofssrv.c
+++ b/src/responder/autofs/autofssrv.c
@@ -214,7 +214,7 @@ int main(int argc, const char *argv[])
     DEBUG_INIT(debug_level, opt_logger);
 
     ret = server_setup("autofs", true, 0, uid, gid,
-                       CONFDB_AUTOFS_CONF_ENTRY, &main_ctx);
+                       CONFDB_AUTOFS_CONF_ENTRY, &main_ctx, true);
     if (ret != EOK) {
         return 2;
     }

--- a/src/responder/common/responder.h
+++ b/src/responder/common/responder.h
@@ -372,7 +372,7 @@ errno_t schedule_get_domains_task(TALLOC_CTX *mem_ctx,
                                   void *callback_pvt);
 
 errno_t csv_string_to_uid_array(TALLOC_CTX *mem_ctx, const char *csv_string,
-                                bool allow_sss_loop,
+                                bool prevent_sss_loops,
                                 size_t *_uid_count, uid_t **_uids);
 
 uid_t client_euid(struct cli_creds *creds);

--- a/src/responder/common/responder.h
+++ b/src/responder/common/responder.h
@@ -372,7 +372,6 @@ errno_t schedule_get_domains_task(TALLOC_CTX *mem_ctx,
                                   void *callback_pvt);
 
 errno_t csv_string_to_uid_array(TALLOC_CTX *mem_ctx, const char *csv_string,
-                                bool prevent_sss_loops,
                                 size_t *_uid_count, uid_t **_uids);
 
 uid_t client_euid(struct cli_creds *creds);

--- a/src/responder/ifp/ifpsrv.c
+++ b/src/responder/ifp/ifpsrv.c
@@ -207,7 +207,7 @@ int ifp_process_init(TALLOC_CTX *mem_ctx,
         goto fail;
     }
 
-    ret = csv_string_to_uid_array(ifp_ctx->rctx, uid_str, true,
+    ret = csv_string_to_uid_array(ifp_ctx->rctx, uid_str, false,
                                   &ifp_ctx->rctx->allowed_uids_count,
                                   &ifp_ctx->rctx->allowed_uids);
     talloc_free(uid_str);
@@ -340,7 +340,7 @@ int main(int argc, const char *argv[])
     DEBUG_INIT(debug_level, opt_logger);
 
     ret = server_setup("ifp", true, 0, 0, 0,
-                       CONFDB_IFP_CONF_ENTRY, &main_ctx);
+                       CONFDB_IFP_CONF_ENTRY, &main_ctx, true);
     if (ret != EOK) return 2;
 
     ret = die_if_parent_died();

--- a/src/responder/ifp/ifpsrv.c
+++ b/src/responder/ifp/ifpsrv.c
@@ -207,7 +207,7 @@ int ifp_process_init(TALLOC_CTX *mem_ctx,
         goto fail;
     }
 
-    ret = csv_string_to_uid_array(ifp_ctx->rctx, uid_str, false,
+    ret = csv_string_to_uid_array(ifp_ctx->rctx, uid_str,
                                   &ifp_ctx->rctx->allowed_uids_count,
                                   &ifp_ctx->rctx->allowed_uids);
     talloc_free(uid_str);

--- a/src/responder/kcm/kcm.c
+++ b/src/responder/kcm/kcm.c
@@ -264,12 +264,6 @@ static int kcm_process_init(TALLOC_CTX *mem_ctx,
     kctx->rctx = rctx;
     kctx->rctx->pvt_ctx = kctx;
 
-    /* KCM operates independently, getpw* recursion is not a concern */
-    ret = unsetenv("_SSS_LOOPS");
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Failed to unset _SSS_LOOPS");
-    }
-
     ret = kcm_get_config(kctx);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "fatal error getting KCM config\n");
@@ -358,7 +352,7 @@ int main(int argc, const char *argv[])
     DEBUG_INIT(debug_level, opt_logger);
 
     ret = server_setup("kcm", true, 0, uid, gid, CONFDB_KCM_CONF_ENTRY,
-                       &main_ctx);
+                       &main_ctx, true);
     if (ret != EOK) return 2;
 
     ret = die_if_parent_died();

--- a/src/responder/nss/nsssrv.c
+++ b/src/responder/nss/nsssrv.c
@@ -691,7 +691,7 @@ int main(int argc, const char *argv[])
     DEBUG_INIT(debug_level, opt_logger);
 
     ret = server_setup("nss", true, 0, uid, gid, CONFDB_NSS_CONF_ENTRY,
-                       &main_ctx);
+                       &main_ctx, false);
     if (ret != EOK) return 2;
 
     ret = die_if_parent_died();

--- a/src/responder/pac/pacsrv.c
+++ b/src/responder/pac/pacsrv.c
@@ -90,7 +90,7 @@ int pac_process_init(TALLOC_CTX *mem_ctx,
         goto fail;
     }
 
-    ret = csv_string_to_uid_array(pac_ctx->rctx, uid_str, false,
+    ret = csv_string_to_uid_array(pac_ctx->rctx, uid_str,
                                   &pac_ctx->rctx->allowed_uids_count,
                                   &pac_ctx->rctx->allowed_uids);
     talloc_free(uid_str);

--- a/src/responder/pac/pacsrv.c
+++ b/src/responder/pac/pacsrv.c
@@ -90,7 +90,7 @@ int pac_process_init(TALLOC_CTX *mem_ctx,
         goto fail;
     }
 
-    ret = csv_string_to_uid_array(pac_ctx->rctx, uid_str, true,
+    ret = csv_string_to_uid_array(pac_ctx->rctx, uid_str, false,
                                   &pac_ctx->rctx->allowed_uids_count,
                                   &pac_ctx->rctx->allowed_uids);
     talloc_free(uid_str);
@@ -203,7 +203,7 @@ int main(int argc, const char *argv[])
     DEBUG_INIT(debug_level, opt_logger);
 
     ret = server_setup("pac", true, 0, uid, gid,
-                       CONFDB_PAC_CONF_ENTRY, &main_ctx);
+                       CONFDB_PAC_CONF_ENTRY, &main_ctx, true);
     if (ret != EOK) return 2;
 
     ret = die_if_parent_died();

--- a/src/responder/pam/pamsrv.c
+++ b/src/responder/pam/pamsrv.c
@@ -69,7 +69,7 @@ static errno_t get_trusted_uids(struct pam_ctx *pctx)
          DEBUG(SSSDBG_TRACE_FUNC, "All UIDs are allowed.\n");
          pctx->trusted_uids_count = 0;
     } else {
-        ret = csv_string_to_uid_array(pctx->rctx, uid_str, true,
+        ret = csv_string_to_uid_array(pctx->rctx, uid_str, false,
                                       &pctx->trusted_uids_count,
                                       &pctx->trusted_uids);
     }
@@ -489,7 +489,8 @@ int main(int argc, const char *argv[])
               "debugging might not work!\n");
     }
 
-    ret = server_setup("pam", true, 0, uid, gid, CONFDB_PAM_CONF_ENTRY, &main_ctx);
+    ret = server_setup("pam", true, 0, uid, gid, CONFDB_PAM_CONF_ENTRY,
+                       &main_ctx, false);
     if (ret != EOK) return 2;
 
     ret = die_if_parent_died();

--- a/src/responder/pam/pamsrv.c
+++ b/src/responder/pam/pamsrv.c
@@ -69,7 +69,7 @@ static errno_t get_trusted_uids(struct pam_ctx *pctx)
          DEBUG(SSSDBG_TRACE_FUNC, "All UIDs are allowed.\n");
          pctx->trusted_uids_count = 0;
     } else {
-        ret = csv_string_to_uid_array(pctx->rctx, uid_str, false,
+        ret = csv_string_to_uid_array(pctx->rctx, uid_str,
                                       &pctx->trusted_uids_count,
                                       &pctx->trusted_uids);
     }

--- a/src/responder/ssh/sshsrv.c
+++ b/src/responder/ssh/sshsrv.c
@@ -209,7 +209,7 @@ int main(int argc, const char *argv[])
     }
 
     ret = server_setup("ssh", true, 0, uid, gid,
-                       CONFDB_SSH_CONF_ENTRY, &main_ctx);
+                       CONFDB_SSH_CONF_ENTRY, &main_ctx, true);
     if (ret != EOK) {
         return 2;
     }

--- a/src/responder/sudo/sudosrv.c
+++ b/src/responder/sudo/sudosrv.c
@@ -197,7 +197,7 @@ int main(int argc, const char *argv[])
     }
 
     ret = server_setup("sudo", true, 0, uid, gid, CONFDB_SUDO_CONF_ENTRY,
-                       &main_ctx);
+                       &main_ctx, true);
     if (ret != EOK) {
         return 2;
     }

--- a/src/tests/cwrap/test_responder_common.c
+++ b/src/tests/cwrap/test_responder_common.c
@@ -52,7 +52,7 @@ void test_uid_csv_to_uid_list(void **state)
 
     check_leaks_push(tmp_ctx);
 
-    ret = csv_string_to_uid_array(tmp_ctx, "1, 2, 3", false, &count, &list);
+    ret = csv_string_to_uid_array(tmp_ctx, "1, 2, 3", true, &count, &list);
     assert_int_equal(ret, EOK);
     assert_int_equal(count, 3);
     assert_int_equal(list[0], 1);
@@ -76,7 +76,7 @@ void test_name_csv_to_uid_list(void **state)
 
     check_leaks_push(tmp_ctx);
 
-    ret = csv_string_to_uid_array(tmp_ctx, "sssd, foobar", true, &count, &list);
+    ret = csv_string_to_uid_array(tmp_ctx, "sssd, foobar", false, &count, &list);
     assert_int_equal(ret, EOK);
     assert_int_equal(count, 2);
     assert_int_equal(list[0], 123);
@@ -99,7 +99,7 @@ void test_csv_to_uid_list_neg(void **state)
 
     check_leaks_push(tmp_ctx);
 
-    ret = csv_string_to_uid_array(tmp_ctx, "nosuchuser", true, &count, &list);
+    ret = csv_string_to_uid_array(tmp_ctx, "nosuchuser", false, &count, &list);
     assert_int_not_equal(ret, EOK);
 
     assert_true(check_leaks_pop(tmp_ctx));

--- a/src/tests/cwrap/test_responder_common.c
+++ b/src/tests/cwrap/test_responder_common.c
@@ -52,7 +52,7 @@ void test_uid_csv_to_uid_list(void **state)
 
     check_leaks_push(tmp_ctx);
 
-    ret = csv_string_to_uid_array(tmp_ctx, "1, 2, 3", true, &count, &list);
+    ret = csv_string_to_uid_array(tmp_ctx, "1, 2, 3", &count, &list);
     assert_int_equal(ret, EOK);
     assert_int_equal(count, 3);
     assert_int_equal(list[0], 1);
@@ -76,7 +76,7 @@ void test_name_csv_to_uid_list(void **state)
 
     check_leaks_push(tmp_ctx);
 
-    ret = csv_string_to_uid_array(tmp_ctx, "sssd, foobar", false, &count, &list);
+    ret = csv_string_to_uid_array(tmp_ctx, "sssd, foobar", &count, &list);
     assert_int_equal(ret, EOK);
     assert_int_equal(count, 2);
     assert_int_equal(list[0], 123);
@@ -99,7 +99,7 @@ void test_csv_to_uid_list_neg(void **state)
 
     check_leaks_push(tmp_ctx);
 
-    ret = csv_string_to_uid_array(tmp_ctx, "nosuchuser", false, &count, &list);
+    ret = csv_string_to_uid_array(tmp_ctx, "nosuchuser", &count, &list);
     assert_int_not_equal(ret, EOK);
 
     assert_true(check_leaks_pop(tmp_ctx));

--- a/src/tests/cwrap/test_server.c
+++ b/src/tests/cwrap/test_server.c
@@ -102,7 +102,7 @@ void test_run_as_root_fg(void **state)
     pid = fork();
     if (pid == 0) {
         ret = server_setup(__FUNCTION__, false, 0, 0, 0,
-                           __FUNCTION__, &main_ctx);
+                           __FUNCTION__, &main_ctx, true);
         assert_int_equal(ret, 0);
         exit(0);
     }
@@ -125,7 +125,7 @@ void test_run_as_sssd_fg(void **state)
     pid = fork();
     if (pid == 0) {
         ret = server_setup(__FUNCTION__, false, 0, sssd->pw_uid, sssd->pw_gid,
-                           __FUNCTION__, &main_ctx);
+                           __FUNCTION__, &main_ctx, true);
         assert_int_equal(ret, 0);
         exit(0);
     }
@@ -150,7 +150,7 @@ void test_run_as_root_daemon(void **state)
     pid = fork();
     if (pid == 0) {
         ret = server_setup(__FUNCTION__, false, FLAGS_PID_FILE,
-                           0, 0, __FUNCTION__, &main_ctx);
+                           0, 0, __FUNCTION__, &main_ctx, true);
         assert_int_equal(ret, 0);
 
         server_loop(main_ctx);

--- a/src/tests/intg/test_kcm.py
+++ b/src/tests/intg/test_kcm.py
@@ -514,6 +514,8 @@ def test_kcm_renewals(setup_for_kcm_renewals_secdb):
     """
     Test that basic KCM renewal works
     """
+    if "LC_TIME" in os.environ:
+        del os.environ["LC_TIME"]
     testenv = setup_for_kcm_renewals_secdb
     testenv.k5kdc.add_principal("user1", "Secret123")
 

--- a/src/tests/responder_socket_access-tests.c
+++ b/src/tests/responder_socket_access-tests.c
@@ -69,7 +69,7 @@ START_TEST(resp_str_to_array_test)
 
     for (c = 0; s2a_data[c].exp_ret != -1; c++) {
         ret = csv_string_to_uid_array(global_talloc_context, s2a_data[c].inp,
-                                      false, &uid_count, &uids);
+                                      &uid_count, &uids);
         ck_assert_msg(ret == s2a_data[c].exp_ret,
                     "csv_string_to_uid_array failed [%d][%s].", ret,
                                                                 strerror(ret));

--- a/src/tests/responder_socket_access-tests.c
+++ b/src/tests/responder_socket_access-tests.c
@@ -69,7 +69,7 @@ START_TEST(resp_str_to_array_test)
 
     for (c = 0; s2a_data[c].exp_ret != -1; c++) {
         ret = csv_string_to_uid_array(global_talloc_context, s2a_data[c].inp,
-                                      true, &uid_count, &uids);
+                                      false, &uid_count, &uids);
         ck_assert_msg(ret == s2a_data[c].exp_ret,
                     "csv_string_to_uid_array failed [%d][%s].", ret,
                                                                 strerror(ret));

--- a/src/util/server.c
+++ b/src/util/server.c
@@ -457,7 +457,8 @@ int server_setup(const char *name, bool is_responder,
                  int flags,
                  uid_t uid, gid_t gid,
                  const char *conf_entry,
-                 struct main_context **main_ctx)
+                 struct main_context **main_ctx,
+                 bool allow_sss_loop)
 {
     struct tevent_context *event_ctx;
     struct main_context *ctx;
@@ -518,8 +519,13 @@ int server_setup(const char *name, bool is_responder,
         }
     }
 
-    setenv("_SSS_LOOPS", "NO", 0);
-
+    if (!allow_sss_loop) {
+        ret = setenv("_SSS_LOOPS", "NO", 0);
+        if (ret != 0) {
+            DEBUG(SSSDBG_OP_FAILURE, "Failed to set _SSS_LOOPS.\n");
+            return ret;
+        }
+    }
     /* To make sure the domain cannot be set from the environment, unset the
      * variable explicitly when setting up any server. Backends later set the
      * value after reading domain from the configuration */

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -204,7 +204,8 @@ int server_setup(const char *name, bool is_responder,
                  int flags,
                  uid_t uid, gid_t gid,
                  const char *conf_entry,
-                 struct main_context **main_ctx);
+                 struct main_context **main_ctx,
+                 bool allow_sss_loop);
 void server_loop(struct main_context *main_ctx);
 void orderly_shutdown(int status);
 


### PR DESCRIPTION
_SSS_LOOPS is not longer systematically set to "NO" and unset when
not required, but set to "NO" only when needed.

Resolves: https://github.com/SSSD/sssd/issues/5696

I also modified a test to make it immune to the value of LC_TIME. The test would fail if the variable was set to an unexpected value.