### PR TITLE
TEST: Add missing markers in pytest.ini

### DIFF
--- a/src/tests/multihost/alltests/pytest.ini
+++ b/src/tests/multihost/alltests/pytest.ini
@@ -1,36 +1,40 @@
 [pytest]
 markers =
+    analyze: Tests for sssctl analyze
     automount: Tests related to autofs
+    autoprivategroup: Automation of auto private groups
+    backtrace: test poor man's backtrace in logs
     configmerge: Tests related to Config merge
     configvalidation: Tests related to sssd config validation
-    misc: Tests related to misc bugs automation
+    defaultdebuglevel: Test default debug level sssd
+    failover: Tests related to failover
+    fips: Tests related to fips when auth_provider is krb5
     hostmap: Tests related to hostmap and network map
     journald: Tests related to journald
-    krb5: Tests related to krb5
     kcm: Tests related to kcm
+    krb5: Tests related to krb5
+    krbldapconnection: Tests related to kerberos ldap connection
     ldapextraattrs: Tests related to Ldap Extra attributes
+    ldaplibdebuglevel: Test ldap_library_debug_level option
     localoverrides: Tests related to Local Overrides
+    misc: Tests related to misc bugs automation
     multidomain: Tests related to SSSD Multiple Domains
     netgroup: Tests related to netgroup
+    no_tier: test cases are not executed on any tier
     nsaccountlock: Tests related to nsaccountlock
     offline: Tests related to ldap offline suite
-    services: Tests related to SSSD sanity services
-    sssctl: Tests related to sssctl tool
-    failover: Tests related to failover
-    sudo: Tests related to sudo
-    krbldapconnection: Tests related to kerberos ldap connection
     passwordcheck: Tests related to password check while updating
         password of user
     proxy: Tests related to sssd-proxy
-    fips: Tests related to fips when auth_provider is krb5
-    ssh: Tests related to ssh responder
-    ldaplibdebuglevel: Test ldap_library_debug_level option
-    no_tier: test cases are not executed on any tier
-    defaultdebuglevel: Test default debug level sssd
-    backtrace: test poor man's backtrace in logs
     rfc2307: Tests related to rfc2307
-    tier1: tier1 test cases with run time of aproximately 60 minutes
+    services: Tests related to SSSD sanity services
+    ssh: Tests related to ssh responder
+    sss_cache: Tests for sss_cache
+    sssctl: Tests related to sssctl tool
+    sudo: Tests related to sudo
     tier1_2: tier1 test cases split to keep runtime upto 60 minutes
     tier1_3: tier1 test cases split to keep runtime upto 60 minutes
+    tier1: tier1 test cases with run time of aproximately 60 minutes
     tier2: tier2 test cases
     tier3: tier3 test cases
+    timelog: Test time is logged for ldap queries in the domain logs


### PR DESCRIPTION
Some markers from alltests were missing in pytest.ini causing warning
messages. Added those markers and sorted them alphabetically for
readability.