### PR TITLE
ci: enable copr builds for CentOS Stream 8

### DIFF
--- a/.github/workflows/copr_build.yml
+++ b/.github/workflows/copr_build.yml
@@ -68,7 +68,7 @@ jobs:
       uses: next-actions/copr/filter-chroots@master
       with:
         coprcfg: ${{ secrets.COPR_SECRETS }}
-        filter: "fedora-.+-x86_64|centos-stream-9-x86_64"
+        filter: "fedora-.+-x86_64|centos-stream-*-x86_64"
         exclude: "fedora-eln-.+"
 
     - name: Create copr project
@@ -93,6 +93,13 @@ jobs:
       env:
         coprcfg: ${{ steps.copr.outputs.coprcfg }}
       run: |
+        # CentOS Stream 8
+        copr-cli --config "$coprcfg" edit-chroot                                                  \
+          --repos 'https://koji.mbox.centos.org/kojifiles/repos/dist-c8-stream-build/latest/$basearch/' \
+          --modules idm:DL1
+          $COPR_ACCOUNT/$COPR_PROJECT/centos-stream-8-x86_64
+
+        # CentOS Stream 9
         copr-cli --config "$coprcfg" edit-chroot                                                  \
           --repos 'https://kojihub.stream.centos.org/kojifiles/repos/c9s-build/latest/$basearch/' \
           $COPR_ACCOUNT/$COPR_PROJECT/centos-stream-9-x86_64


### PR DESCRIPTION
copr-cli now supports `edit-chroot --modules` which was needed
to enable builds for C8S.