### PR TITLE
spec: mention oidc_child in description

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -504,13 +504,14 @@ An implementation of a Kerberos KCM server. Use this package if you want to
 use the KCM: Kerberos credentials cache.
 
 %package idp
-Summary: Kerberos plugins for external identity providers.
+Summary: Kerberos plugins and OIDC helper for external identity providers.
 License: GPLv3+
 Requires: sssd-common = %{version}-%{release}
 
 %description idp
 This package provides Kerberos plugins that are required to enable
-authentication against external identity providers.
+authentication against external identity providers. Additionally a helper
+program to handle the OAuth 2.0 Device Authorization Grant is provided.
 
 %prep
 %autosetup -p1


### PR DESCRIPTION
Since oidc_child is part of the sssd-idp sub-package it should be
mentioned in the summary and the description.