### PR TITLE
ci: allow deprecated functions during build (fix build on f36+)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,14 +29,14 @@ jobs:
       working-directory: x86_64
       run: |
         source ../contrib/fedora/bashrc_sssd
-        make CFLAGS+="$SSS_WARNINGS -Werror"
+        make CFLAGS+="$SSS_WARNINGS -Werror -Wno-error=deprecated-declarations"
 
     - name: make check
       shell: bash
       working-directory: x86_64
       run: |
         source ../contrib/fedora/bashrc_sssd
-        make CFLAGS+="$SSS_WARNINGS -Werror" check
+        make CFLAGS+="$SSS_WARNINGS -Werror -Wno-error=deprecated-declarations" check
 
     - name: make distcheck
       shell: bash

--- a/src/external/libkrad.m4
+++ b/src/external/libkrad.m4
@@ -1,4 +1,4 @@
 AC_CHECK_HEADER(krad.h, [], [AC_MSG_ERROR([krad.h not found])])
-AC_CHECK_LIB(krad, main, [ ], [AC_MSG_ERROR([libkrad not found])])
+AC_CHECK_LIB(krad, krad_packet_get_attr, [ ], [AC_MSG_ERROR([libkrad not found])])
 KRAD_LIBS="-lkrad"
 AC_SUBST(KRAD_LIBS)

--- a/src/util/cert/libcrypto/cert.c
+++ b/src/util/cert/libcrypto/cert.c
@@ -303,7 +303,7 @@ static errno_t rsa_pub_key_to_ssh(TALLOC_CTX *mem_ctx, EVP_PKEY *cert_pub_key,
     unsigned char exponent[OPENSSL_RSA_MAX_PUBEXP_BITS/8];
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
-    RSA *rsa_pub_key = NULL;
+    const RSA *rsa_pub_key = NULL;
     rsa_pub_key = EVP_PKEY_get0_RSA(cert_pub_key);
     if (rsa_pub_key == NULL) {
         ret = ENOMEM;


### PR DESCRIPTION
fedora:latest container switched to Fedora 36 so we are hit
by deprecated warning from functions deprecated in openssl3.

We already have a ticket to fix it, but it is not a trivial fix:
https://github.com/SSSD/sssd/issues/5861