### PR TITLE
ci: add gcc problem matcher to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
     - name: Configure sssd
       uses: ./.github/actions/configure
 
+    - name: Register gcc problem matcher
+      uses: ammaraskar/gcc-problem-matcher@a141586609e2a558729b99a8c574c048f7f56204
+
     - name: make
       shell: bash
       working-directory: x86_64


### PR DESCRIPTION
This annotates gcc warnings and errors in github web ui.