### PR TITLE
LDAP: Allow group rename with non-identical attributes

### DIFF
--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -2240,7 +2240,7 @@ int sysdb_add_incomplete_group(struct sss_domain_info *domain,
 
             DEBUG(SSSDBG_OP_FAILURE,
                   "Another group with GID [%"SPRIgid"] already exists\n", gid);
-            ret = EEXIST;
+            ret = ERR_GID_DUPLICATED;
             goto done;
         }
     }

--- a/src/tests/sysdb-tests.c
+++ b/src/tests/sysdb-tests.c
@@ -1011,19 +1011,23 @@ START_TEST (test_sysdb_incomplete_group_rename)
                 "sysdb_add_incomplete_group error [%d][%s]",
                 ret, strerror(ret));
 
-    /* Adding a group with the same GID and all the other characteristics uknown should fail */
+    /* Adding a group with the same GID and all the other characteristics unknown should succeed */
     ret = sysdb_add_incomplete_group(test_ctx->domain, "incomplete_group_new",
                                      20000, NULL, NULL, NULL, true, 0);
-    ck_assert_msg(ret == EEXIST, "Did not caught a duplicate\n");
+    ck_assert_msg(ret == ERR_GID_DUPLICATED,
+                "Did not catch a rename. ret: %d [%s]",
+                ret, sss_strerror(ret));
 
-    /* A different SID should also trigger a failure */
+    /* A different SID should also succeed */
     ret = sysdb_add_incomplete_group(test_ctx->domain, "incomplete_group_new",
                                      20000, NULL,
                                      "S-1-5-21-123-456-789-222",
                                      NULL, true, 0);
-    ck_assert_msg(ret == EEXIST, "Did not caught a duplicate\n");
+    ck_assert_msg(ret == ERR_GID_DUPLICATED,
+                "Did not catch a rename. ret: %d [%s]",
+                ret, sss_strerror(ret));
 
-    /* But if we know based on a SID that the group is in fact the same,
+    /* If we know based on a SID that the group is in fact the same,
      * let's just change its name
      */
     ret = sysdb_add_incomplete_group(test_ctx->domain, "incomplete_group_new",
@@ -1031,7 +1035,7 @@ START_TEST (test_sysdb_incomplete_group_rename)
                                      "S-1-5-21-123-456-789-111",
                                      NULL, true, 0);
     ck_assert_msg(ret == ERR_GID_DUPLICATED,
-                "Did not catch a legitimate rename. ret: %d [%s]",
+                "Did not catch a rename. ret: %d [%s]",
                 ret, sss_strerror(ret));
 }
 END_TEST


### PR DESCRIPTION
This is related to RedHat Support Case 03116233.  It looks like there are multiple cases in which a specific type of change to an entry in LDAP can cause SSSD to permanently refuse to update its cache of the associated entry (until `sss_cache -E` is run to wipe the whole cache and start over).  This patch addresses one specific case.

Prior to this change:
* If a group was renamed but all other attributes remained the same, then SSSD would detect the rename, delete the original group from the cache, and replace it with the new group.  (See https://github.com/SSSD/sssd/blob/master/src/db/sysdb_ops.c#L2237 and https://github.com/SSSD/sssd/blob/master/src/providers/ldap/sdap_async_initgroups.c#L228)
* However, if any group attribute changes are detected by SSSD at the same time as the rename, then SSSD will ignore the new group permanently (until the cache is manually cleared).  (See https://github.com/SSSD/sssd/blob/master/src/db/sysdb_ops.c#L2243 which is then ignored by https://github.com/SSSD/sssd/blob/master/src/providers/ldap/sdap_async_initgroups.c#L228)

With this change, if a new group has the same GID as an existing group, then the new group will replace the existing group, regardless of whether the other attributes are identical.

The trade-off here is:
If LDAP contains two groups with different names but the same GID, then the original behavior would cause SSSD to use one group and permanently ignore the other, while this new behavior could result in SSSD flapping between the two groups.
However, if SSSD officially doesn't support duplicate GIDs but does support group renames, then it is better to have poor behavior when duplicate GIDs are present than to have permanently broken behavior after some group renames.

For reference, it looks like this logic was last touched in commit ba2d5f7a0adefb017d3f85203d715b725ca8810f
It sounds like that commit was intended to fix this same issue.  It looks to me like that commit failed to fully fix this problem at the time it was implemented, but I haven't actually tested the code at the time of that commit, so it is possible it did fully fix this and some other subsequent change elsewhere in the code broke it again.