### PR TITLE
TEST: Install iproute-tc for tc

### DIFF
--- a/src/tests/multihost/alltests/test_ldap_time_logging.py
+++ b/src/tests/multihost/alltests/test_ldap_time_logging.py
@@ -129,8 +129,8 @@ class TestLdapTimeLogging(object):
         intf = multihost.client[0].run_command(get_intf, raiseonerr=True)
         intf_list = intf.stdout_text.splitlines()
         print(f'List of interfaces - {intf_list}')
-        kernel_extra_pkg = 'yum install -y kernel-modules-extra'
-        multihost.client[0].run_command(kernel_extra_pkg, raiseonerr=True)
+        pkgs = 'yum install -y iproute-tc kernel-modules-extra'
+        multihost.client[0].run_command(pkgs, raiseonerr=True)
         for interface in intf_list:
             tc_rule = f'tc qdisc add dev {interface} root netem delay 800ms'
             multihost.client[0].run_command(tc_rule, raiseonerr=True)


### PR DESCRIPTION
For tc we need iproute-tc package installed if it is not already
installed. In RHEL9.1 it was installed by default but in 8.7 it is not
present.