### PR TITLE
TEST: Fixing multidomain testcase bz2077893

### DIFF
--- a/src/tests/multihost/admultidomain/test_multidomain.py
+++ b/src/tests/multihost/admultidomain/test_multidomain.py
@@ -138,12 +138,19 @@ class TestADMultiDomain(object):
         domain_list_cmd = multihost.client[0].run_command(
             'sssctl domain-list', raiseonerr=False)
         domain_list = domain_list_cmd.stdout_text.split('\n')
-        domain_list.remove("implicit_files")
-        domain_list = domain_list[:-1]
-        multihost_list = multihost.ad
-        multihost_list = multihost_list[:-1]
+        if "" in domain_list:
+            domain_list.remove("")
+        if "implicit_files" in domain_list:
+            domain_list.remove("implicit_files")
+        multihost_list = []
+        for x in multihost.ad:
+            multihost_list.append(x.domainname)
+        # This is necessary because the AD server in the second forest needs to
+        # be removed from the list.
+        multihost_list.pop()
 
-        for x in multihost_list:
-            assert x.domainname in domain_list
+        domain_list.sort()
+        multihost_list.sort()
 
-        assert len(domain_list) == len(multihost_list)
+        assert domain_list == multihost_list
+


### PR DESCRIPTION
implicit files is no longer being listed in sssctl domain-list
it no longer has to be pruned from the output

Signed-off-by: Dan Lavu <dlavu@redhat.com>