### PR TITLE
New option for system hardening.

### DIFF
--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -80,6 +80,7 @@
 #define CONFDB_MONITOR_ENABLE_FILES_DOM "enable_files_domain"
 #define CONFDB_MONITOR_DOMAIN_RESOLUTION_ORDER "domain_resolution_order"
 #define CONFDB_MONITOR_IMPLICIT_PAC_RESPONDER "implicit_pac_responder"
+#define CONFDB_MONITOR_DUMPABLE "core_dumpable"
 
 /* Both monitor and domains */
 #define CONFDB_NAME_REGEX   "re_expression"

--- a/src/config/SSSDConfig/sssdoptions.py
+++ b/src/config/SSSDConfig/sssdoptions.py
@@ -54,6 +54,7 @@ class SSSDOptions(object):
                          'resolver. By default, we will attempt to use inotify for this, and will fall back to '
                          'polling resolv.conf every five seconds if inotify cannot be used.'),
         'implicit_pac_responder': _('Run PAC responder automatically for AD and IPA provider'),
+        'core_dumpable': _('Enable or disable core dumps for all SSSD processes.'),
 
         # [nss]
         'enum_cache_timeout': _('Enumeration cache timeout length (seconds)'),

--- a/src/config/SSSDConfigTest.py
+++ b/src/config/SSSDConfigTest.py
@@ -353,6 +353,7 @@ class SSSDConfigTestSSSDService(unittest.TestCase):
             'try_inotify',
             'monitor_resolv_conf',
             'implicit_pac_responder',
+            'core_dumpable',
         ]
 
         self.assertTrue(type(options) == dict,

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -53,6 +53,7 @@ option = domain_resolution_order
 option = try_inotify
 option = monitor_resolv_conf
 option = implicit_pac_responder
+option = core_dumpable
 
 [rule/allowed_nss_options]
 validator = ini_allowed_options

--- a/src/config/etc/sssd.api.conf
+++ b/src/config/etc/sssd.api.conf
@@ -35,6 +35,7 @@ domain_resolution_order = list, str, false
 try_inotify = bool, None, false
 monitor_resolv_conf = bool, None, false
 implicit_pac_responder = bool, None, false
+core_dumpable = bool, None, false
 
 [nss]
 # Name service

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -707,6 +707,21 @@
                             </para>
                         </listitem>
                     </varlistentry>
+                    <varlistentry>
+                        <term>core_dumpable (boolean)</term>
+                        <listitem>
+                            <para>
+                                This option can be used for general system
+                                hardening: setting it to 'false' forbids core
+                                dumps for all SSSD processes to avoid
+                                leaking plain text passwords. See man page
+                                prctl:PR_SET_DUMPABLE for details.
+                            </para>
+                            <para>
+                                Default: true
+                            </para>
+                        </listitem>
+                    </varlistentry>
                 </variablelist>
             </para>
         </refsect2>

--- a/src/p11_child/p11_child_common.c
+++ b/src/p11_child/p11_child_common.c
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <popt.h>
+#include <sys/prctl.h>
 
 #include "util/util.h"
 #include "util/child_common.h"
@@ -146,6 +147,7 @@ int main(int argc, const char *argv[])
 {
     int opt;
     poptContext pc;
+    int dumpable = 1;
     int debug_fd = -1;
     const char *opt_logger = NULL;
     errno_t ret = 0;
@@ -169,6 +171,8 @@ int main(int argc, const char *argv[])
     struct poptOption long_options[] = {
         POPT_AUTOHELP
         SSSD_DEBUG_OPTS
+        {"dumpable", 0, POPT_ARG_INT, &dumpable, 0,
+         _("Allow core dumps"), NULL },
         {"debug-fd", 0, POPT_ARG_INT, &debug_fd, 0,
          _("An open file descriptor for the debug logs"), NULL},
         SSSD_LOGGER_OPTS
@@ -301,6 +305,8 @@ int main(int argc, const char *argv[])
     }
 
     poptFreeContext(pc);
+
+    prctl(PR_SET_DUMPABLE, (dumpable == 0) ? 0 : 1);
 
     debug_prg_name = talloc_asprintf(NULL, "p11_child[%d]", getpid());
     if (debug_prg_name == NULL) {

--- a/src/providers/ad/ad_gpo_child.c
+++ b/src/providers/ad/ad_gpo_child.c
@@ -26,6 +26,7 @@
 #include <ctype.h>
 #include <unistd.h>
 #include <popt.h>
+#include <sys/prctl.h>
 #include <libsmbclient.h>
 #include <security/pam_modules.h>
 
@@ -656,6 +657,7 @@ main(int argc, const char *argv[])
 {
     int opt;
     poptContext pc;
+    int dumpable = 1;
     int debug_fd = -1;
     uint64_t chain_id;
     const char *opt_logger = NULL;
@@ -672,6 +674,8 @@ main(int argc, const char *argv[])
     struct poptOption long_options[] = {
         POPT_AUTOHELP
         SSSD_DEBUG_OPTS
+        {"dumpable", 0, POPT_ARG_INT, &dumpable, 0,
+         _("Allow core dumps"), NULL },
         {"debug-fd", 0, POPT_ARG_INT, &debug_fd, 0,
          _("An open file descriptor for the debug logs"), NULL},
         {"chain-id", 0, POPT_ARG_LONG, &chain_id,
@@ -695,6 +699,8 @@ main(int argc, const char *argv[])
     }
 
     poptFreeContext(pc);
+
+    prctl(PR_SET_DUMPABLE, (dumpable == 0) ? 0 : 1);
 
     debug_prg_name = talloc_asprintf(NULL, "gpo_child[%d]", getpid());
     if (debug_prg_name == NULL) {

--- a/src/providers/ipa/selinux_child.c
+++ b/src/providers/ipa/selinux_child.c
@@ -27,6 +27,7 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <popt.h>
+#include <sys/prctl.h>
 
 #include "util/util.h"
 #include "util/child_common.h"
@@ -207,6 +208,7 @@ int main(int argc, const char *argv[])
     int opt;
     poptContext pc;
     int debug_fd = -1;
+    int dumpable = 1;
     errno_t ret;
     TALLOC_CTX *main_ctx = NULL;
     uint8_t *buf = NULL;
@@ -223,6 +225,8 @@ int main(int argc, const char *argv[])
     struct poptOption long_options[] = {
         POPT_AUTOHELP
         SSSD_DEBUG_OPTS
+        {"dumpable", 0, POPT_ARG_INT, &dumpable, 0,
+         _("Allow core dumps"), NULL },
         {"debug-fd", 0, POPT_ARG_INT, &debug_fd, 0,
          _("An open file descriptor for the debug logs"), NULL},
         {"chain-id", 0, POPT_ARG_LONG, &chain_id,
@@ -246,6 +250,8 @@ int main(int argc, const char *argv[])
     }
 
     poptFreeContext(pc);
+
+    prctl(PR_SET_DUMPABLE, (dumpable == 0) ? 0 : 1);
 
     debug_prg_name = talloc_asprintf(NULL, "selinux_child[%d]", getpid());
     if (debug_prg_name == NULL) {

--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -28,6 +28,7 @@
 #include <fcntl.h>
 #include <ctype.h>
 #include <popt.h>
+#include <sys/prctl.h>
 
 #include <security/pam_modules.h>
 
@@ -3740,6 +3741,7 @@ int main(int argc, const char *argv[])
     uint32_t offline;
     int opt;
     poptContext pc;
+    int dumpable = 1;
     int debug_fd = -1;
     const char *opt_logger = NULL;
     errno_t ret;
@@ -3754,6 +3756,8 @@ int main(int argc, const char *argv[])
     struct poptOption long_options[] = {
         POPT_AUTOHELP
         SSSD_DEBUG_OPTS
+        {"dumpable", 0, POPT_ARG_INT, &dumpable, 0,
+         _("Allow core dumps"), NULL },
         {"debug-fd", 0, POPT_ARG_INT, &debug_fd, 0,
          _("An open file descriptor for the debug logs"), NULL},
         SSSD_LOGGER_OPTS
@@ -3819,6 +3823,8 @@ int main(int argc, const char *argv[])
     }
 
     poptFreeContext(pc);
+
+    prctl(PR_SET_DUMPABLE, (dumpable == 0) ? 0 : 1);
 
     debug_prg_name = talloc_asprintf(NULL, "krb5_child[%d]", getpid());
     if (!debug_prg_name) {

--- a/src/providers/ldap/ldap_child.c
+++ b/src/providers/ldap/ldap_child.c
@@ -27,6 +27,7 @@
 #include <sys/stat.h>
 #include <signal.h>
 #include <popt.h>
+#include <sys/prctl.h>
 
 #include "util/util.h"
 #include "util/sss_krb5.h"
@@ -619,6 +620,7 @@ int main(int argc, const char *argv[])
     int ret;
     int kerr;
     int opt;
+    int dumpable = 1;
     int debug_fd = -1;
     const char *opt_logger = NULL;
     poptContext pc;
@@ -635,6 +637,8 @@ int main(int argc, const char *argv[])
     struct poptOption long_options[] = {
         POPT_AUTOHELP
         SSSD_DEBUG_OPTS
+        {"dumpable", 0, POPT_ARG_INT, &dumpable, 0,
+         _("Allow core dumps"), NULL },
         {"debug-fd", 0, POPT_ARG_INT, &debug_fd, 0,
          _("An open file descriptor for the debug logs"), NULL},
         SSSD_LOGGER_OPTS
@@ -656,6 +660,8 @@ int main(int argc, const char *argv[])
     }
 
     poptFreeContext(pc);
+
+    prctl(PR_SET_DUMPABLE, (dumpable == 0) ? 0 : 1);
 
     debug_prg_name = talloc_asprintf(NULL, "ldap_child[%d]", getpid());
     if (!debug_prg_name) {

--- a/src/tests/cmocka/dummy_child.c
+++ b/src/tests/cmocka/dummy_child.c
@@ -40,6 +40,7 @@ int main(int argc, const char *argv[])
     errno_t ret;
     uint8_t buf[IN_BUF_SIZE];
     const char *action = NULL;
+    int dumpable;
     const char *guitar;
     const char *drums;
     int timestamp_opt;
@@ -48,6 +49,8 @@ int main(int argc, const char *argv[])
         POPT_AUTOHELP
         SSSD_DEBUG_OPTS
         SSSD_LOGGER_OPTS
+        {"dumpable", 0, POPT_ARG_INT, &dumpable, 0,
+         _("Allow core dumps"), NULL },
         {"guitar", 0, POPT_ARG_STRING, &guitar, 0, _("Who plays guitar"), NULL },
         {"drums", 0, POPT_ARG_STRING, &drums, 0, _("Who plays drums"), NULL },
         POPT_TABLEEND


### PR DESCRIPTION
:config: New option 'core_dumpable' to manage 'PR_SET_DUMPABLE' flag of sssd_pam
and sssd_be processes. Enabled by default.

Resolves: https://github.com/SSSD/sssd/issues/4930