### PR TITLE
TEST: Fix the indentation in doctrings

### DIFF
--- a/src/tests/multihost/ad/test_adparameters.py
+++ b/src/tests/multihost/ad/test_adparameters.py
@@ -174,7 +174,7 @@ class TestBugzillaAutomation(object):
         :steps:
           1. Create AD group with scope as "Global" and type "Security"
           2. Update the properties newly created group and update under
-           "Member of" tab and add Users BUILTIN group.
+             "Member of" tab and add Users BUILTIN group.
           3. Check the group lookup for BUILTIN group.
           4. Check the cache entry, for built in group.
         :expectedresults:
@@ -443,7 +443,7 @@ class TestBugzillaAutomation(object):
         :id: b8382774-e568-4e5b-b787-bdd4db380c28
         :steps:
           1. Add user and set its UPN different from the username,
-            Ex: TestUserUPN@ad.vm
+             Ex: TestUserUPN@ad.vm
           2. Run command "dbus-send --print-reply --system
              --dest=org.freedesktop.sssd.infopipe /org/freedesktop/sssd/
              infopipe org.freedesktop.sssd.infopipe.GetUserAttr string:

--- a/src/tests/multihost/ad/test_automount.py
+++ b/src/tests/multihost/ad/test_automount.py
@@ -109,7 +109,7 @@ class Testautofsresponder(object):
         :id: e8dbd94d-c557-4533-8ab7-bc891e1609a3
         :steps:
           1. Edit sssd.conf and specify below parameters: autofs_provider = ad
-           ldap_autofs_search_base = ou=automount,dc=<ad-domain>
+             ldap_autofs_search_base = ou=automount,dc=<ad-domain>
           2. Restart sssd
           3. Execute automount -m
           4. Access /export shared
@@ -205,7 +205,7 @@ class Testautofsresponder(object):
         :expectedresults:
           1. autofs_provider is not set
           2. Verify automount maps are loaded from AD and client is able to
-           mount nfs share
+             mount nfs share
         """
         # pylint: disable=unused-argument
         client = sssdTools(multihost.client[0])

--- a/src/tests/multihost/ad/test_sudo.py
+++ b/src/tests/multihost/ad/test_sudo.py
@@ -52,9 +52,8 @@ class TestSudo(object):
           1. Should succeed
           2. Verify the the user when logged in with upper
              and lower case can fetch the sudo rules from AD
-        Note: This test case also cover BZ-1622109 and BZ-bz1519287
-        Sudo rules used in the fixture contains multiple
-        sudoUser attributes added.
+        :description: Note: This test case also cover BZ-1622109 and BZ-bz1519287
+         Sudo rules used in the fixture contains multiple sudoUser attributes added.
         """
         multihost.client[0].service_sssd('restart')
         realm = multihost.ad[0].realm
@@ -174,10 +173,10 @@ class TestSudo(object):
         3. Set debug level to 2
 
         :steps:
-         1.Run sudo command as AD-user for whom rule is created
+          1. Run sudo command as AD-user for whom rule is created
         :expectedResuls:
-        1. There should be no error in the sudo or domain log related
-           to 'short-username or non-fqdn username'
+          1. There should be no error in the sudo or domain log related
+             to 'short-username or non-fqdn username'
         """
         client = sssdTools(multihost.client[0], multihost.ad[0])
         domain_name = client.get_domain_section_name()

--- a/src/tests/multihost/alltests/test_automount.py
+++ b/src/tests/multihost/alltests/test_automount.py
@@ -206,9 +206,9 @@ class Testautofsresponder(object):
         :customerscenario: true
         :steps:
             1. Configure SSSD with autofs, automountMap,
-            automount, automountInformation
+               automount, automountInformation
             2. Add 2 automount entries in LDAP with
-            same key ( cn: MIT and cn: mit)
+               same key ( cn: MIT and cn: mit)
             3. We should have the 2 automounts working
         :expectedresults:
             1. Should succeed
@@ -314,7 +314,7 @@ class Testautofsresponder(object):
           1. Access nfs share /export/nfs-test with autofs provider not set
         :expectedresults:
           1. Verify automount maps are loaded from AD and client is able to
-           mount nfs share
+             mount nfs share
         """
         # pylint: disable=unused-argument
         client = sssdTools(multihost.client[0])
@@ -410,7 +410,7 @@ class Testautofsresponder(object):
         :id: 92640015-52b9-4e76-9e63-ea7357eec9cd
         :steps:
           1. Add Indirect map auto.idmtest which has mount point keys
-           from foo1 to foo20 pointing to /projects/foo1 to /projects/foo20
+             from foo1 to foo20 pointing to /projects/foo1 to /projects/foo20
         :expectedresults:
           1. Verify sssd doesn't use (cn=*)(objectclass=nisObject)
         """

--- a/src/tests/multihost/alltests/test_default_debug_level.py
+++ b/src/tests/multihost/alltests/test_default_debug_level.py
@@ -33,9 +33,9 @@ class TestDefaultDebugLevel(object):
           1. sssd should use default debug level with no level defined
           2. sssd services start successfully
           3. Log files has
-            a. default level set to 0x0070
-            b. 0x1f7c0 logs for "SSSDBG_IMPORTANT_INFO"
-            c. Other logs could be <= 0x0040
+             a. default level set to 0x0070
+             b. 0x1f7c0 logs for "SSSDBG_IMPORTANT_INFO"
+             c. Other logs could be <= 0x0040
         """
         section = f"domain/{ds_instance_name}"
         domain_params = {'debug_level': ''}

--- a/src/tests/multihost/alltests/test_kcm.py
+++ b/src/tests/multihost/alltests/test_kcm.py
@@ -68,7 +68,7 @@ class TestKcm(object):
           1. Configure SSSD with sudo
           2. Leave ou=sudoers empty - do not define any rules
           3. See that smart refresh does not contain
-          modifyTimestamp in the filter
+             modifyTimestamp in the filter
         :expectedresults:
           1. Should succeed
           2. Should succeed

--- a/src/tests/multihost/alltests/test_misc.py
+++ b/src/tests/multihost/alltests/test_misc.py
@@ -244,14 +244,14 @@ class TestMisc(object):
         :customerscenario: true
         :steps:
             1. Configure SSSD with id_provider = ldap and
-            set ldap_schema = rfc2307bis
+               set ldap_schema = rfc2307bis
             2. Add necessary users and groups with uniqueMember.
             3. Check 'getent group ldapgroupname' output.
         :expectedresults:
             1. Should succeed
             2. Should succeed
             3. 'getent group ldapgroupname' should show
-            all it's member ldapusers.
+               all it's member ldapusers.
         """
         tools = sssdTools(multihost.client[0])
         domain_name = tools.get_domain_section_name()

--- a/src/tests/multihost/alltests/test_offline.py
+++ b/src/tests/multihost/alltests/test_offline.py
@@ -68,14 +68,14 @@ class TestOffline(object):
           2. Configure SSSD with only 1  id_provider.
           3. Block "id_provider" using "iptables" command.
           4. Step 6 should fail and similar messages
-            should be observed in log file
-            (/var/log/sssd/sssd_<domainname>.log).
+             should be observed in log file
+             (/var/log/sssd/sssd_<domainname>.log).
           5. The log snip should contain following
-           timeout parameters.
-            - ldap_opt_timeout
-            - ldap_search_timeout
-            - ldap_network_timeout
-            - dns_resolver_timeout
+             timeout parameters.
+             - ldap_opt_timeout
+             - ldap_search_timeout
+             - ldap_network_timeout
+             - dns_resolver_timeout
         :expectedresults:
           1. Should succeed
           2. Should succeed

--- a/src/tests/multihost/alltests/test_services.py
+++ b/src/tests/multihost/alltests/test_services.py
@@ -177,9 +177,9 @@ class TestServices(object):
           1. Find main sssd process id
           2. Send SIGHUP
           3. There should not be any logs for
-            Unable to signal service .* No such
-            file or directory
-            modifyTimestamp in the filter
+             'Unable to signal service .* No such
+             file or directory
+             modifyTimestamp' in the filter
         :expectedresults:
           1. Should succeed
           2. Should succeed

--- a/src/tests/multihost/alltests/test_sssctl_local.py
+++ b/src/tests/multihost/alltests/test_sssctl_local.py
@@ -94,13 +94,12 @@ class Testsssctl(object):
         :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1661182
         :steps:
           1. Configure sssd without any domain
-          2. Restart sssd (sssd should not be
-           running after this)
+          2. Restart sssd (sssd should not be running after this)
           3. Modify existing local user usermod -a -G wheel user1
           4. This message
-           [sss_cache] [confdb_get_domains] (0x0010):
-           No domains configured, fatal error!
-           must not appear in console
+             '[sss_cache] [confdb_get_domains] (0x0010):
+             No domains configured, fatal error!'
+             must not appear in console
         :expectedresults:
           1. Should succeed
           2. Should succeed

--- a/src/tests/multihost/ipa/test_misc.py
+++ b/src/tests/multihost/ipa/test_misc.py
@@ -192,16 +192,15 @@ class Testipabz(object):
             4. Enable SSSD debug logs
             5. Switch to 'admin' user
             6. obtain Kerberos ticket and check that it
-             was obtained using SPAKE pre-authentication.
+               was obtained using SPAKE pre-authentication.
             7. Create sudo configuration that allows an admin to
-             run SUDO rules
+               run SUDO rules
             8. Try 'sudo -l' as admin
             9. As root, check content of sssd_pam.log
-            10. Check if acquired service ticket has
-             req. indicators: 0
-            11. Add pam_sss_gss configuration to /etc/sssd/sssd.conf
-            12. Check if acquired service ticket has req.
-             indicators: 2
+           10. Check if acquired service ticket has req. indicators: 0
+           11. Add pam_sss_gss configuration to /etc/sssd/sssd.conf
+           12. Check if acquired service ticket has req.
+               indicators: 2
         :expectedresults:
             1. Should succeed
             2. Should succeed
@@ -212,9 +211,9 @@ class Testipabz(object):
             7. Should succeed
             8. Should succeed
             9. Should succeed
-            10. Should succeed
-            11. Should succeed
-            12. Should succeed
+           10. Should succeed
+           11. Should succeed
+           12. Should succeed
         """
         client = sssdTools(multihost.client[0])
         domain_params = {'pam_gssapi_services': 'sudo, sudo-i',
@@ -314,7 +313,7 @@ class Testipabz(object):
             3. Configure /etc/pam.d/sudo
             4. Configur /etc/pam.d/sudo-i
             5. Create IPA sudo rule of /usr/sbin/sssctl
-             for user admin
+               for user admin
             6. Check user admin can use sudo command
             7. Restore of files
         :expectedresults:
@@ -451,8 +450,7 @@ class Testipabz(object):
           3. Successfully set the option in sssd.conf.
           4. Successfully logged in to IPA user.
           5. Successfully get a ccache file with the FAST armor ticket
-        :bugzilla:
-        https://bugzilla.redhat.com/show_bug.cgi?id=1859751
+        :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1859751
         """
         sssd_client = sssdTools(multihost.client[0])
         domain_name = f'domain/{sssd_client.get_domain_section_name()}'


### PR DESCRIPTION
The indentation of multiple lines in the steps and expectedresults must
be properly aligned for the importer to pick correctly.