### PR TITLE
CI: fix flake8 and update actions version

### DIFF
--- a/.github/workflows/analyze-target.yml
+++ b/.github/workflows/analyze-target.yml
@@ -81,3 +81,18 @@ jobs:
         name: covscan
         path: |
           ./logs/*.err
+
+  flake8:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Run flake8
+      uses: grantmcconnaughey/lintly-flake8-github-action@d9db4fd0be9fb1cd19206a48ec0773bd93b82cbd
+      with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          failIf: new

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -40,16 +40,3 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
-
-  flake8:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Run flake8
-      uses: grantmcconnaughey/lintly-flake8-github-action@d9db4fd0be9fb1cd19206a48ec0773bd93b82cbd
-      if: github.event_name == 'pull_request'
-      with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          failIf: new

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -24,7 +24,7 @@ jobs:
       uses: ./.github/actions/install-dependencies
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: cpp, python
         queries: +security-and-quality
@@ -39,4 +39,4 @@ jobs:
         make -j$PROCESSORS
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Move flake8 target from pull_request to pull_request_target to be able
to write comments in the PR.

Moreover, CodeQL Action v1 is being deprecated and v2 needs to be used instead.
Reference: https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/