### PR TITLE
names: only check sub-domains for regex match

### DIFF
--- a/src/util/usertools.c
+++ b/src/util/usertools.c
@@ -321,7 +321,7 @@ static struct sss_domain_info * match_any_domain_or_subdomain_name(
         return dom;
     }
 
-    return find_domain_by_name(dom, dmatch, true);
+    return find_domain_by_name_ex(dom, dmatch, true, SSS_GND_SUBDOMAINS);
 }
 
 int sss_parse_name_for_domains(TALLOC_CTX *memctx,


### PR DESCRIPTION
It is allowed to have different regular-expression to split the input
name for different domains. After the regex is evaluated and a domain
name was found in the input it has to be check if the domain name
corresponds to the domain the regex is coming from.

E.g. with the implicit files provider enabled the file provider might
use a simple default regex while and additional IPA or AD provider will
have a more complex one which e.g. properly handles @-characters in
names. When evaluation in input the simple regex will come first and
will split the name but will miss part of the user name part if the name
contains an @-character. Currently SSSD check if the found domain name
matches any of the know domains or sub-domains which is wrong because
the regex was coming from the files provider and hence it should only
handle its own objects.

With this patch not all domains are checked but only the current one and
its sub-domains, if any. This behavior is also mentioned in a comment
already in the code. As a result in the above example the check with
the results form the simple regex with fail and then the more complex
regex of the other domain will be used which can split the name
properly.

Resolves: https://github.com/SSSD/sssd/issues/6055