### PR TITLE
Config: Add the %h template for the 'override_homedir' option

### DIFF
--- a/src/man/include/override_homedir.xml
+++ b/src/man/include/override_homedir.xml
@@ -39,6 +39,13 @@
                     </para></listitem>
             </varlistentry>
             <varlistentry>
+                <term>%h</term>
+                <listitem><para>
+                    The original home directory retrieved
+                    from the identity provider, but in lower case.
+                    </para></listitem>
+            </varlistentry>
+            <varlistentry>
                 <term>%H</term>
                 <listitem><para>
                     The value of configure option

--- a/src/tests/cmocka/test_utils.c
+++ b/src/tests/cmocka/test_utils.c
@@ -45,7 +45,8 @@
 #define FIRST_LETTER "s"
 #define UID      1234
 #define DOMAIN   "sssddomain"
-#define ORIGINAL_HOME "/home/user"
+#define ORIGINAL_HOME "/home/USER"
+#define LOWERCASE_HOME "/home/user"
 #define FLATNAME "flatname"
 #define HOMEDIR_SUBSTR "/mnt/home"
 
@@ -1380,6 +1381,12 @@ void test_expand_homedir_template(void **state)
     check_expanded_value(tmp_ctx, homedir_ctx, "%o"DUMMY, ORIGINAL_HOME DUMMY);
     check_expanded_value(tmp_ctx, homedir_ctx, DUMMY"%o"DUMMY2,
                                                DUMMY ORIGINAL_HOME DUMMY2);
+
+    check_expanded_value(tmp_ctx, homedir_ctx, "%h", LOWERCASE_HOME);
+    check_expanded_value(tmp_ctx, homedir_ctx, DUMMY"%h", DUMMY LOWERCASE_HOME);
+    check_expanded_value(tmp_ctx, homedir_ctx, "%h"DUMMY, LOWERCASE_HOME DUMMY);
+    check_expanded_value(tmp_ctx, homedir_ctx, DUMMY"%h"DUMMY2,
+                                               DUMMY LOWERCASE_HOME DUMMY2);
 
     check_expanded_value(tmp_ctx, homedir_ctx, "%F", FLATNAME);
     check_expanded_value(tmp_ctx, homedir_ctx, DUMMY"%F", DUMMY FLATNAME);

--- a/src/util/sss_nss.c
+++ b/src/util/sss_nss.c
@@ -146,13 +146,25 @@ char *expand_homedir_template(TALLOC_CTX *mem_ctx,
                 break;
 
             case 'o':
+            case 'h':
                 if (homedir_ctx->original == NULL) {
                     DEBUG(SSSDBG_CRIT_FAILURE,
                           "Original home directory for %s is not available, "
                            "using empty string\n", homedir_ctx->username);
                     orig = "";
                 } else {
-                    orig = homedir_ctx->original;
+                    if (*n == 'o') {
+                        orig = homedir_ctx->original;
+                    } else {
+                        orig = sss_tc_utf8_str_tolower(tmp_ctx,
+                                                       homedir_ctx->original);
+                        if (orig == NULL) {
+                            DEBUG(SSSDBG_CRIT_FAILURE,
+                                  "Failed to lowercase the original home "
+                                  "directory.\n");
+                            goto done;
+                        }
+                    }
                 }
                 result = talloc_asprintf_append(result, "%s%s", p, orig);
                 break;


### PR DESCRIPTION
:config: override_homedir now recognizes the %h template which
is replaced by the original home directory retrieved from the
identity provider, but in lower case.

Resolves: https://github.com/SSSD/sssd/issues/6210