### PR TITLE
ldap: allow password changes with shadow pwd policy

### DIFF
--- a/src/man/sssd-ldap.5.xml
+++ b/src/man/sssd-ldap.5.xml
@@ -1103,6 +1103,8 @@ host/*
                             <citerefentry><refentrytitle>shadow</refentrytitle>
                             <manvolnum>5</manvolnum></citerefentry> style
                             attributes to evaluate if the password has expired.
+                            Please see option "ldap_chpass_update_last_change"
+                            as well.
                         </para>
                         <para>
                             <emphasis>mit_kerberos</emphasis> - Use the attributes
@@ -1187,6 +1189,14 @@ host/*
                             ldap_user_shadow_last_change attribute with
                             days since the Epoch after a password change
                             operation.
+                        </para>
+                        <para>
+                            It is recommend to set this option explicitly if
+                            "ldap_pwd_policy = shadow" is used to let SSSD
+                            know if the LDAP server will update
+                            shadowLastChange LDAP attribute automatically
+                            after a password change or if SSSD has to update
+                            it.
                         </para>
                         <para>
                             Default: False


### PR DESCRIPTION
Currently a password change is rejected if
"ldap_pwd_policy = shadow" is used because it was not clear if the
corresponding shadow LDAP attributes get updates as well. But with
commit c975031 SSSD can update the attribute on its own so there is no
need to reject the password change.

Since it is important for SSSD to know if the LDAP server can update the
shadow LDAP attribute automatically or not it is checked if the
ldap_chpass_update_last_change option is set explicitly in sssd.conf. If
not there will be a log message.

Resolves: https://github.com/SSSD/sssd/issues/6220