### PR TITLE
Tests: Rewrite AD tier1, tier2 direct ldap access to powershell.

### DIFF
--- a/src/tests/multihost/ad/conftest.py
+++ b/src/tests/multihost/ad/conftest.py
@@ -390,13 +390,14 @@ def enable_autofs_schema(session_multihost, request):
     ad_password = session_multihost.ad[0].ssh_password
     ad_client = sssdTools(session_multihost.client[0], session_multihost.ad[0])
     try:
-        ad_client.remove_automount()
+        ad_client.remove_automount(verbose=False)
     except subprocess.CalledProcessError:
         print("Automount entry not found")
     else:
         print("Existing automount entry deleted")
     realm_output = ad_client.join_ad(ad_realm, ad_password)
-    ad_client.autofs_ad_schema()
+    ad = ADOperations(session_multihost.ad[0])
+    ad.add_autofs_schema()
 
     def remove_automount_entries():
         """ Remove autofs schema from Windows AD """

--- a/src/tests/multihost/sssd/testlib/common/samba.py
+++ b/src/tests/multihost/sssd/testlib/common/samba.py
@@ -20,13 +20,21 @@ class sambaTools(object):
         self.adhost = adhost
         self.adhost_ip = self.adhost.ip
         self.adhost_ops = ADOperations(self.adhost)
-        self.adhost_conn = self.adhost_ops.ad_conn()
+        self._ad_conn = None
         self.adhost_realm = self.adhost.realm
         self.adhost_password = self.adhost.ssh_password
         self.adhost_hostname = self.adhost.external_hostname
         self.adhost_basedn = self.adhost.domain_basedn_entry
         self.adhost_adminuser = 'Administrator'
         self.host_tools = sssdTools(self.host, self.adhost)
+
+    @property
+    def adhost_conn(self):
+        """AD LDAP connection in lazy initialized property"""
+        if self._ad_conn:
+            return self._ad_conn
+        self._ad_conn = self.adhost_ops.ad_conn()
+        return self._ad_conn
 
     def smbadsconf(self):
         """ Setup smbconf with security = ads """

--- a/src/tests/multihost/sssd/testlib/common/utils.py
+++ b/src/tests/multihost/sssd/testlib/common/utils.py
@@ -1721,7 +1721,7 @@ class ADOperations(object):  # pylint: disable=useless-object-inheritance
                   f"-OtherAttributes @{{\"nisMapName\"=\"auto.direct\" ; " \
                   f"\"nisMapEntry\"=\"{nismapentry}\"}}'"
         add = self.ad_host.run_command(add_map, raiseonerr=False)
-        ret = 'Success' if add.returncode == 0 else 'Failure'
+        ret = 'Success' if add.returncode == 0 else 'Failed to add an ADObject'
         return ret
 
     def delete_map(self, name):
@@ -1730,7 +1730,8 @@ class ADOperations(object):  # pylint: disable=useless-object-inheritance
                   f"Remove-ADObject -Confirm:$False -Identity " \
                   f"\"CN={name},cn=auto.direct,ou=automount,{self.ad_basedn}\"'"
         del_cmd = self.ad_host.run_command(del_map, raiseonerr=False)
-        ret = 'Success' if del_cmd.returncode == 0 else 'Failure'
+        ret = 'Success' if del_cmd.returncode == 0 else 'Failed to ' \
+                                                        'delete an ADObject'
         return ret
 
     def expire_account(self, user):


### PR DESCRIPTION
Tests: Rewrite autofs_ad_schema from direct ldap access to powershell.
Tests: Modify sambaTools to lazy initialize ldap AD connection
Tests: Add a fixture add_etc_host_records for Testcifs to solve name resolution issue.
Tests: Rewrite reset_machine_password using powershell for TestHostKeytabRotation tests.
Note that AD tier 2 sudo test rewrite are not part if this MR.