### PR TITLE
version.m4: update version to 2.8.0

### DIFF
--- a/version.m4
+++ b/version.m4
@@ -1,5 +1,5 @@
 # Primary version number
-m4_define([VERSION_NUMBER], [2.7.0])
+m4_define([VERSION_NUMBER], [2.8.0])
 
 # If the PRERELEASE_VERSION_NUMBER is set, we'll append
 # it to the release tag when creating an RPM or SRPM


### PR DESCRIPTION
This will generate nightly builds in COPR with a higher version number
than the current released version. This, in turn, will allow us to test
the FreeIPA tests.