### PR TITLE
COMPONENT: /src/util/server.c

### DIFF
--- a/src/util/server.c
+++ b/src/util/server.c
@@ -260,7 +260,7 @@ void orderly_shutdown(int status)
         kill(-getpgrp(), SIGTERM);
     }
 #endif
-    DEBUG(SSSDBG_IMPORTANT_INFO, "Shutting down (status = %d)", status);
+    DEBUG(SSSDBG_IMPORTANT_INFO, "Shutting down (status = %d)\n", status);
     sss_log(SSS_LOG_INFO, "Shutting down (status = %d)", status);
     exit(status);
 }


### PR DESCRIPTION
Explanation
Currently there is no new line character at the end of the “Shutting down” log message.
This log message is printed every time any SSSD process is being shut down.
