### PR TITLE
Centralized sbus

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1216,6 +1216,7 @@ libsss_iface_sync_la_LDFLAGS = \
 
 pkglib_LTLIBRARIES += libsss_util.la
 libsss_util_la_SOURCES = \
+    src/sbus/sbus_opath.c \
     src/confdb/confdb.c \
     src/db/sysdb.c \
     src/db/sysdb_ops.c \

--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -22,6 +22,7 @@
 #include "config.h"
 
 #include <ctype.h>
+#include "sbus/sbus_opath.h"
 #include "util/util.h"
 #include "confdb/confdb.h"
 #include "confdb/confdb_private.h"
@@ -913,6 +914,30 @@ static char *confdb_get_domain_hostname(TALLOC_CTX *mem_ctx,
     return talloc_strdup(mem_ctx, sys);
 }
 
+char *confdb_get_domain_bus(TALLOC_CTX *mem_ctx,
+                            struct sss_domain_info *domain)
+{
+    struct sss_domain_info *head;
+    char *safe_name;
+    char *bus_name;
+
+
+    /* There is only one bus that belongs to the top level domain. */
+    head = get_domains_head(domain);
+
+    safe_name = sbus_opath_escape(mem_ctx, head->name);
+    if (safe_name == NULL) {
+        return NULL;
+    }
+
+    /* Parts of bus names must not start with digit thus we concatenate
+     * the name with underscore instead of period. */
+    bus_name = talloc_asprintf(mem_ctx, "sssd.domain_%s", safe_name);
+    talloc_free(safe_name);
+
+    return bus_name;
+}
+
 static errno_t confdb_init_domain(struct sss_domain_info *domain,
                                   struct ldb_result *res)
 {
@@ -931,7 +956,6 @@ static errno_t confdb_init_domain(struct sss_domain_info *domain,
         ret = ENOMEM;
         goto done;
     }
-    domain->conn_name = domain->name;
 
     tmp = ldb_msg_find_attr_as_string(res->msgs[0],
                                       CONFDB_DOMAIN_ID_PROVIDER,
@@ -1051,6 +1075,12 @@ static errno_t confdb_init_domain(struct sss_domain_info *domain,
                   "Invalid value for %s\n", CONFDB_DOMAIN_FALLBACK_TO_NSS);
             goto done;
         }
+    }
+
+    domain->conn_name = confdb_get_domain_bus(domain, domain);
+    if (!domain->conn_name) {
+        ret = ENOMEM;
+        goto done;
     }
 
     domain->not_found_counter = 0;

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -746,6 +746,18 @@ int confdb_certmap_to_sysdb(struct confdb_ctx *cdb,
                             struct sss_domain_info *dom);
 
 /**
+ * Return domain bus name.
+ *
+ * @param[in] domain The domain where the bus name is stored
+ *
+ * @return NULL - A safe name could not be created
+ * @return bus_name - A concatenated safe name for the domain's bus
+ */
+char *
+confdb_get_domain_bus(TALLOC_CTX *mem_ctx,
+                      struct sss_domain_info *domain);
+
+/**
  * @}
  */
 #endif

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -2002,7 +2002,7 @@ static int monitor_process_init(struct mt_ctx *ctx,
     talloc_zfree(tmp_ctx);
 
     req = sbus_server_create_and_connect_send(ctx, ctx->ev, SSS_BUS_MONITOR,
-                                              NULL, SSS_MONITOR_ADDRESS,
+                                              NULL, SSS_MASTER_ADDRESS,
                                               false, 100, ctx->uid, ctx->gid,
                                               NULL, NULL);
     if (req == NULL) {

--- a/src/providers/backend.h
+++ b/src/providers/backend.h
@@ -104,7 +104,7 @@ struct be_ctx {
     /* Periodically check if we can go online. */
     struct be_ptask *check_if_online_ptask;
 
-    struct sbus_connection *mon_conn;
+    struct sbus_connection *sbus_conn;
 
     struct be_refresh_ctx *refresh_ctx;
 

--- a/src/providers/data_provider/dp.c
+++ b/src/providers/data_provider/dp.c
@@ -24,6 +24,7 @@
 #include "providers/data_provider/dp.h"
 #include "providers/data_provider/dp_private.h"
 #include "providers/data_provider/dp_iface.h"
+#include "sbus/sbus.h"
 #include "sss_iface/sss_iface_async.h"
 #include "providers/backend.h"
 #include "util/util.h"
@@ -149,20 +150,12 @@ dp_init_send(TALLOC_CTX *mem_ctx,
     struct dp_init_state *state;
     struct tevent_req *subreq;
     struct tevent_req *req;
-    char *sbus_address;
     errno_t ret;
 
     req = tevent_req_create(mem_ctx, &state, struct dp_init_state);
     if (req == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
         return NULL;
-    }
-
-    sbus_address = sss_iface_domain_address(state, be_ctx->domain);
-    if (sbus_address == NULL) {
-        DEBUG(SSSDBG_FATAL_FAILURE, "Could not get sbus backend address.\n");
-        ret = ENOMEM;
-        goto done;
     }
 
     state->provider = talloc_zero(be_ctx, struct data_provider);
@@ -184,10 +177,9 @@ dp_init_send(TALLOC_CTX *mem_ctx,
      */
     talloc_set_destructor(state->provider, dp_destructor);
 
-    subreq = sbus_server_create_and_connect_send(state->provider, ev,
-        sbus_name, NULL, sbus_address, true, 1000, uid, gid,
-        (sbus_server_on_connection_cb)dp_client_init,
-        (sbus_server_on_connection_data)state->provider);
+    subreq = sbus_connect_private_send(state->provider, ev,
+                                       SSS_MASTER_ADDRESS,
+                                       sbus_name, NULL);
     if (subreq == NULL) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Unable to create subrequest!\n");
         ret = ENOMEM;
@@ -216,9 +208,8 @@ static void dp_init_done(struct tevent_req *subreq)
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct dp_init_state);
 
-    ret = sbus_server_create_and_connect_recv(state->provider, subreq,
-                                              &state->provider->sbus_server,
-                                              &state->provider->sbus_conn);
+    ret = sbus_connect_private_recv(state->provider, subreq,
+                                    &state->provider->sbus_conn);
     talloc_zfree(subreq);
     if (ret != EOK) {
         tevent_req_error(req, ret);
@@ -260,9 +251,15 @@ done:
 }
 
 errno_t dp_init_recv(TALLOC_CTX *mem_ctx,
-                     struct tevent_req *req)
+                     struct tevent_req *req,
+                     struct sbus_connection **_conn)
 {
+    struct dp_init_state *state;
+    state = tevent_req_data(req, struct dp_init_state);
+
     TEVENT_REQ_RETURN_ON_ERROR(req);
+
+    *_conn = talloc_steal(mem_ctx, state->provider->sbus_conn);
 
     return EOK;
 }

--- a/src/providers/data_provider/dp.h
+++ b/src/providers/data_provider/dp.h
@@ -126,7 +126,8 @@ dp_init_send(TALLOC_CTX *mem_ctx,
              const char *sbus_name);
 
 errno_t dp_init_recv(TALLOC_CTX *mem_ctx,
-                     struct tevent_req *req);
+                     struct tevent_req *req,
+                     struct sbus_connection **_conn);
 
 void dp_client_cancel_timeout(struct sbus_connection *conn);
 

--- a/src/providers/data_provider/dp_resp_client.c
+++ b/src/providers/data_provider/dp_resp_client.c
@@ -44,7 +44,7 @@ static const char *user_clients[] = {
 
 static const char *all_clients[] = {
     SSS_BUS_NSS,
-    SSS_BUS_PAM,
+//     SSS_BUS_PAM,
     SSS_BUS_IFP,
     SSS_BUS_PAC,
     SSS_BUS_SUDO,

--- a/src/providers/data_provider/dp_resp_client.c
+++ b/src/providers/data_provider/dp_resp_client.c
@@ -177,8 +177,6 @@ void dp_sbus_reset_groups_ncache(struct data_provider *provider,
 
 void dp_sbus_reset_users_memcache(struct data_provider *provider)
 {
-    struct tevent_req *subreq;
-
     if (provider == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "No provider pointer\n");
         return;
@@ -187,22 +185,12 @@ void dp_sbus_reset_users_memcache(struct data_provider *provider)
     DEBUG(SSSDBG_TRACE_FUNC,
           "Ordering NSS responder to invalidate the users\n");
 
-    subreq = sbus_call_nss_memcache_InvalidateAllUsers_send(provider,
-                 provider->sbus_conn, SSS_BUS_NSS, SSS_BUS_PATH);
-    if (subreq == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
-        return;
-    }
-
-    tevent_req_set_callback(subreq, sbus_unwanted_reply, NULL);
-
+    sbus_emit_nss_memcache_InvalidateAllUsers(provider->sbus_conn, SSS_BUS_PATH);
     return;
 }
 
 void dp_sbus_reset_groups_memcache(struct data_provider *provider)
 {
-    struct tevent_req *subreq;
-
     if (provider == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "No provider pointer\n");
         return;
@@ -211,22 +199,12 @@ void dp_sbus_reset_groups_memcache(struct data_provider *provider)
     DEBUG(SSSDBG_TRACE_FUNC,
           "Ordering NSS responder to invalidate the groups\n");
 
-    subreq = sbus_call_nss_memcache_InvalidateAllGroups_send(provider,
-                 provider->sbus_conn, SSS_BUS_NSS, SSS_BUS_PATH);
-    if (subreq == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
-        return;
-    }
-
-    tevent_req_set_callback(subreq, sbus_unwanted_reply, NULL);
-
+    sbus_emit_nss_memcache_InvalidateAllGroups(provider->sbus_conn, SSS_BUS_PATH);
     return;
 }
 
 void dp_sbus_reset_initgr_memcache(struct data_provider *provider)
 {
-    struct tevent_req *subreq;
-
     if (provider == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "No provider pointer\n");
         return;
@@ -235,23 +213,13 @@ void dp_sbus_reset_initgr_memcache(struct data_provider *provider)
     DEBUG(SSSDBG_TRACE_FUNC,
           "Ordering NSS responder to invalidate the initgroups\n");
 
-    subreq = sbus_call_nss_memcache_InvalidateAllInitgroups_send(provider,
-                 provider->sbus_conn, SSS_BUS_NSS, SSS_BUS_PATH);
-    if (subreq == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
-        return;
-    }
-
-    tevent_req_set_callback(subreq, sbus_unwanted_reply, NULL);
-
+    sbus_emit_nss_memcache_InvalidateAllInitgroups(provider->sbus_conn, SSS_BUS_PATH);
     return;
 }
 
 void dp_sbus_invalidate_group_memcache(struct data_provider *provider,
                                        gid_t gid)
 {
-    struct tevent_req *subreq;
-
     if (provider == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "No provider pointer\n");
         return;
@@ -261,15 +229,6 @@ void dp_sbus_invalidate_group_memcache(struct data_provider *provider,
           "Ordering NSS responder to invalidate the group %"PRIu32" \n",
           gid);
 
-    subreq = sbus_call_nss_memcache_InvalidateGroupById_send(provider,
-                 provider->sbus_conn, SSS_BUS_NSS, SSS_BUS_PATH,
-                 (uint32_t)gid);
-    if (subreq == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
-        return;
-    }
-
-    tevent_req_set_callback(subreq, sbus_unwanted_reply, NULL);
-
+    sbus_emit_nss_memcache_InvalidateGroupById(provider->sbus_conn, SSS_BUS_PATH, (uint32_t)gid);
     return;
 }

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -495,7 +495,7 @@ be_register_monitor_iface(struct sbus_connection *conn, struct be_ctx *be_ctx)
         {NULL, NULL}
     };
 
-    return sbus_connection_add_path_map(be_ctx->mon_conn, paths);
+    return sbus_connection_add_path_map(be_ctx->sbus_conn, paths);
 }
 
 static void dp_initialized(struct tevent_req *req);
@@ -644,21 +644,20 @@ static void dp_initialized(struct tevent_req *req)
 
     be_ctx = tevent_req_callback_data(req, struct be_ctx);
 
-    ret = dp_init_recv(be_ctx, req);
+    ret = dp_init_recv(be_ctx, req, &be_ctx->sbus_conn);
     talloc_zfree(req);
     if (ret !=  EOK) {
         goto done;
     }
 
-    ret = sss_monitor_service_init(be_ctx, be_ctx->ev, be_ctx->sbus_name,
-                                   be_ctx->identity, DATA_PROVIDER_VERSION,
-                                   MT_SVC_PROVIDER, NULL, &be_ctx->mon_conn);
+    ret = sss_monitor_provider_init(be_ctx->sbus_conn, be_ctx->identity,
+                                    DATA_PROVIDER_VERSION, MT_SVC_PROVIDER);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Unable to initialize monitor connection\n");
         goto done;
     }
 
-    ret = be_register_monitor_iface(be_ctx->mon_conn, be_ctx);
+    ret = be_register_monitor_iface(be_ctx->sbus_conn, be_ctx);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Unable to register monitor interface "
               "[%d]: %s\n", ret, sss_strerror(ret));

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -589,7 +589,7 @@ errno_t be_process_init(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    be_ctx->sbus_name = sss_iface_domain_bus(be_ctx, be_ctx->domain);
+    be_ctx->sbus_name = confdb_get_domain_bus(be_ctx, be_ctx->domain);
     if (be_ctx->sbus_name == NULL) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Could not get sbus backend name.\n");
         ret = ENOMEM;

--- a/src/providers/proxy/proxy_child.c
+++ b/src/providers/proxy/proxy_child.c
@@ -369,7 +369,7 @@ proxy_cli_init(struct pc_ctx *ctx)
         goto done;
     }
 
-    sbus_busname = sss_iface_domain_bus(tmp_ctx, ctx->domain);
+    sbus_busname = confdb_get_domain_bus(tmp_ctx, ctx->domain);
     if (sbus_busname == NULL) {
         ret = ENOMEM;
         goto done;

--- a/src/responder/autofs/autofssrv.c
+++ b/src/responder/autofs/autofssrv.c
@@ -86,7 +86,7 @@ autofs_register_service_iface(struct autofs_ctx *autofs_ctx,
         )
     );
 
-    ret = sbus_connection_add_path(rctx->mon_conn, SSS_BUS_PATH, &iface_svc);
+    ret = sbus_connection_add_path(rctx->sbus_conn, SSS_BUS_PATH, &iface_svc);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Unable to register service interface"
               "[%d]: %s\n", ret, sss_strerror(ret));
@@ -156,7 +156,7 @@ autofs_process_init(TALLOC_CTX *mem_ctx,
                                    SSS_AUTOFS_SBUS_SERVICE_NAME,
                                    SSS_AUTOFS_SBUS_SERVICE_VERSION,
                                    MT_SVC_SERVICE,
-                                   &rctx->last_request_time, &rctx->mon_conn);
+                                   &rctx->last_request_time, &rctx->sbus_conn);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "fatal error setting up message bus\n");
         goto fail;

--- a/src/responder/common/cache_req/plugins/cache_req_autofs_entry_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_autofs_entry_by_name.c
@@ -71,19 +71,14 @@ cache_req_autofs_entry_by_name_dp_send(TALLOC_CTX *mem_ctx,
                                        struct sss_domain_info *domain,
                                        struct ldb_result *result)
 {
-    struct be_conn *be_conn;
-    errno_t ret;
-
-    ret = sss_dp_get_domain_conn(cr->rctx, domain->conn_name, &be_conn);
-    if (ret != EOK) {
+    if (cr->rctx->sbus_conn == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "BUG: The Data Provider connection for %s is not available!\n",
-              domain->name);
+            "BUG: The D-Bus connection is not available!\n");
         return NULL;
     }
 
-    return sbus_call_dp_autofs_GetEntry_send(mem_ctx, be_conn->conn,
-                                             be_conn->bus_name, SSS_BUS_PATH,
+    return sbus_call_dp_autofs_GetEntry_send(mem_ctx, cr->rctx->sbus_conn,
+                                             domain->conn_name, SSS_BUS_PATH,
                                              0, data->name.name,
                                              data->autofs_entry_name,
                                              cr->rctx->client_id_num);

--- a/src/responder/common/cache_req/plugins/cache_req_autofs_map_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_autofs_map_by_name.c
@@ -68,19 +68,14 @@ cache_req_autofs_map_by_name_dp_send(TALLOC_CTX *mem_ctx,
                                      struct sss_domain_info *domain,
                                      struct ldb_result *result)
 {
-    struct be_conn *be_conn;
-    errno_t ret;
-
-    ret = sss_dp_get_domain_conn(cr->rctx, domain->conn_name, &be_conn);
-    if (ret != EOK) {
+    if (cr->rctx->sbus_conn == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "BUG: The Data Provider connection for %s is not available!\n",
-              domain->name);
+            "BUG: The D-Bus connection is not available!\n");
         return NULL;
     }
 
-    return sbus_call_dp_autofs_GetMap_send(mem_ctx, be_conn->conn,
-                                           be_conn->bus_name, SSS_BUS_PATH,
+    return sbus_call_dp_autofs_GetMap_send(mem_ctx, cr->rctx->sbus_conn,
+                                           domain->conn_name, SSS_BUS_PATH,
                                            0, data->name.name,
                                            cr->rctx->client_id_num);
 }

--- a/src/responder/common/cache_req/plugins/cache_req_autofs_map_entries.c
+++ b/src/responder/common/cache_req/plugins/cache_req_autofs_map_entries.c
@@ -100,19 +100,14 @@ cache_req_autofs_map_entries_dp_send(TALLOC_CTX *mem_ctx,
                                      struct sss_domain_info *domain,
                                      struct ldb_result *result)
 {
-    struct be_conn *be_conn;
-    errno_t ret;
-
-    ret = sss_dp_get_domain_conn(cr->rctx, domain->conn_name, &be_conn);
-    if (ret != EOK) {
+    if (cr->rctx->sbus_conn == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "BUG: The Data Provider connection for %s is not available!\n",
-              domain->name);
+            "BUG: The D-Bus connection is not available!\n");
         return NULL;
     }
 
-    return sbus_call_dp_autofs_Enumerate_send(mem_ctx, be_conn->conn,
-                                              be_conn->bus_name, SSS_BUS_PATH,
+    return sbus_call_dp_autofs_Enumerate_send(mem_ctx, cr->rctx->sbus_conn,
+                                              domain->conn_name, SSS_BUS_PATH,
                                               0, data->name.name,
                                               cr->rctx->client_id_num);
 }

--- a/src/responder/common/cache_req/plugins/cache_req_ssh_host_id_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_ssh_host_id_by_name.c
@@ -72,19 +72,14 @@ cache_req_host_by_name_dp_send(TALLOC_CTX *mem_ctx,
                                struct sss_domain_info *domain,
                                struct ldb_result *result)
 {
-    struct be_conn *be_conn;
-    errno_t ret;
-
-    ret = sss_dp_get_domain_conn(cr->rctx, domain->conn_name, &be_conn);
-    if (ret != EOK) {
+    if (cr->rctx->sbus_conn == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "BUG: The Data Provider connection for %s is not available!\n",
-              domain->name);
+            "BUG: The D-Bus connection is not available!\n");
         return NULL;
     }
 
-    return sbus_call_dp_dp_hostHandler_send(mem_ctx, be_conn->conn,
-                                            be_conn->bus_name, SSS_BUS_PATH,
+    return sbus_call_dp_dp_hostHandler_send(mem_ctx, cr->rctx->sbus_conn,
+                                            domain->conn_name, SSS_BUS_PATH,
                                             0, data->name.name, data->alias,
                                             cr->rctx->client_id_num);
 }

--- a/src/responder/common/responder.h
+++ b/src/responder/common/responder.h
@@ -76,22 +76,6 @@ struct cli_protocol {
     struct cli_protocol_version *cli_protocol_version;
 };
 
-struct resp_ctx;
-
-struct be_conn {
-    struct be_conn *next;
-    struct be_conn *prev;
-
-    struct resp_ctx *rctx;
-
-    const char *cli_name;
-    struct sss_domain_info *domain;
-
-    char *bus_name;
-    char *sbus_address;
-    struct sbus_connection *conn;
-};
-
 struct resp_ctx {
     struct tevent_context *ev;
     struct tevent_fd *lfde;
@@ -105,8 +89,7 @@ struct resp_ctx {
     struct sss_nc_ctx *ncache;
     struct sss_names_ctx *global_names;
 
-    struct sbus_connection *mon_conn;
-    struct be_conn *be_conns;
+    struct sbus_connection *sbus_conn;
 
     struct sss_domain_info *domains;
     int domains_timeout;
@@ -210,8 +193,6 @@ int sss_process_init(TALLOC_CTX *mem_ctx,
                      connection_setup_t conn_setup,
                      struct resp_ctx **responder_ctx);
 
-int sss_dp_get_domain_conn(struct resp_ctx *rctx, const char *domain,
-                           struct be_conn **_conn);
 struct sss_domain_info *
 responder_get_domain(struct resp_ctx *rctx, const char *domain);
 

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -711,139 +711,6 @@ static errno_t setup_client_idle_timer(struct cli_ctx *cctx)
     return EOK;
 }
 
-static void
-sss_dp_on_reconnect(struct sbus_connection *conn,
-                    enum sbus_reconnect_status status,
-                    struct be_conn *be_conn);
-
-static void
-sss_dp_init_done(struct tevent_req *req);
-
-static errno_t
-sss_dp_init(struct resp_ctx *rctx,
-            const char *conn_name,
-            const char *cli_name,
-            struct sss_domain_info *domain)
-{
-    struct tevent_req *req;
-    struct be_conn *be_conn;
-    int max_retries;
-    errno_t ret;
-
-    ret = confdb_get_int(rctx->cdb, rctx->confdb_service_path,
-                         CONFDB_SERVICE_RECON_RETRIES, 3, &max_retries);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to read confdb [%d]: %s\n",
-              ret, sss_strerror(ret));
-        return ret;
-    }
-
-    be_conn = talloc_zero(rctx, struct be_conn);
-    if (!be_conn) return ENOMEM;
-
-    be_conn->cli_name = cli_name;
-    be_conn->domain = domain;
-    be_conn->rctx = rctx;
-
-    be_conn->sbus_address = sss_iface_domain_address(be_conn, domain);
-    if (be_conn->sbus_address == NULL) {
-        DEBUG(SSSDBG_FATAL_FAILURE, "Could not locate DP address.\n");
-        ret = ENOMEM;
-        goto done;
-    }
-
-    be_conn->bus_name = confdb_get_domain_bus(be_conn, domain);
-    if (be_conn->bus_name == NULL) {
-        DEBUG(SSSDBG_FATAL_FAILURE, "Could not locate DP address.\n");
-        ret = ENOMEM;
-        goto done;
-    }
-
-    ret = sss_iface_connect_address(be_conn, rctx->ev, conn_name,
-                                    be_conn->sbus_address, NULL,
-                                    &be_conn->conn);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_FATAL_FAILURE, "Failed to connect to backend server.\n");
-        goto done;
-    }
-
-    ret = sss_resp_register_sbus_iface(be_conn->conn, rctx);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_FATAL_FAILURE, "Cannot register generic responder "
-              "interface [%d]: %s\n", ret, sss_strerror(ret));
-        goto done;
-    }
-
-    sbus_reconnect_enable(be_conn->conn, max_retries, sss_dp_on_reconnect,
-                          be_conn);
-
-    DLIST_ADD_END(rctx->be_conns, be_conn, struct be_conn *);
-
-    /* Identify ourselves to the DP */
-    req = sbus_call_dp_client_Register_send(be_conn, be_conn->conn,
-                                            be_conn->bus_name,
-                                            SSS_BUS_PATH, cli_name);
-    if (req == NULL) {
-        ret = ENOMEM;
-        goto done;
-    }
-
-    tevent_req_set_callback(req, sss_dp_init_done, be_conn);
-
-    ret = EOK;
-
-done:
-    if (ret != EOK) {
-        talloc_free(be_conn);
-    }
-
-    return ret;
-}
-
-static void
-sss_dp_on_reconnect(struct sbus_connection *conn,
-                    enum sbus_reconnect_status status,
-                    struct be_conn *be_conn)
-{
-    struct tevent_req *req;
-
-    if (status != SBUS_RECONNECT_SUCCESS) {
-        DEBUG(SSSDBG_FATAL_FAILURE, "Could not reconnect to %s provider.\n",
-              be_conn->domain->name);
-        return;
-    }
-
-    DEBUG(SSSDBG_TRACE_FUNC, "Reconnected to the Data Provider.\n");
-
-    /* Identify ourselves to the DP */
-    req = sbus_call_dp_client_Register_send(be_conn, be_conn->conn,
-                                            be_conn->bus_name,
-                                            SSS_BUS_PATH,
-                                            be_conn->cli_name);
-    if (req == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "sbus_call_dp_client_Register_send() failed\n");
-        return;
-    }
-
-    tevent_req_set_callback(req, sss_dp_init_done, be_conn);
-}
-
-static void
-sss_dp_init_done(struct tevent_req *req)
-{
-    errno_t ret;
-
-    ret = sbus_call_dp_client_Register_recv(req);
-    talloc_zfree(req);
-
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to register client with DP\n");
-        return;
-    }
-
-    DEBUG(SSSDBG_TRACE_FUNC, "Client is registered with DP\n");
-}
-
 int create_pipe_fd(const char *sock_name, int *_fd, mode_t umaskval)
 {
     struct sockaddr_un addr;
@@ -1464,13 +1331,6 @@ int sss_process_init(TALLOC_CTX *mem_ctx,
                    dom->name);
             goto fail;
         }
-
-        ret = sss_dp_init(rctx, conn_name, svc_name, dom);
-        if (ret != EOK) {
-            DEBUG(SSSDBG_FATAL_FAILURE,
-                  "fatal error setting up backend connector\n");
-            goto fail;
-        }
     }
 
     ret = sysdb_init(rctx, rctx->domains);
@@ -1512,24 +1372,6 @@ int sss_process_init(TALLOC_CTX *mem_ctx,
 fail:
     talloc_free(rctx);
     return ret;
-}
-
-int sss_dp_get_domain_conn(struct resp_ctx *rctx, const char *domain,
-                           struct be_conn **_conn)
-{
-    struct be_conn *iter;
-
-    if (!rctx->be_conns) return ENOENT;
-
-    for (iter = rctx->be_conns; iter; iter = iter->next) {
-        if (strcasecmp(domain, iter->domain->conn_name) == 0) break;
-    }
-
-    if (!iter) return ENOENT;
-
-    *_conn = iter;
-
-    return EOK;
 }
 
 struct sss_domain_info *

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -752,7 +752,7 @@ sss_dp_init(struct resp_ctx *rctx,
         goto done;
     }
 
-    be_conn->bus_name = sss_iface_domain_bus(be_conn, domain);
+    be_conn->bus_name = confdb_get_domain_bus(be_conn, domain);
     if (be_conn->bus_name == NULL) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Could not locate DP address.\n");
         ret = ENOMEM;
@@ -1522,7 +1522,7 @@ int sss_dp_get_domain_conn(struct resp_ctx *rctx, const char *domain,
     if (!rctx->be_conns) return ENOENT;
 
     for (iter = rctx->be_conns; iter; iter = iter->next) {
-        if (strcasecmp(domain, iter->domain->name) == 0) break;
+        if (strcasecmp(domain, iter->domain->conn_name) == 0) break;
     }
 
     if (!iter) return ENOENT;

--- a/src/responder/common/responder_get_domains.c
+++ b/src/responder/common/responder_get_domains.c
@@ -42,7 +42,6 @@ get_subdomains_send(TALLOC_CTX *mem_ctx,
     struct get_subdomains_state *state;
     struct tevent_req *subreq;
     struct tevent_req *req;
-    struct be_conn *be_conn;
     errno_t ret;
 
     req = tevent_req_create(mem_ctx, &state, struct get_subdomains_state);
@@ -65,19 +64,18 @@ get_subdomains_send(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    ret = sss_dp_get_domain_conn(rctx, dom->conn_name, &be_conn);
-    if (ret != EOK) {
+    if (rctx->sbus_conn == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "BUG: The Data Provider connection for %s is not available!\n",
-              dom->name);
+            "BUG: The D-Bus connection is not available!\n");
         ret = EIO;
         goto done;
     }
 
-    subreq = sbus_call_dp_dp_getDomains_send(state, be_conn->conn,
-                                             be_conn->bus_name,
+    subreq = sbus_call_dp_dp_getDomains_send(state, rctx->sbus_conn,
+                                             dom->conn_name,
                                              SSS_BUS_PATH, hint);
-    if (subreq == NULL) {
+
+   if (subreq == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
         ret = ENOMEM;
         goto done;
@@ -701,7 +699,6 @@ sss_dp_get_account_domain_send(TALLOC_CTX *mem_ctx,
     struct sss_dp_get_account_domain_state *state;
     struct tevent_req *subreq;
     struct tevent_req *req;
-    struct be_conn *be_conn;
     uint32_t entry_type;
     char *filter;
     uint32_t dp_flags;
@@ -713,11 +710,9 @@ sss_dp_get_account_domain_send(TALLOC_CTX *mem_ctx,
         return NULL;
     }
 
-    ret = sss_dp_get_domain_conn(rctx, dom->conn_name, &be_conn);
-    if (ret != EOK) {
+    if (rctx->sbus_conn == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "BUG: The Data Provider connection for %s is not available!\n",
-              dom->name);
+            "BUG: The D-Bus connection is not available!\n");
         ret = EIO;
         goto done;
     }
@@ -747,8 +742,8 @@ sss_dp_get_account_domain_send(TALLOC_CTX *mem_ctx,
 
     dp_flags = fast_reply ? DP_FAST_REPLY : 0;
 
-    subreq = sbus_call_dp_dp_getAccountDomain_send(state, be_conn->conn,
-                                                   be_conn->bus_name,
+    subreq = sbus_call_dp_dp_getAccountDomain_send(state, rctx->sbus_conn,
+                                                   dom->conn_name,
                                                    SSS_BUS_PATH, dp_flags,
                                                    entry_type, filter,
                                                    rctx->client_id_num);

--- a/src/responder/common/responder_iface.c
+++ b/src/responder/common/responder_iface.c
@@ -152,7 +152,7 @@ sss_resp_register_service_iface(struct resp_ctx *rctx)
         )
     );
 
-    ret = sbus_connection_add_path(rctx->mon_conn, SSS_BUS_PATH, &iface_svc);
+    ret = sbus_connection_add_path(rctx->sbus_conn, SSS_BUS_PATH, &iface_svc);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Unable to register service interface"
               "[%d]: %s\n", ret, sss_strerror(ret));

--- a/src/responder/ifp/ifp_domains.c
+++ b/src/responder/ifp/ifp_domains.c
@@ -568,7 +568,6 @@ ifp_domains_domain_is_online_send(TALLOC_CTX *mem_ctx,
     struct sss_domain_info *dom;
     struct tevent_req *subreq;
     struct tevent_req *req;
-    struct be_conn *be_conn;
     errno_t ret;
 
     req = tevent_req_create(mem_ctx, &state,
@@ -584,15 +583,15 @@ ifp_domains_domain_is_online_send(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    ret = sss_dp_get_domain_conn(ifp_ctx->rctx, dom->conn_name, &be_conn);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "BUG: The Data Provider connection for "
-              "%s is not available!\n", dom->name);
+    if (ifp_ctx->rctx->sbus_conn == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+            "BUG: The D-Bus connection is not available!\n");
+        ret = ENOENT;
         goto done;
     }
 
-    subreq = sbus_call_dp_backend_IsOnline_send(state, be_conn->conn,
-                be_conn->bus_name, SSS_BUS_PATH, dom->name);
+    subreq = sbus_call_dp_backend_IsOnline_send(state, ifp_ctx->rctx->sbus_conn,
+                dom->conn_name, SSS_BUS_PATH, dom->name);
     if (subreq == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
         ret = ENOMEM;
@@ -663,7 +662,6 @@ ifp_domains_domain_list_services_send(TALLOC_CTX *mem_ctx,
     struct sss_domain_info *dom;
     struct tevent_req *subreq;
     struct tevent_req *req;
-    struct be_conn *be_conn;
     errno_t ret;
 
     req = tevent_req_create(mem_ctx, &state,
@@ -679,15 +677,15 @@ ifp_domains_domain_list_services_send(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    ret = sss_dp_get_domain_conn(ifp_ctx->rctx, dom->conn_name, &be_conn);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "BUG: The Data Provider connection for "
-              "%s is not available!\n", dom->name);
+    if (ifp_ctx->rctx->sbus_conn == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+            "BUG: The D-Bus connection is not available!\n");
+        ret = ENOENT;
         goto done;
     }
 
-    subreq = sbus_call_dp_failover_ListServices_send(state, be_conn->conn,
-                be_conn->bus_name, SSS_BUS_PATH, dom->name);
+    subreq = sbus_call_dp_failover_ListServices_send(state, ifp_ctx->rctx->sbus_conn,
+                dom->conn_name, SSS_BUS_PATH, dom->name);
     if (subreq == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
         ret = ENOMEM;
@@ -759,7 +757,6 @@ ifp_domains_domain_active_server_send(TALLOC_CTX *mem_ctx,
     struct sss_domain_info *dom;
     struct tevent_req *subreq;
     struct tevent_req *req;
-    struct be_conn *be_conn;
     errno_t ret;
 
     req = tevent_req_create(mem_ctx, &state,
@@ -775,15 +772,15 @@ ifp_domains_domain_active_server_send(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    ret = sss_dp_get_domain_conn(ifp_ctx->rctx, dom->conn_name, &be_conn);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "BUG: The Data Provider connection for "
-              "%s is not available!\n", dom->name);
+    if (ifp_ctx->rctx->sbus_conn == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+            "BUG: The D-Bus connection is not available!\n");
+        ret = ENOENT;
         goto done;
     }
 
-    subreq = sbus_call_dp_failover_ActiveServer_send(state, be_conn->conn,
-                be_conn->bus_name, SSS_BUS_PATH, service);
+    subreq = sbus_call_dp_failover_ActiveServer_send(state, ifp_ctx->rctx->sbus_conn,
+                dom->conn_name, SSS_BUS_PATH, service);
     if (subreq == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
         ret = ENOMEM;
@@ -855,7 +852,6 @@ ifp_domains_domain_list_servers_send(TALLOC_CTX *mem_ctx,
     struct sss_domain_info *dom;
     struct tevent_req *subreq;
     struct tevent_req *req;
-    struct be_conn *be_conn;
     errno_t ret;
 
     req = tevent_req_create(mem_ctx, &state,
@@ -871,15 +867,15 @@ ifp_domains_domain_list_servers_send(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    ret = sss_dp_get_domain_conn(ifp_ctx->rctx, dom->conn_name, &be_conn);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "BUG: The Data Provider connection for "
-              "%s is not available!\n", dom->name);
+    if (ifp_ctx->rctx->sbus_conn == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+            "BUG: The D-Bus connection is not available!\n");
+        ret = ENOENT;
         goto done;
     }
 
-    subreq = sbus_call_dp_failover_ListServers_send(state, be_conn->conn,
-                be_conn->bus_name, SSS_BUS_PATH, service);
+    subreq = sbus_call_dp_failover_ListServers_send(state, ifp_ctx->rctx->sbus_conn,
+                dom->conn_name, SSS_BUS_PATH, service);
     if (subreq == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
         ret = ENOMEM;
@@ -950,7 +946,6 @@ ifp_domains_domain_refresh_access_rules_send(TALLOC_CTX *mem_ctx,
     struct sss_domain_info *dom;
     struct tevent_req *subreq;
     struct tevent_req *req;
-    struct be_conn *be_conn;
     errno_t ret;
 
     req = tevent_req_create(mem_ctx, &state,
@@ -966,15 +961,15 @@ ifp_domains_domain_refresh_access_rules_send(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    ret = sss_dp_get_domain_conn(ifp_ctx->rctx, dom->conn_name, &be_conn);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "BUG: The Data Provider connection for "
-              "%s is not available!\n", dom->name);
+    if (ifp_ctx->rctx->sbus_conn == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+            "BUG: The D-Bus connection is not available!\n");
+        ret = ENOENT;
         goto done;
     }
 
-    subreq = sbus_call_dp_access_RefreshRules_send(state, be_conn->conn,
-                be_conn->bus_name, SSS_BUS_PATH);
+    subreq = sbus_call_dp_access_RefreshRules_send(state, ifp_ctx->rctx->sbus_conn,
+                dom->conn_name, SSS_BUS_PATH);
     if (subreq == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
         ret = ENOMEM;

--- a/src/responder/ifp/ifp_iface/sbus_ifp_keygens.c
+++ b/src/responder/ifp/ifp_iface/sbus_ifp_keygens.c
@@ -30,12 +30,14 @@ _sbus_ifp_key_
     struct sbus_request *sbus_req)
 {
     if (sbus_req->sender == NULL) {
-        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s",
-            sbus_req->type, sbus_req->interface, sbus_req->member, sbus_req->path);
+        return talloc_asprintf(mem_ctx, "-:%u:%s:%s.%s:%s",
+            sbus_req->type, sbus_req->destination, sbus_req->interface,
+            sbus_req->member, sbus_req->path);
     }
 
-    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s",
-        sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member, sbus_req->path);
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s:%s.%s:%s",
+        sbus_req->sender->uid, sbus_req->type, sbus_req->destination,
+        sbus_req->interface, sbus_req->member, sbus_req->path);
 }
 
 const char *
@@ -45,14 +47,14 @@ _sbus_ifp_key_s_0
     struct _sbus_ifp_invoker_args_s *args)
 {
     if (sbus_req->sender == NULL) {
-        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%s",
-            sbus_req->type, sbus_req->interface, sbus_req->member,
-            sbus_req->path, args->arg0);
+        return talloc_asprintf(mem_ctx, "-:%u:%s:%s.%s:%s:%s",
+            sbus_req->type, sbus_req->destination, sbus_req->interface,
+            sbus_req->member, sbus_req->path, args->arg0);
     }
 
-    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%s",
-        sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
-        sbus_req->path, args->arg0);
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s:%s.%s:%s:%s",
+        sbus_req->sender->uid, sbus_req->type, sbus_req->destination, sbus_req->interface,
+        sbus_req->member, sbus_req->path, args->arg0);
 }
 
 const char *
@@ -62,14 +64,14 @@ _sbus_ifp_key_ssu_0_1_2
     struct _sbus_ifp_invoker_args_ssu *args)
 {
     if (sbus_req->sender == NULL) {
-        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%s:%s:%" PRIu32 "",
-            sbus_req->type, sbus_req->interface, sbus_req->member,
-            sbus_req->path, args->arg0, args->arg1, args->arg2);
+        return talloc_asprintf(mem_ctx, "-:%u:%s:%s.%s:%s:%s:%s:%" PRIu32 "",
+            sbus_req->type, sbus_req->destination, sbus_req->interface,
+            sbus_req->member, sbus_req->path, args->arg0, args->arg1, args->arg2);
     }
 
-    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%s:%s:%" PRIu32 "",
-        sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
-        sbus_req->path, args->arg0, args->arg1, args->arg2);
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s:%s.%s:%s:%s:%s:%" PRIu32 "",
+        sbus_req->sender->uid, sbus_req->type, sbus_req->destination, sbus_req->interface,
+        sbus_req->member, sbus_req->path, args->arg0, args->arg1, args->arg2);
 }
 
 const char *
@@ -79,14 +81,14 @@ _sbus_ifp_key_su_0_1
     struct _sbus_ifp_invoker_args_su *args)
 {
     if (sbus_req->sender == NULL) {
-        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%s:%" PRIu32 "",
-            sbus_req->type, sbus_req->interface, sbus_req->member,
-            sbus_req->path, args->arg0, args->arg1);
+        return talloc_asprintf(mem_ctx, "-:%u:%s:%s.%s:%s:%s:%" PRIu32 "",
+            sbus_req->type, sbus_req->destination, sbus_req->interface,
+            sbus_req->member, sbus_req->path, args->arg0, args->arg1);
     }
 
-    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%s:%" PRIu32 "",
-        sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
-        sbus_req->path, args->arg0, args->arg1);
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s:%s.%s:%s:%s:%" PRIu32 "",
+        sbus_req->sender->uid, sbus_req->type, sbus_req->destination, sbus_req->interface,
+        sbus_req->member, sbus_req->path, args->arg0, args->arg1);
 }
 
 const char *
@@ -96,12 +98,12 @@ _sbus_ifp_key_u_0
     struct _sbus_ifp_invoker_args_u *args)
 {
     if (sbus_req->sender == NULL) {
-        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%" PRIu32 "",
-            sbus_req->type, sbus_req->interface, sbus_req->member,
-            sbus_req->path, args->arg0);
+        return talloc_asprintf(mem_ctx, "-:%u:%s:%s.%s:%s:%" PRIu32 "",
+            sbus_req->type, sbus_req->destination, sbus_req->interface,
+            sbus_req->member, sbus_req->path, args->arg0);
     }
 
-    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%" PRIu32 "",
-        sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
-        sbus_req->path, args->arg0);
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s:%s.%s:%s:%" PRIu32 "",
+        sbus_req->sender->uid, sbus_req->type, sbus_req->destination, sbus_req->interface,
+        sbus_req->member, sbus_req->path, args->arg0);
 }

--- a/src/responder/ifp/ifpsrv.c
+++ b/src/responder/ifp/ifpsrv.c
@@ -149,7 +149,7 @@ ifp_register_service_iface(struct ifp_ctx *ifp_ctx,
         )
     );
 
-    ret = sbus_connection_add_path(rctx->mon_conn, SSS_BUS_PATH, &iface_svc);
+    ret = sbus_connection_add_path(rctx->sbus_conn, SSS_BUS_PATH, &iface_svc);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Unable to register service interface"
               "[%d]: %s\n", ret, sss_strerror(ret));
@@ -282,9 +282,14 @@ int ifp_process_init(TALLOC_CTX *mem_ctx,
                                    SSS_IFP_SBUS_SERVICE_NAME,
                                    SSS_IFP_SBUS_SERVICE_VERSION,
                                    MT_SVC_SERVICE,
-                                   &rctx->last_request_time, &rctx->mon_conn);
+                                   &rctx->last_request_time, &rctx->sbus_conn);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "fatal error setting up message bus\n");
+        goto fail;
+    }
+
+    ret = sss_resp_register_sbus_iface(rctx->sbus_conn, rctx);
+    if (ret != EOK) {
         goto fail;
     }
 

--- a/src/responder/nss/nss_iface.c
+++ b/src/responder/nss/nss_iface.c
@@ -222,13 +222,15 @@ sss_nss_register_backend_iface(struct sbus_connection *conn,
     SBUS_INTERFACE(iface,
         sssd_nss_MemoryCache,
         SBUS_METHODS(
-            SBUS_SYNC(METHOD, sssd_nss_MemoryCache, UpdateInitgroups, sss_nss_memorycache_update_initgroups, nss_ctx),
-            SBUS_SYNC(METHOD, sssd_nss_MemoryCache, InvalidateAllUsers, sss_nss_memorycache_invalidate_users, nss_ctx),
-            SBUS_SYNC(METHOD, sssd_nss_MemoryCache, InvalidateAllGroups, sss_nss_memorycache_invalidate_groups, nss_ctx),
-            SBUS_SYNC(METHOD, sssd_nss_MemoryCache, InvalidateAllInitgroups, sss_nss_memorycache_invalidate_initgroups, nss_ctx),
-            SBUS_SYNC(METHOD, sssd_nss_MemoryCache, InvalidateGroupById, sss_nss_memorycache_invalidate_group_by_id, nss_ctx)
+            SBUS_SYNC(METHOD, sssd_nss_MemoryCache, UpdateInitgroups,
+                      sss_nss_memorycache_update_initgroups, nss_ctx)
         ),
-        SBUS_SIGNALS(SBUS_NO_SIGNALS),
+        SBUS_SIGNALS(
+            SBUS_EMITS(sssd_nss_MemoryCache, InvalidateAllUsers),
+            SBUS_EMITS(sssd_nss_MemoryCache, InvalidateAllGroups),
+            SBUS_EMITS(sssd_nss_MemoryCache, InvalidateAllInitgroups),
+            SBUS_EMITS(sssd_nss_MemoryCache, InvalidateGroupById)
+        ),
         SBUS_PROPERTIES(SBUS_NO_PROPERTIES)
     );
 
@@ -236,6 +238,23 @@ sss_nss_register_backend_iface(struct sbus_connection *conn,
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Unable to register service interface"
               "[%d]: %s\n", ret, sss_strerror(ret));
+    }
+
+    struct sbus_listener listeners[] = SBUS_LISTENERS(
+        SBUS_LISTEN_SYNC(sssd_nss_MemoryCache, InvalidateAllUsers,
+                         SSS_BUS_PATH, sss_nss_memorycache_invalidate_users, nss_ctx),
+        SBUS_LISTEN_SYNC(sssd_nss_MemoryCache, InvalidateAllGroups,
+                         SSS_BUS_PATH, sss_nss_memorycache_invalidate_groups, nss_ctx),
+        SBUS_LISTEN_SYNC(sssd_nss_MemoryCache, InvalidateAllInitgroups,
+                         SSS_BUS_PATH, sss_nss_memorycache_invalidate_initgroups, nss_ctx),
+        SBUS_LISTEN_SYNC(sssd_nss_MemoryCache, InvalidateGroupById,
+                         SSS_BUS_PATH, sss_nss_memorycache_invalidate_group_by_id, nss_ctx)
+    );
+
+    ret = sbus_router_listen_map(conn, listeners);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Unable to add listeners [%d]: %s\n",
+              ret, sss_strerror(ret));
     }
 
     return ret;

--- a/src/responder/nss/nsssrv.c
+++ b/src/responder/nss/nsssrv.c
@@ -409,7 +409,7 @@ sss_nss_register_service_iface(struct sss_nss_ctx *nss_ctx,
         )
     );
 
-    ret = sbus_connection_add_path(rctx->mon_conn, SSS_BUS_PATH, &iface_svc);
+    ret = sbus_connection_add_path(rctx->sbus_conn, SSS_BUS_PATH, &iface_svc);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Unable to register service interface"
               "[%d]: %s\n", ret, sss_strerror(ret));
@@ -497,7 +497,6 @@ int sss_nss_process_init(TALLOC_CTX *mem_ctx,
 {
     struct resp_ctx *rctx;
     struct sss_cmd_table *nss_cmds;
-    struct be_conn *iter;
     struct sss_nss_ctx *nctx;
     int ret;
     enum idmap_error_code err;
@@ -531,13 +530,6 @@ int sss_nss_process_init(TALLOC_CTX *mem_ctx,
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "fatal error getting nss config\n");
         goto fail;
-    }
-
-    for (iter = nctx->rctx->be_conns; iter; iter = iter->next) {
-        ret = sss_nss_register_backend_iface(iter->conn, nctx);
-        if (ret != EOK) {
-            goto fail;
-        }
     }
 
     err = sss_idmap_init(sss_idmap_talloc, nctx, sss_idmap_talloc_free,
@@ -632,9 +624,19 @@ int sss_nss_process_init(TALLOC_CTX *mem_ctx,
     ret = sss_monitor_service_init(rctx, rctx->ev, SSS_BUS_NSS,
                                    NSS_SBUS_SERVICE_NAME,
                                    NSS_SBUS_SERVICE_VERSION, MT_SVC_SERVICE,
-                                   &rctx->last_request_time, &rctx->mon_conn);
+                                   &rctx->last_request_time, &rctx->sbus_conn);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "fatal error setting up message bus\n");
+        goto fail;
+    }
+
+    ret = sss_resp_register_sbus_iface(rctx->sbus_conn, rctx);
+    if (ret != EOK) {
+        goto fail;
+    }
+
+    ret = sss_nss_register_backend_iface(nctx->rctx->sbus_conn, nctx);
+    if (ret != EOK) {
         goto fail;
     }
 

--- a/src/responder/pac/pacsrv.c
+++ b/src/responder/pac/pacsrv.c
@@ -147,9 +147,14 @@ int pac_process_init(TALLOC_CTX *mem_ctx,
                                    PAC_SBUS_SERVICE_NAME,
                                    PAC_SBUS_SERVICE_VERSION,
                                    MT_SVC_SERVICE,
-                                   &rctx->last_request_time, &rctx->mon_conn);
+                                   &rctx->last_request_time, &rctx->sbus_conn);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "fatal error setting up message bus\n");
+        goto fail;
+    }
+
+    ret = sss_resp_register_sbus_iface(rctx->sbus_conn, rctx);
+    if (ret != EOK) {
         goto fail;
     }
 

--- a/src/responder/pam/pamsrv.c
+++ b/src/responder/pam/pamsrv.c
@@ -396,9 +396,14 @@ static int pam_process_init(TALLOC_CTX *mem_ctx,
                                    SSS_PAM_SBUS_SERVICE_NAME,
                                    SSS_PAM_SBUS_SERVICE_VERSION,
                                    MT_SVC_SERVICE,
-                                   &rctx->last_request_time, &rctx->mon_conn);
+                                   &rctx->last_request_time, &rctx->sbus_conn);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "fatal error setting up message bus\n");
+        goto done;
+    }
+
+    ret = sss_resp_register_sbus_iface(rctx->sbus_conn, rctx);
+    if (ret != EOK) {
         goto done;
     }
 

--- a/src/responder/ssh/sshsrv.c
+++ b/src/responder/ssh/sshsrv.c
@@ -137,9 +137,14 @@ int ssh_process_init(TALLOC_CTX *mem_ctx,
                                    SSS_SSH_SBUS_SERVICE_NAME,
                                    SSS_SSH_SBUS_SERVICE_VERSION,
                                    MT_SVC_SERVICE,
-                                   &rctx->last_request_time, &rctx->mon_conn);
+                                   &rctx->last_request_time, &rctx->sbus_conn);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "fatal error setting up message bus\n");
+        goto fail;
+    }
+
+    ret = sss_resp_register_sbus_iface(rctx->sbus_conn, rctx);
+    if (ret != EOK) {
         goto fail;
     }
 

--- a/src/responder/sudo/sudosrv.c
+++ b/src/responder/sudo/sudosrv.c
@@ -113,9 +113,14 @@ int sudo_process_init(TALLOC_CTX *mem_ctx,
                                    SSS_SUDO_SBUS_SERVICE_NAME,
                                    SSS_SUDO_SBUS_SERVICE_VERSION,
                                    MT_SVC_SERVICE,
-                                   &rctx->last_request_time, &rctx->mon_conn);
+                                   &rctx->last_request_time, &rctx->sbus_conn);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "fatal error setting up message bus\n");
+        goto fail;
+    }
+
+    ret = sss_resp_register_sbus_iface(rctx->sbus_conn, rctx);
+    if (ret != EOK) {
         goto fail;
     }
 

--- a/src/sbus/codegen/templates/keygens.c.tpl
+++ b/src/sbus/codegen/templates/keygens.c.tpl
@@ -35,14 +35,14 @@
         struct _sbus_invoker_args_${key-signature} *args)
     {
         if (sbus_req->sender == NULL) {
-            return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s<loop name="key-argument">:%${key-format}</loop>",
-                sbus_req->type, sbus_req->interface, sbus_req->member,
-                sbus_req->path<loop name="key-argument">, args->arg${key-index}</loop>);
+            return talloc_asprintf(mem_ctx, "-:%u:%s:%s.%s:%s<loop name="key-argument">:%${key-format}</loop>",
+                sbus_req->type, sbus_req->destination, sbus_req->interface,
+                sbus_req->member, sbus_req->path<loop name="key-argument">, args->arg${key-index}</loop>);
         }
 
-        return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s<loop name="key-argument">:%${key-format}</loop>",
-            sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
-            sbus_req->path<loop name="key-argument">, args->arg${key-index}</loop>);
+        return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s:%s.%s:%s<loop name="key-argument">:%${key-format}</loop>",
+            sbus_req->sender->uid, sbus_req->type, sbus_req->destination, sbus_req->interface,
+            sbus_req->member, sbus_req->path<loop name="key-argument">, args->arg${key-index}</loop>);
     }
 
 </template>
@@ -54,12 +54,14 @@
         struct sbus_request *sbus_req)
     {
         if (sbus_req->sender == NULL) {
-            return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s",
-                sbus_req->type, sbus_req->interface, sbus_req->member, sbus_req->path);
+            return talloc_asprintf(mem_ctx, "-:%u:%s:%s.%s:%s",
+                sbus_req->type, sbus_req->destination, sbus_req->interface,
+                sbus_req->member, sbus_req->path);
         }
 
-        return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s",
-            sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member, sbus_req->path);
+        return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s:%s.%s:%s",
+            sbus_req->sender->uid, sbus_req->type, sbus_req->destination,
+            sbus_req->interface, sbus_req->member, sbus_req->path);
     }
 
 </template>

--- a/src/sbus/interface_dbus/sbus_dbus_keygens.c
+++ b/src/sbus/interface_dbus/sbus_dbus_keygens.c
@@ -30,12 +30,14 @@ _sbus_dbus_key_
     struct sbus_request *sbus_req)
 {
     if (sbus_req->sender == NULL) {
-        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s",
-            sbus_req->type, sbus_req->interface, sbus_req->member, sbus_req->path);
+        return talloc_asprintf(mem_ctx, "-:%u:%s:%s.%s:%s",
+            sbus_req->type, sbus_req->destination, sbus_req->interface,
+            sbus_req->member, sbus_req->path);
     }
 
-    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s",
-        sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member, sbus_req->path);
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s:%s.%s:%s",
+        sbus_req->sender->uid, sbus_req->type, sbus_req->destination,
+        sbus_req->interface, sbus_req->member, sbus_req->path);
 }
 
 const char *
@@ -45,14 +47,14 @@ _sbus_dbus_key_s_0
     struct _sbus_dbus_invoker_args_s *args)
 {
     if (sbus_req->sender == NULL) {
-        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%s",
-            sbus_req->type, sbus_req->interface, sbus_req->member,
-            sbus_req->path, args->arg0);
+        return talloc_asprintf(mem_ctx, "-:%u:%s:%s.%s:%s:%s",
+            sbus_req->type, sbus_req->destination, sbus_req->interface,
+            sbus_req->member, sbus_req->path, args->arg0);
     }
 
-    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%s",
-        sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
-        sbus_req->path, args->arg0);
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s:%s.%s:%s:%s",
+        sbus_req->sender->uid, sbus_req->type, sbus_req->destination, sbus_req->interface,
+        sbus_req->member, sbus_req->path, args->arg0);
 }
 
 const char *
@@ -62,14 +64,14 @@ _sbus_dbus_key_ss_0_1
     struct _sbus_dbus_invoker_args_ss *args)
 {
     if (sbus_req->sender == NULL) {
-        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%s:%s",
-            sbus_req->type, sbus_req->interface, sbus_req->member,
-            sbus_req->path, args->arg0, args->arg1);
+        return talloc_asprintf(mem_ctx, "-:%u:%s:%s.%s:%s:%s:%s",
+            sbus_req->type, sbus_req->destination, sbus_req->interface,
+            sbus_req->member, sbus_req->path, args->arg0, args->arg1);
     }
 
-    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%s:%s",
-        sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
-        sbus_req->path, args->arg0, args->arg1);
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s:%s.%s:%s:%s:%s",
+        sbus_req->sender->uid, sbus_req->type, sbus_req->destination, sbus_req->interface,
+        sbus_req->member, sbus_req->path, args->arg0, args->arg1);
 }
 
 const char *
@@ -79,12 +81,12 @@ _sbus_dbus_key_su_0
     struct _sbus_dbus_invoker_args_su *args)
 {
     if (sbus_req->sender == NULL) {
-        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%s",
-            sbus_req->type, sbus_req->interface, sbus_req->member,
-            sbus_req->path, args->arg0);
+        return talloc_asprintf(mem_ctx, "-:%u:%s:%s.%s:%s:%s",
+            sbus_req->type, sbus_req->destination, sbus_req->interface,
+            sbus_req->member, sbus_req->path, args->arg0);
     }
 
-    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%s",
-        sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
-        sbus_req->path, args->arg0);
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s:%s.%s:%s:%s",
+        sbus_req->sender->uid, sbus_req->type, sbus_req->destination, sbus_req->interface,
+        sbus_req->member, sbus_req->path, args->arg0);
 }

--- a/src/sss_iface/sbus_sss_client_async.c
+++ b/src/sss_iface/sbus_sss_client_async.c
@@ -2325,79 +2325,6 @@ sbus_call_monitor_RegisterService_recv
 }
 
 struct tevent_req *
-sbus_call_nss_memcache_InvalidateAllGroups_send
-    (TALLOC_CTX *mem_ctx,
-     struct sbus_connection *conn,
-     const char *busname,
-     const char *object_path)
-{
-    return sbus_method_in__out__send(mem_ctx, conn, _sbus_sss_key_,
-        busname, object_path, "sssd.nss.MemoryCache", "InvalidateAllGroups");
-}
-
-errno_t
-sbus_call_nss_memcache_InvalidateAllGroups_recv
-    (struct tevent_req *req)
-{
-    return sbus_method_in__out__recv(req);
-}
-
-struct tevent_req *
-sbus_call_nss_memcache_InvalidateAllInitgroups_send
-    (TALLOC_CTX *mem_ctx,
-     struct sbus_connection *conn,
-     const char *busname,
-     const char *object_path)
-{
-    return sbus_method_in__out__send(mem_ctx, conn, _sbus_sss_key_,
-        busname, object_path, "sssd.nss.MemoryCache", "InvalidateAllInitgroups");
-}
-
-errno_t
-sbus_call_nss_memcache_InvalidateAllInitgroups_recv
-    (struct tevent_req *req)
-{
-    return sbus_method_in__out__recv(req);
-}
-
-struct tevent_req *
-sbus_call_nss_memcache_InvalidateAllUsers_send
-    (TALLOC_CTX *mem_ctx,
-     struct sbus_connection *conn,
-     const char *busname,
-     const char *object_path)
-{
-    return sbus_method_in__out__send(mem_ctx, conn, _sbus_sss_key_,
-        busname, object_path, "sssd.nss.MemoryCache", "InvalidateAllUsers");
-}
-
-errno_t
-sbus_call_nss_memcache_InvalidateAllUsers_recv
-    (struct tevent_req *req)
-{
-    return sbus_method_in__out__recv(req);
-}
-
-struct tevent_req *
-sbus_call_nss_memcache_InvalidateGroupById_send
-    (TALLOC_CTX *mem_ctx,
-     struct sbus_connection *conn,
-     const char *busname,
-     const char *object_path,
-     uint32_t arg_gid)
-{
-    return sbus_method_in_u_out__send(mem_ctx, conn, _sbus_sss_key_u_0,
-        busname, object_path, "sssd.nss.MemoryCache", "InvalidateGroupById", arg_gid);
-}
-
-errno_t
-sbus_call_nss_memcache_InvalidateGroupById_recv
-    (struct tevent_req *req)
-{
-    return sbus_method_in_u_out__recv(req);
-}
-
-struct tevent_req *
 sbus_call_nss_memcache_UpdateInitgroups_send
     (TALLOC_CTX *mem_ctx,
      struct sbus_connection *conn,
@@ -2560,4 +2487,67 @@ sbus_call_service_sysbusReconnect_recv
     (struct tevent_req *req)
 {
     return sbus_method_in__out__recv(req);
+}
+
+static void
+sbus_emit_signal_
+    (struct sbus_connection *conn,
+     const char *path,
+     const char *iface,
+     const char *signal_name)
+{
+    sbus_call_signal_send(conn, NULL, NULL, path, iface, signal_name, NULL);
+}
+
+static void
+sbus_emit_signal_u
+    (struct sbus_connection *conn,
+     const char *path,
+     const char *iface,
+     const char *signal_name,
+     uint32_t arg0)
+{
+    struct _sbus_sss_invoker_args_u args;
+
+    args.arg0 = arg0;
+
+    sbus_call_signal_send(conn, NULL, (sbus_invoker_writer_fn)_sbus_sss_invoker_write_u,
+                          path, iface, signal_name, &args);
+}
+
+void
+sbus_emit_nss_memcache_InvalidateAllGroups
+    (struct sbus_connection *conn,
+     const char *object_path)
+{
+    sbus_emit_signal_(conn, object_path,
+        "sssd.nss.MemoryCache", "InvalidateAllGroups");
+}
+
+void
+sbus_emit_nss_memcache_InvalidateAllInitgroups
+    (struct sbus_connection *conn,
+     const char *object_path)
+{
+    sbus_emit_signal_(conn, object_path,
+        "sssd.nss.MemoryCache", "InvalidateAllInitgroups");
+}
+
+void
+sbus_emit_nss_memcache_InvalidateAllUsers
+    (struct sbus_connection *conn,
+     const char *object_path)
+{
+    sbus_emit_signal_(conn, object_path,
+        "sssd.nss.MemoryCache", "InvalidateAllUsers");
+}
+
+void
+sbus_emit_nss_memcache_InvalidateGroupById
+    (struct sbus_connection *conn,
+     const char *object_path,
+     uint32_t arg_gid)
+{
+    sbus_emit_signal_u(conn, object_path,
+        "sssd.nss.MemoryCache", "InvalidateGroupById", arg_gid);
 }

--- a/src/sss_iface/sbus_sss_client_async.h
+++ b/src/sss_iface/sbus_sss_client_async.h
@@ -374,51 +374,6 @@ sbus_call_monitor_RegisterService_recv
      uint16_t* _monitor_version);
 
 struct tevent_req *
-sbus_call_nss_memcache_InvalidateAllGroups_send
-    (TALLOC_CTX *mem_ctx,
-     struct sbus_connection *conn,
-     const char *busname,
-     const char *object_path);
-
-errno_t
-sbus_call_nss_memcache_InvalidateAllGroups_recv
-    (struct tevent_req *req);
-
-struct tevent_req *
-sbus_call_nss_memcache_InvalidateAllInitgroups_send
-    (TALLOC_CTX *mem_ctx,
-     struct sbus_connection *conn,
-     const char *busname,
-     const char *object_path);
-
-errno_t
-sbus_call_nss_memcache_InvalidateAllInitgroups_recv
-    (struct tevent_req *req);
-
-struct tevent_req *
-sbus_call_nss_memcache_InvalidateAllUsers_send
-    (TALLOC_CTX *mem_ctx,
-     struct sbus_connection *conn,
-     const char *busname,
-     const char *object_path);
-
-errno_t
-sbus_call_nss_memcache_InvalidateAllUsers_recv
-    (struct tevent_req *req);
-
-struct tevent_req *
-sbus_call_nss_memcache_InvalidateGroupById_send
-    (TALLOC_CTX *mem_ctx,
-     struct sbus_connection *conn,
-     const char *busname,
-     const char *object_path,
-     uint32_t arg_gid);
-
-errno_t
-sbus_call_nss_memcache_InvalidateGroupById_recv
-    (struct tevent_req *req);
-
-struct tevent_req *
 sbus_call_nss_memcache_UpdateInitgroups_send
     (TALLOC_CTX *mem_ctx,
      struct sbus_connection *conn,
@@ -519,5 +474,26 @@ sbus_call_service_sysbusReconnect_send
 errno_t
 sbus_call_service_sysbusReconnect_recv
     (struct tevent_req *req);
+
+void
+sbus_emit_nss_memcache_InvalidateAllGroups
+    (struct sbus_connection *conn,
+     const char *object_path);
+
+void
+sbus_emit_nss_memcache_InvalidateAllInitgroups
+    (struct sbus_connection *conn,
+     const char *object_path);
+
+void
+sbus_emit_nss_memcache_InvalidateAllUsers
+    (struct sbus_connection *conn,
+     const char *object_path);
+
+void
+sbus_emit_nss_memcache_InvalidateGroupById
+    (struct sbus_connection *conn,
+     const char *object_path,
+     uint32_t arg_gid);
 
 #endif /* _SBUS_SSS_CLIENT_ASYNC_H_ */

--- a/src/sss_iface/sbus_sss_interface.h
+++ b/src/sss_iface/sbus_sss_interface.h
@@ -703,94 +703,6 @@
         (methods), (signals), (properties)); \
 })
 
-/* Method: sssd.nss.MemoryCache.InvalidateAllGroups */
-#define SBUS_METHOD_SYNC_sssd_nss_MemoryCache_InvalidateAllGroups(handler, data) ({ \
-    SBUS_CHECK_SYNC((handler), (data)); \
-    sbus_method_sync("InvalidateAllGroups", \
-        &_sbus_sss_args_sssd_nss_MemoryCache_InvalidateAllGroups, \
-        NULL, \
-        _sbus_sss_invoke_in__out__send, \
-        _sbus_sss_key_, \
-        (handler), (data)); \
-})
-
-#define SBUS_METHOD_ASYNC_sssd_nss_MemoryCache_InvalidateAllGroups(handler_send, handler_recv, data) ({ \
-    SBUS_CHECK_SEND((handler_send), (data)); \
-    SBUS_CHECK_RECV((handler_recv)); \
-    sbus_method_async("InvalidateAllGroups", \
-        &_sbus_sss_args_sssd_nss_MemoryCache_InvalidateAllGroups, \
-        NULL, \
-        _sbus_sss_invoke_in__out__send, \
-        _sbus_sss_key_, \
-        (handler_send), (handler_recv), (data)); \
-})
-
-/* Method: sssd.nss.MemoryCache.InvalidateAllInitgroups */
-#define SBUS_METHOD_SYNC_sssd_nss_MemoryCache_InvalidateAllInitgroups(handler, data) ({ \
-    SBUS_CHECK_SYNC((handler), (data)); \
-    sbus_method_sync("InvalidateAllInitgroups", \
-        &_sbus_sss_args_sssd_nss_MemoryCache_InvalidateAllInitgroups, \
-        NULL, \
-        _sbus_sss_invoke_in__out__send, \
-        _sbus_sss_key_, \
-        (handler), (data)); \
-})
-
-#define SBUS_METHOD_ASYNC_sssd_nss_MemoryCache_InvalidateAllInitgroups(handler_send, handler_recv, data) ({ \
-    SBUS_CHECK_SEND((handler_send), (data)); \
-    SBUS_CHECK_RECV((handler_recv)); \
-    sbus_method_async("InvalidateAllInitgroups", \
-        &_sbus_sss_args_sssd_nss_MemoryCache_InvalidateAllInitgroups, \
-        NULL, \
-        _sbus_sss_invoke_in__out__send, \
-        _sbus_sss_key_, \
-        (handler_send), (handler_recv), (data)); \
-})
-
-/* Method: sssd.nss.MemoryCache.InvalidateAllUsers */
-#define SBUS_METHOD_SYNC_sssd_nss_MemoryCache_InvalidateAllUsers(handler, data) ({ \
-    SBUS_CHECK_SYNC((handler), (data)); \
-    sbus_method_sync("InvalidateAllUsers", \
-        &_sbus_sss_args_sssd_nss_MemoryCache_InvalidateAllUsers, \
-        NULL, \
-        _sbus_sss_invoke_in__out__send, \
-        _sbus_sss_key_, \
-        (handler), (data)); \
-})
-
-#define SBUS_METHOD_ASYNC_sssd_nss_MemoryCache_InvalidateAllUsers(handler_send, handler_recv, data) ({ \
-    SBUS_CHECK_SEND((handler_send), (data)); \
-    SBUS_CHECK_RECV((handler_recv)); \
-    sbus_method_async("InvalidateAllUsers", \
-        &_sbus_sss_args_sssd_nss_MemoryCache_InvalidateAllUsers, \
-        NULL, \
-        _sbus_sss_invoke_in__out__send, \
-        _sbus_sss_key_, \
-        (handler_send), (handler_recv), (data)); \
-})
-
-/* Method: sssd.nss.MemoryCache.InvalidateGroupById */
-#define SBUS_METHOD_SYNC_sssd_nss_MemoryCache_InvalidateGroupById(handler, data) ({ \
-    SBUS_CHECK_SYNC((handler), (data), uint32_t); \
-    sbus_method_sync("InvalidateGroupById", \
-        &_sbus_sss_args_sssd_nss_MemoryCache_InvalidateGroupById, \
-        NULL, \
-        _sbus_sss_invoke_in_u_out__send, \
-        _sbus_sss_key_u_0, \
-        (handler), (data)); \
-})
-
-#define SBUS_METHOD_ASYNC_sssd_nss_MemoryCache_InvalidateGroupById(handler_send, handler_recv, data) ({ \
-    SBUS_CHECK_SEND((handler_send), (data), uint32_t); \
-    SBUS_CHECK_RECV((handler_recv)); \
-    sbus_method_async("InvalidateGroupById", \
-        &_sbus_sss_args_sssd_nss_MemoryCache_InvalidateGroupById, \
-        NULL, \
-        _sbus_sss_invoke_in_u_out__send, \
-        _sbus_sss_key_u_0, \
-        (handler_send), (handler_recv), (data)); \
-})
-
 /* Method: sssd.nss.MemoryCache.UpdateInitgroups */
 #define SBUS_METHOD_SYNC_sssd_nss_MemoryCache_UpdateInitgroups(handler, data) ({ \
     SBUS_CHECK_SYNC((handler), (data), const char *, const char *, uint32_t *); \
@@ -810,6 +722,102 @@
         NULL, \
         _sbus_sss_invoke_in_ssau_out__send, \
         NULL, \
+        (handler_send), (handler_recv), (data)); \
+})
+
+/* Signal: sssd.nss.MemoryCache.InvalidateAllGroups */
+#define SBUS_SIGNAL_EMITS_sssd_nss_MemoryCache_InvalidateAllGroups() ({ \
+    sbus_signal("InvalidateAllGroups", \
+        _sbus_sss_args_sssd_nss_MemoryCache_InvalidateAllGroups, \
+        NULL); \
+})
+
+#define SBUS_SIGNAL_SYNC_sssd_nss_MemoryCache_InvalidateAllGroups(path, handler, data) ({ \
+    SBUS_CHECK_SYNC((handler), (data)); \
+    sbus_listener_sync("sssd.nss.MemoryCache", "InvalidateAllGroups", (path), \
+        _sbus_sss_invoke_in__out__send, \
+        NULL, \
+        (handler), (data)); \
+})
+
+#define SBUS_SIGNAL_ASYNC_sssd_nss_MemoryCache_InvalidateAllGroups(path, handler_send, handler_recv, data) ({ \
+    SBUS_CHECK_SEND((handler_send), (data)); \
+    SBUS_CHECK_RECV((handler_recv)); \
+    sbus_listener_async("sssd.nss.MemoryCache", "InvalidateAllGroups", (path), \
+        _sbus_sss_invoke_in__out__send, \
+        NULL, \
+        (handler_send), (handler_recv), (data)); \
+})
+
+/* Signal: sssd.nss.MemoryCache.InvalidateAllInitgroups */
+#define SBUS_SIGNAL_EMITS_sssd_nss_MemoryCache_InvalidateAllInitgroups() ({ \
+    sbus_signal("InvalidateAllInitgroups", \
+        _sbus_sss_args_sssd_nss_MemoryCache_InvalidateAllInitgroups, \
+        NULL); \
+})
+
+#define SBUS_SIGNAL_SYNC_sssd_nss_MemoryCache_InvalidateAllInitgroups(path, handler, data) ({ \
+    SBUS_CHECK_SYNC((handler), (data)); \
+    sbus_listener_sync("sssd.nss.MemoryCache", "InvalidateAllInitgroups", (path), \
+        _sbus_sss_invoke_in__out__send, \
+        NULL, \
+        (handler), (data)); \
+})
+
+#define SBUS_SIGNAL_ASYNC_sssd_nss_MemoryCache_InvalidateAllInitgroups(path, handler_send, handler_recv, data) ({ \
+    SBUS_CHECK_SEND((handler_send), (data)); \
+    SBUS_CHECK_RECV((handler_recv)); \
+    sbus_listener_async("sssd.nss.MemoryCache", "InvalidateAllInitgroups", (path), \
+        _sbus_sss_invoke_in__out__send, \
+        NULL, \
+        (handler_send), (handler_recv), (data)); \
+})
+
+/* Signal: sssd.nss.MemoryCache.InvalidateAllUsers */
+#define SBUS_SIGNAL_EMITS_sssd_nss_MemoryCache_InvalidateAllUsers() ({ \
+    sbus_signal("InvalidateAllUsers", \
+        _sbus_sss_args_sssd_nss_MemoryCache_InvalidateAllUsers, \
+        NULL); \
+})
+
+#define SBUS_SIGNAL_SYNC_sssd_nss_MemoryCache_InvalidateAllUsers(path, handler, data) ({ \
+    SBUS_CHECK_SYNC((handler), (data)); \
+    sbus_listener_sync("sssd.nss.MemoryCache", "InvalidateAllUsers", (path), \
+        _sbus_sss_invoke_in__out__send, \
+        NULL, \
+        (handler), (data)); \
+})
+
+#define SBUS_SIGNAL_ASYNC_sssd_nss_MemoryCache_InvalidateAllUsers(path, handler_send, handler_recv, data) ({ \
+    SBUS_CHECK_SEND((handler_send), (data)); \
+    SBUS_CHECK_RECV((handler_recv)); \
+    sbus_listener_async("sssd.nss.MemoryCache", "InvalidateAllUsers", (path), \
+        _sbus_sss_invoke_in__out__send, \
+        NULL, \
+        (handler_send), (handler_recv), (data)); \
+})
+
+/* Signal: sssd.nss.MemoryCache.InvalidateGroupById */
+#define SBUS_SIGNAL_EMITS_sssd_nss_MemoryCache_InvalidateGroupById() ({ \
+    sbus_signal("InvalidateGroupById", \
+        _sbus_sss_args_sssd_nss_MemoryCache_InvalidateGroupById, \
+        NULL); \
+})
+
+#define SBUS_SIGNAL_SYNC_sssd_nss_MemoryCache_InvalidateGroupById(path, handler, data) ({ \
+    SBUS_CHECK_SYNC((handler), (data), uint32_t); \
+    sbus_listener_sync("sssd.nss.MemoryCache", "InvalidateGroupById", (path), \
+        _sbus_sss_invoke_in_u_out__send, \
+        _sbus_sss_key_u_0, \
+        (handler), (data)); \
+})
+
+#define SBUS_SIGNAL_ASYNC_sssd_nss_MemoryCache_InvalidateGroupById(path, handler_send, handler_recv, data) ({ \
+    SBUS_CHECK_SEND((handler_send), (data), uint32_t); \
+    SBUS_CHECK_RECV((handler_recv)); \
+    sbus_listener_async("sssd.nss.MemoryCache", "InvalidateGroupById", (path), \
+        _sbus_sss_invoke_in_u_out__send, \
+        _sbus_sss_key_u_0, \
         (handler_send), (handler_recv), (data)); \
 })
 

--- a/src/sss_iface/sbus_sss_keygens.c
+++ b/src/sss_iface/sbus_sss_keygens.c
@@ -30,12 +30,14 @@ _sbus_sss_key_
     struct sbus_request *sbus_req)
 {
     if (sbus_req->sender == NULL) {
-        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s",
-            sbus_req->type, sbus_req->interface, sbus_req->member, sbus_req->path);
+        return talloc_asprintf(mem_ctx, "-:%u:%s:%s.%s:%s",
+            sbus_req->type, sbus_req->destination, sbus_req->interface,
+            sbus_req->member, sbus_req->path);
     }
 
-    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s",
-        sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member, sbus_req->path);
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s:%s.%s:%s",
+        sbus_req->sender->uid, sbus_req->type, sbus_req->destination,
+        sbus_req->interface, sbus_req->member, sbus_req->path);
 }
 
 const char *
@@ -45,14 +47,14 @@ _sbus_sss_key_s_0
     struct _sbus_sss_invoker_args_s *args)
 {
     if (sbus_req->sender == NULL) {
-        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%s",
-            sbus_req->type, sbus_req->interface, sbus_req->member,
-            sbus_req->path, args->arg0);
+        return talloc_asprintf(mem_ctx, "-:%u:%s:%s.%s:%s:%s",
+            sbus_req->type, sbus_req->destination, sbus_req->interface,
+            sbus_req->member, sbus_req->path, args->arg0);
     }
 
-    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%s",
-        sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
-        sbus_req->path, args->arg0);
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s:%s.%s:%s:%s",
+        sbus_req->sender->uid, sbus_req->type, sbus_req->destination, sbus_req->interface,
+        sbus_req->member, sbus_req->path, args->arg0);
 }
 
 const char *
@@ -62,14 +64,14 @@ _sbus_sss_key_u_0
     struct _sbus_sss_invoker_args_u *args)
 {
     if (sbus_req->sender == NULL) {
-        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%" PRIu32 "",
-            sbus_req->type, sbus_req->interface, sbus_req->member,
-            sbus_req->path, args->arg0);
+        return talloc_asprintf(mem_ctx, "-:%u:%s:%s.%s:%s:%" PRIu32 "",
+            sbus_req->type, sbus_req->destination, sbus_req->interface,
+            sbus_req->member, sbus_req->path, args->arg0);
     }
 
-    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%" PRIu32 "",
-        sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
-        sbus_req->path, args->arg0);
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s:%s.%s:%s:%" PRIu32 "",
+        sbus_req->sender->uid, sbus_req->type, sbus_req->destination, sbus_req->interface,
+        sbus_req->member, sbus_req->path, args->arg0);
 }
 
 const char *
@@ -79,14 +81,14 @@ _sbus_sss_key_ussu_0_1
     struct _sbus_sss_invoker_args_ussu *args)
 {
     if (sbus_req->sender == NULL) {
-        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%" PRIu32 ":%s",
-            sbus_req->type, sbus_req->interface, sbus_req->member,
-            sbus_req->path, args->arg0, args->arg1);
+        return talloc_asprintf(mem_ctx, "-:%u:%s:%s.%s:%s:%" PRIu32 ":%s",
+            sbus_req->type, sbus_req->destination, sbus_req->interface,
+            sbus_req->member, sbus_req->path, args->arg0, args->arg1);
     }
 
-    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%" PRIu32 ":%s",
-        sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
-        sbus_req->path, args->arg0, args->arg1);
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s:%s.%s:%s:%" PRIu32 ":%s",
+        sbus_req->sender->uid, sbus_req->type, sbus_req->destination, sbus_req->interface,
+        sbus_req->member, sbus_req->path, args->arg0, args->arg1);
 }
 
 const char *
@@ -96,14 +98,14 @@ _sbus_sss_key_ussu_0_1_2_3
     struct _sbus_sss_invoker_args_ussu *args)
 {
     if (sbus_req->sender == NULL) {
-        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%" PRIu32 ":%s:%s:%" PRIu32 "",
-            sbus_req->type, sbus_req->interface, sbus_req->member,
-            sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3);
+        return talloc_asprintf(mem_ctx, "-:%u:%s:%s.%s:%s:%" PRIu32 ":%s:%s:%" PRIu32 "",
+            sbus_req->type, sbus_req->destination, sbus_req->interface,
+            sbus_req->member, sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3);
     }
 
-    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%" PRIu32 ":%s:%s:%" PRIu32 "",
-        sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
-        sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3);
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s:%s.%s:%s:%" PRIu32 ":%s:%s:%" PRIu32 "",
+        sbus_req->sender->uid, sbus_req->type, sbus_req->destination, sbus_req->interface,
+        sbus_req->member, sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3);
 }
 
 const char *
@@ -113,14 +115,14 @@ _sbus_sss_key_usu_0_1_2
     struct _sbus_sss_invoker_args_usu *args)
 {
     if (sbus_req->sender == NULL) {
-        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%" PRIu32 ":%s:%" PRIu32 "",
-            sbus_req->type, sbus_req->interface, sbus_req->member,
-            sbus_req->path, args->arg0, args->arg1, args->arg2);
+        return talloc_asprintf(mem_ctx, "-:%u:%s:%s.%s:%s:%" PRIu32 ":%s:%" PRIu32 "",
+            sbus_req->type, sbus_req->destination, sbus_req->interface,
+            sbus_req->member, sbus_req->path, args->arg0, args->arg1, args->arg2);
     }
 
-    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%" PRIu32 ":%s:%" PRIu32 "",
-        sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
-        sbus_req->path, args->arg0, args->arg1, args->arg2);
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s:%s.%s:%s:%" PRIu32 ":%s:%" PRIu32 "",
+        sbus_req->sender->uid, sbus_req->type, sbus_req->destination, sbus_req->interface,
+        sbus_req->member, sbus_req->path, args->arg0, args->arg1, args->arg2);
 }
 
 const char *
@@ -130,14 +132,14 @@ _sbus_sss_key_uusssu_0_1_2_3_4_5
     struct _sbus_sss_invoker_args_uusssu *args)
 {
     if (sbus_req->sender == NULL) {
-        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%s:%s:%s:%" PRIu32 "",
-            sbus_req->type, sbus_req->interface, sbus_req->member,
-            sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3, args->arg4, args->arg5);
+        return talloc_asprintf(mem_ctx, "-:%u:%s:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%s:%s:%s:%" PRIu32 "",
+            sbus_req->type, sbus_req->destination, sbus_req->interface,
+            sbus_req->member, sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3, args->arg4, args->arg5);
     }
 
-    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%s:%s:%s:%" PRIu32 "",
-        sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
-        sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3, args->arg4, args->arg5);
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%s:%s:%s:%" PRIu32 "",
+        sbus_req->sender->uid, sbus_req->type, sbus_req->destination, sbus_req->interface,
+        sbus_req->member, sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3, args->arg4, args->arg5);
 }
 
 const char *
@@ -147,14 +149,14 @@ _sbus_sss_key_uusu_0_1_2_3
     struct _sbus_sss_invoker_args_uusu *args)
 {
     if (sbus_req->sender == NULL) {
-        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%s:%" PRIu32 "",
-            sbus_req->type, sbus_req->interface, sbus_req->member,
-            sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3);
+        return talloc_asprintf(mem_ctx, "-:%u:%s:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%s:%" PRIu32 "",
+            sbus_req->type, sbus_req->destination, sbus_req->interface,
+            sbus_req->member, sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3);
     }
 
-    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%s:%" PRIu32 "",
-        sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
-        sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3);
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%s:%" PRIu32 "",
+        sbus_req->sender->uid, sbus_req->type, sbus_req->destination, sbus_req->interface,
+        sbus_req->member, sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3);
 }
 
 const char *
@@ -164,12 +166,12 @@ _sbus_sss_key_uuusu_0_1_2_3_4
     struct _sbus_sss_invoker_args_uuusu *args)
 {
     if (sbus_req->sender == NULL) {
-        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%" PRIu32 ":%s:%" PRIu32 "",
-            sbus_req->type, sbus_req->interface, sbus_req->member,
-            sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3, args->arg4);
+        return talloc_asprintf(mem_ctx, "-:%u:%s:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%" PRIu32 ":%s:%" PRIu32 "",
+            sbus_req->type, sbus_req->destination, sbus_req->interface,
+            sbus_req->member, sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3, args->arg4);
     }
 
-    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%" PRIu32 ":%s:%" PRIu32 "",
-        sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
-        sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3, args->arg4);
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%" PRIu32 ":%s:%" PRIu32 "",
+        sbus_req->sender->uid, sbus_req->type, sbus_req->destination, sbus_req->interface,
+        sbus_req->member, sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3, args->arg4);
 }

--- a/src/sss_iface/sbus_sss_symbols.c
+++ b/src/sss_iface/sbus_sss_symbols.c
@@ -371,47 +371,6 @@ _sbus_sss_args_sssd_monitor_RegisterService = {
 };
 
 const struct sbus_method_arguments
-_sbus_sss_args_sssd_nss_MemoryCache_InvalidateAllGroups = {
-    .input = (const struct sbus_argument[]){
-        {NULL}
-    },
-    .output = (const struct sbus_argument[]){
-        {NULL}
-    }
-};
-
-const struct sbus_method_arguments
-_sbus_sss_args_sssd_nss_MemoryCache_InvalidateAllInitgroups = {
-    .input = (const struct sbus_argument[]){
-        {NULL}
-    },
-    .output = (const struct sbus_argument[]){
-        {NULL}
-    }
-};
-
-const struct sbus_method_arguments
-_sbus_sss_args_sssd_nss_MemoryCache_InvalidateAllUsers = {
-    .input = (const struct sbus_argument[]){
-        {NULL}
-    },
-    .output = (const struct sbus_argument[]){
-        {NULL}
-    }
-};
-
-const struct sbus_method_arguments
-_sbus_sss_args_sssd_nss_MemoryCache_InvalidateGroupById = {
-    .input = (const struct sbus_argument[]){
-        {.type = "u", .name = "gid"},
-        {NULL}
-    },
-    .output = (const struct sbus_argument[]){
-        {NULL}
-    }
-};
-
-const struct sbus_method_arguments
 _sbus_sss_args_sssd_nss_MemoryCache_UpdateInitgroups = {
     .input = (const struct sbus_argument[]){
         {.type = "s", .name = "user"},
@@ -422,6 +381,27 @@ _sbus_sss_args_sssd_nss_MemoryCache_UpdateInitgroups = {
     .output = (const struct sbus_argument[]){
         {NULL}
     }
+};
+
+const struct sbus_argument
+_sbus_sss_args_sssd_nss_MemoryCache_InvalidateAllGroups[] = {
+    {NULL}
+};
+
+const struct sbus_argument
+_sbus_sss_args_sssd_nss_MemoryCache_InvalidateAllInitgroups[] = {
+    {NULL}
+};
+
+const struct sbus_argument
+_sbus_sss_args_sssd_nss_MemoryCache_InvalidateAllUsers[] = {
+    {NULL}
+};
+
+const struct sbus_argument
+_sbus_sss_args_sssd_nss_MemoryCache_InvalidateGroupById[] = {
+    {.type = "u", .name = "gid"},
+    {NULL}
 };
 
 const struct sbus_method_arguments

--- a/src/sss_iface/sbus_sss_symbols.h
+++ b/src/sss_iface/sbus_sss_symbols.h
@@ -104,19 +104,19 @@ extern const struct sbus_method_arguments
 _sbus_sss_args_sssd_monitor_RegisterService;
 
 extern const struct sbus_method_arguments
-_sbus_sss_args_sssd_nss_MemoryCache_InvalidateAllGroups;
-
-extern const struct sbus_method_arguments
-_sbus_sss_args_sssd_nss_MemoryCache_InvalidateAllInitgroups;
-
-extern const struct sbus_method_arguments
-_sbus_sss_args_sssd_nss_MemoryCache_InvalidateAllUsers;
-
-extern const struct sbus_method_arguments
-_sbus_sss_args_sssd_nss_MemoryCache_InvalidateGroupById;
-
-extern const struct sbus_method_arguments
 _sbus_sss_args_sssd_nss_MemoryCache_UpdateInitgroups;
+
+extern const struct sbus_argument
+_sbus_sss_args_sssd_nss_MemoryCache_InvalidateAllGroups[];
+
+extern const struct sbus_argument
+_sbus_sss_args_sssd_nss_MemoryCache_InvalidateAllInitgroups[];
+
+extern const struct sbus_argument
+_sbus_sss_args_sssd_nss_MemoryCache_InvalidateAllUsers[];
+
+extern const struct sbus_argument
+_sbus_sss_args_sssd_nss_MemoryCache_InvalidateGroupById[];
 
 extern const struct sbus_method_arguments
 _sbus_sss_args_sssd_service_clearEnumCache;

--- a/src/sss_iface/sss_iface.c
+++ b/src/sss_iface/sss_iface.c
@@ -28,18 +28,6 @@
 #include "sss_iface/sss_iface_async.h"
 
 char *
-sss_iface_domain_address(TALLOC_CTX *mem_ctx,
-                         struct sss_domain_info *domain)
-{
-    struct sss_domain_info *head;
-
-    /* There is only one bus that belongs to the top level domain. */
-    head = get_domains_head(domain);
-
-    return talloc_asprintf(mem_ctx, SSS_BACKEND_ADDRESS, head->name);
-}
-
-char *
 sss_iface_proxy_bus(TALLOC_CTX *mem_ctx,
                     uint32_t id)
 {
@@ -118,7 +106,7 @@ sss_monitor_service_init(TALLOC_CTX *mem_ctx,
     errno_t ret;
 
     ret = sss_iface_connect_address(mem_ctx, ev, conn_name,
-                                    SSS_MONITOR_ADDRESS,
+                                    SSS_MASTER_ADDRESS,
                                     last_request_time, &conn);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to connect to monitor sbus server "
@@ -147,6 +135,27 @@ done:
     }
 
     return ret;
+}
+
+errno_t
+sss_monitor_provider_init(struct sbus_connection *conn,
+                          const char *svc_name,
+                          uint16_t svc_version,
+                          uint16_t svc_type)
+{
+    struct tevent_req *req;
+
+    req = sbus_call_monitor_RegisterService_send(conn, conn, SSS_BUS_MONITOR,
+                                                 SSS_BUS_PATH, svc_name,
+                                                 svc_version, svc_type);
+    if (req == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
+        return ENOMEM;
+    }
+
+    tevent_req_set_callback(req, sss_monitor_service_init_done, conn);
+
+    return EOK;
 }
 
 static void

--- a/src/sss_iface/sss_iface.c
+++ b/src/sss_iface/sss_iface.c
@@ -40,31 +40,6 @@ sss_iface_domain_address(TALLOC_CTX *mem_ctx,
 }
 
 char *
-sss_iface_domain_bus(TALLOC_CTX *mem_ctx,
-                     struct sss_domain_info *domain)
-{
-    struct sss_domain_info *head;
-    char *safe_name;
-    char *bus_name;
-
-
-    /* There is only one bus that belongs to the top level domain. */
-    head = get_domains_head(domain);
-
-    safe_name = sbus_opath_escape(mem_ctx, head->name);
-    if (safe_name == NULL) {
-        return NULL;
-    }
-
-    /* Parts of bus names must not start with digit thus we concatenate
-     * the name with underscore instead of period. */
-    bus_name = talloc_asprintf(mem_ctx, "sssd.domain_%s", safe_name);
-    talloc_free(safe_name);
-
-    return bus_name;
-}
-
-char *
 sss_iface_proxy_bus(TALLOC_CTX *mem_ctx,
                     uint32_t id)
 {

--- a/src/sss_iface/sss_iface.h
+++ b/src/sss_iface/sss_iface.h
@@ -30,8 +30,7 @@
 #include "providers/data_provider_req.h"
 #include "providers/data_provider/dp_flags.h"
 
-#define SSS_MONITOR_ADDRESS "unix:path=" PIPE_PATH "/private/sbus-monitor"
-#define SSS_BACKEND_ADDRESS "unix:path=" PIPE_PATH "/private/sbus-dp_%s"
+#define SSS_MASTER_ADDRESS "unix:path=" PIPE_PATH "/private/sbus-master"
 
 #define SSS_BUS_MONITOR     "sssd.monitor"
 #define SSS_BUS_AUTOFS      "sssd.autofs"
@@ -59,13 +58,6 @@
 #define SSS_IFP_SBUS_SERVICE_VERSION 0x0001
 #define PAC_SBUS_SERVICE_NAME "pac"
 #define PAC_SBUS_SERVICE_VERSION 0x0001
-
-/**
- * Return domain address.
- */
-char *
-sss_iface_domain_address(TALLOC_CTX *mem_ctx,
-                         struct sss_domain_info *domain);
 
 /**
  * Return proxy child bus name.

--- a/src/sss_iface/sss_iface.h
+++ b/src/sss_iface/sss_iface.h
@@ -68,13 +68,6 @@ sss_iface_domain_address(TALLOC_CTX *mem_ctx,
                          struct sss_domain_info *domain);
 
 /**
- * Return domain bus name.
- */
-char *
-sss_iface_domain_bus(TALLOC_CTX *mem_ctx,
-                     struct sss_domain_info *domain);
-
-/**
  * Return proxy child bus name.
  */
 char *

--- a/src/sss_iface/sss_iface.xml
+++ b/src/sss_iface/sss_iface.xml
@@ -193,11 +193,11 @@
             <arg name="domain" type="s" direction="in" />
             <arg name="groups" type="au" direction="in" />
         </method>
-        <method name="InvalidateAllUsers" key="True" />
-        <method name="InvalidateAllGroups" key="True" />
-        <method name="InvalidateAllInitgroups" key="True" />
-        <method name="InvalidateGroupById" key="True">
-            <arg name="gid" type="u" direction="in" key="1" />
-        </method>
+        <signal name="InvalidateAllUsers" />
+        <signal name="InvalidateAllGroups" />
+        <signal name="InvalidateAllInitgroups" />
+        <signal name="InvalidateGroupById">
+            <arg name="gid" type="u" key="1" />
+        </signal>
     </interface>
 </node>

--- a/src/sss_iface/sss_iface_async.h
+++ b/src/sss_iface/sss_iface_async.h
@@ -58,6 +58,11 @@ sss_monitor_service_init(TALLOC_CTX *mem_ctx,
                          time_t *last_request_time,
                          struct sbus_connection **_conn);
 
+errno_t
+sss_monitor_provider_init(struct sbus_connection *conn,
+                          const char *svc_name,
+                          uint16_t svc_version,
+                          uint16_t svc_type);
 
 errno_t
 monitor_common_res_init(TALLOC_CTX *mem_ctx,

--- a/src/tools/sssctl/sssctl_logs.c
+++ b/src/tools/sssctl/sssctl_logs.c
@@ -109,7 +109,7 @@ static struct sbus_sync_connection *connect_to_sbus(TALLOC_CTX *mem_ctx)
 {
     struct sbus_sync_connection *conn;
 
-    conn = sbus_sync_connect_private(mem_ctx, SSS_MONITOR_ADDRESS, NULL);
+    conn = sbus_sync_connect_private(mem_ctx, SSS_MASTER_ADDRESS, NULL);
     if (conn == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Failed to connect to the sbus monitor\n");
     }
@@ -134,7 +134,7 @@ static const char *get_busname(TALLOC_CTX *mem_ctx, struct confdb_ctx *confdb,
             goto done;
         }
 
-        busname = sss_iface_domain_bus(mem_ctx, domain);
+        busname = confdb_get_domain_bus(mem_ctx, domain);
     } else {
         busname = talloc_asprintf(mem_ctx, "sssd.%s", component);
     }


### PR DESCRIPTION
These changes modify the way sssd communicates through D-Bus. There is only one central `sbus-master` to which all providers connect and responders target them with the providers' well-known bus names.

1) `domain->conn_name` now holds the bus' well-known name and is used as a way to differentiate between provider targets
2) request keys hold the information about the destination as well to enable chaining of requests even with a single bus
3) `be_conn` structure is completely removed as it has no use in this topology

**Problem:**
- the *test_schedule_get_domains_task* fails during `make check`, from what I understand, this test checks whether a responder can find `sss_domain_info->name = responder_test` in its `be_conn` structure or not, sees that it doesn't, exits, and finishes as intended
- now that `conn_name` differs from `name`, the check looks for the value `sssd.domain_responder_5ftest` which it finds in its `sss_domain_info` list and thus passes so the test does not end here as intended

Bellow you can see both versions with debug messages and with logs from the test

**Original version:**
*responder_get_domains.c*
```c
68     DEBUG(SSSDBG_DEFAULT, "Going to check for domains\n");
69     ret = sss_dp_get_domain_conn(rctx, dom->conn_name, &be_conn);
70     if (ret != EOK) {
71         DEBUG(SSSDBG_CRIT_FAILURE,
72               "BUG: The Data Provider connection for %s is not available!\n", dom->name);
73         ret = EIO;
74         goto done;
75     }
76     DEBUG(SSSDBG_DEFAULT, "Domain check is done\n");
```

*responder_common.c*
```c
1511 int sss_dp_get_domain_conn(struct resp_ctx *rctx, const char *domain,
1512                            struct be_conn **_conn)
1513 {
1514     struct be_conn *iter;
1515
1516     DEBUG(SSSDBG_DEFAULT, "Testing if rctx->be_conns exists\n");
1517     if (!rctx->be_conns) return ENOENT;
1518     DEBUG(SSSDBG_DEFAULT, "Not ENOENT\n");
1519
1520     DEBUG(SSSDBG_DEFAULT, "Iterating until %s is found\n", domain);
1521     for (iter = rctx->be_conns; iter; iter = iter->next) {
1522         DEBUG(SSSDBG_DEFAULT, "Looking at %s\n", iter->domain->name);
1523         if (strcasecmp(domain, iter->domain->name) == 0) break;
1524     }
1525
1526     if (!iter) return ENOENT;
1527     DEBUG(SSSDBG_DEFAULT, "Found the domain, returning EOK\n");
1528
1529     *_conn = iter;
1530
1531     return EOK;
1532 }
```

*responder-get-domains-tests.log*
```
[ RUN      ] test_schedule_get_domains_task
[sssd] [get_subdomains_send] (0x0070): Going to check for domains
[sssd] [sss_dp_get_domain_conn] (0x0070): Testing if rctx->be_conns exists
[sssd] [get_subdomains_send] (0x0020): BUG: The Data Provider connection for responder_test is not available!
[       OK ] test_schedule_get_domains_task
```

**Modified version:**
*responder_get_domains.c*
```c
67     DEBUG(SSSDBG_DEFAULT, "Going to check for domains\n");
68     ret = responder_check_domain_conn(rctx, dom->conn_name);
69     if (ret != EOK) {
70         DEBUG(SSSDBG_CRIT_FAILURE,
71               "BUG: The Data Provider connection %s for %s is not available!\n", dom->conn_name, dom->name);
72         ret = EIO;
73         goto done;
74     }
75     DEBUG(SSSDBG_DEFAULT, "Domain check is done\n");
```

*responder_common.c*
```c
1371 int responder_check_domain_conn(struct resp_ctx *rctx,
1372                                 const char *conn_name)
1373 {
1374     struct sss_domain_info *iter;
1375
1376     DEBUG(SSSDBG_DEFAULT, "Testing if rctx->domains exists\n");
1377     if (!rctx->domains) return EIO;
1378     DEBUG(SSSDBG_DEFAULT, "Not EIO\n");
1379
1380     DEBUG(SSSDBG_DEFAULT, "Iterating until %s is found\n", conn_name);
1381     for (iter = rctx->domains; iter; iter = iter->next) {
1382         DEBUG(SSSDBG_DEFAULT, "Looking at %s\n", iter->conn_name);
1383         if (strcasecmp(conn_name, iter->conn_name) == 0) break;
1384     }
1385
1386     if (!iter) return ENOENT;
1387     DEBUG(SSSDBG_DEFAULT, "Found the domain, returning EOK\n");
```

*responder-get-domains-tests.log*
```
[ RUN      ] test_schedule_get_domains_task
[sssd] [get_subdomains_send] (0x0070): Going to check for domains
[sssd] [responder_check_domain_conn] (0x0070): Testing if rctx->domains exists
[sssd] [responder_check_domain_conn] (0x0070): Not EIO
[sssd] [responder_check_domain_conn] (0x0070): Iterating until sssd.domain_responder_5ftest is found
[sssd] [responder_check_domain_conn] (0x0070): Looking at sssd.domain_responder_5ftest
[sssd] [responder_check_domain_conn] (0x0070): Found the domain, returning EOK
[sssd] [get_subdomains_send] (0x0070): Domain check is done
Leak report for ../src/tests/cmocka/test_responder_common.c:94:
…
<output omitted>

```