### PR TITLE
Cleanup some issues with subdomain config inheritance

### DIFF
--- a/src/man/sssd-ldap.5.xml
+++ b/src/man/sssd-ldap.5.xml
@@ -323,6 +323,11 @@
                             records.
                         </para>
                         <para>
+                            This option can be also set per subdomain or
+                            inherited via
+                            <emphasis>subdomain_inherit</emphasis>.
+                        </para>
+                        <para>
                             Default: 300
                         </para>
                     </listitem>
@@ -345,6 +350,11 @@
                             the server and can't be disabled. By default,
                             the cleanup task will run every 3 hours with
                             enumeration enabled.
+                        </para>
+                        <para>
+                            This option can be also set per subdomain or
+                            inherited via
+                            <emphasis>subdomain_inherit</emphasis>.
                         </para>
                         <para>
                             Default: 0 (disabled)
@@ -393,6 +403,11 @@
                           This options enables or disables use of Token-Groups
                           attribute when performing initgroup for users from
                           Active Directory Server 2008 and later.
+                        </para>
+                        <para>
+                            This option can be also set per subdomain or
+                            inherited via
+                            <emphasis>subdomain_inherit</emphasis>.
                         </para>
                         <para>
                             Default: True for AD and IPA otherwise False.
@@ -450,6 +465,11 @@
                             lookup types.
                         </para>
                         <para>
+                            This option can be also set per subdomain or
+                            inherited via
+                            <emphasis>subdomain_inherit</emphasis>.
+                        </para>
+                        <para>
                             Default: 6
                         </para>
                     </listitem>
@@ -464,6 +484,11 @@
                             are allowed to run before they are cancelled and
                             cached results are returned (and offline mode is
                             entered)
+                        </para>
+                        <para>
+                            This option can be also set per subdomain or
+                            inherited via
+                            <emphasis>subdomain_inherit</emphasis>.
                         </para>
                         <para>
                             Default: 60
@@ -492,6 +517,11 @@
                             returns in case of no activity.
                         </para>
                         <para>
+                            This option can be also set per subdomain or
+                            inherited via
+                            <emphasis>subdomain_inherit</emphasis>.
+                        </para>
+                        <para>
                             Default: 6
                         </para>
                     </listitem>
@@ -508,6 +538,11 @@
                             bind, the timeout of an LDAP bind operation,
                             password change extended operation and the
                             StartTLS operation.
+                        </para>
+                        <para>
+                            This option can be also set per subdomain or
+                            inherited via
+                            <emphasis>subdomain_inherit</emphasis>.
                         </para>
                         <para>
                             Default: 8
@@ -544,6 +579,11 @@
                             <emphasis>ldap_connection_expire_offset</emphasis>
                         </para>
                         <para>
+                            This option can be also set per subdomain or
+                            inherited via
+                            <emphasis>subdomain_inherit</emphasis>.
+                        </para>
+                        <para>
                             Default: 900 (15 minutes)
                         </para>
                     </listitem>
@@ -556,6 +596,11 @@
                             Random offset between 0 and configured value
                             is added to
                             <emphasis>ldap_connection_expire_timeout</emphasis>.
+                        </para>
+                        <para>
+                            This option can be also set per subdomain or
+                            inherited via
+                            <emphasis>subdomain_inherit</emphasis>.
                         </para>
                         <para>
                             Default: 0
@@ -1003,6 +1048,11 @@ host/*
                             SASL/GSSAPI/GSS-SPNEGO.
                         </para>
                         <para>
+                            This option can be also set per subdomain or
+                            inherited via
+                            <emphasis>subdomain_inherit</emphasis>.
+                        </para>
+                        <para>
                             Default: System keytab, normally <filename>/etc/krb5.keytab</filename>
                         </para>
                     </listitem>
@@ -1029,6 +1079,11 @@ host/*
                         <para>
                             Specifies the lifetime in seconds of the TGT if
                             GSSAPI or GSS-SPNEGO is used.
+                        </para>
+                        <para>
+                            This option can be also set per subdomain or
+                            inherited via
+                            <emphasis>subdomain_inherit</emphasis>.
                         </para>
                         <para>
                             Default: 86400 (24 hours)

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2997,6 +2997,11 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                             containing many members.
                         </para>
                         <para>
+                            This option can be also set per subdomain or
+                            inherited via
+                            <emphasis>subdomain_inherit</emphasis>.
+                        </para>
+                        <para>
                             Default: FALSE
                         </para>
                     </listitem>
@@ -3719,10 +3724,44 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                             Currently the following options can be inherited:
                         </para>
                         <para>
-                            ignore_group_members
+                            ldap_search_timeout
+                        </para>
+                        <para>
+                            ldap_network_timeout
+                        </para>
+                        <para>
+                            ldap_opt_timeout
+                        </para>
+                        <para>
+                            ldap_offline_timeout
+                        </para>
+                        <para>
+                            ldap_enumeration_refresh_timeout
+                        </para>
+                        <para>
+                            ldap_enumeration_refresh_offset
                         </para>
                         <para>
                             ldap_purge_cache_timeout
+                        </para>
+                        <para>
+                            ldap_purge_cache_offset
+                        </para>
+                        <para>
+                            ldap_krb5_keytab (the value of krb5_keytab will be
+                            used if ldap_krb5_keytab is not set explicitly)
+                        </para>
+                        <para>
+                            ldap_krb5_ticket_lifetime
+                        </para>
+                        <para>
+                            ldap_enumeration_search_timeout
+                        </para>
+                        <para>
+                            ldap_connection_expire_timeout
+                        </para>
+                        <para>
+                            ldap_connection_expire_offset
                         </para>
                         <para>
                             ldap_connection_idle_timeout
@@ -3734,8 +3773,7 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                             ldap_user_principal
                         </para>
                         <para>
-                            ldap_krb5_keytab (the value of krb5_keytab will be
-                            used if ldap_krb5_keytab is not set explicitly)
+                            ignore_group_members
                         </para>
                         <para>
                             auto_private_groups

--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -335,8 +335,6 @@ ad_subdom_ad_ctx_new(struct be_ctx *be_ctx,
               "behavior later on.\n",
               id_ctx->ad_options->basic[AD_USE_LDAPS].opt_name,
               subdom->name);
-
-        return ret;
     }
 
     if (dp_opt_get_bool(ad_options->basic, AD_USE_LDAPS)) {
@@ -347,7 +345,6 @@ ad_subdom_ad_ctx_new(struct be_ctx *be_ctx,
                                     ad_options->id->basic,
                                     be_ctx->cdb, subdom_conf_path,
                                     SDAP_SASL_MECH);
-    talloc_free(subdom_conf_path);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Failed to inherit option [%s] to sub-domain [%s]. "
@@ -355,9 +352,9 @@ ad_subdom_ad_ctx_new(struct be_ctx *be_ctx,
               "behavior later on.\n",
               id_ctx->ad_options->id->basic[SDAP_SASL_MECH].opt_name,
               subdom->name);
-
-        return ret;
     }
+
+    talloc_free(subdom_conf_path);
 
     ad_site_override = dp_opt_get_string(ad_options->basic, AD_SITE);
 

--- a/src/providers/data_provider.h
+++ b/src/providers/data_provider.h
@@ -200,8 +200,12 @@ struct dp_option {
 
 #define DP_OPTION_TERMINATOR { NULL, 0, NULL_STRING, NULL_STRING }
 
-void dp_option_inherit(char **inherit_opt_list,
-                       int option,
+void dp_option_inherit_match(char **inherit_opt_list,
+                             int option,
+                             struct dp_option *parent_opts,
+                             struct dp_option *subdom_opts);
+
+void dp_option_inherit(int option,
                        struct dp_option *parent_opts,
                        struct dp_option *subdom_opts);
 

--- a/src/providers/data_provider_opts.c
+++ b/src/providers/data_provider_opts.c
@@ -22,12 +22,11 @@
 #include "data_provider.h"
 
 /* =Copy-Option-From-Subdomain-If-Allowed================================= */
-void dp_option_inherit(char **inherit_opt_list,
-                       int option,
-                       struct dp_option *parent_opts,
-                       struct dp_option *subdom_opts)
+void dp_option_inherit_match(char **inherit_opt_list,
+                             int option,
+                             struct dp_option *parent_opts,
+                             struct dp_option *subdom_opts)
 {
-    errno_t ret;
     bool inherit_option;
 
     inherit_option = string_in_list(parent_opts[option].opt_name,
@@ -39,8 +38,17 @@ void dp_option_inherit(char **inherit_opt_list,
         return;
     }
 
+    dp_option_inherit(option, parent_opts, subdom_opts);
+}
+
+void dp_option_inherit(int option,
+                       struct dp_option *parent_opts,
+                       struct dp_option *subdom_opts)
+{
+    errno_t ret;
+
     DEBUG(SSSDBG_CONF_SETTINGS,
-          "Will inherit option %s\n", parent_opts[option].opt_name);
+          "Inheriting option %s\n", parent_opts[option].opt_name);
     switch (parent_opts[option].type) {
     case DP_OPT_NUMBER:
         ret = dp_opt_set_int(subdom_opts,

--- a/src/providers/ldap/sdap.c
+++ b/src/providers/ldap/sdap.c
@@ -278,10 +278,10 @@ static void sdap_inherit_basic_options(char **inherit_opt_list,
     int i;
 
     for (i = 0; inherit_options[i] != SDAP_OPTS_BASIC; i++) {
-        dp_option_inherit(inherit_opt_list,
-                          inherit_options[i],
-                          parent_opts,
-                          subdom_opts);
+        dp_option_inherit_match(inherit_opt_list,
+                                inherit_options[i],
+                                parent_opts,
+                                subdom_opts);
     }
 }
 

--- a/src/providers/ldap/sdap.c
+++ b/src/providers/ldap/sdap.c
@@ -269,10 +269,21 @@ static void sdap_inherit_basic_options(char **inherit_opt_list,
                                        struct dp_option *subdom_opts)
 {
     int inherit_options[] = {
+        SDAP_SEARCH_TIMEOUT,
+        SDAP_NETWORK_TIMEOUT,
+        SDAP_OPT_TIMEOUT,
+        SDAP_OFFLINE_TIMEOUT,
+        SDAP_ENUM_REFRESH_TIMEOUT,
+        SDAP_ENUM_REFRESH_OFFSET,
         SDAP_PURGE_CACHE_TIMEOUT,
+        SDAP_PURGE_CACHE_OFFSET,
+        SDAP_KRB5_KEYTAB,
+        SDAP_KRB5_TICKET_LIFETIME,
+        SDAP_ENUM_SEARCH_TIMEOUT,
+        SDAP_EXPIRE_TIMEOUT,
+        SDAP_EXPIRE_OFFSET,
         SDAP_IDLE_TIMEOUT,
         SDAP_AD_USE_TOKENGROUPS,
-        SDAP_KRB5_KEYTAB,
         SDAP_OPTS_BASIC     /* sentinel */
     };
     int i;

--- a/src/tests/cmocka/test_dp_opts.c
+++ b/src/tests/cmocka/test_dp_opts.c
@@ -423,33 +423,33 @@ void opt_test_inherit(void **state)
     assert_int_equal(ret, EOK);
     assert_defaults(opts);
 
-    dp_option_inherit(NULL, OPT_STRING_NODEFAULT,
-                      opts, opts_copy);
+    dp_option_inherit_match(NULL, OPT_STRING_NODEFAULT,
+                            opts, opts_copy);
     s = dp_opt_get_string(opts_copy, OPT_STRING_NODEFAULT);
     assert_null(s);
 
     /* string */
     assert_nondefault_string_empty(opts_copy);
     set_nondefault_string(opts);
-    dp_option_inherit(discard_const(sd_inherit_match),
-                      OPT_STRING_NODEFAULT,
-                      opts, opts_copy);
+    dp_option_inherit_match(discard_const(sd_inherit_match),
+                            OPT_STRING_NODEFAULT,
+                            opts, opts_copy);
     check_nondefault_string(opts_copy);
 
     /* blob */
     assert_nondefault_blob_empty(opts_copy);
     set_nondefault_blob(opts);
-    dp_option_inherit(discard_const(sd_inherit_match),
-                      OPT_BLOB_NODEFAULT,
-                      opts, opts_copy);
+    dp_option_inherit_match(discard_const(sd_inherit_match),
+                            OPT_BLOB_NODEFAULT,
+                            opts, opts_copy);
     check_nondefault_blob(opts_copy);
 
     /* number */
     assert_nondefault_int_notset(opts_copy);
     set_nondefault_int(opts);
-    dp_option_inherit(discard_const(sd_inherit_match),
-                      OPT_INT_NODEFAULT,
-                      opts, opts_copy);
+    dp_option_inherit_match(discard_const(sd_inherit_match),
+                            OPT_INT_NODEFAULT,
+                            opts, opts_copy);
     assert_nondefault_int_set(opts_copy);
 
     /* bool */
@@ -458,9 +458,9 @@ void opt_test_inherit(void **state)
     ret = dp_opt_set_bool(opts, OPT_BOOL_TRUE, false);
     assert_int_equal(ret, EOK);
 
-    dp_option_inherit(discard_const(sd_inherit_match),
-                      OPT_BOOL_TRUE,
-                      opts, opts_copy);
+    dp_option_inherit_match(discard_const(sd_inherit_match),
+                            OPT_BOOL_TRUE,
+                            opts, opts_copy);
 
     assert_false(dp_opt_get_bool(opts_copy, OPT_BOOL_TRUE));
 }


### PR DESCRIPTION
While developing PR #6003, I discovered several issues with subdomain config inheritance.

This PR corrects those issues and adds all of the connection timeout settings to the subdomain_inherit option.