### PR TITLE
COMPONENT: sdap_handle_id_collision_for_incomplete_groups

### DIFF
--- a/src/providers/ldap/sdap_async_initgroups.c
+++ b/src/providers/ldap/sdap_async_initgroups.c
@@ -3612,7 +3612,7 @@ sdap_handle_id_collision_for_incomplete_groups(struct data_provider *dp,
         DEBUG(SSSDBG_MINOR_FAILURE,
               "Due to an id collision, the new group with gid [\"%"PRIu32"\"] "
               "will not be added as the old group (with the same gid) could "
-              "not be removed from the sysdb!",
+              "not be removed from the sysdb!\n",
               gid);
         return ret;
     }


### PR DESCRIPTION
sdap_handle_id_collision_for_incomplete_groups debug message missing a new line

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2096031