### PR TITLE
Analyzer: Fix escaping raw fstring

### DIFF
--- a/src/tools/analyzer/modules/request.py
+++ b/src/tools/analyzer/modules/request.py
@@ -243,8 +243,8 @@ class RequestAnalyzer:
         be_results = False
         component = source.Component.NSS
         resp = "nss"
-        pattern = [rf'REQ_TRACE.*\[CID #{cid}\\]']
-        pattern.append(rf"\[CID#{cid}\\]")
+        pattern = [rf'REQ_TRACE.*\[CID #{cid}\]']
+        pattern.append(rf"\[CID#{cid}\]")
 
         if args.pam:
             component = source.Component.PAM


### PR DESCRIPTION
Changes converting fstring to raw fstring in https://github.com/SSSD/sssd/pull/6196/commits/66891b60aaee108eead67254e322c52499066afc caused issues for the regex pam pattern processing in analyzer when `\\` was being used.