### PR TITLE
RESPONDER: make every cache_req to reset responder idle timer

### DIFF
--- a/src/responder/common/cache_req/cache_req.c
+++ b/src/responder/common/cache_req/cache_req.c
@@ -1109,6 +1109,9 @@ struct tevent_req *cache_req_send(TALLOC_CTX *mem_ctx,
     struct tevent_req *req;
     errno_t ret;
 
+    /* Always reset the responder idle timer on any activity */
+    rctx->last_request_time = time(NULL);
+
     req = tevent_req_create(mem_ctx, &state, struct cache_req_state);
     if (req == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "tevent_req_create() failed\n");


### PR DESCRIPTION
Currently only /var/lib/sss/pipes/ sockets activity reset idle
timer. This doesn't work for IPF responder where requests are coming
from system dbus.

Resolves: https://github.com/SSSD/sssd/issues/6269