### PR TITLE
RESPONDER: fix responder_idle_handler()

### DIFF
--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -400,7 +400,7 @@ static void responder_idle_handler(struct tevent_context *ev,
         goto end;
     }
 
-    if ((now - rctx->last_request_time) > rctx->idle_timeout) {
+    if ((now - rctx->last_request_time) >= rctx->idle_timeout) {
         /* This responder is idle. Terminate it */
         DEBUG(SSSDBG_TRACE_INTERNAL,
               "Terminating idle responder [%p]\n", rctx);


### PR DESCRIPTION
Since timer fires every timeout/2, with condition '>' it could happen
responder was terminated only after 3*timeout/2 of being idle.
Changing condition to '>=' aligns actual behavior with man page.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=2097014