### PR TITLE
SIDS: Update the well-known SID table

### DIFF
--- a/src/man/include/ldap_id_mapping.xml
+++ b/src/man/include/ldap_id_mapping.xml
@@ -291,6 +291,8 @@ ldap_schema = ad
                 <listitem><para>World Authority</para></listitem>
                 <listitem><para>Local Authority</para></listitem>
                 <listitem><para>Creator Authority</para></listitem>
+                <listitem><para>Mandatory Label Authority</para></listitem>
+                <listitem><para>Authentication Authority</para></listitem>
                 <listitem><para>NT Authority</para></listitem>
                 <listitem><para>Built-in</para></listitem>
             </itemizedlist>
@@ -303,10 +305,12 @@ ldap_schema = ad
             directly SSSD supports to look up the SID by the name as well. To
             avoid collisions only the fully qualified names can be used to look
             up Well-Known SIDs. As a result the domain names <quote>NULL
-            AUTHORITY</quote>, <quote>WORLD AUTHORITY</quote>, <quote> LOCAL
-            AUTHORITY</quote>, <quote>CREATOR AUTHORITY</quote>, <quote>NT
-            AUTHORITY</quote> and <quote>BUILTIN</quote> should not be used as
-            domain names in <filename>sssd.conf</filename>.
+            AUTHORITY</quote>, <quote>WORLD AUTHORITY</quote>, <quote>LOCAL
+            AUTHORITY</quote>, <quote>CREATOR AUTHORITY</quote>,
+            <quote>MANDATORY LABEL AUTHORITY</quote>, <quote>AUTHENTICATION
+            AUTHORITY</quote>, <quote>NT AUTHORITY</quote> and
+            <quote>BUILTIN</quote> should not be used as domain names in
+            <filename>sssd.conf</filename>.
         </para>
     </refsect2>
 

--- a/src/tests/cmocka/test_utils.c
+++ b/src/tests/cmocka/test_utils.c
@@ -1121,11 +1121,64 @@ void test_well_known_sid_to_name(void **state)
     ret = well_known_sid_to_name("S-1-0-0-", &dom, &name);
     assert_int_equal(ret, EINVAL);
 
+    ret = well_known_sid_to_name("S-1-3", &dom, &name);
+    assert_int_equal(ret, EINVAL);
+
+    ret = well_known_sid_to_name("S-1-3-", &dom, &name);
+    assert_int_equal(ret, EINVAL);
+
+    ret = well_known_sid_to_name("S-1-3-4", &dom, &name);
+    assert_int_equal(ret, EOK);
+    assert_string_equal(dom, "CREATOR AUTHORITY");
+    assert_string_equal(name, "OWNER RIGHTS");
+
+    ret = well_known_sid_to_name("S-1-16", &dom, &name);
+    assert_int_equal(ret, EINVAL);
+
+    ret = well_known_sid_to_name("S-1-16-", &dom, &name);
+    assert_int_equal(ret, EINVAL);
+
+    ret = well_known_sid_to_name("S-1-16-8192", &dom, &name);
+    assert_int_equal(ret, EOK);
+    assert_string_equal(dom, "MANDATORY LABEL AUTHORITY");
+    assert_string_equal(name, "MEDIUM");
+
+    ret = well_known_sid_to_name("S-1-18", &dom, &name);
+    assert_int_equal(ret, EINVAL);
+
+    ret = well_known_sid_to_name("S-1-18-", &dom, &name);
+    assert_int_equal(ret, EINVAL);
+
+    ret = well_known_sid_to_name("S-1-18-1", &dom, &name);
+    assert_int_equal(ret, EOK);
+    assert_string_equal(dom, "AUTHENTICATION AUTHORITY");
+    assert_string_equal(name, "AUTHENTICATION ASSERTION");
+
     ret = well_known_sid_to_name("S-1-5", &dom, &name);
     assert_int_equal(ret, EINVAL);
 
     ret = well_known_sid_to_name("S-1-5-", &dom, &name);
     assert_int_equal(ret, EINVAL);
+
+    ret = well_known_sid_to_name("S-1-5-5", &dom, &name);
+    assert_int_equal(ret, EINVAL);
+
+    ret = well_known_sid_to_name("S-1-5-5-", &dom, &name);
+    assert_int_equal(ret, EINVAL);
+
+    ret = well_known_sid_to_name("S-1-5-5-7", &dom, &name);
+    assert_int_equal(ret, EINVAL);
+
+    ret = well_known_sid_to_name("S-1-5-5-7-", &dom, &name);
+    assert_int_equal(ret, EINVAL);
+
+    ret = well_known_sid_to_name("S-1-5-5-7-8-", &dom, &name);
+    assert_int_equal(ret, EINVAL);
+
+    ret = well_known_sid_to_name("S-1-5-5-7-8", &dom, &name);
+    assert_int_equal(ret, EOK);
+    assert_string_equal(dom, "NT AUTHORITY");
+    assert_string_equal(name, "LOGON ID");
 
     ret = well_known_sid_to_name("S-1-5-6", &dom, &name);
     assert_int_equal(ret, EOK);
@@ -1158,6 +1211,33 @@ void test_well_known_sid_to_name(void **state)
     ret = well_known_sid_to_name("S-1-5-32-551-", &dom, &name);
     assert_int_equal(ret, EINVAL);
 
+    ret = well_known_sid_to_name("S-1-5-64", &dom, &name);
+    assert_int_equal(ret, EINVAL);
+
+    ret = well_known_sid_to_name("S-1-5-64-", &dom, &name);
+    assert_int_equal(ret, EINVAL);
+
+    ret = well_known_sid_to_name("S-1-5-64-10", &dom, &name);
+    assert_int_equal(ret, EOK);
+    assert_string_equal(dom, "NT AUTHORITY");
+    assert_string_equal(name, "NTLM AUTHENTICATION");
+
+    ret = well_known_sid_to_name("S-1-5-64-10-", &dom, &name);
+    assert_int_equal(ret, EINVAL);
+
+    ret = well_known_sid_to_name("S-1-5-65", &dom, &name);
+    assert_int_equal(ret, EINVAL);
+
+    ret = well_known_sid_to_name("S-1-5-65-", &dom, &name);
+    assert_int_equal(ret, EINVAL);
+
+    ret = well_known_sid_to_name("S-1-5-65-1", &dom, &name);
+    assert_int_equal(ret, EOK);
+    assert_string_equal(dom, "NT AUTHORITY");
+    assert_string_equal(name, "THIS ORGANIZATION CERTIFICATE");
+
+    ret = well_known_sid_to_name("S-1-5-65-1-", &dom, &name);
+    assert_int_equal(ret, EINVAL);
 }
 
 void test_name_to_well_known_sid(void **state)
@@ -1194,6 +1274,26 @@ void test_name_to_well_known_sid(void **state)
     ret = name_to_well_known_sid("NT AUTHORITY", "DIALUP", &sid);
     assert_int_equal(ret, EOK);
     assert_string_equal(sid, "S-1-5-1");
+
+    ret = name_to_well_known_sid("NT AUTHORITY", "NTLM AUTHENTICATION", &sid);
+    assert_int_equal(ret, EOK);
+    assert_string_equal(sid, "S-1-5-64-10");
+
+    ret = name_to_well_known_sid("NT AUTHORITY", "THIS ORGANIZATION CERTIFICATE", &sid);
+    assert_int_equal(ret, EOK);
+    assert_string_equal(sid, "S-1-5-65-1");
+
+    ret = name_to_well_known_sid("NT AUTHORITY", "LOGON ID", &sid);
+    assert_int_equal(ret, EOK);
+    assert_string_equal(sid, "S-1-5-5-0-0");
+
+    ret = name_to_well_known_sid("MANDATORY LABEL AUTHORITY", "MEDIUM", &sid);
+    assert_int_equal(ret, EOK);
+    assert_string_equal(sid, "S-1-16-8192");
+
+    ret = name_to_well_known_sid("AUTHENTICATION AUTHORITY", "KEY_TRUST_IDENTITY", &sid);
+    assert_int_equal(ret, EOK);
+    assert_string_equal(sid, "S-1-18-4");
 }
 
 #define TEST_SANITIZE_INPUT "TestUser@Test.Domain"

--- a/src/util/well_known_sids.c
+++ b/src/util/well_known_sids.c
@@ -38,17 +38,29 @@
 #define NT_SID_PREFIX_LEN (sizeof(NT_SID_PREFIX) - 1)
 #define NT_DOM_NAME "NT AUTHORITY"
 
+#define NT_AUTH_SID_PREFIX "S-1-5-64-"
+#define NT_AUTH_SID_PREFIX_LEN (sizeof(NT_AUTH_SID_PREFIX) - 1)
+#define NT_AUTH_DOM_NAME NT_DOM_NAME
+
+#define NT_THIS_SID_PREFIX "S-1-5-65-"
+#define NT_THIS_SID_PREFIX_LEN (sizeof(NT_THIS_SID_PREFIX) - 1)
+#define NT_THIS_DOM_NAME NT_DOM_NAME
+
 #define SPECIAL_SID_PREFIX "S-1-"
 #define SPECIAL_SID_PREFIX_LEN (sizeof(SPECIAL_SID_PREFIX) - 1)
 #define NULL_DOM_NAME "NULL AUTHORITY"
 #define WORLD_DOM_NAME "WORLD AUTHORITY"
 #define LOCAL_DOM_NAME "LOCAL AUTHORITY"
 #define CREATOR_DOM_NAME "CREATOR AUTHORITY"
+#define MANDATORY_DOM_NAME "MANDATORY LABEL AUTHORITY"
+#define AUTHENTICATION_DOM_NAME "AUTHENTICATION AUTHORITY"
 
 #define NT_MAP_ENTRY(rid, name) {rid, NT_SID_PREFIX #rid, name}
+#define NT_AUTH_MAP_ENTRY(rid, name) {rid, NT_AUTH_SID_PREFIX #rid, name}
+#define NT_THIS_MAP_ENTRY(rid, name) {rid, NT_THIS_SID_PREFIX #rid, name}
 #define BUILTIN_MAP_ENTRY(rid, name) {rid, BUILTIN_SID_PREFIX #rid, name}
 #define SPECIAL_MAP_ENTRY(id_auth, rid, dom, name) \
-   {(48 + id_auth), (48 + rid), SPECIAL_SID_PREFIX #id_auth "-" #rid, dom, name}
+   {id_auth, rid, SPECIAL_SID_PREFIX #id_auth "-" #rid, dom, name}
 
 struct rid_sid_name {
     uint32_t rid;
@@ -57,8 +69,8 @@ struct rid_sid_name {
 };
 
 struct special_map {
-    const char id_auth;
-    char rid;
+    uint32_t id_auth;
+    uint32_t rid;
     const char *sid;
     const char *dom;
     const char *name;
@@ -83,7 +95,7 @@ struct rid_sid_name builtin_map[] = {
     BUILTIN_MAP_ENTRY(560, "Windows Authorization Access Group"),
     BUILTIN_MAP_ENTRY(561, "Terminal Server License Servers"),
     BUILTIN_MAP_ENTRY(562, "Distributed COM Users"),
-    BUILTIN_MAP_ENTRY(568, "IIS_IUSRS"),
+    BUILTIN_MAP_ENTRY(568, "IIS Users"),
     BUILTIN_MAP_ENTRY(569, "Cryptographic Operators"),
     BUILTIN_MAP_ENTRY(573, "Event Log Readers"),
     BUILTIN_MAP_ENTRY(574, "Certificate Service DCOM Access"),
@@ -97,32 +109,50 @@ struct rid_sid_name builtin_map[] = {
     {UINT32_MAX, NULL, NULL}
 };
 
+#define LOGON_ID_NAME  "LOGON ID"
+#define LOGON_ID_MODEL "S-1-5-5-0-0"
 struct rid_sid_name nt_map[] = {
     NT_MAP_ENTRY(1, "DIALUP"),
     NT_MAP_ENTRY(2, "NETWORK"),
     NT_MAP_ENTRY(3, "BATCH"),
     NT_MAP_ENTRY(4, "INTERACTIVE"),
+    /* NT_MAP_ENTRY(5-x-y, "LOGON ID"),  special case treated separately */
     NT_MAP_ENTRY(6, "SERVICE"),
     NT_MAP_ENTRY(7, "ANONYMOUS LOGON"),
     NT_MAP_ENTRY(8, "PROXY"),
     NT_MAP_ENTRY(9, "ENTERPRISE DOMAIN CONTROLLERS"),
     NT_MAP_ENTRY(10, "SELF"),
     NT_MAP_ENTRY(11, "Authenticated Users"),
-    NT_MAP_ENTRY(12, "RESTRICTED"),
+    NT_MAP_ENTRY(12, "RESTRICTED CODE"),
     NT_MAP_ENTRY(13, "TERMINAL SERVER USER"),
     NT_MAP_ENTRY(14, "REMOTE INTERACTIVE LOGON"),
     NT_MAP_ENTRY(15, "This Organization"),
     NT_MAP_ENTRY(17, "IUSR"),
-    NT_MAP_ENTRY(18, "SYSTEM"),
+    NT_MAP_ENTRY(18, "LOCAL SYSTEM"),
     NT_MAP_ENTRY(19, "LOCAL SERVICE"),
     NT_MAP_ENTRY(20, "NETWORK SERVICE"),
+    NT_MAP_ENTRY(33, "WRITE_RESTRICTED_CODE"),
+    NT_MAP_ENTRY(80, "NT_SERVICE"),
+    NT_MAP_ENTRY(113, "LOCAL_ACCOUNT"),
+    NT_MAP_ENTRY(114, "LOCAL MEMBER OF ADMINISTRATORS GROUP"),
+    NT_MAP_ENTRY(1000, "OTHER_ORGANIZATIONS"),
 
     {UINT32_MAX, NULL, NULL}
 };
 
-/* The code to handle the SIDs of the Null, World, Local and Creator
- * Authorities (id_auth=0,1,2,3 respectively) is optimized to handle only
- * single digit id_auth and rid. */
+struct rid_sid_name nt_auth_map[] = {
+    NT_AUTH_MAP_ENTRY(10, "NTLM AUTHENTICATION"),
+    NT_AUTH_MAP_ENTRY(14, "SCHANNEL AUTHENTICATION"),
+    NT_AUTH_MAP_ENTRY(21, "DIGEST AUTHENTICATION"),
+
+    {UINT32_MAX, NULL, NULL}
+};
+
+struct rid_sid_name nt_this_map[] = {
+    NT_THIS_MAP_ENTRY(1, "THIS ORGANIZATION CERTIFICATE"),
+
+    {UINT32_MAX, NULL, NULL}
+};
 
 struct special_map sp_map[] = {
     SPECIAL_MAP_ENTRY(0, 0, NULL_DOM_NAME, "NULL SID"),
@@ -134,8 +164,20 @@ struct special_map sp_map[] = {
     SPECIAL_MAP_ENTRY(3, 2, CREATOR_DOM_NAME, "CREATOR OWNER SERVER"),
     SPECIAL_MAP_ENTRY(3, 3, CREATOR_DOM_NAME, "CREATOR GROUP SERVER"),
     SPECIAL_MAP_ENTRY(3, 4, CREATOR_DOM_NAME, "OWNER RIGHTS"),
-    SPECIAL_MAP_ENTRY(18,1, "ASSERTED IDENTITY", "AUTHENTICATION ASSERTION"),
-    SPECIAL_MAP_ENTRY(18,2, "ASSERTED IDENTITY", "SERVICE ASSERTION"),
+    SPECIAL_MAP_ENTRY(16, 0, MANDATORY_DOM_NAME, "UNTRUSTED"),
+    SPECIAL_MAP_ENTRY(16, 4096, MANDATORY_DOM_NAME, "LOW"),
+    SPECIAL_MAP_ENTRY(16, 8192, MANDATORY_DOM_NAME, "MEDIUM"),
+    SPECIAL_MAP_ENTRY(16, 8448, MANDATORY_DOM_NAME, "MEDIUM_PLUS"),
+    SPECIAL_MAP_ENTRY(16, 12288, MANDATORY_DOM_NAME, "HIGH"),
+    SPECIAL_MAP_ENTRY(16, 16384, MANDATORY_DOM_NAME, "SYSTEM"),
+    SPECIAL_MAP_ENTRY(16, 20480, MANDATORY_DOM_NAME, "PROTECTED_PROCESS"),
+    SPECIAL_MAP_ENTRY(16, 28672, MANDATORY_DOM_NAME, "SECURE_PROCESS"),
+    SPECIAL_MAP_ENTRY(18, 1, AUTHENTICATION_DOM_NAME, "AUTHENTICATION ASSERTION"),
+    SPECIAL_MAP_ENTRY(18, 2, AUTHENTICATION_DOM_NAME, "SERVICE ASSERTION"),
+    SPECIAL_MAP_ENTRY(18, 3, AUTHENTICATION_DOM_NAME, "FRESH_PUBLIC_KEY_IDENTITY"),
+    SPECIAL_MAP_ENTRY(18, 4, AUTHENTICATION_DOM_NAME, "KEY_TRUST_IDENTITY"),
+    SPECIAL_MAP_ENTRY(18, 5, AUTHENTICATION_DOM_NAME, "KEY_PROPERTY_MFA"),
+    SPECIAL_MAP_ENTRY(18, 6, AUTHENTICATION_DOM_NAME, "KEY_PROPERTY_ATTESTATION"),
 
     {'\0', '\0', NULL, NULL, NULL}
 };
@@ -144,17 +186,22 @@ static errno_t handle_special_sids(const char *sid, const char **dom,
                                    const char **name)
 {
     size_t c;
+    uint32_t rid;
+    uint32_t id_auth;
+    char *endptr;
 
-    if (!isdigit(sid[SPECIAL_SID_PREFIX_LEN])
-            || sid[SPECIAL_SID_PREFIX_LEN + 1] != '-'
-            || !isdigit(sid[SPECIAL_SID_PREFIX_LEN + 2])
-            || sid[SPECIAL_SID_PREFIX_LEN + 3] != '\0' ) {
+    id_auth = strtouint32(sid + SPECIAL_SID_PREFIX_LEN, &endptr, 10);
+    if (errno != 0 || *endptr != '-' || *(endptr + 1) == '\0') {
+        return EINVAL;
+    }
+
+    rid = strtouint32(endptr + 1, &endptr, 10);
+    if (errno != 0 || *endptr != '\0') {
         return EINVAL;
     }
 
     for (c = 0; sp_map[c].name != NULL; c++) {
-        if (sid[SPECIAL_SID_PREFIX_LEN] == sp_map[c].id_auth
-                && sid[SPECIAL_SID_PREFIX_LEN + 2] == sp_map[c].rid) {
+        if (id_auth == sp_map[c].id_auth && rid == sp_map[c].rid) {
             *name = sp_map[c].name;
             *dom = sp_map[c].dom;
             return EOK;
@@ -221,11 +268,98 @@ static errno_t handle_name_to_sid_map(const char *name,
     return EINVAL;
 }
 
+/* This function treats a particular case that does not fit in the normal table */
+static errno_t handle_nt_sids_particular_cases(const char *sid,
+                                               const char **dom,
+                                               const char **name)
+{
+    uint32_t rid;
+    char *endptr;
+    char *startptr;
+    int i;
+
+    rid = (uint32_t) strtouint32(sid + NT_SID_PREFIX_LEN, &endptr, 10);
+    if (errno != 0) {
+        return EINVAL;
+    }
+
+    if (rid == 5) {
+        /* S-1-5-5-x-y, we can ignore x and y, but they must be present.
+         * The x and y values for these SIDs are different for each logon
+         * session and are recycled when the operating system is restarted. */
+        for (i = 1; i <= 2; i++) {
+            if (*endptr != '-') {
+                return EINVAL;
+            }
+
+            startptr = endptr + 1;
+            (void) strtouint32(startptr, &endptr, 10);
+            if (errno != 0 || startptr == endptr) {
+                return EINVAL;
+            }
+        }
+        if (*endptr != '\0') {
+            return EINVAL;
+        }
+
+        *dom = NT_DOM_NAME;
+        *name = LOGON_ID_NAME;
+        return EOK;
+    }
+
+    return EINVAL;
+}
+
+static errno_t handle_nt_particular_cases(const char *name, const char **sid)
+{
+
+
+    if (strcmp(name, LOGON_ID_NAME) == 0) {
+        /* We return a model because the SID includes variable data */
+        *sid = LOGON_ID_MODEL;
+        return EOK;
+    }
+
+    return EINVAL;
+}
+
+static errno_t handle_nt_auth_sids(const char *sid, const char **dom,
+                                   const char **name)
+{
+    return handle_rid_to_name_map(sid, NT_AUTH_SID_PREFIX_LEN, nt_auth_map,
+                                  NT_AUTH_DOM_NAME, dom, name);
+}
+
+static errno_t handle_nt_auth_names(const char *name, const char **sid)
+{
+    return handle_name_to_sid_map(name, nt_auth_map, sid);
+}
+
+static errno_t handle_nt_this_sids(const char *sid, const char **dom,
+                                   const char **name)
+{
+    return handle_rid_to_name_map(sid, NT_THIS_SID_PREFIX_LEN, nt_this_map,
+                                  NT_THIS_DOM_NAME, dom, name);
+}
+
+static errno_t handle_nt_this_names(const char *name, const char **sid)
+{
+    return handle_name_to_sid_map(name, nt_this_map, sid);
+}
+
 static errno_t handle_nt_sids(const char *sid, const char **dom,
                               const char **name)
 {
-    return handle_rid_to_name_map(sid, NT_SID_PREFIX_LEN, nt_map, NT_DOM_NAME,
-                                  dom, name);
+    errno_t ret;
+
+    ret = handle_rid_to_name_map(sid, NT_SID_PREFIX_LEN, nt_map, NT_DOM_NAME,
+                                 dom, name);
+    if (ret == EINVAL) {
+        // These are a particular cases that need to be treated separately
+        ret = handle_nt_sids_particular_cases(sid, dom, name);
+    }
+
+    return ret;
 }
 
 static errno_t handle_nt_names(const char *name, const char **sid)
@@ -262,6 +396,18 @@ errno_t well_known_sid_to_name(const char *sid, const char **dom,
             DEBUG(SSSDBG_IMPORTANT_INFO,
                   "handle_builtin_sids failed for SID: %s\n", sid);
         }
+    } else if (strncmp(sid, NT_AUTH_SID_PREFIX, NT_AUTH_SID_PREFIX_LEN) == 0) {
+        ret = handle_nt_auth_sids(sid, dom, name);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_IMPORTANT_INFO,
+                  "handle_nt_auth_sids failed for SID: %s\n", sid);
+        }
+    } else if (strncmp(sid, NT_THIS_SID_PREFIX, NT_THIS_SID_PREFIX_LEN) == 0) {
+        ret = handle_nt_this_sids(sid, dom, name);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_IMPORTANT_INFO,
+                  "handle_nt_this_sids failed for SID: %s\n", sid);
+        }
     } else if (strncmp(sid, NT_SID_PREFIX, NT_SID_PREFIX_LEN) == 0) {
         ret = handle_nt_sids(sid, dom, name);
         if (ret != EOK) {
@@ -291,9 +437,23 @@ errno_t name_to_well_known_sid(const char *dom, const char *name,
     }
 
     if (strcmp(dom, NT_DOM_NAME) == 0) {
+        /* NT_DOM_NAME == NT_AUTH_DOM_NAME == NT_THIS_DOM_NAME */
         ret = handle_nt_names(name, sid);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "handle_nt_name failed.\n");
+            ret = handle_nt_auth_names(name, sid);
+            if (ret != EOK) {
+                DEBUG(SSSDBG_OP_FAILURE, "handle_nt_auth_names failed.\n");
+                ret = handle_nt_this_names(name, sid);
+                if (ret != EOK) {
+                    DEBUG(SSSDBG_OP_FAILURE, "handle_nt_this_names failed.\n");
+                    ret = handle_nt_particular_cases(name, sid);
+                    if (ret != EOK) {
+                        DEBUG(SSSDBG_OP_FAILURE,
+                              "handle_nt_particular_cases failed.\n");
+                    }
+                }
+            }
         }
     } else if (strcmp(dom, BUILTIN_DOM_NAME) == 0) {
         ret = handle_builtin_names(name, sid);
@@ -303,7 +463,9 @@ errno_t name_to_well_known_sid(const char *dom, const char *name,
     } else if (strcmp(dom, NULL_DOM_NAME) == 0
                 || strcmp(dom, WORLD_DOM_NAME) == 0
                 || strcmp(dom, LOCAL_DOM_NAME) == 0
-                || strcmp(dom, CREATOR_DOM_NAME) == 0) {
+                || strcmp(dom, CREATOR_DOM_NAME) == 0
+                || strcmp(dom, MANDATORY_DOM_NAME) == 0
+                || strcmp(dom, AUTHENTICATION_DOM_NAME) == 0) {
         ret = handle_special_names(dom, name, sid);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "handle_special_name failed.\n");


### PR DESCRIPTION
Updated the well-known SID table based on https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/81d92bba-d22b-4a8c-908a-554ab29148ab

New RIDs were added to the existing tables. Two new tables were created. One particular case was handled (S-1-1-5-5-x-y).

Resolves: https://github.com/SSSD/sssd/issues/6285