### PR TITLE
CLIENT:MC: store context mutex outside of context

### DIFF
--- a/src/sss_client/nss_mc.h
+++ b/src/sss_client/nss_mc.h
@@ -48,7 +48,7 @@ enum sss_mc_state {
 struct sss_cli_mc_ctx {
     enum sss_mc_state initialized;
 #if HAVE_PTHREAD
-    pthread_mutex_t mutex;
+    pthread_mutex_t *mutex;
 #endif
     int fd;
 
@@ -67,7 +67,7 @@ struct sss_cli_mc_ctx {
 };
 
 #if HAVE_PTHREAD
-#define SSS_CLI_MC_CTX_INITIALIZER {UNINITIALIZED, PTHREAD_MUTEX_INITIALIZER, 1, 0, NULL, 0, NULL, 0, NULL, 0, 0}
+#define SSS_CLI_MC_CTX_INITIALIZER(mtx) {UNINITIALIZED, (mtx), 1, 0, NULL, 0, NULL, 0, NULL, 0, 0}
 #else
 #define SSS_CLI_MC_CTX_INITIALIZER {UNINITIALIZED, 1, 0, NULL, 0, NULL, 0, NULL, 0, 0}
 #endif

--- a/src/sss_client/nss_mc_common.c
+++ b/src/sss_client/nss_mc_common.c
@@ -58,14 +58,14 @@ do { \
 static void sss_mt_lock(struct sss_cli_mc_ctx *ctx)
 {
 #if HAVE_PTHREAD
-    pthread_mutex_lock(&ctx->mutex);
+    pthread_mutex_lock(ctx->mutex);
 #endif
 }
 
 static void sss_mt_unlock(struct sss_cli_mc_ctx *ctx)
 {
 #if HAVE_PTHREAD
-    pthread_mutex_unlock(&ctx->mutex);
+    pthread_mutex_unlock(ctx->mutex);
 #endif
 }
 
@@ -131,6 +131,9 @@ errno_t sss_nss_check_header(struct sss_cli_mc_ctx *ctx)
 static void sss_nss_mc_destroy_ctx(struct sss_cli_mc_ctx *ctx)
 {
     uint32_t active_threads = ctx->active_threads;
+#if HAVE_PTHREAD
+    pthread_mutex_t *mutex = ctx->mutex;
+#endif
 
     if ((ctx->mmap_base != NULL) && (ctx->mmap_size != 0)) {
         munmap(ctx->mmap_base, ctx->mmap_size);
@@ -143,6 +146,9 @@ static void sss_nss_mc_destroy_ctx(struct sss_cli_mc_ctx *ctx)
 
     /* restore count of active threads */
     ctx->active_threads = active_threads;
+#if HAVE_PTHREAD
+    ctx->mutex = mutex;
+#endif
 }
 
 static errno_t sss_nss_mc_init_ctx(const char *name,

--- a/src/sss_client/nss_mc_group.c
+++ b/src/sss_client/nss_mc_group.c
@@ -29,7 +29,12 @@
 #include "nss_mc.h"
 #include "shared/safealign.h"
 
+#if HAVE_PTHREAD
+static pthread_mutex_t gr_mc_ctx_mutex = PTHREAD_MUTEX_INITIALIZER;
+static struct sss_cli_mc_ctx gr_mc_ctx = SSS_CLI_MC_CTX_INITIALIZER(&gr_mc_ctx_mutex);
+#else
 static struct sss_cli_mc_ctx gr_mc_ctx = SSS_CLI_MC_CTX_INITIALIZER;
+#endif
 
 static errno_t sss_nss_mc_parse_result(struct sss_mc_rec *rec,
                                        struct group *result,

--- a/src/sss_client/nss_mc_initgr.c
+++ b/src/sss_client/nss_mc_initgr.c
@@ -32,7 +32,12 @@
 #include "nss_mc.h"
 #include "shared/safealign.h"
 
+#if HAVE_PTHREAD
+static pthread_mutex_t initgr_mc_ctx_mutex = PTHREAD_MUTEX_INITIALIZER;
+static struct sss_cli_mc_ctx initgr_mc_ctx = SSS_CLI_MC_CTX_INITIALIZER(&initgr_mc_ctx_mutex);
+#else
 static struct sss_cli_mc_ctx initgr_mc_ctx = SSS_CLI_MC_CTX_INITIALIZER;
+#endif
 
 static errno_t sss_nss_mc_parse_result(struct sss_mc_rec *rec,
                                        long int *start, long int *size,

--- a/src/sss_client/nss_mc_passwd.c
+++ b/src/sss_client/nss_mc_passwd.c
@@ -28,7 +28,12 @@
 #include <time.h>
 #include "nss_mc.h"
 
+#if HAVE_PTHREAD
+static pthread_mutex_t pw_mc_ctx_mutex = PTHREAD_MUTEX_INITIALIZER;
+static struct sss_cli_mc_ctx pw_mc_ctx = SSS_CLI_MC_CTX_INITIALIZER(&pw_mc_ctx_mutex);
+#else
 static struct sss_cli_mc_ctx pw_mc_ctx = SSS_CLI_MC_CTX_INITIALIZER;
+#endif
 
 static errno_t sss_nss_mc_parse_result(struct sss_mc_rec *rec,
                                        struct passwd *result,

--- a/src/sss_client/nss_mc_sid.c
+++ b/src/sss_client/nss_mc_sid.c
@@ -30,7 +30,12 @@
 #include "util/mmap_cache.h"
 #include "idmap/sss_nss_idmap.h"
 
+#if HAVE_PTHREAD
+static pthread_mutex_t sid_mc_ctx_mutex = PTHREAD_MUTEX_INITIALIZER;
+static struct sss_cli_mc_ctx sid_mc_ctx = SSS_CLI_MC_CTX_INITIALIZER(&sid_mc_ctx_mutex);
+#else
 static struct sss_cli_mc_ctx sid_mc_ctx = SSS_CLI_MC_CTX_INITIALIZER;
+#endif
 
 static errno_t mc_get_sid_by_typed_id(uint32_t id, enum sss_id_type object_type,
                                       char **sid, uint32_t *type,


### PR DESCRIPTION
as it should survive context destruction / re-initialization