### PR TITLE
Tests: Add missing URI for device restriction

### DIFF
--- a/src/tests/cmocka/test_pam_srv.c
+++ b/src/tests/cmocka/test_pam_srv.c
@@ -324,6 +324,7 @@ static int pam_test_setup_no_verification(void **state)
     };
 
     struct sss_test_conf_param pam_params[] = {
+        { CONFDB_PAM_P11_URI, "pkcs11:manufacturer=SoftHSM%20project" },
         { "p11_child_timeout", "30" },
         { NULL, NULL }, /* Sentinel */
     };


### PR DESCRIPTION
This is an addendum to https://github.com/SSSD/sssd/pull/5945

This fixes an issue when running unit tests on a system (f34) with a yubikey inserted. This was done already for other pam-srv tests but some pam cert auth tests were added since then which need to be covered.

