### PR TITLE
CACHE_REQ: Fix hybrid lookup log spamming

### DIFF
--- a/src/responder/nss/nss_get_object.c
+++ b/src/responder/nss/nss_get_object.c
@@ -171,7 +171,9 @@ hybrid_domain_retry_data(TALLOC_CTX *mem_ctx,
                                           input_name);
     }
 
-    cache_req_data_set_hybrid_lookup(hybrid_data, true);
+    if (hybrid_data != NULL) {
+        cache_req_data_set_hybrid_lookup(hybrid_data, true);
+    }
 
     return hybrid_data;
 }


### PR DESCRIPTION
Skip calling cache_req_data_set_hybrid_lookup() when hybrid data is NULL for certain NSS request types (e.g. Service by Name).

Fixes an issue with `auto_private_groups = hybrid` causing this below message to be spammed in the logs.
~~~
[nss] [cache_req_data_set_hybrid_lookup] (0x0020): cache_req_data should never be NULL
~~~