### PR TITLE
ci: fix copr builds

### DIFF
--- a/.github/workflows/copr_build.yml
+++ b/.github/workflows/copr_build.yml
@@ -68,7 +68,7 @@ jobs:
       id: chroots
       uses: next-actions/copr/filter-chroots@master
       with:
-        coprcfg: ${{ secrets.COPR_SECRETS }}
+        coprcfg: ${{ steps.copr.outputs.coprcfg }}
         filter: "fedora-.+-x86_64|centos-stream-.*-x86_64"
         exclude: "fedora-eln-.+"
 


### PR DESCRIPTION
We were giving the whole API token to chroot command instead of
configuration file. For some reason, this used to work before.