### PR TITLE
TESTS: Add status field in docstrings

### DIFF
--- a/src/tests/multihost/ad/test_ad_misc.py
+++ b/src/tests/multihost/ad/test_ad_misc.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 import time
 import tempfile

--- a/src/tests/multihost/ad/test_adparameters.py
+++ b/src/tests/multihost/ad/test_adparameters.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 from __future__ import print_function
 import time

--- a/src/tests/multihost/ad/test_adparameters_ported.py
+++ b/src/tests/multihost/ad/test_adparameters_ported.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 # pylint: disable=too-many-lines
 import time

--- a/src/tests/multihost/ad/test_adschema.py
+++ b/src/tests/multihost/ad/test_adschema.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 :caseautomation: Automated
 :testtype: functional
 """

--- a/src/tests/multihost/ad/test_automount.py
+++ b/src/tests/multihost/ad/test_automount.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 
 from __future__ import print_function

--- a/src/tests/multihost/ad/test_cifs.py
+++ b/src/tests/multihost/ad/test_cifs.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 import time
 import pytest

--- a/src/tests/multihost/ad/test_hostkeytabrotation.py
+++ b/src/tests/multihost/ad/test_hostkeytabrotation.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 
 from __future__ import print_function

--- a/src/tests/multihost/ad/test_id_mapping.py
+++ b/src/tests/multihost/ad/test_id_mapping.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 import re
 import time

--- a/src/tests/multihost/ad/test_memcache_sid.py
+++ b/src/tests/multihost/ad/test_memcache_sid.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 
 import pytest

--- a/src/tests/multihost/ad/test_samba_data.py
+++ b/src/tests/multihost/ad/test_samba_data.py
@@ -4,6 +4,7 @@
 :requirement: Add support for passing --add-samba-data to adcli
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 from __future__ import print_function
 import subprocess

--- a/src/tests/multihost/ad/test_sudo.py
+++ b/src/tests/multihost/ad/test_sudo.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 import time
 import re

--- a/src/tests/multihost/alltests/test_automount.py
+++ b/src/tests/multihost/alltests/test_automount.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 
 from __future__ import print_function

--- a/src/tests/multihost/alltests/test_autoprivategroup.py
+++ b/src/tests/multihost/alltests/test_autoprivategroup.py
@@ -5,6 +5,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 from __future__ import print_function
 import pytest

--- a/src/tests/multihost/alltests/test_backtrace.py
+++ b/src/tests/multihost/alltests/test_backtrace.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1949149
 """
 

--- a/src/tests/multihost/alltests/test_config_merging.py
+++ b/src/tests/multihost/alltests/test_config_merging.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 from __future__ import print_function
 import re

--- a/src/tests/multihost/alltests/test_config_validation.py
+++ b/src/tests/multihost/alltests/test_config_validation.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 
 from __future__ import print_function

--- a/src/tests/multihost/alltests/test_default_debug_level.py
+++ b/src/tests/multihost/alltests/test_default_debug_level.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 
 from __future__ import print_function

--- a/src/tests/multihost/alltests/test_failover.py
+++ b/src/tests/multihost/alltests/test_failover.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 import pytest
 from sssd.testlib.common.utils import sssdTools

--- a/src/tests/multihost/alltests/test_hosts.py
+++ b/src/tests/multihost/alltests/test_hosts.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 from __future__ import print_function
 from sssd.testlib.common.utils import sssdTools, LdapOperations

--- a/src/tests/multihost/alltests/test_journald.py
+++ b/src/tests/multihost/alltests/test_journald.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 from __future__ import print_function
 import pytest

--- a/src/tests/multihost/alltests/test_kcm.py
+++ b/src/tests/multihost/alltests/test_kcm.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 
 from __future__ import print_function

--- a/src/tests/multihost/alltests/test_krb5.py
+++ b/src/tests/multihost/alltests/test_krb5.py
@@ -2,6 +2,7 @@
 
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 from __future__ import print_function
 import pytest

--- a/src/tests/multihost/alltests/test_krb_fips.py
+++ b/src/tests/multihost/alltests/test_krb_fips.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 
 import time

--- a/src/tests/multihost/alltests/test_krb_ldap_connection.py
+++ b/src/tests/multihost/alltests/test_krb_ldap_connection.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 from __future__ import print_function
 import subprocess

--- a/src/tests/multihost/alltests/test_krb_ldap_connection_gssapi.py
+++ b/src/tests/multihost/alltests/test_krb_ldap_connection_gssapi.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 from __future__ import print_function
 import time

--- a/src/tests/multihost/alltests/test_ldap_extra_attrs.py
+++ b/src/tests/multihost/alltests/test_ldap_extra_attrs.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 from __future__ import print_function
 import re

--- a/src/tests/multihost/alltests/test_ldap_library_debug_level.py
+++ b/src/tests/multihost/alltests/test_ldap_library_debug_level.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 from __future__ import print_function
 import re

--- a/src/tests/multihost/alltests/test_ldap_time_logging.py
+++ b/src/tests/multihost/alltests/test_ldap_time_logging.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1925559
 """
 from __future__ import print_function

--- a/src/tests/multihost/alltests/test_local_overrides.py
+++ b/src/tests/multihost/alltests/test_local_overrides.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 from __future__ import print_function
 import pytest

--- a/src/tests/multihost/alltests/test_misc.py
+++ b/src/tests/multihost/alltests/test_misc.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 
 from __future__ import print_function

--- a/src/tests/multihost/alltests/test_misc_proxy.py
+++ b/src/tests/multihost/alltests/test_misc_proxy.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 from __future__ import print_function
 import subprocess

--- a/src/tests/multihost/alltests/test_multidomain.py
+++ b/src/tests/multihost/alltests/test_multidomain.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 from __future__ import print_function
 import re

--- a/src/tests/multihost/alltests/test_netgroup.py
+++ b/src/tests/multihost/alltests/test_netgroup.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 
 import time

--- a/src/tests/multihost/alltests/test_ns_account_lock.py
+++ b/src/tests/multihost/alltests/test_ns_account_lock.py
@@ -2,6 +2,7 @@
 
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 :requirement: ns_account_lock
 :casecomponent: sssd
 """

--- a/src/tests/multihost/alltests/test_offline.py
+++ b/src/tests/multihost/alltests/test_offline.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 from __future__ import print_function
 import time

--- a/src/tests/multihost/alltests/test_password_policy.py
+++ b/src/tests/multihost/alltests/test_password_policy.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 from __future__ import print_function
 import re

--- a/src/tests/multihost/alltests/test_proxy.py
+++ b/src/tests/multihost/alltests/test_proxy.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 
 

--- a/src/tests/multihost/alltests/test_proxy_provider_krb_auth.py
+++ b/src/tests/multihost/alltests/test_proxy_provider_krb_auth.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 from __future__ import print_function
 import pytest

--- a/src/tests/multihost/alltests/test_rfc2307.py
+++ b/src/tests/multihost/alltests/test_rfc2307.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 from __future__ import print_function
 import pytest

--- a/src/tests/multihost/alltests/test_services.py
+++ b/src/tests/multihost/alltests/test_services.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 from __future__ import print_function
 import subprocess

--- a/src/tests/multihost/alltests/test_ssh_authorizedkeys.py
+++ b/src/tests/multihost/alltests/test_ssh_authorizedkeys.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 
 import pytest

--- a/src/tests/multihost/alltests/test_sss_cache.py
+++ b/src/tests/multihost/alltests/test_sss_cache.py
@@ -3,6 +3,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 from __future__ import print_function
 import pytest

--- a/src/tests/multihost/alltests/test_sssctl_analyzer.py
+++ b/src/tests/multihost/alltests/test_sssctl_analyzer.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 import pytest
 import re

--- a/src/tests/multihost/alltests/test_sssctl_ldap.py
+++ b/src/tests/multihost/alltests/test_sssctl_ldap.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 
 from __future__ import print_function

--- a/src/tests/multihost/alltests/test_sssctl_local.py
+++ b/src/tests/multihost/alltests/test_sssctl_local.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 from __future__ import print_function
 import pytest

--- a/src/tests/multihost/alltests/test_sssd_nss.py
+++ b/src/tests/multihost/alltests/test_sssd_nss.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 from __future__ import print_function
 import time

--- a/src/tests/multihost/alltests/test_sudo.py
+++ b/src/tests/multihost/alltests/test_sudo.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 import time
 import re

--- a/src/tests/multihost/basic/test_basic.py
+++ b/src/tests/multihost/basic/test_basic.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 import time
 import configparser as ConfigParser

--- a/src/tests/multihost/basic/test_config.py
+++ b/src/tests/multihost/basic/test_config.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 
 from utils_config import set_param, remove_section

--- a/src/tests/multihost/basic/test_files.py
+++ b/src/tests/multihost/basic/test_files.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 import pytest
 

--- a/src/tests/multihost/basic/test_ifp.py
+++ b/src/tests/multihost/basic/test_ifp.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 
 

--- a/src/tests/multihost/basic/test_kcm.py
+++ b/src/tests/multihost/basic/test_kcm.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 import os
 import re

--- a/src/tests/multihost/basic/test_ldap.py
+++ b/src/tests/multihost/basic/test_ldap.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 
 import pytest

--- a/src/tests/multihost/basic/test_sssctl_config_check.py
+++ b/src/tests/multihost/basic/test_sssctl_config_check.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 
 import re

--- a/src/tests/multihost/basic/test_sudo.py
+++ b/src/tests/multihost/basic/test_sudo.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 
 import time

--- a/src/tests/multihost/ipa/test_adhbac.py
+++ b/src/tests/multihost/ipa/test_adhbac.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 import pytest
 import re

--- a/src/tests/multihost/ipa/test_adtrust.py
+++ b/src/tests/multihost/ipa/test_adtrust.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 
 import random

--- a/src/tests/multihost/ipa/test_hbac.py
+++ b/src/tests/multihost/ipa/test_hbac.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 import pytest
 import time

--- a/src/tests/multihost/ipa/test_misc.py
+++ b/src/tests/multihost/ipa/test_misc.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 
 import re

--- a/src/tests/multihost/ipa/test_subid_ranges.py
+++ b/src/tests/multihost/ipa/test_subid_ranges.py
@@ -4,6 +4,7 @@
 :casecomponent: sssd
 :subsystemteam: sst_idm_sssd
 :upstream: yes
+:status: approved
 """
 
 import re


### PR DESCRIPTION
Imported tests into the internal test case management system are set to
draft state. This has to be manually moved into approved state. Adding
this field set with 'approved' state would prevent us from missing to
updated the state and also avoid the extra manual step.