### PR TITLE
SSSCTL: Allow analyzer to work without SSSD setup

### DIFF
--- a/src/tools/sssctl/sssctl.c
+++ b/src/tools/sssctl/sssctl.c
@@ -296,7 +296,7 @@ int main(int argc, const char **argv)
         SSS_TOOL_COMMAND("logs-remove", "Remove existing SSSD log files", 0, sssctl_logs_remove),
         SSS_TOOL_COMMAND("logs-fetch", "Archive SSSD log files in tarball", 0, sssctl_logs_fetch),
         SSS_TOOL_COMMAND("debug-level", "Change or print information about SSSD debug level", 0, sssctl_debug_level),
-        SSS_TOOL_COMMAND("analyze", "Analyze logged data", 0, sssctl_analyze),
+        SSS_TOOL_COMMAND_FLAGS("analyze", "Analyze logged data", 0, sssctl_analyze, SSS_TOOL_FLAG_SKIP_CMD_INIT),
 #ifdef HAVE_LIBINI_CONFIG_V1_3
         SSS_TOOL_DELIMITER("Configuration files tools:"),
         SSS_TOOL_COMMAND_FLAGS("config-check", "Perform static analysis of SSSD configuration", 0, sssctl_config_check, SSS_TOOL_FLAG_SKIP_CMD_INIT),


### PR DESCRIPTION
Fixes an issue when the sssctl analyzer option is used on systems where SSSD is not running or configured. This is
an expected use case when using --logdir option to analyze external log files.

The Analyzer tool does not read any information from SSSD cache or configuration