### PR TITLE
Fix new pycodestyle E275 requirement

### DIFF
--- a/src/config/SSSDConfigTest.py
+++ b/src/config/SSSDConfigTest.py
@@ -45,7 +45,7 @@ def create_temp_dir():
 
 
 def striplist(the_list):
-    return([x.strip() for x in the_list])
+    return ([x.strip() for x in the_list])
 
 
 class SSSDConfigTestValid(unittest.TestCase):

--- a/src/tests/multihost/data/memcachesize.py
+++ b/src/tests/multihost/data/memcachesize.py
@@ -77,7 +77,7 @@ class LookupPerf(object):
                 timestamp = now.strftime("%H:%M:%S:%f")[:-3]
                 print("j = %d, %s, %s" % (j, ug_name, timestamp))
                 if self.find_nss(strace_file, ug_name, i):
-                    return(i)
+                    return (i)
             k1 = int(i / 5)
             k2 = int((2 * i) / 5)
             k3 = int((3 * i) / 5)

--- a/src/tests/multihost/sssd/testlib/common/expect.py
+++ b/src/tests/multihost/sssd/testlib/common/expect.py
@@ -75,7 +75,7 @@ class pexpect_ssh(object):
         if raiseonerr:
             if (int(returncode)) != 0:
                 raise OSException('Command failed with err: %s' % (output_str))
-        return(output_str, returncode)
+        return (output_str, returncode)
 
     def logout(self):
         """ Logout of ssh session """

--- a/src/tests/multihost/sssd/testlib/common/utils.py
+++ b/src/tests/multihost/sssd/testlib/common/utils.py
@@ -564,7 +564,7 @@ class sssdTools(object):
         if cmd.returncode != 0:
             raise SSSDException("Error: %s", cmd.stderr_text)
         else:
-            return(True, cmd.stdout_text)
+            return (True, cmd.stdout_text)
 
     def su_success(self, username, password='Secret123', with_password=True):
         """Helper function for testing su access


### PR DESCRIPTION
Per the pycodestyle changelog https://pypi.org/project/pycodestyle/

2.9.0 (2022-07-30)

Changes:
E275: requires whitespace around keywords. PR #1063.