### PR TITLE
MAN: Remove duplicate dns options

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -3539,8 +3539,8 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                             trying next DNS server.
                         </para>
                         <para>
-                                The AD provider will use this option for the
-                                CLDAP ping timeouts as well.
+                            The AD provider will use this option for the
+                            CLDAP ping timeouts as well.
                         </para>
                         <para>
                             Please see the section <quote>FAILOVER</quote>
@@ -3560,46 +3560,7 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                             Defines the amount of time (in seconds) to
                             wait to resolve single DNS query
                             (e.g. resolution of a hostname or an SRV record)
-                            before try next hostname or DNS discovery.
-                        </para>
-                        <para>
-                            Please see the section <quote>FAILOVER</quote>
-                            for more information about the service
-                            resolution.
-                        </para>
-                        <para>
-                            Default: 3
-                        </para>
-                    </listitem>
-                </varlistentry>
-
-                <varlistentry>
-                    <term>dns_resolver_server_timeout (integer)</term>
-                    <listitem>
-                        <para>
-                            Defines the amount of time (in milliseconds)
-                            SSSD would try to talk to DNS server before
-                            trying next DNS server.
-                        </para>
-                        <para>
-                            Please see the section <quote>FAILOVER</quote>
-                            for more information about the service
-                            resolution.
-                        </para>
-                        <para>
-                            Default: 1000
-                        </para>
-                    </listitem>
-                </varlistentry>
-
-                <varlistentry>
-                    <term>dns_resolver_op_timeout (integer)</term>
-                    <listitem>
-                        <para>
-                            Defines the amount of time (in seconds) to
-                            wait to resolve single DNS query
-                            (e.g. resolution of a hostname or an SRV record)
-                            before try next hostname or DNS discovery.
+                            before trying the next hostname or DNS discovery.
                         </para>
                         <para>
                             Please see the section <quote>FAILOVER</quote>


### PR DESCRIPTION
`dns_resolver_server_timeout` and `dns_resolver_op_timeout` are shown twice.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2115171