### PR TITLE
BUILD: Accept krb5 1.20 for building the PAC plugin

### DIFF
--- a/src/external/pac_responder.m4
+++ b/src/external/pac_responder.m4
@@ -21,7 +21,8 @@ then
         Kerberos\ 5\ release\ 1.16* | \
         Kerberos\ 5\ release\ 1.17* | \
         Kerberos\ 5\ release\ 1.18* | \
-        Kerberos\ 5\ release\ 1.19*)
+        Kerberos\ 5\ release\ 1.19* | \
+        Kerberos\ 5\ release\ 1.20*)
             krb5_version_ok=yes
             AC_MSG_RESULT([yes])
             ;;

--- a/src/sss_client/krb5_authdata_int.h
+++ b/src/sss_client/krb5_authdata_int.h
@@ -160,7 +160,7 @@ typedef krb5_error_code
                              void *dst_request_context);
 
 typedef struct krb5plugin_authdata_client_ftable_v0 {
-    char *name;
+    const char *name;
     krb5_authdatatype *ad_type_list;
     authdata_client_plugin_init_proc init;
     authdata_client_plugin_fini_proc fini;

--- a/src/sss_client/sssd_pac.c
+++ b/src/sss_client/sssd_pac.c
@@ -302,7 +302,7 @@ sssdpac_internalize(krb5_context kcontext,
 static krb5_authdatatype sssdpac_ad_types[] = { KRB5_AUTHDATA_WIN2K_PAC, 0 };
 
 krb5plugin_authdata_client_ftable_v0 authdata_client_0 = {
-    ((void *)((uintptr_t)("sssd_sssdpac"))),
+    "sssd_sssdpac",
     sssdpac_ad_types,
     sssdpac_init,
     sssdpac_fini,


### PR DESCRIPTION
Additionally following MIT Kerberos the 'name' member of struct
krb5plugin_authdata_client_ftable_v0 is made 'const' and the related
code to set the name is simplified.

Resolves: https://github.com/SSSD/sssd/issues/6306