### PR TITLE
Tests: Skip TestBugzillaAutomation::test_0016_forceLDAPS on Windows 2012

### DIFF
--- a/src/tests/multihost/ad/test_adparameters.py
+++ b/src/tests/multihost/ad/test_adparameters.py
@@ -594,6 +594,10 @@ class TestBugzillaAutomation(object):
           1. User information should be returned correctly
           2. Logs should show that port 636 was used to contact AD
         """
+        winver = multihost.ad[0].run_command(
+            "systeminfo", raiseonerr=False).stdout_text
+        if "Microsoft Windows Server 2012" in winver:
+            pytest.skip("Test not valid on windows 2012R2.")
         adjoin(membersw='adcli')
         (aduser, adgroup) = create_aduser_group
         client = sssdTools(multihost.client[0], multihost.ad[0])


### PR DESCRIPTION
Skip the test as it is not valid on Windows 2012R2.
https://bugzilla.redhat.com/show_bug.cgi?id=1822087