### PR TITLE
CLIENT: fix thread unsafe acces to get*ent structs.

### DIFF
--- a/src/sss_client/nss_group.c
+++ b/src/sss_client/nss_group.c
@@ -19,6 +19,8 @@
 
 /* GROUP database NSS interface */
 
+#include "config.h"
+
 #include <nss.h>
 #include <errno.h>
 #include <sys/types.h>
@@ -31,7 +33,11 @@
 #include "nss_mc.h"
 #include "nss_common.h"
 
-static struct sss_nss_getgrent_data {
+static
+#ifdef HAVE_PTHREAD_EXT
+__thread
+#endif
+struct sss_nss_getgrent_data {
     size_t len;
     size_t ptr;
     uint8_t *data;
@@ -53,7 +59,11 @@ enum sss_nss_gr_type {
     GETGR_GID
 };
 
-static struct sss_nss_getgr_data {
+static
+#ifdef HAVE_PTHREAD_EXT
+__thread
+#endif
+struct sss_nss_getgr_data {
     enum sss_nss_gr_type type;
     union {
         char *grname;

--- a/src/sss_client/nss_hosts.c
+++ b/src/sss_client/nss_hosts.c
@@ -20,6 +20,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "config.h"
+
 #include <nss.h>
 #include <netdb.h>
 #include <resolv.h>
@@ -33,7 +35,11 @@
 #include <string.h>
 #include "sss_cli.h"
 
-static struct sss_nss_gethostent_data {
+static
+#ifdef HAVE_PTHREAD_EXT
+__thread
+#endif
+struct sss_nss_gethostent_data {
     size_t len;
     size_t ptr;
     uint8_t *data;

--- a/src/sss_client/nss_ipnetworks.c
+++ b/src/sss_client/nss_ipnetworks.c
@@ -20,6 +20,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "config.h"
+
 #include <nss.h>
 #include <netdb.h>
 #include <resolv.h>
@@ -33,7 +35,11 @@
 #include <string.h>
 #include "sss_cli.h"
 
-static struct sss_nss_getnetent_data {
+static
+#ifdef HAVE_PTHREAD_EXT
+__thread
+#endif
+struct sss_nss_getnetent_data {
     size_t len;
     size_t ptr;
     uint8_t *data;

--- a/src/sss_client/nss_passwd.c
+++ b/src/sss_client/nss_passwd.c
@@ -19,6 +19,8 @@
 
 /* PASSWD database NSS interface */
 
+#include "config.h"
+
 #include <nss.h>
 #include <errno.h>
 #include <sys/types.h>
@@ -30,7 +32,11 @@
 #include "nss_mc.h"
 #include "nss_common.h"
 
-static struct sss_nss_getpwent_data {
+static
+#ifdef HAVE_PTHREAD_EXT
+__thread
+#endif
+struct sss_nss_getpwent_data {
     size_t len;
     size_t ptr;
     uint8_t *data;

--- a/src/sss_client/nss_services.c
+++ b/src/sss_client/nss_services.c
@@ -20,6 +20,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "config.h"
+
 #include <nss.h>
 #include <netdb.h>
 #include <errno.h>
@@ -31,7 +33,11 @@
 #include <string.h>
 #include "sss_cli.h"
 
-static struct sss_nss_getservent_data {
+static
+#ifdef HAVE_PTHREAD_EXT
+__thread
+#endif
+struct sss_nss_getservent_data {
     size_t len;
     size_t ptr;
     uint8_t *data;


### PR DESCRIPTION
All get*ent structs were protected with socket mutex. In case SSSD
is built with lock-free client support, `sss_nss_lock()` is a no-op,
thus resulting in thread unsafe access.

This patch changes those structs to have thread local storage.

This conradicts following note in the man page:
```
The function getgrent_r() is not really reentrant since it shares
the reading position in the stream with all other threads.
```
I'm not sure if 3rd party apps can legally assume this behaviour
based on a note in a man page. And in some cases, non-sharing reading
position between threads might make more sense.
But that way or another, this is better than thread unsafe access.