### PR TITLE
ci: add final result to workflows

### DIFF
--- a/.github/workflows/analyze-target.yml
+++ b/.github/workflows/analyze-target.yml
@@ -81,3 +81,13 @@ jobs:
         name: covscan
         path: |
           ./logs/*.err
+
+  result:
+    name: All tests are successful
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: [cppcheck, covscan]
+    steps:
+      - name: Fail on failure
+        if: ${{ needs.cppcheck.result != 'success' || needs.covscan.result != 'success' }}
+        run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,3 +244,13 @@ jobs:
           multihost-build.log
           multihost-install.log
           multihost-pytest.log
+
+  result:
+    name: All tests are successful
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: [build, intgcheck, multihost]
+    steps:
+      - name: Fail on failure
+        if: ${{ needs.build.result != 'success' || needs.intgcheck.result != 'success' || needs.multihost.result != 'success' }}
+        run: exit 1

--- a/.github/workflows/copr_build.yml
+++ b/.github/workflows/copr_build.yml
@@ -136,3 +136,13 @@ jobs:
         chroots: ${{ matrix.chroot }}
         project: ${{ env.COPR_PROJECT }}
         account: ${{ env.COPR_ACCOUNT }}
+
+  result:
+    name: All copr builds are successful
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Fail on failure
+        if: ${{ needs.build.result != 'success' }}
+        run: exit 1

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -53,3 +53,13 @@ jobs:
       with:
           token: ${{ secrets.GITHUB_TOKEN }}
           failIf: new
+
+  result:
+    name: All tests are successful
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: [codeql, flake8]
+    steps:
+      - name: Fail on failure
+        if: ${{ needs.codeql.result != 'success' || needs.flake8.result != 'success' }}
+        run: exit 1


### PR DESCRIPTION
Given that we have many jobs running as part of the pull request CI it
is quite simple to miss that one of the job has failed.

This commit adds a placeholder job that holds the final result of each
workflow. These jobs are added as 'required to succeed' in GitHub repository
settings to make potential failures more visible.

If one of the job fails, the status check web ui is visible red so it is
simple to spot a failure.