### PR TITLE
SSSCTL: Add passkey exec command

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1919,6 +1919,9 @@ sssctl_SOURCES = \
     src/tools/sssctl/sssctl_cert.c \
     $(SSSD_TOOLS_OBJ) \
     $(NULL)
+if BUILD_PASSKEY
+    sssctl_SOURCES += src/tools/sssctl/sssctl_passkey.c
+endif
 sssctl_LDADD = \
     $(TOOLS_LIBS) \
     $(INI_CONFIG_LIBS) \

--- a/src/tools/sssctl/sssctl.c
+++ b/src/tools/sssctl/sssctl.c
@@ -97,6 +97,30 @@ sssctl_prompt(const char *message,
     return SSSCTL_PROMPT_ERROR;
 }
 
+errno_t sssctl_wrap_command(const char *command,
+                            struct sss_cmdline *cmdline,
+                            struct sss_tool_ctx *tool_ctx,
+                            void *pvt)
+{
+    errno_t ret;
+
+    const char **args = talloc_array_size(tool_ctx,
+                                          sizeof(char *),
+                                          cmdline->argc + 2);
+    if (!args) {
+        return ENOMEM;
+    }
+    memcpy(&args[1], cmdline->argv, sizeof(char *) * cmdline->argc);
+    args[0] = command;
+    args[cmdline->argc + 1] = NULL;
+
+    ret = sssctl_run_command(args);
+
+    talloc_free(args);
+
+    return ret;
+}
+
 errno_t sssctl_run_command(const char *const argv[])
 {
     int ret;
@@ -305,6 +329,10 @@ int main(int argc, const char **argv)
         SSS_TOOL_DELIMITER("Certificate related tools:"),
         SSS_TOOL_COMMAND("cert-show", "Print information about the certificate", 0, sssctl_cert_show),
         SSS_TOOL_COMMAND("cert-map", "Show users mapped to the certificate", 0, sssctl_cert_map),
+#ifdef BUILD_PASSKEY
+        SSS_TOOL_DELIMITER("Passkey related tools:"),
+        SSS_TOOL_COMMAND("passkey-exec", "Perform passkey related operations", 0, sssctl_passkey_exec),
+#endif
         SSS_TOOL_LAST
     };
 

--- a/src/tools/sssctl/sssctl.h
+++ b/src/tools/sssctl/sssctl.h
@@ -47,6 +47,10 @@ enum sssctl_prompt_result
 sssctl_prompt(const char *message,
               enum sssctl_prompt_result defval);
 
+errno_t sssctl_wrap_command(const char *command,
+                            struct sss_cmdline *cmdline,
+                            struct sss_tool_ctx *tool_ctx,
+                            void *pvt);
 errno_t sssctl_run_command(const char *const argv[]); /* argv[0] - command */
 bool sssctl_start_sssd(bool force);
 bool sssctl_stop_sssd(bool force);
@@ -135,4 +139,9 @@ errno_t sssctl_cert_show(struct sss_cmdline *cmdline,
 errno_t sssctl_cert_map(struct sss_cmdline *cmdline,
                         struct sss_tool_ctx *tool_ctx,
                         void *pvt);
+#ifdef BUILD_PASSKEY
+errno_t sssctl_passkey_exec(struct sss_cmdline *cmdline,
+                            struct sss_tool_ctx *tool_ctx,
+                            void *pvt);
+#endif /* BUILD_PASSKEY */
 #endif /* _SSSCTL_H_ */

--- a/src/tools/sssctl/sssctl_logs.c
+++ b/src/tools/sssctl/sssctl_logs.c
@@ -602,19 +602,7 @@ errno_t sssctl_analyze(struct sss_cmdline *cmdline,
 #endif
     errno_t ret;
 
-    const char **args = talloc_array_size(tool_ctx,
-                                          sizeof(char *),
-                                          cmdline->argc + 2);
-    if (!args) {
-        return ENOMEM;
-    }
-    memcpy(&args[1], cmdline->argv, sizeof(char *) * cmdline->argc);
-    args[0] = SSS_ANALYZE;
-    args[cmdline->argc + 1] = NULL;
-
-    ret = sssctl_run_command(args);
-
-    talloc_free(args);
+    ret = sssctl_wrap_command(SSS_ANALYZE, cmdline, tool_ctx, pvt);
 
     return ret;
 }

--- a/src/tools/sssctl/sssctl_passkey.c
+++ b/src/tools/sssctl/sssctl_passkey.c
@@ -1,0 +1,42 @@
+/*
+    Authors:
+        Justin Stephenson <jstephen@redhat.com>
+
+    Passkey related utilities
+
+    Copyright (C) 2022 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <popt.h>
+#include <stdio.h>
+#include <talloc.h>
+
+#include "util/util.h"
+#include "tools/common/sss_tools.h"
+#include "tools/sssctl/sssctl.h"
+
+#define SSS_PASSKEY_CHILD SSSD_LIBEXEC_PATH"/passkey_child"
+
+errno_t sssctl_passkey_exec(struct sss_cmdline *cmdline,
+                            struct sss_tool_ctx *tool_ctx,
+                            void *pvt)
+{
+    errno_t ret;
+
+    ret = sssctl_wrap_command(SSS_PASSKEY_CHILD, cmdline, tool_ctx, pvt);
+
+    return ret;
+}


### PR DESCRIPTION
Simple wrapper which calls the `fido2_child` process, planned to be used with fido2_child --register, troubleshooting, and potentially other operations later.

Argument parsing is handled inside fido2 child therefore this is a simple wrapper redirecting all arguments.

The register operation can be tested with https://github.com/SSSD/sssd/pull/6327