### PR TITLE
sssctl: fix memory management with new POPT

### DIFF
--- a/src/tools/common/sss_tools.c
+++ b/src/tools/common/sss_tools.c
@@ -402,6 +402,11 @@ errno_t sss_tool_popt_ex(struct sss_cmdline *cmdline,
     bool opt_set;
     int ret;
 
+    /* Set output parameter _fopt to NULL value if present. */
+    if (_fopt != NULL) {
+        *_fopt = NULL;
+    }
+
     /* Create help option string. We always need to append command name since
      * we use POPT_CONTEXT_KEEP_FIRST. */
     if (fopt_name == NULL) {
@@ -464,7 +469,14 @@ errno_t sss_tool_popt_ex(struct sss_cmdline *cmdline,
             goto done;
         }
 
-        *_fopt = fopt;
+        if (fopt != NULL) {
+            *_fopt = strdup(fopt);
+            if (*_fopt == NULL) {
+                ERROR("Out of memory!");
+                ret = ENOMEM;
+                goto done;
+            }
+        }
     } else if (_fopt == NULL && fopt != NULL) {
         /* Unexpected free argument. */
         ERROR("Unexpected parameter: %s\n\n", fopt);
@@ -495,6 +507,11 @@ errno_t sss_tool_popt_ex(struct sss_cmdline *cmdline,
 done:
     poptFreeContext(pc);
     talloc_free(help);
+    if (ret != EOK && _fopt != NULL) {
+        free(discard_const(*_fopt));
+        *_fopt = NULL;
+    }
+
     return ret;
 }
 

--- a/src/tools/sssctl/sssctl_access_report.c
+++ b/src/tools/sssctl/sssctl_access_report.c
@@ -396,21 +396,27 @@ errno_t sssctl_access_report(struct sss_cmdline *cmdline,
                            SSS_TOOL_OPT_REQUIRED, &domname, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse command arguments\n");
-        return ret;
+        goto done;
     }
 
     dom = find_domain_by_name(tool_ctx->domains, domname, true);
     if (dom == NULL) {
         ERROR("Cannot find domain %1$s\n", domname);
-        return ERR_DOMAIN_NOT_FOUND;
+        ret = ERR_DOMAIN_NOT_FOUND;
+        goto done;
     }
 
     reporter = get_report_fn(dom->provider);
     if (reporter == NULL) {
         ERROR("Access report not implemented for domains of type %1$s\n",
               dom->provider);
-        return ret;
+        goto done;
     }
 
-    return reporter(tool_ctx, dom);
+    ret = reporter(tool_ctx, dom);
+
+done:
+    free(discard_const(domname));
+
+    return ret;
 }

--- a/src/tools/sssctl/sssctl_cache.c
+++ b/src/tools/sssctl/sssctl_cache.c
@@ -557,7 +557,7 @@ static errno_t parse_cmdline(struct sss_cmdline *cmdline,
                              const char **_orig_name,
                              struct sss_domain_info **_domain)
 {
-    const char *input_name;
+    const char *input_name = NULL;
     const char *orig_name;
     struct sss_domain_info *domain;
     int ret;
@@ -567,20 +567,23 @@ static errno_t parse_cmdline(struct sss_cmdline *cmdline,
                            SSS_TOOL_OPT_REQUIRED, &input_name, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse command arguments\n");
-        return ret;
+        goto done;
     }
 
     ret = sss_tool_parse_name(tool_ctx, tool_ctx, input_name,
                               &orig_name, &domain);
     if (ret != EOK) {
         ERROR("Unable to parse name %s.\n", input_name);
-        return ret;
+        goto done;
     }
 
     *_orig_name = orig_name;
     *_domain = domain;
 
-    return EOK;
+done:
+    free(discard_const(input_name));
+
+    return ret;
 }
 
 struct sssctl_cache_opts {

--- a/src/tools/sssctl/sssctl_cert.c
+++ b/src/tools/sssctl/sssctl_cert.c
@@ -58,13 +58,14 @@ errno_t sssctl_cert_show(struct sss_cmdline *cmdline,
                            SSS_TOOL_OPT_REQUIRED, &cert_b64, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse command arguments\n");
-        return ret;
+        goto done;
     }
 
     tmp_ctx = talloc_new(NULL);
     if (tmp_ctx == NULL) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Out of memory!\n");
-        return ENOMEM;
+        ret = ENOMEM;
+        goto done;
     }
 
     der_cert = sss_base64_decode(tmp_ctx, cert_b64, &der_size);
@@ -85,6 +86,7 @@ errno_t sssctl_cert_show(struct sss_cmdline *cmdline,
 
 done:
     talloc_free(tmp_ctx);
+    free(discard_const(cert_b64));
 
     return ret;
 }
@@ -115,13 +117,14 @@ errno_t sssctl_cert_map(struct sss_cmdline *cmdline,
                            SSS_TOOL_OPT_REQUIRED, &cert_b64, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse command arguments\n");
-        return ret;
+        goto done;
     }
 
     tmp_ctx = talloc_new(NULL);
     if (tmp_ctx == NULL) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Out of memory!\n");
-        return ENOMEM;
+        ret = ENOMEM;
+        goto done;
     }
 
     cert_pem = talloc_asprintf(tmp_ctx, "%s%s\n%s",
@@ -165,8 +168,8 @@ errno_t sssctl_cert_map(struct sss_cmdline *cmdline,
 
     ret = EOK;
 done:
-
     talloc_free(tmp_ctx);
+    free(discard_const(cert_b64));
 
     return ret;
 }

--- a/src/tools/sssctl/sssctl_domains.c
+++ b/src/tools/sssctl/sssctl_domains.c
@@ -313,7 +313,7 @@ errno_t sssctl_domain_status(struct sss_cmdline *cmdline,
                              struct sss_tool_ctx *tool_ctx,
                              void *pvt)
 {
-    TALLOC_CTX *tmp_ctx;
+    TALLOC_CTX *tmp_ctx = NULL;
     struct sssctl_domain_status_opts opts = {0};
     struct sbus_sync_connection *conn;
     const char *path;
@@ -334,7 +334,7 @@ errno_t sssctl_domain_status(struct sss_cmdline *cmdline,
                            SSS_TOOL_OPT_REQUIRED, &opts.domain, &opt_set);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse command arguments\n");
-        return ret;
+        goto done;
     }
 
     if (opt_set == false) {
@@ -347,7 +347,8 @@ errno_t sssctl_domain_status(struct sss_cmdline *cmdline,
     tmp_ctx = talloc_new(NULL);
     if (tmp_ctx == NULL) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Out of memory!\n");
-        return ENOMEM;
+        ret = ENOMEM;
+        goto done;
     }
 
     path = sbus_opath_compose(tmp_ctx, IFP_PATH_DOMAINS, opts.domain);
@@ -401,6 +402,7 @@ errno_t sssctl_domain_status(struct sss_cmdline *cmdline,
 
 done:
     talloc_free(tmp_ctx);
-    return ret;
+    free(discard_const(opts.domain));
 
+    return ret;
 }

--- a/src/tools/sssctl/sssctl_user_checks.c
+++ b/src/tools/sssctl/sssctl_user_checks.c
@@ -241,7 +241,7 @@ errno_t sssctl_user_checks(struct sss_cmdline *cmdline,
                            SSS_TOOL_OPT_REQUIRED, &user, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to parse command arguments\n");
-        return ret;
+        goto done;
     }
 
     PRINT("user: %s\naction: %s\nservice: %s\n\n", user, action, service);
@@ -261,7 +261,8 @@ errno_t sssctl_user_checks(struct sss_cmdline *cmdline,
     ret = pam_start(service, user, &conv, &pamh);
     if (ret != PAM_SUCCESS) {
         ERROR("pam_start failed: %s\n", pam_strerror(pamh, ret));
-        return 1;
+        ret = EPERM;
+        goto done;
     }
 
     if ( strncmp(action, "auth", 4)== 0 ) {
@@ -311,6 +312,10 @@ errno_t sssctl_user_checks(struct sss_cmdline *cmdline,
     free(pam_env);
 
     pam_end(pamh, ret);
+    ret = EOK;
 
-    return 0;
+done:
+    free(discard_const(user));
+
+    return ret;
 }


### PR DESCRIPTION
POPT library behaviour change due to a memory leak. With the new version the value returned by poptGetArg() needs to be copied to avoid pointing to an already freed value.

Resolves: https://github.com/SSSD/sssd/issues/6331