### PR TITLE
SUDO: Fix timezone issues with sudoNotBefore and sudoNotAfter

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -117,6 +117,9 @@ AC_CHECK_FUNCS([ utimensat \
 
 AC_CHECK_FUNCS([ explicit_bzero ])
 
+# Check for the timegm() function (not part of POSIX / Open Group specs)
+AC_CHECK_FUNC([timegm], [], [AC_MSG_ERROR([timegm() function not found])])
+
 #Check for endian headers
 AC_CHECK_HEADERS([endian.h sys/endian.h byteswap.h])
 

--- a/src/tests/cmocka/test_sysdb_sudo.c
+++ b/src/tests/cmocka/test_sysdb_sudo.c
@@ -44,6 +44,12 @@
 #define OVERRIDE_GROUP_NAME "group_sudo_test"
 #define OVERRIDE_UID 2112
 
+/* sysdb_sudo_convert_time function is static */
+extern char *strptime(const char *__restrict __s,
+                      const char *__restrict __fmt,
+                      struct tm *__tp);
+#include "src/db/sysdb_sudo.c"
+
 struct test_user {
     const char *name;
     uid_t uid;
@@ -949,6 +955,26 @@ void test_filter_rules_by_time(void **state)
     talloc_zfree(_rules);
 }
 
+void test_sudo_convert_time(void **state)
+{
+    /* Each ctime should map to its corresponding utime */
+    const char *ctimes[] = {"20220715090000Z",
+                            "20220715090000+0200",
+                            "20220715090000-0200"};
+    const time_t utimes[] = {1657875600,
+                             1657868400,
+                             1657882800};
+    const int ntimes = sizeof(ctimes) / sizeof(ctimes[0]);
+    time_t converted;
+    errno_t ret;
+
+    for (int i = 0; i < ntimes; i++) {
+        ret = sysdb_sudo_convert_time(ctimes[i], &converted);
+        assert_int_equal(ret, EOK);
+        assert_int_equal(converted, utimes[i]);
+    }
+}
+
 int main(int argc, const char *argv[])
 {
     int rv;
@@ -1029,6 +1055,9 @@ int main(int argc, const char *argv[])
         cmocka_unit_test_setup_teardown(test_filter_rules_by_time,
                                         test_sysdb_setup,
                                         test_sysdb_teardown),
+
+        /* sysdb_sudo_convert_time() */
+        cmocka_unit_test(test_sudo_convert_time)
     };
 
     /* Set debug level to invalid value so we can decide if -d 0 was used. */


### PR DESCRIPTION
The current code does not respect generalized time as specified in related before/after attributes. The problem with the current implementation is that it essentially treats them as local time, with no regard to TZ and DST.

This patch is using timegm(3) instead of mktime(3) to address said timezone issues and some bare minimum static unit tests with known verified values to make sure the API is consitent with them.

Resolves:
https://bugzilla.redhat.com/show_bug.cgi?id=2107380