### PR TITLE
krb5: respect krb5_validate for PAC checks

### DIFF
--- a/src/man/include/krb5_options.xml
+++ b/src/man/include/krb5_options.xml
@@ -26,7 +26,16 @@
                 keytab entry as the last entry or the only entry in the keytab file.
             </para>
             <para>
-                Default: false
+                Default: false (IPA and AD provider: true)
+            </para>
+            <para>
+                Please note that the ticket validation is the first step when
+		checking the PAC (see 'pac_check' in the
+                <citerefentry>
+                    <refentrytitle>sssd.conf</refentrytitle>
+                    <manvolnum>5</manvolnum>
+                </citerefentry> manual page for details). If ticket
+                validation is disabled the PAC checks will be skipped as well.
             </para>
         </listitem>
     </varlistentry>

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2253,9 +2253,16 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                         <para>
                             Apply additional checks on the PAC of the Kerberos
                             ticket which is available in Active Directory and
-                            FreeIPA domains, if configured. The following
-                            options can be used alone or in a comma-separated
-                            list:
+                            FreeIPA domains, if configured. Please note that
+			    Kerberos ticket validation must be enabled to be
+                            able to check the PAC, i.e. the krb5_validate option
+                            must be set to 'True' which is the default for the
+                            IPA and AD provider. If krb5_validate is set to
+                            'False' the PAC checks will be skipped.
+			</para>
+                        <para>
+			    The following options can be used alone or in a
+			    comma-separated list:
                             <variablelist>
                             <varlistentry>
                                 <term>no_check</term>

--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -3872,11 +3872,10 @@ int main(int argc, const char *argv[])
         goto done;
     }
 
-    /* To be able to read the PAC we have to request a service ticket where we
-     * have a key to decrypt it, this is the same step we use for validating
-     * the ticket. */
-    if (cli_opts.check_pac_flags != 0) {
-        kr->validate = true;
+    if (cli_opts.check_pac_flags != 0 && !kr->validate) {
+        DEBUG(SSSDBG_IMPORTANT_INFO,
+              "PAC check is requested but krb5_validate is set to false. "
+              "PAC checks will be skipped.\n");
     }
 
     kerr = privileged_krb5_setup(kr, offline);

--- a/src/providers/krb5/krb5_init_shared.c
+++ b/src/providers/krb5/krb5_init_shared.c
@@ -77,6 +77,16 @@ errno_t krb5_child_init(struct krb5_ctx *krb5_auth_ctx,
         goto done;
     }
 
+    if (krb5_auth_ctx->check_pac_flags != 0
+            && !dp_opt_get_bool(krb5_auth_ctx->opts, KRB5_VALIDATE)) {
+        DEBUG(SSSDBG_IMPORTANT_INFO,
+              "PAC check is requested but krb5_validate is set to false. "
+              "PAC checks will be skipped.\n");
+        sss_log(SSS_LOG_WARNING,
+                "PAC check is requested but krb5_validate is set to false. "
+                "PAC checks will be skipped.");
+    }
+
     ret = parse_krb5_map_user(krb5_auth_ctx,
                               dp_opt_get_cstring(krb5_auth_ctx->opts,
                                                  KRB5_MAP_USER),


### PR DESCRIPTION
The first step of checking the PAC is the same as during the Kerberos
ticket validation, requesting a service ticket for a service principal
from the local keytab. By default ticket validation is enable for the
IPA and AD provider where checking the PAC might become important. If
ticket validation is disabled manually it is most probably because there
are issues requesting the service ticket and fixing those is currently
not possible.

Currently when SSSD is configured to check the PAC it ignores the
krb5_validate setting and tries to request a service ticket which would
fail in the case ticket validation is disabled for a reason. To not
cause regressions with this patch SSSD will skip the PAC checks if
ticket validation is disabled.

Resolves: https://github.com/SSSD/sssd/issues/6355