### PR TITLE
DBUS: Add ListByAttr(attr, filter, limit)

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -809,7 +809,8 @@ int sysdb_enumpwent(TALLOC_CTX *mem_ctx,
 
 int sysdb_enumpwent_filter(TALLOC_CTX *mem_ctx,
                            struct sss_domain_info *domain,
-                           const char *name_filter,
+                           const char *attr,
+                           const char *attr_filter,
                            const char *addtl_filter,
                            struct ldb_result **res);
 
@@ -819,7 +820,8 @@ int sysdb_enumpwent_with_views(TALLOC_CTX *mem_ctx,
 
 int sysdb_enumpwent_filter_with_views(TALLOC_CTX *mem_ctx,
                                       struct sss_domain_info *domain,
-                                      const char *name_filter,
+                                      const char *attr,
+                                      const char *attr_filter,
                                       const char *addtl_filter,
                                       struct ldb_result **res);
 

--- a/src/responder/common/cache_req/cache_req.h
+++ b/src/responder/common/cache_req/cache_req.h
@@ -100,6 +100,12 @@ enum cache_req_behavior {
 struct cache_req_data;
 
 struct cache_req_data *
+cache_req_data_attr(TALLOC_CTX *mem_ctx,
+                    enum cache_req_type type,
+                    const char *attr,
+                    const char *filter);
+
+struct cache_req_data *
 cache_req_data_name(TALLOC_CTX *mem_ctx,
                     enum cache_req_type type,
                     const char *name);
@@ -367,6 +373,7 @@ cache_req_user_by_filter_send(TALLOC_CTX *mem_ctx,
                               struct resp_ctx *rctx,
                               enum cache_req_dom_type req_dom_type,
                               const char *domain,
+                              const char *attr,
                               const char *filter);
 
 #define cache_req_user_by_filter_recv(mem_ctx, req, _result) \

--- a/src/responder/common/cache_req/cache_req_data.c
+++ b/src/responder/common/cache_req/cache_req_data.c
@@ -83,10 +83,12 @@ cache_req_data_create(TALLOC_CTX *mem_ctx,
     data->svc.name = &data->name;
 
     switch (type) {
+    case CACHE_REQ_USER_BY_FILTER:
+        data->name.attr = input->name.attr;
+        /* Fallthrough */
     case CACHE_REQ_USER_BY_NAME:
     case CACHE_REQ_USER_BY_UPN:
     case CACHE_REQ_GROUP_BY_NAME:
-    case CACHE_REQ_USER_BY_FILTER:
     case CACHE_REQ_GROUP_BY_FILTER:
     case CACHE_REQ_INITGROUPS:
     case CACHE_REQ_INITGROUPS_BY_UPN:
@@ -294,6 +296,20 @@ cache_req_data_name_attrs(TALLOC_CTX *mem_ctx,
 
     input.name.input = name;
     input.attrs = attrs;
+
+    return cache_req_data_create(mem_ctx, type, &input);
+}
+
+struct cache_req_data *
+cache_req_data_attr(TALLOC_CTX *mem_ctx,
+                    enum cache_req_type type,
+                    const char *attr,
+                    const char *filter)
+{
+    struct cache_req_data input = {0};
+
+    input.name.input = filter;
+    input.name.attr = attr;
 
     return cache_req_data_create(mem_ctx, type, &input);
 }

--- a/src/responder/common/cache_req/cache_req_private.h
+++ b/src/responder/common/cache_req/cache_req_private.h
@@ -61,13 +61,14 @@ struct cache_req {
 };
 
 /**
- * Structure to hold the input strings that
- * should be parsed into name and domain parts.
+ * Structure to hold the information the user passed as parameter
+ * and some strings after processing this information.
  */
 struct cache_req_parsed_name {
     const char *input;  /* Original input. */
     const char *name;   /* Parsed name or UPN. */
     const char *lookup; /* Converted per domain rules. */
+    const char *attr;   /* Attribute name when looking for an attribute */
 };
 
 /**

--- a/src/responder/ifp/ifp_groups.c
+++ b/src/responder/ifp/ifp_groups.c
@@ -322,7 +322,7 @@ ifp_groups_list_by_name_send(TALLOC_CTX *mem_ctx,
     }
 
     state->ifp_ctx = ctx;
-    state->list_ctx = ifp_list_ctx_new(state, ctx, filter, limit);
+    state->list_ctx = ifp_list_ctx_new(state, ctx, NULL, filter, limit);
     if (state->list_ctx == NULL) {
         ret = ENOMEM;
         goto done;
@@ -449,7 +449,7 @@ ifp_groups_list_by_domain_and_name_send(TALLOC_CTX *mem_ctx,
         return NULL;
     }
 
-    state->list_ctx = ifp_list_ctx_new(state, ctx, filter, limit);
+    state->list_ctx = ifp_list_ctx_new(state, ctx, NULL, filter, limit);
     if (state->list_ctx == NULL) {
         ret = ENOMEM;
         goto done;

--- a/src/responder/ifp/ifp_iface/ifp_iface.c
+++ b/src/responder/ifp/ifp_iface/ifp_iface.c
@@ -152,9 +152,10 @@ ifp_register_sbus_interface(struct sbus_connection *conn,
             SBUS_ASYNC(METHOD, org_freedesktop_sssd_infopipe_Users, FindByCertificate, ifp_users_find_by_cert_send, ifp_users_find_by_cert_recv, ctx),
             SBUS_ASYNC(METHOD, org_freedesktop_sssd_infopipe_Users, ListByCertificate, ifp_users_list_by_cert_send, ifp_users_list_by_cert_recv, ctx),
             SBUS_ASYNC(METHOD, org_freedesktop_sssd_infopipe_Users, FindByNameAndCertificate, ifp_users_find_by_name_and_cert_send, ifp_users_find_by_name_and_cert_recv, ctx),
-            SBUS_ASYNC(METHOD, org_freedesktop_sssd_infopipe_Users, ListByName, ifp_users_list_by_name_send, ifp_users_list_by_name_recv, ctx),
+            SBUS_ASYNC(METHOD, org_freedesktop_sssd_infopipe_Users, ListByName, ifp_users_list_by_name_send, ifp_users_list_by_attr_recv, ctx),
             SBUS_ASYNC(METHOD, org_freedesktop_sssd_infopipe_Users, ListByDomainAndName, ifp_users_list_by_domain_and_name_send, ifp_users_list_by_domain_and_name_recv, ctx),
-            SBUS_ASYNC(METHOD, org_freedesktop_sssd_infopipe_Users, FindByValidCertificate, ifp_users_find_by_valid_cert_send, ifp_users_find_by_valid_cert_recv, ctx)
+            SBUS_ASYNC(METHOD, org_freedesktop_sssd_infopipe_Users, FindByValidCertificate, ifp_users_find_by_valid_cert_send, ifp_users_find_by_valid_cert_recv, ctx),
+            SBUS_ASYNC(METHOD, org_freedesktop_sssd_infopipe_Users, ListByAttr, ifp_users_list_by_attr_send, ifp_users_list_by_attr_recv, ctx)
         ),
         SBUS_SIGNALS(SBUS_NO_SIGNALS),
         SBUS_PROPERTIES(SBUS_NO_PROPERTIES)

--- a/src/responder/ifp/ifp_iface/ifp_iface.xml
+++ b/src/responder/ifp/ifp_iface/ifp_iface.xml
@@ -186,6 +186,12 @@
             <arg name="pem_cert" type="s" direction="in" />
             <arg name="result" type="o" direction="out" />
         </method>
+        <method name="ListByAttr">
+            <arg name="attribute" type="s" direction="in" key="1" />
+            <arg name="attr_filter" type="s" direction="in" key="2" />
+            <arg name="limit" type="u" direction="in" key="3" />
+            <arg name="result" type="ao" direction="out" />
+        </method>
     </interface>
 
     <interface name="org.freedesktop.sssd.infopipe.Users.User">

--- a/src/responder/ifp/ifp_iface/sbus_ifp_client_sync.c
+++ b/src/responder/ifp/ifp_iface/sbus_ifp_client_sync.c
@@ -1176,6 +1176,22 @@ sbus_call_ifp_users_FindByValidCertificate
 }
 
 errno_t
+sbus_call_ifp_users_ListByAttr
+    (TALLOC_CTX *mem_ctx,
+     struct sbus_sync_connection *conn,
+     const char *busname,
+     const char *object_path,
+     const char * arg_attribute,
+     const char * arg_attr_filter,
+     uint32_t arg_limit,
+     const char *** _arg_result)
+{
+     return sbus_method_in_ssu_out_ao(mem_ctx, conn,
+          busname, object_path, "org.freedesktop.sssd.infopipe.Users", "ListByAttr", arg_attribute, arg_attr_filter, arg_limit,
+          _arg_result);
+}
+
+errno_t
 sbus_call_ifp_users_ListByCertificate
     (TALLOC_CTX *mem_ctx,
      struct sbus_sync_connection *conn,

--- a/src/responder/ifp/ifp_iface/sbus_ifp_client_sync.h
+++ b/src/responder/ifp/ifp_iface/sbus_ifp_client_sync.h
@@ -285,6 +285,17 @@ sbus_call_ifp_users_FindByValidCertificate
      const char ** _arg_result);
 
 errno_t
+sbus_call_ifp_users_ListByAttr
+    (TALLOC_CTX *mem_ctx,
+     struct sbus_sync_connection *conn,
+     const char *busname,
+     const char *object_path,
+     const char * arg_attribute,
+     const char * arg_attr_filter,
+     uint32_t arg_limit,
+     const char *** _arg_result);
+
+errno_t
 sbus_call_ifp_users_ListByCertificate
     (TALLOC_CTX *mem_ctx,
      struct sbus_sync_connection *conn,

--- a/src/responder/ifp/ifp_iface/sbus_ifp_interface.h
+++ b/src/responder/ifp/ifp_iface/sbus_ifp_interface.h
@@ -1579,6 +1579,28 @@
         (handler_send), (handler_recv), (data)); \
 })
 
+/* Method: org.freedesktop.sssd.infopipe.Users.ListByAttr */
+#define SBUS_METHOD_SYNC_org_freedesktop_sssd_infopipe_Users_ListByAttr(handler, data) ({ \
+    SBUS_CHECK_SYNC((handler), (data), const char *, const char *, uint32_t, const char ***); \
+    sbus_method_sync("ListByAttr", \
+        &_sbus_ifp_args_org_freedesktop_sssd_infopipe_Users_ListByAttr, \
+        NULL, \
+        _sbus_ifp_invoke_in_ssu_out_ao_send, \
+        _sbus_ifp_key_ssu_0_1_2, \
+        (handler), (data)); \
+})
+
+#define SBUS_METHOD_ASYNC_org_freedesktop_sssd_infopipe_Users_ListByAttr(handler_send, handler_recv, data) ({ \
+    SBUS_CHECK_SEND((handler_send), (data), const char *, const char *, uint32_t); \
+    SBUS_CHECK_RECV((handler_recv), const char ***); \
+    sbus_method_async("ListByAttr", \
+        &_sbus_ifp_args_org_freedesktop_sssd_infopipe_Users_ListByAttr, \
+        NULL, \
+        _sbus_ifp_invoke_in_ssu_out_ao_send, \
+        _sbus_ifp_key_ssu_0_1_2, \
+        (handler_send), (handler_recv), (data)); \
+})
+
 /* Method: org.freedesktop.sssd.infopipe.Users.ListByCertificate */
 #define SBUS_METHOD_SYNC_org_freedesktop_sssd_infopipe_Users_ListByCertificate(handler, data) ({ \
     SBUS_CHECK_SYNC((handler), (data), const char *, uint32_t, const char ***); \

--- a/src/responder/ifp/ifp_iface/sbus_ifp_symbols.c
+++ b/src/responder/ifp/ifp_iface/sbus_ifp_symbols.c
@@ -372,6 +372,20 @@ _sbus_ifp_args_org_freedesktop_sssd_infopipe_Users_FindByValidCertificate = {
 };
 
 const struct sbus_method_arguments
+_sbus_ifp_args_org_freedesktop_sssd_infopipe_Users_ListByAttr = {
+    .input = (const struct sbus_argument[]){
+        {.type = "s", .name = "attribute"},
+        {.type = "s", .name = "attr_filter"},
+        {.type = "u", .name = "limit"},
+        {NULL}
+    },
+    .output = (const struct sbus_argument[]){
+        {.type = "ao", .name = "result"},
+        {NULL}
+    }
+};
+
+const struct sbus_method_arguments
 _sbus_ifp_args_org_freedesktop_sssd_infopipe_Users_ListByCertificate = {
     .input = (const struct sbus_argument[]){
         {.type = "s", .name = "pem_cert"},

--- a/src/responder/ifp/ifp_iface/sbus_ifp_symbols.h
+++ b/src/responder/ifp/ifp_iface/sbus_ifp_symbols.h
@@ -113,6 +113,9 @@ extern const struct sbus_method_arguments
 _sbus_ifp_args_org_freedesktop_sssd_infopipe_Users_FindByValidCertificate;
 
 extern const struct sbus_method_arguments
+_sbus_ifp_args_org_freedesktop_sssd_infopipe_Users_ListByAttr;
+
+extern const struct sbus_method_arguments
 _sbus_ifp_args_org_freedesktop_sssd_infopipe_Users_ListByCertificate;
 
 extern const struct sbus_method_arguments

--- a/src/responder/ifp/ifp_private.h
+++ b/src/responder/ifp/ifp_private.h
@@ -104,6 +104,7 @@ bool ifp_is_user_attr_allowed(struct ifp_ctx *ifp_ctx, const char *attr);
 
 /* Used for list calls */
 struct ifp_list_ctx {
+    const char *attr;
     const char *filter;
     uint32_t limit;
 
@@ -117,6 +118,7 @@ struct ifp_list_ctx {
 
 struct ifp_list_ctx *ifp_list_ctx_new(TALLOC_CTX *mem_ctx,
                                       struct ifp_ctx *ctx,
+                                      const char *attr,
                                       const char *filter,
                                       uint32_t limit);
 

--- a/src/responder/ifp/ifp_users.h
+++ b/src/responder/ifp/ifp_users.h
@@ -102,7 +102,7 @@ ifp_users_list_by_name_send(TALLOC_CTX *mem_ctx,
                             uint32_t limit);
 
 errno_t
-ifp_users_list_by_name_recv(TALLOC_CTX *mem_ctx,
+ifp_users_list_by_attr_recv(TALLOC_CTX *mem_ctx,
                             struct tevent_req *req,
                             const char ***_paths);
 
@@ -238,4 +238,17 @@ ifp_cache_object_remove_user(TALLOC_CTX *mem_ctx,
                              struct ifp_ctx *ctx,
                              bool *_result);
 
+struct tevent_req *
+ifp_users_list_by_attr_send(TALLOC_CTX *mem_ctx,
+                            struct tevent_context *ev,
+                            struct sbus_request *sbus_req,
+                            struct ifp_ctx *ctx,
+                            const char *attr,
+                            const char *filter,
+                            uint32_t limit);
+
+errno_t
+ifp_users_list_by_attr_recv(TALLOC_CTX *mem_ctx,
+                            struct tevent_req *req,
+                            const char ***_paths);
 #endif /* IFP_USERS_H_ */

--- a/src/responder/ifp/ifpsrv_util.c
+++ b/src/responder/ifp/ifpsrv_util.c
@@ -289,6 +289,7 @@ static uint32_t ifp_list_limit(struct ifp_ctx *ctx, uint32_t limit)
 
 struct ifp_list_ctx *ifp_list_ctx_new(TALLOC_CTX *mem_ctx,
                                       struct ifp_ctx *ctx,
+                                      const char *attr,
                                       const char *filter,
                                       uint32_t limit)
 {
@@ -302,6 +303,7 @@ struct ifp_list_ctx *ifp_list_ctx_new(TALLOC_CTX *mem_ctx,
     list_ctx->limit = ifp_list_limit(ctx, limit);
     list_ctx->ctx = ctx;
     list_ctx->dom = ctx->rctx->domains;
+    list_ctx->attr = attr;
     list_ctx->filter = filter;
     list_ctx->paths_max = 1;
     list_ctx->paths = talloc_zero_array(list_ctx, const char *,

--- a/src/tests/cmocka/test_responder_cache_req.c
+++ b/src/tests/cmocka/test_responder_cache_req.c
@@ -2484,6 +2484,7 @@ void test_user_by_recent_filter_valid(void **state)
                                         test_ctx->rctx,
                                         CACHE_REQ_POSIX_DOM,
                                         test_ctx->tctx->dom->name,
+                                        NULL,
                                         TEST_USER_PREFIX);
     assert_non_null(req);
 
@@ -2528,6 +2529,7 @@ void test_users_by_recent_filter_valid(void **state)
                                         test_ctx->rctx,
                                         CACHE_REQ_POSIX_DOM,
                                         test_ctx->tctx->dom->name,
+                                        NULL,
                                         TEST_USER_PREFIX);
     assert_non_null(req);
 
@@ -2591,6 +2593,7 @@ void test_users_by_filter_filter_old(void **state)
                                         test_ctx->rctx,
                                         CACHE_REQ_POSIX_DOM,
                                         test_ctx->tctx->dom->name,
+                                        NULL,
                                         TEST_USER_PREFIX);
     assert_non_null(req);
     tevent_req_set_callback(req, cache_req_user_by_filter_test_done, test_ctx);
@@ -2634,6 +2637,7 @@ void test_users_by_filter_filter_files(void **state)
                                         test_ctx->rctx,
                                         CACHE_REQ_POSIX_DOM,
                                         test_ctx->tctx->dom->name,
+                                        NULL,
                                         TEST_USER_PREFIX);
     assert_non_null(req);
     tevent_req_set_callback(req, cache_req_user_by_filter_test_done, test_ctx);
@@ -2670,6 +2674,7 @@ void test_users_by_filter_notfound(void **state)
                                         test_ctx->rctx,
                                         CACHE_REQ_POSIX_DOM,
                                         test_ctx->tctx->dom->name,
+                                        NULL,
                                         TEST_NO_USER_PREFIX);
     assert_non_null(req);
     tevent_req_set_callback(req, cache_req_user_by_filter_test_done, test_ctx);
@@ -2749,6 +2754,7 @@ static void test_users_by_filter_multiple_domains_valid(void **state)
                                         test_ctx->rctx,
                                         CACHE_REQ_POSIX_DOM,
                                         test_ctx->tctx->dom->name,
+                                        NULL,
                                         TEST_USER_PREFIX);
     assert_non_null(req);
     tevent_req_set_callback(req, cache_req_user_by_filter_test_done, test_ctx);
@@ -2796,6 +2802,7 @@ void test_users_by_filter_multiple_domains_notfound(void **state)
                                         test_ctx->rctx,
                                         CACHE_REQ_POSIX_DOM,
                                         domain->name,
+                                        NULL,
                                         TEST_NO_USER_PREFIX);
     assert_non_null(req);
     tevent_req_set_callback(req, cache_req_user_by_filter_test_done, test_ctx);


### PR DESCRIPTION
Extended ListByName()'s mechanics to handle an attribute passed as parameters instead of forcing "name". ListByName() will pass "name."

Created a dbus function ListByAttr() passing the attribute requested by the user.

Resolves: https://github.com/SSSD/sssd/issues/6020

:feature: Introduced the dbus function org.freedesktop.sssd.infopupe.Users.ListByAttr(attr, value, limit) listing users matching the filter attr=value.

Please have in mind these issues below also affect this implementation as they share the mechanics with ListByName(). They have to be addressed separate from this PR.
[[D-Bus] ListByName() fails when not using wildcards](https://github.com/SSSD/sssd/issues/6361)
[[D-Bus] ListByName() returns twice the same entry](https://github.com/SSSD/sssd/issues/6360)