### PR TITLE
CI: Build srpm fix for illegal version tag '-'

### DIFF
--- a/.github/actions/build-sssd-srpm/action.yml
+++ b/.github/actions/build-sssd-srpm/action.yml
@@ -21,24 +21,31 @@ outputs:
 runs:
   using: 'composite'
   steps:
+  # '-' is an illegal character for RPM version tag
+  - name: Sanitize version
+    id: sanitize
+    shell: bash
+    run: |
+      version="$(echo ${{ inputs.version }} | sed 's/-/_/g')"
+      echo "::set-output name=version::$version"
+
   - name: Generate tarball and spec file
     shell: bash
     run: |
       pushd '${{ inputs.working-directory }}'
-      version="${{ inputs.version }}"
       release="${{ inputs.release }}"
-      name="sssd-$version"
+      name="sssd-${{ steps.sanitize.outputs.version }}"
       tar -cvzf "$name.tar.gz" --transform "s,^,$name/," *
 
       cp contrib/sssd.spec.in ./sssd.spec
 
       sed -iE "s/@PACKAGE_NAME@/sssd/g" ./sssd.spec
-      sed -iE "s/@PACKAGE_VERSION@/$version/g" ./sssd.spec
+      sed -iE "s/@PACKAGE_VERSION@/${{ steps.sanitize.outputs.version }}/g" ./sssd.spec
       sed -iE "s/@PRERELEASE_VERSION@/$release/g" ./sssd.spec
       popd
   - name: Build source rpm
     id: srpm
     uses: next-actions/build-srpm@master
     with:
-      tarball: ${{ inputs.working-directory }}/sssd-${{ inputs.version }}.tar.gz
+      tarball: ${{ inputs.working-directory }}/sssd-${{ steps.sanitize.outputs.version }}.tar.gz
       specfile: ${{ inputs.working-directory }}/sssd.spec


### PR DESCRIPTION
Fixes an issue with covscan CI runs on PRs against non-master target branch including a '-' such as `sssd-2-7`.

As covscan runs on self-hosted runners and on `pull_request_target`, it is not straightforward to test therefore validation was done by verifying the covscan step is receiving valid srpm inputs below:

 sssd-2-7: https://github.com/justin-stephenson/sssd/actions/runs/3206960526/jobs/5241327681
master: https://github.com/justin-stephenson/sssd/actions/runs/3206995838/jobs/5241405354