### PR TITLE
Fixes for both ListByName() tickets

### DIFF
--- a/src/responder/common/cache_req/cache_req.c
+++ b/src/responder/common/cache_req/cache_req.c
@@ -1272,7 +1272,7 @@ static void cache_req_input_parsed(struct tevent_req *subreq)
     struct tevent_req *req;
     struct cache_req_state *state;
     char *name;
-    char *domain;
+    char *domain = NULL;
     bool maybe_upn;
     errno_t ret;
 

--- a/src/responder/common/cache_req/cache_req.c
+++ b/src/responder/common/cache_req/cache_req.c
@@ -1312,8 +1312,10 @@ static void cache_req_input_parsed(struct tevent_req *subreq)
         return;
     }
 
-    state->domain_name = domain;
-    ret = cache_req_select_domains(req, domain,
+    if (state->domain_name == NULL) {
+        state->domain_name = domain;
+    }
+    ret = cache_req_select_domains(req, state->domain_name,
                                    state->cr->data->requested_domains);
     if (ret != EAGAIN) {
         tevent_req_error(req, ret);

--- a/src/responder/common/cache_req/cache_req_data.c
+++ b/src/responder/common/cache_req/cache_req_data.c
@@ -68,7 +68,7 @@ cache_req_data_create_attrs(TALLOC_CTX *mem_ctx,
 static struct cache_req_data *
 cache_req_data_create(TALLOC_CTX *mem_ctx,
                       enum cache_req_type type,
-                      struct cache_req_data *input)
+                      const struct cache_req_data *input)
 {
     struct cache_req_data *data;
     errno_t ret;

--- a/src/responder/common/cache_req/cache_req_data.c
+++ b/src/responder/common/cache_req/cache_req_data.c
@@ -84,7 +84,15 @@ cache_req_data_create(TALLOC_CTX *mem_ctx,
 
     switch (type) {
     case CACHE_REQ_USER_BY_FILTER:
-        data->name.attr = input->name.attr;
+        if (input->name.attr == NULL) {
+            data->name.attr = NULL;
+        } else {
+            data->name.attr = talloc_strdup(data, input->name.attr);
+            if (data->name.attr == NULL) {
+                ret = ENOMEM;
+                goto done;
+            }
+        }
         /* Fallthrough */
     case CACHE_REQ_USER_BY_NAME:
     case CACHE_REQ_USER_BY_UPN:

--- a/src/tests/intg/test_infopipe.py
+++ b/src/tests/intg/test_infopipe.py
@@ -659,6 +659,16 @@ def get_user_by_attr(dbus_system_bus, attribute, filter):
     return users_iface.ListByAttr(attribute, filter, 0)
 
 
+def get_user_by_name(dbus_system_bus, filter):
+    users_obj = dbus_system_bus.get_object('org.freedesktop.sssd.infopipe',
+                                           '/org/freedesktop/sssd/infopipe/Users')
+
+    users_iface = dbus.Interface(users_obj,
+                                 "org.freedesktop.sssd.infopipe.Users")
+
+    return users_iface.ListByName(filter, 0)
+
+
 def test_get_extra_attributes_empty(dbus_system_bus,
                                     ldap_conn,
                                     sanity_rfc2307):
@@ -823,4 +833,23 @@ def test_list_by_attr(dbus_system_bus, ldap_conn, sanity_rfc2307):
     assert len(users) == 0
 
     users = get_user_by_attr(dbus_system_bus, "noattr", "*")
+    assert len(users) == 0
+
+
+def test_list_by_name(dbus_system_bus, ldap_conn, sanity_rfc2307):
+    users = get_user_by_name(dbus_system_bus, "user2")
+    assert len(users) == 2
+    assert '/org/freedesktop/sssd/infopipe/Users/LDAP/1002' in users
+    assert '/org/freedesktop/sssd/infopipe/Users/app/user2_40app' in users
+
+    users = get_user_by_name(dbus_system_bus, "user*")
+    assert len(users) == 6
+    assert '/org/freedesktop/sssd/infopipe/Users/LDAP/1001' in users
+    assert '/org/freedesktop/sssd/infopipe/Users/LDAP/1002' in users
+    assert '/org/freedesktop/sssd/infopipe/Users/LDAP/1003' in users
+    assert '/org/freedesktop/sssd/infopipe/Users/app/user1_40app' in users
+    assert '/org/freedesktop/sssd/infopipe/Users/app/user2_40app' in users
+    assert '/org/freedesktop/sssd/infopipe/Users/app/user3_40app' in users
+
+    users = get_user_by_name(dbus_system_bus, "nouser*")
     assert len(users) == 0

--- a/src/tests/intg/test_infopipe.py
+++ b/src/tests/intg/test_infopipe.py
@@ -806,16 +806,18 @@ def test_find_by_valid_certificate(dbus_system_bus,
 
 def test_list_by_attr(dbus_system_bus, ldap_conn, sanity_rfc2307):
     users = get_user_by_attr(dbus_system_bus, "extraName", "user2")
-    # Condition not met because of https://github.com/SSSD/sssd/issues/6360
-    # assert len(users) == 1
-    assert users[0] == '/org/freedesktop/sssd/infopipe/Users/LDAP/1002'
+    assert len(users) == 2
+    assert '/org/freedesktop/sssd/infopipe/Users/LDAP/1002' in users
+    assert '/org/freedesktop/sssd/infopipe/Users/app/user2_40app' in users
 
     users = get_user_by_attr(dbus_system_bus, "extraName", "user*")
-    # Condition not met because of https://github.com/SSSD/sssd/issues/6360
-    # assert len(users) == 3
+    assert len(users) == 6
     assert '/org/freedesktop/sssd/infopipe/Users/LDAP/1001' in users
     assert '/org/freedesktop/sssd/infopipe/Users/LDAP/1002' in users
     assert '/org/freedesktop/sssd/infopipe/Users/LDAP/1003' in users
+    assert '/org/freedesktop/sssd/infopipe/Users/app/user1_40app' in users
+    assert '/org/freedesktop/sssd/infopipe/Users/app/user2_40app' in users
+    assert '/org/freedesktop/sssd/infopipe/Users/app/user3_40app' in users
 
     users = get_user_by_attr(dbus_system_bus, "extraName", "nouser*")
     assert len(users) == 0


### PR DESCRIPTION
Two main fixes, two minor corrections, one updated test and one new test.

* https://github.com/SSSD/sssd/issues/6360
For each domain, a multi domain search is done and all the results for each domain are returned each time. This produces several copies of the same results. In other words, two nested loops on the domains.
Function `cache_req_input_parsed()` decides whether to launch a multi- or single-domain search based on the domain the user requested. If the user didn’t request a domain (such as in a call to `ListByName()`), a multi-domain search is launched, even if we are only looking for the current domain. In that case a single-domain search is enough.
* When introducing `ListByAttr()` a string pointer was simply copied when it should have been _strdupped_.
* Function `cache_req_input_parsed()` uses the returned value `domain` before checking the error code of the function that produced it. At least, let's initialize it with `NULL`.
* `test_list_by_attr()` can now be corrected as the above issue is fixed.
* https://github.com/SSSD/sssd/issues/6361
When looking in the case the `name` attribute, use the fully-qualified name (name@domain).
* `test_list_by_name()` was created.



