### PR TITLE
ci: run on sssd-2-8 and update deprecated code

### DIFF
--- a/.github/actions/build-sssd-srpm/action.yml
+++ b/.github/actions/build-sssd-srpm/action.yml
@@ -27,7 +27,7 @@ runs:
     shell: bash
     run: |
       version="$(echo ${{ inputs.version }} | sed 's/-/_/g')"
-      echo "::set-output name=version::$version"
+      echo "version=$version" >> $GITHUB_OUTPUT
 
   - name: Generate tarball and spec file
     shell: bash

--- a/.github/workflows/analyze-target.yml
+++ b/.github/workflows/analyze-target.yml
@@ -1,7 +1,7 @@
 name: "Analyze (target)"
 on:
   pull_request_target:
-    branches: [master, sssd-2-7]
+    branches: [master, sssd-2-7, sssd-2-8]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true

--- a/.github/workflows/analyze-target.yml
+++ b/.github/workflows/analyze-target.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: false
@@ -35,13 +35,13 @@ jobs:
       contents: read
     steps:
     - name: Checkout target branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.base_ref }}
         path: target
 
     - name: Checkout pull request branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         path: pr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install dependencies
       id: dependencies
@@ -63,7 +63,7 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Get matrix
       id: matrix
@@ -80,7 +80,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: sssd
 
@@ -145,7 +145,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout sssd repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: sssd
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: "ci"
 on:
   push:
-    branches: [master, sssd-2-7]
+    branches: [master, sssd-2-7, sssd-2-8]
   pull_request:
-    branches: [master, sssd-2-7]
+    branches: [master, sssd-2-7, sssd-2-8]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/copr_build.yml
+++ b/.github/workflows/copr_build.yml
@@ -53,7 +53,7 @@ jobs:
         version: ${{ env.COPR_PROJECT }}
 
     - name: Upload source rpm as an artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.srpm.outputs.file }}
         path: ${{ steps.srpm.outputs.path }}

--- a/.github/workflows/copr_build.yml
+++ b/.github/workflows/copr_build.yml
@@ -41,7 +41,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.ref }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -114,7 +114,7 @@ jobs:
       fail-fast: false
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Downlooad source rpm
       uses: actions/download-artifact@v2

--- a/.github/workflows/copr_build.yml
+++ b/.github/workflows/copr_build.yml
@@ -21,7 +21,7 @@
 name: copr
 on:
   pull_request_target:
-    branches: [master, sssd-2-7]
+    branches: [master, sssd-2-7, sssd-2-8]
     types: [opened, synchronize, reopened]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/copr_cleanup.yml
+++ b/.github/workflows/copr_cleanup.yml
@@ -1,7 +1,7 @@
 name: copr cleanup
 on:
   pull_request_target:
-    branches: [master, sssd-2-7]
+    branches: [master, sssd-2-7, sssd-2-8]
     types: [closed]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install dependencies
       uses: ./.github/actions/install-dependencies

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -1,9 +1,9 @@
 name: "Static code analysis"
 on:
   push:
-    branches: [master, sssd-2-7]
+    branches: [master, sssd-2-7, sssd-2-8]
   pull_request:
-    branches: [master, sssd-2-7]
+    branches: [master, sssd-2-7, sssd-2-8]
   schedule:
     # Everyday at midnight
     - cron: '0 0 * * *'

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -17,7 +17,7 @@ jobs:
       security-events: write
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install dependencies
       id: dependencies
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Run flake8
       uses: grantmcconnaughey/lintly-flake8-github-action@d9db4fd0be9fb1cd19206a48ec0773bd93b82cbd

--- a/contrib/ci/get-matrix.py
+++ b/contrib/ci/get-matrix.py
@@ -10,6 +10,7 @@
 import json
 import requests
 import argparse
+import os
 
 
 def get_fedora_releases(type, exclude=[]):
@@ -59,4 +60,5 @@ if __name__ == "__main__":
     print(json.dumps(matrix, indent=2))
 
     if args.action:
-        print(f'::set-output name=matrix::{json.dumps(matrix)}')
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+            f.write(f'matrix={json.dumps(matrix)}')


### PR DESCRIPTION
4acbeee6c (Pavel Březina, 3 minutes ago)
   ci: use GITHUB_OUTPUT instead of set-output

   https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

114964dd2 (Pavel Březina, 27 minutes ago)
   ci: switch to actions/checkout@v3

   checkout@v3 runs on node16 so it will remove deprecation warning: 
   https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

cb6bd7c0c (Pavel Březina, 28 minutes ago)
   ci: enable ci for sssd-2-8 branch