### PR TITLE
certmap: add LDAPU1 mapping rules

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1994,6 +1994,7 @@ libsss_certmap_la_SOURCES = \
     src/lib/certmap/sss_certmap_ldap_mapping.c \
     src/lib/certmap/sss_cert_content_common.c \
     src/util/util_ext.c \
+    src/util/strtonum.c \
     src/util/cert/cert_common.c \
     $(NULL)
 libsss_certmap_la_CFLAGS = \

--- a/Makefile.am
+++ b/Makefile.am
@@ -2009,6 +2009,7 @@ libsss_certmap_la_LDFLAGS = \
 
 libsss_certmap_la_SOURCES += \
     src/lib/certmap/sss_cert_content_crypto.c \
+    src/lib/certmap/sss_cert_digest_crypto.c \
     src/util/crypto/libcrypto/crypto_base64.c \
     src/util/cert/libcrypto/cert.c \
     $(NULL)

--- a/contrib/ci/deps.sh
+++ b/contrib/ci/deps.sh
@@ -180,6 +180,7 @@ if [[ "$DISTRO_BRANCH" == -debian-* ]]; then
         gnutls-bin
         softhsm2
         libp11-kit-dev
+        bc
         libunistring-dev
     )
 

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -141,6 +141,7 @@ BuildRequires: samba-winbind
 BuildRequires: selinux-policy-targeted
 # required for p11_child smartcard tests
 BuildRequires: softhsm >= 2.1.0
+BuildRequires: bc
 BuildRequires: systemd-devel
 BuildRequires: systemtap-sdt-devel
 BuildRequires: uid_wrapper

--- a/src/lib/certmap/sss_cert_content_crypto.c
+++ b/src/lib/certmap/sss_cert_content_crypto.c
@@ -41,6 +41,9 @@
 #define X509_get_key_usage(o) ((o)->ex_kusage)
 #endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
 
+#define OID_NTDS_CA_SECURITY_EXT "1.3.6.1.4.1.311.25.2"
+#define OID_NTDS_OBJECTSID "1.3.6.1.4.1.311.25.2.1"
+
 typedef struct PrincipalName_st {
     ASN1_INTEGER *name_type;
     STACK_OF(ASN1_GENERALSTRING) *name_string;
@@ -64,6 +67,44 @@ ASN1_SEQUENCE(KRB5PrincipalName) = {
 } ASN1_SEQUENCE_END(KRB5PrincipalName)
 
 IMPLEMENT_ASN1_FUNCTIONS(KRB5PrincipalName)
+
+/* Microsoft's CA Security Extension as described in section 2.2.2.7.7.4 of
+ * [MS-WCCE]: Windows Client Certificate Enrollment Protocol
+ * https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/e563cff8-1af6-4e6f-a655-7571ca482e71
+ */
+typedef struct NTDS_OBJECTSID_st {
+    ASN1_OBJECT *type_id;
+    ASN1_OCTET_STRING *value;
+} NTDS_OBJECTSID;
+
+ASN1_SEQUENCE(NTDS_OBJECTSID) = {
+    ASN1_SIMPLE(NTDS_OBJECTSID, type_id, ASN1_OBJECT),
+    ASN1_EXP(NTDS_OBJECTSID, value, ASN1_OCTET_STRING, 0)
+} ASN1_SEQUENCE_END(NTDS_OBJECTSID)
+
+IMPLEMENT_ASN1_FUNCTIONS(NTDS_OBJECTSID)
+
+typedef struct NTDS_CA_SECURITY_EXT_st {
+#define NTDS_CA_SECURITY_EXT_OBJECTSID 0
+    int type;
+    union {
+        NTDS_OBJECTSID *sid;
+    } d;
+} NTDS_CA_SECURITY_EXT;
+
+ASN1_CHOICE(NTDS_CA_SECURITY_EXT) = {
+    ASN1_IMP(NTDS_CA_SECURITY_EXT, d.sid, NTDS_OBJECTSID, NTDS_CA_SECURITY_EXT_OBJECTSID)
+} ASN1_CHOICE_END(NTDS_CA_SECURITY_EXT)
+
+IMPLEMENT_ASN1_FUNCTIONS(NTDS_CA_SECURITY_EXT)
+
+typedef STACK_OF(NTDS_CA_SECURITY_EXT) NTDS_CA_SECURITY_EXTS;
+
+ASN1_ITEM_TEMPLATE(NTDS_CA_SECURITY_EXTS) =
+        ASN1_EX_TEMPLATE_TYPE(ASN1_TFLG_SEQUENCE_OF, 0, SecExts, NTDS_CA_SECURITY_EXT)
+ASN1_ITEM_TEMPLATE_END(NTDS_CA_SECURITY_EXTS)
+
+IMPLEMENT_ASN1_FUNCTIONS(NTDS_CA_SECURITY_EXTS)
 
 enum san_opt openssl_name_type_to_san_opt(int type)
 {
@@ -651,6 +692,94 @@ done:
     return ret;
 }
 
+static int get_sid_ext(TALLOC_CTX *mem_ctx, X509 *cert, const char **_sid)
+{
+    int ret;
+    ASN1_OBJECT *sid_ext_oid = NULL;
+    ASN1_OBJECT *sid_oid = NULL;
+    int idx;
+    X509_EXTENSION *ext = NULL;
+    const unsigned char *p;
+    NTDS_CA_SECURITY_EXTS *sec_exts = NULL;
+    NTDS_CA_SECURITY_EXT *current;
+    char *sid = NULL;
+    const ASN1_OCTET_STRING *ext_data = NULL;
+    size_t c;
+
+    sid_ext_oid = OBJ_txt2obj(OID_NTDS_CA_SECURITY_EXT, 1);
+    if (sid_ext_oid == NULL) {
+        return EIO;
+    }
+
+    idx = X509_get_ext_by_OBJ(cert, sid_ext_oid, -1);
+    ASN1_OBJECT_free(sid_ext_oid);
+    if (idx == -1) {
+        /* Extension most probably not available, no error. */
+        return 0;
+    }
+
+    ext = X509_get_ext(cert, idx);
+    if (ext == NULL) {
+        return EINVAL;
+    }
+
+    ext_data = X509_EXTENSION_get_data(ext);
+    if (ext_data == NULL) {
+        return EINVAL;
+    }
+
+    p = ext_data->data;
+    sec_exts = d2i_NTDS_CA_SECURITY_EXTS(NULL, &p, ext_data->length);
+    if (sec_exts == NULL) {
+        return EIO;
+    }
+
+    ret = EINVAL;
+    for (c = 0; c < OPENSSL_sk_num((const OPENSSL_STACK *) sec_exts); c++) {
+        current = (NTDS_CA_SECURITY_EXT *)
+                          OPENSSL_sk_value((const OPENSSL_STACK *) sec_exts, c);
+        /* Only handle NTDS_CA_SECURITY_EXT_OBJECTSID. So far no other types
+         * are defined. */
+        if (current->type == NTDS_CA_SECURITY_EXT_OBJECTSID) {
+            if (sid != NULL) {
+                /* second SID found, currently not expected */
+                talloc_free(sid);
+                ret = EINVAL;
+                goto done;
+            }
+
+            sid_oid = OBJ_txt2obj(OID_NTDS_OBJECTSID, 1);
+            if (sid_oid == NULL) {
+                ret = EIO;
+                goto done;
+            }
+            if (current->d.sid->type_id == NULL
+                    || OBJ_cmp(current->d.sid->type_id, sid_oid) != 0) {
+                /* Unexpected OID */
+                ret = EINVAL;
+                goto done;
+            }
+
+            sid = talloc_strndup(mem_ctx, (char *) current->d.sid->value->data,
+                                          current->d.sid->value->length);
+            if (sid == NULL) {
+                ret = ENOMEM;
+                goto done;
+            }
+            ret = 0;
+        }
+    }
+
+done:
+    NTDS_CA_SECURITY_EXTS_free(sec_exts);
+    ASN1_OBJECT_free(sid_oid);
+
+    if (ret == 0) {
+        *_sid = sid;
+    }
+    return ret;
+}
+
 static int get_extended_key_usage_oids(TALLOC_CTX *mem_ctx,
                                        X509 *cert,
                                        const char ***_oids)
@@ -911,6 +1040,11 @@ int sss_cert_get_content(TALLOC_CTX *mem_ctx,
 
     ret = get_subject_key_id(cont, cert, &(cont->subject_key_id),
                              &(cont->subject_key_id_size));
+    if (ret != 0) {
+        goto done;
+    }
+
+    ret = get_sid_ext(cont, cert, &(cont->sid_ext));
     if (ret != 0) {
         goto done;
     }

--- a/src/lib/certmap/sss_cert_content_crypto.c
+++ b/src/lib/certmap/sss_cert_content_crypto.c
@@ -592,6 +592,7 @@ static int get_san(TALLOC_CTX *mem_ctx, X509 *cert, struct san_list **san_list)
             if (ret != 0) {
                 goto done;
             }
+            DLIST_ADD(list, item);
             break;
         case GEN_IPADD:
             ret = add_ip_to_san_list(mem_ctx,

--- a/src/lib/certmap/sss_cert_digest_crypto.c
+++ b/src/lib/certmap/sss_cert_digest_crypto.c
@@ -1,0 +1,158 @@
+/*
+   SSSD - digest functions - OpenSSL version
+   The calls defined here should be usable outside of SSSD as well, e.g. in
+   libsss_certmap.
+
+   Copyright (C) Sumit Bose <sbose@redhat.com> 2022
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <string.h>
+#include <ctype.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <talloc.h>
+#include <openssl/opensslv.h>
+#include <openssl/objects.h>
+#include <openssl/evp.h>
+
+#include "lib/certmap/sss_certmap_int.h"
+
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+#define discard_const(ptr) ((void *)((uintptr_t)(ptr)))
+#define EVP_MD_free(ctx)
+#define EVP_MD_fetch(ctx, algorithm, properties) discard_const(EVP_get_digestbyname(algorithm))
+#endif
+
+#define DATA_STEP_SIZE 30
+
+struct get_digest_data {
+    const char **list;
+    size_t size;
+    size_t idx;
+    int error;
+};
+
+static void get_digest_helper(const OBJ_NAME *name, void *arg)
+{
+    struct get_digest_data *data = (struct get_digest_data *) arg;
+    EVP_MD *md = NULL;
+
+    if (data->error != 0) {
+        return;
+    }
+
+    /* All digest names are expected to start with a lower case letter. For
+     * compatibility(?) with older version the digest list might contain some
+     * RSA based signature algorithms, e.g. RSA-SHA1, which should be ignored
+     * here. */
+    if (name == NULL || name->name == NULL || islower(*name->name) == 0
+        || strstr(name->name, "RSA") != NULL
+        || strstr(name->name, "rsa") != NULL) {
+        return;
+    }
+
+    /* check if digest can be fetched. */
+    md = EVP_MD_fetch(NULL, name->name, NULL);
+    if (md == NULL) {
+        return;
+    }
+    EVP_MD_free(md);
+
+    data->list[data->idx] = talloc_strdup(data->list, name->name);
+    if (data->list[data->idx] == NULL) {
+        data->error = ENOMEM;
+        return;
+    }
+
+    data->idx++;
+    if (data->idx == data->size - 1) {
+        data->size += DATA_STEP_SIZE;
+        data->list = talloc_realloc(data->list, data->list,
+                                    const char *, data->size);
+        if (data->list == NULL) {
+            data->error = ENOMEM;
+            return;
+        }
+    }
+    data->list[data->idx] = NULL;
+}
+
+
+int get_digest_list(TALLOC_CTX *mem_ctx, const char ***digest_list)
+{
+    struct get_digest_data data = { 0 };
+
+    data.size = DATA_STEP_SIZE;
+    data.list = talloc_array(mem_ctx, const char *, data.size);
+    if (data.list == NULL) {
+        return ENOMEM;
+    }
+
+    OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS \
+                        | OPENSSL_INIT_ADD_ALL_DIGESTS \
+                        | OPENSSL_INIT_LOAD_CONFIG, NULL);
+
+    OBJ_NAME_do_all(OBJ_NAME_TYPE_MD_METH, get_digest_helper, &data);
+    if (data.error != 0) {
+        talloc_free(data.list);
+        return data.error;
+    }
+
+    *digest_list = data.list;
+
+    return 0;
+}
+
+int get_hash(TALLOC_CTX *mem_ctx, const uint8_t *blob, size_t blob_size,
+             const char *digest, bool upper, bool colon, bool reverse,
+             char **out)
+{
+    int ret;
+    EVP_MD *md = NULL;
+    unsigned char md_value[EVP_MAX_MD_SIZE];
+    unsigned int md_len;
+    char *tmp_str = NULL;
+
+    md = EVP_MD_fetch(NULL, digest, NULL);
+    if (md == NULL) {
+        return EINVAL;
+    }
+
+    ret = EVP_Digest(blob, blob_size, md_value, &md_len, md, NULL);
+    if (ret != 1) {
+        ret = EIO;
+        goto done;
+    }
+
+    ret = bin_to_hex(mem_ctx, upper, colon, reverse, md_value, md_len,
+                     &tmp_str);
+    if (ret != 0) {
+        goto done;
+    }
+
+    *out = tmp_str;
+    ret = 0;
+
+done:
+    if (ret != 0) {
+        talloc_free(tmp_str);
+    }
+    EVP_MD_free(md);
+
+    return ret;
+}

--- a/src/lib/certmap/sss_certmap.c
+++ b/src/lib/certmap/sss_certmap.c
@@ -42,6 +42,58 @@ void sss_debug_fn(const char *file,
     return;
 }
 
+int bin_to_hex(TALLOC_CTX *mem_ctx, bool upper_case, bool colon_sep,
+               bool reverse, uint8_t *buf, size_t len, char **out)
+{
+    char *o;
+    size_t c;
+    const char *fmt = NULL;
+    size_t s;
+    size_t chop_end = 0;
+
+    if (len == 0 || buf == NULL) {
+        return EINVAL;
+    }
+
+    if (upper_case) {
+        if (colon_sep) {
+            fmt = "%02X:";
+            s = 3;
+            chop_end =1;
+        } else {
+            fmt = "%02X";
+            s = 2;
+        }
+    } else {
+        if (colon_sep) {
+            fmt = "%02x:";
+            s = 3;
+            chop_end =1;
+        } else {
+            fmt = "%02x";
+            s = 2;
+        }
+    }
+
+    o = talloc_size(mem_ctx, (len * s) + 1);
+    if (o == NULL) {
+        return ENOMEM;
+    }
+
+    for (c = 0; c < len; c++) {
+        if (reverse) {
+            snprintf(o+(c*s), s+1, fmt, buf[len -1 -c]);
+        } else {
+            snprintf(o+(c*s), s+1, fmt, buf[c]);
+        }
+    }
+    o[(len * s) - chop_end] = '\0';
+
+    *out = o;
+
+    return 0;
+}
+
 static int get_type_prefix(TALLOC_CTX *mem_ctx, const char *match_rule,
                            char **type, const char **rule_start)
 {

--- a/src/lib/certmap/sss_certmap.c
+++ b/src/lib/certmap/sss_certmap.c
@@ -984,6 +984,14 @@ int sss_certmap_init(TALLOC_CTX *mem_ctx,
         return ret;
     }
 
+    ret = get_digest_list(*ctx, &((*ctx)->digest_list));
+    if (ret != 0) {
+        CM_DEBUG((*ctx), "Failed to get digest list.");
+        talloc_free(*ctx);
+        *ctx = NULL;
+        return ret;
+    }
+
     return EOK;
 }
 

--- a/src/lib/certmap/sss_certmap_int.h
+++ b/src/lib/certmap/sss_certmap_int.h
@@ -206,6 +206,8 @@ struct sss_cert_content {
 
     uint8_t *subject_key_id;
     size_t subject_key_id_size;
+
+    const char *sid_ext;
 };
 
 int sss_cert_get_content(TALLOC_CTX *mem_ctx,

--- a/src/lib/certmap/sss_certmap_int.h
+++ b/src/lib/certmap/sss_certmap_int.h
@@ -136,11 +136,17 @@ struct priority_list {
     struct priority_list *next;
 };
 
+enum mapping_rule_version {
+    mapv_ldap = 0,
+    mapv_ldapu1
+};
+
 struct sss_certmap_ctx {
     struct priority_list *prio_list;
     sss_certmap_ext_debug *debug;
     void *debug_priv;
     struct ldap_mapping_rule *default_mapping_rule;
+    enum mapping_rule_version mapv;
     const char **digest_list;
 };
 
@@ -223,9 +229,19 @@ int parse_krb5_match_rule(struct sss_certmap_ctx *ctx,
                           const char *rule_start,
                           struct krb5_match_rule **match_rule);
 
+int check_hex_conversion(const char *inp, bool dec_allowed, bool *_dec,
+                         bool *_upper, bool *_colon, bool *_reverse);
+
+int check_digest_conversion(const char *inp, const char **digest_list,
+                            const char **_dgst, bool *_upper, bool *_colon,
+                            bool *_reverse);
+
 int parse_ldap_mapping_rule(struct sss_certmap_ctx *ctx,
                             const char *rule_start,
                             struct ldap_mapping_rule **mapping_rule);
+
+int check_attr_name_and_or_number(TALLOC_CTX *mem_ctx, const char *inp,
+                                  char **_attr_name, int32_t *_number);
 
 int get_short_name(TALLOC_CTX *mem_ctx, const char *full_name,
                    char delim, char **short_name);
@@ -239,6 +255,9 @@ int add_principal_to_san_list(TALLOC_CTX *mem_ctx, enum san_opt san_opt,
 
 int rdn_list_2_dn_str(TALLOC_CTX *mem_ctx, const char *conversion,
                       const char **rdn_list, char **result);
+
+int rdn_list_2_component(TALLOC_CTX *mem_ctx, const char *conversion,
+                         const char **rdn_list, char **result);
 
 int get_digest_list(TALLOC_CTX *mem_ctx, const char ***digest_list);
 

--- a/src/lib/certmap/sss_certmap_int.h
+++ b/src/lib/certmap/sss_certmap_int.h
@@ -203,6 +203,9 @@ struct sss_cert_content {
     uint8_t *serial_number;
     size_t serial_number_size;
     const char *serial_number_dec_str;
+
+    uint8_t *subject_key_id;
+    size_t subject_key_id_size;
 };
 
 int sss_cert_get_content(TALLOC_CTX *mem_ctx,

--- a/src/lib/certmap/sss_certmap_int.h
+++ b/src/lib/certmap/sss_certmap_int.h
@@ -238,4 +238,7 @@ int add_principal_to_san_list(TALLOC_CTX *mem_ctx, enum san_opt san_opt,
 
 int rdn_list_2_dn_str(TALLOC_CTX *mem_ctx, const char *conversion,
                       const char **rdn_list, char **result);
+
+int bin_to_hex(TALLOC_CTX *mem_ctx, bool upper_case, bool colon_sep,
+               bool reverse, uint8_t *buf, size_t len, char **out);
 #endif /* __SSS_CERTMAP_INT_H__ */

--- a/src/lib/certmap/sss_certmap_int.h
+++ b/src/lib/certmap/sss_certmap_int.h
@@ -217,54 +217,286 @@ struct sss_cert_content {
     const char *sid_ext;
 };
 
+/**
+ * @brief Extract various attributes from a binary X.509 certificate
+ *
+ * @param[in]  mem_ctx     Talloc memory context
+ * @param[in]  der_blob    Binary DER encoded X.509 certificate
+ * @param[in]  der_size    Length of the binary certificate
+ * @param[out] content     Struct with parsed certificate data
+ *
+ * @return
+ *  - 0:      success
+ *  - EINVAL: invalid input
+ *  - ENOMEM: memory allocation error
+ */
 int sss_cert_get_content(TALLOC_CTX *mem_ctx,
                          const uint8_t *der_blob, size_t der_size,
                          struct sss_cert_content **content);
 
+/**
+ * @brief Translate an RDN with NSS attribute names into AD names
+ *
+ * @param[in]  mem_ctx     Talloc memory context
+ * @param[in]  rdn         RDN input string
+ *
+ * @return
+ *  - NULL in case of an error
+ *  - RDN string with AD attribute name and the same value as the input
+ */
 char *check_ad_attr_name(TALLOC_CTX *mem_ctx, const char *rdn);
 
+/**
+ * @brief Translate OpenSSL attribute name to NSS name
+ *
+ * @param[in]  attr         OpenSSL attribute name
+ *
+ * @return
+ *  - NSS attribute name, most of the time it will be the same but there are
+ *    some differences like e.g. 'GN' vs 'givenName'
+ */
 char *openssl_2_nss_attr_name(const char *attr);
 
+/**
+ * @brief Parse matching rule
+ *
+ * @param[in]  ctx          Certmap context
+ * @param[in]  rule_start   Matching rule string
+ * @param[out] mapping_rule Parsed rule struct
+ *
+ * @return
+ *  - 0:      success
+ *  - ENOMEM: memory allocation failure
+ *  - EINVAL: invalid input
+ */
 int parse_krb5_match_rule(struct sss_certmap_ctx *ctx,
                           const char *rule_start,
                           struct krb5_match_rule **match_rule);
 
+/**
+ * @brief Check hex conversion string
+ *
+ * @param[in]  inp         Conversion string
+ * @param[in]  dec_allowed Flag to indicate if 'dec' for decimal output is
+ *                         allowed in the conversion string
+ * @param[out] _dec        Flag to indicate decimal output
+ * @param[out] _upper      Upper flag found in the conversion string
+ * @param[out] _colon      Colon flag found in the conversion string
+ * @param[out] _reverse    Reverse flag found in the conversion string
+ *
+ * @return
+ *  - 0:      success
+ *  - EINVAL: invalid input
+ */
 int check_hex_conversion(const char *inp, bool dec_allowed, bool *_dec,
                          bool *_upper, bool *_colon, bool *_reverse);
 
+/**
+ * @brief Check digest conversion string
+ *
+ * @param[in]  inp         Conversion string
+ * @param[in]  digest_list List of know digest/hash functions
+ * @param[out] _dgst       Name of digest found in the conversion string
+ * @param[out] _upper      Upper flag found in the conversion string
+ * @param[out] _colon      Colon flag found in the conversion string
+ * @param[out] _reverse    Reverse flag found in the conversion string
+ *
+ * @return
+ *  - 0:      success
+ *  - EINVAL: invalid input
+ */
 int check_digest_conversion(const char *inp, const char **digest_list,
                             const char **_dgst, bool *_upper, bool *_colon,
                             bool *_reverse);
 
+/**
+ * @brief Parse mapping rule
+ *
+ * @param[in]  ctx          Certmap context
+ * @param[in]  rule_start   Mapping rule string
+ * @param[out] mapping_rule Parsed rule struct
+ *
+ * @return
+ *  - 0:      success
+ *  - ENOMEM: memory allocation failure
+ *  - EINVAL: invalid input
+ */
 int parse_ldap_mapping_rule(struct sss_certmap_ctx *ctx,
                             const char *rule_start,
                             struct ldap_mapping_rule **mapping_rule);
 
+/**
+ * @brief Split attribute selector option
+ *
+ * @param[in]  mem_ctx     Talloc memory context
+ * @param[in]  inp         Attribute selector string in the format:
+ *                          - attr_name
+ *                          - [number]
+ *                          - attr_name[number]
+ *                         The number 0 is not allowed in the input
+ * @param[out] _attr_name  Attribute name from the input if present, NULL if
+ *                         there is no name in the input
+ * @param[out] _number     Number from the input if present, 0 if there is no
+ *                         number in the input
+ *
+ * @return
+ *  - 0:      success
+ *  - ENOMEM: memory allocation failure
+ *  - EINVAL: invalid input
+ */
 int check_attr_name_and_or_number(TALLOC_CTX *mem_ctx, const char *inp,
                                   char **_attr_name, int32_t *_number);
 
+/**
+ * @brief Get the short name from a fully-qulified name
+ *
+ * @param[in]  mem_ctx     Talloc memory context
+ * @param[in]  full_name   Fully-qulified name in the format
+ *                         "short-name""delimiter""suffix"
+ * @param[in]  delim       Delimiter character
+ * @param[out] short_name  Resulting short name
+ *
+ * @return
+ *  - 0:      success
+ *  - ENOMEM: memory allocation failure
+ *  - EINVAL: invalid input
+ */
 int get_short_name(TALLOC_CTX *mem_ctx, const char *full_name,
                    char delim, char **short_name);
 
+/**
+ * @brief Add generic data to a new san_list item
+ *
+ * @param[in]  mem_ctx     Talloc memory context
+ * @param[in]  is_bin      Binary data not a string
+ * @param[in]  san_opt     Type of Subject alternative name (SAN)
+ * @param[in]  data        Data
+ * @param[in]  len         Length of data
+ * @param[out] san_list    New san_list item
+ *
+ * @return
+ *  - 0:      success
+ *  - ENOMEM: memory allocation failure
+ *  - EINVAL: invalid input
+ */
 int add_to_san_list(TALLOC_CTX *mem_ctx, bool is_bin,
                     enum san_opt san_opt, const uint8_t *data, size_t len,
                     struct san_list **item);
 
+/**
+ * @brief Add a principal and the related short name to a new san_list item
+ *
+ * @param[in]  mem_ctx     Talloc memory context
+ * @param[in]  san_opt     Type of Subject alternative name (SAN)
+ * @param[in]  princ       String representation of the principal
+ * @param[out] item        New san_list item
+ *
+ * @return
+ *  - 0:      success
+ *  - ENOMEM: memory allocation failure
+ */
 int add_principal_to_san_list(TALLOC_CTX *mem_ctx, enum san_opt san_opt,
                               const char *princ, struct san_list **item);
 
+/**
+ * @brief Get DN specified by 'conversion' from 'rdn_list'
+ *
+ * @param[in]  mem_ctx     Talloc memory context
+ * @param[in]  conversion  Specifies how the DN should be formatted:
+ *                          - (ad|ad_x500)|ad_ldap|nss_x500|(nss|nss_ldap)
+ *                         where 'x500' means most specific RDN comes last and
+ *                         'ldap' most specific RDN comes first. 'ad' and
+ *                         'nss' specify if the attributes names should be
+ *                         translated in the way Active Directory or the NSS
+ *                         library is using them.
+ * @param[in]  rdn_list    String array with the the individual RDNs of a DN
+ *                         starting with the most specific component
+ * @param[out] result      The resulting DN
+ *
+ * @return
+ *  - 0:      success
+ *  - EINVAL: unsupported 'conversion'
+ *  - ENOMEM: memory allocation failure
+ */
 int rdn_list_2_dn_str(TALLOC_CTX *mem_ctx, const char *conversion,
                       const char **rdn_list, char **result);
 
+/**
+ * @brief Get attribute value specified by 'conversion' from 'rdn_list'
+ *
+ * @param[in]  mem_ctx     Talloc memory context
+ * @param[in]  conversion  Selection by position and/or name, format:
+ *                          - name
+ *                          - [pos]
+ *                          - name[pos]
+ *                         where 'name' is an attribute name and pos to
+ *                         position of the attribute in the DN starting with
+ *                         1, negative numbers will start at the least
+ *                         specific component of the DN
+ * @param[in]  rdn_list    String array with the the individual RDNs of a DN
+ *                         starting with the most specific component
+ * @param[out] result      The selected attribute value
+ *
+ * @return
+ *  - 0:      success
+ *  - ENOMEM: memory allocation failure
+ *  - EINVAL: unsupported 'conversion' or 'rdn_list'
+ *  - EIO:    no value could be returned
+ */
 int rdn_list_2_component(TALLOC_CTX *mem_ctx, const char *conversion,
                          const char **rdn_list, char **result);
 
+/**
+ * @brief Get list of supported has/digest types
+ *
+ * @param[in]  mem_ctx     Talloc memory context
+ * @param[out] digest_list Resulting list of hash type names
+ *
+ * @return
+ *  - 0:      success
+ *  - ENOMEM: memory allocation failure
+ */
 int get_digest_list(TALLOC_CTX *mem_ctx, const char ***digest_list);
 
+/**
+ * @brief Calculate the digest/hash of some binary data and return it as hex
+ * string
+ *
+ * @param[in]  mem_ctx     Talloc memory context
+ * @param[in]  blob        Binary data to calculate the hash of
+ * @param[in]  blob_size   Length of binary data
+ * @param[in]  digest      Type of hash/digest
+ * @param[in]  upper_case  Use upper-case letters in hex string
+ * @param[in]  colon_sep   Seperate each byte in the hex string with a ':'
+ * @param[in]  reverse     Start at the end of the binary blob
+ * @param[out] out         Resulting hex string
+ *
+ * @return
+ *  - 0:      success
+ *  - EINVAL: invalid hash type
+ *  - EIO:    error while calculating the hash
+ *  - ENOMEM: memory allocation failure
+ */
 int get_hash(TALLOC_CTX *mem_ctx, const uint8_t *blob, size_t blob_size,
              const char *digest, bool upper, bool colon, bool reverse,
              char **out);
 
+/**
+ * @brief Convert a binary blob into a hex string
+ *
+ * @param[in]  mem_ctx     Talloc memory context
+ * @param[in]  upper_case  Use upper-case letters in hex string
+ * @param[in]  colon_sep   Seperate each byte in the hex string with a ':'
+ * @param[in]  reverse     Start at the end of the binary blob
+ * @param[in]  buf         Start of the binary blob
+ * @param[in]  len         Length of the binary blob
+ * @param[out] out         Resulting hex string
+ *
+ * @return
+ *  - 0:      success
+ *  - EINVAL: invalid buffer or length
+ *  - ENOMEM: memory allocation failure
+ */
 int bin_to_hex(TALLOC_CTX *mem_ctx, bool upper_case, bool colon_sep,
                bool reverse, uint8_t *buf, size_t len, char **out);
 #endif /* __SSS_CERTMAP_INT_H__ */

--- a/src/lib/certmap/sss_certmap_int.h
+++ b/src/lib/certmap/sss_certmap_int.h
@@ -199,6 +199,10 @@ struct sss_cert_content {
 
     uint8_t *cert_der;
     size_t cert_der_size;
+
+    uint8_t *serial_number;
+    size_t serial_number_size;
+    const char *serial_number_dec_str;
 };
 
 int sss_cert_get_content(TALLOC_CTX *mem_ctx,

--- a/src/lib/certmap/sss_certmap_int.h
+++ b/src/lib/certmap/sss_certmap_int.h
@@ -141,6 +141,7 @@ struct sss_certmap_ctx {
     sss_certmap_ext_debug *debug;
     void *debug_priv;
     struct ldap_mapping_rule *default_mapping_rule;
+    const char **digest_list;
 };
 
 struct san_list {
@@ -238,6 +239,12 @@ int add_principal_to_san_list(TALLOC_CTX *mem_ctx, enum san_opt san_opt,
 
 int rdn_list_2_dn_str(TALLOC_CTX *mem_ctx, const char *conversion,
                       const char **rdn_list, char **result);
+
+int get_digest_list(TALLOC_CTX *mem_ctx, const char ***digest_list);
+
+int get_hash(TALLOC_CTX *mem_ctx, const uint8_t *blob, size_t blob_size,
+             const char *digest, bool upper, bool colon, bool reverse,
+             char **out);
 
 int bin_to_hex(TALLOC_CTX *mem_ctx, bool upper_case, bool colon_sep,
                bool reverse, uint8_t *buf, size_t len, char **out);

--- a/src/man/sss-certmap.5.xml
+++ b/src/man/sss-certmap.5.xml
@@ -35,6 +35,20 @@
             searched in the userCertificate attribute as DER encoded binary. If
             no domains are given only the local domain will be searched.
         </para>
+        <para>
+            To allow extensions or completely different style of rule the
+            <quote>mapping</quote> and <quote>matching rules</quote> can
+            contain a prefix separated with a ':' from the main part of the
+            rule. The prefix may only contain upper-case ASCII letters and
+            numbers. If the prefix is omitted the default type will be used
+            which is 'KRB5' for the matching rules and 'LDAP' for the mapping
+            rules.
+        </para>
+        <para>
+            The 'sssctl' utility provides the 'cert-eval-rule' command to check
+            if a given certificate matches a matching rules and how the output
+            of a mapping rule would look like.
+        </para>
     </refsect1>
 
     <refsect1 id='components'>
@@ -71,6 +85,12 @@
             a certain part of the certificate and a pattern which should be
             found for the rule to match. Multiple keyword pattern pairs can be
             either joined with '&amp;&amp;' (and) or '&#124;&#124;' (or).
+        </para>
+        <para>
+            Given the similarity to MIT Kerberos the type prefix for this rule
+            is 'KRB5'. But 'KRB5' will also be the default for <quote>matching
+            rules</quote> so that "&lt;SUBJECT&gt;.*,DC=MY,DC=DOMAIN" and
+            "KRB5:&lt;SUBJECT&gt;.*,DC=MY,DC=DOMAIN" are equivalent.
         </para>
         <para>
             The available options are:
@@ -382,6 +402,17 @@
             other hand it would be hard to break the mapping on purpose for a
             specific user.
         </para>
+	<para>
+            The default <quote>mapping rule</quote> type is 'LDAP' which can be
+            added as a prefix to a rule like e.g.
+            'LDAP:(userCertificate;binary={cert!bin})'. There is an extension
+            called 'LDAPU1' which offer more templates for more flexibility. To
+            allow older versions of this library to ignore the extension the
+            prefix 'LDAPU1' must be used when using the new templates in a
+            <quote>mapping rule</quote> otherwise the old version of this
+            library will fail with a parsing error. The new templates are
+            described in section <xref linkend="map_ldapu1"/>.
+        </para>
         <para>
             The templates to add certificate data to the search filter are based
             on Python-style formatting strings. They consist of a keyword in
@@ -604,6 +635,145 @@
                 </varlistentry>
             </variablelist>
         </para>
+    <refsect3 id='map_ldapu1'>
+        <title>LDAPU1 extension</title>
+        <para>
+            The following template are available when using the 'LDAPU1'
+            extension:
+        </para>
+        <para>
+            <variablelist>
+                <varlistentry>
+                    <term>{serial_number[!(dec|hex[_ucr])]}</term>
+                    <listitem>
+                    <para>
+                        This template will add the serial number of the
+                        certificate. By default it will be printed as a
+			hexadecimal number with lower-case letters.
+                    </para>
+                    <para>
+                        With the formatting option '!dec' the number will be
+                        printed as decimal string. The hexadecimal output can
+                        be printed with upper-case letters ('!hex_u'), with a
+                        colon separating the hexadecimal bytes ('!hex_c') or
+                        with the hexadecimal bytes in reverse order ('!hex_r').
+                        The postfix letters can be combined so that e.g.
+                        '!hex_uc' will produce a colon-separated hexadecimal
+                        string with upper-case letters.
+                    </para>
+                    <para>
+                        Example: LDAPU1:(serial={serial_number})
+                    </para>
+                    </listitem>
+                </varlistentry>
+
+                <varlistentry>
+                    <term>{subject_key_id[!hex[_ucr]]}</term>
+                    <listitem>
+                    <para>
+                        This template will add the subject key id of the
+                        certificate. By default it will be printed as a
+			hexadecimal number with lower-case letters.
+                    </para>
+                    <para>
+                        The hexadecimal output can
+                        be printed with upper-case letters ('!hex_u'), with a
+                        colon separating the hexadecimal bytes ('!hex_c') or
+                        with the hexadecimal bytes in reverse order ('!hex_r').
+                        The postfix letters can be combined so that e.g.
+                        '!hex_uc' will produce a colon-separated hexadecimal
+                        string with upper-case letters.
+                    </para>
+                    <para>
+                        Example: LDAPU1:(ski={subject_key_id})
+                    </para>
+                    </listitem>
+                </varlistentry>
+
+                <varlistentry>
+                    <term>{cert[!DIGEST[_ucr]]}</term>
+                    <listitem>
+                    <para>
+                        This template will add the hexadecimal digest/hash of
+                        the certificate where DIGEST must be replaced with the
+                        name of a digest/hash function supported by OpenSSL,
+                        e.g. 'sha512'.
+                    </para>
+                    <para>
+                        The hexadecimal output can
+                        be printed with upper-case letters ('!sha512_u'), with a
+                        colon separating the hexadecimal bytes ('!sha512_c') or
+                        with the hexadecimal bytes in reverse order
+                        ('!sha512_r'). The postfix letters can be combined so
+                        that e.g. '!sha512_uc' will produce a colon-separated
+                        hexadecimal string with upper-case letters.
+                    </para>
+                    <para>
+                        Example: LDAPU1:(dgst={cert!sha256})
+                    </para>
+                    </listitem>
+                </varlistentry>
+
+                <varlistentry>
+                    <term>{subject_dn_component[(.attr_name|[number]]}</term>
+                    <listitem>
+                    <para>
+                        This template will add an attribute value of a component
+                        of the subject DN, by default the value of the most
+                        specific component.
+                    </para>
+                    <para>
+                        A different component can it either selected by
+                        attribute name, e.g. {subject_dn_component.uid} or by
+                        position, e.g. {subject_dn_component.[2]} where
+                        positive numbers start counting from the most specific
+                        component and negative numbers start counting from the
+                        least specific component. Attribute name and the
+                        position can be combined as e.g.
+                        {subject_dn_component.uid[2]} which means that the name
+                        of the second component must be 'uid'.
+                    </para>
+                    <para>
+                        Example: LDAPU1:(uid={subject_dn_component.uid})
+                    </para>
+                    </listitem>
+                </varlistentry>
+
+                <varlistentry>
+                    <term>{issuer_dn_component[(.attr_name|[number]]}</term>
+                    <listitem>
+                    <para>
+                        This template will add an attribute value of a component
+                        of the issuer DN, by default the value of the most
+                        specific component.
+                    </para>
+                    <para>
+                        See 'subject_dn_component' for details about the
+                        attribute name and position specifiers.
+                    </para>
+                    <para>
+                        Example: LDAPU1:(domain={issuer_dn_component.[-2]}.{issuer_dn_component.dc[-1]})
+                    </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>{sid[.rid]}</term>
+                    <listitem>
+                    <para>
+                        This template will add the SID if the corresponding
+                        extension introduced by Microsoft with the OID
+                        1.3.6.1.4.1.311.25.2 is available. With the '.rid'
+                        selector only the last component, i.e. the RID, will be
+                        added.
+                    </para>
+                    <para>
+                        Example: LDAPU1:(objectsid={sid})
+                    </para>
+                    </listitem>
+                </varlistentry>
+            </variablelist>
+        </para>
+    </refsect3>
     </refsect2>
     <refsect2 id='domains'>
         <title>DOMAIN LIST</title>

--- a/src/tests/cmocka/test_certmap.c
+++ b/src/tests/cmocka/test_certmap.c
@@ -39,9 +39,11 @@
 #include <openssl/crypto.h>
 
 #ifdef HAVE_TEST_CA
+#include "tests/test_CA/SSSD_test_cert_x509_0001.h"
 #include "tests/test_CA/SSSD_test_cert_x509_0003.h"
 #include "tests/test_CA/SSSD_test_cert_x509_0004.h"
 #else
+#define SSSD_TEST_CERT_0001 ""
 #define SSSD_TEST_CERT_0003 ""
 #define SSSD_TEST_CERT_0004 ""
 #endif
@@ -794,6 +796,41 @@ const uint8_t test_cert3_der[] = {
 0x61, 0x8b, 0xc7, 0xc1, 0xe4, 0xbe, 0x60, 0x5a, 0x86, 0x5c, 0x86, 0xba, 0x59, 0x97, 0x83, 0x1b,
 0x79, 0x1c, 0x7c, 0x26};
 
+#define TEST_CERT_WITH_SID_EXT \
+    "MIIGFDCCBPygAwIBAgITcgAAAAIq7mYIPbH8OgAAAAAAAjANBgkqhkiG9w0BAQsF" \
+    "ADBAMRIwEAYKCZImiZPyLGQBGRYCdm0xEjAQBgoJkiaJk/IsZAEZFgJhZDEWMBQG" \
+    "A1UEAxMNYWQtUk9PVC1EQy1DQTAeFw0yMjA4MzEwOTA5NDFaFw0yMzA4MzEwOTA5" \
+    "NDFaMBgxFjAUBgNVBAMTDXJvb3QtZGMuYWQudm0wggEiMA0GCSqGSIb3DQEBAQUA" \
+    "A4IBDwAwggEKAoIBAQCrFS4l2bf9VwFl5NSFOKNcASgUwlxbdobpPQ1mB0Vso3fj" \
+    "zo82O8P+zGA9E0ZcrC02w/7MUI7P2HFAyr/TFVBdSa9HM5CIT1CupzJJuLhZQ4/O" \
+    "3gdy1W8aSBosorpVwS5EQYvaLrQascryTiWRu8jBNt2+/9WveMBvTXLDkj/fNK/f" \
+    "7yGIFrWSjCUk37nZGpLUJQbC+0aEiOuyJn7bs2K9fN3dmZmgbwqsWBREQwhqgbCZ" \
+    "5ZWbgs95JGJXScR4S4YKIkHK/hdaOEiqTCTJEpgszKBLdil6Yqt6/66b7Xun64/W" \
+    "I4TfScup292WKRlfB0KVMXYxGPo2kPiI8aVwcqNJAgMBAAGjggMtMIIDKTAvBgkr" \
+    "BgEEAYI3FAIEIh4gAEQAbwBtAGEAaQBuAEMAbwBuAHQAcgBvAGwAbABlAHIwHQYD" \
+    "VR0lBBYwFAYIKwYBBQUHAwIGCCsGAQUFBwMBMA4GA1UdDwEB/wQEAwIFoDB4Bgkq" \
+    "hkiG9w0BCQ8EazBpMA4GCCqGSIb3DQMCAgIAgDAOBggqhkiG9w0DBAICAIAwCwYJ" \
+    "YIZIAWUDBAEqMAsGCWCGSAFlAwQBLTALBglghkgBZQMEAQIwCwYJYIZIAWUDBAEF" \
+    "MAcGBSsOAwIHMAoGCCqGSIb3DQMHMB0GA1UdDgQWBBQURvUMyxhOgBeuK0FniBLp" \
+    "ZfbqwTAfBgNVHSMEGDAWgBQbcHqjwjfOyWv8FEmhCu5zuhB8nzCBxQYDVR0fBIG9" \
+    "MIG6MIG3oIG0oIGxhoGubGRhcDovLy9DTj1hZC1ST09ULURDLUNBLENOPXJvb3Qt" \
+    "ZGMsQ049Q0RQLENOPVB1YmxpYyUyMEtleSUyMFNlcnZpY2VzLENOPVNlcnZpY2Vz" \
+    "LENOPUNvbmZpZ3VyYXRpb24sREM9YWQsREM9dm0/Y2VydGlmaWNhdGVSZXZvY2F0" \
+    "aW9uTGlzdD9iYXNlP29iamVjdENsYXNzPWNSTERpc3RyaWJ1dGlvblBvaW50MIG5" \
+    "BggrBgEFBQcBAQSBrDCBqTCBpgYIKwYBBQUHMAKGgZlsZGFwOi8vL0NOPWFkLVJP" \
+    "T1QtREMtQ0EsQ049QUlBLENOPVB1YmxpYyUyMEtleSUyMFNlcnZpY2VzLENOPVNl" \
+    "cnZpY2VzLENOPUNvbmZpZ3VyYXRpb24sREM9YWQsREM9dm0/Y0FDZXJ0aWZpY2F0" \
+    "ZT9iYXNlP29iamVjdENsYXNzPWNlcnRpZmljYXRpb25BdXRob3JpdHkwOQYDVR0R" \
+    "BDIwMKAfBgkrBgEEAYI3GQGgEgQQpJvI9IWOiU2FjSe9Y6qTk4INcm9vdC1kYy5h" \
+    "ZC52bTBOBgkrBgEEAYI3GQIEQTA/oD0GCisGAQQBgjcZAgGgLwQtUy0xLTUtMjEt" \
+    "Mjk0MDI2MTI2LTMzNzgyNDUwMTgtMTIwMzEwMzk0OS0xMDAxMA0GCSqGSIb3DQEB" \
+    "CwUAA4IBAQBijGUmixRQ5ZY3g0+ppTcMRKKST0HE+UEUnuoBlnG3cBM4yTBBUWSg" \
+    "elzAglwbZbFRWT2ieX7rZzPALNLIyr43eZFpXelZElRGnTNISj9bWV+YEQ1DVGG4" \
+    "b0Z3WsrPS1DiKprgf6mNEg7bmNUcD2AYJzuFOUVVHQu+pwIOpWjVAri8MgU37f+o" \
+    "eY4fwbgbYQoTb6VGk53QPajONCa0sICDasvC0BNgkfLFUsL4y7xmWEtKJl7o+3Bo" \
+    "d+GO2zfbNX8oS/LjZ5f/Vpmiu04VPdiifdYAbfCQez3bevYBQn4D/bq/xVHoHSLY" \
+    "x0N7c7iPuFTCbg+OVrkH3OtPuRT/4kTn"
+
 void test_sss_cert_get_content(void **state)
 {
     int ret;
@@ -831,6 +868,14 @@ void test_sss_cert_get_content(void **state)
     assert_string_equal(content->subject_rdn_list[1], "CN=ipa-devel.ipa.devel");
     assert_null(content->subject_rdn_list[2]);
 
+    assert_int_equal(content->serial_number_size, 1);
+    assert_non_null(content->serial_number);
+    assert_memory_equal(content->serial_number, "\x09", 1);
+    assert_string_equal(content->serial_number_dec_str, "9");
+
+    assert_int_equal(content->subject_key_id_size, 20);
+    assert_non_null(content->subject_key_id);
+    assert_memory_equal(content->subject_key_id, "\x2D\x2B\x3F\xCB\xF5\xB2\xFF\x32\x2C\xA8\xC2\x1C\xDD\xBD\x8C\x80\x1E\xDD\x31\x82", 20);
 
     talloc_free(content);
 }
@@ -909,6 +954,15 @@ FIXME:
         }
     }
 
+    assert_int_equal(content->serial_number_size, 10);
+    assert_non_null(content->serial_number);
+    assert_memory_equal(content->serial_number, "\x61\x22\x88\xc2\x00\x00\x00\x00\x02\xa6", 10);
+    assert_string_equal(content->serial_number_dec_str, "458706592575796350550694");
+
+    assert_int_equal(content->subject_key_id_size, 20);
+    assert_non_null(content->subject_key_id);
+    assert_memory_equal(content->subject_key_id, "\x49\xAC\xAD\xE0\x65\x30\xC4\xCE\xA0\x09\x03\x5B\xAD\x4A\x7B\x49\x5E\xC9\x6C\xB4", 20);
+
     talloc_free(content);
 }
 
@@ -923,6 +977,7 @@ void test_sss_cert_get_content_test_cert_0003(void **state)
     assert_non_null(der);
 
     ret = sss_cert_get_content(NULL, der, der_size, &content);
+    talloc_free(der);
     assert_int_equal(ret, 0);
     assert_non_null(content);
     assert_non_null(content->issuer_str);
@@ -953,6 +1008,15 @@ void test_sss_cert_get_content_test_cert_0003(void **state)
 
     assert_null(content->san_list);
 
+    assert_int_equal(content->serial_number_size, 1);
+    assert_non_null(content->serial_number);
+    assert_memory_equal(content->serial_number, SSSD_TEST_CERT_SERIAL_0003, 1);
+    assert_string_equal(content->serial_number_dec_str, SSSD_TEST_CERT_DEC_SERIAL_0003);
+
+    assert_int_equal(content->subject_key_id_size, 20);
+    assert_non_null(content->subject_key_id);
+    assert_memory_equal(content->subject_key_id, "\x28\x3E\xBB\xD6\xD9\x5C\xFE\xC1\xFB\x7C\x49\x3B\x19\xB4\xD6\x63\xB2\x44\x8C\x41", 20);
+
     talloc_free(content);
 }
 
@@ -967,6 +1031,7 @@ void test_sss_cert_get_content_test_cert_0004(void **state)
     assert_non_null(der);
 
     ret = sss_cert_get_content(NULL, der, der_size, &content);
+    talloc_free(der);
     assert_int_equal(ret, 0);
     assert_non_null(content);
     assert_non_null(content->issuer_str);
@@ -996,6 +1061,73 @@ void test_sss_cert_get_content_test_cert_0004(void **state)
 
     assert_null(content->san_list);
 
+    assert_int_equal(content->serial_number_size, 1);
+    assert_non_null(content->serial_number);
+    assert_memory_equal(content->serial_number, SSSD_TEST_CERT_SERIAL_0004, 1);
+    assert_string_equal(content->serial_number_dec_str, SSSD_TEST_CERT_DEC_SERIAL_0004);
+
+    assert_int_equal(content->subject_key_id_size, 20);
+    assert_non_null(content->subject_key_id);
+    assert_memory_equal(content->subject_key_id, "\xDD\x09\x78\x8E\xE6\x50\xB3\xE3\x3B\x0D\xFB\x9F\xCB\x6D\x66\x48\x95\x1D\xAA\x52", 20);
+
+    talloc_free(content);
+}
+
+void test_sss_cert_get_content_test_cert_0001(void **state)
+{
+    int ret;
+    uint8_t *der;
+    size_t der_size;
+    struct sss_cert_content *content;
+    struct san_list *i;
+    uint32_t check = 0;
+
+    der = sss_base64_decode(NULL, SSSD_TEST_CERT_0001, &der_size);
+    assert_non_null(der);
+
+    ret = sss_cert_get_content(NULL, der, der_size, &content);
+    talloc_free(der);
+    assert_int_equal(ret, 0);
+    assert_non_null(content);
+
+    assert_non_null(content->san_list);
+    DLIST_FOR_EACH(i, content->san_list) {
+        switch (i->san_opt) {
+        case SAN_RFC822_NAME:
+            assert_string_equal(i->val, "sssd-devel@lists.fedorahosted.org");
+            assert_string_equal(i->short_name, "sssd-devel");
+            check |= 1;
+            break;
+        case SAN_URI:
+            assert_string_equal(i->val, "https://github.com/SSSD/sssd//");
+            check |= 2;
+            break;
+        default:
+            assert_true(false);
+        }
+    }
+    assert_int_equal(check, 3);
+
+    talloc_free(content);
+}
+
+void test_sss_cert_get_content_test_cert_with_sid_ext(void **state)
+{
+    int ret;
+    uint8_t *der;
+    size_t der_size;
+    struct sss_cert_content *content;
+
+    der = sss_base64_decode(NULL, TEST_CERT_WITH_SID_EXT, &der_size);
+    assert_non_null(der);
+
+    ret = sss_cert_get_content(NULL, der, der_size, &content);
+    talloc_free(der);
+    assert_int_equal(ret, 0);
+    assert_non_null(content);
+
+    assert_non_null(content->sid_ext);
+    assert_string_equal(content->sid_ext, "S-1-5-21-294026126-3378245018-1203103949-1001");
     talloc_free(content);
 }
 
@@ -1686,6 +1818,1052 @@ static void test_sss_certmap_get_search_filter(void **state)
     sss_certmap_free_ctx(ctx);
 }
 
+static void test_sss_certmap_ldapu1_serial_number(void **state)
+{
+    int ret;
+    struct sss_certmap_ctx *ctx;
+    char *filter;
+    char **domains;
+
+    ret = sss_certmap_init(NULL, ext_debug, NULL, &ctx);
+    assert_int_equal(ret, EOK);
+    assert_non_null(ctx);
+    assert_null(ctx->prio_list);
+
+    ret = sss_certmap_add_rule(ctx, 100,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule100={serial_number}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 100,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule100={serial_number}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule100=612288c20000000002a6");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule100=612288c20000000002a6");
+    assert_null(domains);
+
+
+    ret = sss_certmap_add_rule(ctx, 99,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule99={serial_number!HEX_U}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 99,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule99={serial_number!HEX_U}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule99=612288C20000000002A6");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule99=612288C20000000002A6");
+    assert_null(domains);
+
+
+    ret = sss_certmap_add_rule(ctx, 98,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule98={serial_number!HEX_UC}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 98,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule98={serial_number!HEX_UC}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule98=61:22:88:C2:00:00:00:00:02:A6");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule98=61:22:88:C2:00:00:00:00:02:A6");
+    assert_null(domains);
+
+
+    ret = sss_certmap_add_rule(ctx, 97,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule97={serial_number!hex_c}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 97,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule97={serial_number!hex_c}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule97=61:22:88:c2:00:00:00:00:02:a6");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule97=61:22:88:c2:00:00:00:00:02:a6");
+    assert_null(domains);
+
+
+    ret = sss_certmap_add_rule(ctx, 96,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule96={serial_number!hex}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 96,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule96={serial_number!hex}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule96=612288c20000000002a6");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule96=612288c20000000002a6");
+    assert_null(domains);
+
+
+    ret = sss_certmap_add_rule(ctx, 95,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule95={serial_number!dec}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 95,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule95={serial_number!dec}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule95=458706592575796350550694");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule95=458706592575796350550694");
+    assert_null(domains);
+
+    /* Conversion specifiers are not supported for 'dec' */
+    ret = sss_certmap_add_rule(ctx, 94,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule94={serial_number!dec_u}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 94,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule94={serial_number!dec_u}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    sss_certmap_free_ctx(ctx);
+}
+
+static void test_sss_certmap_ldapu1_subject_key_id(void **state)
+{
+    int ret;
+    struct sss_certmap_ctx *ctx;
+    char *filter;
+    char **domains;
+
+    ret = sss_certmap_init(NULL, ext_debug, NULL, &ctx);
+    assert_int_equal(ret, EOK);
+    assert_non_null(ctx);
+    assert_null(ctx->prio_list);
+
+    /* subject_key_id */
+    ret = sss_certmap_add_rule(ctx, 94,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule94={subject_key_id}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 94,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule94={subject_key_id}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule94=49acade06530c4cea009035bad4a7b495ec96cb4");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule94=49acade06530c4cea009035bad4a7b495ec96cb4");
+    assert_null(domains);
+
+
+    /* subject_key_id!HEX */
+    ret = sss_certmap_add_rule(ctx, 93,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule93={subject_key_id!HEX_U}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 93,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule93={subject_key_id!HEX_U}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule93=49ACADE06530C4CEA009035BAD4A7B495EC96CB4");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule93=49ACADE06530C4CEA009035BAD4A7B495EC96CB4");
+    assert_null(domains);
+
+
+    /* subject_key_id!HEX_COLON */
+    ret = sss_certmap_add_rule(ctx, 92,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule92={subject_key_id!HEX_CU}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 92,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule92={subject_key_id!HEX_CU}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule92=49:AC:AD:E0:65:30:C4:CE:A0:09:03:5B:AD:4A:7B:49:5E:C9:6C:B4");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule92=49:AC:AD:E0:65:30:C4:CE:A0:09:03:5B:AD:4A:7B:49:5E:C9:6C:B4");
+    assert_null(domains);
+
+
+    /* subject_key_id!hex_colon */
+    ret = sss_certmap_add_rule(ctx, 91,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule91={subject_key_id!hex_c}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 91,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule91={subject_key_id!hex_c}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule91=49:ac:ad:e0:65:30:c4:ce:a0:09:03:5b:ad:4a:7b:49:5e:c9:6c:b4");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule91=49:ac:ad:e0:65:30:c4:ce:a0:09:03:5b:ad:4a:7b:49:5e:c9:6c:b4");
+    assert_null(domains);
+
+
+    /* subject_key_id!hex */
+    ret = sss_certmap_add_rule(ctx, 90,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule90={subject_key_id!hex}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 90,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule90={subject_key_id!hex}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule90=49acade06530c4cea009035bad4a7b495ec96cb4");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule90=49acade06530c4cea009035bad4a7b495ec96cb4");
+    assert_null(domains);
+
+
+    /* UNSUPPORTED subject_key_id!dec */
+    ret = sss_certmap_add_rule(ctx, 89,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule89={subject_key_id!dec}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 89,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule89={subject_key_id!dec}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    sss_certmap_free_ctx(ctx);
+}
+
+static void test_sss_certmap_ldapu1_cert(void **state)
+{
+    int ret;
+    struct sss_certmap_ctx *ctx;
+    char *filter;
+    char **domains;
+
+    ret = sss_certmap_init(NULL, ext_debug, NULL, &ctx);
+    assert_int_equal(ret, EOK);
+    assert_non_null(ctx);
+    assert_null(ctx->prio_list);
+
+    /* cert!sha555 */
+    ret = sss_certmap_add_rule(ctx, 89,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule89={cert!sha555}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 89,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule89={cert!sha555}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    /* cert!sha512 */
+    ret = sss_certmap_add_rule(ctx, 88,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule88={cert!sha512}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 88,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule88={cert!sha512}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule88=3ee0583237ae9e6ec7d92dd4a029a9d54147bad48b1b0bad0e4e63380bc9a18ae7b447a03a05b35ad605494a57c359400c0ff3f411c71b96e500f8f2765f6fa3");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule88=3ee0583237ae9e6ec7d92dd4a029a9d54147bad48b1b0bad0e4e63380bc9a18ae7b447a03a05b35ad605494a57c359400c0ff3f411c71b96e500f8f2765f6fa3");
+    assert_null(domains);
+
+    /* cert!sha512_u */
+    ret = sss_certmap_add_rule(ctx, 68,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule68={cert!sha512_u}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 68,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule68={cert!sha512_u}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule68=3EE0583237AE9E6EC7D92DD4A029A9D54147BAD48B1B0BAD0E4E63380BC9A18AE7B447A03A05B35AD605494A57C359400C0FF3F411C71B96E500F8F2765F6FA3");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule68=3EE0583237AE9E6EC7D92DD4A029A9D54147BAD48B1B0BAD0E4E63380BC9A18AE7B447A03A05B35AD605494A57C359400C0FF3F411C71B96E500F8F2765F6FA3");
+    assert_null(domains);
+
+    /* cert!SHA512_CU */
+    ret = sss_certmap_add_rule(ctx, 67,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule67={cert!SHA512_CU}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 67,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule67={cert!SHA512_CU}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule67=3E:E0:58:32:37:AE:9E:6E:C7:D9:2D:D4:A0:29:A9:D5:41:47:BA:D4:8B:1B:0B:AD:0E:4E:63:38:0B:C9:A1:8A:E7:B4:47:A0:3A:05:B3:5A:D6:05:49:4A:57:C3:59:40:0C:0F:F3:F4:11:C7:1B:96:E5:00:F8:F2:76:5F:6F:A3");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule67=3E:E0:58:32:37:AE:9E:6E:C7:D9:2D:D4:A0:29:A9:D5:41:47:BA:D4:8B:1B:0B:AD:0E:4E:63:38:0B:C9:A1:8A:E7:B4:47:A0:3A:05:B3:5A:D6:05:49:4A:57:C3:59:40:0C:0F:F3:F4:11:C7:1B:96:E5:00:F8:F2:76:5F:6F:A3");
+    assert_null(domains);
+
+    /* cert!SHA512_CRU */
+    ret = sss_certmap_add_rule(ctx, 66,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule66={cert!SHA512_CRU}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 66,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule66={cert!SHA512_CRU}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule66=A3:6F:5F:76:F2:F8:00:E5:96:1B:C7:11:F4:F3:0F:0C:40:59:C3:57:4A:49:05:D6:5A:B3:05:3A:A0:47:B4:E7:8A:A1:C9:0B:38:63:4E:0E:AD:0B:1B:8B:D4:BA:47:41:D5:A9:29:A0:D4:2D:D9:C7:6E:9E:AE:37:32:58:E0:3E");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule66=A3:6F:5F:76:F2:F8:00:E5:96:1B:C7:11:F4:F3:0F:0C:40:59:C3:57:4A:49:05:D6:5A:B3:05:3A:A0:47:B4:E7:8A:A1:C9:0B:38:63:4E:0E:AD:0B:1B:8B:D4:BA:47:41:D5:A9:29:A0:D4:2D:D9:C7:6E:9E:AE:37:32:58:E0:3E");
+    assert_null(domains);
+
+    sss_certmap_free_ctx(ctx);
+}
+
+static void test_sss_certmap_ldapu1_subject_dn_component(void **state)
+{
+    int ret;
+    struct sss_certmap_ctx *ctx;
+    char *filter;
+    char **domains;
+
+    ret = sss_certmap_init(NULL, ext_debug, NULL, &ctx);
+    assert_int_equal(ret, EOK);
+    assert_non_null(ctx);
+    assert_null(ctx->prio_list);
+
+    /* subject_dn_component */
+    ret = sss_certmap_add_rule(ctx, 77,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule77={subject_dn_component}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 77,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule77={subject_dn_component}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule77=test.user@email.domain");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule77=test.user@email.domain");
+    assert_null(domains);
+
+    /* subject_dn_component.[...] */
+    ret = sss_certmap_add_rule(ctx, 76,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule76={subject_dn_component.[1]}--{subject_dn_component.[2]}--{subject_dn_component.[3]}--{subject_dn_component.[4]}--{subject_dn_component.[5]}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 76,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule76={subject_dn_component.[1]}--{subject_dn_component.[2]}--{subject_dn_component.[3]}--{subject_dn_component.[4]}--{subject_dn_component.[5]}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule76=test.user@email.domain--t\\20u--Users--ad--devel");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule76=test.user@email.domain--t u--Users--ad--devel");
+    assert_null(domains);
+
+    /* subject_dn_component.[-...] */
+    ret = sss_certmap_add_rule(ctx, 75,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule75={subject_dn_component.[-5]}--{subject_dn_component.[-4]}--{subject_dn_component.[-3]}--{subject_dn_component.[-2]}--{subject_dn_component.[-1]}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 75,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule75={subject_dn_component.[-5]}--{subject_dn_component.[-4]}--{subject_dn_component.[-3]}--{subject_dn_component.[-2]}--{subject_dn_component.[-1]}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule75=test.user@email.domain--t\\20u--Users--ad--devel");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule75=test.user@email.domain--t u--Users--ad--devel");
+    assert_null(domains);
+
+    /* subject_dn_component.[6] */
+    ret = sss_certmap_add_rule(ctx, 74,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule74={subject_dn_component.[6]}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 74,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule74={subject_dn_component.[6]}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, EINVAL);
+
+    /* subject_dn_component.[-6] */
+    ret = sss_certmap_add_rule(ctx, 73,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule73={subject_dn_component.[-6]}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 73,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule73={subject_dn_component.[-6]}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, EINVAL);
+
+    /* subject_dn_component.e */
+    ret = sss_certmap_add_rule(ctx, 72,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule72={subject_dn_component.e}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 72,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule72={subject_dn_component.e}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule72=test.user@email.domain");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule72=test.user@email.domain");
+    assert_null(domains);
+
+    /* subject_dn_component.cn */
+    ret = sss_certmap_add_rule(ctx, 71,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule71={subject_dn_component.cn}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 71,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule71={subject_dn_component.cn}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule71=t\\20u");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule71=t u");
+    assert_null(domains);
+
+    /* subject_dn_component.cn[2] */
+    ret = sss_certmap_add_rule(ctx, 70,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule70={subject_dn_component.cn[2]}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 70,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule70={subject_dn_component.cn[2]}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule70=t\\20u");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule70=t u");
+    assert_null(domains);
+
+    /* subject_dn_component.cn[1] */
+    ret = sss_certmap_add_rule(ctx, 69,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule69={subject_dn_component.cn[1]}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 69,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule60={subject_dn_component.cn[1]}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, EINVAL);
+
+    sss_certmap_free_ctx(ctx);
+}
+
+static void test_sss_certmap_ldapu1_issuer_dn_component(void **state)
+{
+    int ret;
+    struct sss_certmap_ctx *ctx;
+    char *filter;
+    char **domains;
+
+    ret = sss_certmap_init(NULL, ext_debug, NULL, &ctx);
+    assert_int_equal(ret, EOK);
+    assert_non_null(ctx);
+    assert_null(ctx->prio_list);
+
+    /* issuer_dn_component */
+    ret = sss_certmap_add_rule(ctx, 87,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule87={issuer_dn_component}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 87,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule87={issuer_dn_component}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule87=ad-AD-SERVER-CA");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule87=ad-AD-SERVER-CA");
+    assert_null(domains);
+
+    /* issuer_dn_component.[0] */
+    ret = sss_certmap_add_rule(ctx, 86,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule86={issuer_dn_component.[0]}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 86,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule86={issuer_dn_component.[0]}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    /* issuer_dn_component.[1] */
+    ret = sss_certmap_add_rule(ctx, 85,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule85={issuer_dn_component.[1]}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 85,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule85={issuer_dn_component.[1]}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule85=ad-AD-SERVER-CA");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule85=ad-AD-SERVER-CA");
+    assert_null(domains);
+
+    /* issuer_dn_component.[-1] */
+    ret = sss_certmap_add_rule(ctx, 84,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule84={issuer_dn_component.[-1]}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 84,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule84={issuer_dn_component.[-1]}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule84=devel");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule84=devel");
+    assert_null(domains);
+
+    /* issuer_dn_component.[2] */
+    ret = sss_certmap_add_rule(ctx, 83,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule83={issuer_dn_component.[2]}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 83,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule83={issuer_dn_component.[2]}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule83=ad");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule83=ad");
+    assert_null(domains);
+
+    /* issuer_dn_component.[-2] */
+    ret = sss_certmap_add_rule(ctx, 82,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule82={issuer_dn_component.[-2]}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 82,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule82={issuer_dn_component.[-2]}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule82=ad");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule82=ad");
+    assert_null(domains);
+
+    /* issuer_dn_component.[3] */
+    ret = sss_certmap_add_rule(ctx, 81,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule81={issuer_dn_component.[3]}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 81,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule81={issuer_dn_component.[3]}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule81=devel");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule81=devel");
+    assert_null(domains);
+
+    /* issuer_dn_component.[-3] */
+    ret = sss_certmap_add_rule(ctx, 80,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule80={issuer_dn_component.[-3]}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 80,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule80={issuer_dn_component.[-3]}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule80=ad-AD-SERVER-CA");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, discard_const(test_cert2_der),
+                                          sizeof(test_cert2_der),
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule80=ad-AD-SERVER-CA");
+    assert_null(domains);
+
+    /* issuer_dn_component.[4] */
+    ret = sss_certmap_add_rule(ctx, 79,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule79={issuer_dn_component.[4]}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 79,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule79={issuer_dn_component.[4]}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, EINVAL);
+
+    /* issuer_dn_component.[-4] */
+    ret = sss_certmap_add_rule(ctx, 78,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule78={issuer_dn_component.[-4]}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 78,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule78={issuer_dn_component.[-4]}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, discard_const(test_cert2_der),
+                                        sizeof(test_cert2_der),
+                                        &filter, &domains);
+    assert_int_equal(ret, EINVAL);
+
+    sss_certmap_free_ctx(ctx);
+}
+
+static void test_sss_certmap_ldapu1_sid(void **state)
+{
+    int ret;
+    struct sss_certmap_ctx *ctx;
+    char *filter;
+    char **domains;
+
+    uint8_t *der;
+    size_t der_size;
+
+    der = sss_base64_decode(NULL, TEST_CERT_WITH_SID_EXT, &der_size);
+    assert_non_null(der);
+
+    ret = sss_certmap_init(NULL, ext_debug, NULL, &ctx);
+    assert_int_equal(ret, EOK);
+    assert_non_null(ctx);
+    assert_null(ctx->prio_list);
+
+    /* full sid */
+    ret = sss_certmap_add_rule(ctx, 100,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule100={sid}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 100,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule100={sid}", NULL);
+    assert_int_equal(ret, 0);
+
+    ret = sss_certmap_get_search_filter(ctx, der, der_size,
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule100=S-1-5-21-294026126-3378245018-1203103949-1001");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, der, der_size,
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule100=S-1-5-21-294026126-3378245018-1203103949-1001");
+    assert_null(domains);
+
+    /* invalid component */
+    ret = sss_certmap_add_rule(ctx, 99,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule99={sid.abc}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 99,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule99={sid.abc}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    /* rid component */
+    ret = sss_certmap_add_rule(ctx, 98,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule98={sid.rid}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 98,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule98={sid.rid}", NULL);
+    assert_int_equal(ret, 0);
+    ret = sss_certmap_get_search_filter(ctx, der, der_size,
+                                        &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule98=1001");
+    assert_null(domains);
+
+    ret = sss_certmap_expand_mapping_rule(ctx, der, der_size,
+                                          &filter, &domains);
+    assert_int_equal(ret, 0);
+    assert_non_null(filter);
+    assert_string_equal(filter, "rule98=1001");
+    assert_null(domains);
+
+    sss_certmap_free_ctx(ctx);
+}
+
+
 int main(int argc, const char *argv[])
 {
     int rv;
@@ -1707,10 +2885,18 @@ int main(int argc, const char *argv[])
 #ifdef HAVE_TEST_CA
         cmocka_unit_test(test_sss_cert_get_content_test_cert_0003),
         cmocka_unit_test(test_sss_cert_get_content_test_cert_0004),
+        cmocka_unit_test(test_sss_cert_get_content_test_cert_0001),
 #endif
+        cmocka_unit_test(test_sss_cert_get_content_test_cert_with_sid_ext),
         cmocka_unit_test(test_sss_certmap_match_cert),
         cmocka_unit_test(test_sss_certmap_add_mapping_rule),
         cmocka_unit_test(test_sss_certmap_get_search_filter),
+        cmocka_unit_test(test_sss_certmap_ldapu1_serial_number),
+        cmocka_unit_test(test_sss_certmap_ldapu1_subject_key_id),
+        cmocka_unit_test(test_sss_certmap_ldapu1_cert),
+        cmocka_unit_test(test_sss_certmap_ldapu1_subject_dn_component),
+        cmocka_unit_test(test_sss_certmap_ldapu1_issuer_dn_component),
+        cmocka_unit_test(test_sss_certmap_ldapu1_sid),
     };
 
     /* Set debug level to invalid value so we can decide if -d 0 was used. */

--- a/src/tests/test_CA/Makefile.am
+++ b/src/tests/test_CA/Makefile.am
@@ -91,6 +91,8 @@ SSSD_test_cert_pubsshkey_%.pub: SSSD_test_cert_pubkey_%.pem
 
 SSSD_test_cert_x509_%.h: SSSD_test_cert_x509_%.pem
 	@echo "#define SSSD_TEST_CERT_$* \""$(shell cat $< |openssl x509 -outform der | base64 -w 0)"\"" > $@
+	@echo "#define SSSD_TEST_CERT_SERIAL_$* \"\\x"$(shell cat $< |openssl x509 -noout -serial | cut -d= -f2)"\"" >> $@
+	@echo "#define SSSD_TEST_CERT_DEC_SERIAL_$* \""$(shell /bin/echo ibase=16\; $(shell cat $< |openssl x509 -noout -serial | cut -d= -f2) | bc)"\"" >> $@
 
 SSSD_test_cert_pubsshkey_%.h: SSSD_test_cert_pubsshkey_%.pub
 	@echo "#define SSSD_TEST_CERT_SSH_KEY_$* \""$(shell cut -d' ' -f2 $<)"\"" > $@

--- a/src/tests/test_CA/SSSD_test_cert_0004.config
+++ b/src/tests/test_CA/SSSD_test_cert_0004.config
@@ -1,6 +1,8 @@
 # This certificate is used in
 # - test_sss_cert_get_content_test_cert_0004
 # as an example for a simple certificate without KU, EKU and SAN extensions
+# The subjectKeyIdentifier is required to make sure older versions of OpenSSL
+# will generate it as newer version add it automatically.
 [ req ]
 distinguished_name = req_distinguished_name
 prompt = no
@@ -9,3 +11,6 @@ prompt = no
 O = SSSD
 OU = SSSD test
 CN = SSSD test cert 0004
+
+[ req_exts ]
+subjectKeyIdentifier=hash

--- a/src/tools/sssctl/sssctl.c
+++ b/src/tools/sssctl/sssctl.c
@@ -329,6 +329,7 @@ int main(int argc, const char **argv)
         SSS_TOOL_DELIMITER("Certificate related tools:"),
         SSS_TOOL_COMMAND("cert-show", "Print information about the certificate", 0, sssctl_cert_show),
         SSS_TOOL_COMMAND("cert-map", "Show users mapped to the certificate", 0, sssctl_cert_map),
+        SSS_TOOL_COMMAND("cert-eval-rule", "Check mapping and matching rule with a certificate", 0, sssctl_cert_eval_rule),
 #ifdef BUILD_PASSKEY
         SSS_TOOL_DELIMITER("Passkey related tools:"),
         SSS_TOOL_COMMAND_FLAGS("passkey-exec", "Perform passkey related operations", 0, sssctl_passkey_exec, SSS_TOOL_FLAG_SKIP_CMD_INIT|SSS_TOOL_FLAG_SKIP_ROOT_CHECK),

--- a/src/tools/sssctl/sssctl.h
+++ b/src/tools/sssctl/sssctl.h
@@ -144,4 +144,8 @@ errno_t sssctl_passkey_exec(struct sss_cmdline *cmdline,
                             struct sss_tool_ctx *tool_ctx,
                             void *pvt);
 #endif /* BUILD_PASSKEY */
+
+errno_t sssctl_cert_eval_rule(struct sss_cmdline *cmdline,
+                              struct sss_tool_ctx *tool_ctx,
+                              void *pvt);
 #endif /* _SSSCTL_H_ */

--- a/src/tools/sssctl/sssctl_cert.c
+++ b/src/tools/sssctl/sssctl_cert.c
@@ -173,3 +173,117 @@ done:
 
     return ret;
 }
+
+struct priv_sss_debug {
+    bool verbose;
+};
+
+void certmap_ext_debug(void *private, const char *file, long line,
+                       const char *function, const char *format, ...)
+{
+    va_list ap;
+    struct priv_sss_debug *data = private;
+
+    if (data != NULL && data->verbose) {
+        va_start(ap, format);
+        fprintf(stdout, "%s:%ld [%s]: ", file, line, function);
+        vfprintf(stdout, format, ap);
+        fprintf(stdout, "\n");
+        va_end(ap);
+    }
+}
+
+errno_t sssctl_cert_eval_rule(struct sss_cmdline *cmdline,
+                              struct sss_tool_ctx *tool_ctx,
+                              void *pvt)
+{
+    TALLOC_CTX *tmp_ctx = NULL;
+    errno_t ret;
+    int verbose = 0;
+    const char *cert_b64 = NULL;
+    const char *map = NULL;
+    const char *match = NULL;
+    struct sss_certmap_ctx *sss_certmap_ctx = NULL;
+    struct priv_sss_debug priv_sss_debug;
+    uint8_t *der_cert = NULL;
+    size_t der_size;
+    char *filter = NULL;
+    char **domains = NULL;
+
+    /* Parse command line. */
+    struct poptOption options[] = {
+        {"map", 'p', POPT_ARG_STRING, &map, 0, _("Mapping rule"), NULL },
+        {"match", 't', POPT_ARG_STRING, &match, 0, _("Matching rule"), NULL },
+        {"verbose", 'v', POPT_ARG_NONE, &verbose, 0, _("Show debug information"), NULL },
+        POPT_TABLEEND
+    };
+
+    ret = sss_tool_popt_ex(cmdline, options, SSS_TOOL_OPT_OPTIONAL,
+                           NULL, NULL, "CERTIFICATE-BASE64-ENCODED",
+                           _("Specify base64 encoded certificate."),
+                           SSS_TOOL_OPT_REQUIRED, &cert_b64, NULL);
+    if (ret != EOK) {
+        ERROR("Unable to parse command arguments\n");
+        return ret;
+    }
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        ERROR("Out of memory!\n");
+        return ENOMEM;
+    }
+
+    priv_sss_debug.verbose = (verbose != 0);
+
+    ret = sss_certmap_init(tmp_ctx, certmap_ext_debug, &priv_sss_debug,
+                           &sss_certmap_ctx);
+    if (ret != EOK) {
+        ERROR("Failed to setup certmap context.\n");
+        goto done;
+    }
+
+    ret = sss_certmap_add_rule(sss_certmap_ctx, 1, match, map, NULL);
+    if (ret != EOK) {
+        ERROR("Failed to add mapping and matching rules with error [%d][%s].\n",
+              ret, sss_strerror(ret));
+        goto done;
+    }
+
+    der_cert = sss_base64_decode(tmp_ctx, cert_b64, &der_size);
+    if (der_cert == NULL) {
+        ERROR("Failed to decode base64 string.\n");
+        ret = EINVAL;
+        goto done;
+    }
+
+    ret = sss_certmap_match_cert(sss_certmap_ctx, der_cert, der_size);
+    switch (ret) {
+    case 0:
+        PRINT("Certificate matches rule.\n");
+        break;
+    case ENOENT:
+        PRINT("Certificate does not match rule.\n");
+        break;
+    default:
+        ERROR("Error during certificate matching [%d][%s].\n",
+              ret, sss_strerror(ret));
+    }
+
+    ret = sss_certmap_get_search_filter(sss_certmap_ctx, der_cert, der_size,
+                                        &filter, &domains);
+    if (ret != 0) {
+        ERROR("Failed to generate mapping filter [%d][%s].\n",
+              ret, sss_strerror(ret));
+        goto done;
+    }
+    PRINT("Mapping filter:\n\n    %s\n\n", filter);
+    sss_certmap_free_filter_and_domains(filter, domains);
+
+    ret = EOK;
+
+done:
+
+    talloc_free(tmp_ctx);
+
+    return ret;
+}


### PR DESCRIPTION
Add mapping rule templates for the new discovered attributes, templates for
certificate hashes and templates to select individual DN components. To
avoid issues with older versions of the library the new templates must use
the prefix LDAPU1.

:feature: New mapping template for serial number, subject key id, SID,
          certificate hashes and DN components are added to
          libsss_certmap.

Resolves: https://github.com/SSSD/sssd/issues/6403
Resolves: https://github.com/SSSD/sssd/issues/6404