### PR TITLE
BACKEND: Reload resolv.conf after initialization

### DIFF
--- a/src/monitor/monitor_sbus.c
+++ b/src/monitor/monitor_sbus.c
@@ -156,6 +156,11 @@ int monitor_common_res_init(struct sbus_request *dbus_req, void *data)
         return EIO;
     }
 
+    if (dbus_req == NULL) {
+        /* No reply needed */
+        return EOK;
+    }
+
     /* Send an empty reply to acknowledge receipt */
     return sbus_request_return_and_finish(dbus_req, DBUS_TYPE_INVALID);
 }

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -549,6 +549,14 @@ errno_t be_process_init(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
+    /* Load the resolv.conf file in case a call to dbus' resInit() was missed */
+    if (monitor_be_methods.resInit != NULL) {
+        ret = monitor_be_methods.resInit(NULL, (void *) be_ctx);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE, "Unable to reload resolv.conf\n");
+        }
+    }
+
     ret = EOK;
 
 done:


### PR DESCRIPTION
Once the backend initialization is finished, in particular after D-Bus is initialized, reload the resolv.conf file to reload any change signaled through D-Bus before its initializiation.

Resolves: https://github.com/SSSD/sssd/issues/6383