### PR TITLE
Tests: gssapi ssh login minor fix

### DIFF
--- a/src/tests/multihost/alltests/test_misc.py
+++ b/src/tests/multihost/alltests/test_misc.py
@@ -514,7 +514,7 @@ class TestMisc(object):
             ssh.login(multihost.client[0].sys_hostname, 'foo1', 'Secret123')
             ssh.sendline('kdestroy -A -q')
             ssh.prompt(timeout=5)
-            ssh.sendline(f'kinit foo1{dom_name.upper()}')
+            ssh.sendline(f'kinit foo1@{dom_name.upper()}')
             ssh.expect('Password for .*:', timeout=10)
             ssh.sendline('Secret123')
             ssh.prompt(timeout=5)


### PR DESCRIPTION
Trivial fix, the kinit command was missing '@' after usename. It was causing obvious failure to fetch krb ticket.