### PR TITLE
Tests: Removing tests from gating pipe line

### DIFF
--- a/src/tests/multihost/alltests/test_misc_proxy.py
+++ b/src/tests/multihost/alltests/test_misc_proxy.py
@@ -381,6 +381,7 @@ class TestProxyMisc(object):
         assert ssh_res, "Ssh for user foo2 failed."
 
     @staticmethod
+    @pytest.mark.tier2
     def test_bz1368467(multihost, backupsssdconf, create_350_posix_users):
         """
         :title: sssd runs out of available child slots and

--- a/src/tests/multihost/alltests/test_sssd_nss.py
+++ b/src/tests/multihost/alltests/test_sssd_nss.py
@@ -44,6 +44,14 @@ class TestSssdNss(object):
             2. Should succeed
             3. Should succeed
         """
+        version_fedora = 0
+        version_rel_cent = 0
+        if "Fedora" in multihost.client[0].distro:
+            version_fedora = int(re.search(r'\d+', multihost.client[0].distro).group())
+        else:
+            version_rel_cent = float(re.findall(r"\d+\.\d+", multihost.client[0].distro)[0])
+        if version_rel_cent < 9 and version_fedora < 35:
+            pytest.skip("unsupported configuration")
         tools = sssdTools(multihost.client[0])
         sssd_params = {'domains': ds_instance_name}
         tools.sssd_conf('sssd', sssd_params)


### PR DESCRIPTION
test_bz1368467 --- this one looks more perfomance than gatting test_avoid_interlocking_among_threads --- package not available for rhel8(will be restored after available)