### PR TITLE
Several minor fixes

### DIFF
--- a/src/providers/ldap/sdap.c
+++ b/src/providers/ldap/sdap.c
@@ -515,6 +515,7 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
 
         if (ret == ECANCELED) {
             store = false;
+            name = NULL;
         } else if (map) {
             for (i = 1; i < attrs_num; i++) {
                 /* check if this attr is valid with the chosen schema */

--- a/src/providers/ldap/sdap_access.h
+++ b/src/providers/ldap/sdap_access.h
@@ -27,6 +27,7 @@
 
 #include "providers/backend.h"
 #include "providers/ldap/ldap_common.h"
+#include "providers/ldap/sdap_id_op.h"
 
 /* Attributes in sysdb, used for caching last values of lockout or filter
  * access control checks.

--- a/src/providers/proxy/proxy_ipnetworks.c
+++ b/src/providers/proxy/proxy_ipnetworks.c
@@ -233,7 +233,7 @@ get_net_byname(struct proxy_resolver_ctx *ctx,
     if (ret == ENOENT) {
         /* Not found, make sure we remove it from the cache */
         DEBUG(SSSDBG_TRACE_INTERNAL, "Network [%s] not found, removing from "
-              "cache\n", name);
+              "cache\n", search_name);
         sysdb_ipnetwork_delete(domain, search_name, NULL);
         ret = ENOENT;
         goto done;
@@ -334,7 +334,7 @@ get_net_byaddr(struct proxy_resolver_ctx *ctx,
     if (ret == ENOENT) {
         /* Not found, make sure we remove it from the cache */
         DEBUG(SSSDBG_TRACE_INTERNAL, "Network [%s] not found, removing from "
-              "cache\n", name);
+              "cache\n", search_addrstr);
         sysdb_ipnetwork_delete(domain, NULL, search_addrstr);
         ret = ENOENT;
         goto done;

--- a/src/responder/kcm/kcm_renew.c
+++ b/src/responder/kcm/kcm_renew.c
@@ -291,6 +291,8 @@ int kcm_get_renewal_config(struct kcm_ctx *kctx,
                 ret = dp_opt_set_bool(krb5_ctx->opts, i,
                                       default_krb5_opts[i].def_val.boolean);
                 break;
+            default:
+                ret = EINVAL;
         }
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "Failed setting default renewal kerberos "

--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -587,7 +587,7 @@ static int user_info_expire_warn(pam_handle_t *pamh,
     int ret;
     uint32_t expire;
     char user_msg[256];
-    const char* unit="second(s)";
+    const char* unit=_("second(s)");
 
     if (buflen != 2* sizeof(uint32_t)) {
         D(("User info response data has the wrong size"));
@@ -596,13 +596,13 @@ static int user_info_expire_warn(pam_handle_t *pamh,
     memcpy(&expire, buf + sizeof(uint32_t), sizeof(uint32_t));
     if (expire >= DAYSEC) {
         expire /= DAYSEC;
-        unit = "day(s)";
+        unit = _("day(s)");
     } else if (expire >= HOURSEC) {
         expire /= HOURSEC;
-        unit = "hour(s)";
+        unit = _("hour(s)");
     } else if (expire >= MINSEC) {
         expire /= MINSEC;
-        unit = "minute(s)";
+        unit = _("minute(s)");
     }
 
     ret = snprintf(user_msg, sizeof(user_msg),


### PR DESCRIPTION
* Fix some warnings thrown while building. Some of them are not actually needed (false positives) but this helps to have a clean build and identify real warnings.
* Localize some forgotten words. The units (days, hours, minutes) were not localized although they were used in a localized sentence.
* Fixed header file. The sdap_access.h header file was not including the sdap_id_op header file it depends on. Build worked because sdap_id_op.h happened to be always included before sdap_access.h.