### PR TITLE
BUILD: Fix some warnings thrown while building

### DIFF
--- a/src/providers/ldap/sdap.c
+++ b/src/providers/ldap/sdap.c
@@ -415,7 +415,7 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
     int lerrno;
     int i, ret, ai;
     int base_attr_idx = 0;
-    const char *name;
+    const char *name = NULL;
     bool store;
     bool base64;
     char *base_attr;
@@ -532,7 +532,6 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
                 }
             } else {
                 store = false;
-                name = NULL;
             }
         } else {
             name = base_attr;

--- a/src/providers/proxy/proxy_ipnetworks.c
+++ b/src/providers/proxy/proxy_ipnetworks.c
@@ -233,7 +233,7 @@ get_net_byname(struct proxy_resolver_ctx *ctx,
     if (ret == ENOENT) {
         /* Not found, make sure we remove it from the cache */
         DEBUG(SSSDBG_TRACE_INTERNAL, "Network [%s] not found, removing from "
-              "cache\n", name);
+              "cache\n", search_name);
         sysdb_ipnetwork_delete(domain, search_name, NULL);
         ret = ENOENT;
         goto done;
@@ -249,8 +249,8 @@ get_net_byname(struct proxy_resolver_ctx *ctx,
         }
 
         /* Save result into the cache */
-        DEBUG(SSSDBG_TRACE_INTERNAL, "Network [%s] found, saving into "
-              "cache\n", name);
+        DEBUG(SSSDBG_TRACE_INTERNAL, "Network [%s] found as [%s], saving into "
+              "cache\n", search_name, name);
         ret = proxy_save_ipnetwork(domain, !domain->case_sensitive,
                                    domain->resolver_timeout,
                                    name, aliases, address);
@@ -334,7 +334,7 @@ get_net_byaddr(struct proxy_resolver_ctx *ctx,
     if (ret == ENOENT) {
         /* Not found, make sure we remove it from the cache */
         DEBUG(SSSDBG_TRACE_INTERNAL, "Network [%s] not found, removing from "
-              "cache\n", name);
+              "cache\n", search_addrstr);
         sysdb_ipnetwork_delete(domain, NULL, search_addrstr);
         ret = ENOENT;
         goto done;
@@ -350,8 +350,8 @@ get_net_byaddr(struct proxy_resolver_ctx *ctx,
         }
 
         /* Save result into the cache */
-        DEBUG(SSSDBG_TRACE_INTERNAL, "Network [%s] found, saving into "
-              "cache\n", name);
+        DEBUG(SSSDBG_TRACE_INTERNAL, "Network [%s] found as [%s], saving into "
+              "cache\n", search_addrstr, name);
         ret = proxy_save_ipnetwork(domain, !domain->case_sensitive,
                                    domain->resolver_timeout,
                                    name, aliases, address);

--- a/src/responder/kcm/kcm_renew.c
+++ b/src/responder/kcm/kcm_renew.c
@@ -291,6 +291,8 @@ int kcm_get_renewal_config(struct kcm_ctx *kctx,
                 ret = dp_opt_set_bool(krb5_ctx->opts, i,
                                       default_krb5_opts[i].def_val.boolean);
                 break;
+            default:
+                ret = EINVAL;
         }
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "Failed setting default renewal kerberos "


### PR DESCRIPTION
Some of them are not actually needed (false positives) but this helps to have a clean build and identify real warnings. The others are real warnings.

There is one remaining module with warnings that were not addressed. Those warnings are related to the use of some OpenSSL deprecated functions such as `EC_KEY_get0_group()`.