### PR TITLE
Tests: Fix AD hostname machine test and minor tweaks

### DIFF
--- a/src/tests/multihost/ad/pytest.ini
+++ b/src/tests/multihost/ad/pytest.ini
@@ -3,6 +3,7 @@ markers =
    adparameters: AD Parameters test cases. Also contains miscellaneous Bugzilla automations pertaining to AD Provider
    adschema: Test for adschema
    adloginattr: Tests for AD login attributes
+   admisc: Miscellaneous bugzilla automations for AD
    automount: Automount test cases with maps stored in AD schema
    cifs: Cifs test cases
    ad_access_control: Test for AD Access Control

--- a/src/tests/multihost/ad/test_adparameters_ported.py
+++ b/src/tests/multihost/ad/test_adparameters_ported.py
@@ -1252,6 +1252,9 @@ class TestADParamsPorted:
         # Run su
         su_result = client.su_success(aduser)
 
+        # Wait for log to be written
+        time.sleep(15)
+
         # Download sssd log
         log_str = multihost.client[0].get_file_contents(
             f"/var/log/sssd/sssd_{multihost.ad[0].domainname.lower()}.log"). \

--- a/src/tests/multihost/ad/test_adparameters_ported.py
+++ b/src/tests/multihost/ad/test_adparameters_ported.py
@@ -3558,9 +3558,9 @@ class TestADParamsPorted:
         client.sssd_conf(dom_section, sssd_params)
 
         multihost.client[0].run_command(
-             "semanage port -a -t kerberos_port_t -p tcp 6666;"
-             " semanage port -a -t kerberos_port_t -p udp 6666",
-             raiseonerr=False
+            "semanage port -a -t kerberos_port_t -p tcp 6666;"
+            " semanage port -a -t kerberos_port_t -p udp 6666",
+            raiseonerr=False
         )
 
         # Forward ports on AD machine so 6666 works


### PR DESCRIPTION
Fix unstable test by adding a wait before collecting log.
Remove pep8 violation E126.
Add a missing pytest marker.