### PR TITLE
CI: Update core github actions

### DIFF
--- a/.github/workflows/copr_build.yml
+++ b/.github/workflows/copr_build.yml
@@ -117,7 +117,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Downlooad source rpm
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ${{ needs.prepare.outputs.srpm }}
         path: .


### PR DESCRIPTION
Update dependent actions to address:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/