### PR TITLE
CI: Build srpm fix for illegal version tag '-'

### DIFF
--- a/.github/actions/build-sssd-srpm/action.yml
+++ b/.github/actions/build-sssd-srpm/action.yml
@@ -21,24 +21,31 @@ outputs:
 runs:
   using: 'composite'
   steps:
+  # '-' is an illegal character for RPM version tag
+  - name: Sanitize version
+    id: sanitize
+    shell: bash
+    run: |
+      version="$(echo ${{ inputs.version }} | sed 's/-/_/g')"
+      echo "::set-output name=version::$version"
+
   - name: Generate tarball and spec file
     shell: bash
     run: |
       pushd '${{ inputs.working-directory }}'
-      version="${{ inputs.version }}"
       release="${{ inputs.release }}"
-      name="sssd-$version"
+      name="sssd-${{ steps.sanitize.outputs.version }}"
       tar -cvzf "$name.tar.gz" --transform "s,^,$name/," *
 
       cp contrib/sssd.spec.in ./sssd.spec
 
       sed -iE "s/@PACKAGE_NAME@/sssd/g" ./sssd.spec
-      sed -iE "s/@PACKAGE_VERSION@/$version/g" ./sssd.spec
+      sed -iE "s/@PACKAGE_VERSION@/${{ steps.sanitize.outputs.version }}/g" ./sssd.spec
       sed -iE "s/@PRERELEASE_VERSION@/$release/g" ./sssd.spec
       popd
   - name: Build source rpm
     id: srpm
     uses: next-actions/build-srpm@master
     with:
-      tarball: ${{ inputs.working-directory }}/sssd-${{ inputs.version }}.tar.gz
+      tarball: ${{ inputs.working-directory }}/sssd-${{ steps.sanitize.outputs.version }}.tar.gz
       specfile: ${{ inputs.working-directory }}/sssd.spec


### PR DESCRIPTION
error: line 45: Illegal char '-' (0x2d) in: Version: sssd-2-7

Reviewed-by: Iker Pedrosa <ipedrosa@redhat.com>
Reviewed-by: Pavel Březina <pbrezina@redhat.com>
(cherry picked from commit ab89455be398f4688f95489b805c8ae204ba6f0d)