### PR TITLE
PAC: allow to disable UPN check and relax default check

### DIFF
--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -182,7 +182,7 @@
 #define CONFDB_PAC_LIFETIME "pac_lifetime"
 #define CONFDB_PAC_CHECK "pac_check"
 #define CONFDB_PAC_CHECK_DEFAULT "no_check"
-#define CONFDB_PAC_CHECK_IPA_AD_DEFAULT "check_upn, check_upn_dns_info_ex"
+#define CONFDB_PAC_CHECK_IPA_AD_DEFAULT "check_upn, check_upn_allow_missing, check_upn_dns_info_ex"
 
 /* InfoPipe */
 #define CONFDB_IFP_CONF_ENTRY "config/ifp"

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2291,6 +2291,34 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                                 </listitem>
                             </varlistentry>
                             <varlistentry>
+                                <term>check_upn_allow_missing</term>
+                                <listitem>
+                                    <para>This option should be used together
+                                    with 'check_upn' and handles the case where
+                                    a UPN is set on the server-side but is not
+                                    read by SSSD. The typical example is a
+                                    FreeIPA domain where 'ldap_user_principal'
+                                    is set to a not existing attribute name.
+                                    This was typically done to work-around
+                                    issues in the handling of enterprise
+                                    principals. But this is fixed since quite
+                                    some time and FreeIPA can handle enterprise
+                                    principals just fine and there is no need
+                                    anymore to set 'ldap_user_principal'.</para>
+                                    <para>Currently this option is set by
+                                    default to avoid regressions in such
+                                    environments. A log message will be added
+                                    to the system log and SSSD's debug log in
+                                    case a UPN is found in the PAC but not in
+                                    SSSD's cache. To avoid this log message it
+                                    would be best to evaluate if the
+                                    'ldap_user_principal' option can be removed.
+                                    If this is not possible, removing
+                                    'check_upn' will skip the test and avoid the
+                                    log message.</para>
+                                </listitem>
+                            </varlistentry>
+                            <varlistentry>
                                 <term>upn_dns_info_present</term>
                                 <listitem>
                                     <para>The PAC must contain the UPN-DNS-INFO
@@ -2320,7 +2348,7 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                         </para>
                         <para>
                             Default: no_check (AD and IPA provider
-                            'check_upn, check_upn_dns_info_ex')
+                            'check_upn, check_upn_allow_missing, check_upn_dns_info_ex')
                         </para>
                     </listitem>
                 </varlistentry>

--- a/src/providers/ad/ad_pac_common.c
+++ b/src/providers/ad/ad_pac_common.c
@@ -224,9 +224,19 @@ errno_t check_upn_and_sid_from_user_and_pac(struct ldb_message *msg,
 
         if (user_data != NULL) {
             if (strcasecmp(user_data, upn_dns_info->upn_name) != 0) {
-                DEBUG(SSSDBG_CRIT_FAILURE,
-                      "UPN of user entry and PAC do not match.\n");
-                return ERR_CHECK_PAC_FAILED;
+                if (pac_check_opts & CHECK_PAC_CHECK_UPN) {
+                    DEBUG(SSSDBG_CRIT_FAILURE, "UPN of user entry [%s] and "
+                                               "PAC [%s] do not match.\n",
+                                               user_data,
+                                               upn_dns_info->upn_name);
+                    return ERR_CHECK_PAC_FAILED;
+                } else {
+                    DEBUG(SSSDBG_IMPORTANT_INFO, "UPN of user entry [%s] and "
+                                                 "PAC [%s] do not match, "
+                                                 "ignored.\n", user_data,
+                                                 upn_dns_info->upn_name);
+                    return EOK;
+                }
             }
         }
 

--- a/src/util/pac_utils.c
+++ b/src/util/pac_utils.c
@@ -64,12 +64,22 @@ static errno_t check_check_pac_opt(const char *inp, uint32_t *check_pac_flags)
             flags |= CHECK_PAC_CHECK_UPN_DNS_INFO_EX;
             flags |= CHECK_PAC_UPN_DNS_INFO_PRESENT;
             flags |= CHECK_PAC_CHECK_UPN;
+        } else if (strcasecmp(list[c], CHECK_PAC_CHECK_UPN_ALLOW_MISSING_STR) == 0) {
+            flags |= CHECK_PAC_CHECK_UPN_ALLOW_MISSING;
         } else {
             DEBUG(SSSDBG_OP_FAILURE, "Unknown value [%s] for pac_check.\n",
                                      list[c]);
             ret = EINVAL;
             goto done;
         }
+    }
+
+    if ((flags & CHECK_PAC_CHECK_UPN_ALLOW_MISSING)
+                && !(flags & CHECK_PAC_CHECK_UPN)) {
+        DEBUG(SSSDBG_CONF_SETTINGS,
+              "pac_check option '%s' is set but '%s' is not set, this means "
+              "the UPN is not checked.\n",
+              CHECK_PAC_CHECK_UPN_ALLOW_MISSING_STR, CHECK_PAC_CHECK_UPN_STR);
     }
 
     ret = EOK;

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -829,6 +829,8 @@ uint64_t get_spend_time_us(uint64_t st);
 #define CHECK_PAC_CHECK_UPN_DNS_INFO_EX (1 << 3)
 #define CHECK_PAC_UPN_DNS_INFO_EX_PRESENT_STR "upn_dns_info_ex_present"
 #define CHECK_PAC_UPN_DNS_INFO_EX_PRESENT (1 << 4)
+#define CHECK_PAC_CHECK_UPN_ALLOW_MISSING_STR "check_upn_allow_missing"
+#define CHECK_PAC_CHECK_UPN_ALLOW_MISSING (1 << 5)
 
 errno_t get_pac_check_config(struct confdb_ctx *cdb, uint32_t *pac_check_opts);
 #endif /* __SSSD_UTIL_H__ */


### PR DESCRIPTION
To avoid issues with the UPN check during PAC validation  when
'ldap_user_principal' is set to a not existing attribute to skip reading 
user principals a new 'pac_check' option, 'check_upn_allow_missing' is 
added to the default options. With this option only a log message is shown
but the check will not fail.

Resolves: https://github.com/SSSD/sssd/issues/6451