### PR TITLE
ci: fix codeql

### DIFF
--- a/contrib/ci/deps.sh
+++ b/contrib/ci/deps.sh
@@ -136,7 +136,7 @@ if [[ "$DISTRO_BRANCH" == -debian-* ]]; then
         libpopt-dev
         libsasl2-dev
         libselinux1-dev
-        libsemanage1-dev
+        libsemanage-dev
         libsmbclient-dev
         libsystemd-dev
         libtalloc-dev


### PR DESCRIPTION
libsemanage1-dev renamed to libsemanage-dev in debian and its derivatives.