### PR TITLE
Tests: fix test_sssctl_local.py::Testsssctl::test_0002_bz1599207

### DIFF
--- a/src/tests/multihost/alltests/test_sssctl_local.py
+++ b/src/tests/multihost/alltests/test_sssctl_local.py
@@ -65,14 +65,9 @@ class Testsssctl(object):
         multihost.client[0].service_sssd('stop')
         tools.remove_sss_cache('/var/lib/sss/db')
         tools.remove_sss_cache('/var/log/sssd')
-        if client_version(multihost):
-            tools.sssd_conf("sssd",
-                            {'enable_files_domain': 'true'},
-                            action='update')
-        else:
-            rm_cmd = 'rm -f %s' % SSSD_DEFAULT_CONF
-            multihost.client[0].run_command(rm_cmd,
-                                            raiseonerr=False)
+        tools.sssd_conf("sssd",
+                        {'enable_files_domain': 'true'},
+                        action='update')
         multihost.client[0].service_sssd('start')
         for user in users.keys():
             cmd = multihost.client[0].run_command('getent'


### PR DESCRIPTION
test_sssctl_local.py::Testsssctl::test_0002_bz1599207 is affcted by disable "implicit files provider"