### PR TITLE
MAN: Fix option typo on sssd-kcm.8

### DIFF
--- a/src/man/sssd-kcm.8.xml
+++ b/src/man/sssd-kcm.8.xml
@@ -189,7 +189,7 @@ tgt_renewal_inherit = domain-name
             options are described in detail below
             <programlisting>
 krb5_renew_interval
-krb5_renew_lifetime
+krb5_renewable_lifetime
 krb5_lifetime
 krb5_validate
 krb5_canonicalize


### PR DESCRIPTION
The option is called krb5_renewable_lifetime, not krb5_renew_lifetime

Signed-off-by: Cole Robinson <crobinso@redhat.com>