### PR TITLE
passkey: add krb5 plugin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -324,7 +324,7 @@ non_interactive_cmocka_based_tests += test_kcm_renewals
 endif # BUILD_KCM_RENEWAL
 
 if BUILD_PASSKEY
-non_interactive_cmocka_based_tests += test_passkey
+non_interactive_cmocka_based_tests += test_passkey test_krb5_passkey_plugin
 endif # BUILD_PASSKEY
 
 
@@ -916,6 +916,9 @@ dist_noinst_HEADERS = \
     src/p11_child/p11_child.h \
     src/oidc_child/oidc_child_util.h \
     src/passkey_child/passkey_child.h \
+    src/krb5_plugin/common/radius_kdcpreauth.h \
+    src/krb5_plugin/common/radius_clpreauth.h \
+    src/krb5_plugin/common/utils.h \
     $(NULL)
 
 
@@ -3923,6 +3926,21 @@ test_krb5_idp_plugin_LDADD = \
     $(JANSSON_LIBS) \
     $(NULL)
 
+if BUILD_PASSKEY
+test_krb5_passkey_plugin_SOURCES = \
+    src/tests/cmocka/test_krb5_passkey_plugin.c \
+    src/krb5_plugin/common/utils.c \
+    src/krb5_plugin/passkey/passkey_utils.c \
+    $(NULL)
+test_krb5_passkey_plugin_CFLAGS = \
+    $(AM_CFLAGS) \
+    $(NULL)
+test_krb5_passkey_plugin_LDADD = \
+    $(CMOCKA_LIBS) \
+    $(JANSSON_LIBS) \
+    $(NULL)
+endif # BUILD_PASSKEY
+
 if BUILD_KCM_RENEWAL
 test_kcm_renewals_SOURCES = \
 	$(TEST_MOCK_RESP_OBJ) \
@@ -4904,6 +4922,35 @@ sssd_krb5_idp_plugin_la_LDFLAGS = \
 
 dist_noinst_HEADERS += src/krb5_plugin/idp/idp.h
 dist_krb5snippets_DATA += src/krb5_plugin/idp/sssd_enable_idp
+
+if BUILD_PASSKEY
+krb5_plugin_LTLIBRARIES += sssd_krb5_passkey_plugin.la
+
+sssd_krb5_passkey_plugin_la_SOURCES = \
+    src/krb5_plugin/common/utils.c \
+    src/krb5_plugin/common/radius_kdcpreauth.c \
+    src/krb5_plugin/common/radius_clpreauth.c \
+    src/krb5_plugin/passkey/passkey_clpreauth.c \
+    src/krb5_plugin/passkey/passkey_kdcpreauth.c \
+    src/krb5_plugin/passkey/passkey_utils.c \
+    $(NULL)
+sssd_krb5_passkey_plugin_la_CFLAGS = \
+    $(AM_CFLAGS) \
+    $(KRB5_CFLAGS) \
+    $(NULL)
+sssd_krb5_passkey_plugin_la_LIBADD = \
+    $(KRB5_LIBS) \
+    $(KRAD_LIBS) \
+    $(JANSSON_LIBS) \
+    $(NULL)
+sssd_krb5_passkey_plugin_la_LDFLAGS = \
+    -avoid-version \
+    -module \
+    $(NULL)
+
+dist_noinst_HEADERS += src/krb5_plugin/passkey/passkey.h
+dist_krb5snippets_DATA += src/krb5_plugin/passkey/sssd_enable_passkey
+endif # BUILD_PASSKEY
 
 sssd_pac_plugin_la_SOURCES = \
     src/sss_client/sssd_pac.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -3916,6 +3916,7 @@ test_kcm_queue_LDADD = \
 
 test_krb5_idp_plugin_SOURCES = \
     src/tests/cmocka/test_krb5_idp_plugin.c \
+    src/krb5_plugin/common/utils.c \
     src/krb5_plugin/idp/idp_utils.c \
     $(NULL)
 test_krb5_idp_plugin_CFLAGS = \
@@ -4652,6 +4653,7 @@ krb5_child_SOURCES = \
     src/util/become_user.c \
     src/util/util_errors.c \
     src/sss_client/common.c \
+    src/krb5_plugin/common/utils.c \
     src/krb5_plugin/idp/idp_utils.c \
     $(NULL)
 krb5_child_CFLAGS = \
@@ -4902,6 +4904,9 @@ krb5_plugin_LTLIBRARIES = \
     $(NULL)
 
 sssd_krb5_idp_plugin_la_SOURCES = \
+    src/krb5_plugin/common/utils.c \
+    src/krb5_plugin/common/radius_clpreauth.c \
+    src/krb5_plugin/common/radius_kdcpreauth.c \
     src/krb5_plugin/idp/idp_clpreauth.c \
     src/krb5_plugin/idp/idp_kdcpreauth.c \
     src/krb5_plugin/idp/idp_utils.c \

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -513,7 +513,7 @@ Requires: sssd-common = %{version}-%{release}
 Requires: libfido2
 
 %description passkey
-This package provides helper processes and plugins that are required to
+This package provides helper processes and Kerberos plugins that are required to
 enable authentication with passkey token.
 %endif
 
@@ -589,6 +589,12 @@ cp $RPM_BUILD_ROOT/%{_datadir}/sssd-kcm/kcm_default_ccache \
 # Enable krb5 idp plugins by default (when sssd-idp package is installed)
 cp $RPM_BUILD_ROOT/%{_datadir}/sssd/krb5-snippets/sssd_enable_idp \
    $RPM_BUILD_ROOT/%{_sysconfdir}/krb5.conf.d/sssd_enable_idp
+
+# Enable krb5 passkey plugins by default (when sssd-passkey package is installed)
+%if %{build_passkey}
+cp $RPM_BUILD_ROOT/%{_datadir}/sssd/krb5-snippets/sssd_enable_passkey \
+   $RPM_BUILD_ROOT/%{_sysconfdir}/krb5.conf.d/sssd_enable_passkey
+%endif
 
 # krb5 configuration snippet
 cp $RPM_BUILD_ROOT/%{_datadir}/sssd/krb5-snippets/enable_sssd_conf_dir \
@@ -987,6 +993,9 @@ done
 %if %{build_passkey}
 %files passkey
 %attr(755,%{sssd_user},%{sssd_user}) %{_libexecdir}/%{servicename}/passkey_child
+%{_libdir}/%{name}/modules/sssd_krb5_passkey_plugin.so
+%{_datadir}/sssd/krb5-snippets/sssd_enable_passkey
+%config(noreplace) %{_sysconfdir}/krb5.conf.d/sssd_enable_passkey
 %endif
 
 %if 0%{?rhel}

--- a/src/krb5_plugin/common/radius_clpreauth.c
+++ b/src/krb5_plugin/common/radius_clpreauth.c
@@ -1,0 +1,46 @@
+/*
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2023 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <krad.h>
+#include <krb5/kdcpreauth_plugin.h>
+
+#include "radius_kdcpreauth.h"
+#include "util/util.h"
+
+void
+sss_radiuscl_init(krb5_context context,
+                  krb5_clpreauth_moddata moddata,
+                  krb5_clpreauth_modreq *modreq_out)
+{
+    return;
+}
+
+void
+sss_radiuscl_fini(krb5_context context,
+                  krb5_clpreauth_moddata moddata,
+                  krb5_clpreauth_modreq modreq)
+{
+    return;
+}

--- a/src/krb5_plugin/common/radius_clpreauth.h
+++ b/src/krb5_plugin/common/radius_clpreauth.h
@@ -1,0 +1,37 @@
+/*
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2023 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _RADIUS_CLPREAUTH_H_
+#define _RADIUS_CLPREAUTH_H_
+
+#include <stdlib.h>
+#include <krb5/preauth_plugin.h>
+
+void
+sss_radiuscl_init(krb5_context context,
+                  krb5_clpreauth_moddata moddata,
+                  krb5_clpreauth_modreq *modreq_out);
+
+void
+sss_radiuscl_fini(krb5_context context,
+                  krb5_clpreauth_moddata moddata,
+                  krb5_clpreauth_modreq modreq);
+
+#endif /* _RADIUS_CLPREAUTH_H_ */

--- a/src/krb5_plugin/common/radius_kdcpreauth.c
+++ b/src/krb5_plugin/common/radius_kdcpreauth.c
@@ -1,0 +1,611 @@
+/*
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2023 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <krad.h>
+#include <krb5/kdcpreauth_plugin.h>
+
+#include "krb5_plugin/common/radius_kdcpreauth.h"
+#include "krb5_plugin/common/utils.h"
+#include "util/util.h"
+
+krb5_error_code
+sss_radiuskdc_init(const char *plugin_name,
+                   krb5_context kctx,
+                   krb5_kdcpreauth_moddata *_moddata,
+                   const char **_realmnames)
+{
+    struct sss_radiuskdc_state *state;
+
+    state = malloc(sizeof(struct sss_radiuskdc_state));
+    if (state == NULL) {
+        return ENOMEM;
+    }
+
+    state->plugin_name = plugin_name;
+
+    /* IPA is the only consumer so far so it is fine to hardcode the values. */
+    state->server = KRB5_KDC_RUNDIR "/DEFAULT.socket";
+    state->secret = "";
+    state->timeout = 5 * 1000;
+    state->retries = 3;
+
+    *_moddata = (krb5_kdcpreauth_moddata)state;
+
+    return 0;
+}
+
+void
+sss_radiuskdc_fini(krb5_context kctx,
+                   krb5_kdcpreauth_moddata moddata)
+{
+    struct sss_radiuskdc_state *state;
+
+    state = (struct sss_radiuskdc_state *)moddata;
+
+    if (state == NULL) {
+        return;
+    }
+
+    free(state);
+}
+
+int
+sss_radiuskdc_flags(krb5_context kctx,
+                    krb5_preauthtype pa_type)
+{
+    return PA_REPLACES_KEY;
+}
+
+krb5_error_code
+sss_radiuskdc_return_padata(krb5_context kctx,
+                            krb5_pa_data *padata,
+                            krb5_data *req_pkt,
+                            krb5_kdc_req *request,
+                            krb5_kdc_rep *reply,
+                            krb5_keyblock *encrypting_key,
+                            krb5_pa_data **send_pa_out,
+                            krb5_kdcpreauth_callbacks cb,
+                            krb5_kdcpreauth_rock rock,
+                            krb5_kdcpreauth_moddata moddata,
+                            krb5_kdcpreauth_modreq modreq)
+{
+    struct sss_radiuskdc_state *state;
+    krb5_keyblock *armor_key;
+    bool *result;
+
+    state = (struct sss_radiuskdc_state *)moddata;
+    result = (bool *)modreq;
+
+    /* This should not happen. */
+    if (state == NULL) {
+        return EINVAL;
+    }
+
+    /* Verification was not successful. Do not replace the key. */
+    if (result == NULL || *result == false) {
+        return 0;
+    }
+
+    /* Get the armor key. */
+    armor_key = cb->fast_armor(kctx, rock);
+    if (armor_key == NULL) {
+        com_err(state->plugin_name, ENOENT,
+                "No armor key found when returning padata");
+        return ENOENT;
+    }
+
+    /* Replace the reply key with the FAST armor key. */
+    krb5_free_keyblock_contents(kctx, encrypting_key);
+    return krb5_copy_keyblock_contents(kctx, armor_key, encrypting_key);
+}
+
+krb5_error_code
+sss_radiuskdc_enabled(const char *config_name,
+                      krb5_context kctx,
+                      krb5_kdcpreauth_callbacks cb,
+                      krb5_kdcpreauth_rock rock,
+                      char **_config)
+{
+    krb5_error_code ret;
+    char *config;
+
+    ret = cb->get_string(kctx, rock, config_name, &config);
+    if (ret != 0) {
+        return ret;
+    }
+
+    /* Disabled. */
+    if (config == NULL) {
+        return ENOENT;
+    }
+
+    /* Enabled. Return the config string. */
+    *_config = config;
+
+    return 0;
+}
+
+void
+sss_radiuskdc_config_free(struct sss_radiuskdc_config *config)
+{
+    if (config == NULL) {
+        return;
+    }
+
+    free(config->username);
+    free(config->server);
+    free(config->secret);
+    free(config);
+}
+
+krb5_error_code
+sss_radiuskdc_config_init(struct sss_radiuskdc_state *state,
+                          krb5_context kctx,
+                          krb5_const_principal princ,
+                          const char *configstr,
+                          struct sss_radiuskdc_config **_config)
+{
+    struct sss_radiuskdc_config *config;
+    krb5_error_code ret;
+    char *username;
+
+    if (state == NULL) {
+        return EINVAL;
+    }
+
+    config = malloc(sizeof(struct sss_radiuskdc_config));
+    if (config == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+    memset(config, 0, sizeof(struct sss_radiuskdc_config));
+
+    config->server = strdup(state->server);
+    config->secret = strdup(state->secret);
+    config->retries = state->retries;
+    config->timeout = state->timeout;
+
+    if (config->server == NULL || config->secret == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = krb5_unparse_name_flags(kctx, princ, 0, &username);
+    if (ret != 0) {
+        goto done;
+    }
+
+    config->username = strdup(username);
+    krb5_free_unparsed_name(kctx, username);
+    if (config->username == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    *_config = config;
+    ret = 0;
+
+done:
+    if (ret != 0) {
+        sss_radiuskdc_config_free(config);
+    }
+
+    return ret;
+}
+
+krb5_error_code
+sss_radiuskdc_set_cookie(krb5_context context,
+                         krb5_kdcpreauth_callbacks cb,
+                         krb5_kdcpreauth_rock rock,
+                         krb5_preauthtype pa_type,
+                         const krb5_data *state)
+{
+    krb5_data cookie;
+    unsigned int len;
+    uint8_t *blob;
+    size_t pctr;
+
+    len = sizeof(uint16_t) + state->length;
+    blob = malloc(len);
+    if (blob == NULL) {
+        return ENOMEM;
+    }
+
+    pctr = 0;
+    SAFEALIGN_SET_UINT16(&blob[pctr], 1, &pctr);
+    SAFEALIGN_SET_STRING(&blob[pctr], state->data, state->length, &pctr);
+
+    cookie.magic = 0;
+    cookie.data = (char *)blob;
+    cookie.length = len;
+
+    return cb->set_cookie(context, rock, pa_type, &cookie);
+}
+
+krb5_error_code
+sss_radiuskdc_get_cookie(krb5_context context,
+                         krb5_kdcpreauth_callbacks cb,
+                         krb5_kdcpreauth_rock rock,
+                         krb5_preauthtype pa_type,
+                         krb5_data *_state)
+{
+    uint16_t version;
+    krb5_data cookie;
+    krb5_data state;
+    size_t pctr;
+
+    if (!cb->get_cookie(context, rock, pa_type, &cookie)) {
+        return KRB5KDC_ERR_PREAUTH_FAILED;
+    }
+
+    if (cookie.length < sizeof(uint16_t)) {
+        return EINVAL;
+    }
+
+    pctr = 0;
+    SAFEALIGN_COPY_UINT16(&version, cookie.data, &pctr);
+    state.magic = 0;
+    state.data = &cookie.data[pctr];
+    state.length = cookie.length - sizeof(uint16_t);
+
+    *_state = state;
+
+    return 0;
+}
+
+
+/* Some attributes have limited length. In order to accept longer values,
+ * we will concatenate all attribute values to single krb5_data. */
+krb5_error_code
+sss_radiuskdc_get_complete_attr(const krad_packet *rres,
+                                const char *attr_name,
+                                krb5_data *_data)
+{
+    krad_attr attr = krad_attr_name2num(attr_name);
+    const krb5_data *rmsg;
+    krb5_data data = {0};
+    unsigned int memindex;
+    unsigned int i;
+
+    i = 0;
+    do {
+        rmsg = krad_packet_get_attr(rres, attr, i);
+        if (rmsg != NULL) {
+            data.length += rmsg->length;
+        }
+        i++;
+    } while (rmsg != NULL);
+
+    if (data.length == 0) {
+        return ENOENT;
+    }
+
+    data.data = malloc(data.length);
+    if (data.data == NULL) {
+        return ENOMEM;
+    }
+
+    i = 0;
+    memindex = 0;
+    do {
+        rmsg = krad_packet_get_attr(rres, attr, i);
+        if (rmsg != NULL) {
+            memcpy(&data.data[memindex], rmsg->data, rmsg->length);
+            memindex += rmsg->length;
+        }
+        i++;
+    } while (rmsg != NULL);
+
+    if (memindex != data.length) {
+        free(data.data);
+        return ERANGE;
+    }
+
+    *_data = data;
+
+    return 0;
+}
+
+/* From krad internals, RFC 2865 */
+#ifndef UCHAR_MAX
+#define UCHAR_MAX 255
+#endif
+#define MAX_ATTRSIZE (UCHAR_MAX - 2)
+
+krb5_error_code
+sss_radiuskdc_put_complete_attr(krad_attrset *attrset,
+                                krad_attr attr,
+                                const krb5_data *datap)
+{
+    krb5_data state = {0};
+    char *p = datap->data;
+    unsigned int len = datap->length;
+    krb5_error_code ret = 0;
+
+    do {
+        /* - 5 to make sure we fit into minimal value length */
+        state.data = p;
+        state.length = MIN(MAX_ATTRSIZE - 5, len);
+        p += state.length;
+
+        ret = krad_attrset_add(attrset, attr, &(state));
+        if (ret != 0) {
+            break;
+        }
+        len -= state.length;
+    } while (len > 0);
+
+    return ret;
+}
+
+char *
+sss_radiuskdc_get_attr_as_string(const krad_packet *packet, const char *attr)
+{
+    krb5_data data = {0};
+    krb5_error_code ret;
+    char *str;
+
+    ret = sss_radiuskdc_get_complete_attr(packet, attr, &data);
+    if (ret != 0) {
+        return NULL;
+    }
+
+    str = strndup(data.data, data.length);
+    free(data.data);
+
+    return str;
+}
+
+krb5_error_code
+sss_radiuskdc_set_attr_as_string(krad_attrset *attrset,
+                                 const char *attr,
+                                 const char *value)
+{
+    krb5_data data = {0};
+    krb5_error_code ret;
+
+    data.data = discard_const(value);
+    data.length = strlen(value) + 1;
+
+    ret = sss_radiuskdc_put_complete_attr(attrset,
+                                          krad_attr_name2num(attr),
+                                          &data);
+
+    return ret;
+}
+
+void
+sss_radiuskdc_client_free(struct sss_radiuskdc_client *client)
+{
+    if (client == NULL) {
+        return;
+    }
+
+    krad_client_free(client->client);
+    krad_attrset_free(client->attrs);
+    free(client);
+}
+
+struct sss_radiuskdc_client *
+sss_radiuskdc_client_init(krb5_context kctx,
+                          verto_ctx *vctx,
+                          struct sss_radiuskdc_config *config)
+{
+    struct sss_radiuskdc_client *client;
+    char hostname[HOST_NAME_MAX + 1];
+    krb5_data data = {0};
+    krb5_error_code ret;
+
+    client = malloc(sizeof(struct sss_radiuskdc_client));
+    if (client == NULL) {
+        return NULL;
+    }
+    memset(client, 0, sizeof(struct sss_radiuskdc_client));
+
+    ret = krad_client_new(kctx, vctx, &client->client);
+    if (ret != 0) {
+        goto fail;
+    }
+
+    ret = krad_attrset_new(kctx, &client->attrs);
+    if (ret != 0) {
+        goto fail;
+    }
+
+    ret = gethostname(hostname, sizeof(hostname) / sizeof(char));
+    if (ret != 0) {
+        goto fail;
+    }
+
+    data.data = hostname;
+    data.length = strlen(hostname);
+    ret = krad_attrset_add(client->attrs, krad_attr_name2num("NAS-Identifier"),
+                           &data);
+    if (ret != 0) {
+        goto fail;
+    }
+
+    ret = krad_attrset_add_number(client->attrs, krad_attr_name2num("Service-Type"),
+                                  KRAD_SERVICE_TYPE_AUTHENTICATE_ONLY);
+    if (ret != 0) {
+        goto fail;
+    }
+
+    data.data = config->username;
+    data.length = strlen(config->username);
+    ret = krad_attrset_add(client->attrs, krad_attr_name2num("User-Name"),
+                           &data);
+    if (ret != 0) {
+        goto fail;
+    }
+
+    return client;
+
+fail:
+    sss_radiuskdc_client_free(client);
+    return NULL;
+}
+
+void
+sss_radiuskdc_challenge_free(struct sss_radiuskdc_challenge *state)
+{
+    if (state == NULL) {
+        return;
+    }
+
+    sss_radiuskdc_client_free(state->client);
+    free(state);
+}
+
+struct sss_radiuskdc_challenge *
+sss_radiuskdc_challenge_init(krb5_context kctx,
+                             krb5_kdcpreauth_callbacks cb,
+                             krb5_kdcpreauth_rock rock,
+                             krb5_kdcpreauth_edata_respond_fn respond,
+                             void *arg,
+                             struct sss_radiuskdc_config *config)
+{
+    struct sss_radiuskdc_challenge *state;
+
+    state = malloc(sizeof(struct sss_radiuskdc_challenge));
+    if (state == NULL) {
+        return NULL;
+    }
+    memset(state, 0, sizeof(struct sss_radiuskdc_challenge));
+
+    state->kctx = kctx;
+    state->cb = cb;
+    state->rock = rock;
+    state->respond = respond;
+    state->arg = arg;
+
+    state->client = sss_radiuskdc_client_init(kctx,
+                                              cb->event_context(kctx, rock),
+                                              config);
+    if (state->client == NULL) {
+        sss_radiuskdc_challenge_free(state);
+        return NULL;
+    }
+
+    return state;
+}
+
+void
+sss_radiuskdc_verify_free(struct sss_radiuskdc_verify *state)
+{
+    if (state == NULL) {
+        return;
+    }
+
+    sss_string_array_free(state->indicators);
+    sss_radiuskdc_client_free(state->client);
+    free(state);
+}
+
+struct sss_radiuskdc_verify *
+sss_radiuskdc_verify_init(krb5_context kctx,
+                          krb5_kdcpreauth_rock rock,
+                          krb5_kdcpreauth_callbacks cb,
+                          krb5_enc_tkt_part *enc_tkt_reply,
+                          krb5_kdcpreauth_verify_respond_fn respond,
+                          void *arg,
+                          char **indicators,
+                          struct sss_radiuskdc_config *config)
+{
+    struct sss_radiuskdc_verify *state;
+
+    state = malloc(sizeof(struct sss_radiuskdc_verify));
+    if (state == NULL) {
+        return NULL;
+    }
+    memset(state, 0, sizeof(struct sss_radiuskdc_verify));
+
+    state->kctx = kctx;
+    state->rock = rock;
+    state->cb = cb;
+    state->enc_tkt_reply = enc_tkt_reply;
+    state->respond = respond;
+    state->arg = arg;
+
+    state->indicators = sss_string_array_copy(indicators);
+    if (state->indicators == NULL) {
+        sss_radiuskdc_verify_free(state);
+        return NULL;
+    }
+
+    state->client = sss_radiuskdc_client_init(kctx,
+                                              cb->event_context(kctx, rock),
+                                              config);
+    if (state->client == NULL) {
+        sss_radiuskdc_verify_free(state);
+        return NULL;
+    }
+
+    return state;
+}
+
+void
+sss_radiuskdc_verify_done(krb5_error_code rret,
+                          const krad_packet *rreq,
+                          const krad_packet *rres,
+                          void *data)
+{
+    static bool verify_success = true;
+    static bool verify_failure = false;
+    struct sss_radiuskdc_verify *state;
+    krb5_kdcpreauth_modreq modreq;
+    krb5_error_code ret;
+    int i;
+
+    state = (struct sss_radiuskdc_verify *)data;
+    modreq = (krb5_kdcpreauth_modreq)&verify_failure;
+
+    if (rret != 0) {
+        ret = rret;
+        goto done;
+    }
+
+    if (krad_packet_get_code(rres) != krad_code_name2num("Access-Accept")) {
+        ret = KRB5_PREAUTH_FAILED;
+        goto done;
+    }
+
+    state->enc_tkt_reply->flags |= TKT_FLG_PRE_AUTH;
+
+    for (i = 0; state->indicators[i] != NULL; i++) {
+        ret = state->cb->add_auth_indicator(state->kctx, state->rock,
+                                            state->indicators[i]);
+        if (ret != 0) {
+            goto done;
+        }
+    }
+
+    modreq = (krb5_kdcpreauth_modreq)&verify_success;
+    ret = 0;
+
+done:
+    state->respond(state->arg, ret, modreq, NULL, NULL);
+    sss_radiuskdc_verify_free(state);
+}

--- a/src/krb5_plugin/common/radius_kdcpreauth.h
+++ b/src/krb5_plugin/common/radius_kdcpreauth.h
@@ -1,0 +1,185 @@
+/*
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2023 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _RADIUS_KDCPREAUTH_H_
+#define _RADIUS_KDCPREAUTH_H_
+
+#include <stdlib.h>
+#include <krb5/preauth_plugin.h>
+
+struct sss_radiuskdc_state {
+    const char *plugin_name;
+    const char *server;
+    const char *secret;
+    size_t retries;
+    int timeout;
+};
+
+struct sss_radiuskdc_config {
+    char *username;
+    char *server;
+    char *secret;
+    size_t retries;
+    int timeout;
+};
+
+struct sss_radiuskdc_client {
+    krad_client *client;
+    krad_attrset *attrs;
+};
+
+struct sss_radiuskdc_challenge {
+    struct sss_radiuskdc_client *client;
+
+    krb5_context kctx;
+    krb5_kdcpreauth_callbacks cb;
+    krb5_kdcpreauth_rock rock;
+    krb5_kdcpreauth_edata_respond_fn respond;
+    void *arg;
+};
+
+struct sss_radiuskdc_verify {
+    struct sss_radiuskdc_client *client;
+    char **indicators;
+
+    krb5_context kctx;
+    krb5_kdcpreauth_rock rock;
+    krb5_kdcpreauth_callbacks cb;
+    krb5_enc_tkt_part *enc_tkt_reply;
+    krb5_kdcpreauth_verify_respond_fn respond;
+    void *arg;
+};
+
+krb5_error_code
+sss_radiuskdc_init(const char *plugin_name,
+                   krb5_context kctx,
+                   krb5_kdcpreauth_moddata *_moddata,
+                   const char **_realmnames);
+
+void
+sss_radiuskdc_fini(krb5_context kctx,
+                   krb5_kdcpreauth_moddata moddata);
+
+int
+sss_radiuskdc_flags(krb5_context kctx,
+                    krb5_preauthtype pa_type);
+
+krb5_error_code
+sss_radiuskdc_return_padata(krb5_context kctx,
+                            krb5_pa_data *padata,
+                            krb5_data *req_pkt,
+                            krb5_kdc_req *request,
+                            krb5_kdc_rep *reply,
+                            krb5_keyblock *encrypting_key,
+                            krb5_pa_data **send_pa_out,
+                            krb5_kdcpreauth_callbacks cb,
+                            krb5_kdcpreauth_rock rock,
+                            krb5_kdcpreauth_moddata moddata,
+                            krb5_kdcpreauth_modreq modreq);
+
+krb5_error_code
+sss_radiuskdc_enabled(const char *config_name,
+                      krb5_context kctx,
+                      krb5_kdcpreauth_callbacks cb,
+                      krb5_kdcpreauth_rock rock,
+                      char **_config);
+
+void
+sss_radiuskdc_config_free(struct sss_radiuskdc_config *config);
+
+krb5_error_code
+sss_radiuskdc_config_init(struct sss_radiuskdc_state *state,
+                          krb5_context kctx,
+                          krb5_const_principal princ,
+                          const char *configstr,
+                          struct sss_radiuskdc_config **_config);
+
+krb5_error_code
+sss_radiuskdc_set_cookie(krb5_context context,
+                         krb5_kdcpreauth_callbacks cb,
+                         krb5_kdcpreauth_rock rock,
+                         krb5_preauthtype pa_type,
+                         const krb5_data *state);
+
+krb5_error_code
+sss_radiuskdc_get_cookie(krb5_context context,
+                         krb5_kdcpreauth_callbacks cb,
+                         krb5_kdcpreauth_rock rock,
+                         krb5_preauthtype pa_type,
+                         krb5_data *_state);
+
+krb5_error_code
+sss_radiuskdc_get_complete_attr(const krad_packet *rres,
+                                const char *attr_name,
+                                krb5_data *_data);
+
+krb5_error_code
+sss_radiuskdc_put_complete_attr(krad_attrset *attrset,
+                                krad_attr attr,
+                                const krb5_data *datap);
+
+char *
+sss_radiuskdc_get_attr_as_string(const krad_packet *packet, const char *attr);
+
+
+krb5_error_code
+sss_radiuskdc_set_attr_as_string(krad_attrset *attrset,
+                                 const char *attr,
+                                 const char *value);
+
+void
+sss_radiuskdc_client_free(struct sss_radiuskdc_client *client);
+
+struct sss_radiuskdc_client *
+sss_radiuskdc_client_init(krb5_context kctx,
+                          verto_ctx *vctx,
+                          struct sss_radiuskdc_config *config);
+
+void
+sss_radiuskdc_challenge_free(struct sss_radiuskdc_challenge *state);
+
+struct sss_radiuskdc_challenge *
+sss_radiuskdc_challenge_init(krb5_context kctx,
+                             krb5_kdcpreauth_callbacks cb,
+                             krb5_kdcpreauth_rock rock,
+                             krb5_kdcpreauth_edata_respond_fn respond,
+                             void *arg,
+                             struct sss_radiuskdc_config *config);
+
+void
+sss_radiuskdc_verify_free(struct sss_radiuskdc_verify *state);
+
+struct sss_radiuskdc_verify *
+sss_radiuskdc_verify_init(krb5_context kctx,
+                          krb5_kdcpreauth_rock rock,
+                          krb5_kdcpreauth_callbacks cb,
+                          krb5_enc_tkt_part *enc_tkt_reply,
+                          krb5_kdcpreauth_verify_respond_fn respond,
+                          void *arg,
+                          char **indicators,
+                          struct sss_radiuskdc_config *config);
+
+void
+sss_radiuskdc_verify_done(krb5_error_code rret,
+                          const krad_packet *rreq,
+                          const krad_packet *rres,
+                          void *data);
+
+#endif /* _RADIUS_KDCPREAUTH_H_ */

--- a/src/krb5_plugin/common/utils.c
+++ b/src/krb5_plugin/common/utils.c
@@ -1,0 +1,254 @@
+/*
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2023 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <jansson.h>
+#include <krb5/preauth_plugin.h>
+
+#include "krb5_plugin/common/utils.h"
+
+void
+sss_string_array_free(char **array)
+{
+    size_t i;
+
+    if (array == NULL) {
+        return;
+    }
+
+    for (i = 0; array[i] != NULL; i++) {
+        free(array[i]);
+    }
+
+    free(array);
+}
+
+char **
+sss_string_array_copy(char **array)
+{
+    char **copy;
+    size_t i;
+
+    for (i = 0; array[i] != NULL; i++) {
+        /* Just count. */
+    }
+
+    copy = calloc(i + 1, sizeof(char *));
+    if (copy == NULL) {
+        return NULL;
+    }
+
+    for (i = 0; array[i] != NULL; i++) {
+        copy[i] = strdup(array[i]);
+        if (copy[i] == NULL) {
+            sss_string_array_free(copy);
+            return NULL;
+        }
+    }
+
+    copy[i] = NULL;
+
+    return copy;
+}
+
+char **
+sss_json_array_to_strings(json_t *jarray)
+{
+    const char *strval;
+    char **array;
+    json_t *jval;
+    size_t i;
+
+    if (!json_is_array(jarray)) {
+        return NULL;
+    }
+
+    array = calloc(json_array_size(jarray) + 1, sizeof(char *));
+    if (array == NULL) {
+        return NULL;
+    }
+
+    json_array_foreach(jarray, i, jval) {
+        strval = json_string_value(jval);
+        if (strval == NULL) {
+            goto fail;
+        }
+
+        array[i] = strdup(strval);
+        if (array[i] == NULL) {
+            goto fail;
+        }
+    }
+
+    return array;
+
+fail:
+    sss_string_array_free(array);
+
+    return NULL;
+}
+
+json_t *
+sss_strings_to_json_array(char **array)
+{
+    json_t *jarray;
+    json_t *jstr;
+    size_t i;
+    int jret;
+
+    jarray = json_array();
+    if (jarray == NULL) {
+        return NULL;
+    }
+
+    if (array == NULL) {
+        return jarray;
+    }
+
+    for (i = 0; array[i] != NULL; i++) {
+        jstr = json_string(array[i]);
+        if (jstr == NULL) {
+            goto fail;
+        }
+
+        jret = json_array_append_new(jarray, jstr);
+        if (jret != 0) {
+            goto fail;
+        }
+    }
+
+    return jarray;
+
+fail:
+    json_decref(jarray);
+
+    return NULL;
+}
+
+void *
+sss_radius_message_decode(const char *prefix,
+                          sss_radius_message_decode_fn fn,
+                          const char *str)
+{
+    size_t prefix_len;
+
+    if (str == NULL) {
+        return NULL;
+    }
+
+    prefix_len = strlen(prefix);
+    if (strncmp(str, prefix, prefix_len) != 0) {
+        return NULL;
+    }
+
+    return fn(str + prefix_len);
+}
+
+char *
+sss_radius_message_encode(const char *prefix,
+                          sss_radius_message_encode_fn fn,
+                          const void *data)
+{
+    char *json_str;
+    char *str;
+    int aret;
+
+    json_str = fn(data);
+    if (json_str == NULL) {
+        return NULL;
+    }
+
+    aret = asprintf(&str, "%s%s", prefix, json_str);
+    free(json_str);
+    if (aret < 0) {
+        return NULL;
+    }
+
+    return str;
+}
+
+krb5_pa_data *
+sss_radius_encode_padata(krb5_preauthtype patype,
+                         sss_radius_message_encode_fn fn,
+                         const void *data)
+{
+    krb5_pa_data *padata;
+    char *str;
+
+    str = fn(data);
+    if (str == NULL) {
+        return NULL;
+    }
+
+    padata = malloc(sizeof(krb5_pa_data));
+    if (padata == NULL) {
+        free(str);
+        return NULL;
+    }
+
+    padata->pa_type = patype;
+    padata->contents = (krb5_octet*)str;
+    padata->length = strlen(str) + 1;
+
+    return padata;
+}
+
+void *
+sss_radius_decode_padata(sss_radius_message_decode_fn fn,
+                         krb5_pa_data *padata)
+{
+    if (padata->length == 0 || padata->contents == NULL) {
+        return NULL;
+    }
+
+    /* contents is NULL terminated string */
+    if (padata->contents[padata->length - 1] != '\0') {
+        return NULL;
+    }
+
+    return fn((const char*)padata->contents);
+}
+
+krb5_pa_data **
+sss_radius_encode_padata_array(krb5_preauthtype patype,
+                               sss_radius_message_encode_fn fn,
+                               const void *data)
+{
+    krb5_pa_data **array;
+
+    array = calloc(2, sizeof(krb5_pa_data *));
+    if (array == NULL) {
+        return NULL;
+    }
+
+    array[0] = sss_radius_encode_padata(patype, fn, data);
+    array[1] = NULL;
+
+    if (array[0] == NULL) {
+        free(array);
+        return NULL;
+    }
+
+    return array;
+}

--- a/src/krb5_plugin/common/utils.h
+++ b/src/krb5_plugin/common/utils.h
@@ -1,0 +1,68 @@
+/*
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2023 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _KRB5_PLUGIN_UTILS_H_
+#define _KRB5_PLUGIN_UTILS_H_
+
+#include <jansson.h>
+#include <krb5/preauth_plugin.h>
+
+#define is_empty(var) ((var) == NULL || (var)[0] == '\0')
+
+void
+sss_string_array_free(char **array);
+
+char **
+sss_string_array_copy(char **array);
+
+char **
+sss_json_array_to_strings(json_t *jarray);
+
+json_t *
+sss_strings_to_json_array(char **array);
+
+typedef void * (*sss_radius_message_decode_fn)(const char *);
+typedef char * (*sss_radius_message_encode_fn)(const void *);
+
+void *
+sss_radius_message_decode(const char *prefix,
+                          sss_radius_message_decode_fn fn,
+                          const char *str);
+
+char *
+sss_radius_message_encode(const char *prefix,
+                          sss_radius_message_encode_fn fn,
+                          const void *data);
+
+krb5_pa_data *
+sss_radius_encode_padata(krb5_preauthtype patype,
+                         sss_radius_message_encode_fn fn,
+                         const void *data);
+
+void *
+sss_radius_decode_padata(sss_radius_message_decode_fn fn,
+                         krb5_pa_data *padata);
+
+krb5_pa_data **
+sss_radius_encode_padata_array(krb5_preauthtype patype,
+                               sss_radius_message_encode_fn fn,
+                               const void *data);
+
+#endif /* _KRB5_PLUGIN_UTILS_H_ */

--- a/src/krb5_plugin/idp/idp.h
+++ b/src/krb5_plugin/idp/idp.h
@@ -55,9 +55,6 @@ struct sss_idp_oauth2 {
 void
 sss_idp_oauth2_free(struct sss_idp_oauth2 *data);
 
-struct sss_idp_oauth2 *
-sss_idp_oauth2_decode_reply_message(const krb5_data *msg);
-
 krb5_pa_data *
 sss_idp_oauth2_encode_padata(struct sss_idp_oauth2 *data);
 

--- a/src/krb5_plugin/idp/idp_clpreauth.c
+++ b/src/krb5_plugin/idp/idp_clpreauth.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <krb5/clpreauth_plugin.h>
 
+#include "krb5_plugin/common/radius_clpreauth.h"
 #include "idp.h"
 
 static krb5_pa_data **
@@ -87,14 +88,6 @@ sss_idpcl_prompt(krb5_context context,
     free(prompt_str);
 
     return ret;
-}
-
-static void
-sss_idpcl_init(krb5_context context,
-               krb5_clpreauth_moddata moddata,
-               krb5_clpreauth_modreq *modreq_out)
-{
-    return;
 }
 
 static krb5_error_code
@@ -209,14 +202,6 @@ done:
     return ret;
 }
 
-static void
-sss_idpcl_fini(krb5_context context,
-               krb5_clpreauth_moddata moddata,
-               krb5_clpreauth_modreq modreq)
-{
-    return;
-}
-
 krb5_error_code
 clpreauth_idp_initvt(krb5_context context,
                      int maj_ver,
@@ -233,10 +218,10 @@ clpreauth_idp_initvt(krb5_context context,
     vt = (krb5_clpreauth_vtable)vtable;
     vt->name = discard_const(SSSD_IDP_PLUGIN);
     vt->pa_type_list = pa_type_list;
-    vt->request_init = sss_idpcl_init;
+    vt->request_init = sss_radiuscl_init;
     vt->prep_questions = sss_idpcl_prep_questions;
     vt->process = sss_idpcl_process;
-    vt->request_fini = sss_idpcl_fini;
+    vt->request_fini = sss_radiuscl_fini;
     vt->gic_opts = NULL;
 
     return 0;

--- a/src/krb5_plugin/idp/idp_kdcpreauth.c
+++ b/src/krb5_plugin/idp/idp_kdcpreauth.c
@@ -29,23 +29,13 @@
 #include <krb5/kdcpreauth_plugin.h>
 
 #include "shared/safealign.h"
+#include "krb5_plugin/common/radius_kdcpreauth.h"
+#include "krb5_plugin/common/utils.h"
 #include "idp.h"
 #include "util/util.h"
 
-struct sss_idpkdc_state {
-    const char *server;
-    const char *secret;
-    size_t retries;
-    int timeout;
-};
-
 struct sss_idpkdc_config {
-    char *username;
-    char *server;
-    char *secret;
-    size_t retries;
-    int timeout;
-
+    struct sss_radiuskdc_config *radius;
     struct sss_idp_config *idpcfg;
 };
 
@@ -56,15 +46,13 @@ sss_idpkdc_config_free(struct sss_idpkdc_config *config)
         return;
     }
 
+    sss_radiuskdc_config_free(config->radius);
     sss_idp_config_free(config->idpcfg);
-    free(config->username);
-    free(config->server);
-    free(config->secret);
     free(config);
 }
 
 static krb5_error_code
-sss_idpkdc_config_init(struct sss_idpkdc_state *state,
+sss_idpkdc_config_init(struct sss_radiuskdc_state *state,
                        krb5_context kctx,
                        krb5_const_principal princ,
                        const char *configstr,
@@ -72,7 +60,6 @@ sss_idpkdc_config_init(struct sss_idpkdc_state *state,
 {
     struct sss_idpkdc_config *config;
     krb5_error_code ret;
-    char *username;
 
     if (state == NULL) {
         return EINVAL;
@@ -85,30 +72,13 @@ sss_idpkdc_config_init(struct sss_idpkdc_state *state,
     }
     memset(config, 0, sizeof(struct sss_idpkdc_config));
 
+    ret = sss_radiuskdc_config_init(state, kctx, princ, configstr, &config->radius);
+    if (ret != 0) {
+        goto done;
+    }
+
     ret = sss_idp_config_init(configstr, &config->idpcfg);
     if (ret != 0) {
-        goto done;
-    }
-
-    config->server = strdup(state->server);
-    config->secret = strdup(state->secret);
-    config->retries = state->retries;
-    config->timeout = state->timeout;
-
-    if (config->server == NULL || config->secret == NULL) {
-        ret = ENOMEM;
-        goto done;
-    }
-
-    ret = krb5_unparse_name_flags(kctx, princ, 0, &username);
-    if (ret != 0) {
-        goto done;
-    }
-
-    config->username = strdup(username);
-    krb5_free_unparsed_name(kctx, username);
-    if (config->username == NULL) {
-        ret = ENOMEM;
         goto done;
     }
 
@@ -123,260 +93,20 @@ done:
     return ret;
 }
 
-static krb5_error_code
-sss_idpkdc_set_cookie(krb5_context context,
-                      krb5_kdcpreauth_callbacks cb,
-                      krb5_kdcpreauth_rock rock,
-                      const krb5_data *state)
-{
-    krb5_data cookie;
-    unsigned int len;
-    uint8_t *blob;
-    size_t pctr;
-
-    len = sizeof(uint16_t) + state->length;
-    blob = malloc(len);
-    if (blob == NULL) {
-        return ENOMEM;
-    }
-
-    pctr = 0;
-    SAFEALIGN_SET_UINT16(&blob[pctr], 1, &pctr);
-    SAFEALIGN_SET_STRING(&blob[pctr], state->data, state->length, &pctr);
-
-    cookie.magic = 0;
-    cookie.data = (char *)blob;
-    cookie.length = len;
-
-    return cb->set_cookie(context, rock, SSSD_IDP_OAUTH2_PADATA, &cookie);
-}
-
-static krb5_error_code
-sss_idpkdc_get_cookie(krb5_context context,
-                      krb5_kdcpreauth_callbacks cb,
-                      krb5_kdcpreauth_rock rock,
-                      krb5_data *_state)
-{
-    uint16_t version;
-    krb5_data cookie;
-    krb5_data state;
-    size_t pctr;
-
-    if (!cb->get_cookie(context, rock, SSSD_IDP_OAUTH2_PADATA, &cookie)) {
-        return KRB5KDC_ERR_PREAUTH_FAILED;
-    }
-
-    if (cookie.length < sizeof(uint16_t)) {
-        return EINVAL;
-    }
-
-    pctr = 0;
-    SAFEALIGN_COPY_UINT16(&version, cookie.data, &pctr);
-    state.magic = 0;
-    state.data = &cookie.data[pctr];
-    state.length = cookie.length - sizeof(uint16_t);
-
-    *_state = state;
-
-    return 0;
-}
-
-/* Some attributes have limited length. In order to accept longer values,
- * we will concatenate all attribute values to single krb5_data. */
-static krb5_error_code
-sss_idpkdc_get_complete_attr(const krad_packet *rres,
-                             const char *attr_name,
-                             krb5_data *_data)
-{
-    krad_attr attr = krad_attr_name2num(attr_name);
-    const krb5_data *rmsg;
-    krb5_data data = {0};
-    unsigned int memindex;
-    unsigned int i;
-
-    i = 0;
-    do {
-        rmsg = krad_packet_get_attr(rres, attr, i);
-        if (rmsg != NULL) {
-            data.length += rmsg->length;
-        }
-        i++;
-    } while (rmsg != NULL);
-
-    if (data.length == 0) {
-        return ENOENT;
-    }
-
-    data.data = malloc(data.length);
-    if (data.data == NULL) {
-        return ENOMEM;
-    }
-
-    i = 0;
-    memindex = 0;
-    do {
-        rmsg = krad_packet_get_attr(rres, attr, i);
-        if (rmsg != NULL) {
-            memcpy(&data.data[memindex], rmsg->data, rmsg->length);
-            memindex += rmsg->length;
-        }
-        i++;
-    } while (rmsg != NULL);
-
-    if (memindex != data.length) {
-        free(data.data);
-        return ERANGE;
-    }
-
-    *_data = data;
-
-    return 0;
-}
-
-/* From krad internals, RFC 2865 */
-#ifndef UCHAR_MAX
-#define UCHAR_MAX 255
-#endif
-#define MAX_ATTRSIZE (UCHAR_MAX - 2)
-
-static krb5_error_code
-sss_idpkdc_put_complete_attr(krad_attrset *attrset,
-                             krad_attr attr,
-                             const krb5_data *datap)
-{
-    krb5_data state = {0};
-    char *p = datap->data;
-    unsigned int len = datap->length;
-    krb5_error_code ret = 0;
-
-    do {
-        /* - 5 to make sure we fit into minimal value length */
-        state.data = p;
-        state.length = MIN(MAX_ATTRSIZE - 5, len);
-        p += state.length;
-
-        ret = krad_attrset_add(attrset, attr, &(state));
-        if (ret != 0) {
-            break;
-        }
-        len -= state.length;
-    } while (len > 0);
-
-    return ret;
-}
-
-struct sss_idpkdc_radius {
-    krad_client *client;
-    krad_attrset *attrs;
-};
-
-static void
-sss_idpkdc_radius_free(struct sss_idpkdc_radius *radius)
-{
-    if (radius == NULL) {
-        return;
-    }
-
-    krad_client_free(radius->client);
-    krad_attrset_free(radius->attrs);
-    free(radius);
-}
-
-static struct sss_idpkdc_radius *
-sss_idpkdc_radius_init(krb5_context kctx,
-                       verto_ctx *vctx,
-                       struct sss_idpkdc_config *config)
-{
-    struct sss_idpkdc_radius *radius;
-    char hostname[HOST_NAME_MAX + 1];
-    krb5_data data = {0};
-    krb5_error_code ret;
-
-    radius = malloc(sizeof(struct sss_idpkdc_radius));
-    if (radius == NULL) {
-        return NULL;
-    }
-    memset(radius, 0, sizeof(struct sss_idpkdc_radius));
-
-    ret = krad_client_new(kctx, vctx, &radius->client);
-    if (ret != 0) {
-        goto fail;
-    }
-
-    ret = krad_attrset_new(kctx, &radius->attrs);
-    if (ret != 0) {
-        goto fail;
-    }
-
-    ret = gethostname(hostname, sizeof(hostname) / sizeof(char));
-    if (ret != 0) {
-        goto fail;
-    }
-
-    data.data = hostname;
-    data.length = strlen(hostname);
-    ret = krad_attrset_add(radius->attrs, krad_attr_name2num("NAS-Identifier"),
-                           &data);
-    if (ret != 0) {
-        goto fail;
-    }
-
-    ret = krad_attrset_add_number(radius->attrs, krad_attr_name2num("Service-Type"),
-                                  KRAD_SERVICE_TYPE_AUTHENTICATE_ONLY);
-    if (ret != 0) {
-        goto fail;
-    }
-
-    data.data = config->username;
-    data.length = strlen(config->username);
-    ret = krad_attrset_add(radius->attrs, krad_attr_name2num("User-Name"),
-                           &data);
-    if (ret != 0) {
-        goto fail;
-    }
-
-    return radius;
-
-fail:
-    sss_idpkdc_radius_free(radius);
-    return NULL;
-}
-
-struct sss_idpkdc_challenge {
-    struct sss_idpkdc_radius *radius;
-
-    krb5_context kctx;
-    krb5_kdcpreauth_callbacks cb;
-    krb5_kdcpreauth_rock rock;
-    krb5_kdcpreauth_edata_respond_fn respond;
-    void *arg;
-};
-
-static void
-sss_idpkdc_challenge_free(struct sss_idpkdc_challenge *challenge)
-{
-    if (challenge == NULL) {
-        return;
-    }
-
-    sss_idpkdc_radius_free(challenge->radius);
-    free(challenge);
-}
-
 static void
 sss_idpkdc_challenge_done(krb5_error_code rret,
                           const krad_packet *rreq,
                           const krad_packet *rres,
                           void *data)
 {
-    struct sss_idpkdc_challenge *state;
+    struct sss_radiuskdc_challenge *state;
     struct sss_idp_oauth2 *idp_oauth2 = NULL;
     krb5_pa_data *padata = NULL;
     krb5_data rstate = {0};
-    krb5_data rmsg = {0};
+    char *rmsg = NULL;
     krb5_error_code ret;
 
-    state = (struct sss_idpkdc_challenge *)data;
+    state = (struct sss_radiuskdc_challenge *)data;
 
     if (rret != 0) {
         ret = rret;
@@ -388,25 +118,27 @@ sss_idpkdc_challenge_done(krb5_error_code rret,
         goto done;
     }
 
-    ret = sss_idpkdc_get_complete_attr(rres, "Proxy-State", &rstate);
+    ret = sss_radiuskdc_get_complete_attr(rres, "Proxy-State", &rstate);
     if (ret != 0) {
         goto done;
     }
 
-    ret = sss_idpkdc_get_complete_attr(rres, "Reply-Message", &rmsg);
-    if (ret != 0) {
+    rmsg = sss_radiuskdc_get_attr_as_string(rres, "Reply-Message");
+    if (rmsg == NULL) {
+        ret = EINVAL;
         goto done;
     }
 
     /* Remember the RADIUS state so it can be set in the Access-Request message
      * sent in sss_idpkdc_verify(), thus allowing the RADIUS server to
      * associate the message with its internal state. */
-    ret = sss_idpkdc_set_cookie(state->kctx, state->cb, state->rock, &rstate);
+    ret = sss_radiuskdc_set_cookie(state->kctx, state->cb, state->rock,
+                                   SSSD_IDP_OAUTH2_PADATA, &rstate);
     if (ret != 0) {
         goto done;
     }
 
-    idp_oauth2 = sss_idp_oauth2_decode_reply_message(&rmsg);
+    idp_oauth2 = sss_idp_oauth2_decode_challenge(rmsg);
     if (idp_oauth2 == NULL) {
         ret = ENOMEM;
         goto done;
@@ -422,10 +154,10 @@ sss_idpkdc_challenge_done(krb5_error_code rret,
 
 done:
     state->respond(state->arg, ret, padata);
-    sss_idpkdc_challenge_free(state);
+    sss_radiuskdc_challenge_free(state);
     sss_idp_oauth2_free(idp_oauth2);
     free(rstate.data);
-    free(rmsg.data);
+    free(rmsg);
 
     /* padata should not be freed */
 
@@ -435,200 +167,76 @@ done:
 /* Send a password-less Access-Request and expect Access-Challenge response. */
 static krb5_error_code
 sss_idpkdc_challenge_send(krb5_context kctx,
-                          verto_ctx *vctx,
                           krb5_kdcpreauth_callbacks cb,
                           krb5_kdcpreauth_rock rock,
                           krb5_kdcpreauth_edata_respond_fn respond,
                           void *arg,
-                          struct sss_idpkdc_config *config)
+                          struct sss_radiuskdc_config *config)
 {
-    struct sss_idpkdc_challenge *state;
+    struct sss_radiuskdc_challenge *state;
     krb5_error_code ret;
 
-    state = malloc(sizeof(struct sss_idpkdc_challenge));
+    state = sss_radiuskdc_challenge_init(kctx, cb, rock, respond, arg, config);
     if (state == NULL) {
         ret = ENOMEM;
         goto done;
     }
-    memset(state, 0, sizeof(struct sss_idpkdc_challenge));
 
-    state->kctx = kctx;
-    state->cb = cb;
-    state->rock = rock;
-    state->respond = respond;
-    state->arg = arg;
-
-    state->radius = sss_idpkdc_radius_init(kctx, vctx, config);
-    if (state->radius == NULL) {
-        ret = ENOMEM;
-        goto done;
-    }
-
-    ret = krad_client_send(state->radius->client,
+    ret = krad_client_send(state->client->client,
                            krad_code_name2num("Access-Request"),
-                           state->radius->attrs, config->server,
+                           state->client->attrs, config->server,
                            config->secret, config->timeout, config->retries,
                            sss_idpkdc_challenge_done, state);
 
 done:
     if (ret != 0) {
-        sss_idpkdc_challenge_free(state);
+        sss_radiuskdc_challenge_free(state);
     }
 
     return ret;
-}
-
-struct sss_idpkdc_verify {
-    struct sss_idpkdc_radius *radius;
-    struct sss_idpkdc_config *config;
-
-    krb5_context kctx;
-    krb5_kdcpreauth_rock rock;
-    krb5_kdcpreauth_callbacks cb;
-    krb5_enc_tkt_part *enc_tkt_reply;
-    krb5_kdcpreauth_verify_respond_fn respond;
-    void *arg;
-};
-
-static void
-sss_idpkdc_verify_free(struct sss_idpkdc_verify *verify)
-{
-    if (verify == NULL) {
-        return;
-    }
-
-    sss_idpkdc_radius_free(verify->radius);
-    sss_idpkdc_config_free(verify->config);
-    free(verify);
-}
-
-static void
-sss_idpkdc_verify_done(krb5_error_code rret,
-                       const krad_packet *rreq,
-                       const krad_packet *rres,
-                       void *data)
-{
-    static bool verify_success = true;
-    static bool verify_failure = false;
-    struct sss_idpkdc_verify *state;
-    krb5_kdcpreauth_modreq modreq;
-    krb5_error_code ret;
-    int i;
-
-    state = (struct sss_idpkdc_verify *)data;
-    modreq = (krb5_kdcpreauth_modreq)&verify_failure;
-
-    if (rret != 0) {
-        ret = rret;
-        goto done;
-    }
-
-    if (krad_packet_get_code(rres) != krad_code_name2num("Access-Accept")) {
-        ret = KRB5_PREAUTH_FAILED;
-        goto done;
-    }
-
-    state->enc_tkt_reply->flags |= TKT_FLG_PRE_AUTH;
-
-    for (i = 0; state->config->idpcfg->indicators[i] != NULL; i++) {
-        ret = state->cb->add_auth_indicator(state->kctx, state->rock,
-                                            state->config->idpcfg->indicators[i]);
-        if (ret != 0) {
-            goto done;
-        }
-    }
-
-    modreq = (krb5_kdcpreauth_modreq)&verify_success;
-    ret = 0;
-
-done:
-    state->respond(state->arg, ret, modreq, NULL, NULL);
-    sss_idpkdc_verify_free(state);
-    return;
 }
 
 /* Send Access-Request with password and state set to indicate that the user has
  * finished authentication against idp provider. We expect Access-Accept. */
 static krb5_error_code
 sss_idpkdc_verify_send(krb5_context kctx,
-                       verto_ctx *vctx,
                        krb5_kdcpreauth_rock rock,
                        krb5_kdcpreauth_callbacks cb,
                        krb5_enc_tkt_part *enc_tkt_reply,
                        krb5_kdcpreauth_verify_respond_fn respond,
                        void *arg,
                        const krb5_data *rstate,
-                       struct sss_idpkdc_config *config)
+                       char **indicators,
+                       struct sss_radiuskdc_config *config)
 {
-    struct sss_idpkdc_verify *state;
+    struct sss_radiuskdc_verify *state;
     krb5_error_code ret;
 
-    state = malloc(sizeof(struct sss_idpkdc_verify));
+    state = sss_radiuskdc_verify_init(kctx, rock, cb, enc_tkt_reply, respond,
+                                      arg, indicators, config);
     if (state == NULL) {
         return ENOMEM;
     }
-    memset(state, 0, sizeof(struct sss_idpkdc_verify));
 
-    state->config = config;
-    state->kctx = kctx;
-    state->rock = rock;
-    state->cb = cb;
-    state->enc_tkt_reply = enc_tkt_reply;
-    state->respond = respond;
-    state->arg = arg;
-
-    state->radius = sss_idpkdc_radius_init(kctx, vctx, config);
-    if (state->radius == NULL) {
-        ret = ENOMEM;
-        goto done;
-    }
-
-    ret = sss_idpkdc_put_complete_attr(state->radius->attrs,
-                                       krad_attr_name2num("Proxy-State"),
-                                       rstate);
+    ret = sss_radiuskdc_put_complete_attr(state->client->attrs,
+                                          krad_attr_name2num("Proxy-State"),
+                                          rstate);
     if (ret != 0) {
         goto done;
     }
 
-    ret = krad_client_send(state->radius->client,
+    ret = krad_client_send(state->client->client,
                            krad_code_name2num("Access-Request"),
-                           state->radius->attrs, config->server,
+                           state->client->attrs, config->server,
                            config->secret, config->timeout, config->retries,
-                           sss_idpkdc_verify_done, state);
+                           sss_radiuskdc_verify_done, state);
 
 done:
     if (ret != 0) {
-        /* It is the caller responsibility to free config in case of error. */
-        state->config = NULL;
-        sss_idpkdc_verify_free(state);
+        sss_radiuskdc_verify_free(state);
     }
 
     return ret;
-}
-
-static krb5_error_code
-sss_idpkdc_enabled(krb5_context kctx,
-                   krb5_kdcpreauth_callbacks cb,
-                   krb5_kdcpreauth_rock rock,
-                   char **_config)
-{
-    krb5_error_code ret;
-    char *config;
-
-    ret = cb->get_string(kctx, rock, SSSD_IDP_CONFIG, &config);
-    if (ret != 0) {
-        return ret;
-    }
-
-    /* Disabled. */
-    if (config == NULL) {
-        return ENOENT;
-    }
-
-    /* Enabled. Return the config string. */
-    *_config = config;
-
-    return 0;
 }
 
 static krb5_error_code
@@ -636,44 +244,7 @@ sss_idpkdc_init(krb5_context kctx,
                 krb5_kdcpreauth_moddata *_moddata,
                 const char **_realmnames)
 {
-    struct sss_idpkdc_state *state;
-
-    state = malloc(sizeof(struct sss_idpkdc_state));
-    if (state == NULL) {
-        return ENOMEM;
-    }
-
-    /* IPA is the only consumer so far so it is fine to hardcode the values. */
-    state->server = KRB5_KDC_RUNDIR "/DEFAULT.socket";
-    state->secret = "";
-    state->timeout = 5 * 1000;
-    state->retries = 3;
-
-    *_moddata = (krb5_kdcpreauth_moddata)state;
-
-    return 0;
-}
-
-static void
-sss_idpkdc_fini(krb5_context kctx,
-                krb5_kdcpreauth_moddata moddata)
-{
-    struct sss_idpkdc_state *state;
-
-    state = (struct sss_idpkdc_state *)moddata;
-
-    if (state == NULL) {
-        return;
-    }
-
-    free(state);
-}
-
-static int
-sss_idpkdc_flags(krb5_context kctx,
-                 krb5_preauthtype pa_type)
-{
-    return PA_REPLACES_KEY;
+    return sss_radiuskdc_init(SSSD_IDP_PLUGIN, kctx, _moddata, _realmnames);
 }
 
 static void
@@ -687,14 +258,14 @@ sss_idpkdc_edata(krb5_context kctx,
                  void *arg)
 {
     struct sss_idpkdc_config *config = NULL;
-    struct sss_idpkdc_state *state;
+    struct sss_radiuskdc_state *state;
     krb5_keyblock *armor_key;
     char *configstr = NULL;
     krb5_error_code ret;
 
-    state = (struct sss_idpkdc_state *)moddata;
+    state = (struct sss_radiuskdc_state *)moddata;
 
-    ret = sss_idpkdc_enabled(kctx, cb, rock, &configstr);
+    ret = sss_radiuskdc_enabled(SSSD_IDP_CONFIG, kctx, cb, rock, &configstr);
     if (ret != 0) {
         goto done;
     }
@@ -711,8 +282,8 @@ sss_idpkdc_edata(krb5_context kctx,
         goto done;
     }
 
-    ret = sss_idpkdc_challenge_send(kctx, cb->event_context(kctx, rock), cb,
-                                    rock, respond, arg, config);
+    ret = sss_idpkdc_challenge_send(kctx, cb, rock, respond, arg,
+                                    config->radius);
 
 done:
     if (ret != 0) {
@@ -735,15 +306,15 @@ sss_idpkdc_verify(krb5_context kctx,
                   krb5_kdcpreauth_verify_respond_fn respond,
                   void *arg)
 {
-    struct sss_idpkdc_state *state;
+    struct sss_radiuskdc_state *state;
     struct sss_idpkdc_config *config = NULL;
     char *configstr = NULL;
     krb5_error_code ret;
     krb5_data rstate;
 
-    state = (struct sss_idpkdc_state *)moddata;
+    state = (struct sss_radiuskdc_state *)moddata;
 
-    ret = sss_idpkdc_enabled(kctx, cb, rock, &configstr);
+    ret = sss_radiuskdc_enabled(SSSD_IDP_CONFIG, kctx, cb, rock, &configstr);
     if (ret != 0) {
         goto done;
     }
@@ -754,7 +325,8 @@ sss_idpkdc_verify(krb5_context kctx,
         goto done;
     }
 
-    ret = sss_idpkdc_get_cookie(kctx, cb, rock, &rstate);
+    ret = sss_radiuskdc_get_cookie(kctx, cb, rock, SSSD_IDP_OAUTH2_PADATA,
+                                   &rstate);
     if (ret != 0) {
         goto done;
     }
@@ -765,9 +337,8 @@ sss_idpkdc_verify(krb5_context kctx,
     }
 
     /* config is freed by verify_done if ret == 0 */
-    ret = sss_idpkdc_verify_send(kctx, cb->event_context(kctx, rock), rock,
-                                 cb, enc_tkt_reply, respond, arg,
-                                 &rstate, config);
+    ret = sss_idpkdc_verify_send(kctx, rock, cb, enc_tkt_reply, respond, arg,
+            &rstate, config->idpcfg->indicators, config->radius);
     if (ret != 0) {
         goto done;
     }
@@ -776,14 +347,14 @@ sss_idpkdc_verify(krb5_context kctx,
 
 done:
     if (ret != 0) {
-        sss_idpkdc_config_free(config);
         respond(arg, ret, NULL, NULL, NULL);
     }
 
     cb->free_string(kctx, rock, configstr);
+    sss_idpkdc_config_free(config);
 }
 
-static krb5_error_code
+krb5_error_code
 sss_idpkdc_return_padata(krb5_context kctx,
                          krb5_pa_data *padata,
                          krb5_data *req_pkt,
@@ -796,32 +367,14 @@ sss_idpkdc_return_padata(krb5_context kctx,
                          krb5_kdcpreauth_moddata moddata,
                          krb5_kdcpreauth_modreq modreq)
 {
-    krb5_keyblock *armor_key;
-    bool *result;
-
-    result = (bool *)modreq;
-
-    /* Verification was not successful. Do not replace the key. */
-    if (result == NULL || *result == false) {
-        return 0;
-    }
-
     /* Unexpected padata. Return error. */
     if (padata->length != 0) {
         return EINVAL;
     }
 
-    /* Get the armor key. */
-    armor_key = cb->fast_armor(kctx, rock);
-    if (armor_key == NULL) {
-        com_err(SSSD_IDP_PLUGIN, ENOENT,
-                "No armor key found when returning padata");
-        return ENOENT;
-    }
-
-    /* Replace the reply key with the FAST armor key. */
-    krb5_free_keyblock_contents(kctx, encrypting_key);
-    return krb5_copy_keyblock_contents(kctx, armor_key, encrypting_key);
+    return sss_radiuskdc_return_padata(kctx, padata, req_pkt, request, reply,
+                                       encrypting_key, send_pa_out, cb, rock,
+                                       moddata, modreq);
 }
 
 krb5_error_code
@@ -841,13 +394,13 @@ kdcpreauth_idp_initvt(krb5_context kctx,
     vt->name = discard_const(SSSD_IDP_PLUGIN);
     vt->pa_type_list = pa_type_list;
     vt->init = sss_idpkdc_init;
-    vt->fini = sss_idpkdc_fini;
-    vt->flags = sss_idpkdc_flags;
+    vt->fini = sss_radiuskdc_fini;
+    vt->flags = sss_radiuskdc_flags;
     vt->edata = sss_idpkdc_edata;
     vt->verify = sss_idpkdc_verify;
     vt->return_padata = sss_idpkdc_return_padata;
 
-    com_err(SSSD_IDP_PLUGIN, 0, "Loaded");
+    com_err(SSSD_IDP_PLUGIN, 0, "SSSD IdP plugin loaded");
 
     return 0;
 }

--- a/src/krb5_plugin/passkey/passkey.h
+++ b/src/krb5_plugin/passkey/passkey.h
@@ -1,0 +1,97 @@
+/*
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2023 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _PASSKEY_H_
+#define _PASSKEY_H_
+
+#include <stdlib.h>
+#include <krb5/preauth_plugin.h>
+
+#ifndef discard_const
+#define discard_const(ptr) ((void *)((uintptr_t)(ptr)))
+#endif
+
+#define SSSD_PASSKEY_PLUGIN "passkey"
+#define SSSD_PASSKEY_CONFIG "passkey"
+#define SSSD_PASSKEY_PADATA 153 /* PA-REDHAT-PASSKEY */
+#define SSSD_PASSKEY_QUESTION "passkey"
+#define SSSD_PASSKEY_PREFIX "passkey "
+
+struct sss_passkey_config {
+    char **indicators;
+};
+
+void
+sss_passkey_config_free(struct sss_passkey_config *passkey);
+
+krb5_error_code
+sss_passkey_config_init(const char *config,
+                        struct sss_passkey_config **_passkey);
+
+enum sss_passkey_phase {
+    SSS_PASSKEY_PHASE_INIT,
+    SSS_PASSKEY_PHASE_CHALLENGE,
+    SSS_PASSKEY_PHASE_REPLY
+};
+
+struct sss_passkey_challenge {
+    char *domain;
+    char **credential_id_list;
+    int user_verification;
+    char *cryptographic_challenge;
+};
+
+struct sss_passkey_reply {
+    char *credential_id;
+    char *cryptographic_challenge;
+    char *authenticator_data;
+    char *assertion_signature;
+    char *user_id;
+};
+
+struct sss_passkey_message {
+    enum sss_passkey_phase phase;
+    char *state;
+    union {
+        struct sss_passkey_challenge *challenge;
+        struct sss_passkey_reply *reply;
+        void *ptr;
+    } data;
+};
+
+void
+sss_passkey_message_free(struct sss_passkey_message *message);
+
+char *
+sss_passkey_message_encode(const struct sss_passkey_message *data);
+
+struct sss_passkey_message *
+sss_passkey_message_decode(const char *str);
+
+krb5_pa_data *
+sss_passkey_message_encode_padata(const struct sss_passkey_message *data);
+
+struct sss_passkey_message *
+sss_passkey_message_decode_padata(krb5_pa_data *padata);
+
+krb5_pa_data **
+sss_passkey_message_encode_padata_array(const struct sss_passkey_message *data);
+
+#endif /* _PASSKEY_H_ */

--- a/src/krb5_plugin/passkey/passkey_clpreauth.c
+++ b/src/krb5_plugin/passkey/passkey_clpreauth.c
@@ -1,0 +1,183 @@
+/*
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2023 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <krb5/clpreauth_plugin.h>
+
+#include "krb5_plugin/common/radius_clpreauth.h"
+#include "passkey.h"
+
+static krb5_error_code
+sss_passkeycl_prompt(krb5_context context,
+                     krb5_prompter_fct prompter,
+                     void *prompter_data,
+                     struct sss_passkey_message *message,
+                     krb5_data *_reply)
+{
+    return ENOTSUP;
+}
+
+static krb5_error_code
+sss_passkeycl_prep_questions(krb5_context context,
+                             krb5_clpreauth_moddata moddata,
+                             krb5_clpreauth_modreq modreq,
+                             krb5_get_init_creds_opt *opt,
+                             krb5_clpreauth_callbacks cb,
+                             krb5_clpreauth_rock rock,
+                             krb5_kdc_req *request,
+                             krb5_data *encoded_request_body,
+                             krb5_data *encoded_previous_request,
+                             krb5_pa_data *pa_data)
+{
+    struct sss_passkey_message *message;
+    char *question = NULL;
+    krb5_error_code ret;
+
+    message = sss_passkey_message_decode_padata(pa_data);
+    if (message == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    question = sss_passkey_message_encode(message);
+    if (question == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = cb->ask_responder_question(context, rock, SSSD_PASSKEY_QUESTION,
+                                     question);
+
+done:
+    sss_passkey_message_free(message);
+    free(question);
+
+    return ret;
+}
+
+static krb5_error_code
+sss_passkeycl_process(krb5_context context,
+                      krb5_clpreauth_moddata moddata,
+                      krb5_clpreauth_modreq modreq,
+                      krb5_get_init_creds_opt *opt,
+                      krb5_clpreauth_callbacks cb,
+                      krb5_clpreauth_rock rock,
+                      krb5_kdc_req *request,
+                      krb5_data *encoded_request_body,
+                      krb5_data *encoded_previous_request,
+                      krb5_pa_data *pa_data,
+                      krb5_prompter_fct prompter,
+                      void *prompter_data,
+                      krb5_pa_data ***_pa_data_out)
+{
+    krb5_keyblock *as_key;
+    krb5_pa_data **padata;
+    krb5_error_code ret;
+    krb5_data user_reply;
+    struct sss_passkey_message *input_message = NULL;
+    struct sss_passkey_message *reply_message = NULL;
+    char prompt_answer[255] = {0};
+    const char *answer;
+
+    input_message = sss_passkey_message_decode_padata(pa_data);
+    if (input_message == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    /* Get FAST armor key. */
+    as_key = cb->fast_armor(context, rock);
+    if (as_key == NULL) {
+        ret = ENOENT;
+        goto done;
+    }
+
+    answer = cb->get_responder_answer(context, rock, SSSD_PASSKEY_QUESTION);
+    /* Call prompter if we have no answer to present a prompt. */
+    if (answer == NULL) {
+        user_reply.magic = 0;
+        user_reply.length = sizeof(prompt_answer) / sizeof(char);
+        user_reply.data = prompt_answer;
+
+        ret = sss_passkeycl_prompt(context, prompter, prompter_data,
+                                   input_message, &user_reply);
+        if (ret != 0) {
+            goto done;
+        }
+    }
+
+    /* Use FAST armor key as response key. */
+    ret = cb->set_as_key(context, rock, as_key);
+    if (ret != 0) {
+        goto done;
+    }
+
+    /* Encode the answer into the pa_data output. */
+    reply_message = sss_passkey_message_decode(answer);
+    if (reply_message == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    padata = sss_passkey_message_encode_padata_array(reply_message);
+    if (padata == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    cb->disable_fallback(context, rock);
+    *_pa_data_out = padata;
+
+    ret = 0;
+
+done:
+    sss_passkey_message_free(reply_message);
+    sss_passkey_message_free(input_message);
+    return ret;
+}
+
+krb5_error_code
+clpreauth_passkey_initvt(krb5_context context,
+                         int maj_ver,
+                         int min_ver,
+                         krb5_plugin_vtable vtable)
+{
+    static krb5_preauthtype pa_type_list[] = { SSSD_PASSKEY_PADATA, 0 };
+    krb5_clpreauth_vtable vt;
+
+    if (maj_ver != 1) {
+        return KRB5_PLUGIN_VER_NOTSUPP;
+    }
+
+    vt = (krb5_clpreauth_vtable)vtable;
+    vt->name = discard_const(SSSD_PASSKEY_PLUGIN);
+    vt->pa_type_list = pa_type_list;
+    vt->request_init = sss_radiuscl_init;
+    vt->prep_questions = sss_passkeycl_prep_questions;
+    vt->process = sss_passkeycl_process;
+    vt->request_fini = sss_radiuscl_fini;
+    vt->gic_opts = NULL;
+
+    return 0;
+}

--- a/src/krb5_plugin/passkey/passkey_kdcpreauth.c
+++ b/src/krb5_plugin/passkey/passkey_kdcpreauth.c
@@ -1,0 +1,438 @@
+/*
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2023 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <krad.h>
+#include <krb5/kdcpreauth_plugin.h>
+
+#include "shared/safealign.h"
+#include "krb5_plugin/common/radius_kdcpreauth.h"
+#include "krb5_plugin/common/utils.h"
+#include "krb5_plugin/passkey/passkey.h"
+#include "util/util.h"
+
+struct sss_passkeykdc_config {
+    struct sss_radiuskdc_config *radius;
+    struct sss_passkey_config *passkey;
+};
+
+static void
+sss_passkeykdc_config_free(struct sss_passkeykdc_config *config)
+{
+    if (config == NULL) {
+        return;
+    }
+
+    sss_radiuskdc_config_free(config->radius);
+    sss_passkey_config_free(config->passkey);
+    free(config);
+}
+
+static krb5_error_code
+sss_passkeykdc_config_init(struct sss_radiuskdc_state *state,
+                           krb5_context kctx,
+                           krb5_const_principal princ,
+                           const char *configstr,
+                           struct sss_passkeykdc_config **_config)
+{
+    struct sss_passkeykdc_config *config;
+    krb5_error_code ret;
+
+    if (state == NULL) {
+        return EINVAL;
+    }
+
+    config = malloc(sizeof(struct sss_passkeykdc_config));
+    if (config == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+    memset(config, 0, sizeof(struct sss_passkeykdc_config));
+
+    ret = sss_radiuskdc_config_init(state, kctx, princ, configstr, &config->radius);
+    if (ret != 0) {
+        goto done;
+    }
+
+    ret = sss_passkey_config_init(configstr, &config->passkey);
+    if (ret != 0) {
+        goto done;
+    }
+
+
+    *_config = config;
+    ret = 0;
+
+done:
+    if (ret != 0) {
+        sss_passkeykdc_config_free(config);
+    }
+
+    return ret;
+}
+
+static void
+sss_passkeykdc_challenge_done(krb5_error_code rret,
+                              const krad_packet *rreq,
+                              const krad_packet *rres,
+                              void *data)
+{
+    struct sss_passkey_message *message = NULL;
+    struct sss_radiuskdc_challenge *state;
+    krb5_pa_data *padata = NULL;
+    krb5_data cookie = {0};
+    char *reply = NULL;
+    krb5_error_code ret;
+
+    state = (struct sss_radiuskdc_challenge *)data;
+
+    if (rret != 0) {
+        ret = rret;
+        goto done;
+    }
+
+    if (krad_packet_get_code(rres) != krad_code_name2num("Access-Challenge")) {
+        ret = ENOENT;
+        goto done;
+    }
+
+    reply = sss_radiuskdc_get_attr_as_string(rres, "Proxy-State");
+    if (reply == NULL) {
+        ret = EINVAL;
+        goto done;
+    }
+
+    message = sss_passkey_message_decode(reply);
+    if (message == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    if (message->phase != SSS_PASSKEY_PHASE_CHALLENGE) {
+        ret = EINVAL;
+        goto done;
+    }
+
+    /* Remember the whole passkey challenge message in cookie so we can later
+     * verify that the client response is really associated with this request.
+     */
+    cookie.data = reply;
+    cookie.length = strlen(reply) + 1;
+    ret = sss_radiuskdc_set_cookie(state->kctx, state->cb, state->rock,
+                                   SSSD_PASSKEY_PADATA, &cookie);
+    if (ret != 0) {
+        goto done;
+    }
+
+    padata = sss_passkey_message_encode_padata(message);
+    if (padata == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = 0;
+
+done:
+    state->respond(state->arg, ret, padata);
+    sss_radiuskdc_challenge_free(state);
+    sss_passkey_message_free(message);
+    free(reply);
+
+    /* padata should not be freed */
+
+    return;
+}
+
+/* Send a password-less Access-Request and expect Access-Challenge response. */
+static krb5_error_code
+sss_passkeykdc_challenge_send(krb5_context kctx,
+                              krb5_kdcpreauth_callbacks cb,
+                              krb5_kdcpreauth_rock rock,
+                              krb5_kdcpreauth_edata_respond_fn respond,
+                              void *arg,
+                              struct sss_radiuskdc_config *config)
+{
+    struct sss_passkey_message message;
+    struct sss_radiuskdc_challenge *state;
+    char *encoded_message = NULL;
+    krb5_error_code ret;
+
+    state = sss_radiuskdc_challenge_init(kctx, cb, rock, respond, arg, config);
+    if (state == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    message.phase = SSS_PASSKEY_PHASE_INIT;
+    message.state = NULL;
+    message.data.challenge = NULL;
+
+    encoded_message = sss_passkey_message_encode(&message);
+    if (encoded_message == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = sss_radiuskdc_set_attr_as_string(state->client->attrs,
+                                           "Proxy-State",
+                                           encoded_message);
+    if (ret != 0) {
+        goto done;
+    }
+
+    ret = krad_client_send(state->client->client,
+                           krad_code_name2num("Access-Request"),
+                           state->client->attrs, config->server,
+                           config->secret, config->timeout, config->retries,
+                           sss_passkeykdc_challenge_done, state);
+
+done:
+    free(encoded_message);
+
+    if (ret != 0) {
+        sss_radiuskdc_challenge_free(state);
+    }
+
+    return ret;
+}
+
+/* Send Access-Request with password and state set to indicate that the user has
+ * finished authentication against passkey provider. We expect Access-Accept. */
+static krb5_error_code
+sss_passkeykdc_verify_send(krb5_context kctx,
+                           krb5_kdcpreauth_rock rock,
+                           krb5_kdcpreauth_callbacks cb,
+                           krb5_enc_tkt_part *enc_tkt_reply,
+                           krb5_kdcpreauth_verify_respond_fn respond,
+                           void *arg,
+                           const struct sss_passkey_message *message,
+                           char **indicators,
+                           struct sss_radiuskdc_config *config)
+{
+    struct sss_radiuskdc_verify *state;
+    char *encoded_message = NULL;
+    krb5_error_code ret;
+
+    state = sss_radiuskdc_verify_init(kctx, rock, cb, enc_tkt_reply, respond,
+                                      arg, indicators, config);
+    if (state == NULL) {
+        return ENOMEM;
+    }
+
+    encoded_message = sss_passkey_message_encode(message);
+    if (encoded_message == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = sss_radiuskdc_set_attr_as_string(state->client->attrs,
+                                           "Proxy-State",
+                                           encoded_message);
+    if (ret != 0) {
+        goto done;
+    }
+
+    ret = krad_client_send(state->client->client,
+                           krad_code_name2num("Access-Request"),
+                           state->client->attrs, config->server,
+                           config->secret, config->timeout, config->retries,
+                           sss_radiuskdc_verify_done, state);
+
+done:
+    free(encoded_message);
+
+    if (ret != 0) {
+        sss_radiuskdc_verify_free(state);
+    }
+
+    return ret;
+}
+
+static krb5_error_code
+sss_passkeykdc_init(krb5_context kctx,
+                    krb5_kdcpreauth_moddata *_moddata,
+                    const char **_realmnames)
+{
+    return sss_radiuskdc_init(SSSD_PASSKEY_PLUGIN, kctx, _moddata, _realmnames);
+}
+
+static void
+sss_passkeykdc_edata(krb5_context kctx,
+                     krb5_kdc_req *request,
+                     krb5_kdcpreauth_callbacks cb,
+                     krb5_kdcpreauth_rock rock,
+                     krb5_kdcpreauth_moddata moddata,
+                     krb5_preauthtype pa_type,
+                     krb5_kdcpreauth_edata_respond_fn respond,
+                     void *arg)
+{
+    struct sss_passkeykdc_config *config = NULL;
+    struct sss_radiuskdc_state *state;
+    krb5_keyblock *armor_key;
+    char *configstr = NULL;
+    krb5_error_code ret;
+
+    state = (struct sss_radiuskdc_state *)moddata;
+
+    ret = sss_radiuskdc_enabled(SSSD_PASSKEY_CONFIG, kctx, cb, rock, &configstr);
+    if (ret != 0) {
+        goto done;
+    }
+
+    armor_key = cb->fast_armor(kctx, rock);
+    if (armor_key == NULL) {
+        ret = ENOENT;
+        goto done;
+    }
+
+    ret = sss_passkeykdc_config_init(state, kctx, cb->client_name(kctx, rock),
+                                     configstr, &config);
+    if (ret != 0) {
+        goto done;
+    }
+
+    ret = sss_passkeykdc_challenge_send(kctx, cb, rock, respond, arg,
+                                        config->radius);
+
+done:
+    if (ret != 0) {
+        respond(arg, ret, NULL);
+    }
+
+    cb->free_string(kctx, rock, configstr);
+    sss_passkeykdc_config_free(config);
+}
+
+static void
+sss_passkeykdc_verify(krb5_context kctx,
+                      krb5_data *req_pkt,
+                      krb5_kdc_req *request,
+                      krb5_enc_tkt_part *enc_tkt_reply,
+                      krb5_pa_data *pa,
+                      krb5_kdcpreauth_callbacks cb,
+                      krb5_kdcpreauth_rock rock,
+                      krb5_kdcpreauth_moddata moddata,
+                      krb5_kdcpreauth_verify_respond_fn respond,
+                      void *arg)
+{
+    struct sss_radiuskdc_state *state;
+    struct sss_passkeykdc_config *config = NULL;
+    struct sss_passkey_message *message = NULL;
+    struct sss_passkey_message *challenge = NULL;
+    char *configstr = NULL;
+    krb5_error_code ret;
+    krb5_data cookie;
+
+    state = (struct sss_radiuskdc_state *)moddata;
+
+    ret = sss_radiuskdc_enabled(SSSD_PASSKEY_CONFIG, kctx, cb, rock, &configstr);
+    if (ret != 0) {
+        goto done;
+    }
+
+    ret = sss_passkeykdc_config_init(state, kctx, cb->client_name(kctx, rock),
+                                     configstr, &config);
+    if (ret != 0) {
+        goto done;
+    }
+
+    ret = sss_radiuskdc_get_cookie(kctx, cb, rock, SSSD_PASSKEY_PADATA,
+                                   &cookie);
+    if (ret != 0) {
+        goto done;
+    }
+
+    challenge = sss_passkey_message_decode(cookie.data);
+    if (challenge == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    if (pa->pa_type != SSSD_PASSKEY_PADATA || pa->length == 0) {
+        ret = KRB5_PREAUTH_BAD_TYPE;
+        goto done;
+    }
+
+    message = sss_passkey_message_decode_padata(pa);
+    if (message == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    if (message->phase != SSS_PASSKEY_PHASE_REPLY
+        || strcmp(message->state, challenge->state) != 0
+        || strcmp(message->data.reply->cryptographic_challenge,
+                  challenge->data.challenge->cryptographic_challenge) != 0) {
+        ret = EINVAL;
+        goto done;
+    }
+
+    ret = sss_passkeykdc_verify_send(kctx, rock, cb, enc_tkt_reply, respond,
+            arg, message, config->passkey->indicators, config->radius);
+    if (ret != 0) {
+        goto done;
+    }
+
+    ret = 0;
+
+done:
+    if (ret != 0) {
+        respond(arg, ret, NULL, NULL, NULL);
+    }
+
+    cb->free_string(kctx, rock, configstr);
+    sss_passkeykdc_config_free(config);
+    sss_passkey_message_free(message);
+    sss_passkey_message_free(challenge);
+}
+
+krb5_error_code
+kdcpreauth_passkey_initvt(krb5_context kctx,
+                          int maj_ver,
+                          int min_ver,
+                          krb5_plugin_vtable vtable)
+{
+    static krb5_preauthtype pa_type_list[] = { SSSD_PASSKEY_PADATA, 0 };
+    krb5_kdcpreauth_vtable vt;
+
+    if (maj_ver != 1) {
+        return KRB5_PLUGIN_VER_NOTSUPP;
+    }
+
+    vt = (krb5_kdcpreauth_vtable)vtable;
+    vt->name = discard_const(SSSD_PASSKEY_PLUGIN);
+    vt->pa_type_list = pa_type_list;
+    vt->init = sss_passkeykdc_init;
+    vt->fini = sss_radiuskdc_fini;
+    vt->flags = sss_radiuskdc_flags;
+    vt->edata = sss_passkeykdc_edata;
+    vt->verify = sss_passkeykdc_verify;
+    vt->return_padata = sss_radiuskdc_return_padata;
+
+    com_err(SSSD_PASSKEY_PLUGIN, 0, "SSSD passkey plugin loaded");
+
+    return 0;
+}

--- a/src/krb5_plugin/passkey/passkey_utils.c
+++ b/src/krb5_plugin/passkey/passkey_utils.c
@@ -1,0 +1,563 @@
+/*
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2023 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <jansson.h>
+#include <arpa/inet.h>
+#include <krb5/preauth_plugin.h>
+
+#include "krb5_plugin/common/utils.h"
+#include "krb5_plugin/passkey/passkey.h"
+
+void
+sss_passkey_config_free(struct sss_passkey_config *passkey)
+{
+    if (passkey == NULL) {
+        return;
+    }
+
+    sss_string_array_free(passkey->indicators);
+    free(passkey);
+}
+
+/**
+ * {
+ *   "indicators": ["..."] (optional)
+ * }
+ */
+krb5_error_code
+sss_passkey_config_init(const char *config,
+                        struct sss_passkey_config **_passkey)
+{
+    struct sss_passkey_config *passkey;
+    json_t *jindicators = NULL;
+    json_error_t jret;
+    json_t *jroot;
+    krb5_error_code ret;
+
+    passkey = malloc(sizeof(struct sss_passkey_config));
+    if (passkey == NULL) {
+        return ENOMEM;
+    }
+    memset(passkey, 0, sizeof(struct sss_passkey_config));
+
+    jroot = json_loads(config, 0, &jret);
+    if (jroot == NULL) {
+        ret = EINVAL;
+        goto done;
+    }
+
+    ret = json_unpack(jroot, "[{s?:o}]", "indicators", &jindicators);
+    if (ret != 0) {
+        ret = EINVAL;
+        goto done;
+    }
+
+    /* Are indicators set? */
+    if (jindicators != NULL) {
+        passkey->indicators = sss_json_array_to_strings(jindicators);
+        if (passkey->indicators == NULL) {
+            ret = EINVAL;
+            goto done;
+        }
+    }
+
+    *_passkey = passkey;
+
+    ret = 0;
+
+done:
+    if (ret != 0) {
+        sss_passkey_config_free(passkey);
+    }
+
+    if (jroot != NULL) {
+        json_decref(jroot);
+    }
+
+    return ret;
+}
+
+void
+sss_passkey_challenge_free(struct sss_passkey_challenge *data)
+{
+    if (data == NULL) {
+        return;
+    }
+
+    free(data->domain);
+    free(data->cryptographic_challenge);
+    sss_string_array_free(data->credential_id_list);
+
+    free(data);
+}
+
+static struct sss_passkey_challenge *
+sss_passkey_challenge_init(char *domain,
+                           char **credential_id_list,
+                           int user_verification,
+                           char *cryptographic_challenge)
+{
+    struct sss_passkey_challenge *data;
+    krb5_error_code ret;
+
+    /* These are required fields. */
+    if (is_empty(domain)
+        || is_empty(cryptographic_challenge)
+        || credential_id_list == NULL || is_empty(credential_id_list[0])) {
+        return NULL;
+    }
+
+    data = malloc(sizeof(struct sss_passkey_challenge));
+    if (data == NULL) {
+        return NULL;
+    }
+    memset(data, 0, sizeof(struct sss_passkey_challenge));
+
+    data->user_verification = user_verification;
+    data->domain = strdup(domain);
+    data->cryptographic_challenge = strdup(cryptographic_challenge);
+    if (data->domain == NULL || data->cryptographic_challenge == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    data->credential_id_list = sss_string_array_copy(credential_id_list);
+    if (data->credential_id_list == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = 0;
+
+done:
+    if (ret != 0) {
+        sss_passkey_challenge_free(data);
+        return NULL;
+    }
+
+    return data;
+}
+
+static struct sss_passkey_challenge *
+sss_passkey_challenge_from_json_object(json_t *jobject)
+{
+    struct sss_passkey_challenge jdata = {0};
+    struct sss_passkey_challenge *data = NULL;
+    json_t *jcredential_id_list = NULL;
+    char **credential_id_list = NULL;
+    int ret;
+
+    if (jobject == NULL) {
+        return NULL;
+    }
+
+    ret = json_unpack(jobject, "{s:s, s:o, s:i, s:s}",
+                "domain", &jdata.domain,
+                "credential_id_list", &jcredential_id_list,
+                "user_verification", &jdata.user_verification,
+                "cryptographic_challenge", &jdata.cryptographic_challenge);
+    if (ret != 0) {
+        return NULL;
+    }
+
+    if (jcredential_id_list != NULL) {
+        credential_id_list = sss_json_array_to_strings(jcredential_id_list);
+        if (credential_id_list == NULL) {
+            return NULL;
+        }
+    }
+
+    data = sss_passkey_challenge_init(jdata.domain, credential_id_list,
+                                      jdata.user_verification,
+                                      jdata.cryptographic_challenge);
+
+    sss_string_array_free(credential_id_list);
+    return data;
+}
+
+static json_t *
+sss_passkey_challenge_to_json_object(const struct sss_passkey_challenge *data)
+{
+    json_t *jroot;
+    json_t *jcredential_id_list;
+
+    if (data == NULL) {
+        return NULL;
+    }
+
+    /* These are required fields. */
+    if (data->domain == NULL || data->credential_id_list == NULL
+        || data->user_verification == 0 || data->cryptographic_challenge == NULL) {
+        return NULL;
+    }
+
+    jcredential_id_list = sss_strings_to_json_array(data->credential_id_list);
+    if (jcredential_id_list == NULL) {
+        return NULL;
+    }
+
+    jroot = json_pack("{s:s, s:o, s:i, s:s}", "domain", data->domain,
+                        "credential_id_list", jcredential_id_list,
+                        "user_verification", data->user_verification,
+                        "cryptographic_challenge",
+                        data->cryptographic_challenge);
+    if (jroot == NULL) {
+        json_decref(jcredential_id_list);
+        return NULL;
+    }
+
+    return jroot;
+}
+
+void
+sss_passkey_reply_free(struct sss_passkey_reply *data)
+{
+    if (data == NULL) {
+        return;
+    }
+
+    free(data->credential_id);
+    free(data->cryptographic_challenge);
+    free(data->authenticator_data);
+    free(data->assertion_signature);
+    free(data->user_id);
+    free(data);
+}
+
+static struct sss_passkey_reply *
+sss_passkey_reply_init(char *credential_id,
+                       char *cryptographic_challenge,
+                       char *authenticator_data,
+                       char *assertion_signature,
+                       char *user_id)
+{
+    struct sss_passkey_reply *data;
+    krb5_error_code ret;
+
+    /* These are required fields. */
+    if (is_empty(credential_id)
+        || is_empty(cryptographic_challenge)
+        || is_empty(authenticator_data)
+        || is_empty(assertion_signature)) {
+        return NULL;
+    }
+
+    data = malloc(sizeof(struct sss_passkey_reply));
+    if (data == NULL) {
+        return NULL;
+    }
+    memset(data, 0, sizeof(struct sss_passkey_reply));
+
+    data->credential_id = strdup(credential_id);
+    data->cryptographic_challenge = strdup(cryptographic_challenge);
+    data->authenticator_data = strdup(authenticator_data);
+    data->assertion_signature = strdup(assertion_signature);
+    data->user_id = user_id == NULL ? NULL : strdup(user_id);
+    if (data->credential_id == NULL
+        || data->cryptographic_challenge == NULL
+        || data->authenticator_data == NULL
+        || data->assertion_signature == NULL
+        || (user_id != NULL && data->user_id == NULL)) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = 0;
+
+done:
+    if (ret != 0) {
+        sss_passkey_reply_free(data);
+        return NULL;
+    }
+
+    return data;
+}
+
+static struct sss_passkey_reply *
+sss_passkey_reply_from_json_object(json_t *jobject)
+{
+    struct sss_passkey_reply jdata = {0};
+    int ret;
+
+    if (jobject == NULL) {
+        return NULL;
+    }
+
+    ret = json_unpack(jobject, "{s:s, s:s, s:s, s:s, s?:s}",
+                "credential_id", &jdata.credential_id,
+                "cryptographic_challenge", &jdata.cryptographic_challenge,
+                "authenticator_data", &jdata.authenticator_data,
+                "assertion_signature", &jdata.assertion_signature,
+                "user_id", &jdata.user_id);
+    if (ret != 0) {
+        return NULL;
+    }
+
+    return sss_passkey_reply_init(jdata.credential_id,
+                                  jdata.cryptographic_challenge,
+                                  jdata.authenticator_data,
+                                  jdata.assertion_signature,
+                                  jdata.user_id);
+}
+
+static json_t *
+sss_passkey_reply_to_json_object(const struct sss_passkey_reply *data)
+{
+    if (data == NULL) {
+        return NULL;
+    }
+
+    /* These are required fields. */
+    if (data->credential_id == NULL
+       || data->cryptographic_challenge == NULL
+       || data->authenticator_data == NULL
+       || data->assertion_signature == NULL) {
+        return NULL;
+    }
+
+    return json_pack("{s:s, s:s, s:s, s:s, s:s*}",
+                     "credential_id", data->credential_id,
+                     "cryptographic_challenge", data->cryptographic_challenge,
+                     "authenticator_data", data->authenticator_data,
+                     "assertion_signature", data->assertion_signature,
+                     "user_id", data->user_id);
+}
+
+void
+sss_passkey_message_free(struct sss_passkey_message *message)
+{
+    if (message == NULL) {
+        return;
+    }
+
+    switch (message->phase) {
+    case SSS_PASSKEY_PHASE_INIT:
+        break;
+    case SSS_PASSKEY_PHASE_CHALLENGE:
+        sss_passkey_challenge_free(message->data.challenge);
+        break;
+    case SSS_PASSKEY_PHASE_REPLY:
+        sss_passkey_reply_free(message->data.reply);
+        break;
+    default:
+        /* nothing to do */
+        break;
+    }
+
+    free(message->state);
+    free(message);
+}
+
+static struct sss_passkey_message *
+sss_passkey_message_init(enum sss_passkey_phase phase,
+                         const char *state,
+                         void *data)
+{
+    struct sss_passkey_message *message;
+
+    switch (phase) {
+    case SSS_PASSKEY_PHASE_INIT:
+        if (state != NULL || data != NULL) {
+            return NULL;
+        }
+        break;
+    case SSS_PASSKEY_PHASE_CHALLENGE:
+    case SSS_PASSKEY_PHASE_REPLY:
+        if (state == NULL || data == NULL) {
+            return NULL;
+        }
+        break;
+    default:
+        return NULL;
+    }
+
+    message = malloc(sizeof(struct sss_passkey_message));
+    if (message == NULL) {
+        return NULL;
+    }
+    memset(message, 0, sizeof(struct sss_passkey_message));
+
+    message->phase = phase;
+    message->state = state == NULL ? NULL : strdup(state);
+    message->data.ptr = data;
+
+    if (state != NULL && message->state == NULL) {
+        sss_passkey_message_free(message);
+        return NULL;
+    }
+
+    return message;
+}
+
+static struct sss_passkey_message *
+sss_passkey_message_from_json(const char *json_str)
+{
+    struct sss_passkey_message *message = NULL;
+    enum sss_passkey_phase phase = 0;
+    const char *state = NULL;
+    void *data = NULL;
+    json_error_t jret;
+    json_t *jdata = NULL;
+    json_t *jroot;
+    int ret;
+
+    jroot = json_loads(json_str, 0, &jret);
+    if (jroot == NULL) {
+        return NULL;
+    }
+
+    ret = json_unpack(jroot, "{s:i, s?:s, s?:o}",
+                     "phase", &phase,
+                     "state", &state,
+                     "data", &jdata);
+    if (ret != 0) {
+        goto done;
+    }
+
+    switch (phase) {
+    case SSS_PASSKEY_PHASE_INIT:
+        data = NULL;
+        break;
+    case SSS_PASSKEY_PHASE_CHALLENGE:
+        data = sss_passkey_challenge_from_json_object(jdata);
+        if (data == NULL) {
+            goto done;
+        }
+        break;
+    case SSS_PASSKEY_PHASE_REPLY:
+        data = sss_passkey_reply_from_json_object(jdata);
+        if (data == NULL) {
+            goto done;
+        }
+        break;
+    default:
+        goto done;
+    }
+
+    message = sss_passkey_message_init(phase, state, data);
+    if (message == NULL && phase == SSS_PASSKEY_PHASE_CHALLENGE) {
+        sss_passkey_challenge_free(data);
+    } else if (message == NULL && phase == SSS_PASSKEY_PHASE_REPLY) {
+        sss_passkey_reply_free(data);
+    }
+
+done:
+    json_decref(jroot);
+    return message;
+}
+
+static char *
+sss_passkey_message_to_json(const struct sss_passkey_message *message)
+{
+    json_t *jroot;
+    json_t *jdata;
+    char *str;
+
+    if (message == NULL) {
+        return NULL;
+    }
+
+    switch (message->phase) {
+    case SSS_PASSKEY_PHASE_INIT:
+        if (message->state != NULL || message->data.ptr != NULL) {
+            return NULL;
+        }
+        jdata = NULL;
+        break;
+    case SSS_PASSKEY_PHASE_CHALLENGE:
+        if (message->state == NULL || message->data.challenge == NULL) {
+            return NULL;
+        }
+
+        jdata = sss_passkey_challenge_to_json_object(message->data.challenge);
+        if (jdata == NULL) {
+            return NULL;
+        }
+        break;
+    case SSS_PASSKEY_PHASE_REPLY:
+        if (message->state == NULL || message->data.reply == NULL) {
+            return NULL;
+        }
+
+        jdata = sss_passkey_reply_to_json_object(message->data.reply);
+        if (jdata == NULL) {
+            return NULL;
+        }
+        break;
+    default:
+        return NULL;
+    }
+
+    jroot = json_pack("{s:i, s:s*, s:o*}",
+                      "phase", message->phase,
+                      "state", message->state,
+                      "data", jdata);
+    if (jroot == NULL) {
+        json_decref(jdata);
+        return NULL;
+    }
+
+    str = json_dumps(jroot, JSON_COMPACT);
+    json_decref(jroot);
+
+    return str;
+}
+
+char *
+sss_passkey_message_encode(const struct sss_passkey_message *data)
+{
+    return sss_radius_message_encode(SSSD_PASSKEY_PREFIX,
+        (sss_radius_message_encode_fn)sss_passkey_message_to_json, data);
+}
+
+struct sss_passkey_message *
+sss_passkey_message_decode(const char *str)
+{
+    return sss_radius_message_decode(SSSD_PASSKEY_PREFIX,
+        (sss_radius_message_decode_fn)sss_passkey_message_from_json, str);
+}
+
+krb5_pa_data *
+sss_passkey_message_encode_padata(const struct sss_passkey_message *data)
+{
+    return sss_radius_encode_padata(SSSD_PASSKEY_PADATA,
+        (sss_radius_message_encode_fn)sss_passkey_message_encode, data);
+}
+
+struct sss_passkey_message *
+sss_passkey_message_decode_padata(krb5_pa_data *padata)
+{
+    return sss_radius_decode_padata(
+        (sss_radius_message_decode_fn)sss_passkey_message_decode, padata);
+}
+
+krb5_pa_data **
+sss_passkey_message_encode_padata_array(const struct sss_passkey_message *data)
+{
+    return sss_radius_encode_padata_array(SSSD_PASSKEY_PADATA,
+        (sss_radius_message_encode_fn)sss_passkey_message_encode, data);
+}

--- a/src/krb5_plugin/passkey/sssd_enable_passkey
+++ b/src/krb5_plugin/passkey/sssd_enable_passkey
@@ -1,0 +1,14 @@
+# Enable SSSD Passkey Kerberos preauthentication plugins.
+#
+# This will allow you to obtain Kerberos TGT through passkey authentication.
+#
+# To disable the passkey plugin, comment out the following lines.
+
+[plugins]
+ clpreauth = {
+  module = passkey:/usr/lib64/sssd/modules/sssd_krb5_passkey_plugin.so
+ }
+
+ kdcpreauth = {
+  module = passkey:/usr/lib64/sssd/modules/sssd_krb5_passkey_plugin.so
+ }

--- a/src/tests/cmocka/test_krb5_passkey_plugin.c
+++ b/src/tests/cmocka/test_krb5_passkey_plugin.c
@@ -1,0 +1,480 @@
+/*
+    Copyright (C) 2023 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <popt.h>
+
+#include "tests/cmocka/common_mock.h"
+#include "krb5_plugin/passkey/passkey.h"
+
+void test_sss_passkey_message_encode__null(void **state)
+{
+    char *str;
+
+    str = sss_passkey_message_encode(NULL);
+    assert_null(str);
+}
+
+void test_sss_passkey_message_encode__invalid(void **state)
+{
+    struct sss_passkey_message message = {0};
+    char *str;
+
+    message.phase = SSS_PASSKEY_PHASE_CHALLENGE;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    message.phase = SSS_PASSKEY_PHASE_REPLY;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+}
+
+void test_sss_passkey_message_encode__init(void **state)
+{
+    struct sss_passkey_message message = {0};
+    char *str;
+
+    message.phase = SSS_PASSKEY_PHASE_INIT;
+    str = sss_passkey_message_encode(&message);
+    assert_non_null(str);
+    assert_string_equal(str, "passkey {\"phase\":0}");
+    free(str);
+
+    message.phase = SSS_PASSKEY_PHASE_INIT;
+    message.state = discard_const("abcd");
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+}
+
+void test_sss_passkey_message_encode__challenge(void **state)
+{
+    struct sss_passkey_message message = {0};
+    struct sss_passkey_challenge challenge = {0};
+    const char *id_list[] = {"a", "b", NULL};
+    char *str;
+
+    message.phase = SSS_PASSKEY_PHASE_CHALLENGE;
+    message.state = NULL;
+    message.data.challenge = NULL;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    message.phase = SSS_PASSKEY_PHASE_CHALLENGE;
+    message.state = discard_const("abcd");
+    message.data.challenge = NULL;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    challenge.domain = discard_const("domain");
+    challenge.credential_id_list = discard_const(id_list);
+    challenge.user_verification = 1;
+    challenge.cryptographic_challenge = discard_const("crypto-challenge");
+    message.phase = SSS_PASSKEY_PHASE_CHALLENGE;
+    message.state = NULL;
+    message.data.challenge = &challenge;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    challenge.domain = NULL;
+    challenge.credential_id_list = NULL;
+    challenge.user_verification = 0;
+    challenge.cryptographic_challenge = NULL;
+    message.phase = SSS_PASSKEY_PHASE_CHALLENGE;
+    message.state = NULL;
+    message.data.challenge = &challenge;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    challenge.domain = NULL;
+    challenge.credential_id_list = discard_const(id_list);
+    challenge.user_verification = 1;
+    challenge.cryptographic_challenge = discard_const("crypto-challenge");
+    message.phase = SSS_PASSKEY_PHASE_CHALLENGE;
+    message.state = discard_const("abcd");
+    message.data.challenge = &challenge;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    challenge.domain = discard_const("domain");
+    challenge.credential_id_list = NULL;
+    challenge.user_verification = 1;
+    challenge.cryptographic_challenge = discard_const("crypto-challenge");
+    message.phase = SSS_PASSKEY_PHASE_CHALLENGE;
+    message.state = discard_const("abcd");
+    message.data.challenge = &challenge;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    challenge.domain = discard_const("domain");
+    challenge.credential_id_list = discard_const(id_list);
+    challenge.user_verification = 0;
+    challenge.cryptographic_challenge = discard_const("crypto-challenge");
+    message.phase = SSS_PASSKEY_PHASE_CHALLENGE;
+    message.state = discard_const("abcd");
+    message.data.challenge = &challenge;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    challenge.domain = discard_const("domain");
+    challenge.credential_id_list = discard_const(id_list);
+    challenge.user_verification = 1;
+    challenge.cryptographic_challenge = NULL;
+    message.phase = SSS_PASSKEY_PHASE_CHALLENGE;
+    message.state = discard_const("abcd");
+    message.data.challenge = &challenge;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    challenge.domain = discard_const("domain");
+    challenge.credential_id_list = discard_const(id_list);
+    challenge.user_verification = 1;
+    challenge.cryptographic_challenge = discard_const("crypto-challenge");
+    message.phase = SSS_PASSKEY_PHASE_CHALLENGE;
+    message.state = discard_const("abcd");
+    message.data.challenge = &challenge;
+    str = sss_passkey_message_encode(&message);
+    assert_non_null(str);
+    assert_string_equal(str, "passkey {\"phase\":1,\"state\":\"abcd\",\"data\":{\"domain\":\"domain\",\"credential_id_list\":[\"a\",\"b\"],\"user_verification\":1,\"cryptographic_challenge\":\"crypto-challenge\"}}");
+    free(str);
+}
+
+void test_sss_passkey_message_encode__reply(void **state)
+{
+    struct sss_passkey_message message = {0};
+    struct sss_passkey_reply reply = {0};
+    char *str;
+
+    message.phase = SSS_PASSKEY_PHASE_REPLY;
+    message.state = NULL;
+    message.data.reply = NULL;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    message.phase = SSS_PASSKEY_PHASE_REPLY;
+    message.state = discard_const("abcd");
+    message.data.reply = NULL;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    message.phase = SSS_PASSKEY_PHASE_REPLY;
+    message.state = NULL;
+    message.data.reply = &reply;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    reply.credential_id = discard_const("id");
+    reply.cryptographic_challenge = discard_const("crypto-challenge");
+    reply.authenticator_data = discard_const("auth-data");
+    reply.assertion_signature = discard_const("assertion-sig");
+    reply.user_id = NULL;
+    message.phase = SSS_PASSKEY_PHASE_REPLY;
+    message.state = NULL;
+    message.data.reply = &reply;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    reply.credential_id = NULL;
+    reply.cryptographic_challenge = discard_const("crypto-challenge");
+    reply.authenticator_data = discard_const("auth-data");
+    reply.assertion_signature = discard_const("assertion-sig");
+    reply.user_id = NULL;
+    message.phase = SSS_PASSKEY_PHASE_REPLY;
+    message.state = discard_const("abcd");
+    message.data.reply = &reply;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    reply.credential_id = discard_const("id");
+    reply.cryptographic_challenge = NULL;
+    reply.authenticator_data = discard_const("auth-data");
+    reply.assertion_signature = discard_const("assertion-sig");
+    reply.user_id = NULL;
+    message.phase = SSS_PASSKEY_PHASE_REPLY;
+    message.state = discard_const("abcd");
+    message.data.reply = &reply;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    reply.credential_id = discard_const("id");
+    reply.cryptographic_challenge = discard_const("crypto-challenge");
+    reply.authenticator_data = NULL;
+    reply.assertion_signature = discard_const("assertion-sig");
+    reply.user_id = NULL;
+    message.phase = SSS_PASSKEY_PHASE_REPLY;
+    message.state = discard_const("abcd");
+    message.data.reply = &reply;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    reply.credential_id = discard_const("id");
+    reply.cryptographic_challenge = discard_const("crypto-challenge");
+    reply.authenticator_data = discard_const("auth-data");
+    reply.assertion_signature = NULL;
+    reply.user_id = NULL;
+    message.phase = SSS_PASSKEY_PHASE_REPLY;
+    message.state = discard_const("abcd");
+    message.data.reply = &reply;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    reply.credential_id = discard_const("id");
+    reply.cryptographic_challenge = discard_const("crypto-challenge");
+    reply.authenticator_data = discard_const("auth-data");
+    reply.assertion_signature = discard_const("assertion-sig");
+    reply.user_id = NULL;
+    message.phase = SSS_PASSKEY_PHASE_REPLY;
+    message.state = discard_const("abcd");
+    message.data.reply = &reply;
+    str = sss_passkey_message_encode(&message);
+    assert_non_null(str);
+    assert_string_equal(str, "passkey {\"phase\":2,\"state\":\"abcd\",\"data\":{\"credential_id\":\"id\",\"cryptographic_challenge\":\"crypto-challenge\",\"authenticator_data\":\"auth-data\",\"assertion_signature\":\"assertion-sig\"}}");
+    free(str);
+
+    reply.credential_id = discard_const("id");
+    reply.cryptographic_challenge = discard_const("crypto-challenge");
+    reply.authenticator_data = discard_const("auth-data");
+    reply.assertion_signature = discard_const("assertion-sig");
+    reply.user_id = discard_const("user-id");
+    message.phase = SSS_PASSKEY_PHASE_REPLY;
+    message.state = discard_const("abcd");
+    message.data.reply = &reply;
+    str = sss_passkey_message_encode(&message);
+    assert_non_null(str);
+    assert_string_equal(str, "passkey {\"phase\":2,\"state\":\"abcd\",\"data\":{\"credential_id\":\"id\",\"cryptographic_challenge\":\"crypto-challenge\",\"authenticator_data\":\"auth-data\",\"assertion_signature\":\"assertion-sig\",\"user_id\":\"user-id\"}}");
+    free(str);
+}
+
+void test_sss_passkey_message_decode__null(void **state)
+{
+    struct sss_passkey_message *message;
+
+    message = sss_passkey_message_decode(NULL);
+    assert_null(message);
+}
+
+void test_sss_passkey_message_decode__invalid(void **state)
+{
+    struct sss_passkey_message *message;
+    const char *str;
+
+    str = "";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "oauth2";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":10}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":1, \"state\":\"abcd\"}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":1, \"state\":\"abcd\", \"data\":{\"test\":\"test\"}}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":2, \"state\":\"abcd\"}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":2, \"state\":\"abcd\", \"data\":{\"test\":\"test\"}}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+}
+
+void test_sss_passkey_message_decode__init(void **state)
+{
+    struct sss_passkey_message *message;
+    const char *str;
+
+    str = "passkey {\"phase\":0,\"state\":\"abcd\"}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":0,\"data\":{\"test\":\"abcd\"}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":0,\"state\":\"abcd\",\"data\":{\"test\":\"abcd\"}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":0}";
+    message = sss_passkey_message_decode(str);
+    assert_non_null(message);
+    assert_int_equal(message->phase, SSS_PASSKEY_PHASE_INIT);
+    assert_null(message->state);
+    assert_null(message->data.ptr);
+    sss_passkey_message_free(message);
+}
+
+void test_sss_passkey_message_decode__challenge(void **state)
+{
+    struct sss_passkey_message *message;
+    const char *str;
+
+    str = "passkey {\"phase\":1}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":1,\"state\":\"abcd\"}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":1,\"data\":{\"test\":\"abcd\"}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":1,\"state\":\"abcd\",\"data\":{\"domain\":\"domain\",\"credential_id_list\":[\"a\",\"b\"],\"user_verification\":1,\"cryptographic_challenge\":\"crypto-challenge\"}}";
+    message = sss_passkey_message_decode(str);
+    assert_non_null(message);
+    assert_int_equal(message->phase, SSS_PASSKEY_PHASE_CHALLENGE);
+    assert_non_null(message->state);
+    assert_string_equal(message->state, "abcd");
+    assert_non_null(message->data.challenge);
+    assert_non_null(message->data.challenge->domain);
+    assert_string_equal(message->data.challenge->domain, "domain");
+    assert_non_null(message->data.challenge->credential_id_list);
+    assert_string_equal(message->data.challenge->credential_id_list[0], "a");
+    assert_string_equal(message->data.challenge->credential_id_list[1], "b");
+    assert_null(message->data.challenge->credential_id_list[2]);
+    assert_int_equal(message->data.challenge->user_verification, 1);
+    assert_non_null(message->data.challenge->cryptographic_challenge);
+    assert_string_equal(message->data.challenge->cryptographic_challenge, "crypto-challenge");
+    sss_passkey_message_free(message);
+}
+
+void test_sss_passkey_message_decode__reply(void **state)
+{
+    struct sss_passkey_message *message;
+    const char *str;
+
+    str = "passkey {\"phase\":2}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":2,\"state\":\"abcd\"}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":2,\"data\":{\"test\":\"abcd\"}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":2,\"state\":\"abcd\",\"data\":{\"credential_id\":\"id\",\"cryptographic_challenge\":\"crypto-challenge\",\"authenticator_data\":\"auth-data\",\"assertion_signature\":\"assertion-sig\"}}";
+    message = sss_passkey_message_decode(str);
+    assert_non_null(message);
+    assert_int_equal(message->phase, SSS_PASSKEY_PHASE_REPLY);
+    assert_non_null(message->state);
+    assert_string_equal(message->state, "abcd");
+    assert_non_null(message->data.reply);
+    assert_non_null(message->data.reply->credential_id);
+    assert_string_equal(message->data.reply->credential_id, "id");
+    assert_non_null(message->data.reply->cryptographic_challenge);
+    assert_string_equal(message->data.reply->cryptographic_challenge, "crypto-challenge");
+    assert_non_null(message->data.reply->authenticator_data);
+    assert_string_equal(message->data.reply->authenticator_data, "auth-data");
+    assert_non_null(message->data.reply->assertion_signature);
+    assert_string_equal(message->data.reply->assertion_signature, "assertion-sig");
+    sss_passkey_message_free(message);
+}
+
+void test_sss_passkey_config_init__invalid(void **state)
+{
+    struct sss_passkey_config *passkeycfg;
+    krb5_error_code ret;
+
+    ret = sss_passkey_config_init("not-json", &passkeycfg);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_passkey_config_init("", &passkeycfg);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_passkey_config_init("[]", &passkeycfg);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_passkey_config_init("[{\"indicators\": \"test\"}]", &passkeycfg);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_passkey_config_init("{\"indicators\": \"test\"}", &passkeycfg);
+    assert_int_equal(ret, EINVAL);
+}
+
+void test_sss_passkey_config_init__ok(void **state)
+{
+    struct sss_passkey_config *passkeycfg;
+    krb5_error_code ret;
+
+    ret = sss_passkey_config_init("[{}]", &passkeycfg);
+    assert_int_equal(ret, 0);
+    assert_non_null(passkeycfg);
+    assert_null(passkeycfg->indicators);
+    sss_passkey_config_free(passkeycfg);
+
+    ret = sss_passkey_config_init("[{\"indicators\": [\"i1\"]}]", &passkeycfg);
+    assert_int_equal(ret, 0);
+    assert_non_null(passkeycfg);
+    assert_non_null(passkeycfg->indicators);
+    assert_non_null(passkeycfg->indicators[0]);
+    assert_null(passkeycfg->indicators[1]);
+    assert_string_equal(passkeycfg->indicators[0], "i1");
+    sss_passkey_config_free(passkeycfg);
+
+    ret = sss_passkey_config_init("[{\"indicators\": [\"i1\", \"i2\"]}]", &passkeycfg);
+    assert_int_equal(ret, 0);
+    assert_non_null(passkeycfg);
+    assert_non_null(passkeycfg->indicators);
+    assert_non_null(passkeycfg->indicators[0]);
+    assert_non_null(passkeycfg->indicators[1]);
+    assert_null(passkeycfg->indicators[2]);
+    assert_string_equal(passkeycfg->indicators[0], "i1");
+    assert_string_equal(passkeycfg->indicators[1], "i2");
+    sss_passkey_config_free(passkeycfg);
+}
+
+int main(int argc, const char *argv[])
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_sss_passkey_message_encode__null),
+        cmocka_unit_test(test_sss_passkey_message_encode__invalid),
+        cmocka_unit_test(test_sss_passkey_message_encode__init),
+        cmocka_unit_test(test_sss_passkey_message_encode__challenge),
+        cmocka_unit_test(test_sss_passkey_message_encode__reply),
+        cmocka_unit_test(test_sss_passkey_message_decode__null),
+        cmocka_unit_test(test_sss_passkey_message_decode__invalid),
+        cmocka_unit_test(test_sss_passkey_message_decode__init),
+        cmocka_unit_test(test_sss_passkey_message_decode__challenge),
+        cmocka_unit_test(test_sss_passkey_message_decode__reply),
+        cmocka_unit_test(test_sss_passkey_config_init__invalid),
+        cmocka_unit_test(test_sss_passkey_config_init__ok),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/tests/dlopen-tests.c
+++ b/src/tests/dlopen-tests.c
@@ -71,6 +71,9 @@ struct so {
                                        NULL } },
 #endif
     { "sssd_krb5_idp_plugin.so", { LIBPFX"sssd_krb5_idp_plugin.so", NULL } },
+#ifdef BUILD_PASSKEY
+    { "sssd_krb5_passkey_plugin.so", { LIBPFX"sssd_krb5_passkey_plugin.so", NULL } },
+#endif
 #ifdef HAVE_PAC_RESPONDER
     { "sssd_pac_plugin.so", { LIBPFX"sssd_pac_plugin.so", NULL } },
 #endif


### PR DESCRIPTION
The plugin is very similar to idp plugin so I took everything
that can be shared out and converted it into a common API.

Since the communication is now two-way (in idp plugin we only
receive data from ipa-otpd but never send any, now we need to
send data as well) and I didn't find any better attribute in
RADIUS protocol that we could use, all data (both incoming
and outgoing) is send in `Proxy-State`.

1. Initial request (kdc plugin -> ipa_otpd)

```
passkey {
  phase: 0
}
```

2. ipa_otpd reply (ipa_otpd -> kdc plugin -> krb5 client plugin -> krb5_child)

```
passkey {
  phase: 1,
  state: "ipa_otpd state",
  data: {
    domain: "...",
    credential_id_list: ["...", ...],
    user_verification: X,
    cryptographic_challenge: "..."
  }
}
```

3. passkey device reply (krb5_child -> krb5 client plugin -> kdc plugin -> ipa_otpd)

```
passkey {
  phase: 2,
  state: "ipa_otpd state",
  data: {
    credential_id: "...",
    cryptographic_challenge: "...",
    authenticator_data: "...",
    assertion_signature: "..."
  }
}
```