### PR TITLE
PAC: allow to disable UPN check and relax default check - sssd-2-7

### DIFF
--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -181,7 +181,7 @@
 #define CONFDB_PAC_LIFETIME "pac_lifetime"
 #define CONFDB_PAC_CHECK "pac_check"
 #define CONFDB_PAC_CHECK_DEFAULT "no_check"
-#define CONFDB_PAC_CHECK_IPA_AD_DEFAULT "check_upn, check_upn_dns_info_ex"
+#define CONFDB_PAC_CHECK_IPA_AD_DEFAULT "check_upn, check_upn_allow_missing, check_upn_dns_info_ex"
 
 /* InfoPipe */
 #define CONFDB_IFP_CONF_ENTRY "config/ifp"

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2276,6 +2276,34 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                                 </listitem>
                             </varlistentry>
                             <varlistentry>
+                                <term>check_upn_allow_missing</term>
+                                <listitem>
+                                    <para>This option should be used together
+                                    with 'check_upn' and handles the case where
+                                    a UPN is set on the server-side but is not
+                                    read by SSSD. The typical example is a
+                                    FreeIPA domain where 'ldap_user_principal'
+                                    is set to a not existing attribute name.
+                                    This was typically done to work-around
+                                    issues in the handling of enterprise
+                                    principals. But this is fixed since quite
+                                    some time and FreeIPA can handle enterprise
+                                    principals just fine and there is no need
+                                    anymore to set 'ldap_user_principal'.</para>
+                                    <para>Currently this option is set by
+                                    default to avoid regressions in such
+                                    environments. A log message will be added
+                                    to the system log and SSSD's debug log in
+                                    case a UPN is found in the PAC but not in
+                                    SSSD's cache. To avoid this log message it
+                                    would be best to evaluate if the
+                                    'ldap_user_principal' option can be removed.
+                                    If this is not possible, removing
+                                    'check_upn' will skip the test and avoid the
+                                    log message.</para>
+                                </listitem>
+                            </varlistentry>
+                            <varlistentry>
                                 <term>upn_dns_info_present</term>
                                 <listitem>
                                     <para>The PAC must contain the UPN-DNS-INFO
@@ -2305,7 +2333,7 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                         </para>
                         <para>
                             Default: no_check (AD and IPA provider
-                            'check_upn, check_upn_dns_info_ex')
+                            'check_upn, check_upn_allow_missing, check_upn_dns_info_ex')
                         </para>
                     </listitem>
                 </varlistentry>

--- a/src/providers/ad/ad_pac_common.c
+++ b/src/providers/ad/ad_pac_common.c
@@ -224,9 +224,19 @@ errno_t check_upn_and_sid_from_user_and_pac(struct ldb_message *msg,
 
         if (user_data != NULL) {
             if (strcasecmp(user_data, upn_dns_info->upn_name) != 0) {
-                DEBUG(SSSDBG_CRIT_FAILURE,
-                      "UPN of user entry and PAC do not match.\n");
-                return ERR_CHECK_PAC_FAILED;
+                if (pac_check_opts & CHECK_PAC_CHECK_UPN) {
+                    DEBUG(SSSDBG_CRIT_FAILURE, "UPN of user entry [%s] and "
+                                               "PAC [%s] do not match.\n",
+                                               user_data,
+                                               upn_dns_info->upn_name);
+                    return ERR_CHECK_PAC_FAILED;
+                } else {
+                    DEBUG(SSSDBG_IMPORTANT_INFO, "UPN of user entry [%s] and "
+                                                 "PAC [%s] do not match, "
+                                                 "ignored.\n", user_data,
+                                                 upn_dns_info->upn_name);
+                    return EOK;
+                }
             }
         }
 

--- a/src/providers/ipa/ipa_s2n_exop.c
+++ b/src/providers/ipa/ipa_s2n_exop.c
@@ -2467,8 +2467,6 @@ static errno_t ipa_s2n_save_objects(struct sss_domain_info *dom,
     time_t now;
     struct sss_nss_homedir_ctx homedir_ctx;
     char *name = NULL;
-    char *realm;
-    char *short_name = NULL;
     char *upn = NULL;
     gid_t gid;
     gid_t orig_gid = 0;
@@ -2605,48 +2603,6 @@ static errno_t ipa_s2n_save_objects(struct sss_domain_info *dom,
                 DEBUG(SSSDBG_OP_FAILURE,
                       "sysdb_attrs_add_lc_name_alias_safe failed.\n");
                 goto done;
-            }
-
-            if (upn == NULL) {
-                /* We also have to store a fake UPN here, because otherwise the
-                 * krb5 child later won't be able to properly construct one as
-                 * the username is fully qualified but the child doesn't have
-                 * access to the regex to deconstruct it */
-                /* FIXME: The real UPN is available from the PAC, we should get
-                 * it from there. */
-                realm = get_uppercase_realm(tmp_ctx, dom->name);
-                if (!realm) {
-                    DEBUG(SSSDBG_OP_FAILURE, "failed to get realm.\n");
-                    ret = ENOMEM;
-                    goto done;
-                }
-
-                ret = sss_parse_internal_fqname(tmp_ctx, attrs->a.user.pw_name,
-                                                &short_name, NULL);
-                if (ret != EOK) {
-                    DEBUG(SSSDBG_CRIT_FAILURE,
-                          "Cannot parse internal name %s\n",
-                          attrs->a.user.pw_name);
-                    goto done;
-                }
-
-                upn = talloc_asprintf(tmp_ctx, "%s@%s", short_name, realm);
-                if (!upn) {
-                    DEBUG(SSSDBG_OP_FAILURE, "failed to format UPN.\n");
-                    ret = ENOMEM;
-                    goto done;
-                }
-
-                /* We might already have the SID or the UPN from other sources
-                 * hence sysdb_attrs_add_string_safe is used to avoid double
-                 * entries. */
-                ret = sysdb_attrs_add_string_safe(attrs->sysdb_attrs, SYSDB_UPN,
-                                                  upn);
-                if (ret != EOK) {
-                    DEBUG(SSSDBG_OP_FAILURE,
-                          "sysdb_attrs_add_string failed.\n");
-                    goto done;
-                }
             }
 
             if (req_input->type == REQ_INP_SECID) {

--- a/src/util/pac_utils.c
+++ b/src/util/pac_utils.c
@@ -64,12 +64,22 @@ static errno_t check_check_pac_opt(const char *inp, uint32_t *check_pac_flags)
             flags |= CHECK_PAC_CHECK_UPN_DNS_INFO_EX;
             flags |= CHECK_PAC_UPN_DNS_INFO_PRESENT;
             flags |= CHECK_PAC_CHECK_UPN;
+        } else if (strcasecmp(list[c], CHECK_PAC_CHECK_UPN_ALLOW_MISSING_STR) == 0) {
+            flags |= CHECK_PAC_CHECK_UPN_ALLOW_MISSING;
         } else {
             DEBUG(SSSDBG_OP_FAILURE, "Unknown value [%s] for pac_check.\n",
                                      list[c]);
             ret = EINVAL;
             goto done;
         }
+    }
+
+    if ((flags & CHECK_PAC_CHECK_UPN_ALLOW_MISSING)
+                && !(flags & CHECK_PAC_CHECK_UPN)) {
+        DEBUG(SSSDBG_CONF_SETTINGS,
+              "pac_check option '%s' is set but '%s' is not set, this means "
+              "the UPN is not checked.\n",
+              CHECK_PAC_CHECK_UPN_ALLOW_MISSING_STR, CHECK_PAC_CHECK_UPN_STR);
     }
 
     ret = EOK;

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -818,6 +818,8 @@ uint64_t get_spend_time_us(uint64_t st);
 #define CHECK_PAC_CHECK_UPN_DNS_INFO_EX (1 << 3)
 #define CHECK_PAC_UPN_DNS_INFO_EX_PRESENT_STR "upn_dns_info_ex_present"
 #define CHECK_PAC_UPN_DNS_INFO_EX_PRESENT (1 << 4)
+#define CHECK_PAC_CHECK_UPN_ALLOW_MISSING_STR "check_upn_allow_missing"
+#define CHECK_PAC_CHECK_UPN_ALLOW_MISSING (1 << 5)
 
 errno_t get_pac_check_config(struct confdb_ctx *cdb, uint32_t *pac_check_opts);
 #endif /* __SSSD_UTIL_H__ */


### PR DESCRIPTION
To avoid issues with the UPN check during PAC validation when
'ldap_user_principal' is set to a not existing attribute to skip reading
user principals a new 'pac_check' option, 'check_upn_allow_missing' is
added to the default options. With this option only a log message is shown
but the check will not fail.

Resolves: https://github.com/SSSD/sssd/issues/6451