### PR TITLE
BACKEND: Reload resolv.conf after initialization

### DIFF
--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -605,6 +605,12 @@ errno_t be_process_init(TALLOC_CTX *mem_ctx,
 
     tevent_req_set_callback(req, dp_initialized, be_ctx);
 
+    /* Load the resolv.conf file in case a call to dbus' resInit() was missed */
+    ret = data_provider_res_init(be_ctx, NULL, be_ctx);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_MINOR_FAILURE, "Unable to reload resolv.conf\n");
+    }
+
     ret = EOK;
 
 done:


### PR DESCRIPTION
Once the backend initialization is finished, in particular after D-Bus is initialized, reload the resolv.conf file to retrieve any change signaled through D-Bus before its initialization.

Resolves: https://github.com/SSSD/sssd/issues/6383

This is an intermediate fix while waiting for [PR #6421](https://github.com/SSSD/sssd/pull/6421) to be ready to be merged.