### PR TITLE
Tests: port bash idmap testcase to pytest

### DIFF
--- a/src/tests/multihost/ad/conftest.py
+++ b/src/tests/multihost/ad/conftest.py
@@ -459,6 +459,25 @@ def enable_autofs_service(session_multihost,
 
 
 @pytest.fixture(scope="class")
+def create_idmap_users_groups(session_multihost, request):
+    """ create Ad idmap users and groups """
+    ad = ADOperations(session_multihost.ad[0])
+    usrgrp = ['posix_usr', 'posix_grp', 'noposix_usr', 'noposix_grp']
+    for object in usrgrp:
+        ad.delete_ad_user_group(object)
+    ad.create_ad_nonposix_user('noposix_usr')
+    ad.create_ad_nonposix_group('noposix_grp')
+    ad.add_user_member_of_group('noposix_grp', 'noposix_usr')
+    ad.create_ad_unix_user_group('posix_usr', 'posix_grp')
+
+    def remove_idmap_objects():
+        """ Remove AD idmap users and groups """
+        for object in usrgrp:
+            ad.delete_ad_user_group(object)
+    request.addfinalizer(remove_idmap_objects)
+
+
+@pytest.fixture(scope="class")
 def enable_ad_sudoschema(session_multihost):
     """ Enable AD Sudo schema """
     basedn = session_multihost.ad[0].domain_basedn_entry

--- a/src/tests/multihost/ad/pytest.ini
+++ b/src/tests/multihost/ad/pytest.ini
@@ -8,6 +8,7 @@ markers =
    cifs: Cifs test cases
    ad_access_control: Test for AD Access Control
    dyndns: dynamic dns test cases
+   idmap: Tests related to idmap
    idmaprange: Tests related to ldap idmap range
    keytabrotation: keytab rotation using adcli
    memcachesid: Test for mem cache sid

--- a/src/tests/multihost/ad/test_idmap.py
+++ b/src/tests/multihost/ad/test_idmap.py
@@ -1,0 +1,69 @@
+""" AD idmap tests from bash
+:requirement: IDM-SSSD-REQ: idmap
+:casecomponent: sssd
+:subsystemteam: sst_idm_sssd
+:upstream: yes
+:status: approved
+"""
+import pytest
+
+from sssd.testlib.common.utils import sssdTools
+
+
+@pytest.mark.usefixtures('joinad', 'create_idmap_users_groups')
+@pytest.mark.tier1_3
+@pytest.mark.idmap
+class Testidmap(object):
+    """ Test cases for idmap
+    :setup:
+        1. Join to AD using realm command.
+        2. Create a non-POSIX user and a non-POSIX group
+        3. Create a user and a group with posix attributes
+    """
+    @staticmethod
+    def test_001_idmap_disable(multihost):
+        """
+        :title: with ldap provider idmapping is disabled
+        :description: Disable idmapping for ldap provider and confirm the
+         only the users, and group, with posix attributes defined in AD-server
+         are returned
+        :id: 989ec7eb-451c-49c4-9b09-e3ac005721d7
+        :setup:
+            1. Configure ldap_provider with idmapping disabled
+        :steps:
+            1. Fetch non-posix users and groups information
+            2. Fetch posix users and groups information
+            3. Log in as a posix-user
+        :expectedresults:
+            1. Non-posix user and group should not be returned
+            2. POSIX user and group information should be returned
+            3. POSIX user should be able to log in
+        """
+        client = sssdTools(multihost.client[0], multihost.ad[0])
+        client.backup_sssd_conf()
+        domain_name = client.get_domain_section_name()
+        dom_section = f'domain/{domain_name}'
+        params = {'id_provider': 'ldap',
+                  'ldap_uri': f'ldap://{multihost.ad[0].hostname}',
+                  'ldap_schema': 'ad',
+                  'ldap_id_mapping': 'false',
+                  'ldap_default_bind_dn': f'CN=administrator,CN=Users,{multihost.ad[0].domain_basedn_entry}',
+                  'ldap_default_authtok': f'{multihost.ad[0].ssh_password}',
+                  'ldap_default_authtok_type': 'password',
+                  'debug_level': '0xFFF0',
+                  'use_fully_qualified_names': 'false',
+                  'ldap_tls_cacert': '/etc/openldap/certs/ad_cert.pem',
+                  'ldap_tls_reqcert': 'demand',
+                  'ldap_referrals': 'false'}
+        client.sssd_conf(dom_section, params)
+        client.clear_sssd_cache()
+        cmd1 = multihost.client[0].run_command('getent passwd noposix_usr', raiseonerr=False)
+        cmd2 = multihost.client[0].run_command('getent group noposix_grp', raiseonerr=False)
+        cmd3 = multihost.client[0].run_command('getent passwd posix_usr', raiseonerr=False)
+        cmd4 = multihost.client[0].run_command('getent group posix_grp', raiseonerr=False)
+        client.restore_sssd_conf()
+        assert client.auth_from_client('posix_usr', 'Secret123') == 3, 'ssh login failed for posix-user'
+        assert cmd1.returncode == 2, 'non-posix user is returned by sssd, it should not be'
+        assert cmd2.returncode == 2, 'non-posix group is returned by sssd, it should not be'
+        assert cmd3.returncode == 0, 'posix-user is not returned by sssd'
+        assert cmd4.returncode == 0, 'posix-group is not returned by sssd'


### PR DESCRIPTION
The flaky idmap test is ported to pytest