### PR TITLE
p11: fix size of argument array

### DIFF
--- a/src/responder/pam/pamsrv_p11.c
+++ b/src/responder/pam/pamsrv_p11.c
@@ -746,7 +746,7 @@ struct tevent_req *pam_check_cert_send(TALLOC_CTX *mem_ctx,
     struct timeval tv;
     int pipefd_to_child[2] = PIPE_INIT;
     int pipefd_from_child[2] = PIPE_INIT;
-    const char *extra_args[19] = { NULL };
+    const char *extra_args[20] = { NULL };
     uint8_t *write_buf = NULL;
     size_t write_buf_len = 0;
     size_t arg_c;


### PR DESCRIPTION
Currently 19 options can be set for p11_child and the a NULL at the end
the array must have 20 elements.

Resolves: https://github.com/SSSD/sssd/issues/6479