### PR TITLE
ci: increase timeout for covscan

### DIFF
--- a/.github/workflows/analyze-target.yml
+++ b/.github/workflows/analyze-target.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: covscan
     permissions:
       contents: read
+    timeout-minutes: 1440
     steps:
     - name: Checkout target branch
       uses: actions/checkout@v3


### PR DESCRIPTION
Covscan task started recently taking more then six hours to finish.
Six hours is the default timeout and maximum limit for github-hosted
runner but we can increase it for self-hosted runner.