### PR TITLE
Add support for ldapi:// URLs

### DIFF
--- a/src/providers/be_dyndns.h
+++ b/src/providers/be_dyndns.h
@@ -134,7 +134,7 @@ sss_get_dualstack_addresses(TALLOC_CTX *mem_ctx,
 struct sss_iface_addr *
 sss_iface_addr_get_next(struct sss_iface_addr *address);
 
-struct sockaddr_storage*
+struct sockaddr *
 sss_iface_addr_get_address(struct sss_iface_addr *address);
 
 #endif /* DP_DYNDNS_H_ */

--- a/src/providers/data_provider_fo.c
+++ b/src/providers/data_provider_fo.c
@@ -660,7 +660,6 @@ errno_t be_resolve_server_process(struct tevent_req *subreq,
 
     if (fo_get_server_name(state->srv)) {
         struct resolv_hostent *srvaddr;
-        char ipaddr[128];
         srvaddr = fo_get_server_hostent(state->srv);
         if (!srvaddr) {
             DEBUG(SSSDBG_CRIT_FAILURE,
@@ -669,12 +668,19 @@ errno_t be_resolve_server_process(struct tevent_req *subreq,
             return EFAULT;
         }
 
-        inet_ntop(srvaddr->family, srvaddr->addr_list[0]->ipaddr,
-                  ipaddr, 128);
+        if (!srvaddr->addr_list[0]) {
+            DEBUG(SSSDBG_FUNC_DATA, "Found socket for server %s: [%s]\n",
+                  fo_get_server_str_name(state->srv), srvaddr->name);
+        }
+        else {
+            char ipaddr[128];
+            inet_ntop(srvaddr->family, srvaddr->addr_list[0]->ipaddr,
+                      ipaddr, 128);
 
-        DEBUG(SSSDBG_FUNC_DATA, "Found address for server %s: [%s] TTL %d\n",
-              fo_get_server_str_name(state->srv), ipaddr,
-              srvaddr->addr_list[0]->ttl);
+            DEBUG(SSSDBG_FUNC_DATA, "Found address for server %s: [%s] TTL %d\n",
+                  fo_get_server_str_name(state->srv), ipaddr,
+                  srvaddr->addr_list[0]->ttl);
+        }
     }
 
     srv_status_change = fo_get_server_hostname_last_change(state->srv);

--- a/src/providers/fail_over.c
+++ b/src/providers/fail_over.c
@@ -353,8 +353,9 @@ get_server_status(struct fo_server *server)
         }
     }
 
-    if (server->common->rhostent && STATUS_DIFF(server->common, tv) >
-        server->common->rhostent->addr_list[0]->ttl) {
+    if (server->common->rhostent && server->common->rhostent->addr_list[0] &&
+            STATUS_DIFF(server->common, tv) >
+            server->common->rhostent->addr_list[0]->ttl) {
         DEBUG(SSSDBG_CONF_SETTINGS,
               "Hostname resolution expired, resetting the server "
                   "status of '%s'\n", SERVER_NAME(server));

--- a/src/providers/ipa/ipa_common.c
+++ b/src/providers/ipa/ipa_common.c
@@ -876,9 +876,10 @@ static void ipa_resolve_callback(void *private_data, struct fo_server *server)
     TALLOC_CTX *tmp_ctx = NULL;
     struct ipa_service *service;
     struct resolv_hostent *srvaddr;
-    struct sockaddr_storage *sockaddr;
+    struct sockaddr *sockaddr;
     char *new_uri;
     const char *srv_name;
+    socklen_t sockaddr_len;
     int ret;
 
     tmp_ctx = talloc_new(NULL);
@@ -903,7 +904,7 @@ static void ipa_resolve_callback(void *private_data, struct fo_server *server)
         return;
     }
 
-    sockaddr = resolv_get_sockaddr_address(tmp_ctx, srvaddr, LDAP_PORT);
+    sockaddr = resolv_get_sockaddr_address(tmp_ctx, srvaddr, LDAP_PORT, &sockaddr_len);
     if (sockaddr == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "resolv_get_sockaddr_address failed.\n");
         talloc_free(tmp_ctx);
@@ -930,6 +931,7 @@ static void ipa_resolve_callback(void *private_data, struct fo_server *server)
     service->sdap->uri = new_uri;
     talloc_zfree(service->sdap->sockaddr);
     service->sdap->sockaddr = talloc_steal(service, sockaddr);
+    service->sdap->sockaddr_len = sockaddr_len;
 
     if (service->krb5_service->write_kdcinfo) {
         ret = write_krb5info_file_from_fo_server(service->krb5_service,

--- a/src/providers/ipa/ipa_s2n_exop.c
+++ b/src/providers/ipa/ipa_s2n_exop.c
@@ -181,7 +181,7 @@ static struct tevent_req *ipa_s2n_exop_send(TALLOC_CTX *mem_ctx,
                                   msgid);
 
     stat_info = talloc_asprintf(state, "server: [%s] %s",
-                                sdap_get_server_ip_str_safe(state->sh),
+                                sdap_get_server_peer_str_safe(state->sh),
                                 stat_info_in != NULL ? stat_info_in
                                                      : "IPA EXOP");
     if (stat_info == NULL) {

--- a/src/providers/ldap/ldap_auth.c
+++ b/src/providers/ldap/ldap_auth.c
@@ -732,6 +732,11 @@ static struct tevent_req *auth_connect_send(struct tevent_req *req)
         }
     }
 
+    if (ldap_is_ldapi_url(state->sdap_service->uri)) {
+        /* Don't force TLS on if we're a unix domain socket */
+        use_tls = false;
+    }
+
     subreq = sdap_cli_connect_send(state, state->ev, state->ctx->opts,
                                    state->ctx->be,
                                    state->sdap_service, false,
@@ -806,7 +811,8 @@ static void auth_connect_done(struct tevent_req *subreq)
         return;
     }
 
-    if (!check_encryption_used(state->sh->ldap) &&
+    if (!ldap_is_ldapi_url(state->sdap_service->uri) &&
+            !check_encryption_used(state->sh->ldap) &&
             !dp_opt_get_bool(state->ctx->opts->basic, SDAP_DISABLE_AUTH_TLS)) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Aborting the authentication request.\n");
         sss_log(SSS_LOG_CRIT, "Aborting the authentication request.\n");

--- a/src/providers/ldap/ldap_common.c
+++ b/src/providers/ldap/ldap_common.c
@@ -74,10 +74,11 @@ static void sdap_uri_callback(void *private_data, struct fo_server *server)
     TALLOC_CTX *tmp_ctx = NULL;
     struct sdap_service *service;
     struct resolv_hostent *srvaddr;
-    struct sockaddr_storage *sockaddr;
+    struct sockaddr *sockaddr;
     const char *tmp;
     const char *srv_name;
     char *new_uri;
+    socklen_t sockaddr_len;
 
     tmp_ctx = talloc_new(NULL);
     if (tmp_ctx == NULL) {
@@ -103,7 +104,8 @@ static void sdap_uri_callback(void *private_data, struct fo_server *server)
     }
 
     sockaddr = resolv_get_sockaddr_address(tmp_ctx, srvaddr,
-                                           fo_get_server_port(server));
+                                           fo_get_server_port(server),
+                                           &sockaddr_len);
     if (sockaddr == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "resolv_get_sockaddr_address failed.\n");
         talloc_free(tmp_ctx);
@@ -143,6 +145,7 @@ static void sdap_uri_callback(void *private_data, struct fo_server *server)
     service->uri = new_uri;
     talloc_zfree(service->sockaddr);
     service->sockaddr = talloc_steal(service, sockaddr);
+    service->sockaddr_len = sockaddr_len;
     talloc_free(tmp_ctx);
 }
 

--- a/src/providers/ldap/sdap.h
+++ b/src/providers/ldap/sdap.h
@@ -89,7 +89,8 @@ struct sdap_service {
     char *name;
     char *uri;
     char *kinit_service_name;
-    struct sockaddr_storage *sockaddr;
+    struct sockaddr *sockaddr;
+    socklen_t sockaddr_len;
 };
 
 struct sdap_ppolicy_data {

--- a/src/providers/ldap/sdap_async.c
+++ b/src/providers/ldap/sdap_async.c
@@ -677,7 +677,7 @@ struct tevent_req *sdap_exop_modify_passwd_send(TALLOC_CTX *memctx,
           "ldap_extended_operation sent, msgid = %d\n", msgid);
 
     stat_info = talloc_asprintf(state, "server: [%s] modify passwd dn: [%s]",
-                                sdap_get_server_ip_str_safe(state->sh),
+                                sdap_get_server_peer_str_safe(state->sh),
                                 user_dn);
     if (stat_info == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to create info string, ignored.\n");
@@ -849,7 +849,7 @@ sdap_modify_send(TALLOC_CTX *mem_ctx,
     }
 
     stat_info = talloc_asprintf(state, "server: [%s] modify dn: [%s] attr: [%s]",
-                                sdap_get_server_ip_str_safe(state->sh), dn,
+                                sdap_get_server_peer_str_safe(state->sh), dn,
                                 attr);
     if (stat_info == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to create info string, ignored.\n");
@@ -1339,13 +1339,12 @@ static errno_t add_to_deref_reply(TALLOC_CTX *mem_ctx,
     return EOK;
 }
 
-const char *sdap_get_server_ip_str(struct sdap_handle *sh)
+const char *sdap_get_server_peer_str(struct sdap_handle *sh)
 {
     int ret;
     int fd;
-    struct sockaddr_storage ss;
-    socklen_t ss_len = sizeof(ss);
-    struct sockaddr *s_addr = (struct sockaddr *)&ss;
+    struct sockaddr sa;
+    socklen_t sa_len = sizeof(sa);
     char ip[NI_MAXHOST];
     static char out[NI_MAXHOST + 8];
     int port;
@@ -1356,30 +1355,72 @@ const char *sdap_get_server_ip_str(struct sdap_handle *sh)
         return NULL;
     }
 
-    ret = getpeername(fd, s_addr, &ss_len);
+    ret = getpeername(fd, &sa, &sa_len);
     if (ret == -1) {
-        DEBUG(SSSDBG_MINOR_FAILURE, "getsockname failed\n");
+        DEBUG(SSSDBG_MINOR_FAILURE, "getpeername failed\n");
         return NULL;
     }
 
-    ret = getnameinfo(s_addr, ss_len,
-                      ip, sizeof(ip), NULL, 0, NI_NUMERICHOST);
-    if (ret != 0) {
-        DEBUG(SSSDBG_MINOR_FAILURE, "getnameinfo failed\n");
-        return NULL;
-    }
+    switch (sa.sa_family) {
+    case AF_INET: {
+        struct sockaddr_in in;
+        socklen_t in_len = sizeof(in);
 
-    switch (s_addr->sa_family) {
-    case AF_INET:
-        port = ntohs(((struct sockaddr_in *)s_addr)->sin_port);
+        ret = getpeername(fd, (struct sockaddr *)(&in), &in_len);
+        if (ret == -1) {
+            DEBUG(SSSDBG_MINOR_FAILURE, "getpeername failed\n");
+            return NULL;
+        }
+
+        ret = getnameinfo((struct sockaddr *)(&in), in_len,
+                          ip, sizeof(ip), NULL, 0, NI_NUMERICHOST);
+        if (ret != 0) {
+            DEBUG(SSSDBG_MINOR_FAILURE, "getnameinfo failed\n");
+            return NULL;
+        }
+
+        port = ntohs(in.sin_port);
         ret = snprintf(out, sizeof(out), "%s:%d", ip, port);
         break;
-    case AF_INET6:
-        port = ntohs(((struct sockaddr_in6 *)s_addr)->sin6_port);
+    }
+    case AF_INET6: {
+        struct sockaddr_in6 in6;
+        socklen_t in6_len = sizeof(in6);
+
+        ret = getpeername(fd, (struct sockaddr *)(&in6), &in6_len);
+        if (ret == -1) {
+            DEBUG(SSSDBG_MINOR_FAILURE, "getpeername failed\n");
+            return NULL;
+        }
+
+        ret = getnameinfo((struct sockaddr *)(&in6), in6_len,
+                          ip, sizeof(ip), NULL, 0, NI_NUMERICHOST);
+        if (ret != 0) {
+            DEBUG(SSSDBG_MINOR_FAILURE, "getnameinfo failed\n");
+            return NULL;
+        }
+
+        port = ntohs(in6.sin6_port);
         ret = snprintf(out, sizeof(out), "[%s]:%d", ip, port);
         break;
+    }
+    case AF_UNIX: {
+        struct sockaddr_un un;
+        socklen_t un_len = sizeof(un);
+
+        ret = getpeername(fd, (struct sockaddr *)(&un), &un_len);
+        if (ret == -1) {
+            DEBUG(SSSDBG_MINOR_FAILURE, "getpeername failed\n");
+            return NULL;
+        }
+
+        ret = snprintf(out, sizeof(out), "%.*s",
+            (int)strnlen(un.sun_path, un_len - offsetof(struct sockaddr_un,
+                sun_path)), un.sun_path);
+        break;
+    }
     default:
-        ret = snprintf(out, sizeof(out), "%s", ip);
+        return NULL;
     }
 
     if (ret < 0 || ret >= sizeof(out)) {
@@ -1389,9 +1430,9 @@ const char *sdap_get_server_ip_str(struct sdap_handle *sh)
     return out;
 }
 
-const char *sdap_get_server_ip_str_safe(struct sdap_handle *sh)
+const char *sdap_get_server_peer_str_safe(struct sdap_handle *sh)
 {
-    const char *ip = sdap_get_server_ip_str(sh);
+    const char *ip = sdap_get_server_peer_str(sh);
     return ip != NULL ? ip : "- IP not available -";
 }
 
@@ -1402,11 +1443,11 @@ static void sdap_print_server(struct sdap_handle *sh)
     /* The purpose of the call is to add the server IP to the debug output if
      * debug_level is SSSDBG_TRACE_INTERNAL or higher */
     if (DEBUG_IS_SET(SSSDBG_TRACE_INTERNAL)) {
-        ip = sdap_get_server_ip_str(sh);
+        ip = sdap_get_server_peer_str(sh);
         if (ip != NULL) {
             DEBUG(SSSDBG_TRACE_INTERNAL, "Searching %s\n", ip);
         } else {
-            DEBUG(SSSDBG_OP_FAILURE, "sdap_get_server_ip_str failed.\n");
+            DEBUG(SSSDBG_OP_FAILURE, "sdap_get_server_peer_str failed.\n");
         }
     }
 }
@@ -1658,7 +1699,7 @@ static errno_t sdap_get_generic_ext_step(struct tevent_req *req)
     DEBUG(SSSDBG_TRACE_INTERNAL, "ldap_search_ext called, msgid = %d\n", msgid);
 
     stat_info = talloc_asprintf(state, "server: [%s] filter: [%s] base: [%s]",
-                                sdap_get_server_ip_str_safe(state->sh),
+                                sdap_get_server_peer_str_safe(state->sh),
                                 state->filter, state->search_base);
     if (stat_info == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to create info string, ignored.\n");

--- a/src/providers/ldap/sdap_async.h
+++ b/src/providers/ldap/sdap_async.h
@@ -37,8 +37,9 @@ struct tevent_req *sdap_connect_send(TALLOC_CTX *memctx,
                                      struct tevent_context *ev,
                                      struct sdap_options *opts,
                                      const char *uri,
-                                     struct sockaddr_storage *sockaddr,
-                                     bool use_start_tls);
+                                     struct sockaddr *sockaddr,
+                                     socklen_t sockaddr_len,
+				     bool use_start_tls);
 int sdap_connect_recv(struct tevent_req *req,
                       TALLOC_CTX *memctx,
                       struct sdap_handle **sh);

--- a/src/providers/ldap/sdap_async_connection.c
+++ b/src/providers/ldap/sdap_async_connection.c
@@ -339,7 +339,7 @@ static void sdap_sys_connect_done(struct tevent_req *subreq)
     }
 
     stat_info = talloc_asprintf(state, "server: [%s] START TLS",
-                                sdap_get_server_ip_str_safe(state->sh));
+                                sdap_get_server_peer_str_safe(state->sh));
     if (stat_info == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to create info string, ignored.\n");
     }
@@ -720,7 +720,7 @@ static struct tevent_req *simple_bind_send(TALLOC_CTX *memctx,
     }
 
     stat_info = talloc_asprintf(state, "server: [%s] simple bind: [%s]",
-                                sdap_get_server_ip_str_safe(state->sh),
+                                sdap_get_server_peer_str_safe(state->sh),
                                 state->user_dn);
     if (stat_info == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to create info string, ignored.\n");

--- a/src/providers/ldap/sdap_async_connection.c
+++ b/src/providers/ldap/sdap_async_connection.c
@@ -65,7 +65,8 @@ struct tevent_req *sdap_connect_send(TALLOC_CTX *memctx,
                                      struct tevent_context *ev,
                                      struct sdap_options *opts,
                                      const char *uri,
-                                     struct sockaddr_storage *sockaddr,
+                                     struct sockaddr *sockaddr,
+                                     socklen_t sockaddr_len,
                                      bool use_start_tls)
 {
     struct tevent_req *req;
@@ -111,8 +112,7 @@ struct tevent_req *sdap_connect_send(TALLOC_CTX *memctx,
     timeout = dp_opt_get_int(state->opts->basic, SDAP_NETWORK_TIMEOUT);
 
     subreq = sss_ldap_init_send(state, ev, state->uri, sockaddr,
-                                sizeof(struct sockaddr_storage),
-                                timeout);
+                                sockaddr_len, timeout);
     if (subreq == NULL) {
         ret = ENOMEM;
         DEBUG(SSSDBG_CRIT_FAILURE, "sss_ldap_init_send failed.\n");
@@ -538,7 +538,8 @@ static void sdap_connect_host_resolv_done(struct tevent_req *subreq)
     struct tevent_req *req = NULL;
     struct sdap_connect_host_state *state = NULL;
     struct resolv_hostent *hostent = NULL;
-    struct sockaddr_storage *sockaddr = NULL;
+    struct sockaddr *sockaddr = NULL;
+    socklen_t sockaddr_len;
     int status;
     errno_t ret;
 
@@ -553,7 +554,8 @@ static void sdap_connect_host_resolv_done(struct tevent_req *subreq)
         goto done;
     }
 
-    sockaddr = resolv_get_sockaddr_address(state, hostent, state->port);
+    sockaddr = resolv_get_sockaddr_address(state, hostent, state->port,
+                                           &sockaddr_len);
     if (sockaddr == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "resolv_get_sockaddr_address() failed\n");
         ret = EIO;
@@ -563,7 +565,8 @@ static void sdap_connect_host_resolv_done(struct tevent_req *subreq)
     DEBUG(SSSDBG_TRACE_FUNC, "Connecting to %s\n", state->uri);
 
     subreq = sdap_connect_send(state, state->ev, state->opts,
-                               state->uri, sockaddr, state->use_start_tls);
+                               state->uri, sockaddr, sockaddr_len,
+                               state->use_start_tls);
     if (subreq == NULL) {
         ret = ENOMEM;
         goto done;
@@ -1601,6 +1604,7 @@ static void sdap_cli_resolve_done(struct tevent_req *subreq)
     subreq = sdap_connect_send(state, state->ev, state->opts,
                                state->service->uri,
                                state->service->sockaddr,
+                               state->service->sockaddr_len,
                                state->use_tls);
     if (!subreq) {
         tevent_req_error(req, ENOMEM);
@@ -1629,6 +1633,7 @@ static void sdap_cli_connect_done(struct tevent_req *subreq)
         subreq = sdap_connect_send(state, state->ev, state->opts,
                                    state->service->uri,
                                    state->service->sockaddr,
+                                   state->service->sockaddr_len,
                                    state->use_tls);
 
         if (!subreq) {
@@ -1976,6 +1981,7 @@ static errno_t sdap_cli_auth_reconnect(struct tevent_req *req)
     subreq = sdap_connect_send(state, state->ev, state->opts,
                                state->service->uri,
                                state->service->sockaddr,
+                               state->service->sockaddr_len,
                                state->use_tls);
 
     if (subreq == NULL) {

--- a/src/providers/ldap/sdap_async_private.h
+++ b/src/providers/ldap/sdap_async_private.h
@@ -75,10 +75,10 @@ errno_t deref_string_to_val(const char *str, int *val);
 
 /* Extract server IP from sdap_handle and return it as string or NULL in case
  * of an error */
-const char *sdap_get_server_ip_str(struct sdap_handle *sh);
+const char *sdap_get_server_peer_str(struct sdap_handle *sh);
 
-/* Same as sdap_get_server_ip_str() but always returns a strings */
-const char *sdap_get_server_ip_str_safe(struct sdap_handle *sh);
+/* Same as sdap_get_server_peer_str() but always returns a strings */
+const char *sdap_get_server_peer_str_safe(struct sdap_handle *sh);
 
 /* from sdap_child_helpers.c */
 

--- a/src/resolv/async_resolv.c
+++ b/src/resolv/async_resolv.c
@@ -1073,6 +1073,9 @@ struct gethostbyname_state {
 };
 
 static errno_t
+resolv_gethostbyname_unix(TALLOC_CTX *mem_ctx, const char *path,
+                          struct resolv_hostent **_rhostent);
+static errno_t
 resolv_gethostbyname_address(TALLOC_CTX *mem_ctx, const char *address,
                              struct resolv_hostent **_rhostent);
 static inline int
@@ -1118,6 +1121,21 @@ resolv_gethostbyname_send(TALLOC_CTX *mem_ctx, struct tevent_context *ev,
     state->db = db;
     state->dbi = 0;
 
+    /* Do not attempt to resolve unix domain sockets */
+    if (resolv_is_unix(state->name)) {
+        ret = resolv_gethostbyname_unix(state, state->name,
+                                        &state->rhostent);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Cannot create a fake hostent structure\n");
+            goto fail;
+        }
+
+        tevent_req_done(req);
+        tevent_req_post(req, ev);
+        return req;
+    }
+
     /* Do not attempt to resolve IP addresses */
     if (resolv_is_address(state->name)) {
         ret = resolv_gethostbyname_address(state, state->name,
@@ -1147,6 +1165,18 @@ fail:
 }
 
 bool
+resolv_is_unix(const char *name)
+{
+    if (name && name[0] == '/') {
+        return 1;
+    }
+    DEBUG(SSSDBG_TRACE_ALL,
+          "[%s] does not look like a unix domain socket\n", name);
+
+    return 0;
+}
+
+bool
 resolv_is_address(const char *name)
 {
     struct addrinfo hints;
@@ -1171,6 +1201,43 @@ resolv_is_address(const char *name)
     }
 
     return ret == 0;
+}
+
+static errno_t
+resolv_gethostbyname_unix(TALLOC_CTX *mem_ctx, const char *path,
+                          struct resolv_hostent **_rhostent)
+{
+    struct resolv_hostent *rhostent;
+    TALLOC_CTX *tmp_ctx;
+    errno_t ret;
+
+    tmp_ctx = talloc_new(NULL);
+    if (!tmp_ctx) return ENOMEM;
+
+    rhostent = talloc_zero(tmp_ctx, struct resolv_hostent);
+    if (!rhostent) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    rhostent->name = talloc_strdup(rhostent, path);
+    rhostent->addr_list = talloc_array(rhostent, struct resolv_addr *, 1);
+
+    if (!rhostent->name ||
+        !rhostent->addr_list) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    rhostent->addr_list[0] = NULL;
+    rhostent->family = AF_UNIX;
+    rhostent->aliases = NULL;
+
+    *_rhostent = talloc_move(mem_ctx, &rhostent);
+    ret = EOK;
+done:
+    talloc_free(tmp_ctx);
+    return ret;
 }
 
 static errno_t
@@ -1468,24 +1535,46 @@ resolv_get_string_ptr_address(TALLOC_CTX *mem_ctx,
     return straddr;
 }
 
-struct sockaddr_storage *
+struct sockaddr *
 resolv_get_sockaddr_address_index(TALLOC_CTX *mem_ctx,
                                   struct resolv_hostent *hostent,
-                                  int port, int addrindex)
+                                  int port, int addrindex,
+                                  socklen_t *sockaddr_len)
 {
-    struct sockaddr_storage *sockaddr;
+    struct sockaddr *sockaddr;
+    int len;
 
     if (!hostent) return NULL;
 
-    sockaddr = talloc_zero(mem_ctx, struct sockaddr_storage);
+    switch(hostent->family) {
+        case AF_INET:
+            len = sizeof(struct sockaddr_in);
+            break;
+        case AF_INET6:
+            len = sizeof(struct sockaddr_in6);
+            break;
+        case AF_UNIX:
+            len = sizeof(struct sockaddr_un);
+            break;
+        default:
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Unknown address family %d\n", hostent->family);
+            return NULL;
+    }
+
+    sockaddr = (struct sockaddr *)talloc_zero(mem_ctx, struct sockaddr_storage);
     if (sockaddr == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "talloc_zero failed.\n");
         return NULL;
     }
 
+    if (sockaddr_len != NULL) {
+        *sockaddr_len = len;
+    }
+
     switch(hostent->family) {
         case AF_INET:
-            sockaddr->ss_family = AF_INET;
+            sockaddr->sa_family = AF_INET;
             memcpy(&((struct sockaddr_in *) sockaddr)->sin_addr,
                    hostent->addr_list[addrindex]->ipaddr,
                    sizeof(struct in_addr));
@@ -1493,13 +1582,24 @@ resolv_get_sockaddr_address_index(TALLOC_CTX *mem_ctx,
 
             break;
         case AF_INET6:
-            sockaddr->ss_family = AF_INET6;
+            sockaddr->sa_family = AF_INET6;
             memcpy(&((struct sockaddr_in6 *) sockaddr)->sin6_addr,
                    hostent->addr_list[addrindex]->ipaddr,
                    sizeof(struct in6_addr));
             ((struct sockaddr_in6 *) sockaddr)->sin6_port = (in_port_t) htons(port);
             break;
-        default:
+        case AF_UNIX:
+            sockaddr->sa_family = AF_UNIX;
+            strncpy(((struct sockaddr_un *) sockaddr)->sun_path, hostent->name,
+                    sizeof(((struct sockaddr_un *) sockaddr)->sun_path) - 1);
+            if (strlen(hostent->name) >=
+                    sizeof(((struct sockaddr_un *) sockaddr)->sun_path)) {
+                DEBUG(SSSDBG_CRIT_FAILURE,
+                      "Path '%s' too long\n", hostent->name);
+                return NULL;
+            }
+	    break;
+	default:
             DEBUG(SSSDBG_CRIT_FAILURE,
                   "Unknown address family %d\n", hostent->family);
             return NULL;

--- a/src/resolv/async_resolv.c
+++ b/src/resolv/async_resolv.c
@@ -1568,10 +1568,6 @@ resolv_get_sockaddr_address_index(TALLOC_CTX *mem_ctx,
         return NULL;
     }
 
-    if (sockaddr_len != NULL) {
-        *sockaddr_len = len;
-    }
-
     switch(hostent->family) {
         case AF_INET:
             sockaddr->sa_family = AF_INET;
@@ -1603,6 +1599,10 @@ resolv_get_sockaddr_address_index(TALLOC_CTX *mem_ctx,
             DEBUG(SSSDBG_CRIT_FAILURE,
                   "Unknown address family %d\n", hostent->family);
             return NULL;
+    }
+
+    if (sockaddr_len != NULL) {
+        *sockaddr_len = len;
     }
 
     return sockaddr;

--- a/src/resolv/async_resolv.h
+++ b/src/resolv/async_resolv.h
@@ -155,13 +155,14 @@ resolv_get_string_ptr_address(TALLOC_CTX *mem_ctx,
 #define resolv_get_string_address(mem_ctx, hostent) \
         resolv_get_string_address_index(mem_ctx, hostent, 0)
 
-struct sockaddr_storage *
+struct sockaddr *
 resolv_get_sockaddr_address_index(TALLOC_CTX *mem_ctx,
                                   struct resolv_hostent *hostent,
-                                  int port, int addrindex);
+                                  int port, int addrindex,
+                                  socklen_t *sockaddr_len);
 
-#define resolv_get_sockaddr_address(mem_ctx, rhostent, port) \
-        resolv_get_sockaddr_address_index(mem_ctx, rhostent, port, 0)
+#define resolv_get_sockaddr_address(mem_ctx, rhostent, port, sockaddr_len) \
+        resolv_get_sockaddr_address_index(mem_ctx, rhostent, port, 0, sockaddr_len)
 
 /** Get SRV record **/
 struct tevent_req *resolv_getsrv_send(TALLOC_CTX *mem_ctx,
@@ -222,4 +223,8 @@ errno_t resolv_discover_srv_recv(TALLOC_CTX *mem_ctx,
 
 bool
 resolv_is_address(const char *name);
+
+bool
+resolv_is_unix(const char *name);
+
 #endif /* __ASYNC_RESOLV_H__ */

--- a/src/tests/cmocka/test_dyndns.c
+++ b/src/tests/cmocka/test_dyndns.c
@@ -205,7 +205,7 @@ void will_return_getifaddrs(const char *ifname, const char *straddr,
 void dyndns_test_sss_iface_addr_get_misc(void **state)
 {
     struct sss_iface_addr addrs[3];
-    struct sockaddr_storage ss[3];
+    struct sockaddr ss[3];
 
     addrs[0].prev = NULL;
     addrs[0].next = &addrs[1];

--- a/src/tests/cmocka/test_resolv_fake.c
+++ b/src/tests/cmocka/test_resolv_fake.c
@@ -357,6 +357,26 @@ void test_resolv_is_address(void **state)
     assert_false(ret);
 }
 
+void test_resolv_is_unix(void **state)
+{
+    bool ret;
+
+    ret = resolv_is_unix("10.192.211.37");
+    assert_false(ret);
+
+    ret = resolv_is_unix("2001:0db8:85a3:0000:0000:8a2e:0370:7334");
+    assert_false(ret);
+
+    ret = resolv_is_unix("sssd.ldap.com");
+    assert_false(ret);
+
+    ret = resolv_is_unix("testhostname");
+    assert_false(ret);
+
+    ret = resolv_is_unix("/tmp/socket");
+    assert_true(ret);
+}
+
 int main(int argc, const char *argv[])
 {
     int rv;
@@ -373,6 +393,7 @@ int main(int argc, const char *argv[])
                                         test_resolv_fake_setup,
                                         test_resolv_fake_teardown),
         cmocka_unit_test(test_resolv_is_address),
+        cmocka_unit_test(test_resolv_is_unix),
     };
 
     /* Set debug level to invalid value so we can decide if -d 0 was used. */

--- a/src/util/sss_ldap.c
+++ b/src/util/sss_ldap.c
@@ -142,7 +142,7 @@ static int sss_ldap_init_state_destructor(void *data)
 struct tevent_req *sss_ldap_init_send(TALLOC_CTX *mem_ctx,
                                       struct tevent_context *ev,
                                       const char *uri,
-                                      struct sockaddr_storage *addr,
+                                      struct sockaddr *addr,
                                       int addr_len, int timeout)
 {
     int ret = EOK;

--- a/src/util/sss_ldap.h
+++ b/src/util/sss_ldap.h
@@ -76,7 +76,7 @@ int sss_ldap_control_create(const char *oid, int iscritical,
 struct tevent_req *sss_ldap_init_send(TALLOC_CTX *mem_ctx,
                                       struct tevent_context *ev,
                                       const char *uri,
-                                      struct sockaddr_storage *addr,
+                                      struct sockaddr *addr,
                                       int addr_len, int timeout);
 
 int sss_ldap_init_recv(struct tevent_req *req, LDAP **ldap, int *sd);

--- a/src/util/sss_sockets.c
+++ b/src/util/sss_sockets.c
@@ -106,15 +106,16 @@ errno_t set_fd_common_opts(int fd, int timeout)
 
     /* SO_KEEPALIVE and TCP_NODELAY are set by OpenLDAP client libraries but
      * failures are ignored.*/
-    ret = setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &dummy, sizeof(dummy));
-    if (ret != 0) {
-        ret = errno;
-        DEBUG(SSSDBG_FUNC_DATA,
-              "setsockopt SO_KEEPALIVE failed.[%d][%s].\n", ret,
-                  strerror(ret));
-    }
-
     if (domain != AF_UNIX && type == SOCK_STREAM) {
+
+        ret = setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &dummy, sizeof(dummy));
+        if (ret != 0) {
+            ret = errno;
+            DEBUG(SSSDBG_FUNC_DATA,
+                  "setsockopt SO_KEEPALIVE failed.[%d][%s].\n", ret,
+                      strerror(ret));
+        }
+
         ret = setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &dummy, sizeof(dummy));
         if (ret != 0) {
             ret = errno;

--- a/src/util/sss_sockets.h
+++ b/src/util/sss_sockets.h
@@ -35,7 +35,7 @@ int sssd_async_connect_recv(struct tevent_req *req);
 struct tevent_req *sssd_async_socket_init_send(TALLOC_CTX *mem_ctx,
                                                struct tevent_context *ev,
                                                bool use_udp,
-                                               struct sockaddr_storage *addr,
+                                               struct sockaddr *addr,
                                                socklen_t addr_len, int timeout);
 int sssd_async_socket_init_recv(struct tevent_req *req, int *sd);
 

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -31,6 +31,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <netinet/in.h>
+#include <sys/un.h>
 
 #include <talloc.h>
 #include <tevent.h>


### PR DESCRIPTION
Make sssd aware of unix domain sockets, allowing connections to local LDAP servers.

Make use of struct sockaddr and socklen_t consistent across the code.

Resolves: https://github.com/SSSD/sssd/issues/1651

:feature: Add support for ldapi:// URLs