### PR TITLE
Passkey two new actions: assertion obtention and verification

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3845,7 +3845,11 @@ test_passkey_LDFLAGS = \
     -Wl,-wrap,fido_assert_set_clientdata_hash \
     -Wl,-wrap,fido_dev_get_assert \
     -Wl,-wrap,fido_dev_is_fido2 \
-    -Wl,-wrap,fido_assert_verify
+    -Wl,-wrap,fido_assert_verify \
+    -Wl,-wrap,fido_assert_authdata_ptr \
+    -Wl,-wrap,fido_assert_authdata_len \
+    -Wl,-wrap,fido_assert_sig_ptr \
+    -Wl,-wrap,fido_assert_sig_len
 test_passkey_LDADD = \
     $(CMOCKA_LIBS) \
     $(SSSD_LIBS) \
@@ -3853,6 +3857,7 @@ test_passkey_LDADD = \
     $(LIBADD_DL) \
     $(PASSKEY_LIBS) \
     libsss_test_common.la \
+    $(JANSSON_LIBS) \
     $(NULL)
 endif # BUILD_PASSKEY
 
@@ -4781,6 +4786,7 @@ passkey_child_LDADD = \
     $(PASSKEY_LIBS) \
     $(SSSD_INTERNAL_LTLIBS) \
     $(CRYPTO_LIBS) \
+    $(JANSSON_LIBS) \
     $(NULL)
 endif # BUILD_PASSKEY
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -3849,7 +3849,10 @@ test_passkey_LDFLAGS = \
     -Wl,-wrap,fido_assert_authdata_ptr \
     -Wl,-wrap,fido_assert_authdata_len \
     -Wl,-wrap,fido_assert_sig_ptr \
-    -Wl,-wrap,fido_assert_sig_len
+    -Wl,-wrap,fido_assert_sig_len \
+    -Wl,-wrap,fido_assert_set_count \
+    -Wl,-wrap,fido_assert_set_authdata \
+    -Wl,-wrap,fido_assert_set_sig
 test_passkey_LDADD = \
     $(CMOCKA_LIBS) \
     $(SSSD_LIBS) \

--- a/src/passkey_child/passkey_child.c
+++ b/src/passkey_child/passkey_child.c
@@ -84,6 +84,15 @@ int main(int argc, const char *argv[])
             ERROR("Error getting assertion data.\n");
             goto done;
         }
+    } else if (data.action == ACTION_VERIFY_ASSERT) {
+        ret = verify_assert_data(&data);
+        if (ret == EOK) {
+            PRINT("Verification success.\n");
+            goto done;
+        } else {
+            ERROR("Verification error.\n");
+            goto done;
+        }
     }
 
 done:

--- a/src/passkey_child/passkey_child.c
+++ b/src/passkey_child/passkey_child.c
@@ -72,7 +72,7 @@ int main(int argc, const char *argv[])
     } else if (data.action == ACTION_AUTHENTICATE) {
         ret = authenticate(&data);
         if (ret == EOK) {
-            printf("Authentication success.\n");
+            PRINT("Authentication success.\n");
             goto done;
         } else {
             ERROR("Authentication error.\n");

--- a/src/passkey_child/passkey_child.c
+++ b/src/passkey_child/passkey_child.c
@@ -78,6 +78,12 @@ int main(int argc, const char *argv[])
             ERROR("Authentication error.\n");
             goto done;
         }
+    } else if (data.action == ACTION_GET_ASSERT) {
+        ret = get_assert_data(&data);
+        if (ret != EOK) {
+            ERROR("Error getting assertion data.\n");
+            goto done;
+        }
     }
 
 done:

--- a/src/passkey_child/passkey_child.h
+++ b/src/passkey_child/passkey_child.h
@@ -39,7 +39,8 @@ enum action_opt {
     ACTION_NONE,
     ACTION_REGISTER,
     ACTION_AUTHENTICATE,
-    ACTION_GET_ASSERT
+    ACTION_GET_ASSERT,
+    ACTION_VERIFY_ASSERT
 };
 
 enum credential_type {
@@ -56,6 +57,8 @@ struct passkey_data {
     char **public_key_list;
     int public_key_size;
     const char *crypto_challenge;
+    const char *auth_data;
+    const char *signature;
     int type;
     fido_opt_t user_verification;
     enum credential_type cred_type;
@@ -353,6 +356,19 @@ set_assert_client_data_hash(const struct passkey_data *data,
                             fido_assert_t *_assert);
 
 /**
+ * @brief Set authenticator data and signature in the assert
+ *
+ * @param[in] data passkey data
+ * @param[in,out] _assert Assert
+ *
+ * @return 0 if the data was set properly,
+ *         error code otherwise.
+ */
+errno_t
+set_assert_auth_data_signature(const struct passkey_data *data,
+                               fido_assert_t *_assert);
+
+/**
  * @brief Set options in the assert
  *
  * @param[in] up User presence check
@@ -522,5 +538,19 @@ print_assert_data(const char *key_handle, const char *crypto_challenge,
  */
 errno_t
 get_assert_data(struct passkey_data *data);
+
+/**
+ * @brief Verify assertion data
+ *
+ * Prepare the assertion data, including the authenticator data and the
+ * signature; decode the public key and verify the assertion.
+ *
+ * @param[in] data passkey data
+ *
+ * @return 0 if the assertion was obtained properly,
+ *         error code otherwise.
+ */
+errno_t
+verify_assert_data(struct passkey_data *data);
 
 #endif /* __PASSKEY_CHILD_H__ */

--- a/src/passkey_child/passkey_child.h
+++ b/src/passkey_child/passkey_child.h
@@ -320,6 +320,22 @@ errno_t
 get_assert_user_id(TALLOC_CTX *mem_ctx, fido_assert_t *assert,
                    unsigned char **_user_id);
 
+/*
+ * @brief Select authenticator for verification
+ *
+ *
+ * @param[in] data passkey data
+ * @param[out] _dev Device information
+ * @param[out] _assert Assert
+ * @param[out] _index Index for key handle list
+ *
+ * @return 0 if the authenticator was selected properly,
+ *         error code otherwise.
+ */
+errno_t
+select_authenticator(struct passkey_data *data, fido_dev_t **_dev,
+                     fido_assert_t **_assert, int *_index);
+
 /**
  * @brief Set client data hash in the assert
  *
@@ -348,8 +364,8 @@ set_assert_options(fido_opt_t up, fido_opt_t uv, fido_assert_t *_assert);
  * @brief Prepare assert
  *
  * @param[in] data passkey data
- * @param[in] count Index for key handle list
- * @param[out] assert Assert
+ * @param[in] index Index for key handle list
+ * @param[out] _assert Assert
  *
  * @return 0 if the assert was prepared properly,
  *         error code otherwise.

--- a/src/passkey_child/passkey_child_credentials.c
+++ b/src/passkey_child/passkey_child_credentials.c
@@ -216,7 +216,7 @@ read_pin(char **pin)
         goto done;
     }
 
-    printf("Enter PIN:\n");
+    PRINT("Enter PIN:\n");
     fflush(stdout);
     bytes_read = getline(&line_ptr, &line_len, stdin);
     if (bytes_read == -1) {
@@ -226,7 +226,7 @@ read_pin(char **pin)
         /* Remove the end of line '\n' character */
         line_ptr[--bytes_read] = '\0';
     }
-    printf("\n");
+    PRINT("\n");
 
     ret = tcsetattr(STDIN_FILENO, TCSAFLUSH, &old);
     if (ret != 0) {
@@ -280,7 +280,7 @@ generate_credentials(struct passkey_data *data, fido_dev_t *dev,
     }
 
     if (data->quiet == false) {
-        printf("Please touch the device.\n");
+        PRINT("Please touch the device.\n");
         fflush(stdout);
     }
     ret = fido_dev_make_cred(dev, cred, pin);
@@ -411,9 +411,9 @@ print_credentials(const struct passkey_data *data,
     }
 
     if (data->cred_type == CRED_SERVER_SIDE) {
-        printf("passkey:%s,%s\n", b64_cred_id, pem_key);
+        PRINT("passkey:%s,%s\n", b64_cred_id, pem_key);
     } else {
-        printf("passkey:%s,%s,%s\n", b64_cred_id, pem_key, b64_user_id);
+        PRINT("passkey:%s,%s,%s\n", b64_cred_id, pem_key, b64_user_id);
     }
     ret = EOK;
 


### PR DESCRIPTION
Two new actions that divide the key authentication. This way the authentication process can be handled from two different places, as requested by the Kerberos integration.

New action to obtain the assertion data. For that purpose, prepare the assertion request data, select the device to use, select the authenticator, get the device options and compare them with the organization policy, request the assert, get the authenticator data, get the signature and print this all information.

New action to verify the assertion data. To this end, prepare the assertion data, including the authenticator data and the signature; decode the public key and verify the assertion.

Resolves: https://github.com/SSSD/sssd/issues/6228

## How to test

The words in bold should be replaced by a real value.

Obtain the assertion data:
$ echo -n "**123456**" | ./passkey_child --get-assert --domain=**test.com** --key-handle=**WXPmGkj1inQhLic7LK91S9zuhre/1r39o1wzqQJNLUW/ylcLzuw4kb/cocOF8j9bCkpdh27RomHOM76j++wmUA==** --cryptographic-challenge=mZmBWUaJGwEjSNQvkFaicpCzDKhap2pQlfi8FXsv68k=

Outputs:
WXPmGkj1inQhLic7LK91S9zuhre/1r39o1wzqQJNLUW/ylcLzuw4kb/cocOF8j9bCkpdh27RomHOM76j++wmUA==
mZmBWUaJGwEjSNQvkFaicpCzDKhap2pQlfi8FXsv68k=
WCWZq3FdhKO8Xg6SqlDmelgTY3/RdEvTAasI+HGR3bgW4AEAAAEo
MEUCIQCBhABLUFGUqonhNNJJ/1Op3R1DcgPD+VFzl3r20mPjlAIgXc3czDWTWdzoKce9CcyqPBA/UbNMEfVaf3TW/QFHGgk=

The output from the previous command is:
- Key handle: WXPmGkj1inQhLic7LK91S9zuhre/1r39o1wzqQJNLUW/ylcLzuw4kb/cocOF8j9bCkpdh27RomHOM76j++wmUA==
- Cryptographic challenge: mZmBWUaJGwEjSNQvkFaicpCzDKhap2pQlfi8FXsv68k=
- Authenticator data: WCWZq3FdhKO8Xg6SqlDmelgTY3/RdEvTAasI+HGR3bgW4AEAAAEo
- Signature: MEUCIQCBhABLUFGUqonhNNJJ/1Op3R1DcgPD+VFzl3r20mPjlAIgXc3czDWTWdzoKce9CcyqPBA/UbNMEfVaf3TW/QFHGgk=

Optionally, if discoverable credentials are used, another string for the user id is printed:
9I0TXBAiHq/bUD/Fg2zsRPDSPiAILq4pJunPNZOp+Xc=

The output from that command is the input for the verification:
$ ./passkey_child --verify-assert --domain=**test.com** --key-handle=**WXPmGkj1inQhLic7LK91S9zuhre/1r39o1wzqQJNLUW/ylcLzuw4kb/cocOF8j9bCkpdh27RomHOM76j++wmUA==** --public-key=**MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyOBBSTHztQC757ShjFUFtjeF7L9w8tBO6GXVGS2BuTiXHv+rCizxzpkxojo2bvKrI2f8EcjoXJPtLbxdoZ53Yg==** --cryptographic-challenge=mZmBWUaJGwEjSNQvkFaicpCzDKhap2pQlfi8FXsv68k= --auth-data=**WCWZq3FdhKO8Xg6SqlDmelgTY3/RdEvTAasI+HGR3bgW4AAAAAER** --signature=**MEQCIQCGWLq2Dm1SftSp88sHsDP241L26NcKzC0Do4pnvyz1yQIfcG4vAxxyp08Y375qWJ/AWyk1YVyloeOFg6U0zuh5GQ==**

PS: the public key is the output from the registration command.