### PR TITLE
Fixes for oidc_child - sssd-2-7

### DIFF
--- a/src/oidc_child/oidc_child.c
+++ b/src/oidc_child/oidc_child.c
@@ -119,9 +119,9 @@ static errno_t set_endpoints(struct devicecode_ctx *dc_ctx,
     }
 
     if (scope != NULL && *scope != '\0') {
-        dc_ctx->scope = talloc_strdup(dc_ctx, scope);
+        dc_ctx->scope = url_encode_string(dc_ctx, scope);
         if (dc_ctx->scope == NULL) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "Failed to copy scopes.\n");
+            DEBUG(SSSDBG_CRIT_FAILURE, "Failed to encode and copy scopes.\n");
             ret = ENOMEM;
             goto done;
         }

--- a/src/oidc_child/oidc_child.c
+++ b/src/oidc_child/oidc_child.c
@@ -454,7 +454,7 @@ int main(int argc, const char *argv[])
     }
 
     if (opts.get_device_code) {
-        ret = get_devicecode(dc_ctx, opts.client_id);
+        ret = get_devicecode(dc_ctx, opts.client_id, opts.client_secret);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "Failed to get device code.\n");
             goto done;

--- a/src/oidc_child/oidc_child_curl.c
+++ b/src/oidc_child/oidc_child_curl.c
@@ -26,6 +26,41 @@
 #include <curl/curl.h>
 #include "oidc_child/oidc_child_util.h"
 
+char *url_encode_string(TALLOC_CTX *mem_ctx, const char *inp)
+{
+    CURL *curl_ctx = NULL;
+    char *tmp;
+    char *out = NULL;
+
+    if (inp == NULL) {
+        DEBUG(SSSDBG_TRACE_ALL, "Empty input.\n");
+        return NULL;
+    }
+
+    curl_ctx = curl_easy_init();
+    if (curl_ctx == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to initialize curl.\n");
+        return NULL;
+    }
+
+    tmp = curl_easy_escape(curl_ctx, inp, 0);
+    if (tmp == NULL) {
+        DEBUG(SSSDBG_TRACE_ALL, "curl_easy_escape failed for [%s].\n", inp);
+        goto done;
+    }
+
+    out = talloc_strdup(mem_ctx, tmp);
+    curl_free(tmp);
+    if (out == NULL) {
+        DEBUG(SSSDBG_TRACE_ALL, "talloc_strdup failed.\n");
+        goto done;
+    }
+
+done:
+    curl_easy_cleanup(curl_ctx);
+    return (out);
+}
+
 /* The curl write_callback will always append the received data. To start a
  * new string call clean_http_data() before the curl request.*/
 void clean_http_data(struct devicecode_ctx *dc_ctx)

--- a/src/oidc_child/oidc_child_curl.c
+++ b/src/oidc_child/oidc_child_curl.c
@@ -378,8 +378,14 @@ errno_t get_token(TALLOC_CTX *mem_ctx,
             break;
         }
 
-        sleep(dc_ctx->interval);
         waiting_time += dc_ctx->interval;
+        if (waiting_time >= dc_ctx->expires_in) {
+            /* Next sleep will end after the request is expired on the
+             * server side, so we can just error out now. */
+            ret = ETIMEDOUT;
+            break;
+        }
+        sleep(dc_ctx->interval);
     } while (waiting_time < dc_ctx->expires_in);
 
     if (ret != EOK) {

--- a/src/oidc_child/oidc_child_curl.c
+++ b/src/oidc_child/oidc_child_curl.c
@@ -428,7 +428,7 @@ done:
 #define DEFAULT_SCOPE "user"
 
 errno_t get_devicecode(struct devicecode_ctx *dc_ctx,
-                       const char *client_id)
+                       const char *client_id, const char *client_secret)
 {
     int ret;
 
@@ -441,6 +441,16 @@ errno_t get_devicecode(struct devicecode_ctx *dc_ctx,
     if (post_data == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to allocate memory for POST data.\n");
         return ENOMEM;
+    }
+
+    if (client_secret != NULL) {
+        post_data = talloc_asprintf_append(post_data, "&client_secret=%s",
+                                           client_secret);
+        if (post_data == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "Failed to add client secret to POST data.\n");
+            return ENOMEM;
+        }
     }
 
     clean_http_data(dc_ctx);

--- a/src/oidc_child/oidc_child_json.c
+++ b/src/oidc_child/oidc_child_json.c
@@ -413,6 +413,12 @@ errno_t parse_token_result(struct devicecode_ctx *dc_ctx,
         if (strcmp(json_string_value(tmp), "authorization_pending") == 0) {
             json_decref(result);
             return EAGAIN;
+        } else if (strcmp(json_string_value(tmp), "slow_down") == 0) {
+            /* RFC 8628: "... the interval MUST be increased by 5 seconds for"
+             *           "this and all subsequent requests." */
+            dc_ctx->interval += 5;
+            json_decref(result);
+            return EAGAIN;
         } else {
             *error_description = get_json_string(dc_ctx, result,
                                                  "error_description");

--- a/src/oidc_child/oidc_child_util.h
+++ b/src/oidc_child/oidc_child_util.h
@@ -61,6 +61,8 @@ struct devicecode_ctx {
 };
 
 /* oidc_child_curl.c */
+char *url_encode_string(TALLOC_CTX *mem_ctx, const char *inp);
+
 errno_t init_curl(void *p);
 
 void clean_http_data(struct devicecode_ctx *dc_ctx);

--- a/src/oidc_child/oidc_child_util.h
+++ b/src/oidc_child/oidc_child_util.h
@@ -73,7 +73,7 @@ errno_t get_openid_configuration(struct devicecode_ctx *dc_ctx,
 errno_t get_jwks(struct devicecode_ctx *dc_ctx);
 
 errno_t get_devicecode(struct devicecode_ctx *dc_ctx,
-                       const char *client_id);
+                       const char *client_id, const char *client_secret);
 
 errno_t get_token(TALLOC_CTX *mem_ctx,
                   struct devicecode_ctx *dc_ctx, const char *client_id,


### PR DESCRIPTION
oidc_child: increase wait interval by 5s if 'slow_down' is returned

While waiting for the user to authenticate with the IdP oidc_child
currently only handles the error code 'authorization_pending' and waits for
the given interval until a new request is send. But there is also
'slow_down' which should not be treated as fatal error but should just
increase the waiting time permanently for 5s.

oidc_child: use client secret if available to get device code

Some IdP have the concept of confidential client, i.e. clients where the
client's secret can be stored safely by the related application. For a
confidential client some IdPs expects that the client secret is used in all
requests together with the client ID although OAuth2 specs currently only
mention this explicitly for the token request. To make sure the device code
can be requested in this case the client secret is added to the device code
request if the secret is provided.

oidc_child: escape scopes

Before using the user provided scopes in the HTTP request they should be
properly escaped according to RFC-3986.

Resolves: #6146