### PR TITLE
CI: remove flake8 action

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -41,25 +41,12 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
 
-  flake8:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-
-    - name: Run flake8
-      uses: grantmcconnaughey/lintly-flake8-github-action@d9db4fd0be9fb1cd19206a48ec0773bd93b82cbd
-      if: github.event_name == 'pull_request'
-      with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          failIf: new
-
   result:
     name: All tests are successful
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    needs: [codeql, flake8]
+    needs: [codeql]
     steps:
       - name: Fail on failure
-        if: ${{ needs.codeql.result != 'success' || needs.flake8.result != 'success' }}
+        if: ${{ needs.codeql.result != 'success' }}
         run: exit 1


### PR DESCRIPTION
When a new issue is found, the action is unable to report it properly in the PR and it fails.