### PR TITLE
TESTS: dropping idmap testcase from gating

### DIFF
--- a/src/tests/multihost/ad/test_idmap.py
+++ b/src/tests/multihost/ad/test_idmap.py
@@ -11,7 +11,7 @@ from sssd.testlib.common.utils import sssdTools
 
 
 @pytest.mark.usefixtures('joinad', 'create_idmap_users_groups')
-@pytest.mark.tier1_3
+@pytest.mark.tier2
 @pytest.mark.idmap
 class Testidmap(object):
     """ Test cases for idmap


### PR DESCRIPTION
dropping idmap disabled from gating as test is unstable against 2012r2