### PR TITLE
memberof: don't use LDB_FLAG_MOD_REPLACE with empty element

### DIFF
--- a/src/ldb_modules/memberof.c
+++ b/src/ldb_modules/memberof.c
@@ -2215,6 +2215,10 @@ static int mbof_del_mod_entry(struct mbof_del_operation *delop)
         }
         el->num_values = j;
 
+        if (el->num_values == 0) { /* everything was skipped */
+            talloc_zfree(el->values);
+            el->flags = LDB_FLAG_MOD_DELETE;
+        }
     }
     else {
         ret = ldb_msg_add_empty(msg, DB_MEMBEROF, LDB_FLAG_MOD_DELETE, &el);


### PR DESCRIPTION
If `mbof_del_mod_entry()` skips all elements in `new_list`, code would end up performing `LDB_FLAG_MOD_REPLACE` with empty `el`.

This probably could be a reason of:
```
[sysdb_set_cache_entry_attr] (0x0080): ldb_modify failed: [Constraint violation](19)[attribute 'memberof': attribute on 'name=...,cn=groups,cn=...,cn=sysdb' specified, but with 0 values (illegal)]
```

While it's unclear how (and if) code could actually reach this state, additional check won't hurt.