### PR TITLE
Tests: Fix minor error in root privilage test

### DIFF
--- a/src/tests/multihost/alltests/test_sssctl_analyzer.py
+++ b/src/tests/multihost/alltests/test_sssctl_analyzer.py
@@ -323,6 +323,7 @@ class TestSssctlAnalyze(object):
         # Create directory
         # Copy logs to above directory
         # Change ownership to a local user
+        multihost.client[0].run_command("rm -vfr /tmp/sssd", raiseonerr=False)
         for command in ["mkdir /tmp/sssd",
                         "cp -vf /var/log/sssd/* /tmp/sssd",
                         "chown user5000 /tmp/sssd/",


### PR DESCRIPTION
mkdir: cannot create directory ‘/tmp/sssd’: File exists