### PR TITLE
Add force second factor

### DIFF
--- a/src/man/pam_sss.8.xml
+++ b/src/man/pam_sss.8.xml
@@ -56,6 +56,9 @@
             <arg choice='opt'>
                 <replaceable>require_cert_auth</replaceable>
             </arg>
+            <arg choice='opt'>
+                <replaceable>force_second_factor</replaceable>
+            </arg>
         </cmdsynopsis>
     </refsynopsisdiv>
 
@@ -246,6 +249,19 @@ auth sufficient pam_sss.so allow_missing_name
                         If no Smartcard is available after the timeout or
                         certificate based authentication is not allowed for the
                         current service PAM_AUTHINFO_UNAVAIL is returned.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term>
+                    <option>force_second_factor</option>
+                </term>
+                <listitem>
+                    <para>
+                        For sshd, if you have enabled 2FA and want to require 
+                        that both factors are provided, versus providing them
+			            all in the first factor, set this option. A NULL or
+		                empty second factor will cause login to fail.	
                     </para>
                 </listitem>
             </varlistentry>

--- a/src/sss_client/sss_cli.h
+++ b/src/sss_client/sss_cli.h
@@ -406,6 +406,7 @@ enum pam_item_type {
 #define PAM_CLI_FLAGS_PROMPT_ALWAYS (1 << 7)
 #define PAM_CLI_FLAGS_TRY_CERT_AUTH (1 << 8)
 #define PAM_CLI_FLAGS_REQUIRE_CERT_AUTH (1 << 9)
+#define PAM_CLI_FLAGS_FORCE_SECOND_FACTOR (1 << 10)
 
 #define SSS_NSS_MAX_ENTRIES 256
 #define SSS_NSS_HEADER_SIZE (sizeof(uint32_t) * 4)


### PR DESCRIPTION
In our use case, we have 2FA configured using SSSD with Kerberos/FAST and OTP configured on the KDCs.  A secondary principal is created for each user that holds their OTP credentials.

Also, in our configuration, ssh prompts for both the First and Second factor.

What we found was that someone configured for OTP could bypass the 2FA requirement for ssh if they entered their primary principal password as the first factor due to how the pam_sss code allows an empty second factor.  In a perfect world the primary principal would be scrambled/removed when 2FA is setup but we are in a transition state.

This pull request adds a 'force_second_factor' option that if set requires the second factor to be provided if and only if the PAM service being used is sshd.  A NULL or missing second factor results in a return of PAM_CRED_INSUFFICIENT.

Hopefully this is useful to someone else as well. 