### PR TITLE
sudo: skip smart refresh if it happens inside full refresh

### DIFF
--- a/src/providers/be_ptask.c
+++ b/src/providers/be_ptask.c
@@ -447,6 +447,11 @@ time_t be_ptask_get_timeout(struct be_ptask *task)
     return task->timeout;
 }
 
+bool be_ptask_running(struct be_ptask *task)
+{
+    return task->req != NULL;
+}
+
 struct be_ptask_sync_ctx {
     be_ptask_sync_t fn;
     void *pvt;

--- a/src/providers/be_ptask.h
+++ b/src/providers/be_ptask.h
@@ -147,5 +147,6 @@ void be_ptask_destroy(struct be_ptask **task);
 
 time_t be_ptask_get_period(struct be_ptask *task);
 time_t be_ptask_get_timeout(struct be_ptask *task);
+bool be_ptask_running(struct be_ptask *task);
 
 #endif /* _DP_PTASK_H_ */


### PR DESCRIPTION
When a full refresh is finished succesfully, it reschedules the next
smart refresh so it does not run any time soon (or at the same time).

However, if the full refresh interval is multiple of smart refresh 
interval, then smart refresh often triggers during an ongoing full
refresh. We want to avoid that.

This was caught when rewriting `test_improve_refresh_timers_sudo_timeout`
to the new framework.

Test is in the framework PR: `test_sudo__prefer_full_refresh_over_smart_refresh`