### PR TITLE
sssctl config-check command makes id_provider mandatory

### DIFF
--- a/src/tests/cmocka/test_config_check.c
+++ b/src/tests/cmocka/test_config_check.c
@@ -105,7 +105,8 @@ void config_check_test_bad_section_name(void **state)
 
 void config_check_test_bad_chars_in_section_name(void **state)
 {
-    char cfg_str[] = "[domain/LD@P]";
+    char cfg_str[] = "[domain/LD@P]\n"
+                     "id_provider = files\n";
     const char *expected_errors[] = {
         "[rule/allowed_sections]: Section [domain/LD@P] is not allowed. "
         "Check for typos.",
@@ -239,6 +240,7 @@ void config_check_test_good_sections(void **state)
                      "[pam]\n"
                      "[nss]\n"
                      "[domain/testdom.test]\n"
+                     "id_provider = files\n"
                      "[domain/testdom.test/testsubdom.testdom.test]\n"
                      "[application/myapp]\n"
                      "[ssh]\n"
@@ -250,9 +252,21 @@ void config_check_test_good_sections(void **state)
     config_check_test_common(cfg_str, 0, expected_errors);
 }
 
+void config_check_test_missing_id_provider(void **state)
+{
+    char cfg_str[] = "[domain/A.test]\n";
+    const char *expected_errors[] = {
+        "[rule/sssd_checks]: Attribute 'id_provider' is missing in "
+        "section 'domain/A.test'.",
+    };
+
+    config_check_test_common(cfg_str, 1, expected_errors);
+}
+
 void config_check_test_inherit_from_in_normal_dom(void **state)
 {
     char cfg_str[] = "[domain/A.test]\n"
+                     "id_provider = files\n"
                      "inherit_from = domain\n";
     const char *expected_errors[] = {
         "[rule/sssd_checks]: Attribute 'inherit_from' is not allowed in "
@@ -294,6 +308,7 @@ int main(int argc, const char *argv[])
         cmocka_unit_test(config_check_test_bad_subdom_option_name),
         cmocka_unit_test(config_check_test_bad_certmap_option_name),
         cmocka_unit_test(config_check_test_good_sections),
+        cmocka_unit_test(config_check_test_missing_id_provider),
         cmocka_unit_test(config_check_test_inherit_from_in_normal_dom),
         cmocka_unit_test(config_check_test_inherit_from_in_app_dom),
     };

--- a/src/tests/cmocka/test_config_check.c
+++ b/src/tests/cmocka/test_config_check.c
@@ -270,7 +270,7 @@ void config_check_test_inherit_from_in_normal_dom(void **state)
                      "inherit_from = domain\n";
     const char *expected_errors[] = {
         "[rule/sssd_checks]: Attribute 'inherit_from' is not allowed in "
-        "section 'domain/A.test'. Check for typos.",
+        "section 'domain/A.test'.",
     };
 
     config_check_test_common(cfg_str, 1, expected_errors);

--- a/src/util/sss_ini.c
+++ b/src/util/sss_ini.c
@@ -654,7 +654,7 @@ static int custom_sssd_checks(const char *rule_name,
     ret = EOK;
 done:
     ini_free_section_list(cfg_sections);
-    return EOK;
+    return ret;
 }
 
 static int sss_ini_call_validators_errobj(struct sss_ini *data,

--- a/src/util/sss_ini.c
+++ b/src/util/sss_ini.c
@@ -607,8 +607,7 @@ static errno_t check_domain_inherit_from(char *cfg_section,
     if (vo != NULL) {
         ret = ini_errobj_add_msg(errobj,
                                  "Attribute 'inherit_from' is not "
-                                 "allowed in section '%s'. Check for "
-                                 "typos.",
+                                 "allowed in section '%s'.",
                                  cfg_section);
         if (ret != EOK) {
             goto done;


### PR DESCRIPTION
`sssctl config-check` accepts the presence of `id_provider` for the domains but does not consider it as mandatory. The different commits:

1. Extract the code checking that `inherit_from` is not present to its own function.
2. Fix `custom_sssd_checks()` that always returns `EOK`.
3. Make `id_provider` mandatory for domains and verify the value to be valid (`ad`, `files`, `ipa`, `ldap`, `proxy`); but `id_provider` is not accepted for subdomains.
4. Update the existing tests and create a new one testing this case.
