### PR TITLE
passkey: do not copy more than received

### DIFF
--- a/src/passkey_child/passkey_child_credentials.c
+++ b/src/passkey_child/passkey_child_credentials.c
@@ -173,7 +173,7 @@ passkey_recv_pin(TALLOC_CTX *mem_ctx, int fd, char **_pin)
         return EINVAL;
     }
 
-    str = talloc_strdup(mem_ctx, (char *) buf);
+    str = talloc_strndup(mem_ctx, (char *) buf, len);
     if (str == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "talloc_strndup failed.\n");
         return ENOMEM;


### PR DESCRIPTION
Since buf is not initialized to 0 talloc_strdup() might actually copy
more data than was received.