### PR TITLE
SSS_CLIENT: fix a number of issues

### DIFF
--- a/src/sss_client/common.c
+++ b/src/sss_client/common.c
@@ -161,8 +161,7 @@ static enum sss_status sss_cli_send_req(enum sss_cli_command cmd,
         case 1:
             if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) {
                 *errnop = EPIPE;
-            }
-            if (!(pfd.revents & POLLOUT)) {
+            } else if (!(pfd.revents & POLLOUT)) {
                 *errnop = EBUSY;
             }
             break;
@@ -273,8 +272,7 @@ static enum sss_status sss_cli_recv_rep(enum sss_cli_command cmd,
             }
             if (pfd.revents & (POLLERR | POLLNVAL)) {
                 *errnop = EPIPE;
-            }
-            if (!(pfd.revents & POLLIN)) {
+            } else if (!(pfd.revents & POLLIN)) {
                 *errnop = EBUSY;
             }
             break;
@@ -725,8 +723,7 @@ static enum sss_status sss_cli_check_socket(int *errnop,
         case 1:
             if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) {
                 *errnop = EPIPE;
-            }
-            if (!(pfd.revents & (POLLIN | POLLOUT))) {
+            } else if (!(pfd.revents & (POLLIN | POLLOUT))) {
                 *errnop = EBUSY;
             }
             break;

--- a/src/sss_client/common.c
+++ b/src/sss_client/common.c
@@ -159,7 +159,11 @@ static enum sss_status sss_cli_send_req(enum sss_cli_command cmd,
             *errnop = ETIME;
             break;
         case 1:
-            if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) {
+            if (pfd.revents & (POLLERR | POLLHUP)) {
+                *errnop = EPIPE;
+            } else if (pfd.revents & POLLNVAL) {
+                /* Invalid request: fd is not opened */
+                sss_cli_sd = -1;
                 *errnop = EPIPE;
             } else if (!(pfd.revents & POLLOUT)) {
                 *errnop = EBUSY;
@@ -270,7 +274,11 @@ static enum sss_status sss_cli_recv_rep(enum sss_cli_command cmd,
             if (pfd.revents & (POLLHUP)) {
                 pollhup = true;
             }
-            if (pfd.revents & (POLLERR | POLLNVAL)) {
+            if (pfd.revents & POLLERR) {
+                *errnop = EPIPE;
+            } else if (pfd.revents & POLLNVAL) {
+                /* Invalid request: fd is not opened */
+                sss_cli_sd = -1;
                 *errnop = EPIPE;
             } else if (!(pfd.revents & POLLIN)) {
                 *errnop = EBUSY;
@@ -721,7 +729,11 @@ static enum sss_status sss_cli_check_socket(int *errnop,
             *errnop = ETIME;
             break;
         case 1:
-            if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) {
+            if (pfd.revents & (POLLERR | POLLHUP)) {
+                *errnop = EPIPE;
+            } else if (pfd.revents & POLLNVAL) {
+                /* Invalid request: fd is not opened */
+                sss_cli_sd = -1;
                 *errnop = EPIPE;
             } else if (!(pfd.revents & (POLLIN | POLLOUT))) {
                 *errnop = EBUSY;

--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -118,7 +118,10 @@ static void close_fd(pam_handle_t *pamh, void *ptr, int err)
 #endif /* PAM_DATA_REPLACE */
 
     D(("Closing the fd"));
+
+    sss_pam_lock();
     sss_cli_close_socket();
+    sss_pam_unlock();
 }
 
 struct cert_auth_info {

--- a/src/sss_client/pam_sss_gss.c
+++ b/src/sss_client/pam_sss_gss.c
@@ -581,7 +581,9 @@ int pam_sm_authenticate(pam_handle_t *pamh,
     }
 
 done:
+    sss_pam_lock();
     sss_cli_close_socket();
+    sss_pam_unlock();
     free(username);
     free(domain);
     free(target);


### PR DESCRIPTION
returned by common read/write/check helpers.

It's kind of expected that in case `(POLLERR | POLLHUP | POLLNVAL)` error condition is detected, regular `POLLIN/POLLOUT` won't be set. Error code set by error condition should have a priority. This enables users of this helper to retry attempt (as designed).