### PR TITLE
nssidmap: add getsidbyusername and getsidbygroupname

### DIFF
--- a/src/python/pysss_nss_idmap.c
+++ b/src/python/pysss_nss_idmap.c
@@ -33,6 +33,8 @@
 
 enum lookup_type {
     SIDBYNAME,
+    SIDBYUSERNAME,
+    SIDBYGROUPNAME,
     SIDBYID,
     SIDBYUID,
     SIDBYGID,
@@ -113,7 +115,9 @@ static char *py_string_or_unicode_as_string(PyObject *inp)
     return PyBytes_AS_STRING(py_str);
 }
 
-static int do_getsidbyname(PyObject *py_result, PyObject *py_name)
+static int do_getsidbyname(enum lookup_type type,
+                           PyObject *py_result,
+                           PyObject *py_name)
 {
     int ret;
     const char *name;
@@ -125,7 +129,19 @@ static int do_getsidbyname(PyObject *py_result, PyObject *py_name)
         return EINVAL;
     }
 
-    ret = sss_nss_getsidbyname(name, &sid, &id_type);
+    switch (type) {
+    case SIDBYNAME:
+        ret = sss_nss_getsidbyname(name, &sid, &id_type);
+        break;
+    case SIDBYUSERNAME:
+        ret = sss_nss_getsidbyusername(name, &sid, &id_type);
+        break;
+    case SIDBYGROUPNAME:
+        ret = sss_nss_getsidbygroupname(name, &sid, &id_type);
+        break;
+    default:
+        return EINVAL;
+    }
     if (ret == 0) {
         ret = add_dict(py_result, py_name, PyUnicode_FromString(SSS_SID_KEY),
                        PyUnicode_FromString(sid), PYNUMBER_FROMLONG(id_type));
@@ -311,7 +327,9 @@ static int do_lookup(enum lookup_type type, PyObject *py_result,
 {
     switch(type) {
     case SIDBYNAME:
-        return do_getsidbyname(py_result, py_inp);
+    case SIDBYUSERNAME:
+    case SIDBYGROUPNAME:
+        return do_getsidbyname(type, py_result, py_inp);
         break;
     case NAMEBYSID:
         return do_getnamebysid(py_result, py_inp);
@@ -426,6 +444,44 @@ static PyObject * py_getsidbyname(PyObject *module, PyObject *args)
     return check_args(SIDBYNAME, args);
 }
 
+PyDoc_STRVAR(getsidbyusername_doc,
+"getsidbyusername(name or list/tuple of names) -> dict(name => dict(results))\n\
+\n\
+Returns a dictionary with a dictionary of results for each given name.\n\
+The result dictionary contain the SID and the type of the object which can be\n\
+accessed with the key constants SID_KEY and TYPE_KEY, respectively.\n\
+\n\
+The return type can be one of the following constants:\n\
+- ID_NOT_SPECIFIED\n\
+- ID_USER\n\
+- ID_GROUP\n\
+- ID_BOTH"
+);
+
+static PyObject * py_getsidbyusername(PyObject *module, PyObject *args)
+{
+    return check_args(SIDBYUSERNAME, args);
+}
+
+PyDoc_STRVAR(getsidbygroupname_doc,
+"getsidbygroupname(name or list/tuple of names) -> dict(name => dict(results))\n\
+\n\
+Returns a dictionary with a dictionary of results for each given name.\n\
+The result dictionary contain the SID and the type of the object which can be\n\
+accessed with the key constants SID_KEY and TYPE_KEY, respectively.\n\
+\n\
+The return type can be one of the following constants:\n\
+- ID_NOT_SPECIFIED\n\
+- ID_USER\n\
+- ID_GROUP\n\
+- ID_BOTH"
+);
+
+static PyObject * py_getsidbygroupname(PyObject *module, PyObject *args)
+{
+    return check_args(SIDBYGROUPNAME, args);
+}
+
 PyDoc_STRVAR(getsidbyid_doc,
 "getsidbyid(id or list/tuple of id) -> dict(id => dict(results))\n\
 \n\
@@ -533,6 +589,10 @@ static PyObject * py_getlistbycert(PyObject *module, PyObject *args)
 static PyMethodDef methods[] = {
     { sss_py_const_p(char, "getsidbyname"), (PyCFunction) py_getsidbyname,
       METH_VARARGS, getsidbyname_doc },
+    { sss_py_const_p(char, "getsidbyusername"), (PyCFunction) py_getsidbyusername,
+      METH_VARARGS, getsidbyusername_doc },
+    { sss_py_const_p(char, "getsidbygroupname"), (PyCFunction) py_getsidbygroupname,
+      METH_VARARGS, getsidbygroupname_doc },
     { sss_py_const_p(char, "getsidbyid"), (PyCFunction) py_getsidbyid,
       METH_VARARGS, getsidbyid_doc },
     { sss_py_const_p(char, "getsidbyuid"), (PyCFunction) py_getsidbyuid,

--- a/src/responder/nss/nss_cmd.c
+++ b/src/responder/nss/nss_cmd.c
@@ -1142,6 +1142,28 @@ static errno_t sss_nss_cmd_getsidbyname(struct cli_ctx *cli_ctx)
                               SSS_MC_NONE, sss_nss_protocol_fill_sid);
 }
 
+static errno_t sss_nss_cmd_getsidbyusername(struct cli_ctx *cli_ctx)
+{
+    /* The attributes besides SYSDB_SID_STR are needed to handle some corner
+     * cases with respect to user-private-groups */
+    const char *attrs[] = { SYSDB_SID_STR, SYSDB_UIDNUM, SYSDB_GIDNUM,
+                            SYSDB_OBJECTCATEGORY, NULL };
+
+    return sss_nss_getby_name(cli_ctx, false, CACHE_REQ_USER_BY_NAME, attrs,
+                              SSS_MC_NONE, sss_nss_protocol_fill_sid);
+}
+
+static errno_t sss_nss_cmd_getsidbygroupname(struct cli_ctx *cli_ctx)
+{
+    /* The attributes besides SYSDB_SID_STR are needed to handle some corner
+     * cases with respect to user-private-groups */
+    const char *attrs[] = { SYSDB_SID_STR, SYSDB_UIDNUM, SYSDB_GIDNUM,
+                            SYSDB_OBJECTCATEGORY, NULL };
+
+    return sss_nss_getby_name(cli_ctx, false, CACHE_REQ_GROUP_BY_NAME, attrs,
+                              SSS_MC_NONE, sss_nss_protocol_fill_sid);
+}
+
 static errno_t sss_nss_cmd_getsidbyid(struct cli_ctx *cli_ctx)
 {
     const char *attrs[] = { SYSDB_SID_STR, SYSDB_UIDNUM, SYSDB_GIDNUM,
@@ -1374,6 +1396,8 @@ struct sss_cmd_table *get_sss_nss_cmds(void)
         { SSS_NSS_GETSERVENT, sss_nss_cmd_getservent },
         { SSS_NSS_ENDSERVENT, sss_nss_cmd_endservent },
         { SSS_NSS_GETSIDBYNAME, sss_nss_cmd_getsidbyname },
+        { SSS_NSS_GETSIDBYUSERNAME, sss_nss_cmd_getsidbyusername },
+        { SSS_NSS_GETSIDBYGROUPNAME, sss_nss_cmd_getsidbygroupname },
         { SSS_NSS_GETSIDBYID, sss_nss_cmd_getsidbyid },
         { SSS_NSS_GETSIDBYUID, sss_nss_cmd_getsidbyuid },
         { SSS_NSS_GETSIDBYGID, sss_nss_cmd_getsidbygid },

--- a/src/sss_client/idmap/sss_nss_idmap.c
+++ b/src/sss_client/idmap/sss_nss_idmap.c
@@ -249,6 +249,8 @@ static int sss_nss_getyyybyxxx(union input inp, enum sss_cli_command cmd,
 
     switch (cmd) {
     case SSS_NSS_GETSIDBYNAME:
+    case SSS_NSS_GETSIDBYUSERNAME:
+    case SSS_NSS_GETSIDBYGROUPNAME:
     case SSS_NSS_GETNAMEBYSID:
     case SSS_NSS_GETIDBYSID:
     case SSS_NSS_GETORIGBYNAME:
@@ -333,6 +335,8 @@ static int sss_nss_getyyybyxxx(union input inp, enum sss_cli_command cmd,
     case SSS_NSS_GETSIDBYUID:
     case SSS_NSS_GETSIDBYGID:
     case SSS_NSS_GETSIDBYNAME:
+    case SSS_NSS_GETSIDBYUSERNAME:
+    case SSS_NSS_GETSIDBYGROUPNAME:
     case SSS_NSS_GETNAMEBYSID:
     case SSS_NSS_GETNAMEBYCERT:
         if (data_len <= 1 || repbuf[replen - 1] != '\0') {
@@ -402,8 +406,11 @@ done:
     return ret;
 }
 
-int sss_nss_getsidbyname_timeout(const char *fq_name, unsigned int timeout,
-                                 char **sid, enum sss_id_type *type)
+static int _sss_nss_getsidbyxxxname_timeout(enum sss_cli_command cmd,
+                                            const char *fq_name,
+                                            unsigned int timeout,
+                                            char **sid,
+                                            enum sss_id_type *type)
 {
     int ret;
     union input inp;
@@ -415,7 +422,7 @@ int sss_nss_getsidbyname_timeout(const char *fq_name, unsigned int timeout,
 
     inp.str = fq_name;
 
-    ret = sss_nss_getyyybyxxx(inp, SSS_NSS_GETSIDBYNAME, timeout, &out);
+    ret = sss_nss_getyyybyxxx(inp, cmd, timeout, &out);
     if (ret == EOK) {
         *sid = out.d.str;
         *type = out.type;
@@ -424,10 +431,52 @@ int sss_nss_getsidbyname_timeout(const char *fq_name, unsigned int timeout,
     return ret;
 }
 
+int sss_nss_getsidbyname_timeout(const char *fq_name, unsigned int timeout,
+                                 char **sid, enum sss_id_type *type)
+{
+    return _sss_nss_getsidbyxxxname_timeout(SSS_NSS_GETSIDBYNAME, fq_name,
+                                            timeout, sid, type);
+}
+
 int sss_nss_getsidbyname(const char *fq_name, char **sid,
                          enum sss_id_type *type)
 {
-    return sss_nss_getsidbyname_timeout(fq_name, NO_TIMEOUT, sid, type);
+    return _sss_nss_getsidbyxxxname_timeout(SSS_NSS_GETSIDBYNAME, fq_name,
+                                            NO_TIMEOUT, sid, type);
+}
+
+int sss_nss_getsidbyusername_timeout(const char *fq_name,
+                                     unsigned int timeout,
+                                     char **sid,
+                                     enum sss_id_type *type)
+{
+    return _sss_nss_getsidbyxxxname_timeout(SSS_NSS_GETSIDBYUSERNAME, fq_name,
+                                            timeout, sid, type);
+}
+
+int sss_nss_getsidbyusername(const char *fq_name,
+                             char **sid,
+                             enum sss_id_type *type)
+{
+    return _sss_nss_getsidbyxxxname_timeout(SSS_NSS_GETSIDBYUSERNAME, fq_name,
+                                            NO_TIMEOUT, sid, type);
+}
+
+int sss_nss_getsidbygroupname_timeout(const char *fq_name,
+                                      unsigned int timeout,
+                                      char **sid,
+                                      enum sss_id_type *type)
+{
+    return _sss_nss_getsidbyxxxname_timeout(SSS_NSS_GETSIDBYGROUPNAME, fq_name,
+                                            timeout, sid, type);
+}
+
+int sss_nss_getsidbygroupname(const char *fq_name,
+                              char **sid,
+                              enum sss_id_type *type)
+{
+    return _sss_nss_getsidbyxxxname_timeout(SSS_NSS_GETSIDBYGROUPNAME, fq_name,
+                                            NO_TIMEOUT, sid, type);
 }
 
 int sss_nss_getsidbyid_timeout(uint32_t id, unsigned int timeout,

--- a/src/sss_client/idmap/sss_nss_idmap.exports
+++ b/src/sss_client/idmap/sss_nss_idmap.exports
@@ -66,3 +66,12 @@ SSS_NSS_IDMAP_0.6.0 {
         sss_nss_getorigbygroupname;
         sss_nss_getorigbygroupname_timeout;
 } SSS_NSS_IDMAP_0.5.0;
+
+SSS_NSS_IDMAP_0.7.0 {
+    # public functions
+    global:
+        sss_nss_getsidbyusername;
+        sss_nss_getsidbyusername_timeout;
+        sss_nss_getsidbygroupname;
+        sss_nss_getsidbygroupname_timeout;
+} SSS_NSS_IDMAP_0.6.0;

--- a/src/sss_client/idmap/sss_nss_idmap.h
+++ b/src/sss_client/idmap/sss_nss_idmap.h
@@ -66,6 +66,36 @@ int sss_nss_getsidbyname(const char *fq_name, char **sid,
                          enum sss_id_type *type);
 
 /**
+ * @brief Find SID by fully qualified user name
+ *
+ * @param[in] fq_name  Fully qualified name of a user
+ * @param[out] sid     String representation of the SID of the requested user,
+ *                     must be freed by the caller
+ * @param[out] type    Type of the object related to the given name
+ *
+ * @return
+ *  - see #sss_nss_getsidbyname
+ */
+int sss_nss_getsidbyusername(const char *fq_name,
+                             char **sid,
+                             enum sss_id_type *type);
+
+/**
+ * @brief Find SID by fully qualified group name
+ *
+ * @param[in] fq_name  Fully qualified name of a group
+ * @param[out] sid     String representation of the SID of the requested group,
+ *                     must be freed by the caller
+ * @param[out] type    Type of the object related to the given name
+ *
+ * @return
+ *  - see #sss_nss_getsidbyname
+ */
+int sss_nss_getsidbygroupname(const char *fq_name,
+                              char **sid,
+                              enum sss_id_type *type);
+
+/**
  * @brief Find SID by a POSIX UID or GID
  *
  * @param[in] id       POSIX UID or GID
@@ -394,6 +424,40 @@ int sss_nss_getgrouplist_timeout(const char *name, gid_t group,
  */
 int sss_nss_getsidbyname_timeout(const char *fq_name, unsigned int timeout,
                                  char **sid, enum sss_id_type *type);
+
+/**
+ * @brief Find SID by fully qualified user name with timeout
+ *
+ * @param[in] fq_name  Fully qualified name of a user
+ * @param[in] timeout  timeout in milliseconds
+ * @param[out] sid     String representation of the SID of the requested user,
+ *                     must be freed by the caller
+ * @param[out] type    Type of the object related to the given name
+ *
+ * @return
+ *  - see #sss_nss_getsidbyname_timeout
+ */
+int sss_nss_getsidbyusername_timeout(const char *fq_name,
+                                     unsigned int timeout,
+                                     char **sid,
+                                     enum sss_id_type *type);
+
+/**
+ * @brief Find SID by fully qualified group name with timeout
+ *
+ * @param[in] fq_name  Fully qualified name of a group
+ * @param[in] timeout  timeout in milliseconds
+ * @param[out] sid     String representation of the SID of the requested group,
+ *                     must be freed by the caller
+ * @param[out] type    Type of the object related to the given name
+ *
+ * @return
+ *  - see #sss_nss_getsidbyname_timeout
+ */
+int sss_nss_getsidbygroupname_timeout(const char *fq_name,
+                                      unsigned int timeout,
+                                      char **sid,
+                                      enum sss_id_type *type);
 
 /**
  * @brief Find SID by a POSIX UID or GID with timeout

--- a/src/sss_client/sss_cli.h
+++ b/src/sss_client/sss_cli.h
@@ -297,6 +297,15 @@ SSS_NSS_GETORIGBYGROUPNAME = 0x011B, /**< Takes a zero terminated fully qualifie
                                      second the value. Hence the list should
                                      have an even number of strings, if not
                                      the whole list is invalid. */
+SSS_NSS_GETSIDBYUSERNAME = 0x011C, /**< Takes a zero terminated fully qualified
+                                    name and returns the zero terminated
+                                    string representation of the SID of the
+                                    user with the given name. */
+SSS_NSS_GETSIDBYGROUPNAME = 0x011D, /**< Takes a zero terminated fully qualified
+                                     name and returns the zero terminated
+                                     string representation of the SID of the
+                                     group with the given name. */
+
 
 /* subid */
     SSS_NSS_GET_SUBID_RANGES = 0x0130, /**< Requests both subuid and subgid ranges

--- a/src/tests/cmocka/common_mock_resp_dp.c
+++ b/src/tests/cmocka/common_mock_resp_dp.c
@@ -40,7 +40,6 @@ sss_dp_get_account_send(TALLOC_CTX *mem_ctx,
     return test_req_succeed_send(mem_ctx, rctx->ev);
 }
 
-
 errno_t
 sss_dp_get_account_recv(TALLOC_CTX *mem_ctx,
                         struct tevent_req *req,

--- a/src/tests/intg/test_pysss_nss_idmap.py
+++ b/src/tests/intg/test_pysss_nss_idmap.py
@@ -219,6 +219,13 @@ def test_user_operations(ldap_conn, simple_ad):
     assert output[pysss_nss_idmap.TYPE_KEY] == pysss_nss_idmap.ID_USER
     assert output[pysss_nss_idmap.SID_KEY] == user_sid
 
+    output = pysss_nss_idmap.getsidbyusername(user)[user]
+    assert output[pysss_nss_idmap.TYPE_KEY] == pysss_nss_idmap.ID_USER
+    assert output[pysss_nss_idmap.SID_KEY] == user_sid
+
+    output = pysss_nss_idmap.getsidbygroupname(user)
+    assert len(output) == 0
+
     output = pysss_nss_idmap.getsidbyid(user_id)[user_id]
     assert output[pysss_nss_idmap.TYPE_KEY] == pysss_nss_idmap.ID_USER
     assert output[pysss_nss_idmap.SID_KEY] == user_sid
@@ -247,6 +254,13 @@ def test_group_operations(ldap_conn, simple_ad):
     output = pysss_nss_idmap.getsidbyname(group)[group]
     assert output[pysss_nss_idmap.TYPE_KEY] == pysss_nss_idmap.ID_GROUP
     assert output[pysss_nss_idmap.SID_KEY] == group_sid
+
+    output = pysss_nss_idmap.getsidbygroupname(group)[group]
+    assert output[pysss_nss_idmap.TYPE_KEY] == pysss_nss_idmap.ID_GROUP
+    assert output[pysss_nss_idmap.SID_KEY] == group_sid
+
+    output = pysss_nss_idmap.getsidbyusername(group)
+    assert len(output) == 0
 
     output = pysss_nss_idmap.getsidbyid(group_id)[group_id]
     assert output[pysss_nss_idmap.TYPE_KEY] == pysss_nss_idmap.ID_GROUP


### PR DESCRIPTION
:feature: NSS IDMAP has two new methods: `getsidbyusername` and
  `getsidbygroupname`

Resolves: https://github.com/SSSD/sssd/issues/6565