### PR TITLE
Skip group members that point to an entry in the views base search

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -25,6 +25,7 @@
 #include "util/util.h"
 #include "confdb/confdb.h"
 #include "sss_client/sss_cli.h"
+#include <ldb.h>
 #include <tevent.h>
 
 #define CACHE_SYSDB_FILE "cache_%s.ldb"

--- a/src/providers/ad/ad_common.c
+++ b/src/providers/ad/ad_common.c
@@ -1311,6 +1311,7 @@ ad_set_search_bases(struct sdap_options *id_opts,
     size_t o;
     struct sdap_domain *sdap_dom;
     bool has_default;
+    struct ldb_context *ldb;
     const int search_base_options[] = { SDAP_USER_SEARCH_BASE,
                                         SDAP_GROUP_SEARCH_BASE,
                                         SDAP_NETGROUP_SEARCH_BASE,
@@ -1328,6 +1329,7 @@ ad_set_search_bases(struct sdap_options *id_opts,
         /* If no specific sdom was given, use the first in the list. */
         sdap_dom = id_opts->sdom;
     }
+    ldb = sysdb_ctx_get_ldb(sdap_dom->dom->sysdb);
 
     has_default = sdap_dom->search_bases != NULL;
 
@@ -1361,31 +1363,31 @@ ad_set_search_bases(struct sdap_options *id_opts,
     }
 
     /* Default search */
-    ret = sdap_parse_search_base(id_opts, id_opts->basic,
+    ret = sdap_parse_search_base(id_opts, ldb, id_opts->basic,
                                  SDAP_SEARCH_BASE,
                                  &sdap_dom->search_bases);
     if (ret != EOK && ret != ENOENT) goto done;
 
     /* User search */
-    ret = sdap_parse_search_base(id_opts, id_opts->basic,
+    ret = sdap_parse_search_base(id_opts, ldb, id_opts->basic,
                                  SDAP_USER_SEARCH_BASE,
                                  &sdap_dom->user_search_bases);
     if (ret != EOK && ret != ENOENT) goto done;
 
     /* Group search base */
-    ret = sdap_parse_search_base(id_opts, id_opts->basic,
+    ret = sdap_parse_search_base(id_opts, ldb, id_opts->basic,
                                  SDAP_GROUP_SEARCH_BASE,
                                  &sdap_dom->group_search_bases);
     if (ret != EOK && ret != ENOENT) goto done;
 
     /* Netgroup search */
-    ret = sdap_parse_search_base(id_opts, id_opts->basic,
+    ret = sdap_parse_search_base(id_opts, ldb, id_opts->basic,
                                  SDAP_NETGROUP_SEARCH_BASE,
                                  &sdap_dom->netgroup_search_bases);
     if (ret != EOK && ret != ENOENT) goto done;
 
     /* Service search */
-    ret = sdap_parse_search_base(id_opts, id_opts->basic,
+    ret = sdap_parse_search_base(id_opts, ldb, id_opts->basic,
                                  SDAP_SERVICE_SEARCH_BASE,
                                  &sdap_dom->service_search_bases);
     if (ret != EOK && ret != ENOENT) goto done;

--- a/src/providers/ipa/ipa_autofs.c
+++ b/src/providers/ipa/ipa_autofs.c
@@ -40,7 +40,9 @@ errno_t ipa_autofs_init(TALLOC_CTX *mem_ctx,
 
     DEBUG(SSSDBG_TRACE_INTERNAL, "Initializing autofs IPA back end\n");
 
-    ret = ipa_get_autofs_options(id_ctx->ipa_options, be_ctx->cdb,
+    ret = ipa_get_autofs_options(id_ctx->ipa_options,
+                                 sysdb_ctx_get_ldb(be_ctx->domain->sysdb),
+                                 be_ctx->cdb,
                                  be_ctx->conf_path, &id_ctx->sdap_id_ctx->opts);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Cannot get IPA autofs options\n");

--- a/src/providers/ipa/ipa_common.h
+++ b/src/providers/ipa/ipa_common.h
@@ -262,6 +262,7 @@ int ipa_get_auth_options(struct ipa_options *ipa_opts,
                          struct dp_option **_opts);
 
 int ipa_get_autofs_options(struct ipa_options *ipa_opts,
+                           struct ldb_context *ldb,
                            struct confdb_ctx *cdb,
                            const char *conf_path,
                            struct sdap_options **_opts);

--- a/src/providers/ipa/ipa_init.c
+++ b/src/providers/ipa/ipa_init.c
@@ -611,6 +611,11 @@ static errno_t ipa_init_misc(struct be_ctx *be_ctx,
         return ret;
     }
 
+    /* We must ignore entries in the views search base
+     * (default: cn=views,cn=accounts,$BASEDN) */
+    sdap_id_ctx->opts->sdom->ignore_user_search_bases = \
+                                   ipa_id_ctx->ipa_options->views_search_bases;
+
     return EOK;
 }
 

--- a/src/providers/ipa/ipa_sudo.c
+++ b/src/providers/ipa/ipa_sudo.c
@@ -262,7 +262,9 @@ ipa_sudo_init_ipa_schema(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    ret = sdap_parse_search_base(sudo_ctx, sudo_ctx->sdap_opts->basic,
+    ret = sdap_parse_search_base(sudo_ctx,
+                                 sysdb_ctx_get_ldb(be_ctx->domain->sysdb),
+                                 sudo_ctx->sdap_opts->basic,
                                  SDAP_SUDO_SEARCH_BASE,
                                  &sudo_ctx->sudo_sb);
     if (ret != EOK) {

--- a/src/providers/ldap/ldap_common.h
+++ b/src/providers/ldap/ldap_common.h
@@ -22,6 +22,8 @@
 #ifndef _LDAP_COMMON_H_
 #define _LDAP_COMMON_H_
 
+#include <ldb.h>
+
 #include "providers/backend.h"
 #include "providers/ldap/sdap.h"
 #include "providers/ldap/sdap_id_op.h"
@@ -241,6 +243,7 @@ int ldap_get_options(TALLOC_CTX *memctx,
                      struct sdap_options **_opts);
 
 int ldap_get_sudo_options(struct confdb_ctx *cdb,
+                          struct ldb_context *ldb,
                           const char *conf_path,
                           struct sdap_options *opts,
                           struct sdap_attr_map *native_map,
@@ -249,6 +252,7 @@ int ldap_get_sudo_options(struct confdb_ctx *cdb,
                           bool *include_netgroups);
 
 int ldap_get_autofs_options(TALLOC_CTX *memctx,
+                            struct ldb_context *ldb,
                             struct confdb_ctx *cdb,
                             const char *conf_path,
                             struct sdap_options *opts);
@@ -398,10 +402,12 @@ struct sdap_domain *sdap_domain_get_by_dn(struct sdap_options *opts,
                                           const char *dn);
 
 errno_t sdap_parse_search_base(TALLOC_CTX *mem_ctx,
+                               struct ldb_context *ldb,
                                struct dp_option *opts, int class,
                                struct sdap_search_base ***_search_bases);
 errno_t common_parse_search_base(TALLOC_CTX *mem_ctx,
                                  const char *unparsed_base,
+                                 struct ldb_context *ldb,
                                  const char *class_name,
                                  const char *old_filter,
                                  struct sdap_search_base ***_search_bases);

--- a/src/providers/ldap/ldap_options.c
+++ b/src/providers/ldap/ldap_options.c
@@ -18,6 +18,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "db/sysdb.h"
 #include "providers/ldap/ldap_common.h"
 #include "providers/ldap/ldap_opts.h"
 #include "providers/ldap/sdap_async_private.h"
@@ -39,6 +40,7 @@ int ldap_get_options(TALLOC_CTX *memctx,
     struct sdap_attr_map *default_iphost_map;
     struct sdap_attr_map *default_ipnetwork_map;
     struct sdap_options *opts;
+    struct ldb_context *ldb;
     char *schema;
     char *pwmodify;
     const char *search_base;
@@ -101,50 +103,52 @@ int ldap_get_options(TALLOC_CTX *memctx,
                   "connecting to the LDAP server.\n");
     }
 
+    ldb = sysdb_ctx_get_ldb(dom->sysdb);
+
     /* Default search */
-    ret = sdap_parse_search_base(opts, opts->basic,
+    ret = sdap_parse_search_base(opts, ldb, opts->basic,
                                  SDAP_SEARCH_BASE,
                                  &opts->sdom->search_bases);
     if (ret != EOK && ret != ENOENT) goto done;
 
     /* User search */
-    ret = sdap_parse_search_base(opts, opts->basic,
+    ret = sdap_parse_search_base(opts, ldb, opts->basic,
                                  SDAP_USER_SEARCH_BASE,
                                  &opts->sdom->user_search_bases);
     if (ret != EOK && ret != ENOENT) goto done;
 
     /* Group search base */
-    ret = sdap_parse_search_base(opts, opts->basic,
+    ret = sdap_parse_search_base(opts, ldb, opts->basic,
                                  SDAP_GROUP_SEARCH_BASE,
                                  &opts->sdom->group_search_bases);
     if (ret != EOK && ret != ENOENT) goto done;
 
     /* Netgroup search */
-    ret = sdap_parse_search_base(opts, opts->basic,
+    ret = sdap_parse_search_base(opts, ldb, opts->basic,
                                  SDAP_NETGROUP_SEARCH_BASE,
                                  &opts->sdom->netgroup_search_bases);
     if (ret != EOK && ret != ENOENT) goto done;
 
     /* Netgroup search */
-    ret = sdap_parse_search_base(opts, opts->basic,
+    ret = sdap_parse_search_base(opts, ldb, opts->basic,
                                  SDAP_HOST_SEARCH_BASE,
                                  &opts->sdom->host_search_bases);
     if (ret != EOK && ret != ENOENT) goto done;
 
     /* Service search */
-    ret = sdap_parse_search_base(opts, opts->basic,
+    ret = sdap_parse_search_base(opts, ldb, opts->basic,
                                  SDAP_SERVICE_SEARCH_BASE,
                                  &opts->sdom->service_search_bases);
     if (ret != EOK && ret != ENOENT) goto done;
 
     /* IP host search */
-    ret = sdap_parse_search_base(opts, opts->basic,
+    ret = sdap_parse_search_base(opts, ldb, opts->basic,
                                  SDAP_IPHOST_SEARCH_BASE,
                                  &opts->sdom->iphost_search_bases);
     if (ret != EOK && ret != ENOENT) goto done;
 
     /* IP network search */
-    ret = sdap_parse_search_base(opts, opts->basic,
+    ret = sdap_parse_search_base(opts, ldb, opts->basic,
                                  SDAP_IPNETWORK_SEARCH_BASE,
                                  &opts->sdom->ipnetwork_search_bases);
     if (ret != EOK && ret != ENOENT) goto done;
@@ -432,6 +436,7 @@ done:
 }
 
 int ldap_get_sudo_options(struct confdb_ctx *cdb,
+                          struct ldb_context *ldb,
                           const char *conf_path,
                           struct sdap_options *opts,
                           struct sdap_attr_map *native_map,
@@ -464,8 +469,8 @@ int ldap_get_sudo_options(struct confdb_ctx *cdb,
               "connecting to the LDAP server.\n");
     }
 
-    ret = sdap_parse_search_base(opts, opts->basic,
-                                 SDAP_SUDO_SEARCH_BASE,
+    ret = sdap_parse_search_base(opts, ldb,
+                                 opts->basic, SDAP_SUDO_SEARCH_BASE,
                                  &opts->sdom->sudo_search_bases);
     if (ret != EOK && ret != ENOENT) {
         DEBUG(SSSDBG_OP_FAILURE, "Could not parse SUDO search base\n");
@@ -491,6 +496,7 @@ int ldap_get_sudo_options(struct confdb_ctx *cdb,
 }
 
 int ldap_get_autofs_options(TALLOC_CTX *memctx,
+                            struct ldb_context *ldb,
                             struct confdb_ctx *cdb,
                             const char *conf_path,
                             struct sdap_options *opts)
@@ -522,7 +528,7 @@ int ldap_get_autofs_options(TALLOC_CTX *memctx,
               "connecting to the LDAP server.\n");
     }
 
-    ret = sdap_parse_search_base(opts, opts->basic,
+    ret = sdap_parse_search_base(opts, ldb, opts->basic,
                                  SDAP_AUTOFS_SEARCH_BASE,
                                  &opts->sdom->autofs_search_bases);
     if (ret != EOK && ret != ENOENT) {
@@ -572,6 +578,7 @@ int ldap_get_autofs_options(TALLOC_CTX *memctx,
 }
 
 errno_t sdap_parse_search_base(TALLOC_CTX *mem_ctx,
+                               struct ldb_context *ldb,
                                struct dp_option *opts, int class,
                                struct sdap_search_base ***_search_bases)
 {
@@ -623,13 +630,14 @@ errno_t sdap_parse_search_base(TALLOC_CTX *mem_ctx,
     unparsed_base = dp_opt_get_string(opts, class);
     if (!unparsed_base || unparsed_base[0] == '\0') return ENOENT;
 
-    return common_parse_search_base(mem_ctx, unparsed_base,
+    return common_parse_search_base(mem_ctx, unparsed_base, ldb,
                                     class_name, old_filter,
                                     _search_bases);
 }
 
 errno_t common_parse_search_base(TALLOC_CTX *mem_ctx,
                                  const char *unparsed_base,
+                                 struct ldb_context *ldb,
                                  const char *class_name,
                                  const char *old_filter,
                                  struct sdap_search_base ***_search_bases)
@@ -637,7 +645,6 @@ errno_t common_parse_search_base(TALLOC_CTX *mem_ctx,
     errno_t ret;
     struct sdap_search_base **search_bases;
     TALLOC_CTX *tmp_ctx;
-    struct ldb_context *ldb;
     struct ldb_dn *ldn;
     struct ldb_parse_tree *tree;
     char **split_bases;
@@ -647,13 +654,6 @@ errno_t common_parse_search_base(TALLOC_CTX *mem_ctx,
 
     tmp_ctx = talloc_new(NULL);
     if (!tmp_ctx) {
-        ret = ENOMEM;
-        goto done;
-    }
-
-    /* Create a throwaway LDB context for validating the DN */
-    ldb = ldb_init(tmp_ctx, NULL);
-    if (!ldb) {
         ret = ENOMEM;
         goto done;
     }
@@ -693,7 +693,7 @@ errno_t common_parse_search_base(TALLOC_CTX *mem_ctx,
                     class_name);
         }
 
-        ret = sdap_create_search_base(search_bases, unparsed_base,
+        ret = sdap_create_search_base(search_bases, ldb, unparsed_base,
                                       LDAP_SCOPE_SUBTREE, old_filter,
                                       &search_bases[0]);
         if (ret != EOK) {
@@ -747,9 +747,9 @@ errno_t common_parse_search_base(TALLOC_CTX *mem_ctx,
                 ret = EINVAL;
                 goto done;
             }
-            talloc_zfree(ldn);
 
             /* Set the search base DN */
+            search_bases[i]->ldb_basedn = talloc_steal(search_bases[i], ldn);
             search_bases[i]->basedn = talloc_strdup(search_bases[i],
                                                     split_bases[c]);
             if (!search_bases[i]->basedn) {

--- a/src/providers/ldap/sdap.c
+++ b/src/providers/ldap/sdap.c
@@ -1131,6 +1131,7 @@ static char *get_naming_context(TALLOC_CTX *mem_ctx,
 
 errno_t
 sdap_create_search_base(TALLOC_CTX *mem_ctx,
+                        struct ldb_context *ldb,
                         const char *unparsed_base,
                         int scope,
                         const char *filter,
@@ -1140,17 +1141,9 @@ sdap_create_search_base(TALLOC_CTX *mem_ctx,
     TALLOC_CTX *tmp_ctx;
     errno_t ret;
     struct ldb_dn *ldn;
-    struct ldb_context *ldb;
 
     tmp_ctx = talloc_new(NULL);
     if (!tmp_ctx) {
-        ret = ENOMEM;
-        goto done;
-    }
-
-    /* Create a throwaway LDB context for validating the DN */
-    ldb = ldb_init(tmp_ctx, NULL);
-    if (!ldb) {
         ret = ENOMEM;
         goto done;
     }
@@ -1168,7 +1161,7 @@ sdap_create_search_base(TALLOC_CTX *mem_ctx,
     }
 
     /* Validate the basedn */
-    ldn = ldb_dn_new(tmp_ctx, ldb, unparsed_base);
+    ldn = ldb_dn_new(base, ldb, unparsed_base);
     if (!ldn) {
         ret = ENOMEM;
         goto done;
@@ -1180,6 +1173,8 @@ sdap_create_search_base(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
+    base->ldb = ldb;
+    base->ldb_basedn = ldn;
     base->scope = scope;
     base->filter = filter;
 
@@ -1243,7 +1238,8 @@ static errno_t sdap_set_search_base(struct sdap_options *opts,
         goto done;
     }
 
-    ret = sdap_parse_search_base(opts, opts->basic, class, bases);
+    ret = sdap_parse_search_base(opts, sysdb_ctx_get_ldb(sdom->dom->sysdb),
+                                 opts->basic, class, bases);
     if (ret != EOK) goto done;
 
     ret = EOK;

--- a/src/providers/ldap/sdap.h
+++ b/src/providers/ldap/sdap.h
@@ -463,6 +463,7 @@ struct sdap_domain {
     struct sdap_search_base **iphost_search_bases;
     struct sdap_search_base **ipnetwork_search_bases;
     struct sdap_search_base **autofs_search_bases;
+    struct sdap_search_base **ignore_user_search_bases;
 #ifdef BUILD_SUBID
     struct sdap_search_base **subid_ranges_search_bases;
 #endif

--- a/src/providers/ldap/sdap.h
+++ b/src/providers/ldap/sdap.h
@@ -22,6 +22,7 @@
 #ifndef _SDAP_H_
 #define _SDAP_H_
 
+#include <ldb.h>
 #include "providers/backend.h"
 #include <ldap.h>
 #include "util/sss_ldap.h"
@@ -420,12 +421,15 @@ struct sdap_attr_map {
 
 struct sdap_search_base {
     const char *basedn;
+    struct ldb_context *ldb;
+    struct ldb_dn *ldb_basedn;
     int scope;
     const char *filter;
 };
 
 errno_t
 sdap_create_search_base(TALLOC_CTX *mem_ctx,
+                        struct ldb_context *ldb,
                         const char *unparsed_base,
                         int scope,
                         const char *filter,

--- a/src/providers/ldap/sdap_autofs.c
+++ b/src/providers/ldap/sdap_autofs.c
@@ -469,8 +469,8 @@ errno_t sdap_autofs_init(TALLOC_CTX *mem_ctx,
 
     DEBUG(SSSDBG_TRACE_INTERNAL, "Initializing autofs LDAP back end\n");
 
-    ret = ldap_get_autofs_options(id_ctx, be_ctx->cdb, be_ctx->conf_path,
-                                  id_ctx->opts);
+    ret = ldap_get_autofs_options(id_ctx, sysdb_ctx_get_ldb(be_ctx->domain->sysdb),
+                                  be_ctx->cdb, be_ctx->conf_path, id_ctx->opts);
     if (ret != EOK) {
         return ret;
     }

--- a/src/providers/ldap/sdap_domain.c
+++ b/src/providers/ldap/sdap_domain.c
@@ -200,7 +200,8 @@ sdap_domain_subdom_add(struct sdap_id_ctx *sdap_id_ctx,
         }
         sdom->search_bases[1] = NULL;
 
-        ret = sdap_create_search_base(sdom, sdom->basedn, LDAP_SCOPE_SUBTREE,
+        ret = sdap_create_search_base(sdom, sysdb_ctx_get_ldb(dom->sysdb),
+                                      sdom->basedn, LDAP_SCOPE_SUBTREE,
                                       NULL, &sdom->search_bases[0]);
         if (ret) {
             DEBUG(SSSDBG_OP_FAILURE, "Cannot create new sdap search base\n");

--- a/src/providers/ldap/sdap_sudo.c
+++ b/src/providers/ldap/sdap_sudo.c
@@ -183,8 +183,9 @@ errno_t sdap_sudo_init(TALLOC_CTX *mem_ctx,
 
     sudo_ctx->id_ctx = id_ctx;
 
-    ret = ldap_get_sudo_options(be_ctx->cdb, be_ctx->conf_path, id_ctx->opts,
-                                native_map,
+    ret = ldap_get_sudo_options(be_ctx->cdb,
+                                sysdb_ctx_get_ldb(be_ctx->domain->sysdb),
+                                be_ctx->conf_path, id_ctx->opts, native_map,
                                 &sudo_ctx->use_host_filter,
                                 &sudo_ctx->include_regexp,
                                 &sudo_ctx->include_netgroups);

--- a/src/tests/cmocka/test_nested_groups.c
+++ b/src/tests/cmocka/test_nested_groups.c
@@ -20,6 +20,7 @@
 
 #include <talloc.h>
 #include <tevent.h>
+#include <ldb.h>
 #include <errno.h>
 #include <popt.h>
 
@@ -56,6 +57,8 @@ bool _dp_target_enabled(struct data_provider *provider,
 #define OBJECT_BASE_DN "cn=objects,dc=test,dc=com"
 #define GROUP_BASE_DN "cn=groups," OBJECT_BASE_DN
 #define USER_BASE_DN "cn=users," OBJECT_BASE_DN
+#define EXCLUDE_BASE_DN "cn=exclude," USER_BASE_DN
+#define BAD_BASE_DN "cn=bad," USER_BASE_DN
 
 struct nested_groups_test_ctx {
     struct sss_test_ctx *tctx;
@@ -224,6 +227,83 @@ static void nested_groups_test_one_group_unique_members(void **state)
 
     ret = test_ev_loop(test_ctx->tctx);
     assert_true(check_leaks_pop(req_mem_ctx) == true);
+    talloc_zfree(req_mem_ctx);
+
+    /* check return code */
+    assert_int_equal(ret, ERR_OK);
+
+    /* Check the users */
+    assert_int_equal(test_ctx->num_users, N_ELEMENTS(expected));
+    assert_int_equal(test_ctx->num_groups, 1);
+
+    compare_sysdb_string_array_noorder(test_ctx->users,
+                                       expected, N_ELEMENTS(expected));
+}
+
+static void nested_groups_test_one_group_unique_members_one_ignored(void **state)
+{
+    struct nested_groups_test_ctx *test_ctx = NULL;
+    struct sdap_search_base **ignore;
+    struct sysdb_attrs *rootgroup = NULL;
+    struct tevent_req *req = NULL;
+    TALLOC_CTX *req_mem_ctx = NULL;
+    errno_t ret;
+    const char *users[] = { "cn=user1," USER_BASE_DN,
+                            "cn=user2," EXCLUDE_BASE_DN,
+                            NULL };
+    const struct sysdb_attrs *user1_reply[2] = { NULL };
+    const char * expected[] = { "user1" };
+
+
+    test_ctx = talloc_get_type_abort(*state, struct nested_groups_test_ctx);
+
+    /* mock return values */
+    rootgroup = mock_sysdb_group_rfc2307bis(test_ctx, GROUP_BASE_DN, 1000,
+                                            "rootgroup", users);
+
+    /* Set the exclude bases */
+    ignore = talloc_zero_array(test_ctx, struct sdap_search_base *, 3);
+    assert_non_null(ignore);
+
+    ignore[0] = talloc_zero(ignore, struct sdap_search_base);
+    assert_non_null(ignore[0]);
+    ignore[0]->basedn = BAD_BASE_DN;
+    ignore[0]->ldb_basedn = ldb_dn_new(ignore[0],
+                                       sysdb_ctx_get_ldb(test_ctx->tctx->sysdb),
+                                       ignore[0]->basedn);
+    assert_non_null(ignore[0]->ldb_basedn);
+
+    ignore[1] = talloc_zero(ignore, struct sdap_search_base);
+    assert_non_null(ignore[1]);
+    ignore[1]->basedn = EXCLUDE_BASE_DN;
+    ignore[1]->ldb_basedn = ldb_dn_new(ignore[1],
+                                       sysdb_ctx_get_ldb(test_ctx->tctx->sysdb),
+                                       ignore[1]->basedn);
+    assert_non_null(ignore[1]->ldb_basedn);
+
+    test_ctx->sdap_domain->ignore_user_search_bases = ignore;
+
+    user1_reply[0] = mock_sysdb_user(test_ctx, USER_BASE_DN, 2001, "user1");
+    assert_non_null(user1_reply[0]);
+    will_return(sdap_get_generic_recv, 1);
+    will_return(sdap_get_generic_recv, user1_reply);
+    will_return(sdap_get_generic_recv, ERR_OK);
+
+    sss_will_return_always(sdap_has_deref_support, false);
+
+    /* run test, check for memory leaks */
+    req_mem_ctx = talloc_new(global_talloc_context);
+    assert_non_null(req_mem_ctx);
+    check_leaks_push(req_mem_ctx);
+
+    req = sdap_nested_group_send(req_mem_ctx, test_ctx->tctx->ev,
+                                 test_ctx->sdap_domain, test_ctx->sdap_opts,
+                                 test_ctx->sdap_handle, rootgroup);
+    assert_non_null(req);
+    tevent_req_set_callback(req, nested_groups_test_done, test_ctx);
+
+    ret = test_ev_loop(test_ctx->tctx);
+    assert_true(check_leaks_pop(req_mem_ctx));
     talloc_zfree(req_mem_ctx);
 
     /* check return code */
@@ -1293,6 +1373,7 @@ int main(int argc, const char *argv[])
     const struct CMUnitTest tests[] = {
         new_test(one_group_no_members),
         new_test(one_group_unique_members),
+        new_test(one_group_unique_members_one_ignored),
         new_test(one_group_dup_users),
         new_test(one_group_unique_group_members),
         new_test(one_group_dup_group_members),

--- a/src/tests/cmocka/test_sdap.c
+++ b/src/tests/cmocka/test_sdap.c
@@ -212,7 +212,7 @@ char *__wrap_ldap_next_attribute(LDAP *ld,
 }
 
 /* Mock parsing search base without overlinking the test */
-errno_t sdap_parse_search_base(TALLOC_CTX *mem_ctx,
+errno_t sdap_parse_search_base(TALLOC_CTX *mem_ctx, struct ldb_context *ldb,
                                struct dp_option *opts, int class,
                                struct sdap_search_base ***_search_bases)
 {
@@ -983,6 +983,7 @@ static struct sdap_domain *create_sdap_domain(struct sdap_options *opts,
 {
     errno_t ret;
     struct sdap_domain *sdom;
+    struct ldb_context *ldb;
 
     ret = sdap_domain_add(opts, dom, &sdom);
     assert_int_equal(ret, EOK);
@@ -991,7 +992,10 @@ static struct sdap_domain *create_sdap_domain(struct sdap_options *opts,
     assert_non_null(sdom->search_bases);
     sdom->search_bases[1] = NULL;
 
-    ret = sdap_create_search_base(sdom, sdom->basedn,
+    ldb = ldb_init(sdom, NULL);
+    assert_non_null(ldb);
+
+    ret = sdap_create_search_base(sdom, ldb, sdom->basedn,
                                   LDAP_SCOPE_SUBTREE,
                                   NULL,
                                   &sdom->search_bases[0]);

--- a/src/tests/cmocka/test_sdap_initgr.c
+++ b/src/tests/cmocka/test_sdap_initgr.c
@@ -460,7 +460,9 @@ static void test_user_is_from_another_domain(void **state)
     assert_non_null(other_sdom->search_bases);
     other_sdom->search_bases[1] = NULL;
 
-    ret = sdap_create_search_base(other_sdom, object_bases[2],
+    ret = sdap_create_search_base(other_sdom,
+                                  sysdb_ctx_get_ldb(dom_info->sysdb),
+                                  object_bases[2],
                                   LDAP_SCOPE_SUBTREE, NULL,
                                   &other_sdom->search_bases[0]);
     assert_int_equal(ret, EOK);

--- a/src/tests/ipa_ldap_opt-tests.c
+++ b/src/tests/ipa_ldap_opt-tests.c
@@ -50,6 +50,7 @@ struct test_domain test_domains[] = {
 
 /* Mock parsing search base without overlinking the test */
 errno_t sdap_parse_search_base(TALLOC_CTX *mem_ctx,
+                               struct ldb_context *ldb,
                                struct dp_option *opts, int class,
                                struct sdap_search_base ***_search_bases)
 {


### PR DESCRIPTION
 SDAP: Ignore the cn=views entries in nested groups

When resolving the nested groups, any entry in `cn=views,cn=accounts,$BASEDN` (or whatever the user configured using `ipa_views_search_base`) must be ignored.

A test was added for this case.

Resolves: https://github.com/SSSD/sssd/issues/6548
