### PR TITLE
Removing unnecessary restart for non root pipelines

### DIFF
--- a/src/tests/multihost/ad/conftest.py
+++ b/src/tests/multihost/ad/conftest.py
@@ -778,7 +778,6 @@ def setup_session(request, session_multihost):
         master.update_resolv_conf(session_multihost.ad[0].ip)
     client.client_install_pkgs()
     client.update_resolv_conf(session_multihost.ad[0].ip)
-    client.clear_sssd_cache()
     client.systemsssdauth(realm, ad_host)
 
     def teardown_session():


### PR DESCRIPTION
This allows us to do minimal changes to run existing tests, not as the root user. Testing the non root feature of SSSD. Adding an ansible play that creates a stub configuration file in /etc/sssd/conf.d/ i.e. /etc/sssd/conf.d/nonroot.conf containing

[sssd]
user = sssd

This sssd restart happens before SSSD is configured and when it contains the stub file, it is an invalid configuration.

Signed-off-by: Dan Lavu <dlavu@redhat.com>