### PR TITLE
MONITOR: fix `socket_activated` flag initialization

### DIFF
--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -242,7 +242,6 @@ get_service_in_the_list(struct mt_ctx *mt_ctx,
 
     for (svc = mt_ctx->svc_list; svc != NULL; svc = svc->next) {
         if (strcasecmp(svc->identity, svc_name) == 0) {
-            svc->socket_activated = false;
             *_svc = svc;
             return EOK;
         }
@@ -1801,6 +1800,8 @@ static int start_service(struct mt_svc *svc)
     struct timeval tv;
 
     DEBUG(SSSDBG_CONF_SETTINGS,"Queueing service %s for startup\n", svc->name);
+
+    svc->socket_activated = false;
 
     tv = tevent_timeval_current();
 


### PR DESCRIPTION
When socket activated service connects for a first time, it is added to `mt_ctx->svc_list` by `socket_activated_service_not_found()` with a proper `socket_activated = true`.
But when it reconnects again, `get_service_in_the_list()` finds it in `mt_ctx->svc_list` and overwrites `socket_activated = false` unconditionally. This patch moves moves `socket_activated = false` to `start_service()`.

Resolves: https://github.com/SSSD/sssd/issues/6324