### PR TITLE
certmap: Handle type change of x400Address

### DIFF
--- a/src/external/crypto.m4
+++ b/src/external/crypto.m4
@@ -2,3 +2,29 @@ AC_DEFUN([AM_CHECK_LIBCRYPTO],
          [PKG_CHECK_MODULES([CRYPTO],[libcrypto])
           PKG_CHECK_MODULES([SSL],[libssl])
 ])
+
+AC_MSG_CHECKING([whether OpenSSL's x400Address is ASN1_STRING])
+SAVE_CFLAGS=$CFLAGS
+CFLAGS="$CFLAGS -Werror -Wall -Wextra"
+AC_COMPILE_IFELSE(
+                  [AC_LANG_SOURCE([
+                      #include <openssl/x509v3.h>
+
+                      int main(void)
+                      {
+                          GENERAL_NAME gn = { 0 };
+
+                          return ASN1_STRING_length(gn.d.x400Address);
+                      }
+                  ])],
+                  [
+                      AC_MSG_RESULT([yes])
+                      AC_DEFINE([HAVE_X400ADDRESS_STRING],
+                             [1],
+                             [whether OpenSSL's x400Address is ASN1_STRING])],
+                  [
+                      AC_MSG_RESULT([no])
+                      AC_MSG_WARN([OpenSSL's x400Address is not of ASN1_STRING type])
+                  ])
+
+CFLAGS=$SAVE_CFLAGS

--- a/src/lib/certmap/sss_cert_content_crypto.c
+++ b/src/lib/certmap/sss_cert_content_crypto.c
@@ -662,10 +662,11 @@ static int get_san(TALLOC_CTX *mem_ctx, X509 *cert, struct san_list **san_list)
                 goto done;
             }
 
-            /* i2d_TYPE increment the second argument so that it points to the end of
-             * the written data hence we cannot use i->bin_val directly. */
+            /* i2d_EDIPARTYNAME increment the second argument so that it points
+             * to the end of the written data hence we cannot use data directly.
+             */
             p = data;
-            len = i2d_EDIPARTYNAME(current->d.ediPartyName, &data);
+            len = i2d_EDIPARTYNAME(current->d.ediPartyName, &p);
 
             ret = add_to_san_list(mem_ctx, true,
                                   openssl_name_type_to_san_opt(current->type),


### PR DESCRIPTION
Due to CVE-2023-0286 the type of the x400Address member of the
GENERAL_NAME struct was changed from ASN1_TYPE to ASN1_STRING. The
following patch tries to make sure that the x400Address can be extracted
from the certificate in either case.