### PR TITLE
SSSDConfig: use 'setuptools' instead of 'distutils'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5475,13 +5475,15 @@ install-exec-hook: installsssddirs
 if BUILD_PYTHON2_BINDINGS
 	if [ "$(DESTDIR)" = "" ]; then \
 		cd $(builddir)/src/config; \
-		$(PYTHON2) setup.py build --build-base $(abs_builddir)/src/config \
-			install $(DISTSETUPOPTS) --prefix=$(PYTHON2_PREFIX) \
+		$(MKDIR_P) "$(python2dir)"; \
+		PYTHONPATH="$(PYTHONPATH):$(python2dir)" $(PYTHON2) setup.py build \
+			--build-base $(abs_builddir)/src/config install $(DISTSETUPOPTS) --prefix=$(PYTHON2_PREFIX) \
 			--record=$(abs_builddir)/src/config/.files2; \
 	else \
 		cd $(builddir)/src/config; \
-		$(PYTHON2) setup.py build --build-base $(abs_builddir)/src/config \
-			install $(DISTSETUPOPTS) --prefix=$(PYTHON2_PREFIX) \
+		$(MKDIR_P) "$(python2dir)"; \
+		PYTHONPATH="$(PYTHONPATH):$(python2dir)" $(PYTHON2) setup.py build \
+			--build-base $(abs_builddir)/src/config install $(DISTSETUPOPTS) --prefix=$(PYTHON2_PREFIX) \
 			--record=$(abs_builddir)/src/config/.files2 --root=$(DESTDIR); \
 	fi
 	cd $(DESTDIR)$(py2execdir) && \
@@ -5493,13 +5495,15 @@ endif
 if BUILD_PYTHON3_BINDINGS
 	if [ "$(DESTDIR)" = "" ]; then \
 		cd $(builddir)/src/config; \
-		$(PYTHON3) setup.py build --build-base $(abs_builddir)/src/config \
-			install $(DISTSETUPOPTS) --prefix=$(PYTHON3_PREFIX) \
+		$(MKDIR_P) "$(python3dir)"; \
+		PYTHONPATH="$(PYTHONPATH):$(python3dir)" $(PYTHON3) setup.py build \
+			--build-base $(abs_builddir)/src/config install $(DISTSETUPOPTS) --prefix=$(PYTHON3_PREFIX) \
 			--record=$(abs_builddir)/src/config/.files3; \
 	else \
 		cd $(builddir)/src/config; \
-		$(PYTHON3) setup.py build --build-base $(abs_builddir)/src/config \
-			install $(DISTSETUPOPTS) --prefix=$(PYTHON3_PREFIX) \
+		$(MKDIR_P) "$(python3dir)"; \
+		PYTHONPATH="$(PYTHONPATH):$(python3dir)" $(PYTHON3) setup.py build \
+			--build-base $(abs_builddir)/src/config install $(DISTSETUPOPTS) --prefix=$(PYTHON3_PREFIX) \
 			--record=$(abs_builddir)/src/config/.files3 --root=$(DESTDIR); \
 	fi
 	cd $(DESTDIR)$(py3execdir) && \
@@ -5563,10 +5567,16 @@ uninstall-hook:
 if BUILD_PYTHON2_BINDINGS
 	cd $(DESTDIR)$(py2execdir) && \
 		rm -f pysss.so pyhbac.so pysss_murmur.so pysss_nss_idmap.so
+	rm -fr "$(DESTDIR)$(python2dir)/easy-install.pth"
+	rm -fr "$(DESTDIR)$(python2dir)/__pycache__"
+	rm -fr "$(DESTDIR)$(python2dir)/site.py"
 endif
 if BUILD_PYTHON3_BINDINGS
 	cd $(DESTDIR)$(py3execdir) && \
 		rm -f pysss.so pyhbac.so pysss_murmur.so pysss_nss_idmap.so
+	rm -fr "$(DESTDIR)$(python3dir)/easy-install.pth"
+	rm -fr "$(DESTDIR)$(python3dir)/__pycache__"
+	rm -fr "$(DESTDIR)$(python3dir)/site.py"
 endif
 if BUILD_SAMBA
 	rm $(DESTDIR)/$(winbindplugindir)/sss.so

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -144,7 +144,7 @@ BuildRequires: pcre2-devel
 BuildRequires: pkgconfig
 BuildRequires: popt-devel
 BuildRequires: python3-devel
-BuildRequires: (python3-setuptools if python3 >= 3.12)
+BuildRequires: python3-setuptools
 BuildRequires: samba-devel
 # required for idmap_sss.so
 BuildRequires: samba-winbind

--- a/src/config/setup.py.in
+++ b/src/config/setup.py.in
@@ -19,10 +19,10 @@
 #
 
 """
-Python-level packaging using distutils.
+Python-level packaging using setuptools.
 """
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='SSSDConfig',


### PR DESCRIPTION
The Python standard library distutils module will be removed from Python 3.12+