### PR TITLE
krb5: add joined/parent domain to [domain_realm]

### DIFF
--- a/src/tests/cmocka/test_utils.c
+++ b/src/tests/cmocka/test_utils.c
@@ -2140,6 +2140,8 @@ static void test_sss_get_domain_mappings_content(void **state)
     assert_int_equal(ret, EOK);
     assert_string_equal(content,
                         "[domain_realm]\n"
+                        ".configured.dom = CONFIGURED.DOM\n"
+                        "configured.dom = CONFIGURED.DOM\n"
                         ".subdom1.dom = SUBDOM1.DOM\n"
                         "subdom1.dom = SUBDOM1.DOM\n"
                         ".subdom2.dom = SUBDOM2.DOM\n"
@@ -2165,6 +2167,8 @@ static void test_sss_get_domain_mappings_content(void **state)
     assert_int_equal(ret, EOK);
     assert_string_equal(content,
                         "[domain_realm]\n"
+                        ".configured.dom = CONFIGURED.DOM\n"
+                        "configured.dom = CONFIGURED.DOM\n"
                         ".subdom1.dom = SUBDOM1.DOM\n"
                         "subdom1.dom = SUBDOM1.DOM\n"
                         ".subdom2.dom = SUBDOM2.DOM\n"

--- a/src/util/domain_info_utils.c
+++ b/src/util/domain_info_utils.c
@@ -316,11 +316,17 @@ errno_t sss_get_domain_mappings_content(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    /* This loops skips the starting parent and start rigth with the first
-     * subdomain. Although in all the interesting cases (AD and IPA) the
-     * default is that realm and DNS domain are the same strings (expect case)
-     * and no domain_realm mapping is needed we might consider to add this
-     * domain here as well to cover corner cases? */
+    /* Start with the parent domain */
+    o = talloc_asprintf_append(o, ".%s = %s\n%s = %s\n",
+                              domain->name, domain->realm, domain->name,
+                              domain->realm);
+    if (o == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "talloc_asprintf_append failed.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+    /* This loops skips the starting parent and starts right with the first
+     * subdomain, if any. */
     for (dom = get_next_domain(domain, SSS_GND_DESCEND);
                 dom && IS_SUBDOMAIN(dom); /* if we get back to a parent, stop */
                 dom = get_next_domain(dom, 0)) {


### PR DESCRIPTION
So far only discovered sub-domains were adding to the [domain_realm]
section of one of the krb5 config snippets SSSD is generating. To fix
recent issues which were caused my missing entries of the joined domain
this domain is now added as well.

Resolves: https://github.com/SSSD/sssd/issues/6600