### PR TITLE
Passkey: Use correct User verification comparison

### DIFF
--- a/src/responder/pam/pamsrv_passkey.c
+++ b/src/responder/pam/pamsrv_passkey.c
@@ -287,13 +287,10 @@ static errno_t check_passkey_verification(TALLOC_CTX *mem_ctx,
 
     /* If require user verification setting is set in LDAP, use it */
     if (verification_from_ldap != NULL) {
-        if (strcmp(verification_from_ldap, "on") == 0) {
+        if (strcasecmp(verification_from_ldap, "true") == 0) {
             verification = PAM_PASSKEY_VERIFICATION_ON;
-        } else if (strcmp(verification_from_ldap, "off") == 0) {
+        } else if (strcasecmp(verification_from_ldap, "false") == 0) {
             verification = PAM_PASSKEY_VERIFICATION_OFF;
-        /* Else, default, don't specify user-verification arg */
-        } else {
-            verification = PAM_PASSKEY_VERIFICATION_OMIT;
         }
         DEBUG(SSSDBG_TRACE_FUNC, "Passkey verification is being enforced from LDAP\n");
     } else {


### PR DESCRIPTION
IPA require user verification configuration value changed from "on, off, default" to a boolean value of "True" or "False". This broke authentication with user verification set to false  and no PIN set on device.

We also don't need the else clause here.