### PR TITLE
Add readthedocs configuration to build system test documenation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,16 @@
+version: 2
+sphinx:
+  configuration: src/tests/system/docs/conf.py
+python:
+  install:
+  - requirements: src/tests/system/docs/requirements.txt
+build:
+  os: ubuntu-22.04
+  apt_packages:
+  - libldap2-dev
+  - libsasl2-dev
+  - libssl-dev
+  - python3-dev
+  tools:
+    python: '3.11'
+formats: []

--- a/src/tests/system/docs/requirements.txt
+++ b/src/tests/system/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx >= 3.0
 sphinx_rtd_theme >= 1.1.0
 sphinx_design
+-r ../requirements.txt


### PR DESCRIPTION
This will allow us to create readthedocs project to host the documentation
for system test. Once it is done, I will make it available under tests.sssd.io.