### PR TITLE
Tests: Add a remedy for a missing multihost_dir.

### DIFF
--- a/src/tests/multihost/admultidomain/conftest.py
+++ b/src/tests/multihost/admultidomain/conftest.py
@@ -4,9 +4,12 @@ from __future__ import print_function
 import subprocess
 import random
 import pytest
-from sssd.testlib.common.qe_class import session_multihost
 from sssd.testlib.common.paths import SSSD_DEFAULT_CONF
 from sssd.testlib.common.utils import sssdTools
+
+pytest_plugins = (
+    'sssd.testlib.common.fixtures',
+)
 
 
 def pytest_configure():
@@ -148,7 +151,7 @@ def clear_sssd_cache(session_multihost):
 
 # ################### Session scoped fixtures #########################
 @pytest.fixture(scope="session", autouse=True)
-def setup_session(request, session_multihost):
+def setup_session(request, session_multihost, create_testdir):
     """ Setup Session """
     client = sssdTools(session_multihost.client[0])
     realm = session_multihost.ad[1].realm

--- a/src/tests/multihost/basic/conftest.py
+++ b/src/tests/multihost/basic/conftest.py
@@ -1,4 +1,3 @@
-from sssd.testlib.common.qe_class import session_multihost
 from sssd.testlib.common.libkrb5 import krb5srv
 from sssd.testlib.common.utils import sssdTools, PkiTools
 from sssd.testlib.common.utils import LdapOperations
@@ -6,6 +5,7 @@ from sssd.testlib.common.libdirsrv import DirSrvWrap
 from sssd.testlib.common.exceptions import PkiLibException
 from sssd.testlib.common.exceptions import LdapException
 from sssd.testlib.common.exceptions import SSSDException
+
 import pytest
 try:
     import ConfigParser
@@ -15,6 +15,9 @@ import os
 import tempfile
 import ldap
 
+pytest_plugins = (
+    'sssd.testlib.common.fixtures',
+)
 
 def pytest_configure():
     pytest.num_masters = 1
@@ -447,7 +450,8 @@ def setup_session(request, session_multihost,
                   setup_ldap,
                   setup_kerberos,
                   create_posix_usersgroups,
-                  enable_oddjob):
+                  enable_oddjob,
+                  create_testdir):
     """ Run all session scoped fixtures """
     # pylint: disable=unused-argument
     _pytest_fixture = [package_install, run_authselect,

--- a/src/tests/multihost/sssd/testlib/common/fixtures.py
+++ b/src/tests/multihost/sssd/testlib/common/fixtures.py
@@ -1,0 +1,109 @@
+import pytest
+from pytest_multihost import make_multihost_fixture
+
+from .qe_class import QeConfig
+
+
+@pytest.fixture(scope="session", autouse=True)
+def session_multihost(request):
+    # pylint: disable=no-member
+    """Multihost plugin fixture for session scope"""
+    if pytest.num_ad > 0:
+        mhost = make_multihost_fixture(request, descriptions=[
+            {
+                'type': 'sssd',
+                'hosts':
+                {
+                    'master': pytest.num_masters,
+                    'atomic': pytest.num_atomic,
+                    'replica': pytest.num_replicas,
+                    'client': pytest.num_clients,
+                    'other': pytest.num_others,
+                }
+            },
+            {
+                'type': 'ad',
+                'hosts':
+                {
+                    'ad': pytest.num_ad,
+                },
+            },
+        ], config_class=QeConfig,)
+    else:
+        mhost = make_multihost_fixture(request, descriptions=[
+            {
+                'type': 'sssd',
+                'hosts':
+                {
+                    'master': pytest.num_masters,
+                    'atomic': pytest.num_atomic,
+                    'replica': pytest.num_replicas,
+                    'client': pytest.num_clients,
+                    'other': pytest.num_others,
+                }
+            },
+        ], config_class=QeConfig,)
+    mhost.domain = mhost.config.domains[0]
+    mhost.master = mhost.domain.hosts_by_role('master')
+    mhost.atomic = mhost.domain.hosts_by_role('atomic')
+    mhost.replica = mhost.domain.hosts_by_role('replica')
+    mhost.client = mhost.domain.hosts_by_role('client')
+    mhost.others = mhost.domain.hosts_by_role('other')
+
+    if pytest.num_ad > 0:
+        mhost.ad = []
+        for i in range(1, pytest.num_ad + 1):
+            print(i)
+            print(mhost.config.domains[i].hosts_by_role('ad'))
+            mhost.ad.extend(mhost.config.domains[i].hosts_by_role('ad'))
+
+    yield mhost
+
+
+@pytest.fixture(scope='session', autouse=True)
+def create_testdir(session_multihost, request):
+    """
+    Create test dir on the hosts and backup resolv.conf
+    @param session_multihost: Multihost fixture
+    @param request: Pytest request
+    """
+    print(f"Testdir is '{session_multihost.config.test_dir}'")
+    test_dir = session_multihost.config.test_dir if \
+        session_multihost.config.test_dir else '/root/multihost_tests'
+    config_dir_cmd = f"mkdir -p {test_dir}"
+    env_file_cmd = f"touch {test_dir}/env.sh"
+    rm_config_cmd = f"rm -rf {test_dir}"
+    ad_test_dir = '/home/Administrator'
+    ad_config_dir_cmd = f"mkdir -p {ad_test_dir}"
+    ad_env_file_cmd = f"touch {ad_test_dir}/env.sh"
+    ad_rm_config_cmd = f"rm -rf {ad_test_dir}"
+    bkup_resolv_conf = 'cp -a /etc/resolv.conf /etc/resolv.conf.orig'
+    restore_resolv_conf = 'cp -a /etc/resolv.conf.orig /etc/resolv.conf'
+
+    for machine in session_multihost.atomic + session_multihost.others +\
+            session_multihost.replica:
+        machine.run_command(config_dir_cmd)
+        machine.run_command(env_file_cmd)
+
+    for machine in session_multihost.client + session_multihost.master:
+        machine.run_command(config_dir_cmd)
+        machine.run_command(env_file_cmd)
+        machine.run_command(bkup_resolv_conf)
+
+    for machine in session_multihost.ad:
+        machine.run_command(ad_config_dir_cmd)
+        machine.run_command(ad_env_file_cmd)
+
+    def remove_test_dir():
+        for machine in session_multihost.client + session_multihost.master:
+            machine.run_command(rm_config_cmd)
+            machine.run_command(restore_resolv_conf)
+
+        for machine in session_multihost.atomic + session_multihost.others +\
+                session_multihost.replica:
+            machine.run_command(config_dir_cmd)
+
+        for machine in session_multihost.ad:
+            machine.run_command(ad_rm_config_cmd)
+
+    request.addfinalizer(remove_test_dir)


### PR DESCRIPTION
Move the create_testdir fixture to fixtures.py and make sure that it is used. Extend it to create testdir and env.sh also on windows machines.

Reviewed-by: Dan Lavu <dlavu@redhat.com>