### PR TITLE
LDAP: Handle MIT LDAP KDB password expiry

### DIFF
--- a/src/providers/ldap/ldap_auth.c
+++ b/src/providers/ldap/ldap_auth.c
@@ -100,7 +100,10 @@ static errno_t check_pwexpire_kerberos(const char *expire_date, time_t now,
            "daylight [%d] now [%ld] expire_time [%ld].\n", tzname[0],
            tzname[1], timezone, daylight, now, expire_time);
 
-    if (difftime(now, expire_time) > 0.0) {
+    if (expire_time == 0) {
+        /* Used by the MIT LDAP KDB plugin to indicate "never" */
+        ret = EOK;
+    } else if (difftime(now, expire_time) > 0.0) {
         DEBUG(SSSDBG_CONF_SETTINGS, "Kerberos password expired.\n");
         if (pd != NULL) {
             ret = add_expired_warning(pd, 0);


### PR DESCRIPTION
Currently SSSD only treats a missing krbPasswordExpiration attribute as an indication that a given password never expires (which is how the FreeIPA KDB plugin handles the expiry). The MIT implementation, however, treats *either* a missing attribute *or* a zero attribute as meaning that the password doesn't expire.

$ kadmin getprinc bob
Principal: bob@EXAMPLE.COM
...
Password expiration date: [never]
...
$ ldapsearch -Z -x -LLL "(uid=bob)" | grep krbPasswordExpiration
krbPasswordExpiration: 19700101000000Z

Note that 19700101000000Z == (time_t)0

Resolves: https://github.com/SSSD/sssd/issues/6612