### PR TITLE
Remove the need for a keytab when using fast with anonymous pkinit

### DIFF
--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -3682,15 +3682,18 @@ static krb5_error_code privileged_krb5_setup(struct krb5_req *kr,
 
     if (!(offline ||
             (kr->fast_val == K5C_FAST_NEVER && kr->validate == false))) {
-        kerr = copy_keytab_into_memory(kr, kr->ctx, kr->keytab, &mem_keytab,
-                                       NULL);
-        if (kerr != 0) {
-            DEBUG(SSSDBG_OP_FAILURE, "copy_keytab_into_memory failed.\n");
-            return kerr;
-        }
+        /* A Keytab is not used if fast with anonymous pkinit is used (and validate is false)*/
+        if(!(kr->cli_opts->fast_use_anonymous_pkinit == true && kr->validate == false)){
+            kerr = copy_keytab_into_memory(kr, kr->ctx, kr->keytab, &mem_keytab,
+                                        NULL);
+            if (kerr != 0) {
+                DEBUG(SSSDBG_OP_FAILURE, "copy_keytab_into_memory failed.\n");
+                return kerr;
+            }
 
-        talloc_free(kr->keytab);
-        kr->keytab = mem_keytab;
+            talloc_free(kr->keytab);
+            kr->keytab = mem_keytab;
+        }
 
         if (kr->fast_val != K5C_FAST_NEVER) {
             kerr = k5c_setup_fast(kr, kr->fast_val == K5C_FAST_DEMAND);


### PR DESCRIPTION
I created an issue describing the reason for the change: https://github.com/SSSD/sssd/issues/6531

In short, SSSD supports fast with anonymous pkinit. Anonymous pkinit does not need a keytab file to function. However, the current sssd source always attempts to copy a keytab into memory when fast is being used even if anonymous pkinit is being used. If the keytab file is missing, sssd will crash and authentication will not work.