### PR TITLE
Tests: Make sure that session_multihost.ad is always available.

### DIFF
--- a/src/tests/multihost/sssd/testlib/common/fixtures.py
+++ b/src/tests/multihost/sssd/testlib/common/fixtures.py
@@ -49,6 +49,7 @@ def session_multihost(request):
     mhost.replica = mhost.domain.hosts_by_role('replica')
     mhost.client = mhost.domain.hosts_by_role('client')
     mhost.others = mhost.domain.hosts_by_role('other')
+    mhost.ad = []
 
     if pytest.num_ad > 0:
         mhost.ad = []


### PR DESCRIPTION
We need it to be defined at least as an empty list so we do not get an AtributeError when we try to iterate over it.