### PR TITLE
ad: skip filtering if ad_enabled_domains is set

### DIFF
--- a/src/man/sssd-ad.5.xml
+++ b/src/man/sssd-ad.5.xml
@@ -158,10 +158,18 @@ ldap_id_mapping = False
                     <term>ad_enabled_domains (string)</term>
                     <listitem>
                         <para>
-                            A comma-separated list of enabled Active Directory domains.
-                            If provided, SSSD will ignore any domains not listed in this
-                            option. If left unset, all domains from the AD forest will
-                            be available.
+                            A comma-separated list of enabled Active Directory
+                            domains. If provided, SSSD will ignore any domains
+                            not listed in this option. If left unset, all
+                            discovered domains from the AD forest will be
+                            available.
+                        </para>
+                        <para>
+                            During the discovery of the domains SSSD will
+                            filter out some domains where flags or attributes
+                            indicate that they do not belong to the local
+                            forest or are not trusted. If ad_enabled_domains is
+                            set, SSSD will try to enable all listed domains.
                         </para>
                         <para>
                             For proper operation, this option must be specified in all

--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -1524,12 +1524,19 @@ static void ad_get_root_domain_done(struct tevent_req *subreq)
         goto done;
     }
 
-    ret = ad_filter_domains(state, unfiltered_reply, unfiltered_reply_count,
-                            &state->reply, &state->reply_count);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "Failed to filter list of returned domains.\n");
-        goto done;
+    if (state->sd_ctx->ad_enabled_domains == NULL) {
+        ret = ad_filter_domains(state, unfiltered_reply, unfiltered_reply_count,
+                                &state->reply, &state->reply_count);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "Failed to filter list of returned domains.\n");
+            goto done;
+        }
+    } else {
+        DEBUG(SSSDBG_TRACE_ALL,
+              "ad_enabled_domains is set, skipping domain filtering.\n");
+        state->reply_count = unfiltered_reply_count;
+        state->reply = unfiltered_reply;
     }
 
     if (state->reply_count == 0

--- a/src/tests/multihost/basic/test_ldapapi.py
+++ b/src/tests/multihost/basic/test_ldapapi.py
@@ -19,7 +19,7 @@ def set_ldap_uri(multihost):
     master = sssdTools(multihost.master[0])
     domain_params = {'ldap_uri': ldap_uri}
     master.sssd_conf(f'domain/{domain_name}', domain_params)
-    multihost.client[0].service_sssd('restart')
+    multihost.master[0].service_sssd('restart')
 
 
 @pytest.mark.usefixtures("set_ldap_uri")


### PR DESCRIPTION
The domain filtering based on LDAP attributes might be too strict in
forests which have a long and complex history where not all attributes
might be updated to reflect the current state, e.g. membership to the
local forest. To skip the filtering the ad_enabled_domains attribute can
be set to the list of expected domains.

Resolves: https://github.com/SSSD/sssd/issues/6626