### PR TITLE
Add passkey kerberos preauthentication support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4648,6 +4648,7 @@ krb5_child_SOURCES = \
     src/sss_client/common.c \
     src/krb5_plugin/common/utils.c \
     src/krb5_plugin/idp/idp_utils.c \
+    src/krb5_plugin/passkey/passkey_utils.c \
     $(NULL)
 krb5_child_CFLAGS = \
     $(AM_CFLAGS) \
@@ -4664,6 +4665,7 @@ krb5_child_LDADD = \
     $(CLIENT_LIBS) \
     $(SYSTEMD_LOGIN_LIBS) \
     $(JANSSON_LIBS) \
+    libsss_sbus.la \
     $(NULL)
 
 ldap_child_SOURCES = \

--- a/Makefile.am
+++ b/Makefile.am
@@ -322,7 +322,7 @@ non_interactive_cmocka_based_tests += test_kcm_renewals
 endif # BUILD_KCM_RENEWAL
 
 if BUILD_PASSKEY
-non_interactive_cmocka_based_tests += test_passkey
+non_interactive_cmocka_based_tests += test_passkey test_krb5_passkey_plugin
 endif # BUILD_PASSKEY
 
 
@@ -916,6 +916,9 @@ dist_noinst_HEADERS = \
     src/p11_child/p11_child.h \
     src/oidc_child/oidc_child_util.h \
     src/passkey_child/passkey_child.h \
+    src/krb5_plugin/common/radius_kdcpreauth.h \
+    src/krb5_plugin/common/radius_clpreauth.h \
+    src/krb5_plugin/common/utils.h \
     $(NULL)
 
 
@@ -3908,6 +3911,21 @@ test_krb5_idp_plugin_LDADD = \
     $(JANSSON_LIBS) \
     $(NULL)
 
+if BUILD_PASSKEY
+test_krb5_passkey_plugin_SOURCES = \
+    src/tests/cmocka/test_krb5_passkey_plugin.c \
+    src/krb5_plugin/common/utils.c \
+    src/krb5_plugin/passkey/passkey_utils.c \
+    $(NULL)
+test_krb5_passkey_plugin_CFLAGS = \
+    $(AM_CFLAGS) \
+    $(NULL)
+test_krb5_passkey_plugin_LDADD = \
+    $(CMOCKA_LIBS) \
+    $(JANSSON_LIBS) \
+    $(NULL)
+endif # BUILD_PASSKEY
+
 if BUILD_KCM_RENEWAL
 test_kcm_renewals_SOURCES = \
 	$(TEST_MOCK_RESP_OBJ) \
@@ -4888,6 +4906,35 @@ sssd_krb5_idp_plugin_la_LDFLAGS = \
 
 dist_noinst_HEADERS += src/krb5_plugin/idp/idp.h
 dist_krb5snippets_DATA += src/krb5_plugin/idp/sssd_enable_idp
+
+if BUILD_PASSKEY
+krb5_plugin_LTLIBRARIES += sssd_krb5_passkey_plugin.la
+
+sssd_krb5_passkey_plugin_la_SOURCES = \
+    src/krb5_plugin/common/utils.c \
+    src/krb5_plugin/common/radius_kdcpreauth.c \
+    src/krb5_plugin/common/radius_clpreauth.c \
+    src/krb5_plugin/passkey/passkey_clpreauth.c \
+    src/krb5_plugin/passkey/passkey_kdcpreauth.c \
+    src/krb5_plugin/passkey/passkey_utils.c \
+    $(NULL)
+sssd_krb5_passkey_plugin_la_CFLAGS = \
+    $(AM_CFLAGS) \
+    $(KRB5_CFLAGS) \
+    $(NULL)
+sssd_krb5_passkey_plugin_la_LIBADD = \
+    $(KRB5_LIBS) \
+    $(KRAD_LIBS) \
+    $(JANSSON_LIBS) \
+    $(NULL)
+sssd_krb5_passkey_plugin_la_LDFLAGS = \
+    -avoid-version \
+    -module \
+    $(NULL)
+
+dist_noinst_HEADERS += src/krb5_plugin/passkey/passkey.h
+dist_krb5snippets_DATA += src/krb5_plugin/passkey/sssd_enable_passkey
+endif # BUILD_PASSKEY
 
 sssd_pac_plugin_la_SOURCES = \
     src/sss_client/sssd_pac.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -3852,7 +3852,10 @@ test_passkey_LDFLAGS = \
     -Wl,-wrap,fido_assert_authdata_ptr \
     -Wl,-wrap,fido_assert_authdata_len \
     -Wl,-wrap,fido_assert_sig_ptr \
-    -Wl,-wrap,fido_assert_sig_len
+    -Wl,-wrap,fido_assert_sig_len \
+    -Wl,-wrap,fido_assert_set_count \
+    -Wl,-wrap,fido_assert_set_authdata \
+    -Wl,-wrap,fido_assert_set_sig
 test_passkey_LDADD = \
     $(CMOCKA_LIBS) \
     $(SSSD_LIBS) \

--- a/Makefile.am
+++ b/Makefile.am
@@ -3848,7 +3848,11 @@ test_passkey_LDFLAGS = \
     -Wl,-wrap,fido_assert_set_clientdata_hash \
     -Wl,-wrap,fido_dev_get_assert \
     -Wl,-wrap,fido_dev_is_fido2 \
-    -Wl,-wrap,fido_assert_verify
+    -Wl,-wrap,fido_assert_verify \
+    -Wl,-wrap,fido_assert_authdata_ptr \
+    -Wl,-wrap,fido_assert_authdata_len \
+    -Wl,-wrap,fido_assert_sig_ptr \
+    -Wl,-wrap,fido_assert_sig_len
 test_passkey_LDADD = \
     $(CMOCKA_LIBS) \
     $(SSSD_LIBS) \
@@ -3856,6 +3860,7 @@ test_passkey_LDADD = \
     $(LIBADD_DL) \
     $(PASSKEY_LIBS) \
     libsss_test_common.la \
+    $(JANSSON_LIBS) \
     $(NULL)
 endif # BUILD_PASSKEY
 
@@ -4801,6 +4806,7 @@ passkey_child_LDADD = \
     $(PASSKEY_LIBS) \
     $(SSSD_INTERNAL_LTLIBS) \
     $(CRYPTO_LIBS) \
+    $(JANSSON_LIBS) \
     $(NULL)
 endif # BUILD_PASSKEY
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -3901,6 +3901,7 @@ test_kcm_queue_LDADD = \
 
 test_krb5_idp_plugin_SOURCES = \
     src/tests/cmocka/test_krb5_idp_plugin.c \
+    src/krb5_plugin/common/utils.c \
     src/krb5_plugin/idp/idp_utils.c \
     $(NULL)
 test_krb5_idp_plugin_CFLAGS = \
@@ -4637,6 +4638,7 @@ krb5_child_SOURCES = \
     src/util/become_user.c \
     src/util/util_errors.c \
     src/sss_client/common.c \
+    src/krb5_plugin/common/utils.c \
     src/krb5_plugin/idp/idp_utils.c \
     $(NULL)
 krb5_child_CFLAGS = \
@@ -4886,6 +4888,9 @@ krb5_plugin_LTLIBRARIES = \
     $(NULL)
 
 sssd_krb5_idp_plugin_la_SOURCES = \
+    src/krb5_plugin/common/utils.c \
+    src/krb5_plugin/common/radius_clpreauth.c \
+    src/krb5_plugin/common/radius_kdcpreauth.c \
     src/krb5_plugin/idp/idp_clpreauth.c \
     src/krb5_plugin/idp/idp_kdcpreauth.c \
     src/krb5_plugin/idp/idp_utils.c \

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -530,7 +530,7 @@ Requires: sssd-common = %{version}-%{release}
 Requires: libfido2
 
 %description passkey
-This package provides helper processes and plugins that are required to
+This package provides helper processes and Kerberos plugins that are required to
 enable authentication with passkey token.
 %endif
 
@@ -606,6 +606,12 @@ cp $RPM_BUILD_ROOT/%{_datadir}/sssd-kcm/kcm_default_ccache \
 # Enable krb5 idp plugins by default (when sssd-idp package is installed)
 cp $RPM_BUILD_ROOT/%{_datadir}/sssd/krb5-snippets/sssd_enable_idp \
    $RPM_BUILD_ROOT/%{_sysconfdir}/krb5.conf.d/sssd_enable_idp
+
+# Enable krb5 passkey plugins by default (when sssd-passkey package is installed)
+%if %{build_passkey}
+cp $RPM_BUILD_ROOT/%{_datadir}/sssd/krb5-snippets/sssd_enable_passkey \
+   $RPM_BUILD_ROOT/%{_sysconfdir}/krb5.conf.d/sssd_enable_passkey
+%endif
 
 # krb5 configuration snippet
 cp $RPM_BUILD_ROOT/%{_datadir}/sssd/krb5-snippets/enable_sssd_conf_dir \
@@ -1014,6 +1020,9 @@ done
 %if %{build_passkey}
 %files passkey
 %attr(755,%{sssd_user},%{sssd_user}) %{_libexecdir}/%{servicename}/passkey_child
+%{_libdir}/%{name}/modules/sssd_krb5_passkey_plugin.so
+%{_datadir}/sssd/krb5-snippets/sssd_enable_passkey
+%config(noreplace) %{_sysconfdir}/krb5.conf.d/sssd_enable_passkey
 %endif
 
 %if 0%{?rhel}

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -152,7 +152,7 @@
 #define CONFDB_PAM_GSSAPI_INDICATORS_MAP "pam_gssapi_indicators_map"
 #define CONFDB_PAM_PASSKEY_AUTH "pam_passkey_auth"
 #define CONFDB_PAM_PASSKEY_CHILD_TIMEOUT "passkey_child_timeout"
-#define CONFDB_PAM_DEBUG_LIBFIDO2 "debug_libfido2"
+#define CONFDB_PAM_PASSKEY_DEBUG_LIBFIDO2 "passkey_debug_libfido2"
 
 /* SUDO */
 #define CONFDB_SUDO_CONF_ENTRY "config/sudo"

--- a/src/config/SSSDConfig/sssdoptions.py
+++ b/src/config/SSSDConfig/sssdoptions.py
@@ -116,7 +116,7 @@ class SSSDOptions(object):
                                        'must be enforced for PAM access with GSSAPI authentication'),
         'pam_passkey_auth': _('Allow passkey device authentication.'),
         'passkey_child_timeout': _('How many seconds will pam_sss wait for passkey_child to finish'),
-        'debug_libfido2': _('Enable debugging in the libfido2 library'),
+        'passkey_debug_libfido2': _('Enable debugging in the libfido2 library'),
 
         # [sudo]
         'sudo_timed': _('Whether to evaluate the time-based attributes in sudo rules'),

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -145,7 +145,7 @@ option = pam_gssapi_check_upn
 option = pam_gssapi_indicators_map
 option = pam_passkey_auth
 option = passkey_child_timeout
-option = debug_libfido2
+option = passkey_debug_libfido2
 
 [rule/allowed_sudo_options]
 validator = ini_allowed_options

--- a/src/config/etc/sssd.api.conf
+++ b/src/config/etc/sssd.api.conf
@@ -88,7 +88,7 @@ pam_gssapi_check_upn = bool, None, false
 pam_gssapi_indicators_map = str, None, false
 pam_passkey_auth = bool, None, false
 passkey_child_timeout = int, None, false
-debug_libfido2 = bool, None, false
+passkey_debug_libfido2 = bool, None, false
 
 [sudo]
 # sudo service

--- a/src/krb5_plugin/common/radius_clpreauth.c
+++ b/src/krb5_plugin/common/radius_clpreauth.c
@@ -1,0 +1,46 @@
+/*
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2022 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <krad.h>
+#include <krb5/kdcpreauth_plugin.h>
+
+#include "radius_kdcpreauth.h"
+#include "util/util.h"
+
+void
+sss_radiuscl_init(krb5_context context,
+                  krb5_clpreauth_moddata moddata,
+                  krb5_clpreauth_modreq *modreq_out)
+{
+    return;
+}
+
+void
+sss_radiuscl_fini(krb5_context context,
+                  krb5_clpreauth_moddata moddata,
+                  krb5_clpreauth_modreq modreq)
+{
+    return;
+}

--- a/src/krb5_plugin/common/radius_clpreauth.h
+++ b/src/krb5_plugin/common/radius_clpreauth.h
@@ -1,0 +1,37 @@
+/*
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2022 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _RADIUS_CLPREAUTH_H_
+#define _RADIUS_CLPREAUTH_H_
+
+#include <stdlib.h>
+#include <krb5/preauth_plugin.h>
+
+void
+sss_radiuscl_init(krb5_context context,
+                  krb5_clpreauth_moddata moddata,
+                  krb5_clpreauth_modreq *modreq_out);
+
+void
+sss_radiuscl_fini(krb5_context context,
+                  krb5_clpreauth_moddata moddata,
+                  krb5_clpreauth_modreq modreq);
+
+#endif /* _RADIUS_CLPREAUTH_H_ */

--- a/src/krb5_plugin/common/radius_kdcpreauth.c
+++ b/src/krb5_plugin/common/radius_kdcpreauth.c
@@ -1,0 +1,611 @@
+/*
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2022 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <krad.h>
+#include <krb5/kdcpreauth_plugin.h>
+
+#include "krb5_plugin/common/radius_kdcpreauth.h"
+#include "krb5_plugin/common/utils.h"
+#include "util/util.h"
+
+krb5_error_code
+sss_radiuskdc_init(const char *plugin_name,
+                   krb5_context kctx,
+                   krb5_kdcpreauth_moddata *_moddata,
+                   const char **_realmnames)
+{
+    struct sss_radiuskdc_state *state;
+
+    state = malloc(sizeof(struct sss_radiuskdc_state));
+    if (state == NULL) {
+        return ENOMEM;
+    }
+
+    state->plugin_name = plugin_name;
+
+    /* IPA is the only consumer so far so it is fine to hardcode the values. */
+    state->server = KRB5_KDC_RUNDIR "/DEFAULT.socket";
+    state->secret = "";
+    state->timeout = 5 * 1000;
+    state->retries = 3;
+
+    *_moddata = (krb5_kdcpreauth_moddata)state;
+
+    return 0;
+}
+
+void
+sss_radiuskdc_fini(krb5_context kctx,
+                   krb5_kdcpreauth_moddata moddata)
+{
+    struct sss_radiuskdc_state *state;
+
+    state = (struct sss_radiuskdc_state *)moddata;
+
+    if (state == NULL) {
+        return;
+    }
+
+    free(state);
+}
+
+int
+sss_radiuskdc_flags(krb5_context kctx,
+                    krb5_preauthtype pa_type)
+{
+    return PA_REPLACES_KEY;
+}
+
+krb5_error_code
+sss_radiuskdc_return_padata(krb5_context kctx,
+                            krb5_pa_data *padata,
+                            krb5_data *req_pkt,
+                            krb5_kdc_req *request,
+                            krb5_kdc_rep *reply,
+                            krb5_keyblock *encrypting_key,
+                            krb5_pa_data **send_pa_out,
+                            krb5_kdcpreauth_callbacks cb,
+                            krb5_kdcpreauth_rock rock,
+                            krb5_kdcpreauth_moddata moddata,
+                            krb5_kdcpreauth_modreq modreq)
+{
+    struct sss_radiuskdc_state *state;
+    krb5_keyblock *armor_key;
+    bool *result;
+
+    state = (struct sss_radiuskdc_state *)moddata;
+    result = (bool *)modreq;
+
+    /* This should not happen. */
+    if (state == NULL) {
+        return EINVAL;
+    }
+
+    /* Verification was not successful. Do not replace the key. */
+    if (result == NULL || *result == false) {
+        return 0;
+    }
+
+    /* Get the armor key. */
+    armor_key = cb->fast_armor(kctx, rock);
+    if (armor_key == NULL) {
+        com_err(state->plugin_name, ENOENT,
+                "No armor key found when returning padata");
+        return ENOENT;
+    }
+
+    /* Replace the reply key with the FAST armor key. */
+    krb5_free_keyblock_contents(kctx, encrypting_key);
+    return krb5_copy_keyblock_contents(kctx, armor_key, encrypting_key);
+}
+
+krb5_error_code
+sss_radiuskdc_enabled(const char *config_name,
+                      krb5_context kctx,
+                      krb5_kdcpreauth_callbacks cb,
+                      krb5_kdcpreauth_rock rock,
+                      char **_config)
+{
+    krb5_error_code ret;
+    char *config;
+
+    ret = cb->get_string(kctx, rock, config_name, &config);
+    if (ret != 0) {
+        return ret;
+    }
+
+    /* Disabled. */
+    if (config == NULL) {
+        return ENOENT;
+    }
+
+    /* Enabled. Return the config string. */
+    *_config = config;
+
+    return 0;
+}
+
+void
+sss_radiuskdc_config_free(struct sss_radiuskdc_config *config)
+{
+    if (config == NULL) {
+        return;
+    }
+
+    free(config->username);
+    free(config->server);
+    free(config->secret);
+    free(config);
+}
+
+krb5_error_code
+sss_radiuskdc_config_init(struct sss_radiuskdc_state *state,
+                          krb5_context kctx,
+                          krb5_const_principal princ,
+                          const char *configstr,
+                          struct sss_radiuskdc_config **_config)
+{
+    struct sss_radiuskdc_config *config;
+    krb5_error_code ret;
+    char *username;
+
+    if (state == NULL) {
+        return EINVAL;
+    }
+
+    config = malloc(sizeof(struct sss_radiuskdc_config));
+    if (config == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+    memset(config, 0, sizeof(struct sss_radiuskdc_config));
+
+    config->server = strdup(state->server);
+    config->secret = strdup(state->secret);
+    config->retries = state->retries;
+    config->timeout = state->timeout;
+
+    if (config->server == NULL || config->secret == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = krb5_unparse_name_flags(kctx, princ, 0, &username);
+    if (ret != 0) {
+        goto done;
+    }
+
+    config->username = strdup(username);
+    krb5_free_unparsed_name(kctx, username);
+    if (config->username == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    *_config = config;
+    ret = 0;
+
+done:
+    if (ret != 0) {
+        sss_radiuskdc_config_free(config);
+    }
+
+    return ret;
+}
+
+krb5_error_code
+sss_radiuskdc_set_cookie(krb5_context context,
+                         krb5_kdcpreauth_callbacks cb,
+                         krb5_kdcpreauth_rock rock,
+                         krb5_preauthtype pa_type,
+                         const krb5_data *state)
+{
+    krb5_data cookie;
+    unsigned int len;
+    uint8_t *blob;
+    size_t pctr;
+
+    len = sizeof(uint16_t) + state->length;
+    blob = malloc(len);
+    if (blob == NULL) {
+        return ENOMEM;
+    }
+
+    pctr = 0;
+    SAFEALIGN_SET_UINT16(&blob[pctr], 1, &pctr);
+    SAFEALIGN_SET_STRING(&blob[pctr], state->data, state->length, &pctr);
+
+    cookie.magic = 0;
+    cookie.data = (char *)blob;
+    cookie.length = len;
+
+    return cb->set_cookie(context, rock, pa_type, &cookie);
+}
+
+krb5_error_code
+sss_radiuskdc_get_cookie(krb5_context context,
+                         krb5_kdcpreauth_callbacks cb,
+                         krb5_kdcpreauth_rock rock,
+                         krb5_preauthtype pa_type,
+                         krb5_data *_state)
+{
+    uint16_t version;
+    krb5_data cookie;
+    krb5_data state;
+    size_t pctr;
+
+    if (!cb->get_cookie(context, rock, pa_type, &cookie)) {
+        return KRB5KDC_ERR_PREAUTH_FAILED;
+    }
+
+    if (cookie.length < sizeof(uint16_t)) {
+        return EINVAL;
+    }
+
+    pctr = 0;
+    SAFEALIGN_COPY_UINT16(&version, cookie.data, &pctr);
+    state.magic = 0;
+    state.data = &cookie.data[pctr];
+    state.length = cookie.length - sizeof(uint16_t);
+
+    *_state = state;
+
+    return 0;
+}
+
+
+/* Some attributes have limited length. In order to accept longer values,
+ * we will concatenate all attribute values to single krb5_data. */
+krb5_error_code
+sss_radiuskdc_get_complete_attr(const krad_packet *rres,
+                                const char *attr_name,
+                                krb5_data *_data)
+{
+    krad_attr attr = krad_attr_name2num(attr_name);
+    const krb5_data *rmsg;
+    krb5_data data = {0};
+    unsigned int memindex;
+    unsigned int i;
+
+    i = 0;
+    do {
+        rmsg = krad_packet_get_attr(rres, attr, i);
+        if (rmsg != NULL) {
+            data.length += rmsg->length;
+        }
+        i++;
+    } while (rmsg != NULL);
+
+    if (data.length == 0) {
+        return ENOENT;
+    }
+
+    data.data = malloc(data.length);
+    if (data.data == NULL) {
+        return ENOMEM;
+    }
+
+    i = 0;
+    memindex = 0;
+    do {
+        rmsg = krad_packet_get_attr(rres, attr, i);
+        if (rmsg != NULL) {
+            memcpy(&data.data[memindex], rmsg->data, rmsg->length);
+            memindex += rmsg->length;
+        }
+        i++;
+    } while (rmsg != NULL);
+
+    if (memindex != data.length) {
+        free(data.data);
+        return ERANGE;
+    }
+
+    *_data = data;
+
+    return 0;
+}
+
+/* From krad internals, RFC 2865 */
+#ifndef UCHAR_MAX
+#define UCHAR_MAX 255
+#endif
+#define MAX_ATTRSIZE (UCHAR_MAX - 2)
+
+krb5_error_code
+sss_radiuskdc_put_complete_attr(krad_attrset *attrset,
+                                krad_attr attr,
+                                const krb5_data *datap)
+{
+    krb5_data state = {0};
+    char *p = datap->data;
+    unsigned int len = datap->length;
+    krb5_error_code ret = 0;
+
+    do {
+        /* - 5 to make sure we fit into minimal value length */
+        state.data = p;
+        state.length = MIN(MAX_ATTRSIZE - 5, len);
+        p += state.length;
+
+        ret = krad_attrset_add(attrset, attr, &(state));
+        if (ret != 0) {
+            break;
+        }
+        len -= state.length;
+    } while (len > 0);
+
+    return ret;
+}
+
+char *
+sss_radiuskdc_get_attr_as_string(const krad_packet *packet, const char *attr)
+{
+    krb5_data data = {0};
+    krb5_error_code ret;
+    char *str;
+
+    ret = sss_radiuskdc_get_complete_attr(packet, attr, &data);
+    if (ret != 0) {
+        return NULL;
+    }
+
+    str = strndup(data.data, data.length);
+    free(data.data);
+
+    return str;
+}
+
+krb5_error_code
+sss_radiuskdc_set_attr_as_string(krad_attrset *attrset,
+                                 const char *attr,
+                                 const char *value)
+{
+    krb5_data data = {0};
+    krb5_error_code ret;
+
+    data.data = discard_const(value);
+    data.length = strlen(value) + 1;
+
+    ret = sss_radiuskdc_put_complete_attr(attrset,
+                                          krad_attr_name2num(attr),
+                                          &data);
+
+    return ret;
+}
+
+void
+sss_radiuskdc_client_free(struct sss_radiuskdc_client *client)
+{
+    if (client == NULL) {
+        return;
+    }
+
+    krad_client_free(client->client);
+    krad_attrset_free(client->attrs);
+    free(client);
+}
+
+struct sss_radiuskdc_client *
+sss_radiuskdc_client_init(krb5_context kctx,
+                          verto_ctx *vctx,
+                          struct sss_radiuskdc_config *config)
+{
+    struct sss_radiuskdc_client *client;
+    char hostname[HOST_NAME_MAX + 1];
+    krb5_data data = {0};
+    krb5_error_code ret;
+
+    client = malloc(sizeof(struct sss_radiuskdc_client));
+    if (client == NULL) {
+        return NULL;
+    }
+    memset(client, 0, sizeof(struct sss_radiuskdc_client));
+
+    ret = krad_client_new(kctx, vctx, &client->client);
+    if (ret != 0) {
+        goto fail;
+    }
+
+    ret = krad_attrset_new(kctx, &client->attrs);
+    if (ret != 0) {
+        goto fail;
+    }
+
+    ret = gethostname(hostname, sizeof(hostname) / sizeof(char));
+    if (ret != 0) {
+        goto fail;
+    }
+
+    data.data = hostname;
+    data.length = strlen(hostname);
+    ret = krad_attrset_add(client->attrs, krad_attr_name2num("NAS-Identifier"),
+                           &data);
+    if (ret != 0) {
+        goto fail;
+    }
+
+    ret = krad_attrset_add_number(client->attrs, krad_attr_name2num("Service-Type"),
+                                  KRAD_SERVICE_TYPE_AUTHENTICATE_ONLY);
+    if (ret != 0) {
+        goto fail;
+    }
+
+    data.data = config->username;
+    data.length = strlen(config->username);
+    ret = krad_attrset_add(client->attrs, krad_attr_name2num("User-Name"),
+                           &data);
+    if (ret != 0) {
+        goto fail;
+    }
+
+    return client;
+
+fail:
+    sss_radiuskdc_client_free(client);
+    return NULL;
+}
+
+void
+sss_radiuskdc_challenge_free(struct sss_radiuskdc_challenge *state)
+{
+    if (state == NULL) {
+        return;
+    }
+
+    sss_radiuskdc_client_free(state->client);
+    free(state);
+}
+
+struct sss_radiuskdc_challenge *
+sss_radiuskdc_challenge_init(krb5_context kctx,
+                             krb5_kdcpreauth_callbacks cb,
+                             krb5_kdcpreauth_rock rock,
+                             krb5_kdcpreauth_edata_respond_fn respond,
+                             void *arg,
+                             struct sss_radiuskdc_config *config)
+{
+    struct sss_radiuskdc_challenge *state;
+
+    state = malloc(sizeof(struct sss_radiuskdc_challenge));
+    if (state == NULL) {
+        return NULL;
+    }
+    memset(state, 0, sizeof(struct sss_radiuskdc_challenge));
+
+    state->kctx = kctx;
+    state->cb = cb;
+    state->rock = rock;
+    state->respond = respond;
+    state->arg = arg;
+
+    state->client = sss_radiuskdc_client_init(kctx,
+                                              cb->event_context(kctx, rock),
+                                              config);
+    if (state->client == NULL) {
+        sss_radiuskdc_challenge_free(state);
+        return NULL;
+    }
+
+    return state;
+}
+
+void
+sss_radiuskdc_verify_free(struct sss_radiuskdc_verify *state)
+{
+    if (state == NULL) {
+        return;
+    }
+
+    sss_string_array_free(state->indicators);
+    sss_radiuskdc_client_free(state->client);
+    free(state);
+}
+
+struct sss_radiuskdc_verify *
+sss_radiuskdc_verify_init(krb5_context kctx,
+                          krb5_kdcpreauth_rock rock,
+                          krb5_kdcpreauth_callbacks cb,
+                          krb5_enc_tkt_part *enc_tkt_reply,
+                          krb5_kdcpreauth_verify_respond_fn respond,
+                          void *arg,
+                          char **indicators,
+                          struct sss_radiuskdc_config *config)
+{
+    struct sss_radiuskdc_verify *state;
+
+    state = malloc(sizeof(struct sss_radiuskdc_verify));
+    if (state == NULL) {
+        return NULL;
+    }
+    memset(state, 0, sizeof(struct sss_radiuskdc_verify));
+
+    state->kctx = kctx;
+    state->rock = rock;
+    state->cb = cb;
+    state->enc_tkt_reply = enc_tkt_reply;
+    state->respond = respond;
+    state->arg = arg;
+
+    state->indicators = sss_string_array_copy(indicators);
+    if (state->indicators == NULL) {
+        sss_radiuskdc_verify_free(state);
+        return NULL;
+    }
+
+    state->client = sss_radiuskdc_client_init(kctx,
+                                              cb->event_context(kctx, rock),
+                                              config);
+    if (state->client == NULL) {
+        sss_radiuskdc_verify_free(state);
+        return NULL;
+    }
+
+    return state;
+}
+
+void
+sss_radiuskdc_verify_done(krb5_error_code rret,
+                          const krad_packet *rreq,
+                          const krad_packet *rres,
+                          void *data)
+{
+    static bool verify_success = true;
+    static bool verify_failure = false;
+    struct sss_radiuskdc_verify *state;
+    krb5_kdcpreauth_modreq modreq;
+    krb5_error_code ret;
+    int i;
+
+    state = (struct sss_radiuskdc_verify *)data;
+    modreq = (krb5_kdcpreauth_modreq)&verify_failure;
+
+    if (rret != 0) {
+        ret = rret;
+        goto done;
+    }
+
+    if (krad_packet_get_code(rres) != krad_code_name2num("Access-Accept")) {
+        ret = KRB5_PREAUTH_FAILED;
+        goto done;
+    }
+
+    state->enc_tkt_reply->flags |= TKT_FLG_PRE_AUTH;
+
+    for (i = 0; state->indicators[i] != NULL; i++) {
+        ret = state->cb->add_auth_indicator(state->kctx, state->rock,
+                                            state->indicators[i]);
+        if (ret != 0) {
+            goto done;
+        }
+    }
+
+    modreq = (krb5_kdcpreauth_modreq)&verify_success;
+    ret = 0;
+
+done:
+    state->respond(state->arg, ret, modreq, NULL, NULL);
+    sss_radiuskdc_verify_free(state);
+}

--- a/src/krb5_plugin/common/radius_kdcpreauth.h
+++ b/src/krb5_plugin/common/radius_kdcpreauth.h
@@ -1,0 +1,185 @@
+/*
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2022 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _RADIUS_KDCPREAUTH_H_
+#define _RADIUS_KDCPREAUTH_H_
+
+#include <stdlib.h>
+#include <krb5/preauth_plugin.h>
+
+struct sss_radiuskdc_state {
+    const char *plugin_name;
+    const char *server;
+    const char *secret;
+    size_t retries;
+    int timeout;
+};
+
+struct sss_radiuskdc_config {
+    char *username;
+    char *server;
+    char *secret;
+    size_t retries;
+    int timeout;
+};
+
+struct sss_radiuskdc_client {
+    krad_client *client;
+    krad_attrset *attrs;
+};
+
+struct sss_radiuskdc_challenge {
+    struct sss_radiuskdc_client *client;
+
+    krb5_context kctx;
+    krb5_kdcpreauth_callbacks cb;
+    krb5_kdcpreauth_rock rock;
+    krb5_kdcpreauth_edata_respond_fn respond;
+    void *arg;
+};
+
+struct sss_radiuskdc_verify {
+    struct sss_radiuskdc_client *client;
+    char **indicators;
+
+    krb5_context kctx;
+    krb5_kdcpreauth_rock rock;
+    krb5_kdcpreauth_callbacks cb;
+    krb5_enc_tkt_part *enc_tkt_reply;
+    krb5_kdcpreauth_verify_respond_fn respond;
+    void *arg;
+};
+
+krb5_error_code
+sss_radiuskdc_init(const char *plugin_name,
+                   krb5_context kctx,
+                   krb5_kdcpreauth_moddata *_moddata,
+                   const char **_realmnames);
+
+void
+sss_radiuskdc_fini(krb5_context kctx,
+                   krb5_kdcpreauth_moddata moddata);
+
+int
+sss_radiuskdc_flags(krb5_context kctx,
+                    krb5_preauthtype pa_type);
+
+krb5_error_code
+sss_radiuskdc_return_padata(krb5_context kctx,
+                            krb5_pa_data *padata,
+                            krb5_data *req_pkt,
+                            krb5_kdc_req *request,
+                            krb5_kdc_rep *reply,
+                            krb5_keyblock *encrypting_key,
+                            krb5_pa_data **send_pa_out,
+                            krb5_kdcpreauth_callbacks cb,
+                            krb5_kdcpreauth_rock rock,
+                            krb5_kdcpreauth_moddata moddata,
+                            krb5_kdcpreauth_modreq modreq);
+
+krb5_error_code
+sss_radiuskdc_enabled(const char *config_name,
+                      krb5_context kctx,
+                      krb5_kdcpreauth_callbacks cb,
+                      krb5_kdcpreauth_rock rock,
+                      char **_config);
+
+void
+sss_radiuskdc_config_free(struct sss_radiuskdc_config *config);
+
+krb5_error_code
+sss_radiuskdc_config_init(struct sss_radiuskdc_state *state,
+                          krb5_context kctx,
+                          krb5_const_principal princ,
+                          const char *configstr,
+                          struct sss_radiuskdc_config **_config);
+
+krb5_error_code
+sss_radiuskdc_set_cookie(krb5_context context,
+                         krb5_kdcpreauth_callbacks cb,
+                         krb5_kdcpreauth_rock rock,
+                         krb5_preauthtype pa_type,
+                         const krb5_data *state);
+
+krb5_error_code
+sss_radiuskdc_get_cookie(krb5_context context,
+                         krb5_kdcpreauth_callbacks cb,
+                         krb5_kdcpreauth_rock rock,
+                         krb5_preauthtype pa_type,
+                         krb5_data *_state);
+
+krb5_error_code
+sss_radiuskdc_get_complete_attr(const krad_packet *rres,
+                                const char *attr_name,
+                                krb5_data *_data);
+
+krb5_error_code
+sss_radiuskdc_put_complete_attr(krad_attrset *attrset,
+                                krad_attr attr,
+                                const krb5_data *datap);
+
+char *
+sss_radiuskdc_get_attr_as_string(const krad_packet *packet, const char *attr);
+
+
+krb5_error_code
+sss_radiuskdc_set_attr_as_string(krad_attrset *attrset,
+                                 const char *attr,
+                                 const char *value);
+
+void
+sss_radiuskdc_client_free(struct sss_radiuskdc_client *client);
+
+struct sss_radiuskdc_client *
+sss_radiuskdc_client_init(krb5_context kctx,
+                          verto_ctx *vctx,
+                          struct sss_radiuskdc_config *config);
+
+void
+sss_radiuskdc_challenge_free(struct sss_radiuskdc_challenge *state);
+
+struct sss_radiuskdc_challenge *
+sss_radiuskdc_challenge_init(krb5_context kctx,
+                             krb5_kdcpreauth_callbacks cb,
+                             krb5_kdcpreauth_rock rock,
+                             krb5_kdcpreauth_edata_respond_fn respond,
+                             void *arg,
+                             struct sss_radiuskdc_config *config);
+
+void
+sss_radiuskdc_verify_free(struct sss_radiuskdc_verify *state);
+
+struct sss_radiuskdc_verify *
+sss_radiuskdc_verify_init(krb5_context kctx,
+                          krb5_kdcpreauth_rock rock,
+                          krb5_kdcpreauth_callbacks cb,
+                          krb5_enc_tkt_part *enc_tkt_reply,
+                          krb5_kdcpreauth_verify_respond_fn respond,
+                          void *arg,
+                          char **indicators,
+                          struct sss_radiuskdc_config *config);
+
+void
+sss_radiuskdc_verify_done(krb5_error_code rret,
+                          const krad_packet *rreq,
+                          const krad_packet *rres,
+                          void *data);
+
+#endif /* _RADIUS_KDCPREAUTH_H_ */

--- a/src/krb5_plugin/common/utils.c
+++ b/src/krb5_plugin/common/utils.c
@@ -1,0 +1,254 @@
+/*
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2021 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <jansson.h>
+#include <krb5/preauth_plugin.h>
+
+#include "krb5_plugin/common/utils.h"
+
+void
+sss_string_array_free(char **array)
+{
+    size_t i;
+
+    if (array == NULL) {
+        return;
+    }
+
+    for (i = 0; array[i] != NULL; i++) {
+        free(array[i]);
+    }
+
+    free(array);
+}
+
+char **
+sss_string_array_copy(char **array)
+{
+    char **copy;
+    size_t i;
+
+    for (i = 0; array[i] != NULL; i++) {
+        /* Just count. */
+    }
+
+    copy = calloc(i + 1, sizeof(char *));
+    if (copy == NULL) {
+        return NULL;
+    }
+
+    for (i = 0; array[i] != NULL; i++) {
+        copy[i] = strdup(array[i]);
+        if (copy[i] == NULL) {
+            sss_string_array_free(copy);
+            return NULL;
+        }
+    }
+
+    copy[i] = NULL;
+
+    return copy;
+}
+
+char **
+sss_json_array_to_strings(json_t *jarray)
+{
+    const char *strval;
+    char **array;
+    json_t *jval;
+    size_t i;
+
+    if (!json_is_array(jarray)) {
+        return NULL;
+    }
+
+    array = calloc(json_array_size(jarray) + 1, sizeof(char *));
+    if (array == NULL) {
+        return NULL;
+    }
+
+    json_array_foreach(jarray, i, jval) {
+        strval = json_string_value(jval);
+        if (strval == NULL) {
+            goto fail;
+        }
+
+        array[i] = strdup(strval);
+        if (array[i] == NULL) {
+            goto fail;
+        }
+    }
+
+    return array;
+
+fail:
+    sss_string_array_free(array);
+
+    return NULL;
+}
+
+json_t *
+sss_strings_to_json_array(char **array)
+{
+    json_t *jarray;
+    json_t *jstr;
+    size_t i;
+    int jret;
+
+    jarray = json_array();
+    if (jarray == NULL) {
+        return NULL;
+    }
+
+    if (array == NULL) {
+        return jarray;
+    }
+
+    for (i = 0; array[i] != NULL; i++) {
+        jstr = json_string(array[i]);
+        if (jstr == NULL) {
+            goto fail;
+        }
+
+        jret = json_array_append_new(jarray, jstr);
+        if (jret != 0) {
+            goto fail;
+        }
+    }
+
+    return jarray;
+
+fail:
+    json_decref(jarray);
+
+    return NULL;
+}
+
+void *
+sss_radius_message_decode(const char *prefix,
+                          sss_radius_message_decode_fn fn,
+                          const char *str)
+{
+    size_t prefix_len;
+
+    if (str == NULL) {
+        return NULL;
+    }
+
+    prefix_len = strlen(prefix);
+    if (strncmp(str, prefix, prefix_len) != 0) {
+        return NULL;
+    }
+
+    return fn(str + prefix_len);
+}
+
+char *
+sss_radius_message_encode(const char *prefix,
+                          sss_radius_message_encode_fn fn,
+                          const void *data)
+{
+    char *json_str;
+    char *str;
+    int aret;
+
+    json_str = fn(data);
+    if (json_str == NULL) {
+        return NULL;
+    }
+
+    aret = asprintf(&str, "%s%s", prefix, json_str);
+    free(json_str);
+    if (aret < 0) {
+        return NULL;
+    }
+
+    return str;
+}
+
+krb5_pa_data *
+sss_radius_encode_padata(krb5_preauthtype patype,
+                         sss_radius_message_encode_fn fn,
+                         const void *data)
+{
+    krb5_pa_data *padata;
+    char *str;
+
+    str = fn(data);
+    if (str == NULL) {
+        return NULL;
+    }
+
+    padata = malloc(sizeof(krb5_pa_data));
+    if (padata == NULL) {
+        free(str);
+        return NULL;
+    }
+
+    padata->pa_type = patype;
+    padata->contents = (krb5_octet*)str;
+    padata->length = strlen(str) + 1;
+
+    return padata;
+}
+
+void *
+sss_radius_decode_padata(sss_radius_message_decode_fn fn,
+                         krb5_pa_data *padata)
+{
+    if (padata->length == 0 || padata->contents == NULL) {
+        return NULL;
+    }
+
+    /* contents is NULL terminated string */
+    if (padata->contents[padata->length - 1] != '\0') {
+        return NULL;
+    }
+
+    return fn((const char*)padata->contents);
+}
+
+krb5_pa_data **
+sss_radius_encode_padata_array(krb5_preauthtype patype,
+                               sss_radius_message_encode_fn fn,
+                               const void *data)
+{
+    krb5_pa_data **array;
+
+    array = calloc(2, sizeof(krb5_pa_data *));
+    if (array == NULL) {
+        return NULL;
+    }
+
+    array[0] = sss_radius_encode_padata(patype, fn, data);
+    array[1] = NULL;
+
+    if (array[0] == NULL) {
+        free(array);
+        return NULL;
+    }
+
+    return array;
+}

--- a/src/krb5_plugin/common/utils.h
+++ b/src/krb5_plugin/common/utils.h
@@ -1,0 +1,68 @@
+/*
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2021 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _KRB5_PLUGIN_UTILS_H_
+#define _KRB5_PLUGIN_UTILS_H_
+
+#include <jansson.h>
+#include <krb5/preauth_plugin.h>
+
+#define is_empty(var) ((var) == NULL || (var)[0] == '\0')
+
+void
+sss_string_array_free(char **array);
+
+char **
+sss_string_array_copy(char **array);
+
+char **
+sss_json_array_to_strings(json_t *jarray);
+
+json_t *
+sss_strings_to_json_array(char **array);
+
+typedef void * (*sss_radius_message_decode_fn)(const char *);
+typedef char * (*sss_radius_message_encode_fn)(const void *);
+
+void *
+sss_radius_message_decode(const char *prefix,
+                          sss_radius_message_decode_fn fn,
+                          const char *str);
+
+char *
+sss_radius_message_encode(const char *prefix,
+                          sss_radius_message_encode_fn fn,
+                          const void *data);
+
+krb5_pa_data *
+sss_radius_encode_padata(krb5_preauthtype patype,
+                         sss_radius_message_encode_fn fn,
+                         const void *data);
+
+void *
+sss_radius_decode_padata(sss_radius_message_decode_fn fn,
+                         krb5_pa_data *padata);
+
+krb5_pa_data **
+sss_radius_encode_padata_array(krb5_preauthtype patype,
+                               sss_radius_message_encode_fn fn,
+                               const void *data);
+
+#endif /* _KRB5_PLUGIN_UTILS_H_ */

--- a/src/krb5_plugin/idp/idp.h
+++ b/src/krb5_plugin/idp/idp.h
@@ -55,9 +55,6 @@ struct sss_idp_oauth2 {
 void
 sss_idp_oauth2_free(struct sss_idp_oauth2 *data);
 
-struct sss_idp_oauth2 *
-sss_idp_oauth2_decode_reply_message(const krb5_data *msg);
-
 krb5_pa_data *
 sss_idp_oauth2_encode_padata(struct sss_idp_oauth2 *data);
 

--- a/src/krb5_plugin/idp/idp_clpreauth.c
+++ b/src/krb5_plugin/idp/idp_clpreauth.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <krb5/clpreauth_plugin.h>
 
+#include "krb5_plugin/common/radius_clpreauth.h"
 #include "idp.h"
 
 static krb5_pa_data **
@@ -87,14 +88,6 @@ sss_idpcl_prompt(krb5_context context,
     free(prompt_str);
 
     return ret;
-}
-
-static void
-sss_idpcl_init(krb5_context context,
-               krb5_clpreauth_moddata moddata,
-               krb5_clpreauth_modreq *modreq_out)
-{
-    return;
 }
 
 static krb5_error_code
@@ -209,14 +202,6 @@ done:
     return ret;
 }
 
-static void
-sss_idpcl_fini(krb5_context context,
-               krb5_clpreauth_moddata moddata,
-               krb5_clpreauth_modreq modreq)
-{
-    return;
-}
-
 krb5_error_code
 clpreauth_idp_initvt(krb5_context context,
                      int maj_ver,
@@ -233,10 +218,10 @@ clpreauth_idp_initvt(krb5_context context,
     vt = (krb5_clpreauth_vtable)vtable;
     vt->name = discard_const(SSSD_IDP_PLUGIN);
     vt->pa_type_list = pa_type_list;
-    vt->request_init = sss_idpcl_init;
+    vt->request_init = sss_radiuscl_init;
     vt->prep_questions = sss_idpcl_prep_questions;
     vt->process = sss_idpcl_process;
-    vt->request_fini = sss_idpcl_fini;
+    vt->request_fini = sss_radiuscl_fini;
     vt->gic_opts = NULL;
 
     return 0;

--- a/src/krb5_plugin/idp/idp_kdcpreauth.c
+++ b/src/krb5_plugin/idp/idp_kdcpreauth.c
@@ -29,23 +29,13 @@
 #include <krb5/kdcpreauth_plugin.h>
 
 #include "shared/safealign.h"
+#include "krb5_plugin/common/radius_kdcpreauth.h"
+#include "krb5_plugin/common/utils.h"
 #include "idp.h"
 #include "util/util.h"
 
-struct sss_idpkdc_state {
-    const char *server;
-    const char *secret;
-    size_t retries;
-    int timeout;
-};
-
 struct sss_idpkdc_config {
-    char *username;
-    char *server;
-    char *secret;
-    size_t retries;
-    int timeout;
-
+    struct sss_radiuskdc_config *radius;
     struct sss_idp_config *idpcfg;
 };
 
@@ -56,15 +46,13 @@ sss_idpkdc_config_free(struct sss_idpkdc_config *config)
         return;
     }
 
+    sss_radiuskdc_config_free(config->radius);
     sss_idp_config_free(config->idpcfg);
-    free(config->username);
-    free(config->server);
-    free(config->secret);
     free(config);
 }
 
 static krb5_error_code
-sss_idpkdc_config_init(struct sss_idpkdc_state *state,
+sss_idpkdc_config_init(struct sss_radiuskdc_state *state,
                        krb5_context kctx,
                        krb5_const_principal princ,
                        const char *configstr,
@@ -72,7 +60,6 @@ sss_idpkdc_config_init(struct sss_idpkdc_state *state,
 {
     struct sss_idpkdc_config *config;
     krb5_error_code ret;
-    char *username;
 
     if (state == NULL) {
         return EINVAL;
@@ -85,30 +72,13 @@ sss_idpkdc_config_init(struct sss_idpkdc_state *state,
     }
     memset(config, 0, sizeof(struct sss_idpkdc_config));
 
+    ret = sss_radiuskdc_config_init(state, kctx, princ, configstr, &config->radius);
+    if (ret != 0) {
+        goto done;
+    }
+
     ret = sss_idp_config_init(configstr, &config->idpcfg);
     if (ret != 0) {
-        goto done;
-    }
-
-    config->server = strdup(state->server);
-    config->secret = strdup(state->secret);
-    config->retries = state->retries;
-    config->timeout = state->timeout;
-
-    if (config->server == NULL || config->secret == NULL) {
-        ret = ENOMEM;
-        goto done;
-    }
-
-    ret = krb5_unparse_name_flags(kctx, princ, 0, &username);
-    if (ret != 0) {
-        goto done;
-    }
-
-    config->username = strdup(username);
-    krb5_free_unparsed_name(kctx, username);
-    if (config->username == NULL) {
-        ret = ENOMEM;
         goto done;
     }
 
@@ -123,260 +93,20 @@ done:
     return ret;
 }
 
-static krb5_error_code
-sss_idpkdc_set_cookie(krb5_context context,
-                      krb5_kdcpreauth_callbacks cb,
-                      krb5_kdcpreauth_rock rock,
-                      const krb5_data *state)
-{
-    krb5_data cookie;
-    unsigned int len;
-    uint8_t *blob;
-    size_t pctr;
-
-    len = sizeof(uint16_t) + state->length;
-    blob = malloc(len);
-    if (blob == NULL) {
-        return ENOMEM;
-    }
-
-    pctr = 0;
-    SAFEALIGN_SET_UINT16(&blob[pctr], 1, &pctr);
-    SAFEALIGN_SET_STRING(&blob[pctr], state->data, state->length, &pctr);
-
-    cookie.magic = 0;
-    cookie.data = (char *)blob;
-    cookie.length = len;
-
-    return cb->set_cookie(context, rock, SSSD_IDP_OAUTH2_PADATA, &cookie);
-}
-
-static krb5_error_code
-sss_idpkdc_get_cookie(krb5_context context,
-                      krb5_kdcpreauth_callbacks cb,
-                      krb5_kdcpreauth_rock rock,
-                      krb5_data *_state)
-{
-    uint16_t version;
-    krb5_data cookie;
-    krb5_data state;
-    size_t pctr;
-
-    if (!cb->get_cookie(context, rock, SSSD_IDP_OAUTH2_PADATA, &cookie)) {
-        return KRB5KDC_ERR_PREAUTH_FAILED;
-    }
-
-    if (cookie.length < sizeof(uint16_t)) {
-        return EINVAL;
-    }
-
-    pctr = 0;
-    SAFEALIGN_COPY_UINT16(&version, cookie.data, &pctr);
-    state.magic = 0;
-    state.data = &cookie.data[pctr];
-    state.length = cookie.length - sizeof(uint16_t);
-
-    *_state = state;
-
-    return 0;
-}
-
-/* Some attributes have limited length. In order to accept longer values,
- * we will concatenate all attribute values to single krb5_data. */
-static krb5_error_code
-sss_idpkdc_get_complete_attr(const krad_packet *rres,
-                             const char *attr_name,
-                             krb5_data *_data)
-{
-    krad_attr attr = krad_attr_name2num(attr_name);
-    const krb5_data *rmsg;
-    krb5_data data = {0};
-    unsigned int memindex;
-    unsigned int i;
-
-    i = 0;
-    do {
-        rmsg = krad_packet_get_attr(rres, attr, i);
-        if (rmsg != NULL) {
-            data.length += rmsg->length;
-        }
-        i++;
-    } while (rmsg != NULL);
-
-    if (data.length == 0) {
-        return ENOENT;
-    }
-
-    data.data = malloc(data.length);
-    if (data.data == NULL) {
-        return ENOMEM;
-    }
-
-    i = 0;
-    memindex = 0;
-    do {
-        rmsg = krad_packet_get_attr(rres, attr, i);
-        if (rmsg != NULL) {
-            memcpy(&data.data[memindex], rmsg->data, rmsg->length);
-            memindex += rmsg->length;
-        }
-        i++;
-    } while (rmsg != NULL);
-
-    if (memindex != data.length) {
-        free(data.data);
-        return ERANGE;
-    }
-
-    *_data = data;
-
-    return 0;
-}
-
-/* From krad internals, RFC 2865 */
-#ifndef UCHAR_MAX
-#define UCHAR_MAX 255
-#endif
-#define MAX_ATTRSIZE (UCHAR_MAX - 2)
-
-static krb5_error_code
-sss_idpkdc_put_complete_attr(krad_attrset *attrset,
-                             krad_attr attr,
-                             const krb5_data *datap)
-{
-    krb5_data state = {0};
-    char *p = datap->data;
-    unsigned int len = datap->length;
-    krb5_error_code ret = 0;
-
-    do {
-        /* - 5 to make sure we fit into minimal value length */
-        state.data = p;
-        state.length = MIN(MAX_ATTRSIZE - 5, len);
-        p += state.length;
-
-        ret = krad_attrset_add(attrset, attr, &(state));
-        if (ret != 0) {
-            break;
-        }
-        len -= state.length;
-    } while (len > 0);
-
-    return ret;
-}
-
-struct sss_idpkdc_radius {
-    krad_client *client;
-    krad_attrset *attrs;
-};
-
-static void
-sss_idpkdc_radius_free(struct sss_idpkdc_radius *radius)
-{
-    if (radius == NULL) {
-        return;
-    }
-
-    krad_client_free(radius->client);
-    krad_attrset_free(radius->attrs);
-    free(radius);
-}
-
-static struct sss_idpkdc_radius *
-sss_idpkdc_radius_init(krb5_context kctx,
-                       verto_ctx *vctx,
-                       struct sss_idpkdc_config *config)
-{
-    struct sss_idpkdc_radius *radius;
-    char hostname[HOST_NAME_MAX + 1];
-    krb5_data data = {0};
-    krb5_error_code ret;
-
-    radius = malloc(sizeof(struct sss_idpkdc_radius));
-    if (radius == NULL) {
-        return NULL;
-    }
-    memset(radius, 0, sizeof(struct sss_idpkdc_radius));
-
-    ret = krad_client_new(kctx, vctx, &radius->client);
-    if (ret != 0) {
-        goto fail;
-    }
-
-    ret = krad_attrset_new(kctx, &radius->attrs);
-    if (ret != 0) {
-        goto fail;
-    }
-
-    ret = gethostname(hostname, sizeof(hostname) / sizeof(char));
-    if (ret != 0) {
-        goto fail;
-    }
-
-    data.data = hostname;
-    data.length = strlen(hostname);
-    ret = krad_attrset_add(radius->attrs, krad_attr_name2num("NAS-Identifier"),
-                           &data);
-    if (ret != 0) {
-        goto fail;
-    }
-
-    ret = krad_attrset_add_number(radius->attrs, krad_attr_name2num("Service-Type"),
-                                  KRAD_SERVICE_TYPE_AUTHENTICATE_ONLY);
-    if (ret != 0) {
-        goto fail;
-    }
-
-    data.data = config->username;
-    data.length = strlen(config->username);
-    ret = krad_attrset_add(radius->attrs, krad_attr_name2num("User-Name"),
-                           &data);
-    if (ret != 0) {
-        goto fail;
-    }
-
-    return radius;
-
-fail:
-    sss_idpkdc_radius_free(radius);
-    return NULL;
-}
-
-struct sss_idpkdc_challenge {
-    struct sss_idpkdc_radius *radius;
-
-    krb5_context kctx;
-    krb5_kdcpreauth_callbacks cb;
-    krb5_kdcpreauth_rock rock;
-    krb5_kdcpreauth_edata_respond_fn respond;
-    void *arg;
-};
-
-static void
-sss_idpkdc_challenge_free(struct sss_idpkdc_challenge *challenge)
-{
-    if (challenge == NULL) {
-        return;
-    }
-
-    sss_idpkdc_radius_free(challenge->radius);
-    free(challenge);
-}
-
 static void
 sss_idpkdc_challenge_done(krb5_error_code rret,
                           const krad_packet *rreq,
                           const krad_packet *rres,
                           void *data)
 {
-    struct sss_idpkdc_challenge *state;
+    struct sss_radiuskdc_challenge *state;
     struct sss_idp_oauth2 *idp_oauth2 = NULL;
     krb5_pa_data *padata = NULL;
     krb5_data rstate = {0};
-    krb5_data rmsg = {0};
+    char *rmsg = NULL;
     krb5_error_code ret;
 
-    state = (struct sss_idpkdc_challenge *)data;
+    state = (struct sss_radiuskdc_challenge *)data;
 
     if (rret != 0) {
         ret = rret;
@@ -388,25 +118,27 @@ sss_idpkdc_challenge_done(krb5_error_code rret,
         goto done;
     }
 
-    ret = sss_idpkdc_get_complete_attr(rres, "Proxy-State", &rstate);
+    ret = sss_radiuskdc_get_complete_attr(rres, "Proxy-State", &rstate);
     if (ret != 0) {
         goto done;
     }
 
-    ret = sss_idpkdc_get_complete_attr(rres, "Reply-Message", &rmsg);
-    if (ret != 0) {
+    rmsg = sss_radiuskdc_get_attr_as_string(rres, "Reply-Message");
+    if (rmsg == NULL) {
+        ret = EINVAL;
         goto done;
     }
 
     /* Remember the RADIUS state so it can be set in the Access-Request message
      * sent in sss_idpkdc_verify(), thus allowing the RADIUS server to
      * associate the message with its internal state. */
-    ret = sss_idpkdc_set_cookie(state->kctx, state->cb, state->rock, &rstate);
+    ret = sss_radiuskdc_set_cookie(state->kctx, state->cb, state->rock,
+                                   SSSD_IDP_OAUTH2_PADATA, &rstate);
     if (ret != 0) {
         goto done;
     }
 
-    idp_oauth2 = sss_idp_oauth2_decode_reply_message(&rmsg);
+    idp_oauth2 = sss_idp_oauth2_decode_challenge(rmsg);
     if (idp_oauth2 == NULL) {
         ret = ENOMEM;
         goto done;
@@ -422,10 +154,10 @@ sss_idpkdc_challenge_done(krb5_error_code rret,
 
 done:
     state->respond(state->arg, ret, padata);
-    sss_idpkdc_challenge_free(state);
+    sss_radiuskdc_challenge_free(state);
     sss_idp_oauth2_free(idp_oauth2);
     free(rstate.data);
-    free(rmsg.data);
+    free(rmsg);
 
     /* padata should not be freed */
 
@@ -435,200 +167,76 @@ done:
 /* Send a password-less Access-Request and expect Access-Challenge response. */
 static krb5_error_code
 sss_idpkdc_challenge_send(krb5_context kctx,
-                          verto_ctx *vctx,
                           krb5_kdcpreauth_callbacks cb,
                           krb5_kdcpreauth_rock rock,
                           krb5_kdcpreauth_edata_respond_fn respond,
                           void *arg,
-                          struct sss_idpkdc_config *config)
+                          struct sss_radiuskdc_config *config)
 {
-    struct sss_idpkdc_challenge *state;
+    struct sss_radiuskdc_challenge *state;
     krb5_error_code ret;
 
-    state = malloc(sizeof(struct sss_idpkdc_challenge));
+    state = sss_radiuskdc_challenge_init(kctx, cb, rock, respond, arg, config);
     if (state == NULL) {
         ret = ENOMEM;
         goto done;
     }
-    memset(state, 0, sizeof(struct sss_idpkdc_challenge));
 
-    state->kctx = kctx;
-    state->cb = cb;
-    state->rock = rock;
-    state->respond = respond;
-    state->arg = arg;
-
-    state->radius = sss_idpkdc_radius_init(kctx, vctx, config);
-    if (state->radius == NULL) {
-        ret = ENOMEM;
-        goto done;
-    }
-
-    ret = krad_client_send(state->radius->client,
+    ret = krad_client_send(state->client->client,
                            krad_code_name2num("Access-Request"),
-                           state->radius->attrs, config->server,
+                           state->client->attrs, config->server,
                            config->secret, config->timeout, config->retries,
                            sss_idpkdc_challenge_done, state);
 
 done:
     if (ret != 0) {
-        sss_idpkdc_challenge_free(state);
+        sss_radiuskdc_challenge_free(state);
     }
 
     return ret;
-}
-
-struct sss_idpkdc_verify {
-    struct sss_idpkdc_radius *radius;
-    struct sss_idpkdc_config *config;
-
-    krb5_context kctx;
-    krb5_kdcpreauth_rock rock;
-    krb5_kdcpreauth_callbacks cb;
-    krb5_enc_tkt_part *enc_tkt_reply;
-    krb5_kdcpreauth_verify_respond_fn respond;
-    void *arg;
-};
-
-static void
-sss_idpkdc_verify_free(struct sss_idpkdc_verify *verify)
-{
-    if (verify == NULL) {
-        return;
-    }
-
-    sss_idpkdc_radius_free(verify->radius);
-    sss_idpkdc_config_free(verify->config);
-    free(verify);
-}
-
-static void
-sss_idpkdc_verify_done(krb5_error_code rret,
-                       const krad_packet *rreq,
-                       const krad_packet *rres,
-                       void *data)
-{
-    static bool verify_success = true;
-    static bool verify_failure = false;
-    struct sss_idpkdc_verify *state;
-    krb5_kdcpreauth_modreq modreq;
-    krb5_error_code ret;
-    int i;
-
-    state = (struct sss_idpkdc_verify *)data;
-    modreq = (krb5_kdcpreauth_modreq)&verify_failure;
-
-    if (rret != 0) {
-        ret = rret;
-        goto done;
-    }
-
-    if (krad_packet_get_code(rres) != krad_code_name2num("Access-Accept")) {
-        ret = KRB5_PREAUTH_FAILED;
-        goto done;
-    }
-
-    state->enc_tkt_reply->flags |= TKT_FLG_PRE_AUTH;
-
-    for (i = 0; state->config->idpcfg->indicators[i] != NULL; i++) {
-        ret = state->cb->add_auth_indicator(state->kctx, state->rock,
-                                            state->config->idpcfg->indicators[i]);
-        if (ret != 0) {
-            goto done;
-        }
-    }
-
-    modreq = (krb5_kdcpreauth_modreq)&verify_success;
-    ret = 0;
-
-done:
-    state->respond(state->arg, ret, modreq, NULL, NULL);
-    sss_idpkdc_verify_free(state);
-    return;
 }
 
 /* Send Access-Request with password and state set to indicate that the user has
  * finished authentication against idp provider. We expect Access-Accept. */
 static krb5_error_code
 sss_idpkdc_verify_send(krb5_context kctx,
-                       verto_ctx *vctx,
                        krb5_kdcpreauth_rock rock,
                        krb5_kdcpreauth_callbacks cb,
                        krb5_enc_tkt_part *enc_tkt_reply,
                        krb5_kdcpreauth_verify_respond_fn respond,
                        void *arg,
                        const krb5_data *rstate,
-                       struct sss_idpkdc_config *config)
+                       char **indicators,
+                       struct sss_radiuskdc_config *config)
 {
-    struct sss_idpkdc_verify *state;
+    struct sss_radiuskdc_verify *state;
     krb5_error_code ret;
 
-    state = malloc(sizeof(struct sss_idpkdc_verify));
+    state = sss_radiuskdc_verify_init(kctx, rock, cb, enc_tkt_reply, respond,
+                                      arg, indicators, config);
     if (state == NULL) {
         return ENOMEM;
     }
-    memset(state, 0, sizeof(struct sss_idpkdc_verify));
 
-    state->config = config;
-    state->kctx = kctx;
-    state->rock = rock;
-    state->cb = cb;
-    state->enc_tkt_reply = enc_tkt_reply;
-    state->respond = respond;
-    state->arg = arg;
-
-    state->radius = sss_idpkdc_radius_init(kctx, vctx, config);
-    if (state->radius == NULL) {
-        ret = ENOMEM;
-        goto done;
-    }
-
-    ret = sss_idpkdc_put_complete_attr(state->radius->attrs,
-                                       krad_attr_name2num("Proxy-State"),
-                                       rstate);
+    ret = sss_radiuskdc_put_complete_attr(state->client->attrs,
+                                          krad_attr_name2num("Proxy-State"),
+                                          rstate);
     if (ret != 0) {
         goto done;
     }
 
-    ret = krad_client_send(state->radius->client,
+    ret = krad_client_send(state->client->client,
                            krad_code_name2num("Access-Request"),
-                           state->radius->attrs, config->server,
+                           state->client->attrs, config->server,
                            config->secret, config->timeout, config->retries,
-                           sss_idpkdc_verify_done, state);
+                           sss_radiuskdc_verify_done, state);
 
 done:
     if (ret != 0) {
-        /* It is the caller responsibility to free config in case of error. */
-        state->config = NULL;
-        sss_idpkdc_verify_free(state);
+        sss_radiuskdc_verify_free(state);
     }
 
     return ret;
-}
-
-static krb5_error_code
-sss_idpkdc_enabled(krb5_context kctx,
-                   krb5_kdcpreauth_callbacks cb,
-                   krb5_kdcpreauth_rock rock,
-                   char **_config)
-{
-    krb5_error_code ret;
-    char *config;
-
-    ret = cb->get_string(kctx, rock, SSSD_IDP_CONFIG, &config);
-    if (ret != 0) {
-        return ret;
-    }
-
-    /* Disabled. */
-    if (config == NULL) {
-        return ENOENT;
-    }
-
-    /* Enabled. Return the config string. */
-    *_config = config;
-
-    return 0;
 }
 
 static krb5_error_code
@@ -636,44 +244,7 @@ sss_idpkdc_init(krb5_context kctx,
                 krb5_kdcpreauth_moddata *_moddata,
                 const char **_realmnames)
 {
-    struct sss_idpkdc_state *state;
-
-    state = malloc(sizeof(struct sss_idpkdc_state));
-    if (state == NULL) {
-        return ENOMEM;
-    }
-
-    /* IPA is the only consumer so far so it is fine to hardcode the values. */
-    state->server = KRB5_KDC_RUNDIR "/DEFAULT.socket";
-    state->secret = "";
-    state->timeout = 5 * 1000;
-    state->retries = 3;
-
-    *_moddata = (krb5_kdcpreauth_moddata)state;
-
-    return 0;
-}
-
-static void
-sss_idpkdc_fini(krb5_context kctx,
-                krb5_kdcpreauth_moddata moddata)
-{
-    struct sss_idpkdc_state *state;
-
-    state = (struct sss_idpkdc_state *)moddata;
-
-    if (state == NULL) {
-        return;
-    }
-
-    free(state);
-}
-
-static int
-sss_idpkdc_flags(krb5_context kctx,
-                 krb5_preauthtype pa_type)
-{
-    return PA_REPLACES_KEY;
+    return sss_radiuskdc_init(SSSD_IDP_PLUGIN, kctx, _moddata, _realmnames);
 }
 
 static void
@@ -687,14 +258,14 @@ sss_idpkdc_edata(krb5_context kctx,
                  void *arg)
 {
     struct sss_idpkdc_config *config = NULL;
-    struct sss_idpkdc_state *state;
+    struct sss_radiuskdc_state *state;
     krb5_keyblock *armor_key;
     char *configstr = NULL;
     krb5_error_code ret;
 
-    state = (struct sss_idpkdc_state *)moddata;
+    state = (struct sss_radiuskdc_state *)moddata;
 
-    ret = sss_idpkdc_enabled(kctx, cb, rock, &configstr);
+    ret = sss_radiuskdc_enabled(SSSD_IDP_CONFIG, kctx, cb, rock, &configstr);
     if (ret != 0) {
         goto done;
     }
@@ -711,8 +282,8 @@ sss_idpkdc_edata(krb5_context kctx,
         goto done;
     }
 
-    ret = sss_idpkdc_challenge_send(kctx, cb->event_context(kctx, rock), cb,
-                                    rock, respond, arg, config);
+    ret = sss_idpkdc_challenge_send(kctx, cb, rock, respond, arg,
+                                    config->radius);
 
 done:
     if (ret != 0) {
@@ -735,15 +306,15 @@ sss_idpkdc_verify(krb5_context kctx,
                   krb5_kdcpreauth_verify_respond_fn respond,
                   void *arg)
 {
-    struct sss_idpkdc_state *state;
+    struct sss_radiuskdc_state *state;
     struct sss_idpkdc_config *config = NULL;
     char *configstr = NULL;
     krb5_error_code ret;
     krb5_data rstate;
 
-    state = (struct sss_idpkdc_state *)moddata;
+    state = (struct sss_radiuskdc_state *)moddata;
 
-    ret = sss_idpkdc_enabled(kctx, cb, rock, &configstr);
+    ret = sss_radiuskdc_enabled(SSSD_IDP_CONFIG, kctx, cb, rock, &configstr);
     if (ret != 0) {
         goto done;
     }
@@ -754,7 +325,8 @@ sss_idpkdc_verify(krb5_context kctx,
         goto done;
     }
 
-    ret = sss_idpkdc_get_cookie(kctx, cb, rock, &rstate);
+    ret = sss_radiuskdc_get_cookie(kctx, cb, rock, SSSD_IDP_OAUTH2_PADATA,
+                                   &rstate);
     if (ret != 0) {
         goto done;
     }
@@ -765,9 +337,8 @@ sss_idpkdc_verify(krb5_context kctx,
     }
 
     /* config is freed by verify_done if ret == 0 */
-    ret = sss_idpkdc_verify_send(kctx, cb->event_context(kctx, rock), rock,
-                                 cb, enc_tkt_reply, respond, arg,
-                                 &rstate, config);
+    ret = sss_idpkdc_verify_send(kctx, rock, cb, enc_tkt_reply, respond, arg,
+            &rstate, config->idpcfg->indicators, config->radius);
     if (ret != 0) {
         goto done;
     }
@@ -776,14 +347,14 @@ sss_idpkdc_verify(krb5_context kctx,
 
 done:
     if (ret != 0) {
-        sss_idpkdc_config_free(config);
         respond(arg, ret, NULL, NULL, NULL);
     }
 
     cb->free_string(kctx, rock, configstr);
+    sss_idpkdc_config_free(config);
 }
 
-static krb5_error_code
+krb5_error_code
 sss_idpkdc_return_padata(krb5_context kctx,
                          krb5_pa_data *padata,
                          krb5_data *req_pkt,
@@ -796,32 +367,14 @@ sss_idpkdc_return_padata(krb5_context kctx,
                          krb5_kdcpreauth_moddata moddata,
                          krb5_kdcpreauth_modreq modreq)
 {
-    krb5_keyblock *armor_key;
-    bool *result;
-
-    result = (bool *)modreq;
-
-    /* Verification was not successful. Do not replace the key. */
-    if (result == NULL || *result == false) {
-        return 0;
-    }
-
     /* Unexpected padata. Return error. */
     if (padata->length != 0) {
         return EINVAL;
     }
 
-    /* Get the armor key. */
-    armor_key = cb->fast_armor(kctx, rock);
-    if (armor_key == NULL) {
-        com_err(SSSD_IDP_PLUGIN, ENOENT,
-                "No armor key found when returning padata");
-        return ENOENT;
-    }
-
-    /* Replace the reply key with the FAST armor key. */
-    krb5_free_keyblock_contents(kctx, encrypting_key);
-    return krb5_copy_keyblock_contents(kctx, armor_key, encrypting_key);
+    return sss_radiuskdc_return_padata(kctx, padata, req_pkt, request, reply,
+                                       encrypting_key, send_pa_out, cb, rock,
+                                       moddata, modreq);
 }
 
 krb5_error_code
@@ -841,13 +394,13 @@ kdcpreauth_idp_initvt(krb5_context kctx,
     vt->name = discard_const(SSSD_IDP_PLUGIN);
     vt->pa_type_list = pa_type_list;
     vt->init = sss_idpkdc_init;
-    vt->fini = sss_idpkdc_fini;
-    vt->flags = sss_idpkdc_flags;
+    vt->fini = sss_radiuskdc_fini;
+    vt->flags = sss_radiuskdc_flags;
     vt->edata = sss_idpkdc_edata;
     vt->verify = sss_idpkdc_verify;
     vt->return_padata = sss_idpkdc_return_padata;
 
-    com_err(SSSD_IDP_PLUGIN, 0, "Loaded");
+    com_err(SSSD_IDP_PLUGIN, 0, "SSSD IdP plugin loaded");
 
     return 0;
 }

--- a/src/krb5_plugin/passkey/passkey.h
+++ b/src/krb5_plugin/passkey/passkey.h
@@ -1,0 +1,97 @@
+/*
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2021 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _PASSKEY_H_
+#define _PASSKEY_H_
+
+#include <stdlib.h>
+#include <krb5/preauth_plugin.h>
+
+#ifndef discard_const
+#define discard_const(ptr) ((void *)((uintptr_t)(ptr)))
+#endif
+
+#define SSSD_PASSKEY_PLUGIN "passkey"
+#define SSSD_PASSKEY_CONFIG "passkey"
+#define SSSD_PASSKEY_PADATA -152 // PA-REDHAT-PASSKEY
+#define SSSD_PASSKEY_QUESTION "passkey"
+#define SSSD_PASSKEY_PREFIX "passkey "
+
+struct sss_passkey_config {
+    char **indicators;
+};
+
+void
+sss_passkey_config_free(struct sss_passkey_config *passkey);
+
+krb5_error_code
+sss_passkey_config_init(const char *config,
+                        struct sss_passkey_config **_passkey);
+
+enum sss_passkey_phase {
+    SSS_PASSKEY_PHASE_INIT,
+    SSS_PASSKEY_PHASE_CHALLENGE,
+    SSS_PASSKEY_PHASE_REPLY
+};
+
+struct sss_passkey_challenge {
+    char *domain;
+    char **credential_id_list;
+    int user_verification;
+    char *cryptographic_challenge;
+};
+
+struct sss_passkey_reply {
+    char *credential_id;
+    char *cryptographic_challenge;
+    char *authenticator_data;
+    char *assertion_signature;
+    char *user_id;
+};
+
+struct sss_passkey_message {
+    enum sss_passkey_phase phase;
+    char *state;
+    union {
+        struct sss_passkey_challenge *challenge;
+        struct sss_passkey_reply *reply;
+        void *ptr;
+    } data;
+};
+
+void
+sss_passkey_message_free(struct sss_passkey_message *message);
+
+char *
+sss_passkey_message_encode(const struct sss_passkey_message *data);
+
+struct sss_passkey_message *
+sss_passkey_message_decode(const char *str);
+
+krb5_pa_data *
+sss_passkey_message_encode_padata(const struct sss_passkey_message *data);
+
+struct sss_passkey_message *
+sss_passkey_message_decode_padata(krb5_pa_data *padata);
+
+krb5_pa_data **
+sss_passkey_message_encode_padata_array(const struct sss_passkey_message *data);
+
+#endif /* _PASSKEY_H_ */

--- a/src/krb5_plugin/passkey/passkey.h
+++ b/src/krb5_plugin/passkey/passkey.h
@@ -33,6 +33,7 @@
 #define SSSD_PASSKEY_PADATA -152 // PA-REDHAT-PASSKEY
 #define SSSD_PASSKEY_QUESTION "passkey"
 #define SSSD_PASSKEY_PREFIX "passkey "
+#define SSSD_PASSKEY_REPLY_STATE "ipa_otpd state"
 
 struct sss_passkey_config {
     char **indicators;
@@ -78,6 +79,11 @@ struct sss_passkey_message {
 
 void
 sss_passkey_message_free(struct sss_passkey_message *message);
+
+struct sss_passkey_message *
+sss_passkey_prefix_json_data(enum sss_passkey_phase phase,
+                             const char *state,
+                             const char *json_str);
 
 char *
 sss_passkey_message_encode(const struct sss_passkey_message *data);

--- a/src/krb5_plugin/passkey/passkey_clpreauth.c
+++ b/src/krb5_plugin/passkey/passkey_clpreauth.c
@@ -1,0 +1,185 @@
+/*
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2021 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <krb5/clpreauth_plugin.h>
+
+#include "krb5_plugin/common/radius_clpreauth.h"
+#include "passkey.h"
+
+static krb5_error_code
+sss_passkeycl_prompt(krb5_context context,
+                     krb5_prompter_fct prompter,
+                     void *prompter_data,
+                     struct sss_passkey_message *message,
+                     krb5_data *_reply)
+{
+    return ENOTSUP;
+}
+
+static krb5_error_code
+sss_passkeycl_prep_questions(krb5_context context,
+                             krb5_clpreauth_moddata moddata,
+                             krb5_clpreauth_modreq modreq,
+                             krb5_get_init_creds_opt *opt,
+                             krb5_clpreauth_callbacks cb,
+                             krb5_clpreauth_rock rock,
+                             krb5_kdc_req *request,
+                             krb5_data *encoded_request_body,
+                             krb5_data *encoded_previous_request,
+                             krb5_pa_data *pa_data)
+{
+    struct sss_passkey_message *message;
+    char *question = NULL;
+    krb5_error_code ret;
+
+    message = sss_passkey_message_decode_padata(pa_data);
+    if (message == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    question = sss_passkey_message_encode(message);
+    if (question == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = cb->ask_responder_question(context, rock, SSSD_PASSKEY_QUESTION,
+                                     question);
+
+done:
+    sss_passkey_message_free(message);
+    free(question);
+
+    return ret;
+}
+
+static krb5_error_code
+sss_passkeycl_process(krb5_context context,
+                      krb5_clpreauth_moddata moddata,
+                      krb5_clpreauth_modreq modreq,
+                      krb5_get_init_creds_opt *opt,
+                      krb5_clpreauth_callbacks cb,
+                      krb5_clpreauth_rock rock,
+                      krb5_kdc_req *request,
+                      krb5_data *encoded_request_body,
+                      krb5_data *encoded_previous_request,
+                      krb5_pa_data *pa_data,
+                      krb5_prompter_fct prompter,
+                      void *prompter_data,
+                      krb5_pa_data ***_pa_data_out)
+{
+    krb5_keyblock *as_key;
+    krb5_pa_data **padata;
+    krb5_error_code ret;
+    krb5_data user_reply;
+    struct sss_passkey_message *input_message = NULL;
+    struct sss_passkey_message *reply_message = NULL;
+    char prompt_answer[255] = {0};
+    const char *answer;
+
+    input_message = sss_passkey_message_decode_padata(pa_data);
+    if (input_message == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    /* Get FAST armor key. */
+    as_key = cb->fast_armor(context, rock);
+    if (as_key == NULL) {
+        ret = ENOENT;
+        goto done;
+    }
+
+    answer = cb->get_responder_answer(context, rock, SSSD_PASSKEY_QUESTION);
+    /* Call prompter if we have no answer. We don't really require any answer,
+     * but we need to present a prompt to the user and wait until the user has
+     * finished authentication via an passkey provider. */
+    if (answer == NULL) {
+        user_reply.magic = 0;
+        user_reply.length = sizeof(prompt_answer) / sizeof(char);
+        user_reply.data = prompt_answer;
+
+        ret = sss_passkeycl_prompt(context, prompter, prompter_data, input_message,
+                                   &user_reply);
+        if (ret != 0) {
+            goto done;
+        }
+    }
+
+    /* Use FAST armor key as response key. */
+    ret = cb->set_as_key(context, rock, as_key);
+    if (ret != 0) {
+        goto done;
+    }
+
+    /* Encode the answer into the pa_data output. */
+    reply_message = sss_passkey_message_decode(answer);
+    if (reply_message == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    padata = sss_passkey_message_encode_padata_array(reply_message);
+    if (padata == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    cb->disable_fallback(context, rock);
+    *_pa_data_out = padata;
+
+    ret = 0;
+
+done:
+    sss_passkey_message_free(reply_message);
+    sss_passkey_message_free(input_message);
+    return ret;
+}
+
+krb5_error_code
+clpreauth_passkey_initvt(krb5_context context,
+                         int maj_ver,
+                         int min_ver,
+                         krb5_plugin_vtable vtable)
+{
+    static krb5_preauthtype pa_type_list[] = { SSSD_PASSKEY_PADATA, 0 };
+    krb5_clpreauth_vtable vt;
+
+    if (maj_ver != 1) {
+        return KRB5_PLUGIN_VER_NOTSUPP;
+    }
+
+    vt = (krb5_clpreauth_vtable)vtable;
+    vt->name = discard_const(SSSD_PASSKEY_PLUGIN);
+    vt->pa_type_list = pa_type_list;
+    vt->request_init = sss_radiuscl_init;
+    vt->prep_questions = sss_passkeycl_prep_questions;
+    vt->process = sss_passkeycl_process;
+    vt->request_fini = sss_radiuscl_fini;
+    vt->gic_opts = NULL;
+
+    return 0;
+}

--- a/src/krb5_plugin/passkey/passkey_kdcpreauth.c
+++ b/src/krb5_plugin/passkey/passkey_kdcpreauth.c
@@ -1,0 +1,438 @@
+/*
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2021 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <krad.h>
+#include <krb5/kdcpreauth_plugin.h>
+
+#include "shared/safealign.h"
+#include "krb5_plugin/common/radius_kdcpreauth.h"
+#include "krb5_plugin/common/utils.h"
+#include "krb5_plugin/passkey/passkey.h"
+#include "util/util.h"
+
+struct sss_passkeykdc_config {
+    struct sss_radiuskdc_config *radius;
+    struct sss_passkey_config *passkey;
+};
+
+static void
+sss_passkeykdc_config_free(struct sss_passkeykdc_config *config)
+{
+    if (config == NULL) {
+        return;
+    }
+
+    sss_radiuskdc_config_free(config->radius);
+    sss_passkey_config_free(config->passkey);
+    free(config);
+}
+
+static krb5_error_code
+sss_passkeykdc_config_init(struct sss_radiuskdc_state *state,
+                           krb5_context kctx,
+                           krb5_const_principal princ,
+                           const char *configstr,
+                           struct sss_passkeykdc_config **_config)
+{
+    struct sss_passkeykdc_config *config;
+    krb5_error_code ret;
+
+    if (state == NULL) {
+        return EINVAL;
+    }
+
+    config = malloc(sizeof(struct sss_passkeykdc_config));
+    if (config == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+    memset(config, 0, sizeof(struct sss_passkeykdc_config));
+
+    ret = sss_radiuskdc_config_init(state, kctx, princ, configstr, &config->radius);
+    if (ret != 0) {
+        goto done;
+    }
+
+    ret = sss_passkey_config_init(configstr, &config->passkey);
+    if (ret != 0) {
+        goto done;
+    }
+
+
+    *_config = config;
+    ret = 0;
+
+done:
+    if (ret != 0) {
+        sss_passkeykdc_config_free(config);
+    }
+
+    return ret;
+}
+
+static void
+sss_passkeykdc_challenge_done(krb5_error_code rret,
+                              const krad_packet *rreq,
+                              const krad_packet *rres,
+                              void *data)
+{
+    struct sss_passkey_message *message = NULL;
+    struct sss_radiuskdc_challenge *state;
+    krb5_pa_data *padata = NULL;
+    krb5_data cookie = {0};
+    char *reply = NULL;
+    krb5_error_code ret;
+
+    state = (struct sss_radiuskdc_challenge *)data;
+
+    if (rret != 0) {
+        ret = rret;
+        goto done;
+    }
+
+    if (krad_packet_get_code(rres) != krad_code_name2num("Access-Challenge")) {
+        ret = ENOENT;
+        goto done;
+    }
+
+    reply = sss_radiuskdc_get_attr_as_string(rres, "Proxy-State");
+    if (reply == NULL) {
+        ret = EINVAL;
+        goto done;
+    }
+
+    message = sss_passkey_message_decode(reply);
+    if (message == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    if (message->phase != SSS_PASSKEY_PHASE_CHALLENGE) {
+        ret = EINVAL;
+        goto done;
+    }
+
+    /* Remember the whole passkey challenge message in cookie so we can later
+     * verify that the client response is really associated with this request.
+     */
+    cookie.data = reply;
+    cookie.length = strlen(reply) + 1;
+    ret = sss_radiuskdc_set_cookie(state->kctx, state->cb, state->rock,
+                                   SSSD_PASSKEY_PADATA, &cookie);
+    if (ret != 0) {
+        goto done;
+    }
+
+    padata = sss_passkey_message_encode_padata(message);
+    if (padata == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = 0;
+
+done:
+    state->respond(state->arg, ret, padata);
+    sss_radiuskdc_challenge_free(state);
+    sss_passkey_message_free(message);
+    free(reply);
+
+    /* padata should not be freed */
+
+    return;
+}
+
+/* Send a password-less Access-Request and expect Access-Challenge response. */
+static krb5_error_code
+sss_passkeykdc_challenge_send(krb5_context kctx,
+                              krb5_kdcpreauth_callbacks cb,
+                              krb5_kdcpreauth_rock rock,
+                              krb5_kdcpreauth_edata_respond_fn respond,
+                              void *arg,
+                              struct sss_radiuskdc_config *config)
+{
+    struct sss_passkey_message message;
+    struct sss_radiuskdc_challenge *state;
+    char *encoded_message = NULL;
+    krb5_error_code ret;
+
+    state = sss_radiuskdc_challenge_init(kctx, cb, rock, respond, arg, config);
+    if (state == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    message.phase = SSS_PASSKEY_PHASE_INIT;
+    message.state = NULL;
+    message.data.challenge = NULL;
+
+    encoded_message = sss_passkey_message_encode(&message);
+    if (encoded_message == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = sss_radiuskdc_set_attr_as_string(state->client->attrs,
+                                           "Proxy-State",
+                                           encoded_message);
+    if (ret != 0) {
+        goto done;
+    }
+
+    ret = krad_client_send(state->client->client,
+                           krad_code_name2num("Access-Request"),
+                           state->client->attrs, config->server,
+                           config->secret, config->timeout, config->retries,
+                           sss_passkeykdc_challenge_done, state);
+
+done:
+    free(encoded_message);
+
+    if (ret != 0) {
+        sss_radiuskdc_challenge_free(state);
+    }
+
+    return ret;
+}
+
+/* Send Access-Request with password and state set to indicate that the user has
+ * finished authentication against passkey provider. We expect Access-Accept. */
+static krb5_error_code
+sss_passkeykdc_verify_send(krb5_context kctx,
+                           krb5_kdcpreauth_rock rock,
+                           krb5_kdcpreauth_callbacks cb,
+                           krb5_enc_tkt_part *enc_tkt_reply,
+                           krb5_kdcpreauth_verify_respond_fn respond,
+                           void *arg,
+                           const struct sss_passkey_message *message,
+                           char **indicators,
+                           struct sss_radiuskdc_config *config)
+{
+    struct sss_radiuskdc_verify *state;
+    char *encoded_message = NULL;
+    krb5_error_code ret;
+
+    state = sss_radiuskdc_verify_init(kctx, rock, cb, enc_tkt_reply, respond,
+                                      arg, indicators, config);
+    if (state == NULL) {
+        return ENOMEM;
+    }
+
+    encoded_message = sss_passkey_message_encode(message);
+    if (encoded_message == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = sss_radiuskdc_set_attr_as_string(state->client->attrs,
+                                           "Proxy-State",
+                                           encoded_message);
+    if (ret != 0) {
+        goto done;
+    }
+
+    ret = krad_client_send(state->client->client,
+                           krad_code_name2num("Access-Request"),
+                           state->client->attrs, config->server,
+                           config->secret, config->timeout, config->retries,
+                           sss_radiuskdc_verify_done, state);
+
+done:
+    free(encoded_message);
+
+    if (ret != 0) {
+        sss_radiuskdc_verify_free(state);
+    }
+
+    return ret;
+}
+
+static krb5_error_code
+sss_passkeykdc_init(krb5_context kctx,
+                    krb5_kdcpreauth_moddata *_moddata,
+                    const char **_realmnames)
+{
+    return sss_radiuskdc_init(SSSD_PASSKEY_PLUGIN, kctx, _moddata, _realmnames);
+}
+
+static void
+sss_passkeykdc_edata(krb5_context kctx,
+                     krb5_kdc_req *request,
+                     krb5_kdcpreauth_callbacks cb,
+                     krb5_kdcpreauth_rock rock,
+                     krb5_kdcpreauth_moddata moddata,
+                     krb5_preauthtype pa_type,
+                     krb5_kdcpreauth_edata_respond_fn respond,
+                     void *arg)
+{
+    struct sss_passkeykdc_config *config = NULL;
+    struct sss_radiuskdc_state *state;
+    krb5_keyblock *armor_key;
+    char *configstr = NULL;
+    krb5_error_code ret;
+
+    state = (struct sss_radiuskdc_state *)moddata;
+
+    ret = sss_radiuskdc_enabled(SSSD_PASSKEY_CONFIG, kctx, cb, rock, &configstr);
+    if (ret != 0) {
+        goto done;
+    }
+
+    armor_key = cb->fast_armor(kctx, rock);
+    if (armor_key == NULL) {
+        ret = ENOENT;
+        goto done;
+    }
+
+    ret = sss_passkeykdc_config_init(state, kctx, cb->client_name(kctx, rock),
+                                     configstr, &config);
+    if (ret != 0) {
+        goto done;
+    }
+
+    ret = sss_passkeykdc_challenge_send(kctx, cb, rock, respond, arg,
+                                        config->radius);
+
+done:
+    if (ret != 0) {
+        respond(arg, ret, NULL);
+    }
+
+    cb->free_string(kctx, rock, configstr);
+    sss_passkeykdc_config_free(config);
+}
+
+static void
+sss_passkeykdc_verify(krb5_context kctx,
+                      krb5_data *req_pkt,
+                      krb5_kdc_req *request,
+                      krb5_enc_tkt_part *enc_tkt_reply,
+                      krb5_pa_data *pa,
+                      krb5_kdcpreauth_callbacks cb,
+                      krb5_kdcpreauth_rock rock,
+                      krb5_kdcpreauth_moddata moddata,
+                      krb5_kdcpreauth_verify_respond_fn respond,
+                      void *arg)
+{
+    struct sss_radiuskdc_state *state;
+    struct sss_passkeykdc_config *config = NULL;
+    struct sss_passkey_message *message = NULL;
+    struct sss_passkey_message *challenge = NULL;
+    char *configstr = NULL;
+    krb5_error_code ret;
+    krb5_data cookie;
+
+    state = (struct sss_radiuskdc_state *)moddata;
+
+    ret = sss_radiuskdc_enabled(SSSD_PASSKEY_CONFIG, kctx, cb, rock, &configstr);
+    if (ret != 0) {
+        goto done;
+    }
+
+    ret = sss_passkeykdc_config_init(state, kctx, cb->client_name(kctx, rock),
+                                     configstr, &config);
+    if (ret != 0) {
+        goto done;
+    }
+
+    ret = sss_radiuskdc_get_cookie(kctx, cb, rock, SSSD_PASSKEY_PADATA,
+                                   &cookie);
+    if (ret != 0) {
+        goto done;
+    }
+
+    challenge = sss_passkey_message_decode(cookie.data);
+    if (challenge == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    if (pa->pa_type != SSSD_PASSKEY_PADATA || pa->length == 0) {
+        ret = KRB5_PREAUTH_BAD_TYPE;
+        goto done;
+    }
+
+    message = sss_passkey_message_decode_padata(pa);
+    if (message == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    if (message->phase != SSS_PASSKEY_PHASE_REPLY
+        || strcmp(message->state, challenge->state) != 0
+        || strcmp(message->data.reply->cryptographic_challenge,
+                  challenge->data.challenge->cryptographic_challenge) != 0) {
+        ret = EINVAL;
+        goto done;
+    }
+
+    ret = sss_passkeykdc_verify_send(kctx, rock, cb, enc_tkt_reply, respond,
+            arg, message, config->passkey->indicators, config->radius);
+    if (ret != 0) {
+        goto done;
+    }
+
+    ret = 0;
+
+done:
+    if (ret != 0) {
+        respond(arg, ret, NULL, NULL, NULL);
+    }
+
+    cb->free_string(kctx, rock, configstr);
+    sss_passkeykdc_config_free(config);
+    sss_passkey_message_free(message);
+    sss_passkey_message_free(challenge);
+}
+
+krb5_error_code
+kdcpreauth_passkey_initvt(krb5_context kctx,
+                          int maj_ver,
+                          int min_ver,
+                          krb5_plugin_vtable vtable)
+{
+    static krb5_preauthtype pa_type_list[] = { SSSD_PASSKEY_PADATA, 0 };
+    krb5_kdcpreauth_vtable vt;
+
+    if (maj_ver != 1) {
+        return KRB5_PLUGIN_VER_NOTSUPP;
+    }
+
+    vt = (krb5_kdcpreauth_vtable)vtable;
+    vt->name = discard_const(SSSD_PASSKEY_PLUGIN);
+    vt->pa_type_list = pa_type_list;
+    vt->init = sss_passkeykdc_init;
+    vt->fini = sss_radiuskdc_fini;
+    vt->flags = sss_radiuskdc_flags;
+    vt->edata = sss_passkeykdc_edata;
+    vt->verify = sss_passkeykdc_verify;
+    vt->return_padata = sss_radiuskdc_return_padata;
+
+    com_err(SSSD_PASSKEY_PLUGIN, 0, "SSSD passkey plugin loaded");
+
+    return 0;
+}

--- a/src/krb5_plugin/passkey/passkey_utils.c
+++ b/src/krb5_plugin/passkey/passkey_utils.c
@@ -1,0 +1,563 @@
+/*
+    Authors:
+        Pavel Březina <pbrezina@redhat.com>
+
+    Copyright (C) 2021 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <jansson.h>
+#include <arpa/inet.h>
+#include <krb5/preauth_plugin.h>
+
+#include "krb5_plugin/common/utils.h"
+#include "krb5_plugin/passkey/passkey.h"
+
+void
+sss_passkey_config_free(struct sss_passkey_config *passkey)
+{
+    if (passkey == NULL) {
+        return;
+    }
+
+    sss_string_array_free(passkey->indicators);
+    free(passkey);
+}
+
+/**
+ * {
+ *   "indicators": ["..."] (optional)
+ * }
+ */
+krb5_error_code
+sss_passkey_config_init(const char *config,
+                        struct sss_passkey_config **_passkey)
+{
+    struct sss_passkey_config *passkey;
+    json_t *jindicators = NULL;
+    json_error_t jret;
+    json_t *jroot;
+    krb5_error_code ret;
+
+    passkey = malloc(sizeof(struct sss_passkey_config));
+    if (passkey == NULL) {
+        return ENOMEM;
+    }
+    memset(passkey, 0, sizeof(struct sss_passkey_config));
+
+    jroot = json_loads(config, 0, &jret);
+    if (jroot == NULL) {
+        ret = EINVAL;
+        goto done;
+    }
+
+    ret = json_unpack(jroot, "[{s?:o}]", "indicators", &jindicators);
+    if (ret != 0) {
+        ret = EINVAL;
+        goto done;
+    }
+
+    /* Are indicators set? */
+    if (jindicators != NULL) {
+        passkey->indicators = sss_json_array_to_strings(jindicators);
+        if (passkey->indicators == NULL) {
+            ret = EINVAL;
+            goto done;
+        }
+    }
+
+    *_passkey = passkey;
+
+    ret = 0;
+
+done:
+    if (ret != 0) {
+        sss_passkey_config_free(passkey);
+    }
+
+    if (jroot != NULL) {
+        json_decref(jroot);
+    }
+
+    return ret;
+}
+
+void
+sss_passkey_challenge_free(struct sss_passkey_challenge *data)
+{
+    if (data == NULL) {
+        return;
+    }
+
+    free(data->domain);
+    free(data->cryptographic_challenge);
+    sss_string_array_free(data->credential_id_list);
+
+    free(data);
+}
+
+static struct sss_passkey_challenge *
+sss_passkey_challenge_init(char *domain,
+                           char **credential_id_list,
+                           int user_verification,
+                           char *cryptographic_challenge)
+{
+    struct sss_passkey_challenge *data;
+    krb5_error_code ret;
+
+    /* These are required fields. */
+    if (is_empty(domain)
+        || is_empty(cryptographic_challenge)
+        || credential_id_list == NULL || is_empty(credential_id_list[0])) {
+        return NULL;
+    }
+
+    data = malloc(sizeof(struct sss_passkey_challenge));
+    if (data == NULL) {
+        return NULL;
+    }
+    memset(data, 0, sizeof(struct sss_passkey_challenge));
+
+    data->user_verification = user_verification;
+    data->domain = strdup(domain);
+    data->cryptographic_challenge = strdup(cryptographic_challenge);
+    if (data->domain == NULL || data->cryptographic_challenge == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    data->credential_id_list = sss_string_array_copy(credential_id_list);
+    if (data->credential_id_list == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = 0;
+
+done:
+    if (ret != 0) {
+        sss_passkey_challenge_free(data);
+        return NULL;
+    }
+
+    return data;
+}
+
+static struct sss_passkey_challenge *
+sss_passkey_challenge_from_json_object(json_t *jobject)
+{
+    struct sss_passkey_challenge jdata = {0};
+    struct sss_passkey_challenge *data = NULL;
+    json_t *jcredential_id_list = NULL;
+    char **credential_id_list = NULL;
+    int ret;
+
+    if (jobject == NULL) {
+        return NULL;
+    }
+
+    ret = json_unpack(jobject, "{s:s, s:o, s:i, s:s}",
+                "domain", &jdata.domain,
+                "credential_id_list", &jcredential_id_list,
+                "user_verification", &jdata.user_verification,
+                "cryptographic_challenge", &jdata.cryptographic_challenge);
+    if (ret != 0) {
+        return NULL;
+    }
+
+    if (jcredential_id_list != NULL) {
+        credential_id_list = sss_json_array_to_strings(jcredential_id_list);
+        if (credential_id_list == NULL) {
+            return NULL;
+        }
+    }
+
+    data = sss_passkey_challenge_init(jdata.domain, credential_id_list,
+                                      jdata.user_verification,
+                                      jdata.cryptographic_challenge);
+
+    sss_string_array_free(credential_id_list);
+    return data;
+}
+
+static json_t *
+sss_passkey_challenge_to_json_object(const struct sss_passkey_challenge *data)
+{
+    json_t *jroot;
+    json_t *jcredential_id_list;
+
+    if (data == NULL) {
+        return NULL;
+    }
+
+    /* These are required fields. */
+    if (data->domain == NULL || data->credential_id_list == NULL
+        || data->user_verification == 0 || data->cryptographic_challenge == NULL) {
+        return NULL;
+    }
+
+    jcredential_id_list = sss_strings_to_json_array(data->credential_id_list);
+    if (jcredential_id_list == NULL) {
+        return NULL;
+    }
+
+    jroot = json_pack("{s:s, s:o, s:i, s:s}", "domain", data->domain,
+                        "credential_id_list", jcredential_id_list,
+                        "user_verification", data->user_verification,
+                        "cryptographic_challenge",
+                        data->cryptographic_challenge);
+    if (jroot == NULL) {
+        json_decref(jcredential_id_list);
+        return NULL;
+    }
+
+    return jroot;
+}
+
+void
+sss_passkey_reply_free(struct sss_passkey_reply *data)
+{
+    if (data == NULL) {
+        return;
+    }
+
+    free(data->credential_id);
+    free(data->cryptographic_challenge);
+    free(data->authenticator_data);
+    free(data->assertion_signature);
+    free(data->user_id);
+    free(data);
+}
+
+static struct sss_passkey_reply *
+sss_passkey_reply_init(char *credential_id,
+                       char *cryptographic_challenge,
+                       char *authenticator_data,
+                       char *assertion_signature,
+                       char *user_id)
+{
+    struct sss_passkey_reply *data;
+    krb5_error_code ret;
+
+    /* These are required fields. */
+    if (is_empty(credential_id)
+        || is_empty(cryptographic_challenge)
+        || is_empty(authenticator_data)
+        || is_empty(assertion_signature)) {
+        return NULL;
+    }
+
+    data = malloc(sizeof(struct sss_passkey_reply));
+    if (data == NULL) {
+        return NULL;
+    }
+    memset(data, 0, sizeof(struct sss_passkey_reply));
+
+    data->credential_id = strdup(credential_id);
+    data->cryptographic_challenge = strdup(cryptographic_challenge);
+    data->authenticator_data = strdup(authenticator_data);
+    data->assertion_signature = strdup(assertion_signature);
+    data->user_id = user_id == NULL ? NULL : strdup(user_id);
+    if (data->credential_id == NULL
+        || data->cryptographic_challenge == NULL
+        || data->authenticator_data == NULL
+        || data->assertion_signature == NULL
+        || (user_id != NULL && data->user_id == NULL)) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = 0;
+
+done:
+    if (ret != 0) {
+        sss_passkey_reply_free(data);
+        return NULL;
+    }
+
+    return data;
+}
+
+static struct sss_passkey_reply *
+sss_passkey_reply_from_json_object(json_t *jobject)
+{
+    struct sss_passkey_reply jdata = {0};
+    int ret;
+
+    if (jobject == NULL) {
+        return NULL;
+    }
+
+    ret = json_unpack(jobject, "{s:s, s:s, s:s, s:s, s?:s}",
+                "credential_id", &jdata.credential_id,
+                "cryptographic_challenge", &jdata.cryptographic_challenge,
+                "authenticator_data", &jdata.authenticator_data,
+                "assertion_signature", &jdata.assertion_signature,
+                "user_id", &jdata.user_id);
+    if (ret != 0) {
+        return NULL;
+    }
+
+    return sss_passkey_reply_init(jdata.credential_id,
+                                  jdata.cryptographic_challenge,
+                                  jdata.authenticator_data,
+                                  jdata.assertion_signature,
+                                  jdata.user_id);
+}
+
+static json_t *
+sss_passkey_reply_to_json_object(const struct sss_passkey_reply *data)
+{
+    if (data == NULL) {
+        return NULL;
+    }
+
+    /* These are required fields. */
+    if (data->credential_id == NULL
+       || data->cryptographic_challenge == NULL
+       || data->authenticator_data == NULL
+       || data->assertion_signature == NULL) {
+        return NULL;
+    }
+
+    return json_pack("{s:s, s:s, s:s, s:s, s:s*}",
+                     "credential_id", data->credential_id,
+                     "cryptographic_challenge", data->cryptographic_challenge,
+                     "authenticator_data", data->authenticator_data,
+                     "assertion_signature", data->assertion_signature,
+                     "user_id", data->user_id);
+}
+
+void
+sss_passkey_message_free(struct sss_passkey_message *message)
+{
+    if (message == NULL) {
+        return;
+    }
+
+    switch (message->phase) {
+    case SSS_PASSKEY_PHASE_INIT:
+        break;
+    case SSS_PASSKEY_PHASE_CHALLENGE:
+        sss_passkey_challenge_free(message->data.challenge);
+        break;
+    case SSS_PASSKEY_PHASE_REPLY:
+        sss_passkey_reply_free(message->data.reply);
+        break;
+    default:
+        /* nothing to do */
+        break;
+    }
+
+    free(message->state);
+    free(message);
+}
+
+static struct sss_passkey_message *
+sss_passkey_message_init(enum sss_passkey_phase phase,
+                         const char *state,
+                         void *data)
+{
+    struct sss_passkey_message *message;
+
+    switch (phase) {
+    case SSS_PASSKEY_PHASE_INIT:
+        if (state != NULL || data != NULL) {
+            return NULL;
+        }
+        break;
+    case SSS_PASSKEY_PHASE_CHALLENGE:
+    case SSS_PASSKEY_PHASE_REPLY:
+        if (state == NULL || data == NULL) {
+            return NULL;
+        }
+        break;
+    default:
+        return NULL;
+    }
+
+    message = malloc(sizeof(struct sss_passkey_message));
+    if (message == NULL) {
+        return NULL;
+    }
+    memset(message, 0, sizeof(struct sss_passkey_message));
+
+    message->phase = phase;
+    message->state = state == NULL ? NULL : strdup(state);
+    message->data.ptr = data;
+
+    if (state != NULL && message->state == NULL) {
+        sss_passkey_message_free(message);
+        return NULL;
+    }
+
+    return message;
+}
+
+static struct sss_passkey_message *
+sss_passkey_message_from_json(const char *json_str)
+{
+    struct sss_passkey_message *message = NULL;
+    enum sss_passkey_phase phase = 0;
+    const char *state = NULL;
+    void *data = NULL;
+    json_error_t jret;
+    json_t *jdata = NULL;
+    json_t *jroot;
+    int ret;
+
+    jroot = json_loads(json_str, 0, &jret);
+    if (jroot == NULL) {
+        return NULL;
+    }
+
+    ret = json_unpack(jroot, "{s:i, s?:s, s?:o}",
+                     "phase", &phase,
+                     "state", &state,
+                     "data", &jdata);
+    if (ret != 0) {
+        goto done;
+    }
+
+    switch (phase) {
+    case SSS_PASSKEY_PHASE_INIT:
+        data = NULL;
+        break;
+    case SSS_PASSKEY_PHASE_CHALLENGE:
+        data = sss_passkey_challenge_from_json_object(jdata);
+        if (data == NULL) {
+            goto done;
+        }
+        break;
+    case SSS_PASSKEY_PHASE_REPLY:
+        data = sss_passkey_reply_from_json_object(jdata);
+        if (data == NULL) {
+            goto done;
+        }
+        break;
+    default:
+        goto done;
+    }
+
+    message = sss_passkey_message_init(phase, state, data);
+    if (message == NULL && phase == SSS_PASSKEY_PHASE_CHALLENGE) {
+        sss_passkey_challenge_free(data);
+    } else if (message == NULL && phase == SSS_PASSKEY_PHASE_REPLY) {
+        sss_passkey_reply_free(data);
+    }
+
+done:
+    json_decref(jroot);
+    return message;
+}
+
+static char *
+sss_passkey_message_to_json(const struct sss_passkey_message *message)
+{
+    json_t *jroot;
+    json_t *jdata;
+    char *str;
+
+    if (message == NULL) {
+        return NULL;
+    }
+
+    switch (message->phase) {
+    case SSS_PASSKEY_PHASE_INIT:
+        if (message->state != NULL || message->data.ptr != NULL) {
+            return NULL;
+        }
+        jdata = NULL;
+        break;
+    case SSS_PASSKEY_PHASE_CHALLENGE:
+        if (message->state == NULL || message->data.challenge == NULL) {
+            return NULL;
+        }
+
+        jdata = sss_passkey_challenge_to_json_object(message->data.challenge);
+        if (jdata == NULL) {
+            return NULL;
+        }
+        break;
+    case SSS_PASSKEY_PHASE_REPLY:
+        if (message->state == NULL || message->data.reply == NULL) {
+            return NULL;
+        }
+
+        jdata = sss_passkey_reply_to_json_object(message->data.reply);
+        if (jdata == NULL) {
+            return NULL;
+        }
+        break;
+    default:
+        return NULL;
+    }
+
+    jroot = json_pack("{s:i, s:s*, s:o*}",
+                      "phase", message->phase,
+                      "state", message->state,
+                      "data", jdata);
+    if (jroot == NULL) {
+        json_decref(jdata);
+        return NULL;
+    }
+
+    str = json_dumps(jroot, JSON_COMPACT);
+    json_decref(jroot);
+
+    return str;
+}
+
+char *
+sss_passkey_message_encode(const struct sss_passkey_message *data)
+{
+    return sss_radius_message_encode(SSSD_PASSKEY_PREFIX,
+        (sss_radius_message_encode_fn)sss_passkey_message_to_json, data);
+}
+
+struct sss_passkey_message *
+sss_passkey_message_decode(const char *str)
+{
+    return sss_radius_message_decode(SSSD_PASSKEY_PREFIX,
+        (sss_radius_message_decode_fn)sss_passkey_message_from_json, str);
+}
+
+krb5_pa_data *
+sss_passkey_message_encode_padata(const struct sss_passkey_message *data)
+{
+    return sss_radius_encode_padata(SSSD_PASSKEY_PADATA,
+        (sss_radius_message_encode_fn)sss_passkey_message_encode, data);
+}
+
+struct sss_passkey_message *
+sss_passkey_message_decode_padata(krb5_pa_data *padata)
+{
+    return sss_radius_decode_padata(
+        (sss_radius_message_decode_fn)sss_passkey_message_decode, padata);
+}
+
+krb5_pa_data **
+sss_passkey_message_encode_padata_array(const struct sss_passkey_message *data)
+{
+    return sss_radius_encode_padata_array(SSSD_PASSKEY_PADATA,
+        (sss_radius_message_encode_fn)sss_passkey_message_encode, data);
+}

--- a/src/krb5_plugin/passkey/passkey_utils.c
+++ b/src/krb5_plugin/passkey/passkey_utils.c
@@ -527,6 +527,41 @@ sss_passkey_message_to_json(const struct sss_passkey_message *message)
     return str;
 }
 
+struct sss_passkey_message *
+sss_passkey_prefix_json_data(enum sss_passkey_phase phase,
+                             const char *state,
+                             const char *json_str)
+{
+    json_error_t jret;
+    json_t *jroot;
+    struct sss_passkey_message *message;
+    void *data;
+
+    if (json_str == NULL) {
+        return NULL;
+    }
+
+    jroot = json_loads(json_str, 0, &jret);
+    if (jroot == NULL) {
+        return NULL;
+    }
+
+    data = sss_passkey_reply_from_json_object(jroot);
+    if (data == NULL) {
+        return NULL;
+    }
+
+    message = sss_passkey_message_init(phase, state, data);
+    if (message == NULL && phase == SSS_PASSKEY_PHASE_CHALLENGE) {
+        sss_passkey_challenge_free(data);
+    } else if (message == NULL && phase == SSS_PASSKEY_PHASE_REPLY) {
+        sss_passkey_reply_free(data);
+    }
+
+    json_decref(jroot);
+    return message;
+}
+
 char *
 sss_passkey_message_encode(const struct sss_passkey_message *data)
 {

--- a/src/krb5_plugin/passkey/sssd_enable_passkey
+++ b/src/krb5_plugin/passkey/sssd_enable_passkey
@@ -1,0 +1,14 @@
+# Enable SSSD Passkey Kerberos preauthentication plugins.
+#
+# This will allow you to obtain Kerberos TGT through passkey authentication.
+#
+# To disable the passkey plugin, comment out the following lines.
+
+[plugins]
+ clpreauth = {
+  module = passkey:/usr/lib64/sssd/modules/sssd_krb5_passkey_plugin.so
+ }
+
+ kdcpreauth = {
+  module = passkey:/usr/lib64/sssd/modules/sssd_krb5_passkey_plugin.so
+ }

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -741,9 +741,10 @@
                                         </para>
                                         <para>
                                         The default is that the key settings
-                                        decide what to do. In the IPA case,
-                                        this will be overwritten by IPA
-                                        passkey configuration.
+                                        decide what to do. In the IPA or
+                                        kerberos pre-authentication case,
+                                        this value will be overwritten by the
+                                        server.
                                         </para>
                                     </listitem>
                                 </varlistentry>

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -748,14 +748,6 @@
                                         </para>
                                     </listitem>
                                 </varlistentry>
-                                <varlistentry>
-                                    <term>debug_libfido2</term>
-                                    <listitem>
-                                        <para> Enable libfido2 debug
-                                        messages, this option is disabled
-                                        by default.</para>
-                                    </listitem>
-                                </varlistentry>
                                 </variablelist>
                             </para>
                         </listitem>
@@ -1680,6 +1672,17 @@ pam_account_locked_message = Account locked, please contact help desk.
                     <listitem>
                         <para>
                             Enable passkey device based authentication.
+                        </para>
+                        <para>
+                            Default: False
+                        </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry condition="build_passkey">
+                    <term>passkey_debug_libfido2 (bool)</term>
+                    <listitem>
+                        <para>
+                            Enable libfido2 library debug messages.
                         </para>
                         <para>
                             Default: False

--- a/src/passkey_child/passkey_child.c
+++ b/src/passkey_child/passkey_child.c
@@ -84,6 +84,15 @@ int main(int argc, const char *argv[])
             ERROR("Error getting assertion data.\n");
             goto done;
         }
+    } else if (data.action == ACTION_VERIFY_ASSERT) {
+        ret = verify_assert_data(&data);
+        if (ret == EOK) {
+            PRINT("Verification success.\n");
+            goto done;
+        } else {
+            ERROR("Verification error.\n");
+            goto done;
+        }
     }
 
 done:

--- a/src/passkey_child/passkey_child.c
+++ b/src/passkey_child/passkey_child.c
@@ -72,7 +72,7 @@ int main(int argc, const char *argv[])
     } else if (data.action == ACTION_AUTHENTICATE) {
         ret = authenticate(&data);
         if (ret == EOK) {
-            printf("Authentication success.\n");
+            PRINT("Authentication success.\n");
             goto done;
         } else {
             ERROR("Authentication error.\n");

--- a/src/passkey_child/passkey_child.c
+++ b/src/passkey_child/passkey_child.c
@@ -78,6 +78,12 @@ int main(int argc, const char *argv[])
             ERROR("Authentication error.\n");
             goto done;
         }
+    } else if (data.action == ACTION_GET_ASSERT) {
+        ret = get_assert_data(&data);
+        if (ret != EOK) {
+            ERROR("Error getting assertion data.\n");
+            goto done;
+        }
     }
 
 done:

--- a/src/passkey_child/passkey_child.h
+++ b/src/passkey_child/passkey_child.h
@@ -39,7 +39,8 @@ enum action_opt {
     ACTION_NONE,
     ACTION_REGISTER,
     ACTION_AUTHENTICATE,
-    ACTION_GET_ASSERT
+    ACTION_GET_ASSERT,
+    ACTION_VERIFY_ASSERT
 };
 
 enum credential_type {
@@ -56,6 +57,8 @@ struct passkey_data {
     char **public_key_list;
     int public_key_size;
     const char *crypto_challenge;
+    const char *auth_data;
+    const char *signature;
     int type;
     fido_opt_t user_verification;
     enum credential_type cred_type;
@@ -353,6 +356,19 @@ set_assert_client_data_hash(const struct passkey_data *data,
                             fido_assert_t *_assert);
 
 /**
+ * @brief Set authenticator data and signature in the assert
+ *
+ * @param[in] data passkey data
+ * @param[in,out] _assert Assert
+ *
+ * @return 0 if the data was set properly,
+ *         error code otherwise.
+ */
+errno_t
+set_assert_auth_data_signature(const struct passkey_data *data,
+                               fido_assert_t *_assert);
+
+/**
  * @brief Set options in the assert
  *
  * @param[in] up User presence check
@@ -522,5 +538,19 @@ print_assert_data(const char *key_handle, const char *crypto_challenge,
  */
 errno_t
 get_assert_data(struct passkey_data *data);
+
+/**
+ * @brief Verify assertion data
+ *
+ * Prepare the assertion data, including the authenticator data and the
+ * signature; decode the public key and verify the assertion.
+ *
+ * @param[in] data passkey data
+ *
+ * @return 0 if the assertion was obtained properly,
+ *         error code otherwise.
+ */
+errno_t
+verify_assert_data(struct passkey_data *data);
 
 #endif /* __PASSKEY_CHILD_H__ */

--- a/src/passkey_child/passkey_child.h
+++ b/src/passkey_child/passkey_child.h
@@ -320,6 +320,22 @@ errno_t
 get_assert_user_id(TALLOC_CTX *mem_ctx, fido_assert_t *assert,
                    unsigned char **_user_id);
 
+/*
+ * @brief Select authenticator for verification
+ *
+ *
+ * @param[in] data passkey data
+ * @param[out] _dev Device information
+ * @param[out] _assert Assert
+ * @param[out] _index Index for key handle list
+ *
+ * @return 0 if the authenticator was selected properly,
+ *         error code otherwise.
+ */
+errno_t
+select_authenticator(struct passkey_data *data, fido_dev_t **_dev,
+                     fido_assert_t **_assert, int *_index);
+
 /**
  * @brief Set client data hash in the assert
  *
@@ -348,8 +364,8 @@ set_assert_options(fido_opt_t up, fido_opt_t uv, fido_assert_t *_assert);
  * @brief Prepare assert
  *
  * @param[in] data passkey data
- * @param[in] count Index for key handle list
- * @param[out] assert Assert
+ * @param[in] index Index for key handle list
+ * @param[out] _assert Assert
  *
  * @return 0 if the assert was prepared properly,
  *         error code otherwise.

--- a/src/passkey_child/passkey_child_assert.c
+++ b/src/passkey_child/passkey_child_assert.c
@@ -22,6 +22,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <jansson.h>
 #include <termios.h>
 #include <stdio.h>
 #include <fido/es256.h>
@@ -75,28 +76,67 @@ done:
 }
 
 errno_t
-set_assert_client_data_hash(fido_assert_t *_assert)
+set_assert_client_data_hash(const struct passkey_data *data,
+                            fido_assert_t *_assert)
 {
+    TALLOC_CTX *tmp_ctx = NULL;
     unsigned char cdh[32];
+    unsigned char *crypto_challenge = NULL;
+    size_t crypto_challenge_len;
     errno_t ret;
 
-    ret = sss_generate_csprng_buffer(cdh, sizeof(cdh));
-    if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "sss_generate_csprng_buffer failed [%d]: %s.\n",
-              ret, fido_strerr(ret));
-        goto done;
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "talloc_new() failed.\n");
+        return ENOMEM;
     }
 
-    ret = fido_assert_set_clientdata_hash(_assert, cdh, sizeof(cdh));
-    if (ret != FIDO_OK) {
-        DEBUG(SSSDBG_OP_FAILURE,
-              "fido_assert_set_clientdata_hash failed [%d]: %s.\n",
-              ret, fido_strerr(ret));
-        goto done;
+    if (data->action == ACTION_AUTHENTICATE) {
+        ret = sss_generate_csprng_buffer(cdh, sizeof(cdh));
+        if (ret != EOK) {
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "sss_generate_csprng_buffer failed [%d]: %s.\n",
+                  ret, fido_strerr(ret));
+            goto done;
+        }
+
+        ret = fido_assert_set_clientdata_hash(_assert, cdh, sizeof(cdh));
+        if (ret != FIDO_OK) {
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "fido_assert_set_clientdata_hash failed [%d]: %s.\n",
+                  ret, fido_strerr(ret));
+            goto done;
+        }
+    } else {
+        crypto_challenge = sss_base64_decode(tmp_ctx, data->crypto_challenge,
+                                             &crypto_challenge_len);
+        if (crypto_challenge == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE, "failed to decode client data hash.\n");
+            ret = ENOMEM;
+            goto done;
+        }
+
+        if (crypto_challenge_len != 32) {
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "cryptographic-challenge length [%ld] must be 32.\n",
+                  crypto_challenge_len);
+            ret = EINVAL;
+            goto done;
+        }
+
+        ret = fido_assert_set_clientdata_hash(_assert, crypto_challenge,
+                                              crypto_challenge_len);
+        if (ret != FIDO_OK) {
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "fido_assert_set_clientdata_hash failed [%d]: %s.\n",
+                  ret, fido_strerr(ret));
+            goto done;
+        }
     }
 
 done:
+    talloc_free(tmp_ctx);
+
     return ret;
 }
 
@@ -122,6 +162,82 @@ set_assert_options(fido_opt_t up, fido_opt_t uv, fido_assert_t *_assert)
     }
 
 done:
+    return ret;
+}
+
+errno_t
+get_assert_auth_data_signature(TALLOC_CTX *mem_ctx, fido_assert_t *assert,
+                               const char **_auth_data,
+                               const char **_signature)
+{
+    TALLOC_CTX *tmp_ctx = NULL;
+    const unsigned char *auth_data;
+    const unsigned char *signature;
+    const char *b64_auth_data;
+    const char *b64_signature;
+    size_t auth_data_len;
+    size_t signature_len;
+    errno_t ret;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "talloc_new() failed.\n");
+        return ENOMEM;
+    }
+
+    auth_data = fido_assert_authdata_ptr(assert, 0);
+    if (auth_data == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "fido_assert_authdata_ptr failed.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    auth_data_len = fido_assert_authdata_len(assert, 0);
+    if (auth_data_len == 0) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "fido_assert_authdata_len failed.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    b64_auth_data = sss_base64_encode(tmp_ctx, auth_data, auth_data_len);
+    if (b64_auth_data == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "failed to encode authenticator data.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    signature = fido_assert_sig_ptr(assert, 0);
+    if (signature == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "fido_assert_sig_ptr failed.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    signature_len = fido_assert_sig_len(assert, 0);
+    if (signature_len == 0) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "fido_assert_sig_len failed.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    b64_signature = sss_base64_encode(tmp_ctx, signature, signature_len);
+    if (b64_signature == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "failed to encode signature.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    *_auth_data = talloc_steal(mem_ctx, b64_auth_data);
+    *_signature = talloc_steal(mem_ctx, b64_signature);
+    ret = EOK;
+
+done:
+    talloc_free(tmp_ctx);
+
     return ret;
 }
 
@@ -167,7 +283,7 @@ prepare_assert(const struct passkey_data *data, int index,
         goto done;
     }
 
-    ret = set_assert_client_data_hash(_assert);
+    ret = set_assert_client_data_hash(data, _assert);
     if (ret != EOK) {
         goto done;
     }
@@ -272,4 +388,38 @@ verify_assert(struct pk_data_t *pk_data, fido_assert_t *assert)
 
 done:
     return ret;
+}
+
+void
+print_assert_data(const char *key_handle, const char *crypto_challenge,
+                  const char *auth_data, const char *signature,
+                  const unsigned char *user_id)
+{
+    json_t *passkey = NULL;
+    char* string = NULL;
+    const char *id = (user_id == NULL) ? "" : (const char *)user_id;
+
+    passkey = json_pack("{s:s*, s:s*, s:s*, s:s*, s:s*}",
+                        "credential_id", key_handle,
+                        "cryptographic_challenge", crypto_challenge,
+                        "authenticator_data", auth_data,
+                        "assertion_signature", signature,
+                        "user_id", id);
+    if (passkey == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to create passkey object.\n");
+        goto done;
+    }
+
+    string = json_dumps(passkey, 0);
+    if (string == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "json_dumps() failed.\n");
+    }
+
+    puts(string);
+    free(string);
+
+done:
+    json_decref(passkey);
+
+    return;
 }

--- a/src/passkey_child/passkey_child_credentials.c
+++ b/src/passkey_child/passkey_child_credentials.c
@@ -216,7 +216,7 @@ read_pin(char **pin)
         goto done;
     }
 
-    printf("Enter PIN:\n");
+    PRINT("Enter PIN:\n");
     fflush(stdout);
     bytes_read = getline(&line_ptr, &line_len, stdin);
     if (bytes_read == -1) {
@@ -226,7 +226,7 @@ read_pin(char **pin)
         /* Remove the end of line '\n' character */
         line_ptr[--bytes_read] = '\0';
     }
-    printf("\n");
+    PRINT("\n");
 
     ret = tcsetattr(STDIN_FILENO, TCSAFLUSH, &old);
     if (ret != 0) {
@@ -280,7 +280,7 @@ generate_credentials(struct passkey_data *data, fido_dev_t *dev,
     }
 
     if (data->quiet == false) {
-        printf("Please touch the device.\n");
+        PRINT("Please touch the device.\n");
         fflush(stdout);
     }
     ret = fido_dev_make_cred(dev, cred, pin);
@@ -411,9 +411,9 @@ print_credentials(const struct passkey_data *data,
     }
 
     if (data->cred_type == CRED_SERVER_SIDE) {
-        printf("passkey:%s,%s\n", b64_cred_id, pem_key);
+        PRINT("passkey:%s,%s\n", b64_cred_id, pem_key);
     } else {
-        printf("passkey:%s,%s,%s\n", b64_cred_id, pem_key, b64_user_id);
+        PRINT("passkey:%s,%s,%s\n", b64_cred_id, pem_key, b64_user_id);
     }
     ret = EOK;
 

--- a/src/passkey_child/passkey_child_credentials.c
+++ b/src/passkey_child/passkey_child_credentials.c
@@ -35,7 +35,7 @@
 
 #include "passkey_child.h"
 
-#define IN_BUF_SIZE 512
+#define IN_BUF_SIZE 1024
 
 errno_t
 prepare_credentials(struct passkey_data *data, fido_dev_t *dev,

--- a/src/providers/krb5/krb5_auth.c
+++ b/src/providers/krb5/krb5_auth.c
@@ -496,7 +496,9 @@ struct tevent_req *krb5_auth_send(TALLOC_CTX *mem_ctx,
                     && authtok_type != SSS_AUTHTOK_TYPE_2FA_SINGLE
                     && authtok_type != SSS_AUTHTOK_TYPE_SC_PIN
                     && authtok_type != SSS_AUTHTOK_TYPE_SC_KEYPAD
-                    && authtok_type != SSS_AUTHTOK_TYPE_OAUTH2) {
+                    && authtok_type != SSS_AUTHTOK_TYPE_OAUTH2
+                    && authtok_type != SSS_AUTHTOK_TYPE_PASSKEY
+                    && authtok_type != SSS_AUTHTOK_TYPE_PASSKEY_REPLY) {
                 /* handle empty password gracefully */
                 if (authtok_type == SSS_AUTHTOK_TYPE_EMPTY) {
                     DEBUG(SSSDBG_CRIT_FAILURE,

--- a/src/providers/krb5/krb5_auth.c
+++ b/src/providers/krb5/krb5_auth.c
@@ -498,6 +498,7 @@ struct tevent_req *krb5_auth_send(TALLOC_CTX *mem_ctx,
                     && authtok_type != SSS_AUTHTOK_TYPE_SC_KEYPAD
                     && authtok_type != SSS_AUTHTOK_TYPE_OAUTH2
                     && authtok_type != SSS_AUTHTOK_TYPE_PASSKEY
+                    && authtok_type != SSS_AUTHTOK_TYPE_PASSKEY_KRB
                     && authtok_type != SSS_AUTHTOK_TYPE_PASSKEY_REPLY) {
                 /* handle empty password gracefully */
                 if (authtok_type == SSS_AUTHTOK_TYPE_EMPTY) {

--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -38,11 +38,14 @@
 #include "util/child_common.h"
 #include "util/find_uid.h"
 #include "util/sss_chain_id.h"
+#include "util/sss_ptr_hash.h"
 #include "src/util/util_errors.h"
+#include "responder/pam/pamsrv_passkey.h"
 #include "providers/backend.h"
 #include "providers/krb5/krb5_auth.h"
 #include "providers/krb5/krb5_utils.h"
 #include "krb5_plugin/idp/idp.h"
+#include "krb5_plugin/passkey/passkey.h"
 #include "sss_cli.h"
 
 #define SSSD_KRB5_CHANGEPW_PRINCIPAL "kadmin/changepw"
@@ -119,6 +122,7 @@ static krb5_context krb5_error_ctx;
 
 static errno_t k5c_attach_otp_info_msg(struct krb5_req *kr);
 static errno_t k5c_attach_oauth2_info_msg(struct krb5_req *kr, struct sss_idp_oauth2 *data);
+static errno_t k5c_attach_passkey_msg(struct krb5_req *kr, struct sss_passkey_challenge *data);
 static errno_t k5c_attach_keep_alive_msg(struct krb5_req *kr);
 static errno_t k5c_recv_data(struct krb5_req *kr, int fd, uint32_t *offline);
 static errno_t k5c_send_data(struct krb5_req *kr, int fd, errno_t error);
@@ -933,6 +937,154 @@ done:
     return kerr;
 }
 
+static krb5_error_code passkey_preauth(struct krb5_req *kr,
+                                       struct sss_passkey_challenge *passkey)
+{
+    struct krb5_req *tmpkr = NULL;
+    uint32_t offline;
+    errno_t ret;
+
+    if (passkey->domain == NULL || passkey->credential_id_list == NULL ||
+        passkey->cryptographic_challenge == NULL) {
+        ret = EINVAL;
+        goto done;
+    }
+
+    ret = k5c_attach_passkey_msg(kr, passkey);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "k5c_attach_passkey_info_msg failed.\n");
+        return ret;
+    }
+
+    /* Challenge was presented. We need to continue the authentication
+     * with this exact child process in order to maintain internal Kerberos
+     * state so we are able to respond to this particular challenge. */
+    ret = k5c_attach_keep_alive_msg(kr);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "k5c_attach_keep_alive_msg failed.\n");
+        return ret;
+    }
+
+    tmpkr = talloc_zero(NULL, struct krb5_req);
+    if (tmpkr == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "talloc_zero failed.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    /* Send reply and wait for next step. */
+    ret = k5c_send_data(kr, STDOUT_FILENO, ret);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Failed to send reply\n");
+    }
+
+    ret = k5c_recv_data(tmpkr, STDIN_FILENO, &offline);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    ret = krb5_req_update(kr, tmpkr);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to update krb request [%d]: %s\n",
+              ret, sss_strerror(ret));
+        goto done;
+    }
+
+done:
+    talloc_free(tmpkr);
+    return ret;
+}
+
+static krb5_error_code answer_passkey(krb5_context kctx,
+                                      struct krb5_req *kr,
+                                      krb5_responder_context rctx)
+{
+    enum sss_authtok_type type;
+    struct sss_passkey_message *msg;
+    struct sss_passkey_message *reply_msg = NULL;
+    const char *challenge;
+    const char *reply;
+    const char *reply_str;
+    enum sss_passkey_phase phase;
+    const char *state;
+    size_t reply_len;
+    krb5_error_code kerr;
+
+    challenge = krb5_responder_get_challenge(kctx, rctx,
+                                             SSSD_PASSKEY_QUESTION);
+    if (challenge == NULL) {
+        return ENOENT;
+    }
+
+    msg = sss_passkey_message_decode(challenge);
+    if (msg == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Unable to decode passkey message\n");
+        return EINVAL;
+    }
+
+    if (kr->pd->cmd == SSS_PAM_PREAUTH) {
+        kerr = passkey_preauth(kr, msg->data.challenge);
+        if (kerr != EOK) {
+            goto done;
+        }
+    }
+
+    if (kr->pd->cmd != SSS_PAM_AUTHENTICATE) {
+        DEBUG(SSSDBG_OP_FAILURE, "Unexpected command [%d]\n", kr->pd->cmd);
+        kerr = EINVAL;
+        goto done;
+    }
+
+    type = sss_authtok_get_type(kr->pd->authtok);
+    if (type != SSS_AUTHTOK_TYPE_PASSKEY_REPLY) {
+        DEBUG(SSSDBG_OP_FAILURE, "Unexpected authentication token type [%s]\n",
+              sss_authtok_type_to_str(type));
+        kerr = EINVAL;
+        goto done;
+    }
+
+    kerr = sss_authtok_get_passkey_reply(kr->pd->authtok, &reply, &reply_len);
+    if (kerr != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "Unexpected command [%d]\n", kr->pd->cmd);
+        goto done;
+    }
+
+    phase = SSS_PASSKEY_PHASE_REPLY;
+    state = SSSD_PASSKEY_REPLY_STATE;
+    reply_msg = sss_passkey_prefix_json_data(phase, state, reply);
+    if (reply_msg == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Unable to prefix passkey message\n");
+        return EINVAL;
+    }
+
+    reply_str = sss_passkey_message_encode(reply_msg);
+    if (msg == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Unable to encode passkey message\n");
+        return EINVAL;
+    }
+
+    /* Don't let SSSD cache the authtoken since it is single-use. */
+    kerr = pam_add_response(kr->pd, SSS_OTP, 0, NULL);
+    if (kerr != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "pam_add_response failed.\n");
+        goto done;
+    }
+
+    kerr = krb5_responder_set_answer(kctx, rctx, SSSD_PASSKEY_QUESTION,
+                                     reply_str);
+    if (kerr != 0) {
+        DEBUG(SSSDBG_OP_FAILURE, "Unable to set passkey answer [%d]\n", kerr);
+        goto done;
+    }
+
+    kerr = EOK;
+
+done:
+    sss_passkey_message_free(reply_msg);
+
+    return kerr;
+}
+
 static krb5_error_code sss_krb5_responder(krb5_context ctx,
                                           void *data,
                                           krb5_responder_context rctx)
@@ -989,6 +1141,8 @@ static krb5_error_code sss_krb5_responder(krb5_context ctx,
                 return answer_pkinit(ctx, kr, rctx);
             } else if (strcmp(question_list[c], SSSD_IDP_OAUTH2_QUESTION) == 0) {
                 return answer_idp_oauth2(ctx, kr, rctx);
+            } else if (strcmp(question_list[c], SSSD_PASSKEY_QUESTION) == 0) {
+                return answer_passkey(ctx, kr, rctx);
             }
         }
     }
@@ -1390,6 +1544,86 @@ static errno_t k5c_attach_oauth2_info_msg(struct krb5_req *kr,
     memcpy(msg + idx, data->user_code, user_code_len);
 
     ret = pam_add_response(kr->pd, SSS_PAM_OAUTH2_INFO, msg_len, msg);
+    talloc_zfree(msg);
+
+    return ret;
+}
+
+static errno_t k5c_attach_passkey_msg(struct krb5_req *kr,
+                                      struct sss_passkey_challenge *data)
+{
+    uint8_t *msg;
+    const char *user_verification;
+    int i;
+    size_t msg_len = 0;
+    size_t domain_len = 0;
+    size_t crypto_len = 0;
+    size_t num_creds = 0;
+    size_t cred_len = 0;
+    size_t verification_len = 0;
+    size_t idx = 0;
+    errno_t ret;
+
+    if (data->domain == NULL || data->credential_id_list == NULL ||
+        data->cryptographic_challenge == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Empty passkey domain, credential id list, or cryptographic "
+              "challenge\n");
+        return EINVAL;
+    }
+
+    user_verification = data->user_verification == 0 ? "false" : "true";
+    verification_len = strlen(user_verification) + 1;
+    msg_len += verification_len;
+
+    crypto_len = strlen(data->cryptographic_challenge) + 1;
+    msg_len += crypto_len;
+
+    domain_len = strlen(data->domain) + 1;
+    msg_len += domain_len;
+
+    /* credentials list size */
+    msg_len += sizeof(uint32_t);
+
+    for (i = 0; data->credential_id_list[i] != NULL; i++) {
+        msg_len += (strlen(data->credential_id_list[i]) + 1);
+    }
+    num_creds = i;
+
+    msg = talloc_zero_size(kr, msg_len);
+    if (msg == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "talloc_size failed.\n");
+        return ENOMEM;
+    }
+
+    /* To avoid sending extraneous data back and forth to pam_sss,
+     * (and reduce boilerplate memcpy code) only the user
+     * verification and cryptographic challenge are retrieved in pam_sss.
+     *
+     * The remaining passkey data (domain, creds list, num_creds)
+     * is sent to the PAM responder and stored in a hash table. The
+     * challenge is used as a unique key of the hash table. The pam_sss
+     * reply includes the challenge which is used to lookup the passkey
+     * data in the PAM responder, ensuring it matches the originating
+     * request */
+    memcpy(msg + idx, user_verification, verification_len);
+    idx += verification_len;
+
+    memcpy(msg + idx, data->cryptographic_challenge, crypto_len);
+    idx += crypto_len;
+
+    memcpy(msg + idx, data->domain, domain_len);
+    idx += domain_len;
+
+    SAFEALIGN_COPY_UINT32(msg + idx, &num_creds, &idx);
+
+    for (i = 0; data->credential_id_list[i] != NULL; i++) {
+        cred_len = strlen(data->credential_id_list[i]) + 1;
+        memcpy(msg + idx, data->credential_id_list[i], cred_len);
+        idx += cred_len;
+    }
+
+    ret = pam_add_response(kr->pd, SSS_PAM_PASSKEY_KRB_INFO, msg_len, msg);
     talloc_zfree(msg);
 
     return ret;
@@ -2685,6 +2919,9 @@ static errno_t unpack_authtok(struct sss_auth_token *tok,
     case SSS_AUTHTOK_TYPE_SC_PIN:
     case SSS_AUTHTOK_TYPE_SC_KEYPAD:
     case SSS_AUTHTOK_TYPE_OAUTH2:
+    case SSS_AUTHTOK_TYPE_PASSKEY:
+    case SSS_AUTHTOK_TYPE_PASSKEY_KRB:
+    case SSS_AUTHTOK_TYPE_PASSKEY_REPLY:
         ret = sss_authtok_set(tok, auth_token_type, (buf + *p),
                               auth_token_length);
         break;

--- a/src/providers/krb5/krb5_child_handler.c
+++ b/src/providers/krb5/krb5_child_handler.c
@@ -90,6 +90,7 @@ static errno_t pack_authtok(struct io_buffer *buf, size_t *rp,
     case SSS_AUTHTOK_TYPE_SC_KEYPAD:
     case SSS_AUTHTOK_TYPE_OAUTH2:
     case SSS_AUTHTOK_TYPE_PASSKEY:
+    case SSS_AUTHTOK_TYPE_PASSKEY_KRB:
     case SSS_AUTHTOK_TYPE_PASSKEY_REPLY:
         data = (char *) sss_authtok_get_data(tok);
         auth_token_length = sss_authtok_get_size(tok);
@@ -845,6 +846,10 @@ static const char *krb5_child_response_type_to_str(int32_t type)
         return "Keep alive";
     case SSS_PAM_OAUTH2_INFO:
         return "OAuth2 info";
+    case SSS_PAM_PASSKEY_INFO:
+        return "Passkey info";
+    case SSS_PAM_PASSKEY_KRB_INFO:
+        return "Passkey kerberos info";
     }
 
     DEBUG(SSSDBG_MINOR_FAILURE, "Unexpected response type %d\n", type);

--- a/src/providers/krb5/krb5_child_handler.c
+++ b/src/providers/krb5/krb5_child_handler.c
@@ -89,6 +89,8 @@ static errno_t pack_authtok(struct io_buffer *buf, size_t *rp,
     case SSS_AUTHTOK_TYPE_SC_PIN:
     case SSS_AUTHTOK_TYPE_SC_KEYPAD:
     case SSS_AUTHTOK_TYPE_OAUTH2:
+    case SSS_AUTHTOK_TYPE_PASSKEY:
+    case SSS_AUTHTOK_TYPE_PASSKEY_REPLY:
         data = (char *) sss_authtok_get_data(tok);
         auth_token_length = sss_authtok_get_size(tok);
         break;

--- a/src/responder/pam/pam_prompting_config.c
+++ b/src/responder/pam/pam_prompting_config.c
@@ -239,6 +239,7 @@ errno_t pam_eval_prompting_config(struct pam_ctx *pctx, struct pam_data *pd)
             cert_auth = true;
             break;
         case SSS_PAM_PASSKEY_INFO:
+        case SSS_PAM_PASSKEY_KRB_INFO:
             passkey_auth = true;
             break;
         case SSS_PASSWORD_PROMPTING:

--- a/src/responder/pam/pamsrv.c
+++ b/src/responder/pam/pamsrv.c
@@ -49,7 +49,7 @@
 #define NO_DOMAINS_ARE_PUBLIC "none"
 #define DEFAULT_ALLOWED_UIDS ALL_UIDS_ALLOWED
 #define DEFAULT_PAM_CERT_AUTH false
-#define DEFAULT_PAM_PASSKEY_AUTH false
+#define DEFAULT_PAM_PASSKEY_AUTH true
 #define DEFAULT_PAM_CERT_DB_PATH SYSCONFDIR"/sssd/pki/sssd_auth_ca_db.pem"
 #define DEFAULT_PAM_INITGROUPS_SCHEME "no_session"
 

--- a/src/responder/pam/pamsrv.h
+++ b/src/responder/pam/pamsrv.h
@@ -72,6 +72,7 @@ struct pam_ctx {
     char **gssapi_indicators_map;
     bool gssapi_check_upn;
     bool passkey_auth;
+    struct pam_passkey_table_data *pk_table_data;
 };
 
 struct pam_auth_req {
@@ -94,7 +95,7 @@ struct pam_auth_req {
     struct cert_auth_info *current_cert;
     bool cert_auth_local;
 
-    struct passkey_auth_data *passkey_data;
+    bool passkey_data_exists;
     uint32_t client_id_num;
 };
 

--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -24,6 +24,7 @@
 #include "util/util.h"
 #include "util/auth_utils.h"
 #include "util/find_uid.h"
+#include "util/sss_ptr_hash.h"
 #include "db/sysdb.h"
 #include "confdb/confdb.h"
 #include "responder/common/responder_packet.h"
@@ -47,6 +48,12 @@ enum pam_verbosity {
 struct pam_initgroup_enum_str {
     enum pam_initgroups_scheme scheme;
     const char *option;
+};
+
+struct pam_passkey_table_data {
+    hash_table_t *table;
+    char *key;
+    struct pk_child_user_data *data;
 };
 
 struct pam_initgroup_enum_str pam_initgroup_enum_str[] = {
@@ -97,6 +104,10 @@ static errno_t check_cert(TALLOC_CTX *mctx,
                           struct pam_ctx *pctx,
                           struct pam_auth_req *preq,
                           struct pam_data *pd);
+
+errno_t passkey_kerberos(struct pam_ctx *pctx,
+                            struct pam_data *pd,
+                            struct pam_auth_req *preq);
 
 int pam_check_user_done(struct pam_auth_req *preq, int ret);
 
@@ -204,6 +215,8 @@ static int extract_authtok_v2(struct sss_auth_token *tok,
     case SSS_AUTHTOK_TYPE_SC_KEYPAD:
     case SSS_AUTHTOK_TYPE_OAUTH2:
     case SSS_AUTHTOK_TYPE_PASSKEY:
+    case SSS_AUTHTOK_TYPE_PASSKEY_KRB:
+    case SSS_AUTHTOK_TYPE_PASSKEY_REPLY:
         ret = sss_authtok_set(tok, auth_token_type,
                               auth_token_data, auth_token_length);
         break;
@@ -858,6 +871,229 @@ done:
     return ret;
 }
 
+errno_t decode_pam_passkey_msg(TALLOC_CTX *mem_ctx,
+                               uint8_t *buf,
+                               size_t len,
+                               struct pk_child_user_data **_data)
+{
+
+    size_t p = 0;
+    size_t pctr = 0;
+    errno_t ret;
+    size_t offset;
+    struct pk_child_user_data *data = NULL;
+    TALLOC_CTX *tmp_ctx;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    data = talloc_zero(tmp_ctx, struct pk_child_user_data);
+    if (data == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to talloc passkey data.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    data->user_verification = talloc_strdup(data, (char *) &buf[p]);
+    if (data->user_verification == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to strdup passkey prompt.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    offset = strlen(data->user_verification) + 1;
+    if (offset >= len) {
+        DEBUG(SSSDBG_OP_FAILURE, "passkey prompt offset failure.\n");
+        ret = EIO;
+        goto done;
+    }
+
+    data->crypto_challenge = talloc_strdup(data, (char *) &buf[p + offset]);
+    if (data->crypto_challenge == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to strdup passkey challenge.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    offset += strlen(data->crypto_challenge) + 1;
+    if (offset >= len) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to strdup passkey challenge.\n");
+        ret = EIO;
+        goto done;
+    }
+
+
+    data->domain = talloc_strdup(data, (char *) &buf[p] + offset);
+    if (data->domain == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to strdup passkey domain.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    offset += strlen(data->domain) + 1;
+    if (offset >= len) {
+        DEBUG(SSSDBG_OP_FAILURE, "passkey domain offset failure.\n");
+        ret = EIO;
+        goto done;
+    }
+
+    SAFEALIGN_COPY_UINT32(&data->num_credentials, &buf[p + offset], &pctr);
+    size_t list_sz = (size_t) data->num_credentials;
+
+    offset += sizeof(uint32_t);
+
+    data->key_handles = talloc_zero_array(data, const char *, list_sz);
+
+    for (int i = 0; i < list_sz; i++) {
+        data->key_handles[i] = talloc_strdup(data->key_handles, (char *) &buf[p + offset]);
+        if (data->key_handles[i] == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE, "Failed to strdup passkey list.\n");
+            ret = ENOMEM;
+            goto done;
+        }
+
+        offset += strlen(data->key_handles[i]) + 1;
+    }
+
+    *_data = talloc_steal(mem_ctx, data);
+
+    ret = EOK;
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+
+errno_t save_passkey_data(TALLOC_CTX *mem_ctx,
+                          struct pam_ctx *pctx,
+                          struct pk_child_user_data *data,
+                          struct pam_auth_req *preq)
+{
+    char *pk_key;
+    errno_t ret;
+    TALLOC_CTX *tmp_ctx;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    /* Passkey data (pk_table_data) is stolen onto client ctx, it will
+     * be freed when the client closes, and the sss_ptr_hash interface
+     * takes care of automatically removing it from the hash table then */
+    pctx->pk_table_data = talloc_zero(tmp_ctx, struct pam_passkey_table_data);
+    if (pctx->pk_table_data == NULL) {
+        return ENOMEM;
+    }
+
+    if (pctx->pk_table_data->table == NULL) {
+        pctx->pk_table_data->table = sss_ptr_hash_create(pctx->pk_table_data,
+                                                         NULL, NULL);
+        if (pctx->pk_table_data->table == NULL) {
+            ret = ENOMEM;
+            goto done;
+        }
+    }
+
+    pk_key = talloc_asprintf(tmp_ctx, "%s", data->crypto_challenge);
+    if (pk_key == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    pctx->pk_table_data->key = talloc_strdup(pctx->pk_table_data, pk_key);
+    if (pk_key == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = sss_ptr_hash_add(pctx->pk_table_data->table, pk_key, data,
+                           struct pk_child_user_data);
+    if (ret == EEXIST) {
+        DEBUG(SSSDBG_TRACE_FUNC, "pk_table key [%s] already exists\n",
+                                 pk_key);
+        goto done;
+    } else if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "Unable to add pk data to hash table "
+              "[%d]: %s\n", ret, sss_strerror(ret));
+        goto done;
+    }
+
+    talloc_steal(mem_ctx, pctx->pk_table_data);
+    pctx->pk_table_data->data = talloc_steal(mem_ctx, data);
+
+    ret = EOK;
+
+done:
+    talloc_free(tmp_ctx);
+
+    return ret;
+}
+
+errno_t pam_eval_passkey_response(struct pam_ctx *pctx,
+                                  struct pam_data *pd,
+                                  struct pam_auth_req *preq,
+                                  bool *_pk_preauth_done)
+{
+    struct response_data *pk_resp;
+    struct pk_child_user_data *pk_data;
+    errno_t ret;
+    TALLOC_CTX *tmp_ctx;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    pk_resp = pd->resp_list;
+
+    while (pk_resp != NULL) {
+        switch (pk_resp->type) {
+        case SSS_PAM_PASSKEY_KRB_INFO:
+            if (!pctx->passkey_auth) {
+                /* Passkey auth is disabled. To avoid passkey prompts appearing,
+                 * don't send SSS_PAM_PASSKEY_KRB_INFO to the client and
+                 * add a dummy response to fallback to normal auth */
+                pk_resp->do_not_send_to_client = true;
+				ret = pam_add_response(pd, SSS_OTP, 0, NULL);
+				if (ret != EOK) {
+					DEBUG(SSSDBG_CRIT_FAILURE, "pam_add_response failed.\n");
+					goto done;
+				}
+                break;
+            }
+            ret = decode_pam_passkey_msg(tmp_ctx, pk_resp->data, pk_resp->len, &pk_data);
+            if (ret != EOK) {
+                DEBUG(SSSDBG_OP_FAILURE, "Failed to decode passkey msg\n");
+                ret = EIO;
+                goto done;
+            }
+
+            ret = save_passkey_data(preq->cctx, pctx, pk_data, preq);
+            if (ret != EOK) {
+                DEBUG(SSSDBG_OP_FAILURE, "Failed to save passkey msg\n");
+                ret = EIO;
+                goto done;
+            }
+            break;
+        /* Passkey non-kerberos preauth has already run */
+        case SSS_PAM_PASSKEY_INFO:
+           *_pk_preauth_done = true;
+        default:
+            break;
+        }
+        pk_resp = pk_resp->next;
+    }
+
+    ret = EOK;
+done:
+    talloc_free(tmp_ctx);
+
+    return ret;
+}
+
 void pam_reply(struct pam_auth_req *preq)
 {
     struct cli_ctx *cctx;
@@ -879,6 +1115,7 @@ void pam_reply(struct pam_auth_req *preq)
     char* pam_account_expired_message;
     char* pam_account_locked_message;
     int pam_verbosity;
+    bool pk_preauth_done;
 
     pd = preq->pd;
     cctx = preq->cctx;
@@ -1103,6 +1340,18 @@ void pam_reply(struct pam_auth_req *preq)
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "Failed to add prompting information, "
                                      "using defaults.\n");
+        }
+
+        ret = pam_eval_passkey_response(pctx, pd, preq, &pk_preauth_done);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_OP_FAILURE, "Failed to eval passkey response\n");
+            goto done;
+        }
+
+        if (may_do_passkey_auth(pctx, pd) && !pk_preauth_done && preq->passkey_data_exists) {
+            ret = passkey_non_kerberos(cctx, cctx->ev, pctx, preq, pd);
+            pam_check_user_done(preq, ret);
+            return;
         }
     }
 
@@ -1546,10 +1795,21 @@ static int pam_forwarder(struct cli_ctx *cctx, int pam_cmd)
         goto done;
     }
 
-    if (may_do_passkey_auth(pctx, pd)) {
-        /* Preauth and Auth */
-        ret = check_passkey(cctx, cctx->ev, pctx, preq, pd);
-        goto done;
+    /* This is set to false inside passkey_non_kerberos() if no passkey data is found.
+     * It is checked in pam_reply() to avoid an endless loop */
+    preq->passkey_data_exists = true;
+
+    if ((pd->cmd == SSS_PAM_AUTHENTICATE)) {
+        if (may_do_passkey_auth(pctx, pd)) {
+            if (sss_authtok_get_type(pd->authtok) == SSS_AUTHTOK_TYPE_PASSKEY_KRB) {
+                ret = passkey_kerberos(pctx, preq->pd, preq);
+                goto done;
+            } else if ((sss_authtok_get_type(pd->authtok) == SSS_AUTHTOK_TYPE_PASSKEY) ||
+                      (sss_authtok_get_type(pd->authtok) == SSS_AUTHTOK_TYPE_EMPTY)) {
+                ret = passkey_non_kerberos(cctx, cctx->ev, pctx, preq, pd);
+                goto done;
+            }
+        }
     }
 
     /* Try backend first for authentication before doing local Smartcard
@@ -1952,6 +2212,24 @@ static void pam_forwarder_cb(struct tevent_req *req)
         goto done;
     }
 
+    /* This is set to false inside passkey_non_kerberos() if no passkey data is found.
+     * It is checked in pam_reply() to avoid an endless loop */
+    preq->passkey_data_exists = true;
+
+
+    if ((pd->cmd == SSS_PAM_AUTHENTICATE)) {
+        if (may_do_passkey_auth(pctx, pd)) {
+            if (sss_authtok_get_type(pd->authtok) == SSS_AUTHTOK_TYPE_PASSKEY_KRB) {
+                ret = passkey_kerberos(pctx, preq->pd, preq);
+                goto done;
+            } else if ((sss_authtok_get_type(pd->authtok) == SSS_AUTHTOK_TYPE_PASSKEY) ||
+                      (sss_authtok_get_type(pd->authtok) == SSS_AUTHTOK_TYPE_EMPTY)) {
+                ret = passkey_non_kerberos(cctx, cctx->ev, pctx, preq, pd);
+                goto done;
+            }
+        }
+    }
+
     /* try backend first for authentication before doing local Smartcard
      * authentication */
     if (pd->cmd != SSS_PAM_AUTHENTICATE && may_do_cert_auth(pctx, pd)) {
@@ -2278,6 +2556,118 @@ static bool pam_can_user_cache_auth(struct sss_domain_info *domain,
     }
 
     return result;
+}
+
+void passkey_kerberos_cb(struct tevent_req *req)
+{
+    struct pam_auth_req *preq = tevent_req_callback_data(req,
+                                                         struct pam_auth_req);
+    errno_t ret = EOK;
+    int child_status;
+
+    ret = pam_passkey_auth_recv(req, &child_status);
+    talloc_free(req);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "PAM passkey auth failed [%d]: %s\n",
+                                 ret, sss_strerror(ret));
+        goto done;
+    }
+
+    DEBUG(SSSDBG_TRACE_FUNC, "passkey child finished with status [%d]\n", child_status);
+
+    pam_check_user_search(preq);
+
+done:
+    pam_check_user_done(preq, ret);
+}
+
+errno_t passkey_kerberos(struct pam_ctx *pctx,
+                            struct pam_data *pd,
+                            struct pam_auth_req *preq)
+{
+    errno_t ret;
+    const char *prompt;
+    const char *key;
+    const char *pin;
+    size_t pin_len;
+    struct pk_child_user_data *data;
+    struct tevent_req *req;
+	int timeout;
+    char *verify_opts;
+    bool debug_libfido2;
+    enum passkey_user_verification verification;
+
+    ret = sss_authtok_get_passkey(preq, preq->pd->authtok,
+                                  &prompt, &key, &pin, &pin_len);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Failure to get passkey authtok\n");
+        return EIO;
+    }
+
+    if (prompt == NULL || key == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Passkey prompt and key are missing or invalid.\n");
+        return EIO;
+    }
+
+    data = sss_ptr_hash_lookup(pctx->pk_table_data->table, key,
+                               struct pk_child_user_data);
+    if (data == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Failed to lookup passkey authtok\n");
+        return EIO;
+    }
+
+    ret = confdb_get_int(pctx->rctx->cdb, CONFDB_PAM_CONF_ENTRY,
+                         CONFDB_PAM_PASSKEY_CHILD_TIMEOUT, PASSKEY_CHILD_TIMEOUT_DEFAULT,
+                         &timeout);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Failed to read passkey_child_timeout from confdb: [%d]: %s\n",
+              ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = confdb_get_string(pctx->rctx->cdb, preq, CONFDB_MONITOR_CONF_ENTRY,
+                            CONFDB_MONITOR_PASSKEY_VERIFICATION, NULL,
+                            &verify_opts);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+            "Failed to read '"CONFDB_MONITOR_PASSKEY_VERIFICATION"' from confdb: [%d]: %s\n",
+            ret, sss_strerror(ret));
+        goto done;
+    }
+
+    /* Always use verification sent from passkey krb5 plugin */
+    ret = read_passkey_conf_verification(preq, verify_opts, NULL, &debug_libfido2);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_MINOR_FAILURE, "Unable to parse passkey verificaton options.\n");
+    }
+
+    if (strcasecmp(data->user_verification, "false") == 0) {
+        verification = PAM_PASSKEY_VERIFICATION_OFF;
+    } else {
+        verification = PAM_PASSKEY_VERIFICATION_ON;
+    }
+
+
+    req = pam_passkey_auth_send(preq->cctx, preq->cctx->ev, timeout, debug_libfido2,
+                                verification, pd, data, true);
+    if (req == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "passkey auth send failed [%d]: [%s]\n",
+              ret, sss_strerror(ret));
+        goto done;
+    }
+
+    tevent_req_set_callback(req, passkey_kerberos_cb, preq);
+
+    ret = EAGAIN;
+
+done:
+
+    return ret;
+
 }
 
 static void pam_dom_forwarder(struct pam_auth_req *preq)

--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -2640,7 +2640,7 @@ errno_t passkey_kerberos(struct pam_ctx *pctx,
     }
 
     /* Always use verification sent from passkey krb5 plugin */
-    ret = read_passkey_conf_verification(preq, verify_opts, NULL, &debug_libfido2);
+    ret = read_passkey_conf_verification(preq, verify_opts, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_MINOR_FAILURE, "Unable to parse passkey verificaton options.\n");
     }
@@ -2651,6 +2651,15 @@ errno_t passkey_kerberos(struct pam_ctx *pctx,
         verification = PAM_PASSKEY_VERIFICATION_ON;
     }
 
+	ret = confdb_get_bool(pctx->rctx->cdb, CONFDB_PAM_CONF_ENTRY,
+						  CONFDB_PAM_PASSKEY_DEBUG_LIBFIDO2, false,
+						  &debug_libfido2);
+	if (ret != EOK) {
+		DEBUG(SSSDBG_OP_FAILURE,
+			"Failed to read '"CONFDB_PAM_PASSKEY_DEBUG_LIBFIDO2"' from confdb: [%d]: %s\n",
+			ret, sss_strerror(ret));
+		goto done;
+	}
 
     req = pam_passkey_auth_send(preq->cctx, preq->cctx->ev, timeout, debug_libfido2,
                                 verification, pd, data, true);

--- a/src/responder/pam/pamsrv_passkey.c
+++ b/src/responder/pam/pamsrv_passkey.c
@@ -20,6 +20,7 @@
 */
 
 #include "util/child_common.h"
+#include "util/authtok.h"
 #include "db/sysdb.h"
 #include "db/sysdb_passkey_user_verification.h"
 #include "responder/pam/pamsrv.h"
@@ -62,7 +63,13 @@ struct passkey_ctx {
     struct pam_auth_req *preq;
 };
 
-static void pam_forwarder_passkey_cb(struct tevent_req *req);
+void pam_forwarder_passkey_cb(struct tevent_req *req);
+
+errno_t pam_passkey_concatenate_keys(TALLOC_CTX *mem_ctx,
+                                     struct pk_child_user_data *pk_data,
+                                     bool kerberos_pa,
+                                     char **_result_kh,
+                                     char **_result_ph);
 
 struct tevent_req *pam_passkey_get_mapping_send(TALLOC_CTX *mem_ctx,
                                                 struct tevent_context *ev,
@@ -78,7 +85,7 @@ struct passkey_get_mapping_state {
     struct cache_req_result *result;
 };
 
-errno_t check_passkey(TALLOC_CTX *mem_ctx,
+errno_t passkey_non_kerberos(TALLOC_CTX *mem_ctx,
                       struct tevent_context *ev,
                       struct pam_ctx *pam_ctx,
                       struct pam_auth_req *preq,
@@ -197,10 +204,10 @@ errno_t pam_passkey_get_mapping_recv(TALLOC_CTX *mem_ctx,
     return EOK;
 }
 
-static errno_t read_passkey_conf_verification(TALLOC_CTX *mem_ctx,
-                                              const char *verify_opts,
-                                              enum passkey_user_verification *_user_verification,
-                                              bool *_debug_libfido2)
+errno_t read_passkey_conf_verification(TALLOC_CTX *mem_ctx,
+                                       const char *verify_opts,
+                                       enum passkey_user_verification *_user_verification,
+                                       bool *_debug_libfido2)
 {
     int ret;
     TALLOC_CTX *tmp_ctx;
@@ -253,7 +260,7 @@ done:
     return ret;
 }
 
-static errno_t check_passkey_verification(TALLOC_CTX *mem_ctx,
+static errno_t passkey_non_kerberos_verification(TALLOC_CTX *mem_ctx,
                                           struct passkey_ctx *pctx,
                                           struct confdb_ctx *cdb,
                                           struct sysdb_ctx *sysdb,
@@ -400,7 +407,7 @@ errno_t process_passkey_data(TALLOC_CTX *mem_ctx,
     _data->domain = talloc_steal(mem_ctx, domain_name);
     _data->key_handles = talloc_steal(mem_ctx, kh_mappings);
     _data->public_keys = talloc_steal(mem_ctx, public_keys);
-    _data->num_passkeys = el->num_values;
+    _data->num_credentials = el->num_values;
 
     ret = EOK;
 done:
@@ -409,7 +416,7 @@ done:
     return ret;
 }
 
-static void pam_forwarder_passkey_cb(struct tevent_req *req)
+void pam_forwarder_passkey_cb(struct tevent_req *req)
 {
     struct pam_auth_req *preq = tevent_req_callback_data(req,
                                                          struct pam_auth_req);
@@ -424,6 +431,7 @@ static void pam_forwarder_passkey_cb(struct tevent_req *req)
         goto done;
     }
 
+    DEBUG(SSSDBG_TRACE_FUNC, "passkey child finished with status [%d]\n", child_status);
     preq->pd->pam_status = PAM_SUCCESS;
     pam_reply(preq);
 
@@ -499,9 +507,9 @@ void pam_passkey_get_user_done(struct tevent_req *req)
         goto done;
     }
 
-    ret = check_passkey_verification(pctx, pctx, pctx->pam_ctx->rctx->cdb,
-                                     result->domain->sysdb, result->domain->dns_name,
-                                     pk_data, &verification, &debug_libfido2);
+    ret = passkey_non_kerberos_verification(pctx, pctx, pctx->pam_ctx->rctx->cdb,
+                                            result->domain->sysdb, result->domain->dns_name,
+                                            pk_data, &verification, &debug_libfido2);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
               "Failed to check passkey verification [%d]: %s\n",
@@ -528,7 +536,7 @@ void pam_passkey_get_user_done(struct tevent_req *req)
     }
 
     req = pam_passkey_auth_send(pctx, pctx->ev, timeout, debug_libfido2,
-                                verification, pctx->pd, pk_data);
+                                verification, pctx->pd, pk_data, false);
     if (req == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "pam_passkey_auth_send failed [%d]: %s\n",
                                  ret, sss_strerror(ret));
@@ -545,6 +553,7 @@ done:
     if (ret == ENOENT) {
         /* No passkey data, continue through to typical auth flow */
         DEBUG(SSSDBG_TRACE_FUNC, "No passkey data found, skipping passkey auth\n");
+        pctx->preq->passkey_data_exists = false;
         pam_check_user_search(pctx->preq);
     } else if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "Unexpected passkey error [%d]: %s."
@@ -567,6 +576,7 @@ struct pam_passkey_auth_send_state {
     char *verify_opts;
     int timeout;
     int child_status;
+    bool kerberos_pa;
 };
 
 static errno_t passkey_child_exec(struct tevent_req *req);
@@ -598,13 +608,15 @@ errno_t get_passkey_child_write_buffer(TALLOC_CTX *mem_ctx,
         return EINVAL;
     }
 
-    if (sss_authtok_get_type(pd->authtok) == SSS_AUTHTOK_TYPE_PASSKEY) {
+    if (sss_authtok_get_type(pd->authtok) == SSS_AUTHTOK_TYPE_PASSKEY ||
+        sss_authtok_get_type(pd->authtok) == SSS_AUTHTOK_TYPE_PASSKEY_KRB) {
         ret = sss_authtok_get_passkey_pin(pd->authtok, &pin, &len);
         if (ret != EOK) {
-            DEBUG(SSSDBG_OP_FAILURE, "sss_authtok_get_sc_pin failed [%d]: %s\n",
+            DEBUG(SSSDBG_OP_FAILURE, "sss_authtok_get_passkey_pin failed [%d]: %s\n",
                                     ret, sss_strerror(ret));
             return ret;
         }
+
         if (pin == NULL || len == 0) {
             DEBUG(SSSDBG_OP_FAILURE, "Missing PIN.\n");
             return EINVAL;
@@ -631,6 +643,34 @@ errno_t get_passkey_child_write_buffer(TALLOC_CTX *mem_ctx,
     return EOK;
 }
 
+static void pam_passkey_child_read_data(struct tevent_req *subreq)
+{
+    uint8_t *buf;
+    ssize_t buf_len;
+    char *str;
+    struct tevent_req *req = tevent_req_callback_data(subreq,
+                                                      struct tevent_req);
+    struct pam_passkey_auth_send_state *state = tevent_req_data(req, struct pam_passkey_auth_send_state);
+    int ret;
+
+    ret = read_pipe_recv(subreq, state, &buf, &buf_len);
+    talloc_zfree(subreq);
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    str = malloc(sizeof(char) * buf_len);
+    snprintf(str, buf_len, "%s", buf);
+
+    sss_authtok_set_passkey_reply(state->pd->authtok, str, 0);
+
+    free(str);
+
+    tevent_req_done(req);
+    return;
+}
+
 static void passkey_child_write_done(struct tevent_req *subreq)
 {
     struct tevent_req *req = tevent_req_callback_data(subreq,
@@ -649,16 +689,80 @@ static void passkey_child_write_done(struct tevent_req *subreq)
     }
 
     PIPE_FD_CLOSE(state->io->write_to_child_fd);
+
+    if (state->kerberos_pa) {
+        /* Read data back from passkey child */
+        subreq = read_pipe_send(state, state->ev, state->io->read_from_child_fd);
+        if (subreq == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE, "read_pipe_send failed.\n");
+            ret = ERR_PASSKEY_CHILD;
+            return;
+        }
+
+        tevent_req_set_callback(subreq, pam_passkey_child_read_data, req);
+    }
+}
+
+errno_t pam_passkey_concatenate_keys(TALLOC_CTX *mem_ctx,
+                                     struct pk_child_user_data *pk_data,
+                                     bool kerberos_pa,
+                                     char **_result_kh,
+                                     char **_result_pk)
+{
+    errno_t ret;
+    char *result_kh = NULL;
+    char *result_pk = NULL;
+
+    result_kh = talloc_strdup(mem_ctx, pk_data->key_handles[0]);
+    if (!kerberos_pa) {
+        result_pk = talloc_strdup(mem_ctx, pk_data->public_keys[0]);
+    }
+
+    for (int i = 1; i < pk_data->num_credentials; i++) {
+        result_kh = talloc_strdup_append(result_kh, ",");
+        if (result_kh == NULL) {
+            ret = ENOMEM;
+            goto done;
+        }
+
+        result_kh = talloc_strdup_append(result_kh, pk_data->key_handles[i]);
+        if (result_kh == NULL) {
+            ret = ENOMEM;
+            goto done;
+        }
+
+        if (!kerberos_pa) {
+            result_pk = talloc_strdup_append(result_pk, ",");
+            if (result_pk == NULL) {
+                ret = ENOMEM;
+                goto done;
+            }
+
+            result_pk = talloc_strdup_append(result_pk, pk_data->public_keys[i]);
+            if (result_kh == NULL || result_pk == NULL) {
+                ret = ENOMEM;
+                goto done;
+            }
+        }
+    }
+
+    *_result_kh = result_kh;
+    *_result_pk = result_pk;
+
+    ret = EOK;
+done:
+    return ret;
 }
 
 struct tevent_req *
 pam_passkey_auth_send(TALLOC_CTX *mem_ctx,
-                    struct tevent_context *ev,
-                    int timeout,
-                    bool debug_libfido2,
-                    enum passkey_user_verification verification,
-                    struct pam_data *pd,
-                    struct pk_child_user_data *pk_data)
+                      struct tevent_context *ev,
+                      int timeout,
+                      bool debug_libfido2,
+                      enum passkey_user_verification verification,
+                      struct pam_data *pd,
+                      struct pk_child_user_data *pk_data,
+                      bool kerberos_pa)
 {
     struct tevent_req *req;
     struct pam_passkey_auth_send_state *state;
@@ -677,6 +781,7 @@ pam_passkey_auth_send(TALLOC_CTX *mem_ctx,
     state->ev = ev;
 
     state->timeout = timeout;
+    state->kerberos_pa = kerberos_pa;
     state->logfile = PASSKEY_CHILD_LOG_FILE;
     state->io = talloc(state, struct child_io_fds);
     if (state->io == NULL) {
@@ -710,35 +815,34 @@ pam_passkey_auth_send(TALLOC_CTX *mem_ctx,
             break;
     }
 
-
-    /* Options retrieved from LDAP */
-    result_kh = talloc_strdup(state, pk_data->key_handles[0]);
-    result_pk = talloc_strdup(state, pk_data->public_keys[0]);
-    for (int i = 1; i < pk_data->num_passkeys; i++) {
-        result_kh = talloc_strdup_append(result_kh, ",");
-        result_pk = talloc_strdup_append(result_pk, ",");
-        if (result_kh == NULL || result_pk == NULL) {
-            ret = ENOMEM;
-            goto done;
-        }
-
-        result_kh = talloc_strdup_append(result_kh, pk_data->key_handles[i]);
-        result_pk = talloc_strdup_append(result_pk, pk_data->public_keys[i]);
-        if (result_kh == NULL || result_pk == NULL) {
-            ret = ENOMEM;
-            goto done;
-        }
+    ret = pam_passkey_concatenate_keys(state, pk_data, state->kerberos_pa,
+                                       &result_kh, &result_pk);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "pam_passkey_concatenate keys failed - [%d]: [%s]\n",
+              ret, sss_strerror(ret));
+        goto done;
     }
 
-    state->extra_args[arg_c++] = result_pk;
-    state->extra_args[arg_c++] = "--public-key";
-    state->extra_args[arg_c++] = result_kh;
-    state->extra_args[arg_c++] = "--key-handle";
-    state->extra_args[arg_c++] = pk_data->domain;
-    state->extra_args[arg_c++] = "--domain";
-    state->extra_args[arg_c++] = state->pd->user;
-    state->extra_args[arg_c++] = "--username";
-    state->extra_args[arg_c++] = "--authenticate";
+
+    if (state->kerberos_pa) {
+        state->extra_args[arg_c++] = pk_data->crypto_challenge;
+        state->extra_args[arg_c++] = "--cryptographic-challenge";
+        state->extra_args[arg_c++] = result_kh;
+        state->extra_args[arg_c++] = "--key-handle";
+        state->extra_args[arg_c++] = pk_data->domain;
+        state->extra_args[arg_c++] = "--domain";
+        state->extra_args[arg_c++] = "--get-assert";
+    } else {
+        state->extra_args[arg_c++] = result_pk;
+        state->extra_args[arg_c++] = "--public-key";
+        state->extra_args[arg_c++] = result_kh;
+        state->extra_args[arg_c++] = "--key-handle";
+        state->extra_args[arg_c++] = pk_data->domain;
+        state->extra_args[arg_c++] = "--domain";
+        state->extra_args[arg_c++] = state->pd->user;
+        state->extra_args[arg_c++] = "--username";
+        state->extra_args[arg_c++] = "--authenticate";
+    }
 
     ret = passkey_child_exec(req);
 
@@ -803,9 +907,14 @@ static errno_t passkey_child_exec(struct tevent_req *req)
         sss_fd_nonblocking(state->io->write_to_child_fd);
 
         /* Set up SIGCHLD handler */
-        ret = child_handler_setup(state->ev, child_pid,
-                                  pam_passkey_auth_done, req,
-                                  &state->child_ctx);
+        if (state->kerberos_pa) {
+            ret = child_handler_setup(state->ev, child_pid, NULL, NULL, NULL);
+        } else {
+            ret = child_handler_setup(state->ev, child_pid,
+                                      pam_passkey_auth_done, req,
+                                      &state->child_ctx);
+        }
+
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "Could not set up child handlers [%d]: %s\n",
                   ret, sss_strerror(ret));
@@ -922,13 +1031,6 @@ bool may_do_passkey_auth(struct pam_ctx *pctx,
     }
 
     if (pd->cmd != SSS_PAM_PREAUTH && pd->cmd != SSS_PAM_AUTHENTICATE) {
-        return false;
-    }
-
-    /* SSS_AUTHTOK_TYPE_EMPTY is used for a passkey with no PIN set */
-    if (pd->cmd == SSS_PAM_AUTHENTICATE &&
-           (sss_authtok_get_type(pd->authtok) != SSS_AUTHTOK_TYPE_PASSKEY)
-           && sss_authtok_get_type(pd->authtok) != SSS_AUTHTOK_TYPE_EMPTY) {
         return false;
     }
 

--- a/src/responder/pam/pamsrv_passkey.c
+++ b/src/responder/pam/pamsrv_passkey.c
@@ -206,8 +206,7 @@ errno_t pam_passkey_get_mapping_recv(TALLOC_CTX *mem_ctx,
 
 errno_t read_passkey_conf_verification(TALLOC_CTX *mem_ctx,
                                        const char *verify_opts,
-                                       enum passkey_user_verification *_user_verification,
-                                       bool *_debug_libfido2)
+                                       enum passkey_user_verification *_user_verification)
 {
     int ret;
     TALLOC_CTX *tmp_ctx;
@@ -242,9 +241,6 @@ errno_t read_passkey_conf_verification(TALLOC_CTX *mem_ctx,
                 DEBUG(SSSDBG_TRACE_FUNC, "user_verification set to false.\n");
                 *_user_verification = PAM_PASSKEY_VERIFICATION_OFF;
             }
-        } else if (strcasecmp(opts[c], "debug_libfido2") == 0) {
-           DEBUG(SSSDBG_TRACE_FUNC, "Enabling debug_libfido2.\n");
-           *_debug_libfido2 = true;
         } else {
            DEBUG(SSSDBG_MINOR_FAILURE,
                  "Unsupported passkey verification option [%s], " \
@@ -292,6 +288,16 @@ static errno_t passkey_non_kerberos_verification(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
+    ret = confdb_get_bool(pctx->pam_ctx->rctx->cdb, CONFDB_PAM_CONF_ENTRY,
+                    CONFDB_PAM_PASSKEY_DEBUG_LIBFIDO2, false,
+                    &debug_libfido2);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+            "Failed to read '"CONFDB_PAM_PASSKEY_DEBUG_LIBFIDO2"' from confdb: [%d]: %s\n",
+            ret, sss_strerror(ret));
+        goto done;
+    }
+
     /* If require user verification setting is set in LDAP, use it */
     if (verification_from_ldap != NULL) {
         if (strcasecmp(verification_from_ldap, "true") == 0) {
@@ -312,7 +318,8 @@ static errno_t passkey_non_kerberos_verification(TALLOC_CTX *mem_ctx,
             goto done;
         }
 
-        ret = read_passkey_conf_verification(tmp_ctx, verify_opts, &verification, &debug_libfido2);
+
+        ret = read_passkey_conf_verification(tmp_ctx, verify_opts, &verification);
         if (ret != EOK) {
             DEBUG(SSSDBG_MINOR_FAILURE, "Unable to parse passkey verificaton options.\n");
             /* Continue anyway */

--- a/src/responder/pam/pamsrv_passkey.h
+++ b/src/responder/pam/pamsrv_passkey.h
@@ -56,8 +56,7 @@ struct pk_child_user_data {
 
 errno_t read_passkey_conf_verification(TALLOC_CTX *mem_ctx,
                                        const char *verify_opts,
-                                       enum passkey_user_verification *_user_verification,
-                                       bool *_debug_libfido2);
+                                       enum passkey_user_verification *_user_verification);
 
 void pam_forwarder_passkey_cb(struct tevent_req *req);
 struct tevent_req *pam_passkey_auth_send(TALLOC_CTX *mem_ctx,

--- a/src/sss_client/pam_message.h
+++ b/src/sss_client/pam_message.h
@@ -64,6 +64,7 @@ struct pam_items {
     char *oauth2_url_complete;
     char *oauth2_pin;
     char *first_factor;
+    char *passkey_key;
     char *passkey_prompt_pin;
     bool password_prompting;
 

--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -207,6 +207,12 @@ static void overwrite_and_free_pam_items(struct pam_items *pi)
     free(pi->otp_challenge);
     pi->otp_challenge = NULL;
 
+    free(pi->passkey_key);
+    pi->passkey_key = NULL;
+
+    free(pi->passkey_prompt_pin);
+    pi->passkey_prompt_pin = NULL;
+
     free_cert_list(pi->cert_list);
     pi->cert_list = NULL;
     pi->selected_cert = NULL;
@@ -1285,6 +1291,29 @@ static int eval_response(pam_handle_t *pamh, size_t buflen, uint8_t *buf,
                 }
 
                 break;
+            case SSS_PAM_PASSKEY_KRB_INFO:
+                free(pi->passkey_prompt_pin);
+                pi->passkey_prompt_pin = strdup((char *) &buf[p]);
+                if (pi->passkey_prompt_pin == NULL) {
+                    D(("strdup failed"));
+                    break;
+                }
+
+                offset = strlen(pi->passkey_prompt_pin) + 1;
+                if (offset >= len) {
+                    D(("Passkey message size mismatch"));
+                    free(pi->passkey_prompt_pin);
+                    pi->passkey_prompt_pin = NULL;
+                    break;
+                }
+
+                free(pi->passkey_key);
+                pi->passkey_key = strdup((char *) &buf[p + offset]);
+                if (pi->passkey_key == NULL) {
+                    D(("strdup failed"));
+                    break;
+                }
+                break;
             case SSS_PAM_PASSKEY_INFO:
                 if (buf[p + (len - 1)] != '\0') {
                     D(("passkey info does not end with \\0."));
@@ -1801,8 +1830,11 @@ static int prompt_passkey(pam_handle_t *pamh, struct pam_items *pi,
     const struct pam_message *mesg[3] = { NULL, NULL, NULL };
     struct pam_message m[3] = { {0}, {0}, {0} };
     struct pam_response *resp = NULL;
+    bool kerberos_preauth;
+    bool prompt_pin;
     int pin_idx = 0;
     int msg_idx = 0;
+    size_t needed_size;
 
     ret = pam_get_item(pamh, PAM_CONV, (const void **) &conv);
     if (ret != PAM_SUCCESS) {
@@ -1813,7 +1845,13 @@ static int prompt_passkey(pam_handle_t *pamh, struct pam_items *pi,
         return PAM_SYSTEM_ERR;
     }
 
-    pi->pam_authtok_type = SSS_AUTHTOK_TYPE_PASSKEY;
+    kerberos_preauth = pi->passkey_key != NULL ? true : false;
+    if ((strcasecmp(pi->passkey_prompt_pin, "false")) == 0) {
+        prompt_pin = false;
+    } else {
+        prompt_pin = true;
+    }
+
 	/* Interactive, prompt a message and wait before continuing */
     if (prompt_interactive != NULL && prompt_interactive[0] != '\0') {
 	    m[msg_idx].msg_style = PAM_PROMPT_ECHO_OFF;
@@ -1825,7 +1863,7 @@ static int prompt_passkey(pam_handle_t *pamh, struct pam_items *pi,
      *
      * If prompt_pin is false but a PIN is set on the device
      * we still prompt for PIN */
-    if ((strcasecmp(pi->passkey_prompt_pin, "true")) == 0) {
+    if (prompt_pin) {
         m[msg_idx].msg_style = PAM_PROMPT_ECHO_OFF;
         m[msg_idx].msg = PASSKEY_DEFAULT_PIN_MSG;
         pin_idx = msg_idx;
@@ -1834,7 +1872,7 @@ static int prompt_passkey(pam_handle_t *pamh, struct pam_items *pi,
 
     /* Prompt to remind the user to touch the device */
     if (prompt_touch != NULL && prompt_touch[0] != '\0') {
-        m[msg_idx].msg_style = PAM_TEXT_INFO;
+        m[msg_idx].msg_style = PAM_PROMPT_ECHO_OFF;
 	    m[msg_idx].msg = prompt_touch;
         msg_idx++;
     }
@@ -1857,39 +1895,58 @@ static int prompt_passkey(pam_handle_t *pamh, struct pam_items *pi,
         return ret;
     }
 
-    if ((strcasecmp(pi->passkey_prompt_pin, "true")) == 0) {
-        if (resp == NULL) {
-            D(("response expected, but resp==NULL"));
-            return PAM_SYSTEM_ERR;
+    if (kerberos_preauth) {
+        if (!prompt_pin) {
+            resp[pin_idx].resp = NULL;
         }
 
-        if (resp[pin_idx].resp == NULL) {
-            pi->pam_authtok = NULL;
-            pi->pam_authtok_type = SSS_AUTHTOK_TYPE_EMPTY;
-            pi->pam_authtok_size=0;
-        } else {
-            pi->pam_authtok = strdup(resp[pin_idx].resp);
-            if (pi->pam_authtok == NULL) {
-                ret = PAM_BUF_ERR;
-                goto done;
-            }
+        pi->pam_authtok_type = SSS_AUTHTOK_TYPE_PASSKEY_KRB;
+        sss_auth_passkey_calc_size(pi->passkey_prompt_pin,
+                                   pi->passkey_key,
+                                   resp[pin_idx].resp,
+                                   &needed_size);
 
-            /* Fallback to password auth if no PIN was entered */
-            if (resp[pin_idx].resp == NULL || resp[pin_idx].resp[0] == '\0') {
-                ret = EIO;
-                goto done;
-            }
-
-			pi->pam_authtok_type = SSS_AUTHTOK_TYPE_PASSKEY;
-			pi->pam_authtok_size=strlen(pi->pam_authtok);
+        pi->pam_authtok = malloc(needed_size);
+        if (pi->pam_authtok == NULL) {
+            D(("malloc failed."));
+            ret = PAM_BUF_ERR;
+            goto done;
         }
+
+        sss_auth_pack_passkey_blob((uint8_t *)pi->pam_authtok,
+                                    pi->passkey_prompt_pin, pi->passkey_key,
+                                    resp[pin_idx].resp);
+
     } else {
-        /* user verification = false, SSS_AUTHTOK_TYPE_PASSKEY will be reset to
-         * SSS_AUTHTOK_TYPE_NULL in PAM responder
-         */
-        pi->pam_authtok_type = SSS_AUTHTOK_TYPE_PASSKEY;
-        pi->pam_authtok = NULL;
-        pi->pam_authtok_size=0;
+        if (!prompt_pin) {
+            /* user verification = false, SSS_AUTHTOK_TYPE_PASSKEY will be reset to
+             * SSS_AUTHTOK_TYPE_NULL in PAM responder
+             */
+            pi->pam_authtok_type = SSS_AUTHTOK_TYPE_PASSKEY;
+            pi->pam_authtok = NULL;
+            pi->pam_authtok_size = 0;
+            ret = PAM_SUCCESS;
+            goto done;
+        } else {
+            pi->pam_authtok_type = SSS_AUTHTOK_TYPE_PASSKEY;
+            pi->pam_authtok = strdup(resp[pin_idx].resp);
+            needed_size = strlen(pi->pam_authtok);
+        }
+    }
+
+    pi->pam_authtok_size = needed_size;
+
+    if (pi->pam_authtok == NULL) {
+        ret = PAM_BUF_ERR;
+        goto done;
+    }
+
+    /* Fallback to password auth if no PIN was entered */
+    if (prompt_pin) {
+        if (resp[pin_idx].resp == NULL || resp[pin_idx].resp[0] == '\0') {
+            ret = EIO;
+            goto done;
+        }
     }
 
     ret = PAM_SUCCESS;

--- a/src/sss_client/sss_cli.h
+++ b/src/sss_client/sss_cli.h
@@ -381,6 +381,9 @@ enum sss_authtok_type {
     SSS_AUTHTOK_TYPE_PASSKEY =    0x0008, /**< Authentication token is a Passkey
                                            * PIN, it may or may not contain
                                            * a trailing \\0 */
+    SSS_AUTHTOK_TYPE_PASSKEY_REPLY = 0x0009, /**< Authentication token contains
+                                           * Passkey reply data presented as
+                                           * a kerberos challenge answer */
 };
 
 /**

--- a/src/sss_client/sss_cli.h
+++ b/src/sss_client/sss_cli.h
@@ -381,9 +381,12 @@ enum sss_authtok_type {
     SSS_AUTHTOK_TYPE_PASSKEY =    0x0008, /**< Authentication token is a Passkey
                                            * PIN, it may or may not contain
                                            * a trailing \\0 */
-    SSS_AUTHTOK_TYPE_PASSKEY_REPLY = 0x0009, /**< Authentication token contains
-                                           * Passkey reply data presented as
-                                           * a kerberos challenge answer */
+    SSS_AUTHTOK_TYPE_PASSKEY_KRB = 0x0009,  /**< Authentication token contains
+                                             * Passkey data used for Kerberos
+                                             * pre-authentication */
+    SSS_AUTHTOK_TYPE_PASSKEY_REPLY = 0x0010, /**< Authentication token contains
+                                              * Passkey reply data presented as
+                                              * a kerberos challenge answer */
 };
 
 /**
@@ -537,11 +540,19 @@ enum response_type {
                             *   - verification_uri_complete
                             *   - user_code
                             */
-    SSS_PAM_PASSKEY_INFO, /**< Indicates that passkey authentication
-                            * is available, including a parameter string
-                            * which dictates whether prompting for PIN is
-                            * needed.
-                            * @param prompt_pin. */
+    SSS_PAM_PASSKEY_INFO, /**< Indicates that passkey authentication is available.
+                            * including a parameter string which dictates whether
+                            * prompting for PIN is needed.
+                            * @param
+                            *   - prompt_pin
+                            */
+    SSS_PAM_PASSKEY_KRB_INFO, /**< A message containing the passkey parameters
+                               * for the user. The key is the cryptographic challenge
+                               * used as the key to the passkey hash table entry.
+                               * @param
+                               *   - user verification (string)
+                               *   - key (string)
+                               */
 };
 
 /**

--- a/src/tests/cmocka/test_krb5_passkey_plugin.c
+++ b/src/tests/cmocka/test_krb5_passkey_plugin.c
@@ -1,0 +1,480 @@
+/*
+    Copyright (C) 2022 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <popt.h>
+
+#include "tests/cmocka/common_mock.h"
+#include "krb5_plugin/passkey/passkey.h"
+
+void test_sss_passkey_message_encode__null(void **state)
+{
+    char *str;
+
+    str = sss_passkey_message_encode(NULL);
+    assert_null(str);
+}
+
+void test_sss_passkey_message_encode__invalid(void **state)
+{
+    struct sss_passkey_message message = {0};
+    char *str;
+
+    message.phase = SSS_PASSKEY_PHASE_CHALLENGE;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    message.phase = SSS_PASSKEY_PHASE_REPLY;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+}
+
+void test_sss_passkey_message_encode__init(void **state)
+{
+    struct sss_passkey_message message = {0};
+    char *str;
+
+    message.phase = SSS_PASSKEY_PHASE_INIT;
+    str = sss_passkey_message_encode(&message);
+    assert_non_null(str);
+    assert_string_equal(str, "passkey {\"phase\":0}");
+    free(str);
+
+    message.phase = SSS_PASSKEY_PHASE_INIT;
+    message.state = discard_const("abcd");
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+}
+
+void test_sss_passkey_message_encode__challenge(void **state)
+{
+    struct sss_passkey_message message = {0};
+    struct sss_passkey_challenge challenge = {0};
+    const char *id_list[] = {"a", "b", NULL};
+    char *str;
+
+    message.phase = SSS_PASSKEY_PHASE_CHALLENGE;
+    message.state = NULL;
+    message.data.challenge = NULL;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    message.phase = SSS_PASSKEY_PHASE_CHALLENGE;
+    message.state = discard_const("abcd");
+    message.data.challenge = NULL;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    challenge.domain = discard_const("domain");
+    challenge.credential_id_list = discard_const(id_list);
+    challenge.user_verification = 1;
+    challenge.cryptographic_challenge = discard_const("crypto-challenge");
+    message.phase = SSS_PASSKEY_PHASE_CHALLENGE;
+    message.state = NULL;
+    message.data.challenge = &challenge;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    challenge.domain = NULL;
+    challenge.credential_id_list = NULL;
+    challenge.user_verification = 0;
+    challenge.cryptographic_challenge = NULL;
+    message.phase = SSS_PASSKEY_PHASE_CHALLENGE;
+    message.state = NULL;
+    message.data.challenge = &challenge;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    challenge.domain = NULL;
+    challenge.credential_id_list = discard_const(id_list);
+    challenge.user_verification = 1;
+    challenge.cryptographic_challenge = discard_const("crypto-challenge");
+    message.phase = SSS_PASSKEY_PHASE_CHALLENGE;
+    message.state = discard_const("abcd");
+    message.data.challenge = &challenge;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    challenge.domain = discard_const("domain");
+    challenge.credential_id_list = NULL;
+    challenge.user_verification = 1;
+    challenge.cryptographic_challenge = discard_const("crypto-challenge");
+    message.phase = SSS_PASSKEY_PHASE_CHALLENGE;
+    message.state = discard_const("abcd");
+    message.data.challenge = &challenge;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    challenge.domain = discard_const("domain");
+    challenge.credential_id_list = discard_const(id_list);
+    challenge.user_verification = 0;
+    challenge.cryptographic_challenge = discard_const("crypto-challenge");
+    message.phase = SSS_PASSKEY_PHASE_CHALLENGE;
+    message.state = discard_const("abcd");
+    message.data.challenge = &challenge;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    challenge.domain = discard_const("domain");
+    challenge.credential_id_list = discard_const(id_list);
+    challenge.user_verification = 1;
+    challenge.cryptographic_challenge = NULL;
+    message.phase = SSS_PASSKEY_PHASE_CHALLENGE;
+    message.state = discard_const("abcd");
+    message.data.challenge = &challenge;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    challenge.domain = discard_const("domain");
+    challenge.credential_id_list = discard_const(id_list);
+    challenge.user_verification = 1;
+    challenge.cryptographic_challenge = discard_const("crypto-challenge");
+    message.phase = SSS_PASSKEY_PHASE_CHALLENGE;
+    message.state = discard_const("abcd");
+    message.data.challenge = &challenge;
+    str = sss_passkey_message_encode(&message);
+    assert_non_null(str);
+    assert_string_equal(str, "passkey {\"phase\":1,\"state\":\"abcd\",\"data\":{\"domain\":\"domain\",\"credential_id_list\":[\"a\",\"b\"],\"user_verification\":1,\"cryptographic_challenge\":\"crypto-challenge\"}}");
+    free(str);
+}
+
+void test_sss_passkey_message_encode__reply(void **state)
+{
+    struct sss_passkey_message message = {0};
+    struct sss_passkey_reply reply = {0};
+    char *str;
+
+    message.phase = SSS_PASSKEY_PHASE_REPLY;
+    message.state = NULL;
+    message.data.reply = NULL;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    message.phase = SSS_PASSKEY_PHASE_REPLY;
+    message.state = discard_const("abcd");
+    message.data.reply = NULL;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    message.phase = SSS_PASSKEY_PHASE_REPLY;
+    message.state = NULL;
+    message.data.reply = &reply;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    reply.credential_id = discard_const("id");
+    reply.cryptographic_challenge = discard_const("crypto-challenge");
+    reply.authenticator_data = discard_const("auth-data");
+    reply.assertion_signature = discard_const("assertion-sig");
+    reply.user_id = NULL;
+    message.phase = SSS_PASSKEY_PHASE_REPLY;
+    message.state = NULL;
+    message.data.reply = &reply;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    reply.credential_id = NULL;
+    reply.cryptographic_challenge = discard_const("crypto-challenge");
+    reply.authenticator_data = discard_const("auth-data");
+    reply.assertion_signature = discard_const("assertion-sig");
+    reply.user_id = NULL;
+    message.phase = SSS_PASSKEY_PHASE_REPLY;
+    message.state = discard_const("abcd");
+    message.data.reply = &reply;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    reply.credential_id = discard_const("id");
+    reply.cryptographic_challenge = NULL;
+    reply.authenticator_data = discard_const("auth-data");
+    reply.assertion_signature = discard_const("assertion-sig");
+    reply.user_id = NULL;
+    message.phase = SSS_PASSKEY_PHASE_REPLY;
+    message.state = discard_const("abcd");
+    message.data.reply = &reply;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    reply.credential_id = discard_const("id");
+    reply.cryptographic_challenge = discard_const("crypto-challenge");
+    reply.authenticator_data = NULL;
+    reply.assertion_signature = discard_const("assertion-sig");
+    reply.user_id = NULL;
+    message.phase = SSS_PASSKEY_PHASE_REPLY;
+    message.state = discard_const("abcd");
+    message.data.reply = &reply;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    reply.credential_id = discard_const("id");
+    reply.cryptographic_challenge = discard_const("crypto-challenge");
+    reply.authenticator_data = discard_const("auth-data");
+    reply.assertion_signature = NULL;
+    reply.user_id = NULL;
+    message.phase = SSS_PASSKEY_PHASE_REPLY;
+    message.state = discard_const("abcd");
+    message.data.reply = &reply;
+    str = sss_passkey_message_encode(&message);
+    assert_null(str);
+
+    reply.credential_id = discard_const("id");
+    reply.cryptographic_challenge = discard_const("crypto-challenge");
+    reply.authenticator_data = discard_const("auth-data");
+    reply.assertion_signature = discard_const("assertion-sig");
+    reply.user_id = NULL;
+    message.phase = SSS_PASSKEY_PHASE_REPLY;
+    message.state = discard_const("abcd");
+    message.data.reply = &reply;
+    str = sss_passkey_message_encode(&message);
+    assert_non_null(str);
+    assert_string_equal(str, "passkey {\"phase\":2,\"state\":\"abcd\",\"data\":{\"credential_id\":\"id\",\"cryptographic_challenge\":\"crypto-challenge\",\"authenticator_data\":\"auth-data\",\"assertion_signature\":\"assertion-sig\"}}");
+    free(str);
+
+    reply.credential_id = discard_const("id");
+    reply.cryptographic_challenge = discard_const("crypto-challenge");
+    reply.authenticator_data = discard_const("auth-data");
+    reply.assertion_signature = discard_const("assertion-sig");
+    reply.user_id = discard_const("user-id");
+    message.phase = SSS_PASSKEY_PHASE_REPLY;
+    message.state = discard_const("abcd");
+    message.data.reply = &reply;
+    str = sss_passkey_message_encode(&message);
+    assert_non_null(str);
+    assert_string_equal(str, "passkey {\"phase\":2,\"state\":\"abcd\",\"data\":{\"credential_id\":\"id\",\"cryptographic_challenge\":\"crypto-challenge\",\"authenticator_data\":\"auth-data\",\"assertion_signature\":\"assertion-sig\",\"user_id\":\"user-id\"}}");
+    free(str);
+}
+
+void test_sss_passkey_message_decode__null(void **state)
+{
+    struct sss_passkey_message *message;
+
+    message = sss_passkey_message_decode(NULL);
+    assert_null(message);
+}
+
+void test_sss_passkey_message_decode__invalid(void **state)
+{
+    struct sss_passkey_message *message;
+    const char *str;
+
+    str = "";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "oauth2";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":10}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":1, \"state\":\"abcd\"}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":1, \"state\":\"abcd\", \"data\":{\"test\":\"test\"}}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":2, \"state\":\"abcd\"}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":2, \"state\":\"abcd\", \"data\":{\"test\":\"test\"}}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+}
+
+void test_sss_passkey_message_decode__init(void **state)
+{
+    struct sss_passkey_message *message;
+    const char *str;
+
+    str = "passkey {\"phase\":0,\"state\":\"abcd\"}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":0,\"data\":{\"test\":\"abcd\"}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":0,\"state\":\"abcd\",\"data\":{\"test\":\"abcd\"}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":0}";
+    message = sss_passkey_message_decode(str);
+    assert_non_null(message);
+    assert_int_equal(message->phase, SSS_PASSKEY_PHASE_INIT);
+    assert_null(message->state);
+    assert_null(message->data.ptr);
+    sss_passkey_message_free(message);
+}
+
+void test_sss_passkey_message_decode__challenge(void **state)
+{
+    struct sss_passkey_message *message;
+    const char *str;
+
+    str = "passkey {\"phase\":1}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":1,\"state\":\"abcd\"}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":1,\"data\":{\"test\":\"abcd\"}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":1,\"state\":\"abcd\",\"data\":{\"domain\":\"domain\",\"credential_id_list\":[\"a\",\"b\"],\"user_verification\":1,\"cryptographic_challenge\":\"crypto-challenge\"}}";
+    message = sss_passkey_message_decode(str);
+    assert_non_null(message);
+    assert_int_equal(message->phase, SSS_PASSKEY_PHASE_CHALLENGE);
+    assert_non_null(message->state);
+    assert_string_equal(message->state, "abcd");
+    assert_non_null(message->data.challenge);
+    assert_non_null(message->data.challenge->domain);
+    assert_string_equal(message->data.challenge->domain, "domain");
+    assert_non_null(message->data.challenge->credential_id_list);
+    assert_string_equal(message->data.challenge->credential_id_list[0], "a");
+    assert_string_equal(message->data.challenge->credential_id_list[1], "b");
+    assert_null(message->data.challenge->credential_id_list[2]);
+    assert_int_equal(message->data.challenge->user_verification, 1);
+    assert_non_null(message->data.challenge->cryptographic_challenge);
+    assert_string_equal(message->data.challenge->cryptographic_challenge, "crypto-challenge");
+    sss_passkey_message_free(message);
+}
+
+void test_sss_passkey_message_decode__reply(void **state)
+{
+    struct sss_passkey_message *message;
+    const char *str;
+
+    str = "passkey {\"phase\":2}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":2,\"state\":\"abcd\"}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":2,\"data\":{\"test\":\"abcd\"}";
+    message = sss_passkey_message_decode(str);
+    assert_null(message);
+
+    str = "passkey {\"phase\":2,\"state\":\"abcd\",\"data\":{\"credential_id\":\"id\",\"cryptographic_challenge\":\"crypto-challenge\",\"authenticator_data\":\"auth-data\",\"assertion_signature\":\"assertion-sig\"}}";
+    message = sss_passkey_message_decode(str);
+    assert_non_null(message);
+    assert_int_equal(message->phase, SSS_PASSKEY_PHASE_REPLY);
+    assert_non_null(message->state);
+    assert_string_equal(message->state, "abcd");
+    assert_non_null(message->data.reply);
+    assert_non_null(message->data.reply->credential_id);
+    assert_string_equal(message->data.reply->credential_id, "id");
+    assert_non_null(message->data.reply->cryptographic_challenge);
+    assert_string_equal(message->data.reply->cryptographic_challenge, "crypto-challenge");
+    assert_non_null(message->data.reply->authenticator_data);
+    assert_string_equal(message->data.reply->authenticator_data, "auth-data");
+    assert_non_null(message->data.reply->assertion_signature);
+    assert_string_equal(message->data.reply->assertion_signature, "assertion-sig");
+    sss_passkey_message_free(message);
+}
+
+void test_sss_passkey_config_init__invalid(void **state)
+{
+    struct sss_passkey_config *passkeycfg;
+    krb5_error_code ret;
+
+    ret = sss_passkey_config_init("not-json", &passkeycfg);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_passkey_config_init("", &passkeycfg);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_passkey_config_init("[]", &passkeycfg);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_passkey_config_init("[{\"indicators\": \"test\"}]", &passkeycfg);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_passkey_config_init("{\"indicators\": \"test\"}", &passkeycfg);
+    assert_int_equal(ret, EINVAL);
+}
+
+void test_sss_passkey_config_init__ok(void **state)
+{
+    struct sss_passkey_config *passkeycfg;
+    krb5_error_code ret;
+
+    ret = sss_passkey_config_init("[{}]", &passkeycfg);
+    assert_int_equal(ret, 0);
+    assert_non_null(passkeycfg);
+    assert_null(passkeycfg->indicators);
+    sss_passkey_config_free(passkeycfg);
+
+    ret = sss_passkey_config_init("[{\"indicators\": [\"i1\"]}]", &passkeycfg);
+    assert_int_equal(ret, 0);
+    assert_non_null(passkeycfg);
+    assert_non_null(passkeycfg->indicators);
+    assert_non_null(passkeycfg->indicators[0]);
+    assert_null(passkeycfg->indicators[1]);
+    assert_string_equal(passkeycfg->indicators[0], "i1");
+    sss_passkey_config_free(passkeycfg);
+
+    ret = sss_passkey_config_init("[{\"indicators\": [\"i1\", \"i2\"]}]", &passkeycfg);
+    assert_int_equal(ret, 0);
+    assert_non_null(passkeycfg);
+    assert_non_null(passkeycfg->indicators);
+    assert_non_null(passkeycfg->indicators[0]);
+    assert_non_null(passkeycfg->indicators[1]);
+    assert_null(passkeycfg->indicators[2]);
+    assert_string_equal(passkeycfg->indicators[0], "i1");
+    assert_string_equal(passkeycfg->indicators[1], "i2");
+    sss_passkey_config_free(passkeycfg);
+}
+
+int main(int argc, const char *argv[])
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_sss_passkey_message_encode__null),
+        cmocka_unit_test(test_sss_passkey_message_encode__invalid),
+        cmocka_unit_test(test_sss_passkey_message_encode__init),
+        cmocka_unit_test(test_sss_passkey_message_encode__challenge),
+        cmocka_unit_test(test_sss_passkey_message_encode__reply),
+        cmocka_unit_test(test_sss_passkey_message_decode__null),
+        cmocka_unit_test(test_sss_passkey_message_decode__invalid),
+        cmocka_unit_test(test_sss_passkey_message_decode__init),
+        cmocka_unit_test(test_sss_passkey_message_decode__challenge),
+        cmocka_unit_test(test_sss_passkey_message_decode__reply),
+        cmocka_unit_test(test_sss_passkey_config_init__invalid),
+        cmocka_unit_test(test_sss_passkey_config_init__ok),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/tests/dlopen-tests.c
+++ b/src/tests/dlopen-tests.c
@@ -69,6 +69,9 @@ struct so {
                                        NULL } },
 #endif
     { "sssd_krb5_idp_plugin.so", { LIBPFX"sssd_krb5_idp_plugin.so", NULL } },
+#ifdef BUILD_PASSKEY
+    { "sssd_krb5_passkey_plugin.so", { LIBPFX"sssd_krb5_passkey_plugin.so", NULL } },
+#endif
 #ifdef HAVE_PAC_RESPONDER
     { "sssd_pac_plugin.so", { LIBPFX"sssd_pac_plugin.so", NULL } },
 #endif

--- a/src/util/authtok-utils.h
+++ b/src/util/authtok-utils.h
@@ -23,6 +23,7 @@
 #include <talloc.h>
 
 #include "sss_client/sss_cli.h"
+#include "sss_client/pam_message.h"
 
 /**
  * @brief Fill memory buffer with Smartcard authentication blob
@@ -142,4 +143,43 @@ errno_t sss_auth_unpack_sc_blob(TALLOC_CTX *mem_ctx,
  * @return     pointer to 0-terminate PIN string in the memory buffer
  */
 const char *sss_auth_get_pin_from_sc_blob(uint8_t *blob, size_t blob_len);
+
+/**
+ * @brief Fill memory buffer with Passkey authentication blob
+ *
+ * @param[in]  buf         Memory buffer containing the Passkey data
+ * @param[in]  prompt      Prompt for pin, "true" or "false"
+ * @param[in]  key         Hash table key used to lookup Passkey data
+ *                         in the PAM responder.
+ * @param[in]  pin         PIN provided by the user. Can be set to
+ *                         NULL if no PIN is provided (user verification false)
+ *
+ * @param[out] _passkey_buf_len  len size of the Passkey authentication blob
+ *
+ * @return     EOK         on success
+ *             EINVAL      if input data is not valid
+ */
+errno_t sss_auth_pack_passkey_blob(uint8_t *buf,
+                                   const char *prompt,
+                                   const char *key,
+                                   const char *pin);
+/**
+ * @brief Calculate size of Passkey authentication data
+ *
+ * @param[in]  prompt      Prompt for pin, "true" or "false"
+ * @param[in]  key         Hash table key used to lookup Passkey data
+ *                         in the PAM responder.
+ * @param[in]  pin         PIN provided by the user. Can be
+ *                         Set to NULL if no PIN is
+ *                         provided (user verification false)
+ *
+ * @param[out] _passkey_buf_len  len size of the Passkey authentication blob
+ *
+ * @return     EOK         on success
+ *             EINVAL      if input data is not valid
+ */
+errno_t sss_auth_passkey_calc_size(const char *prompt,
+                                   const char *key,
+                                   const char *pin,
+                                   size_t *_passkey_buf_len);
 #endif /*  __AUTHTOK_UTILS_H__ */

--- a/src/util/authtok.c
+++ b/src/util/authtok.c
@@ -46,6 +46,10 @@ const char *sss_authtok_type_to_str(enum sss_authtok_type type)
         return "OAuth2";
     case SSS_AUTHTOK_TYPE_PASSKEY:
         return "Passkey";
+    case SSS_AUTHTOK_TYPE_PASSKEY_KRB:
+        return "Passkey kerberos";
+    case SSS_AUTHTOK_TYPE_PASSKEY_REPLY:
+        return "Passkey kerberos reply";
     }
 
     DEBUG(SSSDBG_MINOR_FAILURE, "Unknown authtok type %d\n", type);
@@ -71,6 +75,8 @@ size_t sss_authtok_get_size(struct sss_auth_token *tok)
     case SSS_AUTHTOK_TYPE_2FA_SINGLE:
     case SSS_AUTHTOK_TYPE_OAUTH2:
     case SSS_AUTHTOK_TYPE_PASSKEY:
+    case SSS_AUTHTOK_TYPE_PASSKEY_KRB:
+    case SSS_AUTHTOK_TYPE_PASSKEY_REPLY:
         return tok->length;
     case SSS_AUTHTOK_TYPE_EMPTY:
         return 0;
@@ -109,6 +115,8 @@ errno_t sss_authtok_get_password(struct sss_auth_token *tok,
     case SSS_AUTHTOK_TYPE_2FA_SINGLE:
     case SSS_AUTHTOK_TYPE_OAUTH2:
     case SSS_AUTHTOK_TYPE_PASSKEY:
+    case SSS_AUTHTOK_TYPE_PASSKEY_KRB:
+    case SSS_AUTHTOK_TYPE_PASSKEY_REPLY:
         return EACCES;
     }
 
@@ -137,6 +145,8 @@ errno_t sss_authtok_get_ccfile(struct sss_auth_token *tok,
     case SSS_AUTHTOK_TYPE_2FA_SINGLE:
     case SSS_AUTHTOK_TYPE_OAUTH2:
     case SSS_AUTHTOK_TYPE_PASSKEY:
+    case SSS_AUTHTOK_TYPE_PASSKEY_KRB:
+    case SSS_AUTHTOK_TYPE_PASSKEY_REPLY:
         return EACCES;
     }
 
@@ -165,6 +175,8 @@ errno_t sss_authtok_get_2fa_single(struct sss_auth_token *tok,
     case SSS_AUTHTOK_TYPE_CCFILE:
     case SSS_AUTHTOK_TYPE_OAUTH2:
     case SSS_AUTHTOK_TYPE_PASSKEY:
+    case SSS_AUTHTOK_TYPE_PASSKEY_KRB:
+    case SSS_AUTHTOK_TYPE_PASSKEY_REPLY:
         return EACCES;
     }
 
@@ -193,14 +205,16 @@ errno_t sss_authtok_get_oauth2(struct sss_auth_token *tok,
     case SSS_AUTHTOK_TYPE_CCFILE:
     case SSS_AUTHTOK_TYPE_2FA_SINGLE:
     case SSS_AUTHTOK_TYPE_PASSKEY:
+    case SSS_AUTHTOK_TYPE_PASSKEY_KRB:
+    case SSS_AUTHTOK_TYPE_PASSKEY_REPLY:
         return EACCES;
     }
 
     return EINVAL;
 }
 
-errno_t sss_authtok_get_passkey_pin(struct sss_auth_token *tok,
-                                    const char **pin, size_t *len)
+errno_t sss_authtok_get_passkey_reply(struct sss_auth_token *tok,
+                                      const char **str, size_t *len)
 {
     if (!tok) {
         return EINVAL;
@@ -208,8 +222,8 @@ errno_t sss_authtok_get_passkey_pin(struct sss_auth_token *tok,
     switch (tok->type) {
     case SSS_AUTHTOK_TYPE_EMPTY:
         return ENOENT;
-    case SSS_AUTHTOK_TYPE_PASSKEY:
-        *pin = (const char *)tok->data;
+    case SSS_AUTHTOK_TYPE_PASSKEY_REPLY:
+        *str = (const char *)tok->data;
         if (len) {
             *len = tok->length - 1;
         }
@@ -221,6 +235,54 @@ errno_t sss_authtok_get_passkey_pin(struct sss_auth_token *tok,
     case SSS_AUTHTOK_TYPE_CCFILE:
     case SSS_AUTHTOK_TYPE_2FA_SINGLE:
     case SSS_AUTHTOK_TYPE_OAUTH2:
+    case SSS_AUTHTOK_TYPE_PASSKEY:
+    case SSS_AUTHTOK_TYPE_PASSKEY_KRB:
+        return EACCES;
+    }
+
+    return EINVAL;
+}
+
+errno_t sss_authtok_get_passkey_pin(struct sss_auth_token *tok,
+                                    const char **_pin, size_t *_len)
+{
+    int ret;
+    const char *pin = NULL;
+    const char *key = NULL;
+    const char *prompt = NULL;
+    size_t pin_len = 0;
+
+    if (!tok) {
+        return EINVAL;
+    }
+    switch (tok->type) {
+    case SSS_AUTHTOK_TYPE_EMPTY:
+        return ENOENT;
+    case SSS_AUTHTOK_TYPE_PASSKEY:
+        *_pin = (const char *)tok->data;
+        if (_len) {
+            *_len = tok->length - 1;
+        }
+        return EOK;
+    case SSS_AUTHTOK_TYPE_PASSKEY_KRB:
+        ret = sss_authtok_get_passkey(NULL, tok, &prompt, &key, &pin, &pin_len);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_OP_FAILURE, "sss_authtok_get_passkey failed.\n");
+            return ret;
+        }
+
+        *_pin = pin;
+        *_len = pin_len;
+
+        return EOK;
+    case SSS_AUTHTOK_TYPE_PASSWORD:
+    case SSS_AUTHTOK_TYPE_2FA:
+    case SSS_AUTHTOK_TYPE_SC_PIN:
+    case SSS_AUTHTOK_TYPE_SC_KEYPAD:
+    case SSS_AUTHTOK_TYPE_CCFILE:
+    case SSS_AUTHTOK_TYPE_2FA_SINGLE:
+    case SSS_AUTHTOK_TYPE_OAUTH2:
+    case SSS_AUTHTOK_TYPE_PASSKEY_REPLY:
         return EACCES;
     }
 
@@ -272,6 +334,8 @@ void sss_authtok_set_empty(struct sss_auth_token *tok)
     case SSS_AUTHTOK_TYPE_SC_PIN:
     case SSS_AUTHTOK_TYPE_2FA_SINGLE:
     case SSS_AUTHTOK_TYPE_PASSKEY:
+    case SSS_AUTHTOK_TYPE_PASSKEY_KRB:
+    case SSS_AUTHTOK_TYPE_PASSKEY_REPLY:
     case SSS_AUTHTOK_TYPE_OAUTH2:
         sss_erase_mem_securely(tok->data, tok->length);
         break;
@@ -320,17 +384,29 @@ errno_t sss_authtok_set_oauth2(struct sss_auth_token *tok,
     return sss_authtok_set_string(tok, SSS_AUTHTOK_TYPE_OAUTH2,
                                   "oauth2", str, len);
 }
+
+errno_t sss_authtok_set_passkey_reply(struct sss_auth_token *tok,
+                                      const char *str, size_t len)
+{
+    sss_authtok_set_empty(tok);
+
+    return sss_authtok_set_string(tok, SSS_AUTHTOK_TYPE_PASSKEY_REPLY,
+                                  "passkey kerberos reply", str, len);
+}
+
 errno_t sss_authtok_set_passkey(struct sss_auth_token *tok,
-                               const char *pin, size_t len)
+                                const char *str, size_t len)
 {
     sss_authtok_set_empty(tok);
 
     return sss_authtok_set_string(tok, SSS_AUTHTOK_TYPE_PASSKEY,
-                                  "passkey", pin, len);
+                                  "passkey", str, len);
 }
 
 static errno_t sss_authtok_set_2fa_from_blob(struct sss_auth_token *tok,
                                              const uint8_t *data, size_t len);
+static errno_t sss_authtok_set_passkey_from_blob(struct sss_auth_token *tok,
+                                                 const uint8_t *data, size_t len);
 
 errno_t sss_authtok_set(struct sss_auth_token *tok,
                         enum sss_authtok_type type,
@@ -351,8 +427,12 @@ errno_t sss_authtok_set(struct sss_auth_token *tok,
         return sss_authtok_set_2fa_single(tok, (const char *) data, len);
     case SSS_AUTHTOK_TYPE_OAUTH2:
         return sss_authtok_set_oauth2(tok, (const char *) data, len);
+    case SSS_AUTHTOK_TYPE_PASSKEY_KRB:
+        return sss_authtok_set_passkey_from_blob(tok, data, len);
     case SSS_AUTHTOK_TYPE_PASSKEY:
         return sss_authtok_set_passkey(tok, (const char *) data, len);
+    case SSS_AUTHTOK_TYPE_PASSKEY_REPLY:
+        return sss_authtok_set_passkey_reply(tok, (const char *)data, len);
     case SSS_AUTHTOK_TYPE_EMPTY:
         sss_authtok_set_empty(tok);
         return EOK;
@@ -588,6 +668,171 @@ errno_t sss_authtok_set_2fa(struct sss_auth_token *tok,
     return EOK;
 }
 
+errno_t sss_auth_unpack_passkey_blob(TALLOC_CTX *mem_ctx,
+                                     const uint8_t *blob,
+                                     char **_prompt,
+                                     char **_key,
+                                     char **_pin)
+{
+    size_t c;
+    char *prompt;
+    char *key;
+    char *pin;
+
+    c = 0;
+
+    prompt = talloc_strdup(mem_ctx, (const char *) blob + c);
+    if (prompt == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "talloc_strdup prompt failed.\n");
+        return ENOMEM;
+    }
+    c += strlen(prompt) + 1;
+
+    key = talloc_strdup(mem_ctx, (const char *) blob + c);
+    if (key == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "talloc_strdup key failed.\n");
+        talloc_free(prompt);
+        return ENOMEM;
+    }
+    c += strlen(key) + 1;
+
+    pin = talloc_strdup(mem_ctx, (const char *) blob + c);
+    if (pin == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "talloc_strdup pin failed.\n");
+        talloc_free(prompt);
+        talloc_free(key);
+        return ENOMEM;
+    }
+
+    *_prompt = prompt;
+    *_key = key;
+    *_pin = pin;
+
+    return EOK;
+}
+
+errno_t sss_authtok_set_passkey_krb(struct sss_auth_token *tok,
+                                    const char *prompt,
+                                    const char *key,
+                                    const char *pin)
+{
+    int ret;
+    size_t needed_size;
+
+    if (tok == NULL) {
+        return EINVAL;
+    }
+
+    sss_authtok_set_empty(tok);
+
+    ret = sss_auth_passkey_calc_size(prompt, key, pin, &needed_size);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sss_auth_calc_size failed [%d]: [%s].\n",
+              ret, sss_strerror(ret));
+        return ret;
+    }
+
+    tok->data = talloc_size(tok, needed_size);
+    if (tok->data == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "talloc_size failed.\n");
+        return ENOMEM;
+    }
+
+    ret = sss_auth_pack_passkey_blob(tok->data, prompt, key, pin);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "sss_auth_pack_passkey_blob unexpectedly returned [%d]: [%s].\n",
+              ret, sss_strerror(ret));
+        return EINVAL;
+    }
+
+    tok->length = needed_size;
+    tok->type = SSS_AUTHTOK_TYPE_PASSKEY_KRB;
+
+    return EOK;
+}
+
+static errno_t sss_authtok_set_passkey_from_blob(struct sss_auth_token *tok,
+                                                 const uint8_t *data, size_t len)
+{
+    TALLOC_CTX *tmp_ctx;
+    int ret;
+    char *prompt;
+    char *key;
+    char *pin;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "talloc_new failed.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = sss_auth_unpack_passkey_blob(tmp_ctx, data, &prompt, &key,
+                                       &pin);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sss_auth_unpack_passkey_blob returned [%d]: [%s].\n",
+                                 ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = sss_authtok_set_passkey_krb(tok, prompt, key, pin);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sss_authtok_set_passkey_krb returned [%d]: [%s].\n",
+                                 ret, sss_strerror(ret));
+        goto done;
+    }
+
+    ret = EOK;
+done:
+    talloc_free(tmp_ctx);
+
+    if (ret != EOK) {
+        sss_authtok_set_empty(tok);
+    }
+
+    return ret;
+}
+
+errno_t sss_authtok_get_passkey(TALLOC_CTX *mem_ctx,
+                                struct sss_auth_token *tok,
+                                const char **_prompt,
+                                const char **_key,
+                                const char **_pin,
+                                size_t *_pin_len)
+{
+    char *prompt;
+    char *key;
+    char *pin;
+    size_t pin_len = 0;
+    errno_t ret;
+
+    if (!tok) {
+        return EFAULT;
+    }
+    if (tok->type != SSS_AUTHTOK_TYPE_PASSKEY_KRB) {
+        return (tok->type == SSS_AUTHTOK_TYPE_EMPTY) ? ENOENT : EACCES;
+    }
+
+    ret = sss_auth_unpack_passkey_blob(mem_ctx, tok->data, &prompt, &key,
+                                       &pin);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sss_auth_unpack_passkey_blob returned [%d]: [%s].\n",
+                                 ret, sss_strerror(ret));
+        goto done;
+    }
+
+    pin_len = strlen(pin);
+
+    *_prompt = prompt;
+    *_key = key;
+    *_pin = pin;
+    *_pin_len = pin_len;
+done:
+    return ret;
+
+}
+
 errno_t sss_authtok_set_sc(struct sss_auth_token *tok,
                            enum sss_authtok_type type,
                            const char *pin, size_t pin_len,
@@ -737,6 +982,8 @@ errno_t sss_authtok_get_sc_pin(struct sss_auth_token *tok, const char **_pin,
     case SSS_AUTHTOK_TYPE_2FA_SINGLE:
     case SSS_AUTHTOK_TYPE_OAUTH2:
     case SSS_AUTHTOK_TYPE_PASSKEY:
+    case SSS_AUTHTOK_TYPE_PASSKEY_KRB:
+    case SSS_AUTHTOK_TYPE_PASSKEY_REPLY:
         return EACCES;
     }
 

--- a/src/util/authtok.h
+++ b/src/util/authtok.h
@@ -396,7 +396,7 @@ errno_t sss_authtok_get_2fa_single(struct sss_auth_token *tok,
  *
  * @param tok        A pointer to an sss_auth_token structure to change, also
  *                   used as a memory context to allocate the internal data.
- * @param password   A string where the two authentication factors are
+ * @param str        A string where the two authentication factors are
  *                   concatenated together
  * @param len        The length of the string or, if 0 is passed,
  *                   then strlen(password) will be used internally.
@@ -428,7 +428,7 @@ errno_t sss_authtok_get_oauth2(struct sss_auth_token *tok,
  *
  * @param tok        A pointer to an sss_auth_token structure to change, also
  *                   used as a memory context to allocate the internal data.
- * @param password   A string that holds the one-time password.
+ * @param str   A string that holds the one-time password.
  * @param len        The length of the string or, if 0 is passed,
  *                   then strlen(password) will be used internally.
  *
@@ -437,7 +437,57 @@ errno_t sss_authtok_get_oauth2(struct sss_auth_token *tok,
  */
 errno_t sss_authtok_set_oauth2(struct sss_auth_token *tok,
                                const char *str, size_t len);
+/**
+ * @brief Returns a const string if the auth token is of type
+          SSS_AUTHTOK_TYPE_PASSKEY_REPLY, otherwise it returns an error
+ *
+ * @param tok    A pointer to an sss_auth_token
+ * @param str    A string that holds the passkey assertion data
+ * @param len    The length of the credential string
+ *
+ * @return       EOK on success
+ *               ENOENT if the token is empty
+ *               EACCESS if the token is not a passkey token
+ */
+errno_t sss_authtok_set_passkey_reply(struct sss_auth_token *tok,
+                                      const char *str, size_t len);
+/**
+ * @brief Returns a const string if the auth token is of type
+          SSS_AUTHTOK_TYPE_PASSKEY_REPLY, otherwise it returns an error
+ *
+ * @param tok    A pointer to an sss_auth_token
+ * @param str    A pointer to a const char *, that will point to a null
+ *               terminated string
+ * @param len    The length of the credential string
+ *
+ * @return       EOK on success
+ *               ENOENT if the token is empty
+ *               EACCESS if the token is not a password token
+ */
+errno_t sss_authtok_get_passkey_reply(struct sss_auth_token *tok,
+                                      const char **str, size_t *len);
 
+/**
+ * @brief Returns a const string if the auth token is of type
+          SSS_AUTHTOK_TYPE_PASSKEY, otherwise it returns an error
+ *
+ * @param mem_ctx    Parent talloc context to attach to
+ * @param tok    A pointer to an sss_auth_token
+ * @param prompt A pointer to a const char *, that will point to a null
+ *               terminated string
+ * @param key    A pointer to a const char *, that will point to a null
+ *               terminated string
+ * @param pin    A pointer to a const char *, that will point to a null
+ *               terminated string
+ *
+ * @return       EOK on success
+ *               ENOENT if the token is empty
+ *               EACCESS if the token is not a password token
+ */
+errno_t sss_authtok_get_passkey(TALLOC_CTX *mem_ctx,
+                                struct sss_auth_token *tok,
+                                const char **_prompt, const char **_key,
+                                const char **_pin, size_t *_pin_len);
 /**
  * @brief Returns a const string if the auth token is of type
           SSS_AUTHTOK_TYPE_PASSKEY, otherwise it returns the error code
@@ -455,7 +505,8 @@ errno_t sss_authtok_get_passkey_pin(struct sss_auth_token *tok,
                                     const char **pin, size_t *len);
 
 /**
- * @brief Set passkey credentials into an auth token, replacing any previous data.
+ * @brief Set passkey kerberos preauth credentials into an auth token,
+ *        replacing any previous data.
  *
  * @param tok        A pointer to an sss_auth_token structure to change, also
  *                   used as a memory context to allocate the internal data.
@@ -466,6 +517,7 @@ errno_t sss_authtok_get_passkey_pin(struct sss_auth_token *tok,
  * @return       EOK on success
  *               ENOMEM on error
  */
-errno_t sss_authtok_set_passkey(struct sss_auth_token *tok,
-                                const char *pin, size_t len);
+errno_t sss_authtok_set_passkey_krb(struct sss_auth_token *tok,
+                                    const char *prompt, const char *key,
+                                    const char *pin);
 #endif /*  __AUTHTOK_H__ */

--- a/src/util/child_common.h
+++ b/src/util/child_common.h
@@ -32,8 +32,8 @@
 
 #include "util/util.h"
 
-#define IN_BUF_SIZE         512
-#define CHILD_MSG_CHUNK     256
+#define IN_BUF_SIZE         2048
+#define CHILD_MSG_CHUNK     1024
 
 #define SIGTERM_TO_SIGKILL_TIME 2
 


### PR DESCRIPTION
Add passkey kerberos preauthentication support

* `pam_passkey_auth` default changed to True
* Requires `setenforce 0` currently
* Passkey auth attempts kerberos preauthentication first, if unavailable then falls back to phase 1 passkey auth