### PR TITLE
KCM: Switch default caches only when there is no current default.

### DIFF
--- a/src/responder/kcm/kcmsrv_ops.c
+++ b/src/responder/kcm/kcmsrv_ops.c
@@ -668,8 +668,8 @@ static void kcm_op_initialize_got_default(struct tevent_req *subreq)
         return;
     }
 
-    if (uuid_is_null(old_dfl_uuid) == false) {
-        /* If there was a previous default ccache, switch to the initialized
+    if (uuid_is_null(old_dfl_uuid)) {
+        /* If there was no previous default ccache, switch to the initialized
          * one by default
          */
         /* `dfl_uuid` is output arg and isn't read in kcm_cc_get_uuid() but


### PR DESCRIPTION
Only when there was a current default cache (`(uid_is_null(old_dfl_uuid) == false)`), the default cache was switched. This condition should be negated so that the cache is switched when there is no current default.

Resolves: https://github.com/SSSD/sssd/issues/6357