### PR TITLE
tests: make pytest-ldap aware of TLS options

### DIFF
--- a/src/tests/system/lib/sssd/hosts/base.py
+++ b/src/tests/system/lib/sssd/hosts/base.py
@@ -192,6 +192,7 @@ class BaseLDAPDomainHost(BaseDomainHost):
 
             if self.tls:
                 newconn.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
+                newconn.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
                 newconn.start_tls_s()
 
             newconn.simple_bind_s(self.binddn, self.bindpw)


### PR DESCRIPTION
OPT_X_TLS_NEWCTX must be set to create a new TLS context after
changing TLS options in order to actually use them in python-ldap.

This is required to run the tests inside idm-ci where the internal
hostname that is used in certificate does not match the external
hostname or IP address that is used to connect to the remote host.