### PR TITLE
SSSCTL: Switch passkey-exec to passkey-register

### DIFF
--- a/src/tools/sssctl/sssctl.c
+++ b/src/tools/sssctl/sssctl.c
@@ -98,11 +98,16 @@ sssctl_prompt(const char *message,
 }
 
 errno_t sssctl_wrap_command(const char *command,
+                            const char *subcommand,
                             struct sss_cmdline *cmdline,
                             struct sss_tool_ctx *tool_ctx,
                             void *pvt)
 {
     errno_t ret;
+
+    if (subcommand != NULL) {
+        cmdline->argc++;
+    }
 
     const char **args = talloc_array_size(tool_ctx,
                                           sizeof(char *),
@@ -110,8 +115,16 @@ errno_t sssctl_wrap_command(const char *command,
     if (!args) {
         return ENOMEM;
     }
-    memcpy(&args[1], cmdline->argv, sizeof(char *) * cmdline->argc);
+
     args[0] = command;
+
+    if (subcommand != NULL) {
+        args[1] = subcommand;
+        memcpy(&args[2], cmdline->argv, sizeof(char *) * cmdline->argc);
+    } else {
+        memcpy(&args[1], cmdline->argv, sizeof(char *) * cmdline->argc);
+    }
+
     args[cmdline->argc + 1] = NULL;
 
     ret = sssctl_run_command(args);
@@ -332,7 +345,7 @@ int main(int argc, const char **argv)
         SSS_TOOL_COMMAND("cert-eval-rule", "Check mapping and matching rule with a certificate", 0, sssctl_cert_eval_rule),
 #ifdef BUILD_PASSKEY
         SSS_TOOL_DELIMITER("Passkey related tools:"),
-        SSS_TOOL_COMMAND_FLAGS("passkey-exec", "Perform passkey related operations", 0, sssctl_passkey_exec, SSS_TOOL_FLAG_SKIP_CMD_INIT|SSS_TOOL_FLAG_SKIP_ROOT_CHECK),
+        SSS_TOOL_COMMAND_FLAGS("passkey-register", "Perform passkey registration", 0, sssctl_passkey_register, SSS_TOOL_FLAG_SKIP_CMD_INIT|SSS_TOOL_FLAG_SKIP_ROOT_CHECK),
 #endif
         SSS_TOOL_LAST
     };

--- a/src/tools/sssctl/sssctl.h
+++ b/src/tools/sssctl/sssctl.h
@@ -48,6 +48,7 @@ sssctl_prompt(const char *message,
               enum sssctl_prompt_result defval);
 
 errno_t sssctl_wrap_command(const char *command,
+                            const char *subcommand,
                             struct sss_cmdline *cmdline,
                             struct sss_tool_ctx *tool_ctx,
                             void *pvt);
@@ -140,9 +141,9 @@ errno_t sssctl_cert_map(struct sss_cmdline *cmdline,
                         struct sss_tool_ctx *tool_ctx,
                         void *pvt);
 #ifdef BUILD_PASSKEY
-errno_t sssctl_passkey_exec(struct sss_cmdline *cmdline,
-                            struct sss_tool_ctx *tool_ctx,
-                            void *pvt);
+errno_t sssctl_passkey_register(struct sss_cmdline *cmdline,
+                                struct sss_tool_ctx *tool_ctx,
+                                void *pvt);
 #endif /* BUILD_PASSKEY */
 
 errno_t sssctl_cert_eval_rule(struct sss_cmdline *cmdline,

--- a/src/tools/sssctl/sssctl_logs.c
+++ b/src/tools/sssctl/sssctl_logs.c
@@ -602,7 +602,7 @@ errno_t sssctl_analyze(struct sss_cmdline *cmdline,
 #endif
     errno_t ret;
 
-    ret = sssctl_wrap_command(SSS_ANALYZE, cmdline, tool_ctx, pvt);
+    ret = sssctl_wrap_command(SSS_ANALYZE, NULL, cmdline, tool_ctx, pvt);
 
     return ret;
 }

--- a/src/tools/sssctl/sssctl_passkey.c
+++ b/src/tools/sssctl/sssctl_passkey.c
@@ -30,13 +30,13 @@
 
 #define SSS_PASSKEY_CHILD SSSD_LIBEXEC_PATH"/passkey_child"
 
-errno_t sssctl_passkey_exec(struct sss_cmdline *cmdline,
-                            struct sss_tool_ctx *tool_ctx,
-                            void *pvt)
+errno_t sssctl_passkey_register(struct sss_cmdline *cmdline,
+                                struct sss_tool_ctx *tool_ctx,
+                                void *pvt)
 {
     errno_t ret;
 
-    ret = sssctl_wrap_command(SSS_PASSKEY_CHILD, cmdline, tool_ctx, pvt);
+    ret = sssctl_wrap_command(SSS_PASSKEY_CHILD, "--register", cmdline, tool_ctx, pvt);
 
     return ret;
 }


### PR DESCRIPTION
Users currently only need to call --register