### PR TITLE
util: Improve re_expression defaults

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -3536,8 +3536,22 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                             domains, the flat (NetBIOS) name of the domain.
                         </para>
                         <para>
+                            Default: <quote>^((?P&lt;name&gt;.+)@(?P&lt;domain&gt;[^@]*)|(?P&lt;name&gt;[^@]+))$</quote>
+
+                            which allows two different styles for user names:
+                            <itemizedlist>
+                                <listitem>
+                                    <para>username</para>
+                                </listitem>
+                                <listitem>
+                                    <para>username@domain.name</para>
+                                </listitem>
+                           </itemizedlist>
+                        </para>
+                        <para>
                             Default for the AD and IPA provider:
-                            <quote>(((?P&lt;domain&gt;[^\\]+)\\(?P&lt;name&gt;.+$))|((?P&lt;name&gt;.+)@(?P&lt;domain&gt;[^@]+$))|(^(?P&lt;name&gt;[^@\\]+)$))</quote>
+                            <quote>^(((?P&lt;domain&gt;[^\\]+)\\(?P&lt;name&gt;.+))|((?P&lt;name&gt;.+)@(?P&lt;domain&gt;[^@]+))|((?P&lt;name&gt;[^@\\]+)))$</quote>
+
                             which allows three different styles for user names:
                             <itemizedlist>
                                 <listitem>
@@ -3555,10 +3569,14 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                             integration of users from Windows domains.
                         </para>
                         <para>
-                            Default: <quote>(?P&lt;name&gt;[^@]+)@?(?P&lt;domain&gt;[^@]*$)</quote>
-                            which translates to "the name is everything up to
-                            the <quote>@</quote> sign, the domain everything
-                            after that"
+                            The default re_expression uses the <quote>@</quote>
+                            character as a separator between the name and the
+                            domain. As a result of this setting the default
+                            does not accept the <quote>@</quote> character in
+                            short names (as it is allowed in Windows group
+                            names). If a user wishes to use short names with
+                            <quote>@</quote> they must create their own
+                            re_expression.
                         </para>
                     </listitem>
                 </varlistentry>

--- a/src/responder/ifp/ifpsrv.c
+++ b/src/responder/ifp/ifpsrv.c
@@ -194,7 +194,7 @@ int ifp_process_init(TALLOC_CTX *mem_ctx,
     ifp_ctx->rctx->pvt_ctx = ifp_ctx;
 
     ret = sss_names_init_from_args(ifp_ctx,
-                                   "(?P<name>[^@]+)@?(?P<domain>[^@]*$)",
+                                   SSS_DEFAULT_RE,
                                    "%1$s@%2$s", &ifp_ctx->snctx);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "fatal error initializing regex data\n");

--- a/src/responder/ssh/sshsrv.c
+++ b/src/responder/ssh/sshsrv.c
@@ -61,7 +61,7 @@ int ssh_process_init(TALLOC_CTX *mem_ctx,
     ssh_ctx->rctx->pvt_ctx = ssh_ctx;
 
     ret = sss_names_init_from_args(ssh_ctx,
-                                   "(?P<name>[^@]+)@?(?P<domain>[^@]*$)",
+                                   SSS_DEFAULT_RE,
                                    "%1$s@%2$s", &ssh_ctx->snctx);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "fatal error initializing regex data\n");

--- a/src/tests/common_dom.c
+++ b/src/tests/common_dom.c
@@ -203,9 +203,7 @@ mock_domain(TALLOC_CTX *mem_ctx,
 
     /* init with an AD-style regex to be able to test flat name */
     ret = sss_names_init_from_args(domain,
-                                   "(((?P<domain>[^\\\\]+)\\\\(?P<name>.+$))|" \
-                                   "((?P<name>[^@]+)@(?P<domain>.+$))|" \
-                                   "(^(?P<name>[^@\\\\]+)$))",
+                                   SSS_IPA_AD_DEFAULT_RE,
                                    "%1$s@%2$s", &domain->names);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "cannot create names context\n");

--- a/src/tests/sysdb-tests.c
+++ b/src/tests/sysdb-tests.c
@@ -1551,9 +1551,7 @@ START_TEST (test_sysdb_get_user_attr_subdomain)
     sss_ck_fail_if_msg(subdomain == NULL, "Failed to create new subdomain.");
 
     ret = sss_names_init_from_args(test_ctx,
-                                   "(((?P<domain>[^\\\\]+)\\\\(?P<name>.+$))|" \
-                                   "((?P<name>[^@]+)@(?P<domain>.+$))|" \
-                                   "(^(?P<name>[^@\\\\]+)$))",
+                                   SSS_IPA_AD_DEFAULT_RE,
                                    "%1$s@%2$s", &subdomain->names);
     sss_ck_fail_if_msg(ret != EOK, "Failed to init names.");
 

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -250,11 +250,11 @@ struct sss_names_ctx {
     sss_regexp_t *re;
 };
 
-#define SSS_DEFAULT_RE "(?P<name>[^@]+)@?(?P<domain>[^@]*$)"
+#define SSS_DEFAULT_RE "^((?P<name>.+)@(?P<domain>[^@]+)|(?P<name>[^@]+))$"
 
-#define SSS_IPA_AD_DEFAULT_RE "(((?P<domain>[^\\\\]+)\\\\(?P<name>.+$))|" \
-                              "((?P<name>.+)@(?P<domain>[^@]+$))|" \
-                              "(^(?P<name>[^@\\\\]+)$))"
+#define SSS_IPA_AD_DEFAULT_RE "^(((?P<domain>[^\\\\]+)\\\\(?P<name>.+))|" \
+                              "((?P<name>.+)@(?P<domain>[^@]+))|" \
+                              "((?P<name>[^@\\\\]+)))$"
 
 /* initialize sss_names_ctx directly from arguments */
 int sss_names_init_from_args(TALLOC_CTX *mem_ctx,


### PR DESCRIPTION
The original defaults of re_expressions did not use "^" so they
may skip/ignore some leading character (@ and \).

The new defaults uses ^ and $ to be sure that all characters
are used.

Resolves: https://github.com/SSSD/sssd/issues/6635
