### PR TITLE
tests: fix type errors due to type enhancements in jc

### DIFF
--- a/src/tests/system/lib/sssd/misc/ssh.py
+++ b/src/tests/system/lib/sssd/misc/ssh.py
@@ -19,7 +19,7 @@ class SSHKillableProcess(object):
         argv: list[Any],
         *,
         cwd: str | None = None,
-        env: dict[str, Any] = dict(),
+        env: dict[str, Any] | None = None,
         input: str | None = None,
         read_timeout: float = 2,
         log_level: SSHLog = SSHLog.Full,
@@ -31,8 +31,8 @@ class SSHKillableProcess(object):
         :type argv: list[Any]
         :param cwd: Working directory, defaults to None (= do not change)
         :type cwd: str | None, optional
-        :param env: Additional environment variables, defaults to dict()
-        :type env: dict[str, Any], optional
+        :param env: Additional environment variables, defaults to None
+        :type env: dict[str, Any] | None, optional
         :param input: Content of standard input, defaults to None
         :type input: str | None, optional
         :param read_timeout: Timeout in seconds, how long should the client wait for output, defaults to 30 seconds
@@ -40,6 +40,9 @@ class SSHKillableProcess(object):
         :param log_level: Log level, defaults to SSHLog.Full
         :type log_level: SSHLog, optional
         """
+        if env is None:
+            env = {}
+
         argv = to_list_of_strings(argv)
         command = shlex.join(argv)
         pidfile = "/tmp/.mh.sshkillableprocess.pid"

--- a/src/tests/system/lib/sssd/roles/ad.py
+++ b/src/tests/system/lib/sssd/roles/ad.py
@@ -369,7 +369,7 @@ class ADObject(BaseObject[ADHost, AD]):
 
         return f"{basedn},{self.role.host.naming_context}"
 
-    def _exec(self, op: str, args: list[str] | str = list(), **kwargs) -> SSHProcessResult:
+    def _exec(self, op: str, args: list[str] | str | None = None, **kwargs) -> SSHProcessResult:
         """
         Execute AD command.
 
@@ -380,11 +380,14 @@ class ADObject(BaseObject[ADHost, AD]):
 
         :param op: Command group operation (usually New, Set, Remove, Get)
         :type op: str
-        :param args: List of additional command arguments, defaults to list()
-        :type args: list[str], optional
+        :param args: List of additional command arguments, defaults to None
+        :type args: list[str] | None, optional
         :return: SSH process result.
         :rtype: SSHProcessResult
         """
+        if args is None:
+            args = []
+
         if isinstance(args, list):
             args = " ".join(args)
         elif args is None:

--- a/src/tests/system/lib/sssd/roles/ipa.py
+++ b/src/tests/system/lib/sssd/roles/ipa.py
@@ -223,7 +223,7 @@ class IPAObject(BaseObject[IPAHost, IPA]):
         self.name: str = name
         """Object name."""
 
-    def _exec(self, op: str, args: list[str] = list(), **kwargs) -> SSHProcessResult:
+    def _exec(self, op: str, args: list[str] | None = None, **kwargs) -> SSHProcessResult:
         """
         Execute IPA command.
 
@@ -234,22 +234,28 @@ class IPAObject(BaseObject[IPAHost, IPA]):
 
         :param op: Command group operation (usually add, mod, del, show)
         :type op: str
-        :param args: List of additional command arguments, defaults to list()
-        :type args: list[str], optional
+        :param args: List of additional command arguments, defaults to None
+        :type args: list[str] | None, optional
         :return: SSH process result.
         :rtype: SSHProcessResult
         """
+        if args is None:
+            args = []
+
         return self.role.host.ssh.exec(["ipa", f"{self.command_group}-{op}", self.name, *args], **kwargs)
 
-    def _add(self, attrs: CLIBuilderArgs = dict(), input: str | None = None):
+    def _add(self, attrs: CLIBuilderArgs | None = None, input: str | None = None):
         """
         Add IPA object.
 
-        :param attrs: Object attributes in :class:`pytest_mh.cli.CLIBuilder` format, defaults to dict()
-        :type attrs: pytest_mh.cli.CLIBuilderArgs, optional
+        :param attrs: Object attributes in :class:`pytest_mh.cli.CLIBuilder` format, defaults to None
+        :type attrs: pytest_mh.cli.CLIBuilderArgs | None, optional
         :param input: Contents of standard input given to the executed command, defaults to None
         :type input: str | None, optional
         """
+        if attrs is None:
+            attrs = {}
+
         self._exec("add", self.cli.args(attrs), input=input)
 
     def _modify(self, attrs: CLIBuilderArgs, input: str | None = None):
@@ -924,7 +930,7 @@ class IPAAutomountMap(IPAObject):
         else:
             raise ValueError(f"Unexepected location type: {type(location)}")
 
-    def _exec(self, op: str, args: list[str] = list(), **kwargs) -> SSHProcessResult:
+    def _exec(self, op: str, args: list[str] | None = None, **kwargs) -> SSHProcessResult:
         """
         Execute automoutmap IPA command.
 
@@ -935,11 +941,14 @@ class IPAAutomountMap(IPAObject):
 
         :param op: Command group operation (usually add, mod, del, show)
         :type op: str
-        :param args: List of additional command arguments, defaults to list()
-        :type args: list[str], optional
+        :param args: List of additional command arguments, defaults to None
+        :type args: list[str] | None, optional
         :return: SSH process result.
         :rtype: SSHProcessResult
         """
+        if args is None:
+            args = []
+
         defargs = self.cli.args(
             {
                 "location": (self.cli.option.POSITIONAL, self.location.name),
@@ -995,7 +1004,7 @@ class IPAAutomountKey(IPAObject):
         self.map: IPAAutomountMap = map
         self.info: str | None = None
 
-    def _exec(self, op: str, args: list[str] = list(), **kwargs) -> SSHProcessResult:
+    def _exec(self, op: str, args: list[str] | None = None, **kwargs) -> SSHProcessResult:
         """
         Execute automoutkey IPA command.
 
@@ -1006,11 +1015,14 @@ class IPAAutomountKey(IPAObject):
 
         :param op: Command group operation (usually add, mod, del, show)
         :type op: str
-        :param args: List of additional command arguments, defaults to list()
-        :type args: list[str], optional
+        :param args: List of additional command arguments, defaults to None
+        :type args: list[str] | None, optional
         :return: SSH process result.
         :rtype: SSHProcessResult
         """
+        if args is None:
+            args = []
+
         defargs = self.cli.args(
             {
                 "location": (self.cli.option.POSITIONAL, self.map.location.name),

--- a/src/tests/system/lib/sssd/roles/ldap.py
+++ b/src/tests/system/lib/sssd/roles/ldap.py
@@ -412,19 +412,19 @@ class LDAPObject(BaseObject[HostType, LDAPRoleType]):
     def _modify(
         self,
         *,
-        add: LDAPRecordAttributes = dict(),
-        replace: LDAPRecordAttributes = dict(),
-        delete: LDAPRecordAttributes = dict(),
+        add: LDAPRecordAttributes | None = None,
+        replace: LDAPRecordAttributes | None = None,
+        delete: LDAPRecordAttributes | None = None,
     ) -> None:
         """
         Modify LDAP record.
 
-        :param add: Attributes and values to add, defaults to dict()
-        :type add: LDAPRecordAttributes, optional
-        :param replace: Attributes and values to replace, defaults to dict()
-        :type replace: LDAPRecordAttributes, optional
-        :param delete: Attributes and values to delete, defaults to dict()
-        :type delete: LDAPRecordAttributes, optional
+        :param add: Attributes and values to add, defaults to None
+        :type add: LDAPRecordAttributes | None, optional
+        :param replace: Attributes and values to replace, defaults to None
+        :type replace: LDAPRecordAttributes | None, optional
+        :param delete: Attributes and values to delete, defaults to None
+        :type delete: LDAPRecordAttributes | None, optional
         """
         self.role.ldap.modify(self.dn, add=add, replace=replace, delete=delete)
 

--- a/src/tests/system/lib/sssd/roles/samba.py
+++ b/src/tests/system/lib/sssd/roles/samba.py
@@ -250,7 +250,7 @@ class SambaObject(BaseObject):
         self.name: str = name
         """Object name."""
 
-    def _exec(self, op: str, args: list[str] = list(), **kwargs) -> SSHProcessResult:
+    def _exec(self, op: str, args: list[str] | None = None, **kwargs) -> SSHProcessResult:
         """
         Execute samba-tool command.
 
@@ -261,11 +261,14 @@ class SambaObject(BaseObject):
 
         :param op: Command group operation (usually add, delete, show)
         :type op: str
-        :param args: List of additional command arguments, defaults to list()
-        :type args: list[str], optional
+        :param args: List of additional command arguments, defaults to None
+        :type args: list[str] | None, optional
         :return: SSH process result.
         :rtype: SSHProcessResult
         """
+        if args is None:
+            args = []
+
         return self.role.host.ssh.exec(["samba-tool", self.command, op, self.name, *args], **kwargs)
 
     def _add(self, attrs: CLIBuilderArgs) -> None:

--- a/src/tests/system/lib/sssd/topology.py
+++ b/src/tests/system/lib/sssd/topology.py
@@ -42,7 +42,11 @@ class SSSDTopologyMark(TopologyMark):
     """
 
     def __init__(
-        self, name: str, topology: Topology, fixtures: dict[str, str] = dict(), domains: dict[str, str] = dict()
+        self,
+        name: str,
+        topology: Topology,
+        fixtures: dict[str, str] | None = None,
+        domains: dict[str, str] | None = None,
     ) -> None:
         """
         :param name: Topology name used in pytest output.
@@ -50,13 +54,13 @@ class SSSDTopologyMark(TopologyMark):
         :param topology: Topology required to run the test.
         :type topology: Topology
         :param fixtures: Dynamically created fixtures available during the test run.
-        :type fixtures: dict[str, str], optional
+        :type fixtures: dict[str, str] | None, optional
         :param domains: Automatically created SSSD domains on client host
-        :type domains: dict[str, str], optional
+        :type domains: dict[str, str] | None, optional
         """
         super().__init__(name, topology, fixtures)
 
-        self.domains: dict[str, str] = domains
+        self.domains: dict[str, str] = domains if domains is not None else {}
         """Map hosts to SSSD domains."""
 
     def export(self) -> dict:

--- a/src/tests/system/lib/sssd/utils/authentication.py
+++ b/src/tests/system/lib/sssd/utils/authentication.py
@@ -470,7 +470,7 @@ class KerberosAuthenticationUtils(MultihostUtility[MultihostHost]):
         """SSH client for the target user."""
 
     def kinit(
-        self, principal: str, *, password: str, realm: str | None = None, args: list[str] = list()
+        self, principal: str, *, password: str, realm: str | None = None, args: list[str] | None = None
     ) -> SSHProcessResult:
         """
         Run ``kinit`` command.
@@ -487,17 +487,20 @@ class KerberosAuthenticationUtils(MultihostUtility[MultihostHost]):
         :type password: str
         :param realm: Kerberos realm that is appended to the principal (``$principal@$realm``), defaults to None
         :type realm: str | None, optional
-        :param args: Additional parameters to ``klist``, defaults to list()
-        :type args: list[str], optional
+        :param args: Additional parameters to ``klist``, defaults to None
+        :type args: list[str] | None, optional
         :return: Command result.
         :rtype: SSHProcessResult
         """
+        if args is None:
+            args = []
+
         if realm is not None:
             principal = f"{principal}@{realm}"
 
         return self.ssh.exec(["kinit", *args, principal], input=password)
 
-    def kvno(self, principal: str, *, realm: str | None = None, args: list[str] = list()) -> SSHProcessResult:
+    def kvno(self, principal: str, *, realm: str | None = None, args: list[str] | None = None) -> SSHProcessResult:
         """
         Run ``kvno`` command.
 
@@ -511,25 +514,31 @@ class KerberosAuthenticationUtils(MultihostUtility[MultihostHost]):
         :type principal: str
         :param realm: Kerberos realm that is appended to the principal (``$principal@$realm``), defaults to None
         :type realm: str | None, optional
-        :param args: Additional parameters to ``klist``, defaults to list()
-        :type args: list[str], optional
+        :param args: Additional parameters to ``klist``, defaults to None
+        :type args: list[str] | None, optional
         :return: Command result.
         :rtype: SSHProcessResult
         """
+        if args is None:
+            args = []
+
         if realm is not None:
             principal = f"{principal}@{realm}"
 
         return self.ssh.exec(["kvno", *args, principal])
 
-    def klist(self, *, args: list[str] = list()) -> SSHProcessResult:
+    def klist(self, *, args: list[str] | None = None) -> SSHProcessResult:
         """
         Run ``klist`` command.
 
-        :param args: Additional parameters to ``klist``, defaults to list()
-        :type args: list[str], optional
+        :param args: Additional parameters to ``klist``, defaults to None
+        :type args: list[str] | None, optional
         :return: Command result.
         :rtype: SSHProcessResult
         """
+        if args is None:
+            args = []
+
         return self.ssh.exec(["klist", *args])
 
     def kswitch(self, principal: str, realm: str) -> SSHProcessResult:
@@ -673,12 +682,12 @@ class KerberosAuthenticationUtils(MultihostUtility[MultihostHost]):
 
         return len(result.stdout_lines) - 2
 
-    def list_principals(self, env: dict[str, Any] = dict()) -> dict[str, list[str]]:
+    def list_principals(self, env: dict[str, Any] | None = None) -> dict[str, list[str]]:
         """
         List all principals that have existing credential cache.
 
-        :param env: Additional environment variables passed to ``klist -A`` command, defaults to dict()
-        :type env: dict[str, Any], optional
+        :param env: Additional environment variables passed to ``klist -A`` command, defaults to None
+        :type env: dict[str, Any] | None, optional
         :return: Dictionary with principal as the key and list of available tickets as value.
         :rtype: dict[str, list[str]]
         """

--- a/src/tests/system/lib/sssd/utils/ldap.py
+++ b/src/tests/system/lib/sssd/utils/ldap.py
@@ -110,23 +110,32 @@ class LDAPUtils(MultihostUtility[BaseLDAPDomainHost]):
         self,
         dn: str,
         *,
-        add: LDAPRecordAttributes = dict(),
-        replace: LDAPRecordAttributes = dict(),
-        delete: LDAPRecordAttributes = dict(),
+        add: LDAPRecordAttributes | None = None,
+        replace: LDAPRecordAttributes | None = None,
+        delete: LDAPRecordAttributes | None = None,
     ) -> None:
         """
         Modify LDAP entry.
 
         :param dn: Distinguished name.
         :type dn: str
-        :param add: Attributes to add, defaults to dict()
-        :type add: LDAPRecordAttributes, optional
-        :param replace: Attributes to replace, defaults to dict()
-        :type replace: LDAPRecordAttributes, optional
-        :param delete: Attributes to delete, defaults to dict()
-        :type delete: LDAPRecordAttributes, optional
+        :param add: Attributes to add, defaults to None
+        :type add: LDAPRecordAttributes | None, optional
+        :param replace: Attributes to replace, defaults to None
+        :type replace: LDAPRecordAttributes | None, optional
+        :param delete: Attributes to delete, defaults to None
+        :type delete: LDAPRecordAttributes | None, optional
         """
         modlist = []
+
+        if add is None:
+            add = {}
+
+        if replace is None:
+            replace = {}
+
+        if delete is None:
+            delete = {}
 
         for attr, values in add.items():
             modlist.append((ldap.MOD_ADD, attr, self.__values_to_bytes(values)))

--- a/src/tests/system/lib/sssd/utils/local_users.py
+++ b/src/tests/system/lib/sssd/utils/local_users.py
@@ -241,7 +241,13 @@ class LocalUser(object):
         if not jcresult:
             return {}
 
-        return {k: v for k, v in jcresult[0].items() if not attrs or k in attrs}
+        if not isinstance(jcresult, list):
+            raise TypeError(f"Unexpected type: {type(jcresult)}, expecting list")
+
+        if not isinstance(jcresult[0], dict):
+            raise TypeError(f"Unexpected type: {type(jcresult[0])}, expecting dict")
+
+        return {k: [str(v)] for k, v in jcresult[0].items() if not attrs or k in attrs}
 
 
 class LocalGroup(object):
@@ -335,7 +341,13 @@ class LocalGroup(object):
         if not jcresult:
             return {}
 
-        return {k: v for k, v in jcresult[0].items() if not attrs or k in attrs}
+        if not isinstance(jcresult, list):
+            raise TypeError(f"Unexpected type: {type(jcresult)}, expecting list")
+
+        if not isinstance(jcresult[0], dict):
+            raise TypeError(f"Unexpected type: {type(jcresult[0])}, expecting dict")
+
+        return {k: [str(v)] for k, v in jcresult[0].items() if not attrs or k in attrs}
 
     def add_member(self, member: LocalUser) -> LocalGroup:
         """

--- a/src/tests/system/lib/sssd/utils/tools.py
+++ b/src/tests/system/lib/sssd/utils/tools.py
@@ -143,7 +143,12 @@ class IdEntry(object):
 
     @classmethod
     def FromOutput(cls, stdout: str) -> IdEntry:
-        return cls.FromDict(jc.parse("id", stdout))
+        jcresult = jc.parse("id", stdout)
+
+        if not isinstance(jcresult, dict):
+            raise TypeError(f"Unexpected type: {type(jcresult)}, expecting dict")
+
+        return cls.FromDict(jcresult)
 
 
 class PasswdEntry(object):
@@ -209,6 +214,9 @@ class PasswdEntry(object):
     def FromOutput(cls, stdout: str) -> PasswdEntry:
         result = jc.parse("passwd", stdout)
 
+        if not isinstance(result, list):
+            raise TypeError(f"Unexpected type: {type(result)}, expecting list")
+
         if len(result) != 1:
             raise ValueError("More then one entry was returned")
 
@@ -259,6 +267,9 @@ class GroupEntry(object):
     @classmethod
     def FromOutput(cls, stdout: str) -> GroupEntry:
         result = jc.parse("group", stdout)
+
+        if not isinstance(result, list):
+            raise TypeError(f"Unexpected type: {type(result)}, expecting list")
 
         if len(result) != 1:
             raise ValueError("More then one entry was returned")

--- a/src/tests/system/lib/sssd/utils/tools.py
+++ b/src/tests/system/lib/sssd/utils/tools.py
@@ -312,7 +312,7 @@ class LinuxToolsUtils(MultihostUtility[MultihostHost]):
 
         return IdEntry.FromOutput(command.stdout)
 
-    def grep(self, pattern: str, paths: str | list[str], args: list[str] = list()) -> bool:
+    def grep(self, pattern: str, paths: str | list[str], args: list[str] | None = None) -> bool:
         """
         Run ``grep`` command.
 
@@ -320,27 +320,33 @@ class LinuxToolsUtils(MultihostUtility[MultihostHost]):
         :type pattern: str
         :param paths: Paths to search.
         :type paths: str | list[str]
-        :param args: Additional arguments to ``grep`` command, defaults to [].
-        :type args: list[str], optional
+        :param args: Additional arguments to ``grep`` command, defaults to None.
+        :type args: list[str] | None, optional
         :return: True if grep returned 0, False otherwise.
         :rtype: bool
         """
+        if args is None:
+            args = []
+
         paths = [paths] if isinstance(paths, str) else paths
         command = self.host.ssh.exec(["grep", *args, pattern, *paths])
 
         return command.rc == 0
 
-    def tcpdump(self, pcap_path: str, args: list[Any] = list()) -> SSHKillableProcess:
+    def tcpdump(self, pcap_path: str, args: list[Any] | None = None) -> SSHKillableProcess:
         """
         Run tcpdump. The packets are captured in ``pcap_path``.
 
         :param pcap_path: Path to the capture file.
         :type pcap_path: str
-        :param args: Arguments to ``tcpdump``, defaults to list()
-        :type args: list[Any], optional
+        :param args: Arguments to ``tcpdump``, defaults to None
+        :type args: list[Any] | None, optional
         :return: Killable process.
         :rtype: SSHKillableProcess
         """
+        if args is None:
+            args = []
+
         self.__fs.backup(pcap_path)
 
         command = SSHKillableProcess(self.host.ssh, ["tcpdump", *args, "-w", pcap_path])
@@ -350,15 +356,18 @@ class LinuxToolsUtils(MultihostUtility[MultihostHost]):
 
         return command
 
-    def tshark(self, args: list[Any] = list()) -> SSHProcessResult:
+    def tshark(self, args: list[Any] | None = None) -> SSHProcessResult:
         """
         Execute tshark command with given arguments.
 
-        :param args: Arguments to ``tshark``, defaults to list()
-        :type args: list[Any], optional
+        :param args: Arguments to ``tshark``, defaults to None
+        :type args: list[Any] | None, optional
         :return: SSH Process result
         :rtype: SSHProcessResult
         """
+        if args is None:
+            args = []
+
         return self.host.ssh.exec(["tshark", *args])
 
     def teardown(self):


### PR DESCRIPTION
The library we depend on `jc` made its typing more specific so we need to
check that we got the expected type.