### PR TITLE
COVSCAN: Fix several coverity warnings

### DIFF
--- a/src/external/sizes.m4
+++ b/src/external/sizes.m4
@@ -9,6 +9,7 @@ AC_CHECK_SIZEOF(long long)
 AC_CHECK_SIZEOF(uid_t)
 AC_CHECK_SIZEOF(gid_t)
 AC_CHECK_SIZEOF(id_t)
+AC_CHECK_SIZEOF(time_t)
 
 if test $ac_cv_sizeof_long_long -lt 8 ; then
 AC_MSG_ERROR([SSSD requires long long of 64-bits])

--- a/src/providers/ad/ad_machine_pw_renewal.c
+++ b/src/providers/ad/ad_machine_pw_renewal.c
@@ -211,7 +211,7 @@ ad_machine_account_password_renewal_send(TALLOC_CTX *mem_ctx,
         }
 
         /* Set up timeout handler */
-        tv = tevent_timeval_current_ofs(be_ptask_get_timeout(be_ptask), 0);
+        tv = sss_tevent_timeval_current_ofs_time_t(be_ptask_get_timeout(be_ptask));
         state->timeout_handler = tevent_add_timer(ev, req, tv,
                                     ad_machine_account_password_renewal_timeout,
                                     req);

--- a/src/providers/be_ptask.c
+++ b/src/providers/be_ptask.c
@@ -143,7 +143,7 @@ static void be_ptask_execute(struct tevent_context *ev,
 
     /* schedule timeout */
     if (task->timeout > 0) {
-        tv = tevent_timeval_current_ofs(task->timeout, 0);
+        tv = sss_tevent_timeval_current_ofs_time_t(task->timeout);
         timeout = tevent_add_timer(task->ev, task->req, tv,
                                    be_ptask_timeout, task);
         if (timeout == NULL) {
@@ -229,7 +229,7 @@ static void be_ptask_schedule(struct be_ptask *task,
     }
 
     if(from & BE_PTASK_SCHEDULE_FROM_NOW) {
-        tv = tevent_timeval_current_ofs(delay, 0);
+        tv = sss_tevent_timeval_current_ofs_time_t(delay);
 
         DEBUG(SSSDBG_TRACE_FUNC, "Task [%s]: scheduling task %lu seconds "
               "from now [%lu]\n", task->name, delay, tv.tv_sec);

--- a/src/providers/fail_over.c
+++ b/src/providers/fail_over.c
@@ -163,7 +163,7 @@ fo_context_init(TALLOC_CTX *mem_ctx, struct fo_options *opts)
     ctx->opts->use_search_list = opts->use_search_list;
 
     DEBUG(SSSDBG_TRACE_FUNC,
-          "Created new fail over context, retry timeout is %ld\n",
+          "Created new fail over context, retry timeout is %"SPRItime"\n",
            ctx->opts->retry_timeout);
     return ctx;
 }

--- a/src/providers/ipa/ipa_session.c
+++ b/src/providers/ipa/ipa_session.c
@@ -142,7 +142,7 @@ ipa_fetch_deskprofile_send(TALLOC_CTX *mem_ctx,
         next_request /= 60;
         DEBUG(SSSDBG_TRACE_FUNC,
               "No rules were found in the last request.\n"
-              "Next request will happen in any login after %ld minutes\n",
+              "Next request will happen in any login after %"SPRItime" minutes\n",
               next_request);
         ret = ENOENT;
         goto immediately;

--- a/src/providers/krb5/krb5_ccache.c
+++ b/src/providers/krb5/krb5_ccache.c
@@ -529,7 +529,14 @@ errno_t sss_krb5_cc_verify_ccache(const char *ccname, uid_t uid, gid_t gid,
 
     mcred.client = princ;
     mcred.server = tgt_princ;
-    mcred.times.endtime = time(NULL);
+    /* Type krb5_timestamp is a signed 32-bit integer, so we need to convert the
+     * 64-bit time_t value returned by time(). Just keeping the lower 32 bits
+     * should be enough as Kerberos seems to be planing on making this time
+     * unsigned to avoid the Y2K38 problem.
+     * Please check:
+     * https://web.mit.edu/kerberos/krb5-latest/doc/appdev/y2038.html
+     */
+    mcred.times.endtime = time(NULL) & 0xFFFFFFFF;
 
     kerr = krb5_cc_retrieve_cred(cc->context, cc->ccache,
                                  KRB5_TC_MATCH_TIMES, &mcred, &cred);

--- a/src/providers/krb5/krb5_child_handler.c
+++ b/src/providers/krb5/krb5_child_handler.c
@@ -935,7 +935,8 @@ parse_krb5_child_response(TALLOC_CTX *mem_ctx, uint8_t *buf, ssize_t len,
             tgtt.endtime = int64_to_time_t(time_data);
             SAFEALIGN_COPY_INT64(&time_data, buf+p+3*sizeof(int64_t), NULL);
             tgtt.renew_till = int64_to_time_t(time_data);
-            DEBUG(SSSDBG_TRACE_LIBS, "TGT times are [%ld][%ld][%ld][%ld].\n",
+            DEBUG(SSSDBG_TRACE_LIBS,
+                  "TGT times are [%"SPRItime"][%"SPRItime"][%"SPRItime"][%"SPRItime"].\n",
                   tgtt.authtime, tgtt.starttime, tgtt.endtime, tgtt.renew_till);
         }
 

--- a/src/providers/krb5/krb5_renew_tgt.c
+++ b/src/providers/krb5/krb5_renew_tgt.c
@@ -286,8 +286,7 @@ static void renew_handler(struct renew_tgt_ctx *renew_tgt_ctx)
 
     DEBUG(SSSDBG_TRACE_LIBS, "Adding new renew timer.\n");
 
-    next = tevent_timeval_current_ofs(renew_tgt_ctx->timer_interval,
-                                      0);
+    next = sss_tevent_timeval_current_ofs_time_t(renew_tgt_ctx->timer_interval);
     renew_tgt_ctx->te = tevent_add_timer(renew_tgt_ctx->ev, renew_tgt_ctx,
                                          next, renew_tgt_timer_handler,
                                          renew_tgt_ctx);
@@ -501,8 +500,7 @@ errno_t init_renew_tgt(struct krb5_ctx *krb5_ctx, struct be_ctx *be_ctx,
               "Failed to read ccache files, continuing ...\n");
     }
 
-    next = tevent_timeval_current_ofs(krb5_ctx->renew_tgt_ctx->timer_interval,
-                                      0);
+    next = sss_tevent_timeval_current_ofs_time_t(krb5_ctx->renew_tgt_ctx->timer_interval);
     krb5_ctx->renew_tgt_ctx->te = tevent_add_timer(ev, krb5_ctx->renew_tgt_ctx,
                                                    next, renew_tgt_timer_handler,
                                                    krb5_ctx->renew_tgt_ctx);

--- a/src/providers/ldap/ldap_auth.c
+++ b/src/providers/ldap/ldap_auth.c
@@ -97,8 +97,8 @@ static errno_t check_pwexpire_kerberos(const char *expire_date, time_t now,
 
     DEBUG(SSSDBG_TRACE_ALL,
           "Time info: tzname[0] [%s] tzname[1] [%s] timezone [%ld] "
-           "daylight [%d] now [%ld] expire_time [%ld].\n", tzname[0],
-           tzname[1], timezone, daylight, now, expire_time);
+          "daylight [%d] now [%"SPRItime"] expire_time [%"SPRItime"].\n",
+          tzname[0], tzname[1], timezone, daylight, now, expire_time);
 
     if (expire_time == 0) {
         /* Used by the MIT LDAP KDB plugin to indicate "never" */

--- a/src/providers/ldap/ldap_id_cleanup.c
+++ b/src/providers/ldap/ldap_id_cleanup.c
@@ -201,20 +201,20 @@ static int cleanup_users(struct sdap_options *opts,
 
     if (account_cache_expiration > 0) {
         subfilter = talloc_asprintf(tmpctx,
-                                    "(&(!(%s=0))(|(!(%s=*))(%s<=%ld)))",
+                                    "(&(!(%s=0))(|(!(%s=*))(%s<=%"SPRItime")))",
                                     SYSDB_CACHE_EXPIRE,
                                     SYSDB_LAST_LOGIN,
                                     SYSDB_LAST_LOGIN,
-                                    (long) (now - (account_cache_expiration * 86400)));
+                                    (now - (account_cache_expiration * 86400)));
 
         ts_subfilter = talloc_asprintf(tmpctx,
-                            "(&(!(%s=0))(%s<=%ld)(|(!(%s=*))(%s<=%ld)))",
+                            "(&(!(%s=0))(%s<=%"SPRItime")(|(!(%s=*))(%s<=%"SPRItime")))",
                             SYSDB_CACHE_EXPIRE,
                             SYSDB_CACHE_EXPIRE,
-                            (long) now,
+                            now,
                             SYSDB_LAST_LOGIN,
                             SYSDB_LAST_LOGIN,
-                            (long) (now - (account_cache_expiration * 86400)));
+                            (now - (account_cache_expiration * 86400)));
     } else {
         subfilter = talloc_asprintf(tmpctx,
                                     "(&(!(%s=0))(!(%s=*)))",
@@ -222,10 +222,10 @@ static int cleanup_users(struct sdap_options *opts,
                                     SYSDB_LAST_LOGIN);
 
         ts_subfilter = talloc_asprintf(tmpctx,
-                                       "(&(!(%s=0))(%s<=%ld)(!(%s=*)))",
+                                       "(&(!(%s=0))(%s<=%"SPRItime")(!(%s=*)))",
                                        SYSDB_CACHE_EXPIRE,
                                        SYSDB_CACHE_EXPIRE,
-                                       (long) now,
+                                       now,
                                        SYSDB_LAST_LOGIN);
     }
     if (subfilter == NULL || ts_subfilter == NULL) {
@@ -409,9 +409,8 @@ static int cleanup_groups(TALLOC_CTX *memctx,
         goto done;
     }
 
-    ts_subfilter = talloc_asprintf(tmpctx, "(&(!(%s=0))(%s<=%ld))",
-                                   SYSDB_CACHE_EXPIRE,
-                                   SYSDB_CACHE_EXPIRE, (long)now);
+    ts_subfilter = talloc_asprintf(tmpctx, "(&(!(%s=0))(%s<=%"SPRItime"))",
+                                   SYSDB_CACHE_EXPIRE, SYSDB_CACHE_EXPIRE, now);
     if (ts_subfilter == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to build filter\n");
         ret = ENOMEM;

--- a/src/providers/ldap/ldap_resolver_cleanup.c
+++ b/src/providers/ldap/ldap_resolver_cleanup.c
@@ -50,9 +50,8 @@ cleanup_iphosts(struct sdap_options *opts,
         goto done;
     }
 
-    ts_subfilter = talloc_asprintf(tmp_ctx, "(&(!(%s=0))(%s<=%ld))",
-                                   SYSDB_CACHE_EXPIRE,
-                                   SYSDB_CACHE_EXPIRE, (long)now);
+    ts_subfilter = talloc_asprintf(tmp_ctx, "(&(!(%s=0))(%s<=%"SPRItime"))",
+                                   SYSDB_CACHE_EXPIRE, SYSDB_CACHE_EXPIRE, now);
     if (ts_subfilter == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to build filter\n");
         ret = ENOMEM;
@@ -126,9 +125,8 @@ cleanup_ipnetworks(struct sdap_options *opts,
         goto done;
     }
 
-    ts_subfilter = talloc_asprintf(tmp_ctx, "(&(!(%s=0))(%s<=%ld))",
-                                   SYSDB_CACHE_EXPIRE,
-                                   SYSDB_CACHE_EXPIRE, (long)now);
+    ts_subfilter = talloc_asprintf(tmp_ctx, "(&(!(%s=0))(%s<=%"SPRItime"))",
+                                   SYSDB_CACHE_EXPIRE, SYSDB_CACHE_EXPIRE, now);
     if (ts_subfilter == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to build filter\n");
         ret = ENOMEM;

--- a/src/providers/ldap/sdap_access.c
+++ b/src/providers/ldap/sdap_access.c
@@ -569,8 +569,8 @@ bool nds_check_expired(const char *exp_time_str)
     now = time(NULL);
     DEBUG(SSSDBG_TRACE_ALL,
           "Time info: tzname[0] [%s] tzname[1] [%s] timezone [%ld] "
-           "daylight [%d] now [%ld] expire_time [%ld].\n", tzname[0],
-           tzname[1], timezone, daylight, now, expire_time);
+          "daylight [%d] now [%"SPRItime"] expire_time [%"SPRItime"].\n",
+          tzname[0], tzname[1], timezone, daylight, now, expire_time);
 
     if (difftime(now, expire_time) > 0.0) {
         DEBUG(SSSDBG_CONF_SETTINGS, "NDS account expired.\n");

--- a/src/providers/ldap/sdap_async.c
+++ b/src/providers/ldap/sdap_async.c
@@ -1092,7 +1092,7 @@ sdap_modify_shadow_lastchange_send(TALLOC_CTX *mem_ctx,
     }
 
     /* The attribute contains number of days since the epoch */
-    values[0] = talloc_asprintf(values, "%ld", (long)time(NULL)/86400);
+    values[0] = talloc_asprintf(values, "%"SPRItime, time(NULL)/86400);
     if (values[0] == NULL) {
         ret = ENOMEM;
         goto done;

--- a/src/providers/ldap/sdap_async_connection.c
+++ b/src/providers/ldap/sdap_async_connection.c
@@ -1905,7 +1905,8 @@ static void sdap_cli_auth_step(struct tevent_req *req)
             || (state->sh->expire_time > (now + expire_timeout))) {
         state->sh->expire_time = now + expire_timeout;
         DEBUG(SSSDBG_TRACE_LIBS,
-              "the connection will expire at %ld\n", state->sh->expire_time);
+              "the connection will expire at %"SPRItime"\n",
+              state->sh->expire_time);
     }
 
     if (!state->do_auth ||

--- a/src/providers/ldap/sdap_child_helpers.c
+++ b/src/providers/ldap/sdap_child_helpers.c
@@ -429,7 +429,8 @@ int sdap_get_tgt_recv(struct tevent_req *req,
     }
 
     DEBUG(SSSDBG_TRACE_FUNC,
-          "Child responded: %d [%s], expired on [%ld]\n", res, ccn, (long)expire_time);
+          "Child responded: %d [%s], expired on [%"SPRItime"]\n",
+          res, ccn, expire_time);
     *result = res;
     *kerr = krberr;
     *ccname = ccn;

--- a/src/providers/ldap/sdap_id_op.c
+++ b/src/providers/ldap/sdap_id_op.c
@@ -347,7 +347,7 @@ static int sdap_id_conn_data_start_idle_timer(struct sdap_id_conn_data *conn_dat
     memset(&tv, 0, sizeof(tv));
     tv.tv_sec = now + idle_timeout;
     DEBUG(SSSDBG_TRACE_ALL,
-          "Scheduling connection idle timer to run at %ld\n", tv.tv_sec);
+          "Scheduling connection idle timer to run at %"SPRItime"\n", tv.tv_sec);
 
     conn_data->idle_timer =
               tevent_add_timer(conn_data->conn_cache->id_conn->id_ctx->be->ev,
@@ -396,7 +396,7 @@ static void sdap_id_conn_data_idle_handler(struct tevent_context *ev,
     memset(&tv, 0, sizeof(tv));
     tv.tv_sec = (idle_time == 0 ? now : idle_time) + idle_timeout;
     DEBUG(SSSDBG_TRACE_ALL,
-          "Rescheduling connection idle timer to run at %ld\n", tv.tv_sec);
+          "Rescheduling connection idle timer to run at %"SPRItime"\n", tv.tv_sec);
 
     conn_data->idle_timer =
               tevent_add_timer(conn_data->conn_cache->id_conn->id_ctx->be->ev,

--- a/src/providers/ldap/sdap_sudo_shared.c
+++ b/src/providers/ldap/sdap_sudo_shared.c
@@ -58,7 +58,7 @@ sdap_sudo_ptask_setup_generic(struct be_ctx *be_ctx,
 
         DEBUG(SSSDBG_CONF_SETTINGS, "At least smart refresh needs to be "
               "enabled. Setting smart refresh interval to default value "
-              "(%ld) seconds.\n", smart);
+              "(%"SPRItime") seconds.\n", smart);
     } else if (full > 0 && full <= smart) {
         /* In this case it does not make any sense to run smart refresh. */
         smart = 0;

--- a/src/responder/kcm/kcm_renew.c
+++ b/src/responder/kcm/kcm_renew.c
@@ -719,7 +719,7 @@ static void kcm_renew_tgt_timer_handler(struct tevent_context *ev,
     }
 
     /* Reschedule timer */
-    next = tevent_timeval_current_ofs(renew_tgt_ctx->timer_interval, 0);
+    next = sss_tevent_timeval_current_ofs_time_t(renew_tgt_ctx->timer_interval);
     renew_tgt_ctx->te = tevent_add_timer(ev, renew_tgt_ctx,
                                          next, kcm_renew_tgt_timer_handler,
                                          renew_tgt_ctx);
@@ -755,8 +755,8 @@ errno_t kcm_renewal_setup(struct resp_ctx *rctx,
     krb5_ctx->kcm_renew_tgt_ctx->timer_interval = renew_intv;
 
     /* Check KCM for tickets to renew */
-    next = tevent_timeval_current_ofs(krb5_ctx->kcm_renew_tgt_ctx->timer_interval,
-                                      0);
+    next = sss_tevent_timeval_current_ofs_time_t(
+                                   krb5_ctx->kcm_renew_tgt_ctx->timer_interval);
     krb5_ctx->kcm_renew_tgt_ctx->te = tevent_add_timer(ev, krb5_ctx->kcm_renew_tgt_ctx,
                                                    next,
                                                    kcm_renew_tgt_timer_handler,

--- a/src/responder/nss/nsssrv_mmap_cache.c
+++ b/src/responder/nss/nsssrv_mmap_cache.c
@@ -678,7 +678,7 @@ static errno_t sss_mc_get_record(struct sss_mc_ctx **_mcc,
 
 static inline void sss_mmap_set_rec_header(struct sss_mc_ctx *mcc,
                                            struct sss_mc_rec *rec,
-                                           size_t len, int ttl,
+                                           size_t len, time_t ttl,
                                            const char *key1, size_t key1_len,
                                            const char *key2, size_t key2_len)
 {
@@ -1352,8 +1352,8 @@ errno_t sss_mmap_cache_init(TALLOC_CTX *mem_ctx, const char *name,
         return EOK;
     }
     DEBUG(SSSDBG_CONF_SETTINGS,
-          "Fast '%s' mmap cache: memcache_timeout = %d, slots = %zu\n",
-          mc_type_to_str(type), (int)timeout, n_elem);
+          "Fast '%s' mmap cache: memcache_timeout = %"SPRItime", slots = %zu\n",
+          mc_type_to_str(type), timeout, n_elem);
 
     mc_ctx = talloc_zero(mem_ctx, struct sss_mc_ctx);
     if (!mc_ctx) {

--- a/src/responder/pam/pamsrv_p11.c
+++ b/src/responder/pam/pamsrv_p11.c
@@ -906,7 +906,7 @@ struct tevent_req *pam_check_cert_send(TALLOC_CTX *mem_ctx,
         }
 
         /* Set up timeout handler */
-        tv = tevent_timeval_current_ofs(timeout, 0);
+        tv = sss_tevent_timeval_current_ofs_time_t(timeout);
         state->timeout_handler = tevent_add_timer(ev, req, tv,
                                                   p11_child_timeout, req);
         if(state->timeout_handler == NULL) {

--- a/src/responder/ssh/ssh_cert_to_ssh_key.c
+++ b/src/responder/ssh/ssh_cert_to_ssh_key.c
@@ -230,7 +230,7 @@ static errno_t cert_to_ssh_key_step(struct tevent_req *req)
         }
 
         /* Set up timeout handler */
-        tv = tevent_timeval_current_ofs(state->timeout, 0);
+        tv = sss_tevent_timeval_current_ofs_time_t(state->timeout);
         state->timeout_handler = tevent_add_timer(state->ev, req, tv,
                                                   p11_child_timeout,
                                                   req);

--- a/src/sbus/interface/sbus_interface.c
+++ b/src/sbus/interface/sbus_interface.c
@@ -339,18 +339,9 @@ struct sbus_listener *
 sbus_listener_copy(TALLOC_CTX *mem_ctx,
                    const struct sbus_listener *input)
 {
-    struct sbus_listener *copy;
-
-    copy = talloc_zero(mem_ctx, struct sbus_listener);
-    if (copy == NULL) {
-        return NULL;
-    }
-
     /* All data is either pointer to a static data or it is not a pointer.
      * We can just copy it. */
-    memcpy(copy, input, sizeof(struct sbus_listener));
-
-    return copy;
+    return talloc_memdup(mem_ctx, input, sizeof(struct sbus_listener));
 }
 
 struct sbus_node

--- a/src/sss_client/sss_pac_responder_client.c
+++ b/src/sss_client/sss_pac_responder_client.c
@@ -27,6 +27,7 @@
 #include <sys/syscall.h>
 
 #include "sss_client/sss_cli.h"
+#include "util/util.h"
 
 const uint8_t pac[] = {
 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x10,
@@ -95,9 +96,8 @@ static void *pac_client(void *arg)
     int ret;
     size_t c;
 
-    fprintf(stderr, "[%ld][%d][%ld][%s] started\n", time(NULL), getpid(),
-                                                    syscall(SYS_gettid),
-                                                    (char *) arg);
+    fprintf(stderr, "[%"SPRItime"][%d][%ld][%s] started\n",
+            time(NULL), getpid(), syscall(SYS_gettid), (char *) arg);
     for (c = 0; c < 1000; c++) {
         /* sss_pac_make_request() does not protect the client's file
          * descriptor to the PAC responder. With this one thread will miss a
@@ -121,7 +121,7 @@ static void *pac_client(void *arg)
         }
     }
 
-    fprintf(stderr, "[%ld][%s] done\n", time(NULL),(char *) arg);
+    fprintf(stderr, "[%"SPRItime"][%s] done\n", time(NULL),(char *) arg);
     return NULL;
 }
 

--- a/src/tests/auth-tests.c
+++ b/src/tests/auth-tests.c
@@ -203,7 +203,7 @@ static void do_failed_login_test(uint32_t failed_login_attempts,
 
     ck_assert_msg(delayed_until == expected_delay,
                 "check_failed_login_attempts wrong delay, "
-                "expected [%ld], got [%ld]",
+                "expected [%"SPRItime"], got [%"SPRItime"]",
                 expected_delay, delayed_until);
 
     talloc_free(test_ctx);

--- a/src/tests/sysdb-tests.c
+++ b/src/tests/sysdb-tests.c
@@ -2213,10 +2213,10 @@ static void cached_authentication_without_expiration(uid_t uid,
                                         "return expected result [%d].",
                                         expected_result);
 
-    ck_assert_msg(expire_date == 0, "Wrong expire date, expected [%d], got [%ld]",
+    ck_assert_msg(expire_date == 0, "Wrong expire date, expected [%d], got [%"SPRItime"]",
                                   0, expire_date);
 
-    ck_assert_msg(delayed_until == -1, "Wrong delay, expected [%d], got [%ld]",
+    ck_assert_msg(delayed_until == -1, "Wrong delay, expected [%d], got [%"SPRItime"]",
                                   -1, delayed_until);
 
     talloc_free(test_ctx);
@@ -2276,10 +2276,10 @@ static void cached_authentication_with_expiration(uid_t uid,
                 "result [%d], got [%d].", expected_result, ret);
 
     ck_assert_msg(expire_date == expected_expire_date,
-                "Wrong expire date, expected [%ld], got [%ld]",
+                "Wrong expire date, expected [%"SPRItime"], got [%"SPRItime"]",
                 expected_expire_date, expire_date);
 
-    ck_assert_msg(delayed_until == -1, "Wrong delay, expected [%d], got [%ld]",
+    ck_assert_msg(delayed_until == -1, "Wrong delay, expected [%d], got [%"SPRItime"]",
                                   -1, delayed_until);
 
     talloc_free(test_ctx);

--- a/src/tests/util-tests.c
+++ b/src/tests/util-tests.c
@@ -1048,7 +1048,7 @@ static void convert_time_tz(const char* tz)
                 "setenv failed with errno: %d", errno);
     }
     ck_assert_msg(ret == EOK && difftime(1406894262, unix_time) == 0,
-                "Expecting 1406894262 got: ret[%d] unix_time[%ld]",
+                "Expecting 1406894262 got: ret[%d] unix_time[%"SPRItime"]",
                 ret, unix_time);
 }
 

--- a/src/tools/tools_mc_util.c
+++ b/src/tools/tools_mc_util.c
@@ -168,7 +168,7 @@ static errno_t wait_till_nss_responder_invalidate_cache(void)
 {
     struct stat stat_buf = { 0 };
     const time_t max_wait = 1000000; /* 1 second */
-    const time_t step_time = 5000; /* 5 milliseconds */
+    const __useconds_t step_time = 5000; /* 5 milliseconds */
     const size_t steps_count = max_wait / step_time;
     int ret;
 

--- a/src/util/sss_format.h
+++ b/src/util/sss_format.h
@@ -64,5 +64,13 @@
 # error Unexpected sizeof gid_t
 #endif /* SIZEOF_GID_T */
 
+#if SIZEOF_TIME_T == 8
+# define SPRItime PRId64
+#elif SIZEOF_TIME_T == 4
+# define SPRItime PRId32
+#else
+# error Unexpected sizeof time_t
+#endif /* SIZEOF_TIME_T */
+
 
 #endif /* __SSS_FORMAT_H__ */

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -31,6 +31,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <netinet/in.h>
+#include <limits.h>
 
 #include <talloc.h>
 #include <tevent.h>
@@ -849,4 +850,10 @@ uint64_t get_spend_time_us(uint64_t st);
 #define CHECK_PAC_CHECK_UPN_ALLOW_MISSING (1 << 5)
 
 errno_t get_pac_check_config(struct confdb_ctx *cdb, uint32_t *pac_check_opts);
+
+static inline struct timeval sss_tevent_timeval_current_ofs_time_t(time_t secs)
+{
+    uint32_t secs32 = (secs > UINT_MAX ? UINT_MAX : secs);
+    return tevent_timeval_current_ofs(secs32, 0);
+}
 #endif /* __SSSD_UTIL_H__ */


### PR DESCRIPTION
#### Remove several Y2K38_SAFETY warnings

- Most of them are external function that receive a 32-bit integer but SSSD provided a `time_t` value. For that we created the `sss_tevent_timeval_current_ofs_time_t(time_t t)` wrapper function that handles the conversion. More on [this discussion](https://github.com/SSSD/sssd/pull/6651#discussion_r1158560160). 
- In other cases, an internal function was expecting an `int`, so the function was adapted to accept a `time_t` value. This was a real problem and has been solved.
- Another case is a real problem caused by Kerberos storing times in the 32-bit signed `krb5_timestamp`, but `time()` returning a 64-bit value. It seems Kerberos is planing on making unsigned this a signed value. So the recommended and adopted solution is to use the 32 lower bits. More in [this discussion](https://github.com/SSSD/sssd/pull/6651#discussion_r1160616145).
- Also de DEBUG() trace was corrected to use the right size.

#### Resolve a WRITE_CONST_FIELD warning

- We are initializing the structure, so it is not a problem that we write to `const` fields. in addition, using `talloc_memdup()` is better and avoids the warning.

#### Utilities

- Introduicing `SPRItime` to be used to `printf()` or `DEBUG()` `time_t` values. It is used in one of the fixes.

#### Upstream or Downstream
One question that arouse was whether to send Coverity annotations and fixes upstream. In my opinion, this is the way to go because, on one side, Coverity is run for every upstream pull request and, on the other side, code fixes are better upstream.