### PR TITLE
Tests: Skip test_0002_ad_parameters_junk_domain on multiarch

### DIFF
--- a/src/tests/multihost/ad/test_adparameters_ported.py
+++ b/src/tests/multihost/ad/test_adparameters_ported.py
@@ -288,6 +288,11 @@ class TestADParamsPorted:
           https://bugzilla.redhat.com/show_bug.cgi?id=1091957
           https://bugzilla.redhat.com/show_bug.cgi?id=2098615
         """
+        arch = multihost.client[0].run_command(
+            'uname -m', raiseonerr=False).stdout_text
+        if 'x86_64' not in arch:
+            pytest.skip("Test does not work other arch due to beaker being on"
+                        "different network that openstack.")
         hostname = multihost.client[0].run_command(
             'hostname', raiseonerr=False).stdout_text.rstrip()
         ad_realm = multihost.ad[0].domainname.upper()
@@ -1015,7 +1020,6 @@ class TestADParamsPorted:
         assert uid_cmd.returncode == 0, f"User with {uid} was not found!"
         assert gid_cmd.returncode == 0, f"Group with {gid} was not found!"
         assert su_result, "The su command failed!"
-
 
     @staticmethod
     @pytest.mark.tier2
@@ -3096,7 +3100,7 @@ class TestADParamsPorted:
         client.backup_sssd_conf()
         # Create AD user with posix attributes
         (aduser, _) = create_aduser_group
-        # Configure sssd with junk domain
+        # Configure sssd
         dom_section = f'domain/{client.get_domain_section_name()}'
         ad_domain = multihost.ad[0].domainname
         ad_realm_short = ad_domain.upper().rsplit('.', 1)[0]
@@ -3400,7 +3404,7 @@ class TestADParamsPorted:
         client.backup_sssd_conf()
         # Create AD user with posix attributes
         (aduser, _) = create_aduser_group
-        # Configure sssd with junk domain
+        # Configure sssd with know hosts proxy
         dom_section = f'domain/{client.get_domain_section_name()}'
         ad_domain = multihost.ad[0].domainname
         ad_realm = ad_domain.upper()


### PR DESCRIPTION
The test does not work properly on multiarch due to beaker being on a different network than openstack.
Fixed some misleading comments.