### PR TITLE
Tests: Check id_provider with sssctl check-config

### DIFF
--- a/src/tests/system/tests/test_sssctl.py
+++ b/src/tests/system/tests/test_sssctl.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+
+from lib.sssd.roles.client import Client
+from lib.sssd.topology import KnownTopology
+
+
+@pytest.mark.tier(0)
+@pytest.mark.ticket(bz=2100789)
+@pytest.mark.topology(KnownTopology.LDAP)
+def test_sssctl__check_id_provider(client: Client):
+    """
+    :title: Check id_provider in domain section with sssctl config-check command
+    :setup:
+        1. Create the sssd.conf, here we are using provider as a LDAP server
+    :steps:
+        1. Remove id_provider from domain section.
+        2. Check error message using sssctl config-check.
+    :expectedresults:
+        1. Successfully remove id_provider from domain section.
+        2. Successfully get the error message.
+    :customerscenario: False
+    :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2100789
+    """
+    # create sssd.conf and start the sssd, with deafult configuration with a LDAP server.
+    client.sssd.start()
+
+    # remove id_provider parameter from domain section.
+    client.sssd.config.remove_option("domain/test", "id_provider")
+    client.sssd.config_apply(check_config=False)
+
+    # Check the error message in output of # sssctl config-check
+    output = client.host.ssh.run("sssctl config-check", raise_on_error=False)
+    assert "[rule/sssd_checks]: Attribute 'id_provider' is missing in section 'domain/test'." in output.stdout_lines[1]
+
+
+@pytest.mark.tier(0)
+@pytest.mark.ticket(bz=2100789)
+@pytest.mark.topology(KnownTopology.LDAP)
+def test_sssctl__check_invalid_id_provider(client: Client):
+    """
+    :title: Check id_provider in domain section with sssctl config-check command with provider
+    :setup:
+        1. Create the sssd.conf, here we are using provider as a LDAP server
+    :steps:
+        1. Add invalid, id_provider's value to domain section.
+        2. Check error message using sssctl config-check.
+    :expectedresults:
+        1. Successfully remove id_provider from domain section.
+        2. Successfully get the error message.
+    :customerscenario: False
+    :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2100789
+    """
+    # create sssd.conf and start the sssd, with deafult configuration with a LDAP server.
+    client.sssd.start()
+
+    # Add 'invalid' as a id_provider's value in domain section.
+    client.sssd.config.remove_option("domain/test", "id_provider")
+    client.sssd.domain["id_provider"] = "invalid"
+    client.sssd.config_apply(check_config=False)
+
+    # Check the return code of # sssctl config-check command
+    output = client.host.ssh.run("sssctl config-check", raise_on_error=False)
+    assert (
+        "[rule/sssd_checks]: Attribute 'id_provider' in section 'domain/test' has an invalid value: invalid"
+        in output.stdout_lines[1]
+    )


### PR DESCRIPTION
Add automation of bug which check id_provider parameter from
domain section.
    
Contains following two test cases:
    1. Test when domain section does not have id_provider
    2. Test when id_provider's value is invalid
    
verify:
    [BZ2100789](https://bugzilla.redhat.com/show_bug.cgi?id=2100789)
    [6550](https://github.com/SSSD/sssd/pull/6550)
