### PR TITLE
Tests: Add a timeout to realm join for AD, modify realm leave.

### DIFF
--- a/src/tests/multihost/ad/conftest.py
+++ b/src/tests/multihost/ad/conftest.py
@@ -324,9 +324,13 @@ def adjoin(session_multihost, request):
             client_ad.join_ad(ad_dc, ad_password, mem_sw='samba')
         else:
             client_ad.join_ad(ad_dc, ad_password)
+        session_multihost.client[0].run_command(
+            "cp -af /etc/sssd/sssd.conf /etc/sssd/sssd.conf.adjoin")
 
     def adleave():
         """ Disjoin AD """
+        session_multihost.client[0].run_command(
+            "cp -af /etc/sssd/sssd.conf.adjoin /etc/sssd/sssd.conf")
         _adleave(client_ad)
 
     request.addfinalizer(adleave)


### PR DESCRIPTION
The realm join gets stuck on other architectures particularly on s390x. This makes it fail and suite can continue running instead of waiting for timeout for the whole suite.
Handle the edge case when realm leave fails for the machine and removal from AD is also not done resulting in the following tests unable to join as the machine is already present on AD.