### PR TITLE
passkey: fix copyrights and comments in krb plugin

### DIFF
--- a/src/krb5_plugin/common/radius_clpreauth.c
+++ b/src/krb5_plugin/common/radius_clpreauth.c
@@ -2,7 +2,7 @@
     Authors:
         Pavel Březina <pbrezina@redhat.com>
 
-    Copyright (C) 2022 Red Hat
+    Copyright (C) 2023 Red Hat
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/krb5_plugin/common/radius_clpreauth.h
+++ b/src/krb5_plugin/common/radius_clpreauth.h
@@ -2,7 +2,7 @@
     Authors:
         Pavel Březina <pbrezina@redhat.com>
 
-    Copyright (C) 2022 Red Hat
+    Copyright (C) 2023 Red Hat
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/krb5_plugin/common/radius_kdcpreauth.c
+++ b/src/krb5_plugin/common/radius_kdcpreauth.c
@@ -2,7 +2,7 @@
     Authors:
         Pavel Březina <pbrezina@redhat.com>
 
-    Copyright (C) 2022 Red Hat
+    Copyright (C) 2023 Red Hat
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/krb5_plugin/common/radius_kdcpreauth.h
+++ b/src/krb5_plugin/common/radius_kdcpreauth.h
@@ -2,7 +2,7 @@
     Authors:
         Pavel Březina <pbrezina@redhat.com>
 
-    Copyright (C) 2022 Red Hat
+    Copyright (C) 2023 Red Hat
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/krb5_plugin/common/utils.c
+++ b/src/krb5_plugin/common/utils.c
@@ -2,7 +2,7 @@
     Authors:
         Pavel Březina <pbrezina@redhat.com>
 
-    Copyright (C) 2021 Red Hat
+    Copyright (C) 2023 Red Hat
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/krb5_plugin/common/utils.h
+++ b/src/krb5_plugin/common/utils.h
@@ -2,7 +2,7 @@
     Authors:
         Pavel Březina <pbrezina@redhat.com>
 
-    Copyright (C) 2021 Red Hat
+    Copyright (C) 2023 Red Hat
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/krb5_plugin/passkey/passkey.h
+++ b/src/krb5_plugin/passkey/passkey.h
@@ -2,7 +2,7 @@
     Authors:
         Pavel Březina <pbrezina@redhat.com>
 
-    Copyright (C) 2021 Red Hat
+    Copyright (C) 2023 Red Hat
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/krb5_plugin/passkey/passkey_clpreauth.c
+++ b/src/krb5_plugin/passkey/passkey_clpreauth.c
@@ -2,7 +2,7 @@
     Authors:
         Pavel Březina <pbrezina@redhat.com>
 
-    Copyright (C) 2021 Red Hat
+    Copyright (C) 2023 Red Hat
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -114,16 +114,14 @@ sss_passkeycl_process(krb5_context context,
     }
 
     answer = cb->get_responder_answer(context, rock, SSSD_PASSKEY_QUESTION);
-    /* Call prompter if we have no answer. We don't really require any answer,
-     * but we need to present a prompt to the user and wait until the user has
-     * finished authentication via an passkey provider. */
+    /* Call prompter if we have no answer to present a prompt. */
     if (answer == NULL) {
         user_reply.magic = 0;
         user_reply.length = sizeof(prompt_answer) / sizeof(char);
         user_reply.data = prompt_answer;
 
-        ret = sss_passkeycl_prompt(context, prompter, prompter_data, input_message,
-                                   &user_reply);
+        ret = sss_passkeycl_prompt(context, prompter, prompter_data,
+                                   input_message, &user_reply);
         if (ret != 0) {
             goto done;
         }

--- a/src/krb5_plugin/passkey/passkey_kdcpreauth.c
+++ b/src/krb5_plugin/passkey/passkey_kdcpreauth.c
@@ -2,7 +2,7 @@
     Authors:
         Pavel Březina <pbrezina@redhat.com>
 
-    Copyright (C) 2021 Red Hat
+    Copyright (C) 2023 Red Hat
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/krb5_plugin/passkey/passkey_utils.c
+++ b/src/krb5_plugin/passkey/passkey_utils.c
@@ -2,7 +2,7 @@
     Authors:
         Pavel Březina <pbrezina@redhat.com>
 
-    Copyright (C) 2021 Red Hat
+    Copyright (C) 2023 Red Hat
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/tests/cmocka/test_krb5_passkey_plugin.c
+++ b/src/tests/cmocka/test_krb5_passkey_plugin.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2022 Red Hat
+    Copyright (C) 2023 Red Hat
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
The passkey plugin was merged by accident with Justin's pull request.
This adds changes that were not present.