### PR TITLE
passkey: only accept the client realm as relaying party ID

### DIFF
--- a/src/krb5_plugin/passkey/passkey_clpreauth.c
+++ b/src/krb5_plugin/passkey/passkey_clpreauth.c
@@ -60,6 +60,14 @@ sss_passkeycl_prep_questions(krb5_context context,
         goto done;
     }
 
+    if (message->data.challenge->domain == NULL ||
+        strncasecmp(message->data.challenge->domain,
+                    request->server->realm.data,
+                    request->server->realm.length) != 0) {
+        ret = KRB5KDC_ERR_PREAUTH_FAILED;
+        goto done;
+    }
+
     question = sss_passkey_message_encode(message);
     if (question == NULL) {
         ret = ENOMEM;


### PR DESCRIPTION
FreeIPA expects relaying party ID for FIDO2 exchange to be the same as the realm. If a rogue KDC attempted to inject another relaying party ID, reject it.

We use server principal as opposed to the client one to allow use of enterprise principals. Server principal in AS-REQ would be krbtgt/REALM@REALM for the realm of the client.