### PR TITLE
ci: prepend pr copr build with high version number

### DIFF
--- a/.github/workflows/copr_build.yml
+++ b/.github/workflows/copr_build.yml
@@ -50,7 +50,7 @@ jobs:
       id: srpm
       uses: ./.github/actions/build-sssd-srpm
       with:
-        version: ${{ env.COPR_PROJECT }}
+        version: 9.${{ env.COPR_PROJECT }}
 
     - name: Upload source rpm as an artifact
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Currently, it is not possible to simply install the copr pull reques
package because number is considered to be higher then a string version,
therefore 2.8.0 > pr6286 and dnf considers it a potential installation
to be a downgrade which may cause conflicts.

Prepending 9 makes sure that the pull request copr build always wins.

---

Since copr workflow is pull request target, it will take effect only
after this PR is merged.