### PR TITLE
passkey: don't print User ID

### DIFF
--- a/src/passkey_child/passkey_child.h
+++ b/src/passkey_child/passkey_child.h
@@ -313,19 +313,6 @@ public_key_to_base64(TALLOC_CTX *mem_ctx, const struct passkey_data *data,
 errno_t
 authenticate(struct passkey_data *data);
 
-/**
- * @brief Get user id from assert
- *
- * @param[in] mem_ctx Memory context
- * @param[in] assert Assert
- * @param[out] _user_id User id
- *
- * @return 0 if the user id was obtained properly, error code otherwise.
- */
-errno_t
-get_assert_user_id(TALLOC_CTX *mem_ctx, fido_assert_t *assert,
-                   unsigned char **_user_id);
-
 /*
  * @brief Select authenticator for verification
  *
@@ -515,13 +502,11 @@ verify_assert(struct pk_data_t *data, fido_assert_t *assert);
  * @param[in] crypto_challenge Cryptographic challenge
  * @param[in] auth_data Authenticator data
  * @param[in] signature Assertion signature
- * @param[in] user_id User id
  *
  */
 void
 print_assert_data(const char *key_handle, const char *crypto_challenge,
-                  const char *auth_data, const char *signature,
-                  const unsigned char *user_id);
+                  const char *auth_data, const char *signature);
 
 /**
  * @brief Obtain assertion data

--- a/src/passkey_child/passkey_child_common.c
+++ b/src/passkey_child/passkey_child_common.c
@@ -724,13 +724,6 @@ authenticate(struct passkey_data *data)
         goto done;
     }
 
-    DEBUG(SSSDBG_TRACE_FUNC, "Getting user id.\n");
-    ret = get_assert_user_id(tmp_ctx, assert, &data->user_id);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "Failed to get user id.\n");
-        goto done;
-    }
-
     DEBUG(SSSDBG_TRACE_FUNC, "Resetting assert options.\n");
     ret = set_assert_options(FIDO_OPT_TRUE, data->user_verification, assert);
     if (ret != FIDO_OK) {
@@ -763,10 +756,6 @@ authenticate(struct passkey_data *data)
         goto done;
     }
 
-    if (data->user_id != NULL) {
-        fprintf(stdout,"%s\n", data->user_id);
-        fflush(stdout);
-    }
     ret = FIDO_OK;
 
 done:
@@ -787,7 +776,6 @@ get_assert_data(struct passkey_data *data)
     TALLOC_CTX *tmp_ctx = NULL;
     fido_dev_t *dev = NULL;
     fido_assert_t *assert = NULL;
-    unsigned char *user_id = NULL;
     const char *auth_data = NULL;
     const char *signature = NULL;
     int index;
@@ -807,13 +795,6 @@ get_assert_data(struct passkey_data *data)
     DEBUG(SSSDBG_TRACE_FUNC, "Comparing the device and policy options.\n");
     ret = get_device_options(dev, data);
     if (ret != FIDO_OK) {
-        goto done;
-    }
-
-    DEBUG(SSSDBG_TRACE_FUNC, "Getting user id.\n");
-    ret = get_assert_user_id(tmp_ctx, assert, &user_id);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "Failed to get user id.\n");
         goto done;
     }
 
@@ -838,7 +819,7 @@ get_assert_data(struct passkey_data *data)
     }
 
     print_assert_data(data->key_handle_list[index], data->crypto_challenge,
-                      auth_data, signature, user_id);
+                      auth_data, signature);
 
 done:
     if (dev != NULL) {

--- a/src/passkey_child/passkey_child_credentials.c
+++ b/src/passkey_child/passkey_child_credentials.c
@@ -347,7 +347,6 @@ print_credentials(const struct passkey_data *data,
     const unsigned char *cred_id = NULL;
     const unsigned char *public_key = NULL;
     const char *b64_cred_id = NULL;
-    const char *b64_user_id = NULL;
     char *pem_key = NULL;
     size_t cred_id_len;
     size_t user_key_len;
@@ -403,18 +402,7 @@ print_credentials(const struct passkey_data *data,
         goto done;
     }
 
-    b64_user_id = sss_base64_encode(tmp_ctx, data->user_id, USER_ID_SIZE);
-    if (b64_user_id == NULL) {
-        DEBUG(SSSDBG_OP_FAILURE, "failed to encode user id.\n");
-        ret = ENOMEM;
-        goto done;
-    }
-
-    if (data->cred_type == CRED_SERVER_SIDE) {
-        PRINT("passkey:%s,%s\n", b64_cred_id, pem_key);
-    } else {
-        PRINT("passkey:%s,%s,%s\n", b64_cred_id, pem_key, b64_user_id);
-    }
+    PRINT("passkey:%s,%s\n", b64_cred_id, pem_key);
     ret = EOK;
 
 done:

--- a/src/tests/cmocka/test_passkey_child.c
+++ b/src/tests/cmocka/test_passkey_child.c
@@ -1205,7 +1205,6 @@ void test_authenticate_integration(void **state)
     }
     will_return(__wrap_fido_dev_has_uv, false);
     will_return(__wrap_fido_dev_has_pin, false);
-    will_return(__wrap_fido_assert_user_id_len, 0);
     will_return(__wrap_fido_assert_set_uv, FIDO_OK);
     will_return(__wrap_fido_assert_set_clientdata_hash, FIDO_OK);
     will_return(__wrap_fido_dev_has_uv, false);
@@ -1256,7 +1255,6 @@ void test_get_assert_data_integration(void **state)
     }
     will_return(__wrap_fido_dev_has_uv, false);
     will_return(__wrap_fido_dev_has_pin, false);
-    will_return(__wrap_fido_assert_user_id_len, 0);
     will_return(__wrap_fido_assert_set_uv, FIDO_OK);
     will_return(__wrap_fido_dev_has_uv, false);
     will_return(__wrap_fido_dev_has_pin, false);


### PR DESCRIPTION
The User ID isn't part of any signed data, thus there isn't any indication that it's related to the token. Moreover, the effort to store it securely on the LDAP attribute is quite big. Taking that into account the passkey child doesn't print it and this way we avoid storing it in the LDAP server.

# passkey_child testing

## Register key

```
$ ./passkey_child --register --cred-type=discoverable --username=user --domain=test.com
passkey:yZW9QAvbN8axjZaTf7fICw8frNV3dV8+aBjqn+QMvdMtAhh0ds7XzNAuB8ESODsh,MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyZW9QAvbN8axjZaTf3K81oYdncDqZoQWo0AQq4COIhpHl5vPy50sjIXwH4x1ylI72YL9YIZ8F3v/M77g1CQRVw==
```

## Authentication

```
$echo -n "123456" | ./passkey_child --authenticate --username=user --domain=test.com --key-handle=yZW9QAvbN8axjZaTf7fICw8frNV3dV8+aBjqn+QMvdMtAhh0ds7XzNAuB8ESODsh --public-key=MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyZW9QAvbN8axjZaTf3K81oYdncDqZoQWo0AQq4COIhpHl5vPy50sjIXwH4x1ylI72YL9YIZ8F3v/M77g1CQRVw==
Authentication success.
```

## Assertion obtention

```
$ ./passkey_child --get-assert --domain=test.com --key-handle=yZW9QAvbN8axjZaTf7fICw8frNV3dV8+aBjqn+QMvdMtAhh0ds7XzNAuB8ESODsh --cryptographic-challenge=mZmBWUaJGwEjSNQvkFaicpCzDKhap2pQlfi8FXsv68k=
{"credential_id": "yZW9QAvbN8axjZaTf7fICw8frNV3dV8+aBjqn+QMvdMtAhh0ds7XzNAuB8ESODsh", "cryptographic_challenge": "mZmBWUaJGwEjSNQvkFaicpCzDKhap2pQlfi8FXsv68k=", "authenticator_data": "WCWZq3FdhKO8Xg6SqlDmelgTY3/RdEvTAasI+HGR3bgW4AUAAAAQ", "assertion_signature": "MEYCIQDDy01C/Q1WUDQrgx0GMM5XhevyEA+TexmO0zsmjMlueQIhAKesPRZlO2i65JGRM23wqfTHdUGfrp57vEmXcjJKp/QA", "user_id": ""}
```

## Assertion validation

```
$ ./passkey_child --verify-assert --domain=test.com --key-handle=yZW9QAvbN8axjZaTf7fICw8frNV3dV8+aBjqn+QMvdMtAhh0ds7XzNAuB8ESODsh --public-key=MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyZW9QAvbN8axjZaTf3K81oYdncDqZoQWo0AQq4COIhpHl5vPy50sjIXwH4x1ylI72YL9YIZ8F3v/M77g1CQRVw== --cryptographic-challenge=mZmBWUaJGwEjSNQvkFaicpCzDKhap2pQlfi8FXsv68k= --auth-data=WCWZq3FdhKO8Xg6SqlDmelgTY3/RdEvTAasI+HGR3bgW4AUAAAAQ --signature=MEYCIQDDy01C/Q1WUDQrgx0GMM5XhevyEA+TexmO0zsmjMlueQIhAKesPRZlO2i65JGRM23wqfTHdUGfrp57vEmXcjJKp/QA
Verification success.
```

# End to end testing

Use the [COPR repository](https://copr.fedorainfracloud.org/coprs/ipedrosa/passkey-auth)