### PR TITLE
test: cast to `char *` assert_string_equal() args

### DIFF
--- a/src/tests/cmocka/test_authtok.c
+++ b/src/tests/cmocka/test_authtok.c
@@ -109,7 +109,7 @@ static void test_sss_authtok_password(void **state)
     assert_int_equal(ret, EOK);
     assert_int_equal(type, sss_authtok_get_type(ts->authtoken));
     assert_int_equal(len, sss_authtok_get_size(ts->authtoken));
-    assert_string_equal(data, sss_authtok_get_data(ts->authtoken));
+    assert_string_equal(data, (char *)sss_authtok_get_data(ts->authtoken));
 
     ret = sss_authtok_get_password(ts->authtoken, &pwd, &ret_len);
 
@@ -151,7 +151,7 @@ static void test_sss_authtok_ccfile(void **state)
     assert_int_equal(ret, EOK);
     assert_int_equal(type, sss_authtok_get_type(ts->authtoken));
     assert_int_equal(len, sss_authtok_get_size(ts->authtoken));
-    assert_string_equal(data, sss_authtok_get_data(ts->authtoken));
+    assert_string_equal(data, (char *)sss_authtok_get_data(ts->authtoken));
 
     ret = sss_authtok_get_ccfile(ts->authtoken, &pwd, &ret_len);
 
@@ -175,7 +175,7 @@ static void test_sss_authtok_ccfile(void **state)
     assert_int_equal(ret, EOK);
     assert_int_equal(type, sss_authtok_get_type(ts->authtoken));
     assert_int_equal(len, sss_authtok_get_size(ts->authtoken));
-    assert_string_equal(data, sss_authtok_get_data(ts->authtoken));
+    assert_string_equal(data, (char *)sss_authtok_get_data(ts->authtoken));
 
     ret = sss_authtok_get_ccfile(ts->authtoken, &pwd, &ret_len);
 
@@ -302,7 +302,7 @@ static void test_sss_authtok_copy(void **state)
 
     assert_int_equal(ret, EOK);
     assert_int_equal(type, sss_authtok_get_type(dest_authtoken));
-    assert_string_equal(data, sss_authtok_get_data(dest_authtoken));
+    assert_string_equal(data, (char *)sss_authtok_get_data(dest_authtoken));
     assert_int_equal(len, sss_authtok_get_size(dest_authtoken));
 
     sss_authtok_set_empty(dest_authtoken);
@@ -689,7 +689,7 @@ static void test_sss_authtok_2fa_single(void **state)
     assert_int_equal(ret, EOK);
     assert_int_equal(type, sss_authtok_get_type(ts->authtoken));
     assert_int_equal(len, sss_authtok_get_size(ts->authtoken));
-    assert_string_equal(data, sss_authtok_get_data(ts->authtoken));
+    assert_string_equal(data, (char *)sss_authtok_get_data(ts->authtoken));
 
     ret = sss_authtok_get_2fa_single(ts->authtoken, &pwd, &ret_len);
 
@@ -731,7 +731,7 @@ static void test_sss_authtok_oauth2(void **state)
     assert_int_equal(ret, EOK);
     assert_int_equal(type, sss_authtok_get_type(ts->authtoken));
     assert_int_equal(len, sss_authtok_get_size(ts->authtoken));
-    assert_string_equal(data, sss_authtok_get_data(ts->authtoken));
+    assert_string_equal(data, (char *)sss_authtok_get_data(ts->authtoken));
 
     ret = sss_authtok_get_oauth2(ts->authtoken, &pwd, &ret_len);
 

--- a/src/tests/cmocka/test_child_common.c
+++ b/src/tests/cmocka/test_child_common.c
@@ -446,7 +446,7 @@ static void echo_child_read_done(struct tevent_req *subreq)
     close(echo_state->io_fds->read_from_child_fd);
     echo_state->io_fds->read_from_child_fd = -1;
 
-    assert_string_equal(buf, echo_state->buf.data);
+    assert_string_equal((char *)buf, (char *)echo_state->buf.data);
     echo_state->child_test_ctx->test_ctx->done = true;
 }
 

--- a/src/tests/cmocka/test_pam_srv.c
+++ b/src/tests/cmocka/test_pam_srv.c
@@ -788,7 +788,7 @@ static int test_pam_passkey_preauth_check(uint32_t status, uint8_t *body, size_t
     assert_int_equal(val, 9);
 
     assert_int_equal(*(body + rp + val - 1), 0);
-    assert_string_equal(body + rp, TEST_DOM_NAME);
+    assert_string_equal((char *)(body + rp), TEST_DOM_NAME);
 
     return EOK;
 }
@@ -813,7 +813,7 @@ static int test_pam_passkey_found_preauth_check(uint32_t status, uint8_t *body, 
     assert_int_equal(val, 9);
 
     assert_int_equal(*(body + rp + val - 1), 0);
-    assert_string_equal(body + rp, TEST_DOM_NAME);
+    assert_string_equal((char *)(body + rp), TEST_DOM_NAME);
 
     return EOK;
 }
@@ -839,7 +839,7 @@ static int test_pam_simple_check(uint32_t status, uint8_t *body, size_t blen)
     assert_int_equal(val, 9);
 
     assert_int_equal(*(body + rp + val - 1), 0);
-    assert_string_equal(body + rp, TEST_DOM_NAME);
+    assert_string_equal((char *)(body + rp), TEST_DOM_NAME);
 
     return EOK;
 }
@@ -867,7 +867,7 @@ static int test_pam_cert_check_gdm_smartcard(uint32_t status, uint8_t *body,
     assert_int_equal(val, 9);
 
     assert_int_equal(*(body + rp + val - 1), 0);
-    assert_string_equal(body + rp, TEST_DOM_NAME);
+    assert_string_equal((char *)(body + rp), TEST_DOM_NAME);
     rp += val;
 
     SAFEALIGN_COPY_UINT32(&val, body + rp, &rp);
@@ -876,7 +876,7 @@ static int test_pam_cert_check_gdm_smartcard(uint32_t status, uint8_t *body,
     SAFEALIGN_COPY_UINT32(&val, body + rp, &rp);
     assert_int_equal(val, (strlen(PKCS11_LOGIN_TOKEN_ENV_NAME "=")
                            + sizeof(TEST_TOKEN_NAME)));
-    assert_string_equal(body + rp,
+    assert_string_equal((char *)(body + rp),
                         PKCS11_LOGIN_TOKEN_ENV_NAME "=" TEST_TOKEN_NAME);
     rp += val;
 
@@ -893,31 +893,31 @@ static int test_pam_cert_check_gdm_smartcard(uint32_t status, uint8_t *body,
                                 + sizeof("pamuser")));
 
     assert_int_equal(*(body + rp + sizeof("pamuser@"TEST_DOM_NAME) - 1), 0);
-    assert_string_equal(body + rp, "pamuser@"TEST_DOM_NAME);
+    assert_string_equal((char *)(body + rp), "pamuser@"TEST_DOM_NAME);
     rp += sizeof("pamuser@"TEST_DOM_NAME);
 
     assert_int_equal(*(body + rp + sizeof(TEST_TOKEN_NAME) - 1), 0);
-    assert_string_equal(body + rp, TEST_TOKEN_NAME);
+    assert_string_equal((char *)(body + rp), TEST_TOKEN_NAME);
     rp += sizeof(TEST_TOKEN_NAME);
 
     assert_int_equal(*(body + rp + sizeof(TEST_MODULE_NAME) - 1), 0);
-    assert_string_equal(body + rp, TEST_MODULE_NAME);
+    assert_string_equal((char *)(body + rp), TEST_MODULE_NAME);
     rp += sizeof(TEST_MODULE_NAME);
 
     assert_int_equal(*(body + rp + sizeof(TEST_KEY_ID) - 1), 0);
-    assert_string_equal(body + rp, TEST_KEY_ID);
+    assert_string_equal((char *)(body + rp), TEST_KEY_ID);
     rp += sizeof(TEST_KEY_ID);
 
     assert_int_equal(*(body + rp + sizeof(TEST_LABEL) - 1), 0);
-    assert_string_equal(body + rp, TEST_LABEL);
+    assert_string_equal((char *)(body + rp), TEST_LABEL);
     rp += sizeof(TEST_LABEL);
 
     assert_int_equal(*(body + rp + sizeof(TEST_PROMPT) - 1), 0);
-    assert_string_equal(body + rp, TEST_PROMPT);
+    assert_string_equal((char *)(body + rp), TEST_PROMPT);
     rp += sizeof(TEST_PROMPT);
 
     assert_int_equal(*(body + rp + sizeof("pamuser") - 1), 0);
-    assert_string_equal(body + rp, "pamuser");
+    assert_string_equal((char *)(body + rp), "pamuser");
     rp += sizeof("pamuser");
 
     assert_int_equal(rp, blen);
@@ -930,7 +930,7 @@ static void check_string_array(const char **strs, uint8_t *body, size_t *rp)
 
     for (c = 0; strs[c] != NULL; c++) {
         assert_int_equal(*(body + *rp + strlen(strs[c])), 0);
-        assert_string_equal(body + *rp, strs[c]);
+        assert_string_equal((char *)(body + *rp), strs[c]);
         *rp += strlen(strs[c]) + 1;
     }
 }
@@ -1005,7 +1005,7 @@ static int test_pam_cert_check_ex(uint32_t status, uint8_t *body, size_t blen,
         assert_int_equal(val, 9);
 
         assert_int_equal(*(body + rp + val - 1), 0);
-        assert_string_equal(body + rp, TEST_DOM_NAME);
+        assert_string_equal((char *)(body + rp), TEST_DOM_NAME);
         rp += val;
     }
 
@@ -1089,7 +1089,7 @@ static int test_pam_cert2_token2_check_ex(uint32_t status, uint8_t *body,
     assert_int_equal(val, 9);
 
     assert_int_equal(*(body + rp + val - 1), 0);
-    assert_string_equal(body + rp, TEST_DOM_NAME);
+    assert_string_equal((char *)(body + rp), TEST_DOM_NAME);
     rp += val;
 
     SAFEALIGN_COPY_UINT32(&val, body + rp, &rp);
@@ -1134,7 +1134,7 @@ static int test_pam_cert_X_token_X_check_ex(uint32_t status, uint8_t *body,
     assert_int_equal(val, 9);
 
     assert_int_equal(*(body + rp + val - 1), 0);
-    assert_string_equal(body + rp, TEST_DOM_NAME);
+    assert_string_equal((char *)(body + rp), TEST_DOM_NAME);
     rp += val;
 
     SAFEALIGN_COPY_UINT32(&val, body + rp, &rp);
@@ -1239,7 +1239,7 @@ static int test_pam_offline_chauthtok_check(uint32_t status,
     assert_int_equal(val, 9);
 
     assert_int_equal(*(body + rp + val - 1), 0);
-    assert_string_equal(body + rp, TEST_DOM_NAME);
+    assert_string_equal((char *)(body + rp), TEST_DOM_NAME);
     rp += val;
 
     SAFEALIGN_COPY_UINT32(&val, body + rp, &rp);
@@ -3927,7 +3927,7 @@ static int test_pam_prompt_check(uint32_t status, uint8_t *body, size_t blen)
 
     SAFEALIGN_COPY_UINT32(&val, body + rp, &rp);
     assert_int_equal(val, 9);
-    assert_string_equal(body + rp, TEST_DOM_NAME);
+    assert_string_equal((char *)(body + rp), TEST_DOM_NAME);
     rp += val;
 
 


### PR DESCRIPTION
CI build is reporting the following error several times:
```
error: pointer targets in passing argument 2 of '_assert_string_equal'
differ in signedness [-Werror=pointer-sign]
```

Casting the arguments of assert_string_equal() to `char *` fixes the
issue.