### PR TITLE
Passkey local authentication behavior change

### DIFF
--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -272,6 +272,7 @@
 #define CONFDB_DOMAIN_TYPE_POSIX "posix"
 #define CONFDB_DOMAIN_TYPE_APP "application"
 #define CONFDB_DOMAIN_INHERIT_FROM "inherit_from"
+#define CONFDB_DOMAIN_LOCAL_AUTH_POLICY "local_auth_policy"
 
 /* Proxy Provider */
 #define CONFDB_PROXY_LIBNAME "proxy_lib_name"

--- a/src/config/SSSDConfig/sssdoptions.py
+++ b/src/config/SSSDConfig/sssdoptions.py
@@ -223,6 +223,7 @@ class SSSDOptions(object):
                                                            'should be saved this value determines the minimal length '
                                                            'the first authentication factor (long term password) must '
                                                            'have to be saved as SHA512 hash into the cache.'),
+        'local_auth_policy': _('Local authentication methods policy '),
 
         # [provider/ipa]
         'ipa_domain': _('IPA domain'),

--- a/src/config/SSSDConfigTest.py
+++ b/src/config/SSSDConfigTest.py
@@ -621,7 +621,8 @@ class SSSDConfigTestSSSDDomain(unittest.TestCase):
             'pam_gssapi_check_upn',
             'pam_gssapi_indicators_map',
             'refresh_expired_interval',
-            'refresh_expired_interval_offset']
+            'refresh_expired_interval_offset',
+            'local_auth_policy']
 
         self.assertTrue(type(options) == dict,
                         "Options should be a dictionary")
@@ -981,7 +982,8 @@ class SSSDConfigTestSSSDDomain(unittest.TestCase):
             'refresh_expired_interval',
             'refresh_expired_interval_offset',
             'dyndns_refresh_interval',
-            'dyndns_refresh_interval_offset']
+            'dyndns_refresh_interval_offset',
+            'local_auth_policy']
 
         self.assertTrue(type(options) == dict,
                         "Options should be a dictionary")

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -425,6 +425,7 @@ option = auto_private_groups
 option = pam_gssapi_services
 option = pam_gssapi_check_upn
 option = pam_gssapi_indicators_map
+option = local_auth_policy
 
 #Entry cache timeouts
 option = entry_cache_user_timeout

--- a/src/config/etc/sssd.api.conf
+++ b/src/config/etc/sssd.api.conf
@@ -192,6 +192,7 @@ auto_private_groups = str, None, false
 pam_gssapi_services = str, None, false
 pam_gssapi_check_upn = bool, None, false
 pam_gssapi_indicators_map = str, None, false
+local_auth_policy = str, None, false
 
 #Entry cache timeouts
 entry_cache_user_timeout = int, None, false

--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -161,6 +161,10 @@
 
 #define SYSDB_USER_PASSKEY "userPasskey"
 
+/* Local auth types */
+#define SYSDB_LOCAL_SMARTCARD_AUTH "localSmartcardAuth"
+#define SYSDB_LOCAL_PASSKEY_AUTH "localPasskeyAuth"
+
 #define SYSDB_SUBDOMAIN_REALM "realmName"
 #define SYSDB_SUBDOMAIN_FLAT "flatName"
 #define SYSDB_SUBDOMAIN_DNS "dnsName"

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -743,7 +743,8 @@
                                     <listitem>
                                         <para> Enable or disable the user
                                         verification (i.e. PIN, fingerprint)
-                                        during authentication.
+                                        during authentication. If enabled, the
+                                        PIN will always be requested.
                                         </para>
                                         <para>
                                         The default is that the key settings

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -3983,6 +3983,51 @@ subdomain_inherit = ldap_purge_cache_timeout
                     </listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term>local_auth_policy (string)</term>
+                    <listitem>
+                        <para>
+                            Local authentication methods policy. Some backends
+                            (i.e. LDAP, proxy provider) only support a password
+                            based authentication, while others can handle PKINIT
+                            based Smartcard authentication (AD, IPA),
+                            two-factor authentication (IPA), or other methods
+                            against a central instance. By default in such cases
+                            authentication is only performed with the methods
+                            supported by the backend.
+                        </para>
+                        <para>
+                            There are three possible values for this option:
+                            match, only, enable. <quote>match</quote> is
+                            used to match offline and online states for Kerberos
+                            methods. <quote>only</quote> ignores the online methods
+                            and only offer the local ones. enable allows explicitly
+                            defining the methods for local authentication. As an
+                            example, <quote>enable:passkey</quote>, only enables
+                            passkey for local authentication. Multiple enable values
+                            should be comma-separated, such as
+                            <quote>enable:passkey, enable:smartcard</quote>
+                        </para>
+                        <para>
+                            The following configuration example allows local users
+                            to authenticate locally using any enabled method
+                            (i.e. smartcard, passkey).
+<programlisting>
+[domain/shadowutils]
+id_provider = proxy
+proxy_lib_name = files
+auth_provider = none
+local_auth_policy = only
+</programlisting>
+                        </para>
+                        <para>
+                            This option is ignored for the files provider
+                        </para>
+                        <para>
+                            Default: match
+                        </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
                     <term>auto_private_groups (string)</term>
                     <listitem>
                         <para>

--- a/src/responder/pam/pamsrv.h
+++ b/src/responder/pam/pamsrv.h
@@ -99,6 +99,13 @@ struct pam_auth_req {
     uint32_t client_id_num;
 };
 
+struct pam_resp_auth_type {
+    bool password_auth;
+    bool otp_auth;
+    bool cert_auth;
+    bool passkey_auth;
+};
+
 struct sss_cmd_table *get_pam_cmds(void);
 
 errno_t
@@ -153,6 +160,8 @@ errno_t filter_responses(struct pam_ctx *pctx,
                          struct response_data *resp_list,
                          struct pam_data *pd);
 
+errno_t pam_get_auth_types(struct pam_data *pd,
+                           struct pam_resp_auth_type *_auth_types);
 errno_t pam_eval_prompting_config(struct pam_ctx *pctx, struct pam_data *pd);
 
 enum pam_initgroups_scheme pam_initgroups_string_to_enum(const char *str);

--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -20,7 +20,10 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#define _GNU_SOURCE
+
 #include <time.h>
+#include <string.h>
 #include "util/util.h"
 #include "util/auth_utils.h"
 #include "util/find_uid.h"
@@ -492,6 +495,98 @@ static int pam_parse_in_data(struct pam_data *pd,
     return EOK;
 }
 
+static errno_t
+pam_get_local_auth_policy(struct sss_domain_info *domain,
+                          const char *name,
+                          bool *_sc_allow,
+                          bool *_passkey_allow)
+{
+    TALLOC_CTX *tmp_ctx = NULL;
+    const char *attrs[] = { SYSDB_LOCAL_SMARTCARD_AUTH, SYSDB_LOCAL_PASSKEY_AUTH, NULL };
+    struct ldb_message *ldb_msg;
+    bool sc_allow = false;
+    bool passkey_allow = false;
+    errno_t ret;
+
+    if (name == NULL || *name == '\0') {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Missing user name.\n");
+        ret = EINVAL;
+        goto done;
+    }
+
+    if (domain->sysdb == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Missing sysdb db context.\n");
+        ret = EINVAL;
+        goto done;
+    }
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = sysdb_search_user_by_name(tmp_ctx, domain, name, attrs, &ldb_msg);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "sysdb_search_user_by_name failed [%d][%s].\n",
+              ret, strerror(ret));
+        goto done;
+    }
+
+    sc_allow = ldb_msg_find_attr_as_bool(ldb_msg, SYSDB_LOCAL_SMARTCARD_AUTH,
+                                         false);
+
+    passkey_allow = ldb_msg_find_attr_as_bool(ldb_msg, SYSDB_LOCAL_PASSKEY_AUTH,
+                                              true);
+
+    ret = EOK;
+
+done:
+    if (ret == EOK) {
+        *_sc_allow = sc_allow;
+        *_passkey_allow = passkey_allow;
+    }
+
+    talloc_free(tmp_ctx);
+    return ret;
+}
+static errno_t set_local_auth_type(struct pam_auth_req *preq,
+                                   bool sc_allow,
+                                   bool passkey_allow)
+{
+    struct sysdb_attrs *attrs;
+    errno_t ret;
+
+    attrs = sysdb_new_attrs(preq);
+    if (!attrs) {
+        ret = ENOMEM;
+        goto fail;
+    }
+
+    ret = sysdb_attrs_add_bool(attrs, SYSDB_LOCAL_SMARTCARD_AUTH, sc_allow);
+    if (ret != EOK) {
+        goto fail;
+    }
+
+    ret = sysdb_attrs_add_bool(attrs, SYSDB_LOCAL_PASSKEY_AUTH, passkey_allow);
+    if (ret != EOK) {
+        goto fail;
+    }
+
+    ret = sysdb_set_user_attr(preq->domain, preq->pd->user, attrs,
+                              SYSDB_MOD_REP);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "set_local_auth_type failed.\n");
+        preq->pd->pam_status = PAM_SYSTEM_ERR;
+        goto fail;
+    }
+
+    return EOK;
+
+fail:
+    return ret;
+}
 /*=Save-Last-Login-State===================================================*/
 
 static errno_t set_last_login(struct pam_auth_req *preq)
@@ -743,6 +838,213 @@ errno_t filter_responses(struct pam_ctx *pctx,
     ret = EOK;
 done:
 
+    return ret;
+}
+
+static void do_not_send_cert_info(struct pam_data *pd)
+{
+    struct response_data *resp;
+
+    resp = pd->resp_list;
+    while (resp != NULL) {
+        switch (resp->type) {
+        case SSS_PAM_CERT_INFO:
+        case SSS_PAM_CERT_INFO_WITH_HINT:
+            resp->do_not_send_to_client = true;
+            break;
+        default:
+            break;
+        }
+        resp = resp->next;
+    }
+}
+
+errno_t pam_get_auth_types(struct pam_data *pd,
+                           struct pam_resp_auth_type *_auth_types)
+{
+    int ret;
+    struct response_data *resp;
+    struct pam_resp_auth_type types = {0};
+    bool found_cert_info = false;
+
+    resp = pd->resp_list;
+    while (resp != NULL) {
+        switch (resp->type) {
+        case SSS_PAM_OTP_INFO:
+            types.otp_auth = true;
+            break;
+        case SSS_PAM_CERT_INFO:
+        case SSS_PAM_CERT_INFO_WITH_HINT:
+            found_cert_info = true;
+            break;
+        case SSS_PAM_PASSKEY_INFO:
+        case SSS_PAM_PASSKEY_KRB_INFO:
+            types.passkey_auth = true;
+            break;
+        case SSS_PASSWORD_PROMPTING:
+            types.password_auth = true;
+            break;
+        case SSS_CERT_AUTH_PROMPTING:
+            types.cert_auth = true;
+            break;
+        default:
+            break;
+        }
+        resp = resp->next;
+    }
+
+    if (!types.password_auth && !types.otp_auth && !types.cert_auth && !types.passkey_auth) {
+        /* If the backend cannot determine which authentication types are
+         * available the default would be to prompt for a password. */
+        types.password_auth = true;
+    }
+
+    if (found_cert_info && !types.cert_auth) {
+        do_not_send_cert_info(pd);
+    }
+
+    DEBUG(SSSDBG_TRACE_ALL, "Authentication types for user [%s] and service "
+                            "[%s]:%s%s%s%s\n", pd->user, pd->service,
+                            types.password_auth ? " password": "",
+                            types.otp_auth ? " two-factor" : "",
+                            types.passkey_auth ? " passkey" : "",
+                            types.cert_auth ? " smartcard" : "");
+
+    ret = EOK;
+
+    *_auth_types = types;
+
+    return ret;
+}
+
+static errno_t pam_eval_local_auth_policy(TALLOC_CTX *mem_ctx,
+                                          struct pam_ctx *pctx,
+                                          struct pam_data *pd,
+                                          struct pam_auth_req *preq,
+                                          bool *_sc_allow,
+                                          bool *_passkey_allow,
+                                          char **_local_policy) {
+
+    TALLOC_CTX *tmp_ctx;
+    errno_t ret;
+    const char *domain_cdb;
+    char *local_policy = NULL;
+    bool sc_allow = false;
+    bool passkey_allow = false;
+    struct pam_resp_auth_type auth_types;
+    char **opts;
+    size_t c;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    /* Check local auth policy */
+    domain_cdb = talloc_asprintf(tmp_ctx, CONFDB_DOMAIN_PATH_TMPL, preq->domain->name);
+    if (domain_cdb == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "talloc_asprintf failed.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = confdb_get_string(pctx->rctx->cdb, tmp_ctx, domain_cdb,
+                            CONFDB_DOMAIN_LOCAL_AUTH_POLICY,
+                            "match", &local_policy);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE, "Failed to get the confdb local_auth_policy\n");
+        return ret;
+    }
+
+    /* "only" ignores online methods and allows all local ones */
+    if (strcasecmp(local_policy, "only") == 0) {
+        sc_allow = true;
+        passkey_allow = true;
+    /* Match what the KDC supports and provides */
+    } else if (strcasecmp(local_policy, "match") == 0) {
+        /* Don't overwrite the local auth type when offline */
+        if (pd->pam_status == PAM_SUCCESS && pd->cmd == SSS_PAM_PREAUTH &&
+            !is_domain_provider(preq->domain, "ldap")) {
+            ret = pam_get_auth_types(pd, &auth_types);
+            if (ret != EOK) {
+                DEBUG(SSSDBG_OP_FAILURE, "Failed to get authentication types\n");
+                goto done;
+            }
+
+            if (auth_types.cert_auth) {
+                sc_allow = true;
+            } else if (auth_types.passkey_auth) {
+                passkey_allow = true;
+            }
+
+            /* Store the local auth types, in case we go offline */
+            if (!auth_types.password_auth) {
+                ret = set_local_auth_type(preq, sc_allow, passkey_allow);
+                if (ret != EOK) {
+                    DEBUG(SSSDBG_FATAL_FAILURE,
+                          "Failed to evaluate local auth policy\n");
+                    goto done;
+                }
+            }
+        }
+
+        /* Read the latest auth types */
+        ret = pam_get_local_auth_policy(preq->domain, preq->pd->user,
+                                        &sc_allow, &passkey_allow);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_FATAL_FAILURE,
+                  "Failed to get PAM local auth policy\n");
+            goto done;
+        }
+    /* Check for enable */
+    } else {
+        ret = split_on_separator(tmp_ctx, local_policy, ',', true, true, &opts,
+                                 NULL);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_OP_FAILURE, "split_on_separator failed [%d], %s.\n",
+                                     ret, sss_strerror(ret));
+            goto done;
+        }
+
+        for (c = 0; opts[c] != NULL; c++) {
+            if (strcasestr(opts[c], "passkey") != NULL) {
+                passkey_allow = strstr(opts[c], "enable") ? true : false;
+            } else if (strcasestr(opts[c], "smartcard") != NULL) {
+                sc_allow = strstr(opts[c], "enable") ? true : false;
+            } else {
+               DEBUG(SSSDBG_MINOR_FAILURE,
+                     "Unexpected local auth policy option [%s], " \
+                     "skipping.\n", opts[c]);
+            }
+        }
+
+        /* if passkey is enabled but local Smartcard authentication is not but
+         * possible, the cert info data has to be remove as well if only local
+         * Smartcard authentication is possible. If Smartcard authentication
+         * is possible on the server side we have to keep it because the
+         * 'enable' option should only add local methods but not reject remote
+         * ones. */
+        if (!sc_allow) {
+            /* We do not need the auth_types here but the call will remove
+             * the cert info data if the server does not support Smartcard
+             * authentication. */
+            ret = pam_get_auth_types(pd, &auth_types);
+            if (ret != EOK) {
+                DEBUG(SSSDBG_OP_FAILURE,
+                      "Failed to get authentication types\n");
+                goto done;
+            }
+        }
+    }
+
+    *_sc_allow = sc_allow;
+    *_passkey_allow = passkey_allow;
+    *_local_policy = talloc_steal(mem_ctx, local_policy);
+
+    ret = EOK;
+
+done:
+    talloc_free(tmp_ctx);
     return ret;
 }
 
@@ -1108,6 +1410,7 @@ void pam_reply(struct pam_auth_req *preq)
     struct timeval tv;
     struct tevent_timer *te;
     struct pam_data *pd;
+    char *local_policy = NULL;
     struct pam_ctx *pctx;
     uint32_t user_info_type;
     time_t exp_date = -1;
@@ -1116,6 +1419,8 @@ void pam_reply(struct pam_auth_req *preq)
     char* pam_account_locked_message;
     int pam_verbosity;
     bool pk_preauth_done = false;
+    bool local_sc_auth_allow = false;
+    bool local_passkey_auth_allow = false;
 
     pd = preq->pd;
     cctx = preq->cctx;
@@ -1136,6 +1441,34 @@ void pam_reply(struct pam_auth_req *preq)
           "this result might be changed during processing\n",
           pd->pam_status, pam_strerror(NULL, pd->pam_status));
 
+    if (preq->domain != NULL && preq->domain->name != NULL) {
+        ret = pam_eval_local_auth_policy(cctx, pctx, pd, preq,
+                                         &local_sc_auth_allow,
+                                         &local_passkey_auth_allow,
+                                         &local_policy);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_FATAL_FAILURE,
+                  "Failed to evaluate local auth policy\n");
+            goto done;
+        }
+    }
+
+   /* Ignore local_auth_policy for the files provider, allow local
+    * smartcard auth (default behavior prior to local_auth_policy) */
+    if (is_domain_provider(preq->domain, "files")) {
+        local_sc_auth_allow = true;
+    /* For the ldap auth provider we currently only support
+     * password based authentication */
+    } else if (is_domain_provider(preq->domain, "ldap") && local_policy != NULL
+              && strcasecmp(local_policy, "match") == 0) {
+        local_passkey_auth_allow = false;
+        local_sc_auth_allow = false;
+    }
+
+    DEBUG(SSSDBG_TRACE_FUNC, "Local auth policy allowed: smartcard [%s], passkey [%s]\n",
+                             local_sc_auth_allow ? "True" : "False",
+                             local_passkey_auth_allow ? "True" : "False");
+
     if (pd->cmd == SSS_PAM_AUTHENTICATE
             && !preq->cert_auth_local
             && (pd->pam_status == PAM_AUTHINFO_UNAVAIL
@@ -1152,10 +1485,15 @@ void pam_reply(struct pam_auth_req *preq)
         DEBUG(SSSDBG_IMPORTANT_INFO,
               "Backend cannot handle Smartcard authentication, "
               "trying local Smartcard authentication.\n");
-        preq->cert_auth_local = true;
-        ret = check_cert(cctx, cctx->ev, pctx, preq, pd);
-        pam_check_user_done(preq, ret);
-        return;
+        if (local_sc_auth_allow) {
+            preq->cert_auth_local = true;
+            ret = check_cert(cctx, cctx->ev, pctx, preq, pd);
+            pam_check_user_done(preq, ret);
+            return;
+        } else {
+            DEBUG(SSSDBG_IMPORTANT_INFO,
+                  "Local smartcard auth not allowed by local_auth_policy");
+        }
     }
 
     if (pd->pam_status == PAM_AUTHINFO_UNAVAIL || preq->use_cached_auth) {
@@ -1348,7 +1686,10 @@ void pam_reply(struct pam_auth_req *preq)
             goto done;
         }
 
-        if (may_do_passkey_auth(pctx, pd) && !pk_preauth_done && preq->passkey_data_exists) {
+        if (may_do_passkey_auth(pctx, pd)
+            && !pk_preauth_done
+            && preq->passkey_data_exists
+            && local_passkey_auth_allow) {
             ret = passkey_local(cctx, cctx->ev, pctx, preq, pd);
             pam_check_user_done(preq, ret);
             return;
@@ -2680,13 +3021,22 @@ done:
 
 static void pam_dom_forwarder(struct pam_auth_req *preq)
 {
+    TALLOC_CTX *tmp_ctx = NULL;
     int ret;
     struct pam_ctx *pctx =
             talloc_get_type(preq->cctx->rctx->pvt_ctx, struct pam_ctx);
     const char *cert_user;
     struct ldb_result *cert_user_objs;
+    bool sc_auth;
+    bool passkey_auth;
     size_t c;
+    char *local_policy = NULL;
     bool found = false;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return;
+    }
 
     if (!preq->pd->domain) {
         preq->pd->domain = preq->domain->name;
@@ -2721,6 +3071,23 @@ static void pam_dom_forwarder(struct pam_auth_req *preq)
         preq->use_cached_auth = true;
         pam_reply(preq);
         return;
+    }
+
+    /* Skip online auth when local auth policy = only  */
+    if (may_do_cert_auth(pctx, preq->pd) || may_do_passkey_auth(pctx, preq->pd)) {
+        if (preq->domain->name != NULL) {
+            ret = pam_eval_local_auth_policy(preq->cctx, pctx, preq->pd, preq,
+                                             &sc_auth,
+                                             &passkey_auth,
+                                             &local_policy);
+            if (ret != EOK) {
+                DEBUG(SSSDBG_FATAL_FAILURE,
+                      "Failed to evaluate local auth policy\n");
+                preq->pd->pam_status = PAM_AUTH_ERR;
+                pam_reply(preq);
+                return;
+            }
+        }
     }
 
     if (may_do_cert_auth(pctx, preq->pd) && preq->cert_list != NULL) {
@@ -2786,6 +3153,22 @@ static void pam_dom_forwarder(struct pam_auth_req *preq)
         }
 
         if (found) {
+            if (local_policy != NULL && strcasecmp(local_policy, "only") == 0) {
+                talloc_free(tmp_ctx);
+                DEBUG(SSSDBG_IMPORTANT_INFO, "Local auth only set, skipping online auth\n");
+                if (preq->pd->cmd == SSS_PAM_PREAUTH) {
+                    preq->pd->pam_status = PAM_SUCCESS;
+                } else if (preq->pd->cmd == SSS_PAM_AUTHENTICATE
+                                && IS_SC_AUTHTOK(preq->pd->authtok)
+                                && preq->cert_auth_local) {
+                    preq->pd->pam_status = PAM_SUCCESS;
+                    preq->callback = pam_reply;
+                }
+
+                pam_reply(preq);
+                return;
+            }
+
             /* We are done if we do not have to call the backend */
             if (preq->pd->cmd == SSS_PAM_AUTHENTICATE
                     && preq->cert_auth_local) {
@@ -2809,9 +3192,25 @@ static void pam_dom_forwarder(struct pam_auth_req *preq)
         }
     }
 
+    if (local_policy != NULL && strcasecmp(local_policy, "only") == 0) {
+        talloc_free(tmp_ctx);
+        DEBUG(SSSDBG_IMPORTANT_INFO, "Local auth only set, skipping online auth\n");
+        if (preq->pd->cmd == SSS_PAM_PREAUTH) {
+            preq->pd->pam_status = PAM_SUCCESS;
+        } else if (preq->pd->cmd == SSS_PAM_AUTHENTICATE && IS_SC_AUTHTOK(preq->pd->authtok)) {
+            /* Trigger offline smartcardcard autheitcation */
+            preq->pd->pam_status = PAM_AUTHINFO_UNAVAIL;
+        }
+
+        pam_reply(preq);
+        return;
+    }
+
     preq->callback = pam_reply;
     ret = pam_dp_send_req(preq);
     DEBUG(SSSDBG_CONF_SETTINGS, "pam_dp_send_req returned %d\n", ret);
+
+    talloc_free(tmp_ctx);
 
     if (ret != EOK) {
         preq->pd->pam_status = PAM_SYSTEM_ERR;

--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -1349,7 +1349,7 @@ void pam_reply(struct pam_auth_req *preq)
         }
 
         if (may_do_passkey_auth(pctx, pd) && !pk_preauth_done && preq->passkey_data_exists) {
-            ret = passkey_non_kerberos(cctx, cctx->ev, pctx, preq, pd);
+            ret = passkey_local(cctx, cctx->ev, pctx, preq, pd);
             pam_check_user_done(preq, ret);
             return;
         }
@@ -1806,7 +1806,7 @@ static int pam_forwarder(struct cli_ctx *cctx, int pam_cmd)
         goto done;
     }
 
-    /* This is set to false inside passkey_non_kerberos() if no passkey data is found.
+    /* This is set to false inside passkey_local() if no passkey data is found.
      * It is checked in pam_reply() to avoid an endless loop */
     preq->passkey_data_exists = true;
 
@@ -1817,7 +1817,7 @@ static int pam_forwarder(struct cli_ctx *cctx, int pam_cmd)
                 goto done;
             } else if ((sss_authtok_get_type(pd->authtok) == SSS_AUTHTOK_TYPE_PASSKEY) ||
                       (sss_authtok_get_type(pd->authtok) == SSS_AUTHTOK_TYPE_EMPTY)) {
-                ret = passkey_non_kerberos(cctx, cctx->ev, pctx, preq, pd);
+                ret = passkey_local(cctx, cctx->ev, pctx, preq, pd);
                 goto done;
             }
         }
@@ -2220,7 +2220,7 @@ static void pam_forwarder_cb(struct tevent_req *req)
         goto done;
     }
 
-    /* This is set to false inside passkey_non_kerberos() if no passkey data is found.
+    /* This is set to false inside passkey_local() if no passkey data is found.
      * It is checked in pam_reply() to avoid an endless loop */
     preq->passkey_data_exists = true;
 
@@ -2231,7 +2231,7 @@ static void pam_forwarder_cb(struct tevent_req *req)
                 goto done;
             } else if ((sss_authtok_get_type(pd->authtok) == SSS_AUTHTOK_TYPE_PASSKEY) ||
                       (sss_authtok_get_type(pd->authtok) == SSS_AUTHTOK_TYPE_EMPTY)) {
-                ret = passkey_non_kerberos(cctx, cctx->ev, pctx, preq, pd);
+                ret = passkey_local(cctx, cctx->ev, pctx, preq, pd);
                 goto done;
             }
         }

--- a/src/responder/pam/pamsrv_passkey.c
+++ b/src/responder/pam/pamsrv_passkey.c
@@ -85,7 +85,7 @@ struct passkey_get_mapping_state {
     struct cache_req_result *result;
 };
 
-errno_t passkey_non_kerberos(TALLOC_CTX *mem_ctx,
+errno_t passkey_local(TALLOC_CTX *mem_ctx,
                       struct tevent_context *ev,
                       struct pam_ctx *pam_ctx,
                       struct pam_auth_req *preq,
@@ -256,7 +256,7 @@ done:
     return ret;
 }
 
-static errno_t passkey_non_kerberos_verification(TALLOC_CTX *mem_ctx,
+static errno_t passkey_local_verification(TALLOC_CTX *mem_ctx,
                                           struct passkey_ctx *pctx,
                                           struct confdb_ctx *cdb,
                                           struct sysdb_ctx *sysdb,
@@ -514,7 +514,7 @@ void pam_passkey_get_user_done(struct tevent_req *req)
         goto done;
     }
 
-    ret = passkey_non_kerberos_verification(pctx, pctx, pctx->pam_ctx->rctx->cdb,
+    ret = passkey_local_verification(pctx, pctx, pctx->pam_ctx->rctx->cdb,
                                             result->domain->sysdb, result->domain->dns_name,
                                             pk_data, &verification, &debug_libfido2);
     if (ret != EOK) {

--- a/src/responder/pam/pamsrv_passkey.h
+++ b/src/responder/pam/pamsrv_passkey.h
@@ -35,7 +35,7 @@ enum passkey_user_verification {
     PAM_PASSKEY_VERIFICATION_INVALID
 };
 
-errno_t passkey_non_kerberos(TALLOC_CTX *mem_ctx,
+errno_t passkey_local(TALLOC_CTX *mem_ctx,
                              struct tevent_context *ev,
                              struct pam_ctx *pam_ctx,
                              struct pam_auth_req *preq,

--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -2549,6 +2549,11 @@ static int get_authtok_for_authentication(pam_handle_t *pamh,
                 /* Fallback to password auth if no PIN was entered */
                 if (ret == EIO) {
                     ret = prompt_password(pamh, pi, _("Password: "));
+                    if (pi->pam_authtok_size == 0) {
+                        D(("Empty password failure"));
+                        pi->passkey_prompt_pin = NULL;
+                        return PAM_AUTHTOK_ERR;
+                    }
                 }
             } else {
                 ret = prompt_password(pamh, pi, _("Password: "));

--- a/src/tests/cmocka/test_pam_srv.c
+++ b/src/tests/cmocka/test_pam_srv.c
@@ -315,6 +315,35 @@ static int pam_test_setup(void **state)
         { "enumerate", "false" },
         { "cache_credentials", "true" },
         { "entry_cache_timeout", "300" },
+        { "local_auth_policy", "enable:smartcard" }, /* Needed to allow local sc auth */
+        { NULL, NULL },             /* Sentinel */
+    };
+
+    struct sss_test_conf_param pam_params[] = {
+        { CONFDB_PAM_P11_URI, "pkcs11:manufacturer=SoftHSM%20project" },
+        { "p11_child_timeout", "30" },
+        { "pam_cert_verification", NULL },
+        { NULL, NULL },             /* Sentinel */
+    };
+
+    struct sss_test_conf_param monitor_params[] = {
+        { "certificate_verification", "no_ocsp"},
+        { NULL, NULL },             /* Sentinel */
+    };
+
+    test_pam_setup(dom_params, pam_params, monitor_params, state);
+
+    pam_test_setup_common();
+    return 0;
+}
+
+static int pam_test_setup_passkey(void **state)
+{
+    struct sss_test_conf_param dom_params[] = {
+        { "enumerate", "false" },
+        { "cache_credentials", "true" },
+        { "entry_cache_timeout", "300" },
+        { "local_auth_policy", "enable:passkey" }, /* Needed to allow local passkey auth */
         { NULL, NULL },             /* Sentinel */
     };
 
@@ -342,6 +371,7 @@ static int pam_test_setup_no_verification(void **state)
     struct sss_test_conf_param dom_params[] = {
         { "enumerate", "false" },
         { "cache_credentials", "true" },
+        { "local_auth_policy", "enable:smartcard" }, /* Needed to allow local sc auth */
         { NULL, NULL }, /* Sentinel */
     };
 
@@ -387,6 +417,7 @@ static int pam_cached_test_setup(void **state)
         { "enumerate", "false" },
         { "cache_credentials", "true" },
         { "cached_auth_timeout", CACHED_AUTH_TIMEOUT_STR },
+        { "local_auth_policy", "enable:smartcard" }, /* Needed to allow local sc auth */
         { NULL, NULL },             /* Sentinel */
     };
 
@@ -4592,13 +4623,13 @@ int main(int argc, const char *argv[])
                                         pam_test_setup, pam_test_teardown),
 #ifdef BUILD_PASSKEY
         cmocka_unit_test_setup_teardown(test_pam_passkey_preauth_no_passkey,
-                                        pam_test_setup, pam_test_teardown),
+                                        pam_test_setup_passkey, pam_test_teardown),
         cmocka_unit_test_setup_teardown(test_pam_passkey_preauth_found,
-                                        pam_test_setup, pam_test_teardown),
+                                        pam_test_setup_passkey, pam_test_teardown),
         cmocka_unit_test_setup_teardown(test_pam_passkey_auth,
-                                        pam_test_setup, pam_test_teardown),
+                                        pam_test_setup_passkey, pam_test_teardown),
         cmocka_unit_test_setup_teardown(test_pam_passkey_auth_send,
-                                        pam_test_setup, pam_test_teardown),
+                                        pam_test_setup_passkey, pam_test_teardown),
         cmocka_unit_test_setup_teardown(test_pam_prompting_passkey_interactive,
                                         pam_test_setup_passkey_interactive_prompt, pam_test_teardown),
         cmocka_unit_test_setup_teardown(test_pam_prompting_passkey_interactive_and_touch,

--- a/src/tests/intg/test_pam_responder.py
+++ b/src/tests/intg/test_pam_responder.py
@@ -146,6 +146,7 @@ def format_pam_cert_auth_conf(config):
         debug_level = 10
         id_provider = files
         fallback_to_nss = False
+        local_auth_policy = enable:smartcard
 
         [certmap/auth_only/user1]
         matchrule = <SUBJECT>.*CN=SSSD test cert 0001.*
@@ -180,6 +181,7 @@ def format_pam_cert_auth_conf_name_format(config):
         debug_level = 10
         id_provider = files
         fallback_to_nss = False
+        local_auth_policy = enable:smartcard
 
         [certmap/auth_only/user1]
         matchrule = <SUBJECT>.*CN=SSSD test cert 0001.*

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -680,6 +680,15 @@ errno_t get_dom_names(TALLOC_CTX *mem_ctx,
                       char ***_dom_names,
                       int *_dom_names_count);
 
+__attribute__((always_inline))
+static inline bool is_domain_provider(struct sss_domain_info *domain,
+                                      const char *provider)
+{
+    return domain != NULL &&
+           domain->provider != NULL &&
+           strcasecmp(domain->provider, provider) == 0;
+}
+
 /* Returns true if the provider used for the passed domain is the "files"
  * one. Otherwise returns false. */
 __attribute__((always_inline))


### PR DESCRIPTION
For IPA specifically, we will no longer fallback to local authentication. This enforces the preferred kerberos preauth mechanism to acquire a kerberos ticket during passkey authentication.