### PR TITLE
Tests: Fix pytest markers to remove warnings.

### DIFF
--- a/src/tests/multihost/ad/pytest.ini
+++ b/src/tests/multihost/ad/pytest.ini
@@ -6,13 +6,14 @@ markers =
    admisc: Miscellaneous bugzilla automations for AD
    automount: Automount test cases with maps stored in AD schema
    cifs: Cifs test cases
+   converted: Tests that are already converted to the new framework.
    ad_access_control: Test for AD Access Control
    dyndns: dynamic dns test cases
    idmap: Tests related to idmap
    idmaprange: Tests related to ldap idmap range
    keytabrotation: keytab rotation using adcli
    memcachesid: Test for mem cache sid
-   range_retrieval: Test for AD range retrieval
+   rangeretrieval: Test for AD range retrieval
    sambaidmap: Samba test case with idmap backend as 'sss'
    smbsecretrotation: Samba Secret database rotation
    sudo: Test cases related to sudo using AD backend.

--- a/src/tests/multihost/alltests/pytest.ini
+++ b/src/tests/multihost/alltests/pytest.ini
@@ -7,6 +7,7 @@ markers =
     cache_performance: Tests related to cache performance testing
     configmerge: Tests related to Config merge
     configvalidation: Tests related to sssd config validation
+    converted: Tests that are already converted to the new framework.
     defaultdebuglevel: Test default debug level sssd
     failover: Tests related to failover
     fips: Tests related to fips when auth_provider is krb5

--- a/src/tests/multihost/ipa/pytest.ini
+++ b/src/tests/multihost/ipa/pytest.ini
@@ -5,3 +5,4 @@ markers =
     hbac: Tests hbac in ipa provider environment
     trust: Tests related to IPA AD Trust
     adhbac: Test related to HBAC in IPA-AD Trust environment
+    converted: Tests that are already converted to the new framework.


### PR DESCRIPTION
Missing and incorrect pytest markers were present in tests resulting in warnings.