### PR TITLE
Tests: Ignore chattr result on resolv.conf

### DIFF
--- a/src/tests/multihost/sssd/testlib/common/utils.py
+++ b/src/tests/multihost/sssd/testlib/common/utils.py
@@ -136,9 +136,11 @@ class sssdTools(object):
         else:
             contents = resolv_conf
         contents = nameserver + contents.replace(nameserver, '')
-        self.multihost.run_command("chattr -i /etc/resolv.conf")
+        # Chattr will not work on symlink (like from systemd resolved)
+        # so we ignore result
+        self.multihost.run_command("chattr -i /etc/resolv.conf", raiseonerr=False)
         self.multihost.put_file_contents('/etc/resolv.conf', contents)
-        self.multihost.run_command("chattr +i /etc/resolv.conf")
+        self.multihost.run_command("chattr +i /etc/resolv.conf", raiseonerr=False)
 
     def update_etc_hosts(self, ip_addr, hostname):
         """ Update /etc/hosts with ipaddress and hostname


### PR DESCRIPTION
The resolv.conf can be a symlink (because of systemd/resolved) so chattr will not work on it. We ignore the result so error is not produced on fedora where systemd/resolved is in play.