### PR TITLE
passkey: print mapping data to file

### DIFF
--- a/src/passkey_child/passkey_child.h
+++ b/src/passkey_child/passkey_child.h
@@ -63,6 +63,7 @@ struct passkey_data {
     fido_opt_t user_verification;
     enum credential_type cred_type;
     unsigned char *user_id;
+    char *mapping_file;
     bool quiet;
     bool debug_libfido2;
 };
@@ -239,6 +240,21 @@ verify_credentials(const fido_cred_t *const cred);
 errno_t
 print_credentials(const struct passkey_data *data,
                   const fido_cred_t *const cred);
+
+/**
+ * @brief Print passkey credentials
+ *
+ * @param[in] data passkey data
+ * @param[in] b64_cred_id Credential ID in b64
+ * @param[in] pem_key Public key in PEM format
+ *
+ * @return 0 if the credentials were printed properly,
+ *         another value on error.
+ */
+errno_t
+print_credentials_to_file(const struct passkey_data *data,
+                          const char *b64_cred_id,
+                          const char *pem_key);
 
 /**
  * @brief Format libfido2's es256 data structure to EVP_PKEY

--- a/src/passkey_child/passkey_child_common.c
+++ b/src/passkey_child/passkey_child_common.c
@@ -154,6 +154,7 @@ parse_arguments(TALLOC_CTX *mem_ctx, int argc, const char *argv[],
     data->user_verification = FIDO_OPT_OMIT;
     data->cred_type = CRED_SERVER_SIDE;
     data->user_id = NULL;
+    data->mapping_file = NULL;
     data->quiet = false;
     data->debug_libfido2 = false;
 
@@ -194,6 +195,8 @@ parse_arguments(TALLOC_CTX *mem_ctx, int argc, const char *argv[],
          _("Require user-verification"), "true|false"},
         {"cred-type", 0, POPT_ARG_STRING, &cred_type, 0,
          _("Credential type"), "server-side|discoverable"},
+        {"output-file", 0, POPT_ARG_STRING, &data->mapping_file, 0,
+         _("Write key mapping data to file"), NULL},
         {"quiet", 0, POPT_ARG_NONE, NULL, 'q',
          _("Supress prompts"), NULL},
         {"debug-libfido2", 0, POPT_ARG_NONE, NULL, 'd',
@@ -368,6 +371,7 @@ check_arguments(const struct passkey_data *data)
           data->user_verification);
     DEBUG(SSSDBG_TRACE_FUNC, "cred_type: %d\n",
           data->cred_type);
+    DEBUG(SSSDBG_TRACE_FUNC, "Mapping file: %s\n", data->mapping_file);
     DEBUG(SSSDBG_TRACE_FUNC, "debug_libfido2: %d\n", data->debug_libfido2);
 
     if (data->action == ACTION_NONE) {

--- a/src/tests/cmocka/test_passkey_child.c
+++ b/src/tests/cmocka/test_passkey_child.c
@@ -880,6 +880,7 @@ void test_register_key_integration(void **state)
     data.type = COSE_ES256;
     data.user_verification = FIDO_OPT_FALSE;
     data.cred_type = CRED_SERVER_SIDE;
+    data.mapping_file = NULL;
     data.quiet = false;
     will_return(__wrap_fido_dev_info_manifest, FIDO_OK);
     will_return(__wrap_fido_dev_info_manifest, 1);


### PR DESCRIPTION
## How to test

Add `--mapping-file=FILE` to the options when running the passkey registration. Example:
```
./passkey_child --register --username=user --domain=test.com --mapping-file=map.file
```