### PR TITLE
man: put sssd_user_name.include to builddir

### DIFF
--- a/src/man/Makefile.am
+++ b/src/man/Makefile.am
@@ -127,10 +127,11 @@ SUFFIXES = .1.xml .1 .3.xml .3 .5.xml .5 .8.xml .8
 	$(XSLTPROC) -o $@  $(XSLTPROC_FLAGS) $(DOCBOOK_XSLT) $<
 
 .5.xml.5:
-	@echo -n $(SSSD_USER) > $(dir $<)/sssd_user_name.include
-	$(XMLLINT) $(XMLLINT_FLAGS) $<
-	$(XSLTPROC) -o $@  $(XSLTPROC_FLAGS) $(DOCBOOK_XSLT) $<
-	@rm -f $(dir $<)/sssd_user_name.include
+	@mkdir -p $(builddir)/src/man
+	@echo -n $(SSSD_USER) > $(builddir)/src/man/sssd_user_name.include
+	$(XMLLINT) --path "$(srcdir)/src/man:$(builddir)/src/man" $(XMLLINT_FLAGS) $<
+	$(XSLTPROC) --path "$(srcdir)/src/man:$(builddir)/src/man" -o $@  $(XSLTPROC_FLAGS) $(DOCBOOK_XSLT) $<
+	@rm -f $(builddir)/src/man/sssd_user_name.include
 
 .8.xml.8:
 	$(XMLLINT) $(XMLLINT_FLAGS) $<


### PR DESCRIPTION
Putting it to the source directory makes "make distcheck" fail when
run directly from source directory instead of different build dir.

It produces this error message:
```
/bin/sh: line 1: ../../../../src/man//sssd_user_name.include: Permission denied
```

Because the source directory copied by distcheck is not writable.