### PR TITLE
tests: add importance marker and generate polarion xmls in system tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,6 +339,24 @@ jobs:
       run: |
         yq -i 'del(.domains[0].hosts.[] | select(.role == "ad"))' mhc.yaml
 
+    - name: Check polarion metadata
+      shell: bash
+      working-directory: ./sssd/src/tests/system
+      run: |
+        # Run pytest in collect only mode to quickly catch issues in Polarion metadata.
+        set -ex -o pipefail
+
+        mkdir -p $GITHUB_WORKSPACE/artifacts
+        source .venv/bin/activate
+        pytest \
+          --color=yes \
+          --mh-config=./mhc.yaml \
+          --mh-log-path=$GITHUB_WORKSPACE/mh.log \
+          --mh-artifacts-dir=$GITHUB_WORKSPACE/artifacts \
+          --polarion-config=./polarion.yaml \
+          --output-polarion-testcase=$GITHUB_WORKSPACE/artifacts/testcase.xml \
+          --collect-only . |& tee $GITHUB_WORKSPACE/pytest-collect.log
+
     - name: Run tests
       shell: bash
       working-directory: ./sssd/src/tests/system
@@ -370,6 +388,7 @@ jobs:
           build.log
           install.log
           pytest.log
+          pytest-collect.log
 
   result:
     name: All tests are successful

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,12 +345,16 @@ jobs:
       run: |
         set -ex -o pipefail
 
+        mkdir -p $GITHUB_WORKSPACE/artifacts
         source .venv/bin/activate
         pytest \
           --color=yes \
           --mh-config=./mhc.yaml \
           --mh-log-path=$GITHUB_WORKSPACE/mh.log \
           --mh-artifacts-dir=$GITHUB_WORKSPACE/artifacts \
+          --polarion-config=./polarion.yaml \
+          --output-polarion-testcase=$GITHUB_WORKSPACE/artifacts/testcase.xml \
+          --output-polarion-testrun=$GITHUB_WORKSPACE/artifacts/testrun.xml \
           -vvv . |& tee $GITHUB_WORKSPACE/pytest.log
 
     - name: Upload artifacts

--- a/src/tests/system/conftest.py
+++ b/src/tests/system/conftest.py
@@ -7,6 +7,7 @@ from sssd_test_framework.config import SSSDMultihostConfig
 
 # Load additional plugins
 pytest_plugins = (
+    "pytest_importance",
     "pytest_mh",
     "pytest_ticket",
     "pytest_tier",

--- a/src/tests/system/conftest.py
+++ b/src/tests/system/conftest.py
@@ -10,7 +10,6 @@ pytest_plugins = (
     "pytest_importance",
     "pytest_mh",
     "pytest_ticket",
-    "pytest_tier",
     "sssd_test_framework.fixtures",
 )
 

--- a/src/tests/system/polarion.yaml
+++ b/src/tests/system/polarion.yaml
@@ -1,0 +1,35 @@
+testcase:
+  required:
+    title:
+      transform:
+        pattern: "^(.*)$"
+        replace: "IDM-SSSD-TC: \\1"
+      validate: "IDM-SSSD-TC: (.+)"
+    setup:
+      format: pre
+    steps:
+    expectedresults:
+    customerscenario:
+    caseimportance:
+    requirement:
+  optional:
+    id:
+      default: "idm-sssd-tc::{{ item.id }}"
+    caseautomation:
+      default: "automated"
+    casecomponent:
+      default: "sssd"
+    status:
+      default: "approved"
+    subsystemteam:
+      default: "sst_idm_sssd"
+    upstream:
+      default: "yes"
+    automation_script:
+      default: "{{ tests_url }}/{{ item.location.file }}#L{{ item.location.line }}"
+    testtype:
+      default: "functional"
+    caselevel:
+      default: "system"
+    teardown:
+      format: pre

--- a/src/tests/system/requirements.txt
+++ b/src/tests/system/requirements.txt
@@ -3,4 +3,5 @@ git+https://github.com/next-actions/pytest-importance
 git+https://github.com/next-actions/pytest-mh
 git+https://github.com/next-actions/pytest-ticket
 git+https://github.com/next-actions/pytest-tier
+git+https://github.com/next-actions/pytest-output
 git+https://github.com/SSSD/sssd-test-framework

--- a/src/tests/system/requirements.txt
+++ b/src/tests/system/requirements.txt
@@ -1,4 +1,5 @@
 pytest
+git+https://github.com/next-actions/pytest-importance
 git+https://github.com/next-actions/pytest-mh
 git+https://github.com/next-actions/pytest-ticket
 git+https://github.com/next-actions/pytest-tier

--- a/src/tests/system/tests/test_config.py
+++ b/src/tests/system/tests/test_config.py
@@ -113,7 +113,8 @@ def test_config__add_remove_section(client: Client):
     :expectedresults:
         1. "debug_level" is set to 9 in both domains
         2. Added successfully
-        4. Changes are apllied successfully
+        3. New configuration was written
+        4. Changes are applied successfully
         5. "sssd --genconf-section==$newSection" is called successfully
         6. New section is removed successfully
         7. "sssd --genconf-section==$newSection" is called successfully

--- a/src/tests/system/tests/test_kcm.py
+++ b/src/tests/system/tests/test_kcm.py
@@ -14,7 +14,6 @@ from sssd_test_framework.roles.kdc import KDC
 from sssd_test_framework.topology import KnownTopology
 
 
-@pytest.mark.tier(0)
 @pytest.mark.topology(KnownTopology.Client)
 @pytest.mark.parametrize("ccache_storage", ["memory", "secdb"])
 def test_kcm__kinit_overwrite(client: Client, kdc: KDC, ccache_storage: str):
@@ -61,7 +60,6 @@ def test_kcm__kinit_overwrite(client: Client, kdc: KDC, ccache_storage: str):
             assert krb.cache_count() == 1
 
 
-@pytest.mark.tier(0)
 @pytest.mark.topology(KnownTopology.Client)
 @pytest.mark.parametrize("ccache_storage", ["memory", "secdb"])
 def test_kcm__kinit_collection(client: Client, kdc: KDC, ccache_storage: str):
@@ -151,7 +149,6 @@ def test_kcm__kinit_collection(client: Client, kdc: KDC, ccache_storage: str):
             assert krb.cache_count() == 0
 
 
-@pytest.mark.tier(0)
 @pytest.mark.topology(KnownTopology.Client)
 @pytest.mark.parametrize("ccache_storage", ["memory", "secdb"])
 def test_kcm__kswitch(client: Client, kdc: KDC, ccache_storage: str):
@@ -220,7 +217,6 @@ def test_kcm__kswitch(client: Client, kdc: KDC, ccache_storage: str):
             assert krb.has_tickets("bob", kdc.realm, [kdc.tgt, kdc.qualify("host/bob")])
 
 
-@pytest.mark.tier(0)
 @pytest.mark.topology(KnownTopology.Client)
 @pytest.mark.parametrize("ccache_storage", ["memory", "secdb"])
 def test_kcm__subsidiaries(client: Client, kdc: KDC, ccache_storage: str):
@@ -296,7 +292,6 @@ def test_kcm__subsidiaries(client: Client, kdc: KDC, ccache_storage: str):
             assert principals[kdc.qualify("bob")] == expected[kdc.qualify("bob")]
 
 
-@pytest.mark.tier(0)
 @pytest.mark.topology(KnownTopology.Client)
 @pytest.mark.parametrize("ccache_storage", ["memory", "secdb"])
 def test_kcm__kdestroy_nocache(client: Client, kdc: KDC, ccache_storage: str):
@@ -331,7 +326,6 @@ def test_kcm__kdestroy_nocache(client: Client, kdc: KDC, ccache_storage: str):
                 assert False, f"kdestroy raised an error: {e}"
 
 
-@pytest.mark.tier(0)
 @pytest.mark.topology(KnownTopology.Client)
 def test_kcm__tgt_renewal(client: Client, kdc: KDC):
     """

--- a/src/tests/system/tests/test_kcm.py
+++ b/src/tests/system/tests/test_kcm.py
@@ -1,3 +1,9 @@
+"""
+KCM responder tests.
+
+:requirement: IDM-SSSD-REQ :: SSSD KCM as default Kerberos CCACHE provider
+"""
+
 from __future__ import annotations
 
 import time

--- a/src/tests/system/tests/test_ldap_extra_attrs.py
+++ b/src/tests/system/tests/test_ldap_extra_attrs.py
@@ -12,7 +12,6 @@ from sssd_test_framework.roles.generic import GenericProvider
 from sssd_test_framework.topology import KnownTopologyGroup
 
 
-@pytest.mark.tier(1)
 @pytest.mark.ticket(gh=4153, bz=1362023)
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
 @pytest.mark.parametrize("attrs", ["mail, firstname:givenname, lastname:sn", "given_email:mail"])

--- a/src/tests/system/tests/test_netgroups.py
+++ b/src/tests/system/tests/test_netgroups.py
@@ -12,7 +12,6 @@ from sssd_test_framework.roles.generic import GenericProvider
 from sssd_test_framework.topology import KnownTopologyGroup
 
 
-@pytest.mark.tier(1)
 @pytest.mark.ticket(gh=6652, bz=2162552)
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
 def test_netgroups__add_remove_netgroup_triple(client: Client, provider: GenericProvider):
@@ -55,7 +54,6 @@ def test_netgroups__add_remove_netgroup_triple(client: Client, provider: Generic
     assert len(result.members) == 0
 
 
-@pytest.mark.tier(1)
 @pytest.mark.ticket(gh=6652, bz=2162552)
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
 def test_netgroups__add_remove_netgroup_member(client: Client, provider: GenericProvider):

--- a/src/tests/system/tests/test_shadow.py
+++ b/src/tests/system/tests/test_shadow.py
@@ -12,7 +12,6 @@ from sssd_test_framework.roles.ldap import LDAP
 from sssd_test_framework.topology import KnownTopology
 
 
-@pytest.mark.tier(0)
 @pytest.mark.ticket(bz=1507035)
 @pytest.mark.topology(KnownTopology.LDAP)
 @pytest.mark.parametrize("method", ["su", "ssh"])

--- a/src/tests/system/tests/test_shadow.py
+++ b/src/tests/system/tests/test_shadow.py
@@ -1,3 +1,9 @@
+"""
+LDAP Shadow attributes tests.
+
+:requirement: IDM-SSSD-REQ : LDAP Provider
+"""
+
 from __future__ import annotations
 
 import pytest

--- a/src/tests/system/tests/test_sssctl.py
+++ b/src/tests/system/tests/test_sssctl.py
@@ -11,7 +11,6 @@ from sssd_test_framework.roles.client import Client
 from sssd_test_framework.topology import KnownTopology
 
 
-@pytest.mark.tier(0)
 @pytest.mark.ticket(bz=2100789)
 @pytest.mark.topology(KnownTopology.LDAP)
 def test_sssctl__check_id_provider(client: Client):
@@ -39,7 +38,6 @@ def test_sssctl__check_id_provider(client: Client):
     assert "[rule/sssd_checks]: Attribute 'id_provider' is missing in section 'domain/test'." in output.stdout_lines[1]
 
 
-@pytest.mark.tier(0)
 @pytest.mark.ticket(bz=2100789)
 @pytest.mark.topology(KnownTopology.LDAP)
 def test_sssctl__check_invalid_id_provider(client: Client):

--- a/src/tests/system/tests/test_sssctl.py
+++ b/src/tests/system/tests/test_sssctl.py
@@ -1,3 +1,9 @@
+"""
+SSSCTL tests.
+
+:requirement: IDM-SSSD-REQ: Status utility
+"""
+
 from __future__ import annotations
 
 import pytest
@@ -20,7 +26,6 @@ def test_sssctl__check_id_provider(client: Client):
         1. Successfully remove id_provider from domain section.
         2. Successfully get the error message.
     :customerscenario: False
-    :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2100789
     """
     # create sssd.conf and start the sssd, with deafult configuration with a LDAP server.
     client.sssd.start()
@@ -49,7 +54,6 @@ def test_sssctl__check_invalid_id_provider(client: Client):
         1. Successfully remove id_provider from domain section.
         2. Successfully get the error message.
     :customerscenario: False
-    :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2100789
     """
     # create sssd.conf and start the sssd, with deafult configuration with a LDAP server.
     client.sssd.start()

--- a/src/tests/system/tests/test_sudo.py
+++ b/src/tests/system/tests/test_sudo.py
@@ -19,7 +19,6 @@ from sssd_test_framework.roles.samba import Samba
 from sssd_test_framework.topology import KnownTopology, KnownTopologyGroup
 
 
-@pytest.mark.tier(0)
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
 def test_sudo__user_allowed(client: Client, provider: GenericProvider):
     """
@@ -56,7 +55,6 @@ def test_sudo__user_allowed(client: Client, provider: GenericProvider):
     assert not client.auth.sudo.run("user-2", "Secret123", command="/bin/ls /root")
 
 
-@pytest.mark.tier(0)
 @pytest.mark.topology(KnownTopology.AD)
 @pytest.mark.topology(KnownTopology.LDAP)
 @pytest.mark.topology(KnownTopology.Samba)
@@ -102,7 +100,6 @@ def test_sudo__duplicate_sudo_user(client: Client, provider: GenericProvider):
     assert not client.auth.sudo.run("user-4", "Secret123", command="/bin/ls /root")
 
 
-@pytest.mark.tier(0)
 @pytest.mark.ticket(bz=1380436, gh=4236)
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
 def test_sudo__case_sensitive_false(client: Client, provider: GenericProvider):
@@ -149,7 +146,6 @@ def test_sudo__case_sensitive_false(client: Client, provider: GenericProvider):
     assert client.auth.sudo.run("USER-1", "Secret123", command="/bin/more /root/test")
 
 
-@pytest.mark.tier(0)
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
 def test_sudo__rules_refresh(client: Client, provider: GenericProvider):
     """
@@ -185,7 +181,6 @@ def test_sudo__rules_refresh(client: Client, provider: GenericProvider):
     assert client.auth.sudo.list("user-1", "Secret123", expected=["(root) /bin/less"])
 
 
-@pytest.mark.tier(0)
 @pytest.mark.ticket(bz=1372440, gh=4236)
 @pytest.mark.contains_workaround_for(gh=4483)
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
@@ -222,7 +217,6 @@ def test_sudo__sudo_user_is_group(client: Client, provider: GenericProvider):
     assert client.auth.sudo.run("user-1", "Secret123", command="/bin/ls /root")
 
 
-@pytest.mark.tier(0)
 @pytest.mark.ticket(bz=1826272, gh=5119)
 @pytest.mark.topology(KnownTopologyGroup.AnyAD)
 def test_sudo__sudo_user_is_nonposix_group(client: Client, provider: GenericADProvider):
@@ -255,7 +249,6 @@ def test_sudo__sudo_user_is_nonposix_group(client: Client, provider: GenericADPr
     assert client.auth.sudo.run("user-1", "Secret123", command="/bin/ls /root")
 
 
-@pytest.mark.tier(0)
 @pytest.mark.ticket(bz=1910131)
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
 def test_sudo__runasuser_shortname(client: Client, provider: GenericADProvider):
@@ -283,7 +276,6 @@ def test_sudo__runasuser_shortname(client: Client, provider: GenericADProvider):
     assert client.auth.sudo.list("user-1", "Secret123", expected=["(user-2) /bin/ls"])
 
 
-@pytest.mark.tier(0)
 @pytest.mark.topology(KnownTopology.AD)
 @pytest.mark.topology(KnownTopology.LDAP)
 @pytest.mark.topology(KnownTopology.Samba)
@@ -316,7 +308,6 @@ def test_sudo__runasuser_fqn(client: Client, provider: GenericProvider):
     assert client.auth.sudo.list("user-1", "Secret123", expected=["(user-2) /bin/ls"])
 
 
-@pytest.mark.tier(0)
 @pytest.mark.topology(KnownTopology.LDAP)
 def test_sudo__sudonotbefore_shorttime(client: Client, provider: LDAP):
     """
@@ -372,7 +363,7 @@ def test_sudo__sudonotbefore_shorttime(client: Client, provider: LDAP):
 
 
 @pytest.mark.slow(seconds=15)
-@pytest.mark.tier(2)
+@pytest.mark.importance("low")
 @pytest.mark.ticket(bz=1925514, gh=5609)
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
 def test_sudo__refresh_random_offset(client: Client):
@@ -413,7 +404,7 @@ def test_sudo__refresh_random_offset(client: Client):
 
 
 @pytest.mark.slow(seconds=10)
-@pytest.mark.tier(2)
+@pytest.mark.importance("low")
 @pytest.mark.ticket(bz=1925505, gh=5604)
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
 @pytest.mark.parametrize(["full_interval", "smart_interval"], [(2, 1), (3, 2)])
@@ -480,7 +471,6 @@ def test_sudo__prefer_full_refresh_over_smart_refresh(client: Client, full_inter
             is_skipped = True
 
 
-@pytest.mark.tier(0)
 @pytest.mark.ticket(bz=1294670, gh=3969)
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
 def test_sudo__local_users_negative_cache(client: Client, provider: LDAP):

--- a/src/tests/system/tests/test_sudo.py
+++ b/src/tests/system/tests/test_sudo.py
@@ -1,3 +1,9 @@
+"""
+SUDO responder tests.
+
+:requirement: sudo
+"""
+
 from __future__ import annotations
 
 import re


### PR DESCRIPTION
This adds the importance marker (defaults to medium) and --importance cli option
to filter the tests by their importance. The value of the marker is automatically
converted to the caseimportance metadata field.

It also adds pytest-output to generate polarion xmls and validate test case metadata.
Tests that do not have all metadata specified will yield error.

I still expect some changes or tweaks to the pytest-output plugin so it is not
yet released in pypi. When done, we will switch to the pypi package.