### PR TITLE
passkey: fix two covscan issues

### DIFF
--- a/src/krb5_plugin/passkey/passkey.h
+++ b/src/krb5_plugin/passkey/passkey.h
@@ -81,9 +81,9 @@ void
 sss_passkey_message_free(struct sss_passkey_message *message);
 
 struct sss_passkey_message *
-sss_passkey_prefix_json_data(enum sss_passkey_phase phase,
-                             const char *state,
-                             const char *json_str);
+sss_passkey_message_from_reply_json(enum sss_passkey_phase phase,
+                                    const char *state,
+                                    const char *json_str);
 
 char *
 sss_passkey_message_encode(const struct sss_passkey_message *data);

--- a/src/krb5_plugin/passkey/passkey_utils.c
+++ b/src/krb5_plugin/passkey/passkey_utils.c
@@ -528,9 +528,9 @@ sss_passkey_message_to_json(const struct sss_passkey_message *message)
 }
 
 struct sss_passkey_message *
-sss_passkey_prefix_json_data(enum sss_passkey_phase phase,
-                             const char *state,
-                             const char *json_str)
+sss_passkey_message_from_reply_json(enum sss_passkey_phase phase,
+                                    const char *state,
+                                    const char *json_str)
 {
     json_error_t jret;
     json_t *jroot;

--- a/src/krb5_plugin/passkey/passkey_utils.c
+++ b/src/krb5_plugin/passkey/passkey_utils.c
@@ -535,7 +535,7 @@ sss_passkey_prefix_json_data(enum sss_passkey_phase phase,
     json_error_t jret;
     json_t *jroot;
     struct sss_passkey_message *message;
-    void *data;
+    struct sss_passkey_reply *data;
 
     if (json_str == NULL) {
         return NULL;
@@ -553,9 +553,7 @@ sss_passkey_prefix_json_data(enum sss_passkey_phase phase,
     }
 
     message = sss_passkey_message_init(phase, state, data);
-    if (message == NULL && phase == SSS_PASSKEY_PHASE_CHALLENGE) {
-        sss_passkey_challenge_free(data);
-    } else if (message == NULL && phase == SSS_PASSKEY_PHASE_REPLY) {
+    if (message == NULL) {
         sss_passkey_reply_free(data);
     }
 

--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -1051,7 +1051,7 @@ static krb5_error_code answer_passkey(krb5_context kctx,
 
     phase = SSS_PASSKEY_PHASE_REPLY;
     state = SSSD_PASSKEY_REPLY_STATE;
-    reply_msg = sss_passkey_prefix_json_data(phase, state, reply);
+    reply_msg = sss_passkey_message_from_reply_json(phase, state, reply);
     if (reply_msg == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Unable to prefix passkey message\n");
         kerr = EINVAL;

--- a/src/responder/pam/pamsrv_passkey.c
+++ b/src/responder/pam/pamsrv_passkey.c
@@ -1034,8 +1034,7 @@ bool may_do_passkey_auth(struct pam_ctx *pctx,
 #ifndef BUILD_PASSKEY
     DEBUG(SSSDBG_TRACE_FUNC, "Passkey auth not possible, SSSD built without passkey support!\n");
     return false;
-#endif
-
+#else
     if (!pctx->passkey_auth) {
         return false;
     }
@@ -1049,4 +1048,5 @@ bool may_do_passkey_auth(struct pam_ctx *pctx,
     }
 
     return true;
+#endif /* BUILD_PASSKEY */
 }


### PR DESCRIPTION
Fixes following covscan issues:
```
Error: CLANG_WARNING:
sssd-2.9.0/src/krb5_plugin/passkey/passkey_utils.c:562:5: warning[unix.Malloc]: Potential leak of memory pointed to by 'data'
 #  560|       }
 #  561|
 #  562|->     json_decref(jroot);
 #  563|       return message;
 #  564|   }

Error: UNREACHABLE (CWE-561):
sssd-2.9.0/src/responder/pam/pamsrv_passkey.c:1039: unreachable: This code cannot be reached: "if (!pctx->passkey_auth) {
...".
 # 1037|   #endif
 # 1038|
 # 1039|->     if (!pctx->passkey_auth) {
 # 1040|           return false;
 # 1041|       }
```

Resolves: https://github.com/SSSD/sssd/issues/6733