### PR TITLE
Tests: Gating fixes for RHEL8.9 and RHEL9.3

### DIFF
--- a/src/tests/multihost/alltests/test_config_validation.py
+++ b/src/tests/multihost/alltests/test_config_validation.py
@@ -432,9 +432,8 @@ class TestConfigValidation(object):
         multihost.client[0].run_command(rm_cmd, raiseonerr=False)
         sssctl_cmd = 'sssctl config-check'
         cmd = multihost.client[0].run_command(sssctl_cmd, raiseonerr=False)
-        assert cmd.returncode == 0
         log = re.compile(r'sssd.conf\sdoes\snot\sexist')
-        assert log.search(cmd.stdout_text)
+        assert cmd.returncode == 1 and log.search(cmd.stdout_text)
 
     @pytest.mark.tier1
     def test_0023_checkldaphostobjectdomain(self, multihost, backupsssdconf):
@@ -618,8 +617,7 @@ class TestConfigValidation(object):
          existing snippet directory
         :id: 3d30164f-b80b-4594-883d-1783d9337031
         """
-        sssctl_cmd = 'sssctl config-check -c /tmp/test/sssd.conf -s ' \
-                     '/tmp/does/not/exists'
+        sssctl_cmd = 'sssctl config-check -s /tmp/does/not/exists'
         sssctl_check = multihost.client[0].run_command(sssctl_cmd,
                                                        raiseonerr=False)
         result = sssctl_check.stdout_text.strip()

--- a/src/tests/multihost/alltests/test_offline.py
+++ b/src/tests/multihost/alltests/test_offline.py
@@ -48,6 +48,7 @@ class TestOffline(object):
             get_date = multihost.client[0].run_command(date, raiseonerr=False)
             date_org = get_date.stdout_text
             date = '"' + date_org[0:19] + '"'
+            multihost.client[0].service_sssd('restart')
             # Check server status in syslog
             syslog = 'journalctl --since %s -xeu sssd' % date
             time.sleep(80)

--- a/src/tests/multihost/alltests/test_ssh_authorizedkeys.py
+++ b/src/tests/multihost/alltests/test_ssh_authorizedkeys.py
@@ -32,14 +32,8 @@ class TestSSHkeys(object):
         tools = sssdTools(multihost.client[0])
         domain_name = tools.get_domain_section_name()
         user = 'foo1@%s' % domain_name
-        client = pexpect_ssh(multihost.client[0].sys_hostname, user,
-                             'Secret123', debug=False)
-        try:
-            client.login()
-        except SSHLoginException:
-            pytest.fail("%s failed to login" % user)
-        else:
-            client.logout()
+        ssh = tools.auth_from_client(user, 'Secret123') == 3
+        assert ssh, f"Ssh failed for user {user}!"
         domain_log = '/var/log/sssd/sssd_%s.log' % domain_name
         log = multihost.client[0].get_file_contents(domain_log).decode('utf-8')
         msg = 'Adding sshPublicKey'


### PR DESCRIPTION
    Tests: Gating fixes for RHEL8.9 and RHEL9.3
    
    The following three minor changes are:
    
    for test_config_validation.py,
    1. 'sssctl config-check' returning retuncode as a 1 when
       we don't have sssd.conf file.
    2. Change the 'sssctl' command which only checks the
       non-default snippet directory with option -s.
    
    for test_offline.py,
    3. Add extra restart of sssd to get offline log message
       using journalctl command.
    
    for test_ssh_authorizedkeys.py,
    4. Replace pexpect_ssh to auth_from_client method to login
    the user.