### PR TITLE
krb5: make sure sockets are closed on timeouts

### DIFF
--- a/src/providers/krb5/krb5_child_handler.c
+++ b/src/providers/krb5/krb5_child_handler.c
@@ -281,6 +281,9 @@ static void krb5_child_timeout(struct tevent_context *ev,
         return;
     }
 
+    /* No I/O expected anymore, make sure sockets are closed properly */
+    state->io->in_use = false;
+
     DEBUG(SSSDBG_IMPORTANT_INFO,
           "Timeout for child [%d] reached. In case KDC is distant or network "
            "is slow you may consider increasing value of krb5_auth_timeout.\n",
@@ -511,6 +514,9 @@ static void child_keep_alive_timeout(struct tevent_context *ev,
 
     DEBUG(SSSDBG_IMPORTANT_INFO, "Keep alive timeout for child [%d] reached.\n",
           io->pid);
+
+    /* No I/O expected anymore, make sure sockets are closed properly */
+    io->in_use = false;
 
     krb5_child_terminate(io->pid);
 }


### PR DESCRIPTION
If krb5_child runs into a timeout the backend currently does not close
the I/O sockets because handle_child_done() is not called when the
timeout handlers are acting. To make sure the signal handler can close
the sockets the 'in_use' member of struct child_io_fds is set to
'false'.

Resolves: https://github.com/SSSD/sssd/issues/6744