### PR TITLE
Another implimentation of 'lock free client' feature

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,23 +68,6 @@ LIBS=$SAVE_LIBS
 AM_CONDITIONAL([HAVE_PTHREAD], [test x"$HAVE_PTHREAD" != "x"])
 
 
-SAVE_LIBS=$LIBS
-LIBS=
-AC_LINK_IFELSE(
-    [AC_LANG_PROGRAM([[#include <pthread.h>]],
-        [[static pthread_key_t k;
-          static pthread_once_t f = PTHREAD_ONCE_INIT;
-          pthread_once(&f, NULL);
-          pthread_key_create(&k, NULL);
-        ]])],
-    [AC_DEFINE([HAVE_PTHREAD_EXT], [1], [Extended pthread functionality is available.])
-     HAVE_PTHREAD_EXT=1
-    ],
-    [AC_MSG_WARN([Extended pthread functionality is not available. Lock-free client feature will not be built.])])
-LIBS=$SAVE_LIBS
-AM_CONDITIONAL([BUILD_LOCKFREE_CLIENT], [test x"$HAVE_PTHREAD_EXT" != "x"])
-
-
 # Check library for the timer_create function
 SAVE_LIBS=$LIBS
 LIBS=

--- a/src/man/Makefile.am
+++ b/src/man/Makefile.am
@@ -41,9 +41,6 @@ endif
 if BUILD_KCM_RENEWAL
 KCM_RENEWAL_CONDS = ;enable_kcm_renewal
 endif
-if BUILD_LOCKFREE_CLIENT
-LOCKFREE_CLIENT_CONDS = ;enable_lockfree_support
-endif
 if HAVE_INOTIFY
 HAVE_INOTIFY_CONDS = ;have_inotify
 endif

--- a/src/man/sssd.8.xml
+++ b/src/man/sssd.8.xml
@@ -240,7 +240,7 @@
             If the environment variable SSS_NSS_USE_MEMCACHE is set to "NO",
             client applications will not use the fast in-memory cache.
         </para>
-        <para condition="enable_lockfree_support">
+        <para>
             If the environment variable SSS_LOCKFREE is set to "NO", requests
             from multiple threads of a single application will be serialized.
         </para>

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2297,15 +2297,15 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                             startup.
                         </para>
                         <para>
-                            Default: 0 (only the root user is allowed to access
-                            the PAC responder)
+                            Default: 0<phrase condition="with_non_root_user_support">, &sssd_user_name;</phrase>
                         </para>
                         <para>
-                            Please note that although the UID 0 is used as the
-                            default it will be overwritten with this option. If
-                            you still want to allow the root user to access the
-                            PAC responder, which would be the typical case, you
-                            have to add 0 to the list of allowed UIDs as well.
+                            Please note that default value will be overwritten
+                            with this option. If you still want to allow the
+                            root user
+                            <phrase condition="with_non_root_user_support"> and &sssd_user_name; user</phrase>
+                            to access the PAC responder, which would be the
+                            typical case, you have to list it explictly.
                         </para>
                     </listitem>
                 </varlistentry>

--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -3948,14 +3948,6 @@ static krb5_error_code privileged_krb5_setup(struct krb5_req *kr,
         }
     }
 
-    if (kr->send_pac) {
-        ret = sss_pac_check_and_open();
-        if (ret != EOK) {
-            DEBUG(SSSDBG_MINOR_FAILURE, "Cannot open the PAC responder socket\n");
-            /* Not fatal */
-        }
-    }
-
     return 0;
 }
 

--- a/src/responder/pac/pacsrv.c
+++ b/src/responder/pac/pacsrv.c
@@ -44,7 +44,7 @@
 
 #define SSS_PAC_PIPE_NAME "pac"
 #define DEFAULT_PAC_FD_LIMIT 8192
-#define DEFAULT_ALLOWED_UIDS "0"
+#define DEFAULT_ALLOWED_UIDS "0,"SSSD_USER
 
 int pac_process_init(TALLOC_CTX *mem_ctx,
                      struct tevent_context *ev,

--- a/src/sss_client/idmap/common_ex.c
+++ b/src/sss_client/idmap/common_ex.c
@@ -28,9 +28,7 @@
 #include "common_private.h"
 
 extern struct sss_mutex sss_nss_mtx;
-#ifdef HAVE_PTHREAD_EXT
 bool sss_is_lockfree_mode(void);
-#endif
 
 #define SEC_FROM_MSEC(ms) ((ms) / 1000)
 #define NSEC_FROM_MSEC(ms) (((ms) % 1000) * 1000 * 1000)
@@ -53,11 +51,9 @@ static int sss_mt_timedlock(struct sss_mutex *m, const struct timespec *endtime)
 {
     int ret;
 
-#ifdef HAVE_PTHREAD_EXT
     if (sss_is_lockfree_mode()) {
         return 0;
     }
-#endif
 
     ret = pthread_mutex_timedlock(&m->mtx, endtime);
     if (ret != 0) {

--- a/src/sss_client/nss_group.c
+++ b/src/sss_client/nss_group.c
@@ -33,11 +33,7 @@
 #include "nss_mc.h"
 #include "nss_common.h"
 
-static
-#ifdef HAVE_PTHREAD_EXT
-__thread
-#endif
-struct sss_nss_getgrent_data {
+static __thread struct sss_nss_getgrent_data {
     size_t len;
     size_t ptr;
     uint8_t *data;

--- a/src/sss_client/nss_hosts.c
+++ b/src/sss_client/nss_hosts.c
@@ -35,11 +35,7 @@
 #include <string.h>
 #include "sss_cli.h"
 
-static
-#ifdef HAVE_PTHREAD_EXT
-__thread
-#endif
-struct sss_nss_gethostent_data {
+static __thread struct sss_nss_gethostent_data {
     size_t len;
     size_t ptr;
     uint8_t *data;

--- a/src/sss_client/nss_ipnetworks.c
+++ b/src/sss_client/nss_ipnetworks.c
@@ -35,11 +35,7 @@
 #include <string.h>
 #include "sss_cli.h"
 
-static
-#ifdef HAVE_PTHREAD_EXT
-__thread
-#endif
-struct sss_nss_getnetent_data {
+static __thread struct sss_nss_getnetent_data {
     size_t len;
     size_t ptr;
     uint8_t *data;

--- a/src/sss_client/nss_passwd.c
+++ b/src/sss_client/nss_passwd.c
@@ -32,11 +32,7 @@
 #include "nss_mc.h"
 #include "nss_common.h"
 
-static
-#ifdef HAVE_PTHREAD_EXT
-__thread
-#endif
-struct sss_nss_getpwent_data {
+static __thread struct sss_nss_getpwent_data {
     size_t len;
     size_t ptr;
     uint8_t *data;

--- a/src/sss_client/nss_services.c
+++ b/src/sss_client/nss_services.c
@@ -33,11 +33,7 @@
 #include <string.h>
 #include "sss_cli.h"
 
-static
-#ifdef HAVE_PTHREAD_EXT
-__thread
-#endif
-struct sss_nss_getservent_data {
+static __thread struct sss_nss_getservent_data {
     size_t len;
     size_t ptr;
     uint8_t *data;

--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -109,22 +109,6 @@ static void free_exp_data(pam_handle_t *pamh, void *ptr, int err)
     free(ptr);
 }
 
-static void close_fd(pam_handle_t *pamh, void *ptr, int err)
-{
-#ifdef PAM_DATA_REPLACE
-    if (err & PAM_DATA_REPLACE) {
-        /* Nothing to do */
-        return;
-    }
-#endif /* PAM_DATA_REPLACE */
-
-    D(("Closing the fd"));
-
-    sss_pam_lock();
-    sss_cli_close_socket();
-    sss_pam_unlock();
-}
-
 struct cert_auth_info {
     char *cert_user;
     char *cert;
@@ -1491,7 +1475,7 @@ static int send_and_receive(pam_handle_t *pamh, struct pam_items *pi,
     errnop = 0;
     ret = sss_pam_make_request(task, &rd, &repbuf, &replen, &errnop);
 
-    sret = pam_set_data(pamh, FD_DESTRUCTOR, NULL, close_fd);
+    sret = pam_set_data(pamh, FD_DESTRUCTOR, NULL, NULL);
     if (sret != PAM_SUCCESS) {
         D(("pam_set_data failed, client might leaks fds"));
     }

--- a/src/sss_client/pam_sss_gss.c
+++ b/src/sss_client/pam_sss_gss.c
@@ -582,7 +582,6 @@ int pam_sm_authenticate(pam_handle_t *pamh,
 
 done:
     sss_pam_lock();
-    sss_cli_close_socket();
     sss_pam_unlock();
     free(username);
     free(domain);

--- a/src/sss_client/sss_cli.h
+++ b/src/sss_client/sss_cli.h
@@ -727,14 +727,6 @@ int sss_pam_make_request(enum sss_cli_command cmd,
                          uint8_t **repbuf, size_t *replen,
                          int *errnop);
 
-void sss_cli_close_socket(void);
-
-/* Checks access to the PAC responder and opens the socket, if available.
- * Required for processes like krb5_child that need to open the socket
- * before dropping privs.
- */
-int sss_pac_check_and_open(void);
-
 int sss_pac_make_request(enum sss_cli_command cmd,
                          struct sss_cli_req_data *rd,
                          uint8_t **repbuf, size_t *replen,


### PR DESCRIPTION
Instead of using thread local storage for socket descriptor (a solution that proved to be quite error prone / fragile) just open/close sockets on the fly (per every transaction).

See https://github.com/SSSD/sssd/pull/6507#issuecomment-1382034629