### PR TITLE
Passkey: Adjust IPA passkey config error log level

### DIFF
--- a/src/providers/ipa/ipa_auth.c
+++ b/src/providers/ipa/ipa_auth.c
@@ -140,6 +140,8 @@ static void get_password_migration_flag_done(struct tevent_req *subreq)
     ret = ipa_get_config_recv(subreq, state, &reply);
     talloc_zfree(subreq);
     if (ret) {
+        DEBUG(SSSDBG_IMPORTANT_INFO, "Unable to retrieve migration flag "
+                                     "from IPA server");
         goto done;
     }
 

--- a/src/providers/ipa/ipa_config.c
+++ b/src/providers/ipa/ipa_config.c
@@ -132,8 +132,8 @@ static void ipa_get_config_done(struct tevent_req *subreq)
     }
 
     if (reply_count != 1) {
-        DEBUG(SSSDBG_OP_FAILURE, "Unexpected number of results, expected 1, "
-                                  "got %zu.\n", reply_count);
+        DEBUG(SSSDBG_MINOR_FAILURE, "Unexpected number of results, expected 1, "
+                                    "got %zu.\n", reply_count);
         ret = EINVAL;
         goto done;
     }

--- a/src/providers/ipa/ipa_selinux.c
+++ b/src/providers/ipa/ipa_selinux.c
@@ -1149,7 +1149,7 @@ static void ipa_get_selinux_config_done(struct tevent_req *subreq)
     ret = ipa_get_config_recv(subreq, state, &state->defaults);
     talloc_free(subreq);
     if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "Could not get IPA config\n");
+        DEBUG(SSSDBG_IMPORTANT_INFO, "Could not get IPA config\n");
         goto done;
     }
 

--- a/src/providers/ipa/ipa_subdomains.c
+++ b/src/providers/ipa/ipa_subdomains.c
@@ -2786,7 +2786,7 @@ static void ipa_subdomains_refresh_passkey_done(struct tevent_req *subreq)
     ret = ipa_subdomains_passkey_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to get passkey configuration "
+        DEBUG(SSSDBG_MINOR_FAILURE, "Unable to get passkey configuration "
               "[%d]: %s\n", ret, sss_strerror(ret));
         /* Not good, but let's try to continue with other server side options */
     }

--- a/src/providers/ipa/ipa_subdomains.c
+++ b/src/providers/ipa/ipa_subdomains.c
@@ -1947,7 +1947,7 @@ static void ipa_domain_resolution_order_done(struct tevent_req *subreq)
     ret = ipa_get_config_recv(subreq, state, &config);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE,
+        DEBUG(SSSDBG_IMPORTANT_INFO,
               "Failed to get the domains' resolution order configuration "
               "from the server [%d]: %s\n",
               ret, sss_strerror(ret));
@@ -1958,7 +1958,7 @@ static void ipa_domain_resolution_order_done(struct tevent_req *subreq)
         ret = sysdb_attrs_get_string(config, IPA_DOMAIN_RESOLUTION_ORDER,
                                      &domain_resolution_order);
         if (ret != EOK && ret != ENOENT) {
-            DEBUG(SSSDBG_OP_FAILURE,
+            DEBUG(SSSDBG_IMPORTANT_INFO,
                   "Failed to get the domains' resolution order configuration "
                   "value [%d]: %s\n",
                   ret, sss_strerror(ret));
@@ -2789,6 +2789,8 @@ static void ipa_subdomains_refresh_passkey_done(struct tevent_req *subreq)
         DEBUG(SSSDBG_MINOR_FAILURE, "Unable to get passkey configuration "
               "[%d]: %s\n", ret, sss_strerror(ret));
         /* Not good, but let's try to continue with other server side options */
+        DEBUG(SSSDBG_IMPORTANT_INFO, "Passkey feature is not configured "
+                                     "on IPA server");
     }
 
     subreq = ipa_subdomains_master_send(state, state->ev, state->sd_ctx,

--- a/src/providers/ipa/ipa_subdomains_passkey.c
+++ b/src/providers/ipa/ipa_subdomains_passkey.c
@@ -94,8 +94,8 @@ void ipa_subdomains_passkey_done(struct tevent_req *subreq)
     ret = ipa_get_config_recv(subreq, state, &config);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "Unable to get data from LDAP [%d]: %s\n",
-                      ret, sss_strerror(ret));
+        DEBUG(SSSDBG_MINOR_FAILURE, "Unable to get data from LDAP [%d]: %s\n",
+                        ret, sss_strerror(ret));
         goto done;
     }
 


### PR DESCRIPTION
IPA passkey configuration may not be retrieved if IPA does not contain passkey support. Lower the error level of log messages associated with this failure.