### PR TITLE
ipa: correctly remove missing attributes on netgroup update

### DIFF
--- a/src/db/sysdb.c
+++ b/src/db/sysdb.c
@@ -523,6 +523,15 @@ static int sysdb_attrs_add_val_int(struct sysdb_attrs *attrs,
 
     return EOK;
 }
+
+int sysdb_attrs_add_empty(struct sysdb_attrs *attrs, const char *name)
+{
+    struct ldb_message_element *el;
+
+    /* Calling this will create the element if it does not exist. */
+    return sysdb_attrs_get_el_ext(attrs, name, true, &el);
+}
+
 int sysdb_attrs_add_val(struct sysdb_attrs *attrs,
                         const char *name, const struct ldb_val *val)
 {

--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -391,6 +391,7 @@ enum sysdb_index_actions {
 extern const char *sysdb_ts_cache_attrs[];
 
 /* values are copied in the structure, allocated on "attrs" */
+int sysdb_attrs_add_empty(struct sysdb_attrs *attrs, const char *name);
 int sysdb_attrs_add_val(struct sysdb_attrs *attrs,
                         const char *name, const struct ldb_val *val);
 int sysdb_attrs_add_val_safe(struct sysdb_attrs *attrs,

--- a/src/tests/system/tests/test_netgroups.py
+++ b/src/tests/system/tests/test_netgroups.py
@@ -1,0 +1,108 @@
+"""
+Netgroup tests.
+
+:requirement: netgroup
+"""
+
+from __future__ import annotations
+
+import pytest
+from sssd_test_framework.roles.client import Client
+from sssd_test_framework.roles.generic import GenericProvider
+from sssd_test_framework.topology import KnownTopologyGroup
+
+
+@pytest.mark.tier(1)
+@pytest.mark.ticket(gh=6652, bz=2162552)
+@pytest.mark.topology(KnownTopologyGroup.AnyProvider)
+def test_netgroups__add_remove_netgroup_triple(client: Client, provider: GenericProvider):
+    """
+    :title: Netgroup triple is correctly removed from cached record
+    :setup:
+        1. Create local user "user-1"
+        2. Create netgroup "ng-1"
+        3. Add "(-,user-1,)" triple to the netgroup
+        4. Start SSSD
+    :steps:
+        1. Run "getent netgroup ng-1"
+        2. Remove "(-,user-1,)" triple from "ng-1"
+        3. Invalidate netgroup in cache "sssctl cache-expire -n ng-1"
+        4. Run "getent netgroup ng-1"
+    :expectedresults:
+        1. "(-,user-1,)" is present in the netgroup
+        2. Triple was removed from the netgroup
+        3. Cached record was invalidated
+        4. "(-,user-1,)" is not present in the netgroup
+    :customerscenario: True
+    """
+    user = provider.user("user-1").add()
+    ng = provider.netgroup("ng-1").add().add_member(user=user)
+
+    client.sssd.start()
+
+    result = client.tools.getent.netgroup("ng-1")
+    assert result is not None
+    assert result.name == "ng-1"
+    assert len(result.members) == 1
+    assert "(-, user-1)" in result.members
+
+    ng.remove_member(user=user)
+    client.sssctl.cache_expire(netgroups=True)
+
+    result = client.tools.getent.netgroup("ng-1")
+    assert result is not None
+    assert result.name == "ng-1"
+    assert len(result.members) == 0
+
+
+@pytest.mark.tier(1)
+@pytest.mark.ticket(gh=6652, bz=2162552)
+@pytest.mark.topology(KnownTopologyGroup.AnyProvider)
+def test_netgroups__add_remove_netgroup_member(client: Client, provider: GenericProvider):
+    """
+    :title: Netgroup member is correctly removed from cached record
+    :setup:
+        1. Create local user "user-1"
+        2. Create local user "user-2"
+        3. Create netgroup "ng-1"
+        4. Create netgroup "ng-2"
+        5. Add "(-,user-1,)" triple to the netgroup "ng-1"
+        6. Add "(-,user-2,)" triple to the netgroup "ng-2"
+        7. Add "ng-1" as a member to "ng-2"
+        8. Start SSSD
+    :steps:
+        1. Run "getent netgroup ng-2"
+        2. Remove "ng-1" from "ng-2"
+        3. Invalidate netgroup "ng-2" in cache "sssctl cache-expire -n ng-2"
+        4. Run "getent netgroup ng-2"
+    :expectedresults:
+        1. "(-,user-1,)", "(-,user-2,)" is present in the netgroup
+        2. Netgroup member was removed from the netgroup
+        3. Cached record was invalidated
+        4. "(-,user-1,)" is not present in the netgroup, only "(-,user-2,)"
+    :customerscenario: True
+    """
+    u1 = provider.user("user-1").add()
+    u2 = provider.user("user-2").add()
+
+    ng1 = provider.netgroup("ng-1").add().add_member(user=u1)
+    ng2 = provider.netgroup("ng-2").add().add_member(user=u2, ng=ng1)
+
+    client.sssd.start()
+
+    result = client.tools.getent.netgroup("ng-2")
+    assert result is not None
+    assert result.name == "ng-2"
+    assert len(result.members) == 2
+    assert "(-, user-1)" in result.members
+    assert "(-, user-2)" in result.members
+
+    ng2.remove_member(ng=ng1)
+    client.sssctl.cache_expire(netgroups=True)
+
+    result = client.tools.getent.netgroup("ng-2")
+    assert result is not None
+    assert result.name == "ng-2"
+    assert len(result.members) == 1
+    assert "(-, user-1)" not in result.members
+    assert "(-, user-2)" in result.members


### PR DESCRIPTION
When a netgroup is updated, previously it did not remove the missing
attributes. This caused an issue especially when a member was removed.

Resolves: https://github.com/SSSD/sssd/issues/6652