### PR TITLE
IPA: Do not try to add duplicate values to the LDAP attributes

### DIFF
--- a/src/providers/ipa/ipa_s2n_exop.c
+++ b/src/providers/ipa/ipa_s2n_exop.c
@@ -663,7 +663,7 @@ static errno_t get_extra_attrs(BerElement *ber, struct resp_attrs *resp_attrs)
                 v.length = values[c]->bv_len;
             }
 
-            ret = sysdb_attrs_add_val(resp_attrs->sysdb_attrs, name, &v);
+            ret = sysdb_attrs_add_val_safe(resp_attrs->sysdb_attrs, name, &v);
             if (ret != EOK) {
                 DEBUG(SSSDBG_OP_FAILURE, "sysdb_attrs_add_val failed.\n");
                 ldap_memfree(name);

--- a/src/providers/ipa/ipa_sudo_conversion.c
+++ b/src/providers/ipa/ipa_sudo_conversion.c
@@ -1082,7 +1082,7 @@ combine_cmdgroups(TALLOC_CTX *mem_ctx,
         }
 
         ret = add_strings_lists(mem_ctx, values, cmdgroup->expanded,
-                                false, discard_const(&values));
+                                false, &values);
         if (ret != EOK) {
             talloc_free(tmp_ctx);
             return NULL;

--- a/src/responder/common/responder_utils.c
+++ b/src/responder/common/responder_utils.c
@@ -110,6 +110,11 @@ const char **parse_attr_list_ex(TALLOC_CTX *mem_ctx, const char *conf_str,
             continue;
         }
 
+        /* If the attribute is already in the list, skip it */
+        if (attr_in_list(list, li, allow[i])) {
+            continue;
+        }
+
         list[li] = talloc_strdup(list, allow[i]);
         if (list[li] == NULL) {
             goto done;
@@ -125,6 +130,11 @@ const char **parse_attr_list_ex(TALLOC_CTX *mem_ctx, const char *conf_str,
         for (i = 0; defaults[i]; i++) {
             /* if the attribute is explicitly denied, skip it */
             if (attr_in_list(deny, di, defaults[i])) {
+                continue;
+            }
+
+            /* If the attribute is already in the list, skip it */
+            if (attr_in_list(list, li, defaults[i])) {
                 continue;
             }
 

--- a/src/responder/common/responder_utils.c
+++ b/src/responder/common/responder_utils.c
@@ -30,15 +30,7 @@
 static inline bool
 attr_in_list(const char **list, size_t nlist, const char *str)
 {
-    size_t i;
-
-    for (i = 0; i < nlist; i++) {
-        if (strcasecmp(list[i], str) == 0) {
-            break;
-        }
-    }
-
-    return (i < nlist) ? true : false;
+    return string_in_list_size(str, list, nlist, false);
 }
 
 const char **parse_attr_list_ex(TALLOC_CTX *mem_ctx, const char *conf_str,

--- a/src/responder/ifp/ifp_cache.c
+++ b/src/responder/ifp/ifp_cache.c
@@ -173,8 +173,7 @@ ifp_cache_list_domains(TALLOC_CTX *mem_ctx,
             goto done;
         }
 
-        ret = add_strings_lists(tmp_ctx, paths, tmp_paths, true,
-                                discard_const(&paths));
+        ret = add_strings_lists(tmp_ctx, paths, tmp_paths, true, &paths);
         if (ret != EOK) {
             DEBUG(SSSDBG_CRIT_FAILURE, "Unable to build object list "
                   "[%d]: %s\n", ret, sss_strerror(ret));

--- a/src/responder/nss/nss_cmd.c
+++ b/src/responder/nss/nss_cmd.c
@@ -1209,38 +1209,21 @@ static errno_t sss_nss_cmd_getorigbyname_common(struct cli_ctx *cli_ctx,
     errno_t ret;
     struct sss_nss_ctx *nss_ctx;
     const char **attrs;
-    static const char *defattrs[] = { SYSDB_NAME, SYSDB_OBJECTCATEGORY,
-                                      SYSDB_SID_STR,
-                                      ORIGINALAD_PREFIX SYSDB_NAME,
-                                      ORIGINALAD_PREFIX SYSDB_UIDNUM,
-                                      ORIGINALAD_PREFIX SYSDB_GIDNUM,
-                                      ORIGINALAD_PREFIX SYSDB_GECOS,
-                                      ORIGINALAD_PREFIX SYSDB_HOMEDIR,
-                                      ORIGINALAD_PREFIX SYSDB_SHELL,
-                                      SYSDB_UPN,
-                                      SYSDB_DEFAULT_OVERRIDE_NAME,
-                                      SYSDB_AD_ACCOUNT_EXPIRES,
-                                      SYSDB_AD_USER_ACCOUNT_CONTROL,
-                                      SYSDB_SSH_PUBKEY,
-                                      SYSDB_USER_CERT,
-                                      SYSDB_USER_EMAIL,
-                                      SYSDB_ORIG_DN,
-                                      SYSDB_ORIG_MEMBEROF,
-                                      SYSDB_DEFAULT_ATTRS, NULL };
+    static const char *cache_attrs[] = { SYSDB_NAME,
+                                         SYSDB_OBJECTCATEGORY,
+                                         SYSDB_SID_STR,
+                                         SYSDB_DEFAULT_ATTRS,
+                                         NULL };
 
     nss_ctx = talloc_get_type(cli_ctx->rctx->pvt_ctx, struct sss_nss_ctx);
 
-    if (nss_ctx->extra_attributes != NULL) {
-        ret = add_strings_lists(cli_ctx, defattrs, nss_ctx->extra_attributes,
-                                false, discard_const(&attrs));
-        if (ret != EOK) {
-            DEBUG(SSSDBG_OP_FAILURE,
-                  "Unable to concatenate attributes [%d]: %s\n",
-                  ret, sss_strerror(ret));
-            return ENOMEM;
-        }
-    } else {
-        attrs = defattrs;
+    ret = add_strings_lists_ex(cli_ctx, cache_attrs, nss_ctx->full_attribute_list,
+                               false, true, &attrs);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Unable to concatenate attributes [%d]: %s\n",
+              ret, sss_strerror(ret));
+        return ENOMEM;
     }
 
     return sss_nss_getby_name(cli_ctx, false, type, attrs,

--- a/src/responder/nss/nss_private.h
+++ b/src/responder/nss/nss_private.h
@@ -78,6 +78,7 @@ struct sss_nss_ctx {
     char *fallback_homedir;
     char *homedir_substr;
     const char **extra_attributes;
+    const char **full_attribute_list;
 
     /* Enumeration. */
     struct sss_nss_enum_ctx *pwent;

--- a/src/responder/nss/nsssrv.c
+++ b/src/responder/nss/nsssrv.c
@@ -175,6 +175,23 @@ static int sss_nss_get_config(struct sss_nss_ctx *nctx,
 {
     int ret;
     char *tmp_str;
+    static const char *orig_attrs[] = { SYSDB_SID_STR,
+                                        ORIGINALAD_PREFIX SYSDB_NAME,
+                                        ORIGINALAD_PREFIX SYSDB_UIDNUM,
+                                        ORIGINALAD_PREFIX SYSDB_GIDNUM,
+                                        ORIGINALAD_PREFIX SYSDB_HOMEDIR,
+                                        ORIGINALAD_PREFIX SYSDB_GECOS,
+                                        ORIGINALAD_PREFIX SYSDB_SHELL,
+                                        SYSDB_UPN,
+                                        SYSDB_DEFAULT_OVERRIDE_NAME,
+                                        SYSDB_AD_ACCOUNT_EXPIRES,
+                                        SYSDB_AD_USER_ACCOUNT_CONTROL,
+                                        SYSDB_SSH_PUBKEY,
+                                        SYSDB_USER_CERT,
+                                        SYSDB_USER_EMAIL,
+                                        SYSDB_ORIG_DN,
+                                        SYSDB_ORIG_MEMBEROF,
+                                        NULL };
 
     ret = confdb_get_int(cdb, CONFDB_NSS_CONF_ENTRY,
                          CONFDB_NSS_ENUM_CACHE_TIMEOUT, 120,
@@ -241,6 +258,13 @@ static int sss_nss_get_config(struct sss_nss_ctx *nctx,
             ret = ENOMEM;
             goto done;
         }
+    }
+
+    ret = add_strings_lists_ex(nctx, nctx->extra_attributes, orig_attrs, false,
+                               true, &nctx->full_attribute_list);
+    if (ret != EOK) {
+        ret = ENOMEM;
+        goto done;
     }
 
     ret = 0;

--- a/src/tests/cmocka/test_pam_srv.c
+++ b/src/tests/cmocka/test_pam_srv.c
@@ -4418,6 +4418,7 @@ int main(int argc, const char *argv[])
 {
     poptContext pc;
     int opt;
+    int res;
     const char *single = NULL;
     struct poptOption long_options[] = {
         POPT_AUTOHELP
@@ -4682,8 +4683,6 @@ int main(int argc, const char *argv[])
         return 1;
     }
 
-    poptFreeContext(pc);
-
     DEBUG_CLI_INIT(debug_level);
 
     /* Even though normally the tests should clean up after themselves
@@ -4691,7 +4690,8 @@ int main(int argc, const char *argv[])
     tests_set_cwd();
     test_dom_suite_cleanup(TESTS_PATH, TEST_CONF_DB, TEST_DOM_NAME);
 
-    return sss_cmocka_run_group_tests(tests, sizeof(tests)/sizeof(tests[0]),
-                                      single);
-
+    res = sss_cmocka_run_group_tests(tests, sizeof(tests)/sizeof(tests[0]),
+                                     single);
+    poptFreeContext(pc);
+    return res;
 }

--- a/src/tests/util-tests.c
+++ b/src/tests/util-tests.c
@@ -105,7 +105,7 @@ START_TEST(test_string_in_list)
     ck_assert_msg(!is_in, "String is in empty list.");
 
     is_in = string_in_list("ABC", list, false);
-    ck_assert_msg(is_in, "String is not list.");
+    ck_assert_msg(is_in, "String is not in list.");
 
     is_in = string_in_list("abc", list, false);
     ck_assert_msg(is_in, "String is not case in-sensitive list.");
@@ -116,6 +116,48 @@ START_TEST(test_string_in_list)
     is_in = string_in_list("123", list, false);
     ck_assert_msg(!is_in, "Wrong string found in list.");
 
+}
+END_TEST
+
+START_TEST(test_string_in_list_size)
+{
+    bool is_in;
+    const char *empty_list[] = {};
+    size_t empty_list_size = 0;
+    const char *list[] = {discard_const("ABC"),
+                          discard_const("DEF"),
+                          discard_const("GHI")};
+    size_t list_size = sizeof(list) / sizeof(list[0]);
+
+    is_in = string_in_list_size(NULL, NULL, 0, false);
+    ck_assert_msg(!is_in, "NULL string is in NULL list.");
+
+    is_in = string_in_list_size(NULL, empty_list, empty_list_size, false);
+    ck_assert_msg(!is_in, "NULL string is in empty list.");
+
+    is_in = string_in_list_size(NULL, list, list_size, false);
+    ck_assert_msg(!is_in, "NULL string is in list.");
+
+    is_in = string_in_list_size("ABC", NULL, 0, false);
+    ck_assert_msg(!is_in, "String is in NULL list.");
+
+    is_in = string_in_list_size("ABC", empty_list, empty_list_size, false);
+    ck_assert_msg(!is_in, "String is in empty list.");
+
+    is_in = string_in_list_size("ABC", list, list_size, false);
+    ck_assert_msg(is_in, "String is not in list.");
+
+    is_in = string_in_list_size("abc", list, list_size, false);
+    ck_assert_msg(is_in, "String is not case in-sensitive list.");
+
+    is_in = string_in_list_size("abc", list, list_size, true);
+    ck_assert_msg(!is_in, "Wrong string found in case sensitive list.");
+
+    is_in = string_in_list_size("123", list, list_size, false);
+    ck_assert_msg(!is_in, "Wrong string found in list.");
+
+    is_in = string_in_list_size("GHI", list, list_size - 1, false);
+    ck_assert_msg(!is_in, "Size limit not respected.");
 }
 END_TEST
 
@@ -1121,6 +1163,7 @@ Suite *util_suite(void)
     tcase_add_test (tc_util, test_parse_args);
     tcase_add_test (tc_util, test_add_string_to_list);
     tcase_add_test (tc_util, test_string_in_list);
+    tcase_add_test (tc_util, test_string_in_list_size);
     tcase_add_test (tc_util, test_split_on_separator);
     tcase_add_test (tc_util, test_check_ipv4_addr);
     tcase_add_test (tc_util, test_check_ipv6_addr);

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -434,12 +434,30 @@ bool is_dbus_activated(void);
  * @param[in] copy_strings If set to 'true' the list items will be copied
  *                         otherwise only the pointers to the items are
  *                         copied.
+ * @param[in] skip_dups    Whether the function should skip duplicate values.
  * @param[out] new_list    New NULL-terminated list of strings. Must be freed
  *                         with talloc_free() by the caller. If copy_strings
  *                         is 'true' the new elements will be freed as well.
  */
-errno_t add_strings_lists(TALLOC_CTX *mem_ctx, const char **l1, const char **l2,
-                          bool copy_strings, char ***_new_list);
+errno_t add_strings_lists_ex(TALLOC_CTX *mem_ctx,
+                             const char **l1, const char **l2,
+                             bool copy_strings, bool skip_dups,
+                             const char ***_new_list);
+
+/**
+ * @overload errno_t add_strings_lists_ex(TALLOC_CTX *mem_ctx,
+ *                                        const char **l1, const char **l2,
+ *                                        bool copy_strings, bool skip_dups,
+ *                                        const char ***_new_list)
+ */
+static inline errno_t add_strings_lists(TALLOC_CTX *mem_ctx,
+                                        const char **l1, const char **l2,
+                                        bool copy_strings,
+                                        const char ***_new_list)
+{
+    return add_strings_lists_ex(mem_ctx, l1, l2, copy_strings, false, _new_list);
+}
+
 
 /**
  * @brief set file descriptor as nonblocking

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -532,6 +532,9 @@ errno_t del_string_from_list(const char *string,
 
 bool string_in_list(const char *string, char **list, bool case_sensitive);
 
+bool string_in_list_size(const char *string, const char **list, size_t size,
+                         bool case_sensitive);
+
 int domain_to_basedn(TALLOC_CTX *memctx, const char *domain, char **basedn);
 
 bool is_host_in_domain(const char *host, const char *domain);

--- a/src/util/util_ext.c
+++ b/src/util/util_ext.c
@@ -147,6 +147,27 @@ bool string_in_list(const char *string, char **list, bool case_sensitive)
     return false;
 }
 
+bool string_in_list_size(const char *string, const char **list, size_t size,
+                         bool case_sensitive)
+{
+    size_t c;
+    int(*compare)(const char *s1, const char *s2);
+
+    if (string == NULL || list == NULL || size == 0) {
+        return false;
+    }
+
+    compare = case_sensitive ? strcmp : strcasecmp;
+
+    for (c = 0; c < size; c++) {
+        if (compare(string, list[c]) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 errno_t sss_filter_sanitize_ex(TALLOC_CTX *mem_ctx,
                                const char *input,
                                char **sanitized,


### PR DESCRIPTION
This PR include does 3 things:

1.  When using extra attributes, an attribute could be listed twice and SSSD will try to add it twice to the cache. To handle this situation, each instance will be added to a single attribute with multiple values, but duplicated values will be dropped. This is done by calling `sysdb_attrs_add_val_safe()` instead of `sysdb_attrs_add_val()`.
2. The `extra_attributes` are concatenated to other required attributes for some operations. In some cases the attribute list has duplicate attributes. Extra attributes are now concatenated to the required attributes at start up, checking that no duplicate value is added, and thus prevent the concatenation (and checking) from happening for every operation. The list is kept in the new `full_attribute_list` field.
    An existing test suite was adapted to this new situation as it now needs to initialize the new field.
3. The test suite `pam-srv-tests` accepts a test name as the last argument to just run that test. However, this was failing because a pointer to the name is retrieved but the `poptContext` is freed immediately after, making the pointer invalid. The `poptContext` is now released after using the pointer. 


