### PR TITLE
Tests: Adding c-ares markers for related tests

### DIFF
--- a/src/tests/multihost/ad/pytest.ini
+++ b/src/tests/multihost/ad/pytest.ini
@@ -5,6 +5,7 @@ markers =
    adloginattr: Tests for AD login attributes
    admisc: Miscellaneous bugzilla automations for AD
    automount: Automount test cases with maps stored in AD schema
+   c_ares: Tests for C-ares library
    cifs: Cifs test cases
    converted: Tests that are already converted to the new framework.
    ad_access_control: Test for AD Access Control

--- a/src/tests/multihost/ad/test_adparameters_ported.py
+++ b/src/tests/multihost/ad/test_adparameters_ported.py
@@ -749,6 +749,7 @@ class TestADParamsPorted:
 
     @staticmethod
     @pytest.mark.tier1_2
+    @pytest.mark.c_ares
     def test_0009_ad_parameters_ldap_sasl_full(
             multihost, create_aduser_group):
         """
@@ -833,6 +834,7 @@ class TestADParamsPorted:
 
     @staticmethod
     @pytest.mark.tier2
+    @pytest.mark.c_ares
     def test_0010_ad_parameters_ldap_sasl_short(
             multihost, create_aduser_group):
         """
@@ -919,6 +921,7 @@ class TestADParamsPorted:
 
     @staticmethod
     @pytest.mark.tier1_2
+    @pytest.mark.c_ares
     def test_0011_ad_parameters_server_resolvable(
             multihost, adjoin, create_aduser_group):
         """
@@ -998,6 +1001,7 @@ class TestADParamsPorted:
 
     @staticmethod
     @pytest.mark.tier2
+    @pytest.mark.c_ares
     def test_0012_ad_parameters_server_unresolvable(
             multihost, adjoin, create_aduser_group):
         """
@@ -1051,6 +1055,7 @@ class TestADParamsPorted:
 
     @staticmethod
     @pytest.mark.tier1_2
+    @pytest.mark.c_ares
     def test_0013_ad_parameters_server_srv_record(
             multihost, adjoin, create_aduser_group):
         """
@@ -1110,6 +1115,7 @@ class TestADParamsPorted:
 
     @staticmethod
     @pytest.mark.tier1_2
+    @pytest.mark.c_ares
     def test_0014_ad_parameters_server_blank(
             multihost, adjoin, create_aduser_group):
         """
@@ -1257,6 +1263,7 @@ class TestADParamsPorted:
 
     @staticmethod
     @pytest.mark.tier1_2
+    @pytest.mark.c_ares
     def test_0016_ad_parameters_ad_hostname_valid(
             multihost, adjoin, create_aduser_group):
         """
@@ -2045,6 +2052,7 @@ class TestADParamsPorted:
 
     @staticmethod
     @pytest.mark.tier2
+    @pytest.mark.c_ares
     def test_0026_ad_parameters_dns_failover(
             multihost, adjoin, create_plain_aduser_group):
         """

--- a/src/tests/multihost/ad/test_dyndns.py
+++ b/src/tests/multihost/ad/test_dyndns.py
@@ -98,6 +98,7 @@ def extra_interface(session_multihost, request):
 @pytest.mark.usefixtures("reverse_zone", "disable_dns_forwarders", "change_client_hostname")
 @pytest.mark.dyndns
 @pytest.mark.tier2
+@pytest.mark.c_ares
 class TestDynDns(object):
 
     @staticmethod

--- a/src/tests/multihost/adsites/test_adsites.py
+++ b/src/tests/multihost/adsites/test_adsites.py
@@ -16,6 +16,7 @@ class Testadsites(object):
     3. Create secondary site, move second domain controller to second site
     """
     @pytest.mark.adsites
+    @pytest.mark.c_ares
     def test_001_ad_startup_discovery(self, multihost, adjoin):
         """
         @Title: IDM-SSSD-TC: ad_startup_discovery
@@ -69,6 +70,7 @@ class Testadsites(object):
         assert check_discovery.returncode == 0
 
     @pytest.mark.adsites
+    @pytest.mark.c_ares
     def test_002_ad_startup_discovery_one_server_unreachable(self, multihost,
                                                              adjoin):
         """
@@ -137,6 +139,7 @@ class Testadsites(object):
         multihost.client[0].run_command(fw_remove, raiseonerr=True)
 
     @pytest.mark.adsites
+    @pytest.mark.c_ares
     def test_003_ad_startup_discovery_two_different_sites(self, multihost,
                                                           adjoin, create_site):
         """
@@ -189,6 +192,7 @@ class Testadsites(object):
         assert check_discovery.returncode == 0
 
     @pytest.mark.adsites
+    @pytest.mark.c_ares
     def test_004_ad_startup_discovery_one_server_unreachable(self,
                                                              multihost,
                                                              adjoin,


### PR DESCRIPTION
Adding markers for the tests which have been recognized as c-ares related. These markers will be used for gating pipelines