### PR TITLE
ad: use sAMAccountName to lookup hosts

### DIFF
--- a/src/providers/ad/ad_gpo.c
+++ b/src/providers/ad/ad_gpo.c
@@ -59,6 +59,7 @@
 
 #define AD_AT_DN "distinguishedName"
 #define AD_AT_UAC "userAccountControl"
+#define AD_AT_SAMACCOUNTNAME "sAMAccountName"
 #define AD_AT_CONFIG_NC "configurationNamingContext"
 #define AD_AT_GPLINK "gPLink"
 #define AD_AT_GPOPTIONS "gpOptions"
@@ -2061,7 +2062,7 @@ ad_gpo_connect_done(struct tevent_req *subreq)
     filter = talloc_asprintf(state,
                              "(&(objectclass=%s)(%s=%s))",
                              state->opts->user_map[SDAP_OC_USER].name,
-                             state->opts->user_map[SDAP_AT_USER_NAME].name,
+                             AD_AT_SAMACCOUNTNAME,
                              sam_account_name);
     if (filter == NULL) {
         ret = ENOMEM;


### PR DESCRIPTION
To determine which GPOs apply to the host running SSSD the full DN of
the host object in AD is needed. To fine this object we use the NetBIOS
name of the host which is stored in AD in the sAMAccountName attribute.
Using other attributes, e.g. if ldap_user_name is set to a different
attribute, will most probably cause a failure since those attributes are
not managed as expected for host object. As a result sAMAccountName
should be hardcoded here to avoid issues.

Resolves: https://github.com/SSSD/sssd/issues/6766