### PR TITLE
ci: enable pytest-mh ssh debugging if set in repository variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,53 +8,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    container: quay.io/sssd/ci-client-devel:latest
-    permissions:
-      contents: read
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-
-    - name: Install dependencies
-      id: dependencies
-      uses: ./.github/actions/install-dependencies
-
-    - name: Configure sssd
-      uses: ./.github/actions/configure
-
-    - name: make
-      shell: bash
-      working-directory: x86_64
-      run: |
-        source ../contrib/fedora/bashrc_sssd
-        make CFLAGS+="$SSS_WARNINGS -Werror -Wno-error=deprecated-declarations"
-
-    - name: make check
-      shell: bash
-      working-directory: x86_64
-      run: |
-        source ../contrib/fedora/bashrc_sssd
-        make CFLAGS+="$SSS_WARNINGS -Werror -Wno-error=deprecated-declarations" check
-
-    - name: make distcheck
-      shell: bash
-      working-directory: x86_64
-      run: |
-        source ../contrib/fedora/bashrc_sssd
-        make distcheck
-
-    - uses: actions/upload-artifact@v3
-      if: always()
-      with:
-        name: build
-        path: |
-          x86_64/config.log
-          x86_64/config.h
-          x86_64/test-suite.log
-        if-no-files-found: ignore
-
   prepare:
     runs-on: ubuntu-latest
     permissions:
@@ -69,186 +22,8 @@ jobs:
       id: matrix
       run: ./contrib/ci/get-matrix.py --action
 
-  intgcheck:
-    needs: [prepare, build]
-    strategy:
-      fail-fast: false
-      matrix:
-        tag: ${{ fromJson(needs.prepare.outputs.matrix).intgcheck }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        path: sssd
-
-    - name: Setup containers
-      uses: SSSD/sssd-ci-containers/actions/setup@master
-      with:
-        path: sssd-ci-containers
-        tag: ${{ matrix.tag }}
-        limit: dns client
-        override: |
-          services:
-            client:
-              image: ${REGISTRY}/ci-client-devel:${TAG}
-              volumes:
-              - ../sssd:/sssd:rw
-
-    - name: Run integration tests
-      uses: SSSD/sssd-ci-containers/actions/exec@master
-      with:
-        working-directory: /sssd
-        script: ./contrib/ci/run --moderate
-
-    - name: Print logs
-      uses: next-actions/print-logs@master
-      if: always()
-      with:
-        working-directory: ./sssd/ci-build-debug
-        files: |
-          test-suite.log
-          ci-make-intgcheck.log
-          ci-make-distcheck.log
-
-    - name: Upload main artifacts
-      if: always()
-      uses: actions/upload-artifact@v3
-      with:
-        if-no-files-found: ignore
-        name: ${{ matrix.tag }}-intgcheck
-        path: |
-          ./sssd/*.log
-          ./sssd/ci-build-debug/ci-*.log
-          ./sssd/ci-build-debug/test-suite.log
-          ./sssd/ci-build-debug/ci-mock-result/*.log
-
-    - name: Upload valgrind artifacts
-      if: always()
-      uses: actions/upload-artifact@v3
-      with:
-        if-no-files-found: ignore
-        name: ${{ matrix.tag }}-intgcheck-valgrind
-        path: |
-          ./sssd/ci-build-debug/*.valgrind.log
-
-  multihost:
-    needs: [prepare, build]
-    strategy:
-      fail-fast: false
-      matrix:
-        tag: ${{ fromJson(needs.prepare.outputs.matrix).multihost }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-    - name: Checkout sssd repository
-      uses: actions/checkout@v3
-      with:
-        path: sssd
-
-    - name: Setup containers
-      uses: SSSD/sssd-ci-containers/actions/setup@master
-      with:
-        path: sssd-ci-containers
-        tag: ${{ matrix.tag }}
-        limit: dns client
-        override: |
-          services:
-            client:
-              image: ${REGISTRY}/ci-client-devel:${TAG}
-              shm_size: 4G
-              tmpfs:
-              - /dev/shm
-              volumes:
-              - ../sssd:/sssd:rw
-
-    - name: Build SSSD on the client
-      uses: SSSD/sssd-ci-containers/actions/exec@master
-      with:
-        log-file: multihost-build.log
-        working-directory: /sssd
-        script: |
-          #!/bin/bash
-          set -ex
-
-          ./contrib/ci/run --deps-only
-          autoreconf -if
-
-          mkdir -p /dev/shm/sssd
-          pushd /dev/shm/sssd
-          /sssd/configure --enable-silent-rules
-          make rpms
-
-    - name: Install SSSD on the client
-      uses: SSSD/sssd-ci-containers/actions/exec@master
-      with:
-        log-file: multihost-install.log
-        user: root
-        script: |
-          #!/bin/bash
-          set -ex
-
-          dnf remove -y --noautoremove sssd\*
-          dnf install -y /dev/shm/sssd/rpmbuild/RPMS/*/*.rpm
-          rm -fr /dev/shm/sssd
-
-    - name: Install multihost tests dependencies
-      shell: bash
-      run: |
-        set -ex
-
-        sudo apt-get update
-
-        # Install certutil and dependencies for python-ldap
-        sudo apt-get install -y libnss3-tools libsasl2-dev python3-dev libldap2-dev libssl-dev
-
-        # Virtualenv
-        pip3 install virtualenv
-        python3 -m venv .venv
-        source .venv/bin/activate
-
-        # Install multihost tests requirements
-        pip3 install -r ./sssd/src/tests/multihost/requirements.txt
-
-    - name: Create multihost configuration
-      uses: DamianReeves/write-file-action@41569a7dac64c252caacca7bceefe28b70b38db1
-      with:
-        path: mhc.yml
-        write-mode: overwrite
-        contents: |
-          root_password: 'Secret123'
-          domains:
-          - name: tier0.tests
-            type: sssd
-            hosts:
-            - name: client
-              external_hostname: client.test
-              role: master
-
-    - name: Run basic multihost tests
-      run: |
-        set -ex -o pipefail
-
-        source .venv/bin/activate
-        pytest -s --multihost-config=./mhc.yml ./sssd/src/tests/multihost/basic |& tee multihost-pytest.log
-
-    - name: Upload artifacts
-      if: always()
-      uses: actions/upload-artifact@v3
-      with:
-        if-no-files-found: ignore
-        name: ${{ matrix.tag }}-multihost
-        path: |
-          sssd/ci-install-deps.log
-          multihost-build.log
-          multihost-install.log
-          multihost-pytest.log
-
   system:
-    needs: [prepare, build]
+    needs: [prepare]
     strategy:
       fail-fast: false
       matrix:
@@ -342,13 +117,11 @@ jobs:
     - name: Run tests
       shell: bash
       working-directory: ./sssd/src/tests/system
-      env:
-        MH_SSH_DEBUG: ${{ vars.MH_SSH_DEBUG }}
       run: |
         set -ex -o pipefail
 
         source .venv/bin/activate
-        pytest \
+        MH_SSH_DEBUG=yes pytest \
           --color=yes \
           --mh-config=./mhc.yaml \
           --mh-log-path=$GITHUB_WORKSPACE/mh.log \
@@ -368,17 +141,3 @@ jobs:
           build.log
           install.log
           pytest.log
-
-  result:
-    name: All tests are successful
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    needs: [build, intgcheck, multihost, system]
-    steps:
-      - name: Fail on failure
-        if: |
-          needs.build.result != 'success'
-          || needs.intgcheck.result != 'success'
-          || needs.multihost.result != 'success'
-          || needs.system.result != 'success'
-        run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,8 @@ jobs:
     - name: Run tests
       shell: bash
       working-directory: ./sssd/src/tests/system
+      env:
+        MH_SSH_DEBUG: ${{ vars.MH_SSH_DEBUG }}
       run: |
         set -ex -o pipefail
 


### PR DESCRIPTION
pytest-mh now supports `MH_SSH_DEBUG=yes` which fully logs any SSH
command even if its log level is set to error-only.

This may be useful to debug locally unreproducible issues in low
level code. To enable it, set `MH_SSH_DEBUG=yes` in repository settings:

https://docs.github.com/en/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository

---

There is an issue in PR CI that occurs randomly only on fedora-38
and fedora-39. I was not able to reproduce it locally, nor in github
actions environment on my own fork. This patch allows us to temporarily
enable additional debugging.