### PR TITLE
Tests: Install dependent package for tc command

### DIFF
--- a/src/tests/multihost/sssd/testlib/common/utils.py
+++ b/src/tests/multihost/sssd/testlib/common/utils.py
@@ -81,7 +81,7 @@ class sssdTools(object):
                'samba-winbind-clients autofs nfs-utils authconfig '\
                'authselect cifs-utils openldap-clients firewalld '\
                'tcpdump wireshark-cli expect rsyslog gcc gcc-c++ pam-devel '\
-               'tdb-tools libkcapi-hmaccalc strace iproute-tc'
+               'tdb-tools libkcapi-hmaccalc strace iproute-tc kernel-modules-extra'
         sssd_pkgs = 'sssd sssd-tools sssd-proxy sssd-winbind-idmap '\
                     'libsss_autofs sssd-kcm sssd-dbus'
         extra_pkg = ' nss-pam-ldapd krb5-pkinit'


### PR DESCRIPTION
Adding kernel-modules-extra package. the tc command requires this for its operation to add latency