### PR TITLE
sbus: arm watchdog for sbus_connect_init_send()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4672,7 +4672,6 @@ krb5_child_LDADD = \
     $(CLIENT_LIBS) \
     $(SYSTEMD_LOGIN_LIBS) \
     $(JANSSON_LIBS) \
-    libsss_sbus.la \
     $(NULL)
 
 ldap_child_SOURCES = \

--- a/src/sbus/connection/sbus_connection_connect.c
+++ b/src/sbus/connection/sbus_connection_connect.c
@@ -67,6 +67,8 @@ sbus_connect_init_send(TALLOC_CTX *mem_ctx,
 
     tevent_req_set_callback(subreq, sbus_connect_init_hello_done, req);
 
+    arm_watchdog();
+
     return req;
 }
 
@@ -110,6 +112,8 @@ static void sbus_connect_init_done(struct tevent_req *subreq)
     struct tevent_req *req;
     uint32_t res;
     errno_t ret;
+
+    disarm_watchdog();
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
 

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -791,6 +791,18 @@ int setup_watchdog(struct tevent_context *ev, int interval);
 void teardown_watchdog(void);
 int get_watchdog_ticks(void);
 
+/* The arm_watchdog() and disarm_watchdog() calls will disable and re-enable
+ * the watchdog reset, respectively. This means that after arm_watchdog() is
+ * called the watchdog will not be resetted anymore and it will kill the
+ * process if disarm_watchdog() wasn't called before.
+ * Those calls should only be used when there is no other way to handle
+ * waiting request and recover into a stable state.
+ * Those calls cannot be nested, i.e. after calling arm_watchdog() it should
+ * not be called a second time in a different request because then
+ * disarm_watchdog() will disable the watchdog coverage for both. */
+void arm_watchdog(void);
+void disarm_watchdog(void);
+
 /* from files.c */
 int sss_remove_tree(const char *root);
 int sss_remove_subtree(const char *root);

--- a/src/util/util_watchdog.c
+++ b/src/util/util_watchdog.c
@@ -40,6 +40,7 @@ struct watchdog_ctx {
     time_t timestamp;
     struct tevent_fd *tfd;
     int pipefd[2];
+    bool armed; /* if 'true' ticks counter will not be reset */
 } watchdog_ctx;
 
 static void watchdog_detect_timeshift(void)
@@ -89,8 +90,13 @@ static void watchdog_event_handler(struct tevent_context *ev,
                                    struct timeval current_time,
                                    void *private_data)
 {
-    /* first thing reset the watchdog ticks */
-    watchdog_reset();
+    if (!watchdog_ctx.armed) {
+        /* first thing reset the watchdog ticks */
+        watchdog_reset();
+    } else {
+        DEBUG(SSSDBG_IMPORTANT_INFO,
+              "Watchdog armed, process might be terminated soon.\n");
+    }
 
     /* then set a new watchodg event */
     watchdog_ctx.te = tevent_add_timer(ev, ev,
@@ -197,6 +203,7 @@ int setup_watchdog(struct tevent_context *ev, int interval)
     watchdog_ctx.ev = ev;
     watchdog_ctx.input_interval = interval;
     watchdog_ctx.timestamp = time(NULL);
+    watchdog_ctx.armed = false;
 
     ret = pipe(watchdog_ctx.pipefd);
     if (ret == -1) {
@@ -263,4 +270,21 @@ void teardown_watchdog(void)
 int get_watchdog_ticks(void)
 {
     return __sync_add_and_fetch(&watchdog_ctx.ticks, 0);
+}
+
+void arm_watchdog(void)
+{
+    if (watchdog_ctx.armed) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "arm_watchdog() is called although the watchdog is already armed. "
+              "This indicates a programming error and should be avoided because "
+              "it will most probably not work as expected.\n");
+    }
+
+    watchdog_ctx.armed = true;
+}
+
+void disarm_watchdog(void)
+{
+    watchdog_ctx.armed = false;
 }


### PR DESCRIPTION
There seem to be conditions where the reply in the 
sbus_call_DBus_Hello_send() request gets lost and the backend cannot 
properly initialize its sbus/DBus server. Since the backend cannot be 
connected by the frontends in this state the best way to recover would be a
restart. Since the event-loop is active in this state, e.g. waiting for the
reply, the watchdog will not consider the process as hung and will not
restart the process.

To make the watchdog handle this case arm_watchdog() and disarm_watchdog()
are called before and after the request, respectively.

Resolves: https://github.com/SSSD/sssd/issues/XXXX