### PR TITLE
Fix typo: found => find

### DIFF
--- a/src/providers/proxy/proxy_auth.c
+++ b/src/providers/proxy/proxy_auth.c
@@ -454,7 +454,7 @@ static void proxy_child_sig_handler(struct tevent_context *ev,
               "waitpid failed [%d][%s].\n", ret, strerror(ret));
     } else if (ret == 0) {
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "waitpid did not found a child with changed status.\n");
+              "waitpid did not find a child with changed status.\n");
     } else {
         if (WIFEXITED(child_status)) {
             DEBUG(SSSDBG_CONF_SETTINGS,

--- a/src/util/child_common.c
+++ b/src/util/child_common.c
@@ -638,7 +638,7 @@ static void child_sig_handler(struct tevent_context *ev,
               "waitpid failed [%d][%s].\n", err, strerror(err));
     } else if (ret == 0) {
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "waitpid did not found a child with changed status.\n");
+              "waitpid did not find a child with changed status.\n");
     } else {
         if (WIFEXITED(child_ctx->child_status)) {
             if (WEXITSTATUS(child_ctx->child_status) != 0) {


### PR DESCRIPTION
Fix typo in error message:
"waitpid did not found" => "waitpid did not find"