### PR TITLE
certmap: fix partial string comparison

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2512,6 +2512,7 @@ test_sbus_message_LDADD = \
     libsss_debug.la \
     libsss_test_common.la \
     libsss_sbus.la \
+    $(SSSD_INTERNAL_LTLIBS) \
     $(NULL)
 
 test_sbus_opath_SOURCES = \
@@ -2525,6 +2526,7 @@ test_sbus_opath_LDADD = \
     libsss_debug.la \
     libsss_test_common.la \
     libsss_sbus.la \
+    $(SSSD_INTERNAL_LTLIBS) \
     $(NULL)
 
 if HAVE_CMOCKA

--- a/src/lib/certmap/sss_certmap_ldap_mapping.c
+++ b/src/lib/certmap/sss_certmap_ldap_mapping.c
@@ -228,14 +228,21 @@ int check_digest_conversion(const char *inp, const char **digest_list,
     bool colon = false;
     bool reverse = false;
     char *c;
+    size_t len = 0;
 
     sep = strchr(inp, '_');
+    if (sep != NULL) {
+        len = sep - inp;
+    }
 
     for (d = 0; digest_list[d] != NULL; d++) {
         if (sep == NULL) {
             cmp = strcasecmp(digest_list[d], inp);
         } else {
-            cmp = strncasecmp(digest_list[d], inp, (sep - inp -1));
+            if (strlen(digest_list[d]) != len) {
+                continue;
+            }
+            cmp = strncasecmp(digest_list[d], inp, len);
         }
 
         if (cmp == 0) {

--- a/src/tests/cmocka/test_certmap.c
+++ b/src/tests/cmocka/test_certmap.c
@@ -2183,6 +2183,28 @@ static void test_sss_certmap_ldapu1_cert(void **state)
     assert_non_null(ctx);
     assert_null(ctx->prio_list);
 
+    /* cert!sha */
+    ret = sss_certmap_add_rule(ctx, 91,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule91={cert!sha}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 91,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule91={cert!sha}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    /* cert!sha_u */
+    ret = sss_certmap_add_rule(ctx, 90,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule90={cert!sha_u}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 99,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule90={cert!sha_u}", NULL);
+    assert_int_equal(ret, EINVAL);
+
     /* cert!sha555 */
     ret = sss_certmap_add_rule(ctx, 89,
                             "KRB5:<ISSUER>.*",

--- a/src/tools/sssctl/sssctl.c
+++ b/src/tools/sssctl/sssctl.c
@@ -340,9 +340,9 @@ int main(int argc, const char **argv)
         SSS_TOOL_COMMAND_FLAGS("config-check", "Perform static analysis of SSSD configuration", 0, sssctl_config_check, SSS_TOOL_FLAG_SKIP_CMD_INIT),
 #endif
         SSS_TOOL_DELIMITER("Certificate related tools:"),
-        SSS_TOOL_COMMAND("cert-show", "Print information about the certificate", 0, sssctl_cert_show),
+        SSS_TOOL_COMMAND_FLAGS("cert-show", "Print information about the certificate", 0, sssctl_cert_show, SSS_TOOL_FLAG_SKIP_CMD_INIT|SSS_TOOL_FLAG_SKIP_ROOT_CHECK),
         SSS_TOOL_COMMAND("cert-map", "Show users mapped to the certificate", 0, sssctl_cert_map),
-        SSS_TOOL_COMMAND("cert-eval-rule", "Check mapping and matching rule with a certificate", 0, sssctl_cert_eval_rule),
+        SSS_TOOL_COMMAND_FLAGS("cert-eval-rule", "Check mapping and matching rule with a certificate", 0, sssctl_cert_eval_rule, SSS_TOOL_FLAG_SKIP_CMD_INIT|SSS_TOOL_FLAG_SKIP_ROOT_CHECK),
 #ifdef BUILD_PASSKEY
         SSS_TOOL_DELIMITER("Passkey related tools:"),
         SSS_TOOL_COMMAND_FLAGS("passkey-register", "Perform passkey registration", 0, sssctl_passkey_register, SSS_TOOL_FLAG_SKIP_CMD_INIT|SSS_TOOL_FLAG_SKIP_ROOT_CHECK),


### PR DESCRIPTION
If the formatting option of the certificate digest/hash function contained
and additional specifier separated with a '_' the comparison of the
provided digest name and the available ones was incomplete, the last
character was ignored and the comparison was successful if even if there
was only a partial match.

Resolves: https://github.com/SSSD/sssd/issues/6802