### PR TITLE
SPEC: sync with Fedora spec file

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -144,6 +144,7 @@ BuildRequires: pcre2-devel
 BuildRequires: pkgconfig
 BuildRequires: popt-devel
 BuildRequires: python3-devel
+BuildRequires: (python3-setuptools if python3 >= 3.12)
 BuildRequires: samba-devel
 # required for idmap_sss.so
 BuildRequires: samba-winbind


### PR DESCRIPTION
Bringing https://src.fedoraproject.org/rpms/sssd/c/d3ba8fb11abeefd2f817d58507e5ea3bdada2222 upstream