### PR TITLE
python: replace distutils with setuptools

### DIFF
--- a/src/config/setup.py.in
+++ b/src/config/setup.py.in
@@ -19,10 +19,10 @@
 #
 
 """
-Python-level packaging using distutils.
+Python-level packaging using setuptools.
 """
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='SSSDConfig',


### PR DESCRIPTION
distutils is deprecated for sometime and it was removed in python 3.12
which is now in Fedora Rawhide.

https://github.com/python/cpython/issues/92584
https://fedoraproject.org/wiki/Changes/Python3.12