### PR TITLE
Tests: moving duplicate backtrace from gating

### DIFF
--- a/src/tests/multihost/alltests/test_backtrace.py
+++ b/src/tests/multihost/alltests/test_backtrace.py
@@ -39,10 +39,11 @@ def no_fallback_dir(multihost):
 
 @pytest.mark.usefixtures('setup_sssd', 'create_posix_usersgroups')
 @pytest.mark.backtrace
-@pytest.mark.tier1_2
 class TestPoorManBacktrace(object):
     """ Check sssd backtrace feature """
-    def test_0001_bz2021196(self, multihost, backupsssdconf):
+    @staticmethod
+    @pytest.mark.tier2
+    def test_0001_bz2021196(multihost, backupsssdconf):
         """
         :title: avoid duplicate backtraces
         :id: d4d8a0a0-ab90-4c8f-8087-95dc7ad3f3ae
@@ -109,7 +110,9 @@ class TestPoorManBacktrace(object):
         # backtrace is skipped
         assert pattern2.search(log_str2) and not pattern.search(log_str2)
 
-    def test_0002_bz1949149(self, multihost, backupsssdconf):
+    @staticmethod
+    @pytest.mark.tier1_2
+    def test_0002_bz1949149(multihost, backupsssdconf):
         """
         :title: backtrace is disabled if debug level >= 9
         :id: 50f2d501-3296-4229-86a0-b81844381637
@@ -150,7 +153,9 @@ class TestPoorManBacktrace(object):
             find = re.compile(r'BACKTRACE DUMP ENDS HERE')
             assert not find.search(log_str)
 
-    def test_0003_bz1949149(self, multihost, backupsssdconf):
+    @staticmethod
+    @pytest.mark.tier1_2
+    def test_0003_bz1949149(multihost, backupsssdconf):
         """
         :title: set debug_backtrace_enabled false
         :id: b8084e03-5e21-45ee-a463-65ab537fa110
@@ -190,7 +195,9 @@ class TestPoorManBacktrace(object):
             find = re.compile(r'BACKTRACE DUMP ENDS HERE')
             assert not find.search(log_str)
 
-    def test_0004_bz1949149(self, multihost, backupsssdconf):
+    @staticmethod
+    @pytest.mark.tier1_2
+    def test_0004_bz1949149(multihost, backupsssdconf):
         """
         :title: backtrace level is 0 with debug level set to 0
         :id: 4376d596-a613-447c-8f85-e3f3fbc05728
@@ -234,7 +241,9 @@ class TestPoorManBacktrace(object):
                     log_level = log_lines[index - 1]
                     assert find2.search(log_level)
 
-    def test_0005_bz1949149(self, multihost, backupsssdconf):
+    @staticmethod
+    @pytest.mark.tier1_2
+    def test_0005_bz1949149(multihost, backupsssdconf):
         """
         :title: backtrace level is 1 with debug level set to 1
         :id: 8a8adcdd-63bc-4a64-83cd-5c7b76fe745a


### PR DESCRIPTION
duplicate backtrace is behaving differently on different versions. Moving it out of gating.