### PR TITLE
Tests: Add a skip on version function

### DIFF
--- a/src/tests/multihost/ad/test_adparameters_ported.py
+++ b/src/tests/multihost/ad/test_adparameters_ported.py
@@ -3448,7 +3448,8 @@ class TestADParamsPorted:
           3. Logs contain info about right port being used
              Logs do not contain wrong (default) port being used
         """
-
+        if sssdTools.skip_package_version(multihost.client[0], min_versions=["2.6.2-2"]):
+            pytest.skip("Incompatible version.")
         adjoin(membersw='adcli')
         ad_realm = multihost.ad[0].domainname.upper()
 
@@ -3569,6 +3570,8 @@ class TestADParamsPorted:
         :customerscenario: False
         :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1964121
         """
+        if sssdTools.skip_package_version(multihost.client[0], min_versions=["2.8.1-1"]):
+            pytest.skip("Incompatible version.")
         ad_domain = multihost.ad[0].domainname
         adjoin(membersw='adcli')
         # Create AD user and group
@@ -3637,7 +3640,8 @@ class TestADParamsPorted:
         # UPN of user entry and PAC do not match.
         # To validate the fix we are skipping the whole IPA part and
         # forcing sssd to use mismatched parameter for UPN instead.
-
+        if sssdTools.skip_package_version(multihost.client[0], min_versions=["2.7.3-4", "2.8.2-1"]):
+            pytest.skip("Incompatible version.")
         ad_domain = multihost.ad[0].domainname
         adjoin(membersw='adcli')
         # Create AD user and group
@@ -3722,7 +3726,8 @@ class TestADParamsPorted:
         # forcing sssd to use empty parameter for UPN instead.
         # SSSD should recognize missing/empty upn and skip the check
         # by default now.
-
+        if sssdTools.skip_package_version(multihost.client[0], min_versions=["2.7.3-4", "2.8.2-1"]):
+            pytest.skip("Incompatible version.")
         ad_domain = multihost.ad[0].domainname
         adjoin(membersw='adcli')
         # Create AD user and group
@@ -3798,6 +3803,8 @@ class TestADParamsPorted:
         :customerscenario: True
         :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1913839
         """
+        if sssdTools.skip_package_version(multihost.client[0], min_versions=["2.9.0"]):
+            pytest.skip("Incompatible version.")
         adjoin(membersw='adcli')
         ad_realm = multihost.ad[0].domainname.upper()
         # Create AD user and group

--- a/src/tests/multihost/sssd/testlib/common/utils.py
+++ b/src/tests/multihost/sssd/testlib/common/utils.py
@@ -25,6 +25,7 @@ import ldif
 import pytest
 import pymmh3 as mmh3
 from ldap import modlist
+from packaging import version
 from .authconfig import RedHatAuthConfig
 from .exceptions import PkiLibException
 from .exceptions import LdapException
@@ -1019,6 +1020,87 @@ class sssdTools(object):
                 self.adhost.run_command(short_spn_cmd)
             except subprocess.CalledProcessError:
                 pytest.fail("setspn failed to delete %s SPN" % (short_entry))
+
+    @staticmethod
+    def skip_package_version(
+            multihost_host: object,
+            min_versions: list = None,
+            max_versions: list = None,
+            package: str = "sssd",
+            skip_missing: bool = True,
+            fail_missing: bool = False
+        ):
+        """ Skip test if the package version is not between min_versions and max_versions
+
+        If multiple min versions are defined it is expected that the fix was introduced
+        to different branches at once and the comparison will compare to multiple min versions.
+        For version comparison purposes <major>.<minor> is considered one branch.
+        For branches where min version is not defined, but they fit between other min versions it is
+        assumed that min version is <major>.<minor>.0 to override that add <major>.<minor>.9999.
+
+        Max versions work in similar way.
+
+        When neither min_version and max_version is defined it can be also used to check
+        if the package is present and skip/fail if it is not.
+
+        @param multihost_host: multihost fixture specific host for example multihost.client[0]
+        @param min_versions: list of minimal versions that has the fix implemented
+        @param max_versions: list of maximal versions where the test is valid
+        @param package: package name to be searched via rpm
+        @param skip_missing: skip the test if package is not installed
+        @param fail_missing: fail the test if package is not installed
+        """
+        pkg = multihost_host.run_command(f"rpm -q {package}", raiseonerr=False).stdout_text
+        if package not in pkg:
+            if fail_missing:
+                pytest.fail(f"Package {package} is not installed, failing the test.")
+            if skip_missing:
+                pytest.skip(f"Package {package} is not installed, skipping the test.")
+            return
+        if not min_versions and not max_versions:
+            # No minimal and maximal version requirement just used for checking package presence
+            return
+
+        searched = re.search(r'[0-9]+\.[0-9]+\.[0-9]*-[0-9]+', pkg)
+        if not searched:
+            # TODO: Log the version does not match the expected format.
+            return
+
+        detected_version = searched[0]
+        detected_version_splits = detected_version.split(".")
+        detected_major_minor = detected_version_splits[0] + "." + detected_version_splits[1]
+        detected_parsed = version.parse(detected_version)
+
+        if min_versions:
+            minver_dict = {}
+            for minver in min_versions:
+                splits = minver.split(".")
+                minver_dict[splits[0] + '.' + splits[1]] = version.parse(minver)
+            # We are comparing first versions where major + minor matches.
+            # This helps if the fix was in two different branches like 2.7.2 and 2.9.1
+            # It will make sure that if the current version is 2.9.0-3 it will not
+            # be considered bigger than 2.7.2
+            if detected_major_minor in min_versions:
+                if detected_parsed < minver_dict[detected_major_minor]:
+                    pytest.skip(f"Detected version {detected_version}is lower "
+                                f"than minimal version {minver_dict[detected_major_minor]}")
+            comparison = [detected_parsed >= x for x in minver_dict.values()]
+            if not any(comparison):
+                pytest.skip(f"Detected version {detected_version}is lower than any minimal version.")
+
+        if max_versions:
+            maxver_dict = {}
+            for maxver in max_versions:
+                splits = maxver.split(".")
+                maxver_dict[splits[0] + '.' + splits[1]] = version.parse(maxver)
+            # We are comparing the first versions where major + minor matches.
+            if detected_major_minor in max_versions:
+                if detected_parsed > maxver_dict[detected_major_minor]:
+                    pytest.skip(f"Detected version {detected_version}is higher "
+                                f"than maximal version {maxver_dict[detected_major_minor]}")
+            comparison = [detected_parsed < x for x in maxver_dict.values()]
+            if not any(comparison):
+                pytest.skip(f"Detected version {detected_version}is higher than any maximal version.")
 
 
 class LdapOperations(object):


### PR DESCRIPTION
The idea is to have a unified fuction that can skip tests based on valid versions of package.
Lists of minimal and maximal versions can be provided along with a package name (default sssd) and requested action on missing package. It does not try to account for differences between distrubutions.