### PR TITLE
Passkey: Warning display for fallback

### DIFF
--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -1623,6 +1623,18 @@ void pam_reply(struct pam_auth_req *preq)
         goto done;
     }
 
+    /* Passkey auth user notification if no TGT is granted */
+    if (pd->cmd == SSS_PAM_AUTHENTICATE &&
+        pd->pam_status == PAM_SUCCESS &&
+        preq->pd->passkey_local_done) {
+            user_info_type = SSS_PAM_USER_INFO_NO_KRB_TGT;
+            pam_add_response(pd, SSS_PAM_USER_INFO,
+            sizeof(uint32_t), (const uint8_t *) &user_info_type);
+            DEBUG(SSSDBG_IMPORTANT_INFO,
+                  "User [%s] logged in with local passkey authentication, single "
+                  "sign on ticket is not obtained.\n", pd->user);
+    }
+
     /* Account expiration warning is printed for sshd. If pam_verbosity
      * is equal or above PAM_VERBOSITY_INFO then all services are informed
      * about account expiration.

--- a/src/responder/pam/pamsrv_passkey.c
+++ b/src/responder/pam/pamsrv_passkey.c
@@ -438,6 +438,8 @@ void pam_forwarder_passkey_cb(struct tevent_req *req)
         goto done;
     }
 
+    preq->pd->passkey_local_done = true;
+
     DEBUG(SSSDBG_TRACE_FUNC, "passkey child finished with status [%d]\n", child_status);
     preq->pd->pam_status = PAM_SUCCESS;
     pam_reply(preq);

--- a/src/sss_client/sss_cli.h
+++ b/src/sss_client/sss_cli.h
@@ -637,6 +637,9 @@ enum user_info_type {
                                         * specified length. */
 
     SSS_PAM_USER_INFO_PIN_LOCKED, /**< Tell the user that the PIN is locked */
+    SSS_PAM_USER_INFO_NO_KRB_TGT, /**< Tell the user that Kerberos local/offline
+                                       auth was performed, therefore no TGT
+                                       is granted */
 };
 /**
  * @}

--- a/src/util/sss_pam_data.h
+++ b/src/util/sss_pam_data.h
@@ -74,6 +74,7 @@ struct pam_data {
 #ifdef USE_KEYRING
     key_serial_t key_serial;
 #endif
+    bool passkey_local_done;
 };
 
 /**


### PR DESCRIPTION
Warn the user before and after login that Kerberos ticket may not have been granted.