### PR TITLE
mc: recover from invalid memory cache size

### DIFF
--- a/src/responder/nss/nsssrv_mmap_cache.c
+++ b/src/responder/nss/nsssrv_mmap_cache.c
@@ -722,6 +722,57 @@ static errno_t sss_mmap_cache_invalidate(struct sss_mc_ctx *mcc,
     return EOK;
 }
 
+static errno_t sss_mmap_cache_validate_or_reinit(struct sss_mc_ctx **_mcc)
+{
+    struct sss_mc_ctx *mcc = *_mcc;
+    struct stat fdstat;
+    bool reinit = false;
+    errno_t ret;
+
+    /* No mcc initialized? Memory cache may be disabled. */
+    if (mcc == NULL || mcc->fd < 0) {
+        ret = EINVAL;
+        reinit = false;
+        goto done;
+    }
+
+    if (fstat(mcc->fd, &fdstat) == -1) {
+        ret = errno;
+        DEBUG(SSSDBG_CRIT_FAILURE,
+            "Unable to stat memory cache [file=%s, fd=%d] [%d]: %s\n",
+            mcc->file, mcc->fd, ret, sss_strerror(ret));
+        reinit = true;
+        goto done;
+    }
+
+    if (fdstat.st_nlink == 0) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Memory cache file was removed\n");
+        ret = ENOENT;
+        reinit = true;
+        goto done;
+    }
+
+    if (fdstat.st_size != mcc->mmap_size) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+            "Memory cache is corrupted, invalid size [file=%s, fd=%d, "
+            "expected_size=%zu, real_size=%zu]\n",
+            mcc->file, mcc->fd, mcc->mmap_size, fdstat.st_size);
+        ret = EINVAL;
+        reinit = true;
+        goto done;
+    }
+
+    ret = EOK;
+    reinit = false;
+
+done:
+    if (reinit) {
+        return sss_mmap_cache_reinit(talloc_parent(mcc), -1, -1, -1, -1, _mcc);
+    }
+
+    return ret;
+}
+
 /***************************************************************************
  * passwd map
  ***************************************************************************/
@@ -744,9 +795,9 @@ errno_t sss_mmap_cache_pw_store(struct sss_mc_ctx **_mcc,
     size_t pos;
     int ret;
 
-    if (mcc == NULL) {
-        /* cache not initialized? */
-        return EINVAL;
+    ret = sss_mmap_cache_validate_or_reinit(&mcc);
+    if (ret != EOK) {
+        return ret;
     }
 
     ret = snprintf(uidstr, 11, "%ld", (long)uid);
@@ -815,9 +866,9 @@ errno_t sss_mmap_cache_pw_invalidate_uid(struct sss_mc_ctx *mcc, uid_t uid)
     char *uidstr;
     errno_t ret;
 
-    if (mcc == NULL) {
-        /* cache not initialized? */
-        return EINVAL;
+    ret = sss_mmap_cache_validate_or_reinit(&mcc);
+    if (ret != EOK) {
+        return ret;
     }
 
     uidstr = talloc_asprintf(NULL, "%ld", (long)uid);
@@ -886,9 +937,9 @@ int sss_mmap_cache_gr_store(struct sss_mc_ctx **_mcc,
     size_t pos;
     int ret;
 
-    if (mcc == NULL) {
-        /* cache not initialized? */
-        return EINVAL;
+    ret = sss_mmap_cache_validate_or_reinit(&mcc);
+    if (ret != EOK) {
+        return ret;
     }
 
     ret = snprintf(gidstr, 11, "%ld", (long)gid);
@@ -953,9 +1004,9 @@ errno_t sss_mmap_cache_gr_invalidate_gid(struct sss_mc_ctx *mcc, gid_t gid)
     char *gidstr;
     errno_t ret;
 
-    if (mcc == NULL) {
-        /* cache not initialized? */
-        return EINVAL;
+    ret = sss_mmap_cache_validate_or_reinit(&mcc);
+    if (ret != EOK) {
+        return ret;
     }
 
     gidstr = talloc_asprintf(NULL, "%ld", (long)gid);
@@ -1018,9 +1069,9 @@ errno_t sss_mmap_cache_initgr_store(struct sss_mc_ctx **_mcc,
     size_t pos;
     int ret;
 
-    if (mcc == NULL) {
-        /* cache not initialized? */
-        return EINVAL;
+    ret = sss_mmap_cache_validate_or_reinit(&mcc);
+    if (ret != EOK) {
+        return ret;
     }
 
     /* array of gids + name + unique_name */
@@ -1087,8 +1138,9 @@ errno_t sss_mmap_cache_sid_store(struct sss_mc_ctx **_mcc,
     size_t rec_len;
     int ret;
 
-    if (mcc == NULL) {
-        return EINVAL;
+    ret = sss_mmap_cache_validate_or_reinit(&mcc);
+    if (ret != EOK) {
+        return ret;
     }
 
     ret = snprintf(idkey, sizeof(idkey), "%d-%ld",


### PR DESCRIPTION
If we access the mmap file outside its boundaries a SIGBUS is raised.
We can now safely recover if the file has unexpected size.

---

I will give a test build to the customer. If it works and we agree on
this approach, I will make the test more profound.