### PR TITLE
git: add commit template for tests

### DIFF
--- a/.git-commit-template-tests
+++ b/.git-commit-template-tests
@@ -1,0 +1,10 @@
+TESTS: add tests for xyz functionality
+
+Optional explanation. Explain information and decisions that are not directly
+visible from the test code.
+
+Verifies: https://github.com/SSSD/sssd/issues/XXXX
+
+# Keep the commit subject and description meaningful so it can be easily
+# looked up. The subject should reflect what you are testing, avoid adding
+# ticket numbers and links to the subject.


### PR DESCRIPTION
The template can be enabled with:

```
git config commit.template .git-commit-template-tests
```