### PR TITLE
A couple of cosmetic changes related to IFP:

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -90,6 +90,7 @@ sssdkcmdatadir = $(datadir)/sssd-kcm
 deskprofilepath = $(sss_statedir)/deskprofile
 
 if HAVE_SYSTEMD_UNIT
+ifp_dbus_exec_comment = \# If system is configured to use systemd ifp service ("SystemdService=") then "Exec=" and "User=" options are not used
 ifp_exec_cmd = $(sssdlibexecdir)/sssd_ifp --uid 0 --gid 0 --dbus-activated
 ifp_systemdservice = SystemdService=sssd-ifp.service
 ifp_restart = Restart=on-failure
@@ -105,6 +106,7 @@ if SSSD_NON_ROOT_USER
 additional_caps = CAP_DAC_OVERRIDE
 endif
 else
+ifp_dbus_exec_comment = \# "sss_signal" is used to force SSSD monitor to trigger "sssd_ifp" reconnection to dbus
 ifp_exec_cmd = $(sssdlibexecdir)/sss_signal
 ifp_systemdservice =
 ifp_restart =
@@ -1746,6 +1748,7 @@ EXTRA_DIST += \
 
 ifp_edit_cmd = $(edit_cmd) \
         -e 's|@ifp_exec_cmd[@]|$(ifp_exec_cmd)|g' \
+        -e 's|@ifp_dbus_exec_comment[@]|$(ifp_dbus_exec_comment)|g' \
         -e 's|@ifp_systemdservice[@]|$(ifp_systemdservice)|g' \
         -e 's|@ifp_restart[@]|$(ifp_restart)|g'
 

--- a/src/responder/ifp/org.freedesktop.sssd.infopipe.service.in
+++ b/src/responder/ifp/org.freedesktop.sssd.infopipe.service.in
@@ -1,5 +1,6 @@
 [D-BUS Service]
 Name=org.freedesktop.sssd.infopipe
+@ifp_dbus_exec_comment@
 Exec=@ifp_exec_cmd@
 User=root
 @ifp_systemdservice@

--- a/src/sbus/connection/sbus_dbus.c
+++ b/src/sbus/connection/sbus_dbus.c
@@ -42,8 +42,14 @@ sbus_dbus_request_name(DBusConnection *dbus_conn, const char *name)
 
     dbret = dbus_bus_request_name(dbus_conn, name, flags, &dbus_error);
     if (dbret == -1) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to request name on the "
-              "system bus [%s]: %s\n", dbus_error.name, dbus_error.message);
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to request name '%s' on the system"
+              " bus [%s]: %s\n", name, dbus_error.name, dbus_error.message);
+        if (dbus_error_has_name(&dbus_error, DBUS_ERROR_ACCESS_DENIED)) {
+            DEBUG(SSSDBG_FATAL_FAILURE,
+                  "Access denied - check dbus service configuration.\n");
+            sss_log(SSS_LOG_CRIT, "SSSD dbus service can't acquire bus name"
+                    " - check dbus service configuration.");
+        }
         ret = EIO;
         goto done;
     } else if (dbret != DBUS_REQUEST_NAME_REPLY_PRIMARY_OWNER) {


### PR DESCRIPTION
 - warn loudly in case of dbus service policy misconfiguration - this might be common pitfall during transition toward non-privileged sssd
 - remove excessive "Exec=" from dbus service file in case SSSD is built with system support (it had a wrong value anyway, imo)