### PR TITLE
spec-file updates:

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -764,7 +764,7 @@ done
 %attr(700,%{sssd_user},%{sssd_user}) %dir %{dbpath}
 %attr(775,%{sssd_user},%{sssd_user}) %dir %{mcpath}
 %attr(700,root,root) %dir %{secdbpath}
-%attr(751,root,root) %dir %{deskprofilepath}
+%attr(751,%{sssd_user},%{sssd_user}) %dir %{deskprofilepath}
 %ghost %attr(0664,%{sssd_user},%{sssd_user}) %verify(not md5 size mtime) %{mcpath}/passwd
 %ghost %attr(0664,%{sssd_user},%{sssd_user}) %verify(not md5 size mtime) %{mcpath}/group
 %ghost %attr(0664,%{sssd_user},%{sssd_user}) %verify(not md5 size mtime) %{mcpath}/initgroups

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -771,7 +771,7 @@ done
 %attr(755,%{sssd_user},%{sssd_user}) %dir %{pipepath}
 %attr(750,%{sssd_user},root) %dir %{pipepath}/private
 %attr(755,%{sssd_user},%{sssd_user}) %dir %{pubconfpath}
-%attr(755,%{sssd_user},%{sssd_user}) %dir %{gpocachepath}
+%attr(750,%{sssd_user},%{sssd_user}) %dir %{gpocachepath}
 %attr(750,%{sssd_user},%{sssd_user}) %dir %{_var}/log/%{name}
 %attr(700,%{sssd_user},%{sssd_user}) %dir %{_sysconfdir}/sssd
 %attr(700,%{sssd_user},%{sssd_user}) %dir %{_sysconfdir}/sssd/conf.d


### PR DESCRIPTION
 - restore proper ownership of `deskprofilepath`
 - `gpocachepath` doesn't need public r-x access