### PR TITLE
Fix compilation warning

### DIFF
--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -1185,9 +1185,11 @@ void pam_reply(struct pam_auth_req *preq)
     char* pam_account_expired_message;
     char* pam_account_locked_message;
     int pam_verbosity;
-    bool pk_preauth_done = false;
     bool local_sc_auth_allow = false;
     bool local_passkey_auth_allow = false;
+#ifdef BUILD_PASSKEY
+    bool pk_preauth_done = false;
+#endif /* BUILD_PASSKEY */
 
     pd = preq->pd;
     cctx = preq->cctx;


### PR DESCRIPTION
```
  ../src/responder/pam/pamsrv_cmd.c: In function ‘pam_reply’:
  ../src/responder/pam/pamsrv_cmd.c:1188:10: warning: unused variable ‘pk_preauth_done’ [-Wunused-variable]
   1188 |     bool pk_preauth_done = false;
```
in case SSSD is built without 'passkey' support.