### PR TITLE
Proxy: Avoid ldb_modify failed error

### DIFF
--- a/src/providers/proxy/proxy_id.c
+++ b/src/providers/proxy/proxy_id.c
@@ -1418,7 +1418,6 @@ static int get_initgr(TALLOC_CTX *mem_ctx,
     }
 
     uid = pwd->pw_uid;
-    memset(buffer, 0, buflen);
 
     /* Canonicalize the username in case it was actually an alias */
     if (ctx->fast_alias == true) {


### PR DESCRIPTION
Resolves the sysdb errors returned in the proxy provider logs when `proxy_fast_alias` is True.

This extraneous memset call would overwrite the previously returned pwd buffer, therefore an attempt was made to update the user's SYSDB_PWD with an empty value causing the error.

This PR will allow the test in https://github.com/SSSD/sssd/pull/6872 to succeed.