### PR TITLE
Allow ignoring the ppolicy extension

### DIFF
--- a/src/config/SSSDConfig/sssdoptions.py
+++ b/src/config/SSSDConfig/sssdoptions.py
@@ -395,6 +395,7 @@ class SSSDOptions(object):
 
         'ldap_disable_paging': _('Disable the LDAP paging control'),
         'ldap_disable_range_retrieval': _('Disable Active Directory range retrieval'),
+        'ldap_use_ppolicy': _('Use the ppolicy extension'),
 
         # [provider/ldap/id]
         'ldap_search_timeout': _('Length of time to wait for a search request'),

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -744,6 +744,7 @@ option = ldap_tls_cipher_suite
 option = ldap_tls_key
 option = ldap_tls_reqcert
 option = ldap_uri
+option = ldap_use_ppolicy
 option = ldap_user_ad_account_expires
 option = ldap_user_ad_user_account_control
 option = ldap_user_authorized_host

--- a/src/config/etc/sssd.api.d/sssd-ldap.conf
+++ b/src/config/etc/sssd.api.d/sssd-ldap.conf
@@ -43,6 +43,7 @@ ldap_connection_idle_timeout = int, None, false
 ldap_disable_paging = bool, None, false
 ldap_disable_range_retrieval = bool, None, false
 wildcard_limit = int, None, false
+ldap_use_ppolicy = bool, None, false
 
 [provider/ldap/id]
 ldap_search_timeout = int, None, false

--- a/src/man/sssd-ldap.5.xml
+++ b/src/man/sssd-ldap.5.xml
@@ -1639,6 +1639,21 @@ ldap_access_filter = (employeeType=admin)
                     </listitem>
                 </varlistentry>
 
+                <varlistentry>
+                    <term>ldap_use_ppolicy (boolean)</term>
+                    <listitem>
+                        <para>
+                            Turns on requesting and relying on the server-side
+                            password policy controls. Disabling this allows
+                            interacting with services which send back invalid
+                            ppolicy extension.
+                        </para>
+                        <para>
+                            Default: true
+                        </para>
+                    </listitem>
+                </varlistentry>
+
             </variablelist>
         </para>
     </refsect1>

--- a/src/providers/ad/ad_opts.c
+++ b/src/providers/ad/ad_opts.c
@@ -167,6 +167,7 @@ struct dp_option ad_def_ldap_opts[] = {
     { "ldap_pwdlockout_dn", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "wildcard_limit", DP_OPT_NUMBER, { .number = 1000 }, NULL_NUMBER},
     { "ldap_library_debug_level", DP_OPT_NUMBER, NULL_NUMBER, NULL_NUMBER},
+    { "ldap_use_ppolicy", DP_OPT_BOOL, BOOL_TRUE, BOOL_TRUE },
     DP_OPTION_TERMINATOR
 };
 

--- a/src/providers/ipa/ipa_auth.c
+++ b/src/providers/ipa/ipa_auth.c
@@ -345,6 +345,7 @@ static void ipa_pam_auth_handler_connect_done(struct tevent_req *subreq)
     struct ldb_message *msg;
     const char *dn;
     int timeout;
+    bool use_ppolicy;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
@@ -379,9 +380,11 @@ static void ipa_pam_auth_handler_connect_done(struct tevent_req *subreq)
 
     timeout = dp_opt_get_int(state->auth_ctx->sdap_auth_ctx->opts->basic,
                              SDAP_OPT_TIMEOUT);
+    use_ppolicy = dp_opt_get_bool(state->auth_ctx->sdap_auth_ctx->opts->basic,
+                                  SDAP_USE_PPOLICY);
 
     subreq = sdap_auth_send(state, state->ev, sh, NULL, NULL, dn,
-                            state->pd->authtok, timeout);
+                            state->pd->authtok, timeout, use_ppolicy);
     if (subreq == NULL) {
         goto done;
     }

--- a/src/providers/ipa/ipa_opts.c
+++ b/src/providers/ipa/ipa_opts.c
@@ -177,6 +177,7 @@ struct dp_option ipa_def_ldap_opts[] = {
     { "ldap_pwdlockout_dn", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "wildcard_limit", DP_OPT_NUMBER, { .number = 1000 }, NULL_NUMBER},
     { "ldap_library_debug_level", DP_OPT_NUMBER, NULL_NUMBER, NULL_NUMBER},
+    { "ldap_use_ppolicy", DP_OPT_BOOL, BOOL_TRUE, BOOL_TRUE },
     DP_OPTION_TERMINATOR
 };
 

--- a/src/providers/ldap/ldap_opts.c
+++ b/src/providers/ldap/ldap_opts.c
@@ -134,6 +134,7 @@ struct dp_option default_basic_opts[] = {
     { "ldap_pwdlockout_dn", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "wildcard_limit", DP_OPT_NUMBER, { .number = 1000 }, NULL_NUMBER},
     { "ldap_library_debug_level", DP_OPT_NUMBER, NULL_NUMBER, NULL_NUMBER},
+    { "ldap_use_ppolicy", DP_OPT_BOOL, BOOL_TRUE, BOOL_TRUE },
     DP_OPTION_TERMINATOR
 };
 

--- a/src/providers/ldap/sdap.h
+++ b/src/providers/ldap/sdap.h
@@ -237,6 +237,7 @@ enum sdap_basic_opt {
     SDAP_PWDLOCKOUT_DN,
     SDAP_WILDCARD_LIMIT,
     SDAP_LIBRARY_DEBUG_LEVEL,
+    SDAP_USE_PPOLICY,
 
     SDAP_OPTS_BASIC /* opts counter */
 };

--- a/src/providers/ldap/sdap_async.h
+++ b/src/providers/ldap/sdap_async.h
@@ -146,7 +146,8 @@ struct tevent_req *sdap_auth_send(TALLOC_CTX *memctx,
                                   const char *sasl_user,
                                   const char *user_dn,
                                   struct sss_auth_token *authtok,
-                                  int simple_bind_timeout);
+                                  int simple_bind_timeout,
+                                  bool use_ppolicy);
 
 errno_t sdap_auth_recv(struct tevent_req *req,
                        TALLOC_CTX *memctx,
@@ -170,7 +171,8 @@ struct tevent_req *sdap_exop_modify_passwd_send(TALLOC_CTX *memctx,
                                                 char *user_dn,
                                                 const char *password,
                                                 const char *new_password,
-                                                int timeout);
+                                                int timeout,
+                                                bool use_ppolicy);
 errno_t sdap_exop_modify_passwd_recv(struct tevent_req *req,
                                      TALLOC_CTX *mem_ctx,
                                      char **user_error_msg);

--- a/src/tests/system/tests/test_ldap.py
+++ b/src/tests/system/tests/test_ldap.py
@@ -16,8 +16,9 @@ from sssd_test_framework.topology import KnownTopology
 @pytest.mark.importance("critical")
 @pytest.mark.authentication
 @pytest.mark.parametrize("modify_mode", ["exop", "ldap_modify"])
+@pytest.mark.parametrize("use_ppolicy", ["true", "false"])
 @pytest.mark.topology(KnownTopology.LDAP)
-def test_ldap__change_password(client: Client, ldap: LDAP, modify_mode: str):
+def test_ldap__change_password(client: Client, ldap: LDAP, modify_mode: str, use_ppolicy: str):
     """
     :title: Change password with "ldap_pwmodify_mode" set to @modify_mode
     :setup:
@@ -45,6 +46,7 @@ def test_ldap__change_password(client: Client, ldap: LDAP, modify_mode: str):
     ldap.aci.add('(targetattr="userpassword")(version 3.0; acl "pwp test"; allow (all) userdn="ldap:///self";)')
 
     client.sssd.domain["ldap_pwmodify_mode"] = modify_mode
+    client.sssd.domain["ldap_use_ppolicy"] = use_ppolicy
     client.sssd.start()
 
     assert client.auth.ssh.password(user, old_pass), "Authentication with old correct password failed"
@@ -57,8 +59,9 @@ def test_ldap__change_password(client: Client, ldap: LDAP, modify_mode: str):
 
 @pytest.mark.ticket(bz=[795044, 1695574])
 @pytest.mark.parametrize("modify_mode", ["exop", "ldap_modify"])
+@pytest.mark.parametrize("use_ppolicy", ["true", "false"])
 @pytest.mark.topology(KnownTopology.LDAP)
-def test_ldap__change_password_new_pass_not_match(client: Client, ldap: LDAP, modify_mode: str):
+def test_ldap__change_password_new_pass_not_match(client: Client, ldap: LDAP, modify_mode: str, use_ppolicy: str):
     """
     :title: Change password with "ldap_pwmodify_mode" set to @modify_mode, but retyped password do not match
     :setup:
@@ -76,6 +79,7 @@ def test_ldap__change_password_new_pass_not_match(client: Client, ldap: LDAP, mo
     ldap.aci.add('(targetattr="userpassword")(version 3.0; acl "pwp test"; allow (all) userdn="ldap:///self";)')
 
     client.sssd.domain["ldap_pwmodify_mode"] = modify_mode
+    client.sssd.domain["ldap_use_ppolicy"] = use_ppolicy
     client.sssd.start()
 
     assert not client.auth.passwd.password(
@@ -85,8 +89,9 @@ def test_ldap__change_password_new_pass_not_match(client: Client, ldap: LDAP, mo
 
 @pytest.mark.ticket(bz=[795044, 1695574, 1795220])
 @pytest.mark.parametrize("modify_mode", ["exop", "ldap_modify"])
+@pytest.mark.parametrize("use_ppolicy", ["true", "false"])
 @pytest.mark.topology(KnownTopology.LDAP)
-def test_ldap__change_password_lowercase(client: Client, ldap: LDAP, modify_mode: str):
+def test_ldap__change_password_lowercase(client: Client, ldap: LDAP, modify_mode: str, use_ppolicy: str):
     """
     :title: Change password to lower-case letters, password check fail
     :setup:
@@ -108,6 +113,7 @@ def test_ldap__change_password_lowercase(client: Client, ldap: LDAP, modify_mode
     ldap.ldap.modify("cn=config", replace={"passwordCheckSyntax": "on"})
 
     client.sssd.domain["ldap_pwmodify_mode"] = modify_mode
+    client.sssd.domain["ldap_use_ppolicy"] = use_ppolicy
     client.sssd.start()
 
     assert not client.auth.passwd.password(
@@ -122,8 +128,9 @@ def test_ldap__change_password_lowercase(client: Client, ldap: LDAP, modify_mode
 
 @pytest.mark.ticket(bz=[1695574, 1795220])
 @pytest.mark.parametrize("modify_mode", ["exop", "ldap_modify"])
+@pytest.mark.parametrize("use_ppolicy", ["true", "false"])
 @pytest.mark.topology(KnownTopology.LDAP)
-def test_ldap__change_password_wrong_current(client: Client, ldap: LDAP, modify_mode: str):
+def test_ldap__change_password_wrong_current(client: Client, ldap: LDAP, modify_mode: str, use_ppolicy: str):
     """
     :title: Password change failed because an incorrect password was used
     :setup:
@@ -141,6 +148,7 @@ def test_ldap__change_password_wrong_current(client: Client, ldap: LDAP, modify_
     ldap.aci.add('(targetattr="userpassword")(version 3.0; acl "pwp test"; allow (all) userdn="ldap:///self";)')
 
     client.sssd.domain["ldap_pwmodify_mode"] = modify_mode
+    client.sssd.domain["ldap_use_ppolicy"] = use_ppolicy
     client.sssd.start()
 
     assert not client.auth.passwd.password("user1", "wrong123", "Newpass123"), "Password change did not fail"


### PR DESCRIPTION
Introduce `ldap_use_ppolicy` and allow disabling it to interact with providers that send broken ppolicy responses.
This fixes interaction with the Okta LDAP gateway.