### PR TITLE
sss_iface: do not add cli_id to chain key

### DIFF
--- a/src/sss_iface/sbus_sss_client_async.c
+++ b/src/sss_iface/sbus_sss_client_async.c
@@ -1861,7 +1861,7 @@ sbus_call_dp_autofs_Enumerate_send
      const char * arg_mapname,
      uint32_t arg_cli_id)
 {
-    return sbus_method_in_usu_out__send(mem_ctx, conn, _sbus_sss_key_usu_0_1_2,
+    return sbus_method_in_usu_out__send(mem_ctx, conn, _sbus_sss_key_usu_0_1,
         busname, object_path, "sssd.DataProvider.Autofs", "Enumerate", arg_dp_flags, arg_mapname, arg_cli_id);
 }
 
@@ -1883,7 +1883,7 @@ sbus_call_dp_autofs_GetEntry_send
      const char * arg_entryname,
      uint32_t arg_cli_id)
 {
-    return sbus_method_in_ussu_out__send(mem_ctx, conn, _sbus_sss_key_ussu_0_1_2_3,
+    return sbus_method_in_ussu_out__send(mem_ctx, conn, _sbus_sss_key_ussu_0_1_2,
         busname, object_path, "sssd.DataProvider.Autofs", "GetEntry", arg_dp_flags, arg_mapname, arg_entryname, arg_cli_id);
 }
 
@@ -1904,7 +1904,7 @@ sbus_call_dp_autofs_GetMap_send
      const char * arg_mapname,
      uint32_t arg_cli_id)
 {
-    return sbus_method_in_usu_out__send(mem_ctx, conn, _sbus_sss_key_usu_0_1_2,
+    return sbus_method_in_usu_out__send(mem_ctx, conn, _sbus_sss_key_usu_0_1,
         busname, object_path, "sssd.DataProvider.Autofs", "GetMap", arg_dp_flags, arg_mapname, arg_cli_id);
 }
 
@@ -2142,7 +2142,7 @@ sbus_call_dp_dp_getAccountDomain_send
      const char * arg_filter,
      uint32_t arg_cli_id)
 {
-    return sbus_method_in_uusu_out_qus_send(mem_ctx, conn, _sbus_sss_key_uusu_0_1_2_3,
+    return sbus_method_in_uusu_out_qus_send(mem_ctx, conn, _sbus_sss_key_uusu_0_1_2,
         busname, object_path, "sssd.dataprovider", "getAccountDomain", arg_dp_flags, arg_entry_type, arg_filter, arg_cli_id);
 }
 
@@ -2170,7 +2170,7 @@ sbus_call_dp_dp_getAccountInfo_send
      const char * arg_extra,
      uint32_t arg_cli_id)
 {
-    return sbus_method_in_uusssu_out_qus_send(mem_ctx, conn, _sbus_sss_key_uusssu_0_1_2_3_4_5,
+    return sbus_method_in_uusssu_out_qus_send(mem_ctx, conn, _sbus_sss_key_uusssu_0_1_2_3_4,
         busname, object_path, "sssd.dataprovider", "getAccountInfo", arg_dp_flags, arg_entry_type, arg_filter, arg_domain, arg_extra, arg_cli_id);
 }
 
@@ -2267,7 +2267,7 @@ sbus_call_dp_dp_resolverHandler_send
      const char * arg_filter_value,
      uint32_t arg_cli_id)
 {
-    return sbus_method_in_uuusu_out_qus_send(mem_ctx, conn, _sbus_sss_key_uuusu_0_1_2_3_4,
+    return sbus_method_in_uuusu_out_qus_send(mem_ctx, conn, _sbus_sss_key_uuusu_0_1_2_3,
         busname, object_path, "sssd.dataprovider", "resolverHandler", arg_dp_flags, arg_entry_type, arg_filter_type, arg_filter_value, arg_cli_id);
 }
 

--- a/src/sss_iface/sbus_sss_interface.h
+++ b/src/sss_iface/sbus_sss_interface.h
@@ -166,7 +166,7 @@
         &_sbus_sss_args_sssd_DataProvider_Autofs_Enumerate, \
         NULL, \
         _sbus_sss_invoke_in_usu_out__send, \
-        _sbus_sss_key_usu_0_1_2, \
+        _sbus_sss_key_usu_0_1, \
         (handler), (data)); \
 })
 
@@ -177,7 +177,7 @@
         &_sbus_sss_args_sssd_DataProvider_Autofs_Enumerate, \
         NULL, \
         _sbus_sss_invoke_in_usu_out__send, \
-        _sbus_sss_key_usu_0_1_2, \
+        _sbus_sss_key_usu_0_1, \
         (handler_send), (handler_recv), (data)); \
 })
 
@@ -188,7 +188,7 @@
         &_sbus_sss_args_sssd_DataProvider_Autofs_GetEntry, \
         NULL, \
         _sbus_sss_invoke_in_ussu_out__send, \
-        _sbus_sss_key_ussu_0_1_2_3, \
+        _sbus_sss_key_ussu_0_1_2, \
         (handler), (data)); \
 })
 
@@ -199,7 +199,7 @@
         &_sbus_sss_args_sssd_DataProvider_Autofs_GetEntry, \
         NULL, \
         _sbus_sss_invoke_in_ussu_out__send, \
-        _sbus_sss_key_ussu_0_1_2_3, \
+        _sbus_sss_key_ussu_0_1_2, \
         (handler_send), (handler_recv), (data)); \
 })
 
@@ -210,7 +210,7 @@
         &_sbus_sss_args_sssd_DataProvider_Autofs_GetMap, \
         NULL, \
         _sbus_sss_invoke_in_usu_out__send, \
-        _sbus_sss_key_usu_0_1_2, \
+        _sbus_sss_key_usu_0_1, \
         (handler), (data)); \
 })
 
@@ -221,7 +221,7 @@
         &_sbus_sss_args_sssd_DataProvider_Autofs_GetMap, \
         NULL, \
         _sbus_sss_invoke_in_usu_out__send, \
-        _sbus_sss_key_usu_0_1_2, \
+        _sbus_sss_key_usu_0_1, \
         (handler_send), (handler_recv), (data)); \
 })
 
@@ -522,7 +522,7 @@
         &_sbus_sss_args_sssd_dataprovider_getAccountDomain, \
         NULL, \
         _sbus_sss_invoke_in_uusu_out_qus_send, \
-        _sbus_sss_key_uusu_0_1_2_3, \
+        _sbus_sss_key_uusu_0_1_2, \
         (handler), (data)); \
 })
 
@@ -533,7 +533,7 @@
         &_sbus_sss_args_sssd_dataprovider_getAccountDomain, \
         NULL, \
         _sbus_sss_invoke_in_uusu_out_qus_send, \
-        _sbus_sss_key_uusu_0_1_2_3, \
+        _sbus_sss_key_uusu_0_1_2, \
         (handler_send), (handler_recv), (data)); \
 })
 
@@ -544,7 +544,7 @@
         &_sbus_sss_args_sssd_dataprovider_getAccountInfo, \
         NULL, \
         _sbus_sss_invoke_in_uusssu_out_qus_send, \
-        _sbus_sss_key_uusssu_0_1_2_3_4_5, \
+        _sbus_sss_key_uusssu_0_1_2_3_4, \
         (handler), (data)); \
 })
 
@@ -555,7 +555,7 @@
         &_sbus_sss_args_sssd_dataprovider_getAccountInfo, \
         NULL, \
         _sbus_sss_invoke_in_uusssu_out_qus_send, \
-        _sbus_sss_key_uusssu_0_1_2_3_4_5, \
+        _sbus_sss_key_uusssu_0_1_2_3_4, \
         (handler_send), (handler_recv), (data)); \
 })
 
@@ -632,7 +632,7 @@
         &_sbus_sss_args_sssd_dataprovider_resolverHandler, \
         NULL, \
         _sbus_sss_invoke_in_uuusu_out_qus_send, \
-        _sbus_sss_key_uuusu_0_1_2_3_4, \
+        _sbus_sss_key_uuusu_0_1_2_3, \
         (handler), (data)); \
 })
 
@@ -643,7 +643,7 @@
         &_sbus_sss_args_sssd_dataprovider_resolverHandler, \
         NULL, \
         _sbus_sss_invoke_in_uuusu_out_qus_send, \
-        _sbus_sss_key_uuusu_0_1_2_3_4, \
+        _sbus_sss_key_uuusu_0_1_2_3, \
         (handler_send), (handler_recv), (data)); \
 })
 

--- a/src/sss_iface/sbus_sss_keygens.c
+++ b/src/sss_iface/sbus_sss_keygens.c
@@ -90,86 +90,86 @@ _sbus_sss_key_ussu_0_1
 }
 
 const char *
-_sbus_sss_key_ussu_0_1_2_3
+_sbus_sss_key_ussu_0_1_2
    (TALLOC_CTX *mem_ctx,
     struct sbus_request *sbus_req,
     struct _sbus_sss_invoker_args_ussu *args)
 {
     if (sbus_req->sender == NULL) {
-        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%" PRIu32 ":%s:%s:%" PRIu32 "",
-            sbus_req->type, sbus_req->interface, sbus_req->member,
-            sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3);
-    }
-
-    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%" PRIu32 ":%s:%s:%" PRIu32 "",
-        sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
-        sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3);
-}
-
-const char *
-_sbus_sss_key_usu_0_1_2
-   (TALLOC_CTX *mem_ctx,
-    struct sbus_request *sbus_req,
-    struct _sbus_sss_invoker_args_usu *args)
-{
-    if (sbus_req->sender == NULL) {
-        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%" PRIu32 ":%s:%" PRIu32 "",
+        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%" PRIu32 ":%s:%s",
             sbus_req->type, sbus_req->interface, sbus_req->member,
             sbus_req->path, args->arg0, args->arg1, args->arg2);
     }
 
-    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%" PRIu32 ":%s:%" PRIu32 "",
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%" PRIu32 ":%s:%s",
         sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
         sbus_req->path, args->arg0, args->arg1, args->arg2);
 }
 
 const char *
-_sbus_sss_key_uusssu_0_1_2_3_4_5
+_sbus_sss_key_usu_0_1
+   (TALLOC_CTX *mem_ctx,
+    struct sbus_request *sbus_req,
+    struct _sbus_sss_invoker_args_usu *args)
+{
+    if (sbus_req->sender == NULL) {
+        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%" PRIu32 ":%s",
+            sbus_req->type, sbus_req->interface, sbus_req->member,
+            sbus_req->path, args->arg0, args->arg1);
+    }
+
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%" PRIu32 ":%s",
+        sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
+        sbus_req->path, args->arg0, args->arg1);
+}
+
+const char *
+_sbus_sss_key_uusssu_0_1_2_3_4
    (TALLOC_CTX *mem_ctx,
     struct sbus_request *sbus_req,
     struct _sbus_sss_invoker_args_uusssu *args)
 {
     if (sbus_req->sender == NULL) {
-        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%s:%s:%s:%" PRIu32 "",
+        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%s:%s:%s",
             sbus_req->type, sbus_req->interface, sbus_req->member,
-            sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3, args->arg4, args->arg5);
+            sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3, args->arg4);
     }
 
-    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%s:%s:%s:%" PRIu32 "",
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%s:%s:%s",
         sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
-        sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3, args->arg4, args->arg5);
+        sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3, args->arg4);
 }
 
 const char *
-_sbus_sss_key_uusu_0_1_2_3
+_sbus_sss_key_uusu_0_1_2
    (TALLOC_CTX *mem_ctx,
     struct sbus_request *sbus_req,
     struct _sbus_sss_invoker_args_uusu *args)
 {
     if (sbus_req->sender == NULL) {
-        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%s:%" PRIu32 "",
+        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%s",
             sbus_req->type, sbus_req->interface, sbus_req->member,
-            sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3);
+            sbus_req->path, args->arg0, args->arg1, args->arg2);
     }
 
-    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%s:%" PRIu32 "",
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%s",
         sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
-        sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3);
+        sbus_req->path, args->arg0, args->arg1, args->arg2);
 }
 
 const char *
-_sbus_sss_key_uuusu_0_1_2_3_4
+_sbus_sss_key_uuusu_0_1_2_3
    (TALLOC_CTX *mem_ctx,
     struct sbus_request *sbus_req,
     struct _sbus_sss_invoker_args_uuusu *args)
 {
     if (sbus_req->sender == NULL) {
-        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%" PRIu32 ":%s:%" PRIu32 "",
+        return talloc_asprintf(mem_ctx, "-:%u:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%" PRIu32 ":%s",
             sbus_req->type, sbus_req->interface, sbus_req->member,
-            sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3, args->arg4);
+            sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3);
     }
 
-    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%" PRIu32 ":%s:%" PRIu32 "",
+    return talloc_asprintf(mem_ctx, "%"PRIi64":%u:%s.%s:%s:%" PRIu32 ":%" PRIu32 ":%" PRIu32 ":%s",
         sbus_req->sender->uid, sbus_req->type, sbus_req->interface, sbus_req->member,
-        sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3, args->arg4);
+        sbus_req->path, args->arg0, args->arg1, args->arg2, args->arg3);
 }

--- a/src/sss_iface/sbus_sss_keygens.h
+++ b/src/sss_iface/sbus_sss_keygens.h
@@ -49,31 +49,31 @@ _sbus_sss_key_ussu_0_1
     struct _sbus_sss_invoker_args_ussu *args);
 
 const char *
-_sbus_sss_key_ussu_0_1_2_3
+_sbus_sss_key_ussu_0_1_2
    (TALLOC_CTX *mem_ctx,
     struct sbus_request *sbus_req,
     struct _sbus_sss_invoker_args_ussu *args);
 
 const char *
-_sbus_sss_key_usu_0_1_2
+_sbus_sss_key_usu_0_1
    (TALLOC_CTX *mem_ctx,
     struct sbus_request *sbus_req,
     struct _sbus_sss_invoker_args_usu *args);
 
 const char *
-_sbus_sss_key_uusssu_0_1_2_3_4_5
+_sbus_sss_key_uusssu_0_1_2_3_4
    (TALLOC_CTX *mem_ctx,
     struct sbus_request *sbus_req,
     struct _sbus_sss_invoker_args_uusssu *args);
 
 const char *
-_sbus_sss_key_uusu_0_1_2_3
+_sbus_sss_key_uusu_0_1_2
    (TALLOC_CTX *mem_ctx,
     struct sbus_request *sbus_req,
     struct _sbus_sss_invoker_args_uusu *args);
 
 const char *
-_sbus_sss_key_uuusu_0_1_2_3_4
+_sbus_sss_key_uuusu_0_1_2_3
    (TALLOC_CTX *mem_ctx,
     struct sbus_request *sbus_req,
     struct _sbus_sss_invoker_args_uuusu *args);

--- a/src/sss_iface/sss_iface.xml
+++ b/src/sss_iface/sss_iface.xml
@@ -91,18 +91,18 @@
         <method name="GetMap">
             <arg name="dp_flags" type="u" direction="in" key="1" />
             <arg name="mapname" type="s" direction="in" key="2" />
-            <arg name="cli_id" type="u" direction="in" key="3" />
+            <arg name="cli_id" type="u" direction="in" />
         </method>
         <method name="GetEntry">
             <arg name="dp_flags" type="u" direction="in" key="1" />
             <arg name="mapname" type="s" direction="in" key="2" />
             <arg name="entryname" type="s" direction="in" key="3" />
-            <arg name="cli_id" type="u" direction="in" key="4" />
+            <arg name="cli_id" type="u" direction="in" />
         </method>
         <method name="Enumerate">
             <arg name="dp_flags" type="u" direction="in" key="1" />
             <arg name="mapname" type="s" direction="in" key="2" />
-            <arg name="cli_id" type="u" direction="in" key="3" />
+            <arg name="cli_id" type="u" direction="in" />
         </method>
     </interface>
 
@@ -133,7 +133,7 @@
             <arg name="entry_type" type="u" direction="in" key="2" />
             <arg name="filter_type" type="u" direction="in" key="3" />
             <arg name="filter_value" type="s" direction="in" key="4" />
-            <arg name="cli_id" type="u" direction="in" key="5" />
+            <arg name="cli_id" type="u" direction="in" />
             <arg name="dp_error" type="q" direction="out" />
             <arg name="error" type="u" direction="out" />
             <arg name="error_message" type="s" direction="out" />
@@ -150,7 +150,7 @@
             <arg name="filter" type="s" direction="in" key="3" />
             <arg name="domain" type="s" direction="in" key="4" />
             <arg name="extra" type="s" direction="in" key="5" />
-            <arg name="cli_id" type="u" direction="in" key="6" />
+            <arg name="cli_id" type="u" direction="in" />
             <arg name="dp_error" type="q" direction="out" />
             <arg name="error" type="u" direction="out" />
             <arg name="error_message" type="s" direction="out" />
@@ -159,7 +159,7 @@
             <arg name="dp_flags" type="u" direction="in" key="1" />
             <arg name="entry_type" type="u" direction="in" key="2" />
             <arg name="filter" type="s" direction="in" key="3" />
-            <arg name="cli_id" type="u" direction="in" key="4" />
+            <arg name="cli_id" type="u" direction="in" />
             <arg name="dp_error" type="q" direction="out" />
             <arg name="error" type="u" direction="out" />
             <arg name="domain_name" type="s" direction="out" />


### PR DESCRIPTION
Otherwise we only chaing identical requests from the same client
which effectively renders chaining not functional.

Resolves: https://github.com/SSSD/sssd/issues/6911

---

I tested this with:

```
for i in {1..100} ; do getent passwd user-1@ldap.test & done
```

But SSSD is still quite fast and only the first two-three requests
run in parallel and are chained. Other requests where served by cache.