### PR TITLE
KCM: Remove the oldest expired credential if no more space.

### DIFF
--- a/src/responder/kcm/secrets/secrets.c
+++ b/src/responder/kcm/secrets/secrets.c
@@ -381,11 +381,12 @@ static int local_db_check_peruid_number_of_secrets(TALLOC_CTX *mem_ctx,
         ret = local_db_remove_oldest_expired_secret(res, req);
         if (ret != EOK) {
             if (ret == ERR_NO_MATCHING_CREDS) {
+                /* max_uid_secrets is incremented by 2 for internal entries. */
                 DEBUG(SSSDBG_OP_FAILURE,
                       "Cannot store any more secrets for this client (basedn %s) "
                       "as the maximum allowed limit (%d) has been reached\n",
                       ldb_dn_get_linearized(cli_basedn),
-                      req->quota->max_uid_secrets);
+                      req->quota->max_uid_secrets - 2);
                 ret = ERR_SEC_INVALID_TOO_MANY_SECRETS;
             }
             goto done;


### PR DESCRIPTION
When adding a new credential to KCM and the user has already reached their limit, the oldest expired credential will be removed to free some space.
If no expired credential is found to be removed, the operation will fail as it happened in the previous versions.

Resolves: https://github.com/SSSD/sssd/issues/6667

