### PR TITLE
Passkey: Allow kerberos preauth for "false" UV

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3860,6 +3860,7 @@ test_passkey_LDFLAGS = \
     -Wl,-wrap,fido_dev_open \
     -Wl,-wrap,fido_dev_has_uv \
     -Wl,-wrap,fido_dev_has_pin \
+    -Wl,-wrap,fido_dev_supports_uv \
     -Wl,-wrap,fido_dev_make_cred \
     -Wl,-wrap,fido_cred_x5c_ptr \
     -Wl,-wrap,fido_cred_verify \

--- a/src/krb5_plugin/passkey/passkey_utils.c
+++ b/src/krb5_plugin/passkey/passkey_utils.c
@@ -211,7 +211,7 @@ sss_passkey_challenge_to_json_object(const struct sss_passkey_challenge *data)
 
     /* These are required fields. */
     if (data->domain == NULL || data->credential_id_list == NULL
-        || data->user_verification == 0 || data->cryptographic_challenge == NULL) {
+        || data->cryptographic_challenge == NULL) {
         return NULL;
     }
 

--- a/src/passkey_child/passkey_child_devices.c
+++ b/src/passkey_child/passkey_child_devices.c
@@ -201,10 +201,12 @@ get_device_options(fido_dev_t *dev, struct passkey_data *_data)
 {
     bool has_pin;
     bool has_uv;
+    bool supports_uv;
     errno_t ret;
 
     has_uv = fido_dev_has_uv(dev);
     has_pin = fido_dev_has_pin(dev);
+    supports_uv = fido_dev_supports_uv(dev);
 
     if (_data->user_verification == FIDO_OPT_TRUE && has_pin != true
         && has_uv != true) {
@@ -222,6 +224,16 @@ get_device_options(fido_dev_t *dev, struct passkey_data *_data)
               "but the key settings are enforcing it. Thus, enforcing the "
               "user-verification.\n");
         _data->user_verification = FIDO_OPT_TRUE;
+        ret = EOK;
+        goto done;
+    }
+
+    if (_data->user_verification == FIDO_OPT_FALSE
+        && supports_uv == false) {
+        DEBUG(SSSDBG_CONF_SETTINGS,
+              "Policy disabled user-verification but the key doesn't support "
+              "it. Thus, omitting the user-verification.\n");
+        _data->user_verification = FIDO_OPT_OMIT;
         ret = EOK;
         goto done;
     }

--- a/src/tests/cmocka/test_krb5_passkey_plugin.c
+++ b/src/tests/cmocka/test_krb5_passkey_plugin.c
@@ -122,16 +122,6 @@ void test_sss_passkey_message_encode__challenge(void **state)
 
     challenge.domain = discard_const("domain");
     challenge.credential_id_list = discard_const(id_list);
-    challenge.user_verification = 0;
-    challenge.cryptographic_challenge = discard_const("crypto-challenge");
-    message.phase = SSS_PASSKEY_PHASE_CHALLENGE;
-    message.state = discard_const("abcd");
-    message.data.challenge = &challenge;
-    str = sss_passkey_message_encode(&message);
-    assert_null(str);
-
-    challenge.domain = discard_const("domain");
-    challenge.credential_id_list = discard_const(id_list);
     challenge.user_verification = 1;
     challenge.cryptographic_challenge = NULL;
     message.phase = SSS_PASSKEY_PHASE_CHALLENGE;


### PR DESCRIPTION
When IPA passkey configuration sets `require-user-verification=false` then the user verification value will be 0. We need to allow this configuration within the plugin.