### PR TITLE
Increase child buffer size to handle multiple passkey mappings

### DIFF
--- a/src/util/atomic_io.c
+++ b/src/util/atomic_io.c
@@ -87,7 +87,11 @@ ssize_t sss_atomic_read_safe_s(int fd, void *buf, size_t buf_len, size_t *_len)
     }
 
     if (ulen > buf_len) {
-        return ERANGE;
+        if (_len != NULL) {
+            *_len = ulen;
+        }
+        errno = ERANGE;
+        return -1;
     }
 
     if (_len != NULL) {


### PR DESCRIPTION
Increase the child response size capacity, this is needed to handle multiple passkey mappings returned from the krb5 child in kerberos pre-authentication.

Linked issue can be reproduced by adding several passkey mappings to an IPA user, until the krb5 child buffer size is > 1024 bytes.
