### PR TITLE
Tests: alltest/test_sssctl_local.py converted to system/tests/sssctl.py and to system/tests/sss_cache.py

### DIFF
--- a/src/tests/multihost/alltests/test_sssctl_local.py
+++ b/src/tests/multihost/alltests/test_sssctl_local.py
@@ -23,6 +23,7 @@ class Testsssctl(object):
     """
     This is test case class for sssctl suite
     """
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__user_show_cache_expiration_time')
     @pytest.mark.tier1_2
     def test_0001_bz1640576(self, multihost,
                             backupsssdconf,
@@ -50,6 +51,7 @@ class Testsssctl(object):
             assert 'Cache entry expiration time: Never'\
                    in cmd.stdout_text
 
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__handle_implicit_domain')
     @pytest.mark.tier1_2
     def test_0002_bz1599207(self, multihost,
                             backupsssdconf,
@@ -79,6 +81,7 @@ class Testsssctl(object):
             assert 'Cache entry creation date' in \
                    cmd.stdout_text and cmd.returncode == 0
 
+    @pytest.mark.converted('test_sss_cache.py', 'test_sss_cache__cache_expire_message')
     @pytest.mark.tier1_2
     def test_0003_bz1661182(self, multihost,
                             backupsssdconf):

--- a/src/tests/system/tests/test_sss_cache.py
+++ b/src/tests/system/tests/test_sss_cache.py
@@ -1,0 +1,45 @@
+"""
+sss_cache tests.
+
+:requirement: IDM-SSSD-REQ: Status utility
+"""
+
+from __future__ import annotations
+
+import pytest
+from pytest_mh.ssh import SSHProcessError
+from sssd_test_framework.roles.client import Client
+from sssd_test_framework.topology import KnownTopology
+
+
+@pytest.mark.ticket(bz=1661182)
+@pytest.mark.topology(KnownTopology.Client)
+def test_sss_cache__cache_expire_message(client: Client):
+    """
+    :title: sss_cache do not print fake error messages
+    :setup:
+        1. Configure SSSD without any domain
+        2. Set to sssd section "enable_files_domain" to "false"
+        3. Create local user
+    :steps:
+        1. Restart SSSD
+        2. Modify existing local user
+        3. Expire cache with specific options
+    :expectedresults:
+        1. Error is raised, SSSD is not running
+        2. Modified successfully
+        3. Output did not contain wrong messages
+    :customerscenario: True
+    """
+    client.sssd.sssd["enable_files_domain"] = "false"
+    client.local.user("user1").add()
+
+    with pytest.raises(SSHProcessError):
+        client.sssd.restart()
+
+    res = client.host.ssh.run("usermod -a -G wheel user1")
+    assert "No domains configured, fatal error!" not in res.stdout
+
+    for cmd in ("sss_cache -U", "sss_cache -G", "sss_cache -E", "sss_cache --user=nonexisting"):
+        res = client.host.ssh.run(cmd)
+        assert "No domains configured, fatal error!" not in res.stdout

--- a/src/tests/system/tests/test_sssctl.py
+++ b/src/tests/system/tests/test_sssctl.py
@@ -67,3 +67,72 @@ def test_sssctl__check_invalid_id_provider(client: Client):
         "[rule/sssd_checks]: Attribute 'id_provider' in section 'domain/test' has an invalid value: invalid"
         in output.stdout_lines[1]
     )
+
+
+@pytest.mark.ticket(bz=1640576)
+@pytest.mark.builtwith("files-provider")
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__user_show_cache_expiration_time(client: Client):
+    """
+    :title: sssctl user-show reports correct expiration time of local user
+    :setup:
+        1. Add local users
+        2. Configure local domain
+        3. Start SSSD
+    :steps:
+        1. Call sssctl user-show $user
+        2. Check correct output
+    :expectedresults:
+        1. Called successfully
+        2. Output is as expected
+    :customerscenario: True
+    """
+    client.local.user("local1").add()
+    client.local.user("local2").add()
+    client.local.user("local3").add()
+
+    client.sssd.common.local()
+    client.sssd.default_domain = "local"
+    client.sssd.domain["id_provider"] = "files"
+    client.sssd.domain["passwd_files"] = "/etc/passwd"
+
+    client.sssd.start()
+
+    for user in {"local1", "local2", "local3"}:
+        cmd = client.sssctl.user_show(user=user)
+        assert cmd.rc == 0, "Command call failed"
+        assert "Cache entry expiration time: Never" in cmd.stdout, "Wrong output"
+
+
+@pytest.mark.ticket(bz=1599207)
+@pytest.mark.builtwith("files-provider")
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__handle_implicit_domain(client: Client):
+    """
+    :title: sssctl handle implicit domain
+    :setup:
+        1. Add local users
+        2. Set sssd "enable_files_domain" to "true"
+        3. Start SSSD
+    :steps:
+        1. Call getent passwd user -s sss
+        2. Call sssctl user-show --user=$user
+        3. Check correct output
+    :expectedresults:
+        1. Called successfully
+        2. Called successfully
+        3. Output is correct
+    :customerscenario: True
+    """
+    client.local.user("local1").add()
+    client.local.user("local2").add()
+    client.local.user("local3").add()
+
+    client.sssd.sssd["enable_files_domain"] = "true"
+    client.sssd.start()
+
+    for user in {"local1", "local2", "local3"}:
+        assert client.tools.getent.passwd(user, service="sss") is not None
+        cmd = client.sssctl.user_show(user=user)
+        assert cmd.rc == 0
+        assert "Cache entry creation date" in cmd.stdout


### PR DESCRIPTION
I converted three tests to the NF. I thought that I will put all three tests to the same file(sssctl.py) but I found out that `test_sss_cache__cache_expire_message` works differently depending on how it's called (`sss_cache --user=nonexist` vs `sssctl cache-expire --user=nonexist`). That is why I split these test to different files.
I look forward to your comments! 