### PR TITLE
ipa: do not go offline if group does not have SID

### DIFF
--- a/src/tests/system/tests/test_trust_identity.py
+++ b/src/tests/system/tests/test_trust_identity.py
@@ -1,0 +1,61 @@
+"""
+Identity of trusted users and groups.
+
+:requirement: IDM-SSSD-REQ: Testing SSSD in IPA Provider
+"""
+
+from __future__ import annotations
+
+import pytest
+from sssd_test_framework.roles.generic import GenericADProvider
+from sssd_test_framework.roles.ipa import IPA
+from sssd_test_framework.topology import KnownTopologyGroup
+
+
+@pytest.mark.importance("low")
+@pytest.mark.ticket(jira="RHEL-3925", gh=6942)
+@pytest.mark.topology(KnownTopologyGroup.IPATrust)
+def test_trust_identity__group_without_sid(ipa: IPA, trusted: GenericADProvider):
+    """
+    :title: Subdomain goes offline if IPA group is missing SID
+    :setup:
+        1. Create IPA external group "external-group" and add AD user "Administrator" as a member
+        2. Create IPA posix group "posix-group" and add "external-group" as a member
+        3. Clear SSSD cache and logs on IPA server
+        4. Restart SSSD on IPA server
+    :steps:
+        1. Resolve user "Administrator@addomain"
+        2. Expire user "Administrator@addomain"
+        3. Resolve user "Administrator@addomain"
+        4. Run "sssctl domain-status addomain"
+    :expectedresults:
+        1. User is resolved and member of posix-group
+        2. User is expired in SSSD cache
+        3. User is resolved and member of posix-group
+        4. The Active Directory domain is still online
+    :customerscenario: True
+    """
+    username = trusted.fqn("administrator")
+    external = ipa.group("external-group").add(external=True).add_member(username)
+    ipa.group("posix-group").add(gid=5001).add_member(external)
+
+    ipa.sssd.clear(db=True, memcache=True, logs=True)
+    ipa.sssd.restart()
+
+    # Cache trusted user
+    result = ipa.tools.id(username)
+    assert result is not None
+    assert result.user.name == username
+    assert result.memberof("posix-group")
+
+    # Expire the user and resolve it again, this will trigger the affected code path
+    ipa.sssctl.cache_expire(user=username)
+    result = ipa.tools.id(username)
+    assert result is not None
+    assert result.user.name == username
+    assert result.memberof("posix-group")
+
+    # Check that SSSD did not go offline
+    status = ipa.sssctl.domain_status(trusted.domain, online=True)
+    assert "online status: offline" not in status.stdout.lower()
+    assert "online status: online" in status.stdout.lower()


### PR DESCRIPTION
This happens during applying overrides on cached group
during initgroups of trusted user. If the group does not
have SID (it's GID is outside the sidgen range), SSSD goes
offline.

Only SSSD running in server_mode is affected.

This patch ignores error in single group and rather continues
processing the remaining groups.

Resolves: https://github.com/SSSD/sssd/issues/6942

---

Running the test also requires:
- https://github.com/SSSD/sssd-test-framework/pull/46
- https://github.com/SSSD/sssd-test-framework/pull/47
- https://github.com/SSSD/sssd-ci-containers/pull/60
- https://github.com/SSSD/sssd/pull/6954

CI will currently fail, because we do not build and install SSSD
on the IPA server. I need to update ci-containers and the workflow
to do that. But the patch is ready for review and you can run
the test locally.