### PR TITLE
KCM uses its own configuration

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1792,6 +1792,7 @@ sssd_kcm_SOURCES = \
     src/util/sss_sockets.c \
     src/util/sss_krb5.c \
     src/util/sss_iobuf.c \
+    src/confdb/confdb_setup.c \
     $(SSSD_RESPONDER_OBJ) \
     $(NULL)
 sssd_kcm_CFLAGS = \

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -40,6 +40,7 @@
 
 #define CONFDB_DEFAULT_CFG_FILE_VER 2
 #define CONFDB_FILE "config.ldb"
+#define CONFDB_KCM_FILE "config_kcm.ldb"
 #define SSSD_CONFIG_FILE_NAME "sssd.conf"
 #define SSSD_CONFIG_FILE SSSD_CONF_DIR"/"SSSD_CONFIG_FILE_NAME
 #define CONFDB_DEFAULT_CONFIG_DIR_NAME "conf.d"

--- a/src/confdb/confdb_setup.h
+++ b/src/confdb/confdb_setup.h
@@ -23,6 +23,9 @@
 #define CONFDB_SETUP_H_
 
 #include <stdbool.h>
+#include <talloc.h>
+
+#include "util/util_errors.h"
 
 #define CONFDB_BASE_LDIF \
      "dn: @ATTRIBUTES\n" \
@@ -38,6 +41,8 @@
      "dn: @MODULES\n" \
      "@LIST: server_sort\n" \
      "\n"
+
+struct confdb_ctx;
 
 errno_t confdb_setup(TALLOC_CTX *mem_ctx,
                      const char *cdb_file,

--- a/src/confdb/confdb_setup.h
+++ b/src/confdb/confdb_setup.h
@@ -22,6 +22,8 @@
 #ifndef CONFDB_SETUP_H_
 #define CONFDB_SETUP_H_
 
+#include <stdbool.h>
+
 #define CONFDB_BASE_LDIF \
      "dn: @ATTRIBUTES\n" \
      "cn: CASE_INSENSITIVE\n" \
@@ -42,6 +44,7 @@ errno_t confdb_setup(TALLOC_CTX *mem_ctx,
                      const char *config_file,
                      const char *config_dir,
                      const char *only_section,
+                     bool allow_missing_file,
                      struct confdb_ctx **_cdb);
 
 #endif /* CONFDB_SETUP_H_ */

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -2226,7 +2226,7 @@ int main(int argc, const char *argv[])
     ret = close(STDIN_FILENO);
     if (ret != EOK) return 6;
 
-    ret = server_setup(SSSD_MONITOR_NAME, false, flags, 0, 0,
+    ret = server_setup(SSSD_MONITOR_NAME, false, flags, 0, 0, CONFDB_FILE,
                        monitor->conf_path, &main_ctx, false);
     if (ret != EOK) return 2;
 

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -2001,6 +2001,7 @@ int main(int argc, const char *argv[])
         POPT_AUTOHELP
         SSSD_MAIN_OPTS
         SSSD_LOGGER_OPTS
+        SSSD_CONFIG_OPTS(opt_config_file)
         {"daemon", 'D', POPT_ARG_NONE, &opt_daemon, 0, \
          _("Become a daemon (default)"), NULL }, \
         {"interactive", 'i', POPT_ARG_NONE, &opt_interactive, 0, \
@@ -2008,8 +2009,6 @@ int main(int argc, const char *argv[])
         {"disable-netlink", '\0', POPT_ARG_NONE | POPT_ARGFLAG_DOC_HIDDEN,
             &opt_netlinkoff, 0, \
          _("Disable netlink interface"), NULL}, \
-        {"config", 'c', POPT_ARG_STRING, &opt_config_file, 0, \
-         _("Specify a non-default config file"), NULL}, \
         {"genconf", 'g', POPT_ARG_NONE, &opt_genconf, 0, \
          _("Refresh the configuration database, then exit"), \
          NULL}, \

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -1502,7 +1502,7 @@ errno_t load_configuration(TALLOC_CTX *mem_ctx,
     }
 
     ret = confdb_setup(ctx, cdb_file, config_file, config_dir, only_section,
-                       &ctx->cdb);
+                       false, &ctx->cdb);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Unable to setup ConfDB [%d]: %s\n",
              ret, sss_strerror(ret));

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -830,7 +830,8 @@ int main(int argc, const char *argv[])
     confdb_path = talloc_asprintf(NULL, CONFDB_DOMAIN_PATH_TMPL, be_domain);
     if (!confdb_path) return 2;
 
-    ret = server_setup(srv_name, false, 0, 0, 0, confdb_path, &main_ctx, false);
+    ret = server_setup(srv_name, false, 0, 0, 0, CONFDB_FILE,
+                       confdb_path, &main_ctx, false);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Could not set up mainloop [%d]\n", ret);
         return 2;

--- a/src/providers/proxy/proxy_child.c
+++ b/src/providers/proxy/proxy_child.c
@@ -562,7 +562,8 @@ int main(int argc, const char *argv[])
     conf_entry = talloc_asprintf(NULL, CONFDB_DOMAIN_PATH_TMPL, domain);
     if (!conf_entry) return 2;
 
-    ret = server_setup(srv_name, false, 0, 0, 0, conf_entry, &main_ctx, true);
+    ret = server_setup(srv_name, false, 0, 0, 0, CONFDB_FILE, conf_entry,
+                       &main_ctx, true);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Could not set up mainloop [%d]\n", ret);
         return 2;

--- a/src/responder/autofs/autofssrv.c
+++ b/src/responder/autofs/autofssrv.c
@@ -215,7 +215,7 @@ int main(int argc, const char *argv[])
     debug_log_file = "sssd_autofs";
     DEBUG_INIT(debug_level, opt_logger);
 
-    ret = server_setup("autofs", true, 0, uid, gid,
+    ret = server_setup("autofs", true, 0, uid, gid, CONFDB_FILE,
                        CONFDB_AUTOFS_CONF_ENTRY, &main_ctx, true);
     if (ret != EOK) {
         return 2;

--- a/src/responder/ifp/ifpsrv.c
+++ b/src/responder/ifp/ifpsrv.c
@@ -341,7 +341,7 @@ int main(int argc, const char *argv[])
     debug_log_file = "sssd_ifp";
     DEBUG_INIT(debug_level, opt_logger);
 
-    ret = server_setup("ifp", true, 0, uid, gid,
+    ret = server_setup("ifp", true, 0, uid, gid, CONFDB_FILE,
                        CONFDB_IFP_CONF_ENTRY, &main_ctx, true);
     if (ret != EOK) return 2;
 

--- a/src/responder/kcm/kcm.c
+++ b/src/responder/kcm/kcm.c
@@ -351,8 +351,8 @@ int main(int argc, const char *argv[])
     debug_log_file = "sssd_kcm";
     DEBUG_INIT(debug_level, opt_logger);
 
-    ret = server_setup("kcm", true, 0, uid, gid, CONFDB_KCM_CONF_ENTRY,
-                       &main_ctx, true);
+    ret = server_setup("kcm", true, 0, uid, gid, CONFDB_FILE,
+                       CONFDB_KCM_CONF_ENTRY, &main_ctx, true);
     if (ret != EOK) return 2;
 
     ret = die_if_parent_died();

--- a/src/responder/nss/nsssrv.c
+++ b/src/responder/nss/nsssrv.c
@@ -716,8 +716,8 @@ int main(int argc, const char *argv[])
     debug_log_file = "sssd_nss";
     DEBUG_INIT(debug_level, opt_logger);
 
-    ret = server_setup("nss", true, 0, uid, gid, CONFDB_NSS_CONF_ENTRY,
-                       &main_ctx, false);
+    ret = server_setup("nss", true, 0, uid, gid, CONFDB_FILE,
+                       CONFDB_NSS_CONF_ENTRY, &main_ctx, false);
     if (ret != EOK) return 2;
 
     ret = die_if_parent_died();

--- a/src/responder/pac/pacsrv.c
+++ b/src/responder/pac/pacsrv.c
@@ -208,7 +208,7 @@ int main(int argc, const char *argv[])
     debug_log_file = "sssd_pac";
     DEBUG_INIT(debug_level, opt_logger);
 
-    ret = server_setup("pac", true, 0, uid, gid,
+    ret = server_setup("pac", true, 0, uid, gid, CONFDB_FILE,
                        CONFDB_PAC_CONF_ENTRY, &main_ctx, true);
     if (ret != EOK) return 2;
 

--- a/src/responder/pam/pamsrv.c
+++ b/src/responder/pam/pamsrv.c
@@ -504,8 +504,8 @@ int main(int argc, const char *argv[])
               "debugging might not work!\n");
     }
 
-    ret = server_setup("pam", true, 0, uid, gid, CONFDB_PAM_CONF_ENTRY,
-                       &main_ctx, false);
+    ret = server_setup("pam", true, 0, uid, gid, CONFDB_FILE,
+                       CONFDB_PAM_CONF_ENTRY, &main_ctx, false);
     if (ret != EOK) return 2;
 
     ret = die_if_parent_died();

--- a/src/responder/ssh/sshsrv.c
+++ b/src/responder/ssh/sshsrv.c
@@ -208,7 +208,7 @@ int main(int argc, const char *argv[])
               "debugging might not work!\n");
     }
 
-    ret = server_setup("ssh", true, 0, uid, gid,
+    ret = server_setup("ssh", true, 0, uid, gid, CONFDB_FILE,
                        CONFDB_SSH_CONF_ENTRY, &main_ctx, true);
     if (ret != EOK) {
         return 2;

--- a/src/responder/sudo/sudosrv.c
+++ b/src/responder/sudo/sudosrv.c
@@ -196,8 +196,8 @@ int main(int argc, const char *argv[])
         }
     }
 
-    ret = server_setup("sudo", true, 0, uid, gid, CONFDB_SUDO_CONF_ENTRY,
-                       &main_ctx, true);
+    ret = server_setup("sudo", true, 0, uid, gid, CONFDB_FILE,
+                       CONFDB_SUDO_CONF_ENTRY, &main_ctx, true);
     if (ret != EOK) {
         return 2;
     }

--- a/src/sysv/gentoo/sssd-kcm.in
+++ b/src/sysv/gentoo/sssd-kcm.in
@@ -8,11 +8,6 @@ command_background="true"
 command_args="--uid=0 --gid=0 --logger=files ${SSSD_KCM_OPTIONS}"
 pidfile="@pidpath@/sssd_kcm.pid"
 
-start_pre()
-{
-    "@sbindir@/sssd" --genconf-section=kcm || return $?
-}
-
 depend()
 {
     need localmount clock

--- a/src/sysv/systemd/sssd-kcm.service.in
+++ b/src/sysv/systemd/sssd-kcm.service.in
@@ -9,7 +9,6 @@ Also=sssd-kcm.socket
 
 [Service]
 Environment=DEBUG_LOGGER=--logger=files
-ExecStartPre=-@sbindir@/sssd --genconf-section=kcm
 ExecStart=@libexecdir@/sssd/sssd_kcm --uid 0 --gid 0 ${DEBUG_LOGGER}
 # Currently SSSD KCM server ('sssd_kcm') always runs under 'root'
 # ('User=' and 'Group=' defaults to 'root' for system services)

--- a/src/tests/cwrap/test_server.c
+++ b/src/tests/cwrap/test_server.c
@@ -101,7 +101,7 @@ void test_run_as_root_fg(void **state)
 
     pid = fork();
     if (pid == 0) {
-        ret = server_setup(__FUNCTION__, false, 0, 0, 0,
+        ret = server_setup(__FUNCTION__, false, 0, 0, 0, CONFDB_FILE,
                            __FUNCTION__, &main_ctx, true);
         assert_int_equal(ret, 0);
         exit(0);
@@ -125,7 +125,7 @@ void test_run_as_sssd_fg(void **state)
     pid = fork();
     if (pid == 0) {
         ret = server_setup(__FUNCTION__, false, 0, sssd->pw_uid, sssd->pw_gid,
-                           __FUNCTION__, &main_ctx, true);
+                           CONFDB_FILE, __FUNCTION__, &main_ctx, true);
         assert_int_equal(ret, 0);
         exit(0);
     }
@@ -149,8 +149,8 @@ void test_run_as_root_daemon(void **state)
 
     pid = fork();
     if (pid == 0) {
-        ret = server_setup(__FUNCTION__, false, FLAGS_PID_FILE,
-                           0, 0, __FUNCTION__, &main_ctx, true);
+        ret = server_setup(__FUNCTION__, false, FLAGS_PID_FILE, 0, 0,
+                           CONFDB_FILE, __FUNCTION__, &main_ctx, true);
         assert_int_equal(ret, 0);
 
         server_loop(main_ctx);

--- a/src/tests/intg/test_kcm.py
+++ b/src/tests/intg/test_kcm.py
@@ -79,9 +79,6 @@ def create_conf_fixture(request, contents):
 
 
 def create_sssd_kcm_fixture(sock_path, krb5_conf_path, request):
-    if subprocess.call(['sssd', "--genconf"]) != 0:
-        raise Exception("failed to regenerate confdb")
-
     resp_path = os.path.join(config.LIBEXEC_PATH, "sssd", "sssd_kcm")
     if not os.access(resp_path, os.X_OK):
         # It would be cleaner to use pytest.mark.skipif on the package level

--- a/src/tools/common/sss_tools.c
+++ b/src/tools/common/sss_tools.c
@@ -102,8 +102,7 @@ static errno_t sss_tool_confdb_init(TALLOC_CTX *mem_ctx,
 
     ret = confdb_setup(mem_ctx, path,
                        SSSD_CONFIG_FILE, CONFDB_DEFAULT_CONFIG_DIR,
-                       NULL,
-                       &confdb);
+                       NULL, false, &confdb);
     talloc_zfree(path);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Unable to setup ConfDB [%d]: %s\n",

--- a/src/tools/sssctl/sssctl_config.c
+++ b/src/tools/sssctl/sssctl_config.c
@@ -71,8 +71,7 @@ errno_t sssctl_config_check(struct sss_cmdline *cmdline,
     const char *config_path = NULL;
     const char *config_snippet_path = NULL;
     struct poptOption long_options[] = {
-        {"config", 'c', POPT_ARG_STRING, &config_path,
-            0, _("Specify a non-default config file"), NULL},
+        SSSD_CONFIG_OPTS(config_path)
         {"snippet", 's', POPT_ARG_STRING, &config_snippet_path,
             0, _("Specify a non-default snippet dir (The default is to look in "
                  "the same place where the main config file is located. For "

--- a/src/util/server.c
+++ b/src/util/server.c
@@ -475,6 +475,7 @@ static const char *get_pid_path(void)
 int server_setup(const char *name, bool is_responder,
                  int flags,
                  uid_t uid, gid_t gid,
+                 const char *db_file,
                  const char *conf_entry,
                  struct main_context **main_ctx,
                  bool allow_sss_loop)
@@ -622,8 +623,7 @@ int server_setup(const char *name, bool is_responder,
         return EIO;
     }
 
-    conf_db = talloc_asprintf(ctx, "%s/%s",
-                              get_db_path(), CONFDB_FILE);
+    conf_db = talloc_asprintf(ctx, "%s/%s", get_db_path(), db_file);
     if (conf_db == NULL) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Out of memory, aborting!\n");
         return ENOMEM;

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -96,6 +96,10 @@
         {"gid", 0, POPT_ARG_INT, &gid, 0, \
           _("The group ID to run the server as"), NULL},
 
+#define SSSD_CONFIG_OPTS(opt_config_file) \
+        {"config", 'c', POPT_ARG_STRING, &opt_config_file, 0, \
+         _("Specify a non-default config file"), NULL}, \
+
 extern int socket_activated;
 
 #ifdef HAVE_SYSTEMD

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -216,6 +216,7 @@ int pidfile(const char *file);
 int server_setup(const char *name, bool is_responder,
                  int flags,
                  uid_t uid, gid_t gid,
+                 const char *db_file,
                  const char *conf_entry,
                  struct main_context **main_ctx,
                  bool allow_sss_loop);


### PR DESCRIPTION
* CONFDB: Fixed some missing dependencies in a header file
This header file was missing some `#include`s it needs.

* CONFDB: Allow loading an empty configuration
This is done with a parameter. The old behavior is kept for the other components than KCM.

* UTILS: Add the db file name to server_setup()'s parameters
Helper for the last commit.

* UTILS: Create a macro for the `--config` option
Helper for the last commit.

* KCM handles its own configuration
KCM now uses the `${SSS_STATEDIR}/db/config_kcm.ldb` database to store its configuration.
`config.ldb` is no longer used by KCM.

Resolves: https://github.com/SSSD/sssd/issues/6926


