### PR TITLE
MC: a couple of additions to 641e5f73d3bd5b3d32cafd551013d3bfd2a52732

### DIFF
--- a/src/responder/nss/nss_get_object.c
+++ b/src/responder/nss/nss_get_object.c
@@ -34,13 +34,13 @@ memcache_delete_entry_by_name(struct sss_nss_ctx *nss_ctx,
 
     switch (type) {
     case SSS_MC_PASSWD:
-        ret = sss_mmap_cache_pw_invalidate(nss_ctx->pwd_mc_ctx, name);
+        ret = sss_mmap_cache_pw_invalidate(&nss_ctx->pwd_mc_ctx, name);
         break;
     case SSS_MC_GROUP:
-        ret = sss_mmap_cache_gr_invalidate(nss_ctx->grp_mc_ctx, name);
+        ret = sss_mmap_cache_gr_invalidate(&nss_ctx->grp_mc_ctx, name);
         break;
     case SSS_MC_INITGROUPS:
-        ret = sss_mmap_cache_initgr_invalidate(nss_ctx->initgr_mc_ctx, name);
+        ret = sss_mmap_cache_initgr_invalidate(&nss_ctx->initgr_mc_ctx, name);
         break;
     default:
         return EINVAL;
@@ -66,10 +66,10 @@ memcache_delete_entry_by_id(struct sss_nss_ctx *nss_ctx,
 
     switch (type) {
     case SSS_MC_PASSWD:
-        ret = sss_mmap_cache_pw_invalidate_uid(nss_ctx->pwd_mc_ctx, (uid_t)id);
+        ret = sss_mmap_cache_pw_invalidate_uid(&nss_ctx->pwd_mc_ctx, (uid_t)id);
         break;
     case SSS_MC_GROUP:
-        ret = sss_mmap_cache_gr_invalidate_gid(nss_ctx->grp_mc_ctx, (gid_t)id);
+        ret = sss_mmap_cache_gr_invalidate_gid(&nss_ctx->grp_mc_ctx, (gid_t)id);
         break;
     default:
         return EINVAL;

--- a/src/responder/nss/nss_iface.c
+++ b/src/responder/nss/nss_iface.c
@@ -78,7 +78,7 @@ sss_nss_update_initgr_memcache(struct sss_nss_ctx *nctx,
 
     if (ret == ENOENT || res->count == 0) {
         /* The user is gone. Invalidate the mc record */
-        ret = sss_mmap_cache_pw_invalidate(nctx->pwd_mc_ctx, delete_name);
+        ret = sss_mmap_cache_pw_invalidate(&nctx->pwd_mc_ctx, delete_name);
         if (ret != EOK && ret != ENOENT) {
             DEBUG(SSSDBG_CRIT_FAILURE,
                   "Internal failure in memory cache code: %d [%s]\n",
@@ -125,7 +125,7 @@ sss_nss_update_initgr_memcache(struct sss_nss_ctx *nctx,
         for (i = 0; i < gnum; i++) {
             id = groups[i];
 
-            ret = sss_mmap_cache_gr_invalidate_gid(nctx->grp_mc_ctx, id);
+            ret = sss_mmap_cache_gr_invalidate_gid(&nctx->grp_mc_ctx, id);
             if (ret != EOK && ret != ENOENT) {
                 DEBUG(SSSDBG_CRIT_FAILURE,
                       "Internal failure in memory cache code: %d [%s]\n",
@@ -134,7 +134,7 @@ sss_nss_update_initgr_memcache(struct sss_nss_ctx *nctx,
         }
 
         to_sized_string(delete_name, fq_name);
-        ret = sss_mmap_cache_initgr_invalidate(nctx->initgr_mc_ctx,
+        ret = sss_mmap_cache_initgr_invalidate(&nctx->initgr_mc_ctx,
                                                delete_name);
         if (ret != EOK && ret != ENOENT) {
             DEBUG(SSSDBG_CRIT_FAILURE,
@@ -208,7 +208,7 @@ sss_nss_memorycache_invalidate_group_by_id(TALLOC_CTX *mem_ctx,
     DEBUG(SSSDBG_TRACE_LIBS,
           "Invalidating group %u from memory cache\n", gid);
 
-    sss_mmap_cache_gr_invalidate_gid(nctx->grp_mc_ctx, gid);
+    sss_mmap_cache_gr_invalidate_gid(&nctx->grp_mc_ctx, gid);
 
     return EOK;
 }

--- a/src/responder/nss/nsssrv_mmap_cache.h
+++ b/src/responder/nss/nsssrv_mmap_cache.h
@@ -63,17 +63,17 @@ errno_t sss_mmap_cache_sid_store(struct sss_mc_ctx **_mcc,
                                  uint32_t type,          /* enum sss_id_type*/
                                  bool explicit_lookup);  /* false ~ by_id(), true ~ by_uid/gid() */
 
-errno_t sss_mmap_cache_pw_invalidate(struct sss_mc_ctx *mcc,
+errno_t sss_mmap_cache_pw_invalidate(struct sss_mc_ctx **_mcc,
                                      const struct sized_string *name);
 
-errno_t sss_mmap_cache_pw_invalidate_uid(struct sss_mc_ctx *mcc, uid_t uid);
+errno_t sss_mmap_cache_pw_invalidate_uid(struct sss_mc_ctx **_mcc, uid_t uid);
 
-errno_t sss_mmap_cache_gr_invalidate(struct sss_mc_ctx *mcc,
+errno_t sss_mmap_cache_gr_invalidate(struct sss_mc_ctx **_mcc,
                                      const struct sized_string *name);
 
-errno_t sss_mmap_cache_gr_invalidate_gid(struct sss_mc_ctx *mcc, gid_t gid);
+errno_t sss_mmap_cache_gr_invalidate_gid(struct sss_mc_ctx **_mcc, gid_t gid);
 
-errno_t sss_mmap_cache_initgr_invalidate(struct sss_mc_ctx *mcc,
+errno_t sss_mmap_cache_initgr_invalidate(struct sss_mc_ctx **_mcc,
                                          const struct sized_string *name);
 
 errno_t sss_mmap_cache_reinit(TALLOC_CTX *mem_ctx,


### PR DESCRIPTION
 - handle all invalidations consistently
 - supply a valid pointer to `sss_mmap_cache_validate_or_reinit()`, not a pointer to a local var