### PR TITLE
dyndns: PTR record updates separately

### DIFF
--- a/src/man/sssd-ad.5.xml
+++ b/src/man/sssd-ad.5.xml
@@ -1263,6 +1263,11 @@ ad_gpo_map_deny = +my_pam_service
                             Applicable only when dyndns_update is true.
                         </para>
                         <para>
+                            Note that <emphasis>dyndns_update_per_family</emphasis>
+                            parameter does not apply for PTR record updates.
+                            Those updates are always sent separately.
+                        </para>
+                        <para>
                             Default: True
                         </para>
                     </listitem>

--- a/src/man/sssd-ipa.5.xml
+++ b/src/man/sssd-ipa.5.xml
@@ -287,6 +287,11 @@
                             are changed.
                         </para>
                         <para>
+                            Note that <emphasis>dyndns_update_per_family</emphasis>
+                            parameter does not apply for PTR record updates.
+                            Those updates are always sent separately.
+                        </para>
+                        <para>
                             Default: False (disabled)
                         </para>
                     </listitem>

--- a/src/providers/be_dyndns.c
+++ b/src/providers/be_dyndns.c
@@ -402,7 +402,7 @@ nsupdate_msg_add_ptr(char *update_msg, struct sss_iface_addr *addresses,
             }
 
             updateipv4 = talloc_asprintf_append(updateipv4,
-                                                "update add %s %d in PTR %s.\n",
+                                                "update add %s %d in PTR %s.\nsend\n",
                                                 ptr, ttl, hostname);
             break;
         case AF_INET6:
@@ -415,7 +415,7 @@ nsupdate_msg_add_ptr(char *update_msg, struct sss_iface_addr *addresses,
                 }
             }
             updateipv6 = talloc_asprintf_append(updateipv6,
-                                                "update add %s %d in PTR %s.\n",
+                                                "update add %s %d in PTR %s.\nsend\n",
                                                 ptr, ttl, hostname);
             break;
         }
@@ -426,21 +426,9 @@ nsupdate_msg_add_ptr(char *update_msg, struct sss_iface_addr *addresses,
         }
     }
 
-    if (update_per_family && updateipv4[0] && updateipv6[0]) {
-        /* update per family and both families present */
-        return talloc_asprintf_append(update_msg,
-                                      "%s"
-                                      "send\n"
-                                      "%s"
-                                      "send\n",
-                                      updateipv4,
-                                      updateipv6);
-    }
-
     return talloc_asprintf_append(update_msg,
                                   "%s"
-                                  "%s"
-                                  "send\n",
+                                  "%s",
                                   updateipv4,
                                   updateipv6);
 }

--- a/src/tests/cmocka/test_dyndns.c
+++ b/src/tests/cmocka/test_dyndns.c
@@ -663,11 +663,13 @@ void dyndns_test_create_ptr_msg(void **state)
     assert_string_equal(msg,
                         "\nupdate delete 1.0.168.192.in-addr.arpa. in PTR\n"
                         "update add 1.0.168.192.in-addr.arpa. 1234 in PTR bran_stark.\n"
+                        "send\n"
                         "update delete 2.0.168.192.in-addr.arpa. in PTR\n"
                         "update add 2.0.168.192.in-addr.arpa. 1234 in PTR bran_stark.\n"
                         "send\n"
                         "update delete 4.4.4.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.a.b.d.c.1.0.0.2.ip6.arpa. in PTR\n"
                         "update add 4.4.4.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.a.b.d.c.1.0.0.2.ip6.arpa. 1234 in PTR bran_stark.\n"
+                        "send\n"
                         "update delete 5.5.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.a.b.d.c.1.0.0.2.ip6.arpa. in PTR\n"
                         "update add 5.5.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.a.b.d.c.1.0.0.2.ip6.arpa. 1234 in PTR bran_stark.\n"
                         "send\n");
@@ -680,10 +682,13 @@ void dyndns_test_create_ptr_msg(void **state)
     assert_string_equal(msg,
                         "\nupdate delete 1.0.168.192.in-addr.arpa. in PTR\n"
                         "update add 1.0.168.192.in-addr.arpa. 1234 in PTR bran_stark.\n"
+                        "send\n"
                         "update delete 2.0.168.192.in-addr.arpa. in PTR\n"
                         "update add 2.0.168.192.in-addr.arpa. 1234 in PTR bran_stark.\n"
+                        "send\n"
                         "update delete 4.4.4.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.a.b.d.c.1.0.0.2.ip6.arpa. in PTR\n"
                         "update add 4.4.4.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.a.b.d.c.1.0.0.2.ip6.arpa. 1234 in PTR bran_stark.\n"
+                        "send\n"
                         "update delete 5.5.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.a.b.d.c.1.0.0.2.ip6.arpa. in PTR\n"
                         "update add 5.5.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.a.b.d.c.1.0.0.2.ip6.arpa. 1234 in PTR bran_stark.\n"
                         "send\n");


### PR DESCRIPTION
DNS server does not allow updates for different zones in one single step. Those updates must be sent separately.

It is complicated and in some cases impossible to detect that PTR updates does not fit into one zone because it often depends on DNS server configuration.

With this patch PTR record updates are always sent separately.

Resolves: https://github.com/SSSD/sssd/issues/6956