### PR TITLE
Backport of #6919: SUDO service: ${DEBUG_LOGGER} was missed for 'sudo'

### DIFF
--- a/src/sysv/systemd/sssd-sudo.service.in
+++ b/src/sysv/systemd/sssd-sudo.service.in
@@ -12,7 +12,7 @@ Also=sssd-sudo.socket
 Environment=DEBUG_LOGGER=--logger=files
 EnvironmentFile=-@environment_file@
 ExecStartPre=-/bin/chown @SSSD_USER@:@SSSD_USER@ @logpath@/sssd_sudo.log
-ExecStart=@libexecdir@/sssd/sssd_sudo --socket-activated
+ExecStart=@libexecdir@/sssd/sssd_sudo ${DEBUG_LOGGER} --socket-activated
 Restart=on-failure
 User=@SSSD_USER@
 Group=@SSSD_USER@


### PR DESCRIPTION
service in a7277fecf7a65ab6c83b36f009c558cdfbf997d2

Resolves: https://github.com/SSSD/sssd/issues/6920

(cherry picked from commit 01bee47a1557c0d21c9f35384c53758c70cf97c5)