### PR TITLE
Passkey: Increase conv message size for prompting

### DIFF
--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -1849,8 +1849,8 @@ static int prompt_passkey(pam_handle_t *pamh, struct pam_items *pi,
 {
     int ret;
     const struct pam_conv *conv;
-    const struct pam_message *mesg[3] = { NULL, NULL, NULL };
-    struct pam_message m[3] = { {0}, {0}, {0} };
+    const struct pam_message *mesg[4] = { NULL, NULL, NULL, NULL };
+    struct pam_message m[4] = { {0}, {0}, {0}, {0} };
     struct pam_response *resp = NULL;
     bool kerberos_preauth;
     bool prompt_pin;


### PR DESCRIPTION
Array size needs to handle the prompts for interactive, touch, pin prompt, and kerberos pre-auth warning message which could all be displayed with the below configuration.

[prompting/passkey]
interactive = True
touch = True

Before the fix:

~~~
[justin@fedora ~]$ su - alice@ldap              
Kerberos TGT will not be granted upon login, user experience will be affected.
Insert your Passkey device, then press ENTER.
Enter PIN:                                     
erroneous conversation (-405297200)
su: Authentication failure
~~~

After the fix.
~~~
[justin@fedora ~]$ su - alice@ldap
Kerberos TGT will not be granted upon login, user experience will be affected.
Insert your Passkey device, then press ENTER.
Enter PIN:
Please touch the device.
~~~