### PR TITLE
cli: caculate the wait_time in milliseconds

### DIFF
--- a/src/sss_client/common.c
+++ b/src/sss_client/common.c
@@ -617,7 +617,7 @@ static int sss_cli_open_socket(int *errnop, const char *socket_name, int timeout
         socklen_t errnosize;
         struct pollfd pfd;
 
-        wait_time += sleep_time;
+        wait_time += sleep_time * 1000;
 
         ret = connect(sd, (struct sockaddr *)&nssaddr,
                       sizeof(nssaddr));


### PR DESCRIPTION
The timeout we pass in is 300000ms, and we sleep 1s every time we get a EAGAIN error, so we need to multiply 1000 for sleep_time.