### PR TITLE
Tests: Skip tests unstable on other archs and tweak realm join.

### DIFF
--- a/src/tests/multihost/sssd/testlib/common/utils.py
+++ b/src/tests/multihost/sssd/testlib/common/utils.py
@@ -406,6 +406,13 @@ class sssdTools(object):
                     f'--client-software={client_software} ' \
                     f'--server-software={server_software} ' \
                     f'--membership-software={membership_software} -v'
+        # For AD sasl authid tests we need to have user-principal populated.
+        if server_software == 'active-directory':
+            hostname = self.multihost.run_command(
+                'hostname', raiseonerr=False).stdout_text.rstrip()
+            ad_realm = self.adhost.domainname.upper()
+            realm_cmd += f' --user-principal=host/{hostname}@{ad_realm}'
+
         print(realm_cmd)
         cmd = self.multihost.run_command(realm_cmd, stdin_text=admin_password,
                                          raiseonerr=False)


### PR DESCRIPTION
Unify realm join for AD params tests to use code with timeout to prevent suite freezing in sasl authid tests.
Set the whole suite as flaky to retry when realm join freezes.