### PR TITLE
CI: Add dependabot to get updates of github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly


### PR DESCRIPTION
Automate checking for GH actions updates with [dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)

I'm not sure if we will need to ignore any specific actions but it can be done with https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

Example PR from dependabot looks like https://github.com/linux-system-roles/tlog/pull/103