### PR TITLE
Tests: add follow-symlinks to sed for nsswitch

### DIFF
--- a/src/tests/multihost/alltests/test_automount_from_bash.py
+++ b/src/tests/multihost/alltests/test_automount_from_bash.py
@@ -103,7 +103,7 @@ def create_users(multihost, request):
     client.run_command("authselect select sssd --force")
     client.run_command("cp -f /etc/nsswitch.conf /etc/nsswitch.conf.backup")
     client.run_command("cp -f /etc/sysconfig/autofs /etc/sysconfig/autofs_bkp")
-    client.run_command("sed -i 's/automount:  files/automount:  sss files/g' /etc/nsswitch.conf")
+    client.run_command("sed --follow-symlinks -i 's/automount:  files/automount:  sss files/g' /etc/nsswitch.conf")
     ldap_uri = f'ldap://{multihost.master[0].sys_hostname}'
     ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
     ldap_inst.org_unit("mount", ds_suffix)


### PR DESCRIPTION
The multihost/alltests/test_automount_from_bash.py test module runs a sed against /etc/nsswitch.conf which convers it from a link to a file. This causes issues with authselect in later tests resulting in test errors.  This can be fixed by adding the --follow-symlinks option.

The restore() from the fixture should return the config to it's original content.