### PR TITLE
configure: use 'LDB_CFLAGS'

### DIFF
--- a/src/external/libldb.m4
+++ b/src/external/libldb.m4
@@ -3,10 +3,13 @@ AC_SUBST(LDB_LIBS)
 
 PKG_CHECK_MODULES(LDB, ldb >= 0.9.2)
 
+SAVE_CFLAGS=$CFLAGS
+CFLAGS="$CFLAGS $LDB_CFLAGS"
 AC_CHECK_HEADERS(ldb.h ldb_module.h,
    [AC_CHECK_LIB(ldb, ldb_init, [LDB_LIBS="-lldb"], , -ltevent -ltdb -ldl -lldap) ],
    [AC_MSG_ERROR([LDB header files are not installed])]
 )
+CFLAGS=$SAVE_CFLAGS
 
 AC_ARG_WITH([ldb-lib-dir],
             [AC_HELP_STRING([--with-ldb-lib-dir=PATH],

--- a/src/tests/cwrap/Makefile.am
+++ b/src/tests/cwrap/Makefile.am
@@ -9,7 +9,17 @@ AM_CPPFLAGS = \
     -DRUNDIR=\"$(runstatedir)\" \
     -DSSS_STATEDIR=\"$(localstatedir)/lib/sss\" \
     -DSYSCONFDIR=\"$(sysconfdir)\" \
+    $(POPT_CFLAGS) \
+    $(TALLOC_CFLAGS) \
+    $(TDB_CFLAGS) \
+    $(TEVENT_CFLAGS) \
+    $(LDB_CFLAGS) \
     $(DBUS_CFLAGS) \
+    $(PCRE_CFLAGS) \
+    $(INI_CONFIG_CFLAGS) \
+    $(DHASH_CFLAGS) \
+    $(LIBNL_CFLAGS) \
+    $(OPENLDAP_CFLAGS) \
     $(GLIB2_CFLAGS) \
     $(NULL)
 


### PR DESCRIPTION
Fixes `configure` and `make-check-valgrind` CI steps for Debian.