### PR TITLE
TESTS: Adapt the KCM tests to the new behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
         if-no-files-found: ignore
         name: ${{ matrix.tag }}-intgcheck
         path: |
-          ./sssd/*.log
+          ./sssd/var/log/sssd/*.log
           ./sssd/ci-build-debug/ci-*.log
           ./sssd/ci-build-debug/test-suite.log
           ./sssd/ci-build-debug/ci-mock-result/*.log

--- a/src/tests/intg/test_kcm.py
+++ b/src/tests/intg/test_kcm.py
@@ -114,8 +114,13 @@ def create_sssd_kcm_fixture(sock_path, krb5_conf_path, request):
         try:
             os.unlink(os.path.join(config.SECDB_PATH, "secrets.ldb"))
         except OSError as osex:
-            if osex.errno == 2:
-                pass
+            if osex.errno != 2:
+                raise osex
+        try:
+            os.unlink(abs_sock_path)
+        except OSError as osex:
+            if osex.errno != 2:
+                raise osex
 
     request.addfinalizer(kcm_teardown)
     return kcm_pid

--- a/src/tests/intg/test_pam_responder.py
+++ b/src/tests/intg/test_pam_responder.py
@@ -827,6 +827,7 @@ def setup_krb5(request, kdc_instance, passwd_ops_setup):
     passwd_ops_setup.useradd(**USER2)
     kdc_instance.add_principal("user1", "Secret123User1")
     kdc_instance.add_principal("user2", "Secret123User2")
+    time.sleep(2)   # Give KDC time to initialize
     return None
 
 


### PR DESCRIPTION
1. Corrected the path to the logs for the artifacts.
2. KCM tests where sometimes failing because they were opening the pipe while KCM was shutting down. This was happening because tests were successfully opening the pipe because it was left over by the previous instance of KCM. So to avoid this we immediately remove the pipe during teardown. With this, tests will fail to open it and keep trying until it is re-created by the new instance of KCM.
These tests started to fail sporadically after https://github.com/SSSD/sssd/pull/6948 was pushed, because the start-up time is now longer.
3. Some PAM tests sometimes fail because they start before KDC has finished its initialization. Adding a short delay to let it complete its initialization before launching the actual tests.

