### PR TITLE
struct sss_cli_mc_ctx added fd_inode, ensure that open and close fd are

### DIFF
--- a/src/sss_client/nss_mc.h
+++ b/src/sss_client/nss_mc.h
@@ -53,6 +53,7 @@ struct sss_cli_mc_ctx {
     pthread_mutex_t *mutex;
 #endif
     int fd;
+    ino_t fd_inode;
 
     uint32_t seed;          /* seed from the tables header */
 
@@ -69,9 +70,9 @@ struct sss_cli_mc_ctx {
 };
 
 #if HAVE_PTHREAD
-#define SSS_CLI_MC_CTX_INITIALIZER(mtx) {UNINITIALIZED, (mtx), -1, 0, NULL, 0, NULL, 0, NULL, 0, 0}
+#define SSS_CLI_MC_CTX_INITIALIZER(mtx) {UNINITIALIZED, (mtx), -1, 0, 0, NULL, 0, NULL, 0, NULL, 0, 0}
 #else
-#define SSS_CLI_MC_CTX_INITIALIZER {UNINITIALIZED, -1, 0, NULL, 0, NULL, 0, NULL, 0, 0}
+#define SSS_CLI_MC_CTX_INITIALIZER {UNINITIALIZED, -1, 0, 0, NULL, 0, NULL, 0, NULL, 0, 0}
 #endif
 
 errno_t sss_nss_mc_get_ctx(const char *name, struct sss_cli_mc_ctx *ctx);


### PR DESCRIPTION
Save the inode number while opening the file, and verify the inode number when closing the file to ensure that the same file is being opened and closed.

Used to solve the following issue: [](https://github.com/SSSD/sssd/issues/6986)