### PR TITLE
Tests: Fix autofs cleanups

### DIFF
--- a/src/tests/multihost/alltests/test_automount.py
+++ b/src/tests/multihost/alltests/test_automount.py
@@ -294,10 +294,9 @@ class Testautofsresponder(object):
         time.sleep(2)
         MIT_export = multihost.client[0].run_command("ls /home/MIT")
         mit_export = multihost.client[0].run_command("ls /home/mit")
-        assert 'export1' in MIT_export.stdout_text
-        assert 'export2' in mit_export.stdout_text
         restore = 'cp -af /etc/exports.backup /etc/exports'
         multihost.master[0].run_command(restore)
+        multihost.client[0].run_command("systemctl stop autofs", raiseonerr=False)
         stop_nfs = 'systemctl stop nfs-server'
         multihost.master[0].run_command(stop_nfs)
         for dn_dn in [f'automountinformation={nfs_server_ip}:/export1,'
@@ -312,6 +311,8 @@ class Testautofsresponder(object):
             multihost.master[0].run_command(f'ldapdelete -x -D '
                                             f'"cn=Directory Manager" '
                                             f'-w Secret123 -H ldap:// {dn_dn}')
+        assert 'export1' in MIT_export.stdout_text
+        assert 'export2' in mit_export.stdout_text
 
     @pytest.mark.parametrize('add_nisobject', ['/export'], indirect=True)
     @pytest.mark.tier2

--- a/src/tests/multihost/alltests/test_automount_from_bash.py
+++ b/src/tests/multihost/alltests/test_automount_from_bash.py
@@ -50,11 +50,12 @@ def common_sssd_setup(multihost):
 
 
 @pytest.fixture(scope='function')
-def ldap_autofs(multihost):
+def ldap_autofs(multihost, request):
     """
     This is common sssd setup used in this test suite.
     """
     tools = sssdTools(multihost.client[0])
+    multihost.client[0].run_command("mount")
     tools.sssd_conf("nss", {'filter_groups': 'root',
                             'filter_users': 'root',
                             'debug_level': '9'}, action='update')
@@ -71,6 +72,10 @@ def ldap_autofs(multihost):
                                         "ldap_autofs_entry_value": "nisMapEntry"}, action='update')
     tools.clear_sssd_cache()
 
+    def restore():
+        """Will restore client after test."""
+        multihost.client[0].run_command("systemctl restart autofs", raiseonerr=False)
+    request.addfinalizer(restore)
 
 @pytest.fixture(scope='class')
 def nfs_server_setup(multihost, request):


### PR DESCRIPTION
Autofs tests were not cleaning properly leaving behind stuck/unresponsive mounts. This was failing other tests that were executed after these suites. Tests were stuck when trying to create a new local users or listing dirs.