### PR TITLE
intg: return status code for calls requiring it in fake nss module

### DIFF
--- a/src/tests/intg/nss_call.c
+++ b/src/tests/intg/nss_call.c
@@ -60,6 +60,7 @@ enum nss_status _nss_call_getpwuid_r(uid_t uid, struct passwd *result,
 enum nss_status _nss_call_setpwent(void)
 {
     setpwent();
+    return NSS_STATUS_SUCCESS;
 }
 
 enum nss_status _nss_call_getpwent_r(struct passwd *result,
@@ -74,6 +75,7 @@ enum nss_status _nss_call_getpwent_r(struct passwd *result,
 enum nss_status _nss_call_endpwent(void)
 {
     endpwent();
+    return NSS_STATUS_SUCCESS;
 }
 
 enum nss_status _nss_call_getgrnam_r(const char *name, struct group *result,
@@ -95,6 +97,7 @@ enum nss_status _nss_call_getgrgid_r(gid_t gid, struct group *result,
 enum nss_status _nss_call_setgrent(void)
 {
     setgrent();
+    return NSS_STATUS_SUCCESS;
 }
 
 enum nss_status _nss_call_getgrent_r(struct group *result,
@@ -108,6 +111,7 @@ enum nss_status _nss_call_getgrent_r(struct group *result,
 enum nss_status _nss_call_endgrent(void)
 {
     endgrent();
+    return NSS_STATUS_SUCCESS;
 }
 
 enum nss_status _nss_call_initgroups_dyn(const char *user, gid_t group,


### PR DESCRIPTION
To avoid gcc warning that a function is not returning value.

```
/shared/workspace/sssd/src/tests/intg/nss_call.c: In function '_nss_call_setpwent':
/shared/workspace/sssd/src/tests/intg/nss_call.c:63:1: error: control reaches end of non-void function [-Werror=return-type]
   63 | }
      | ^
/shared/workspace/sssd/src/tests/intg/nss_call.c: In function '_nss_call_endpwent':
/shared/workspace/sssd/src/tests/intg/nss_call.c:77:1: error: control reaches end of non-void function [-Werror=return-type]
   77 | }
      | ^
/shared/workspace/sssd/src/tests/intg/nss_call.c: In function '_nss_call_setgrent':
/shared/workspace/sssd/src/tests/intg/nss_call.c:98:1: error: control reaches end of non-void function [-Werror=return-type]
   98 | }
      | ^
/shared/workspace/sssd/src/tests/intg/nss_call.c: In function '_nss_call_endgrent':
/shared/workspace/sssd/src/tests/intg/nss_call.c:111:1: error: control reaches end of non-void function [-Werror=return-type]
  111 | }
      | ^
```