### PR TITLE
CI: clean configure.sh, distro.sh and deps.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,7 @@ jobs:
           ./sssd/ci-build-debug/ci-*.log
           ./sssd/ci-build-debug/test-suite.log
           ./sssd/ci-build-debug/ci-mock-result/*.log
+          ./sssd/ci-build-debug/src/tests/cwrap/test-suite.log
 
     - name: Upload valgrind artifacts
       if: always()

--- a/contrib/ci/configure.sh
+++ b/contrib/ci/configure.sh
@@ -29,54 +29,34 @@ declare -a CONFIGURE_ARG_LIST=(
     "--enable-ldb-version-check"
     "--with-syslog=journald"
     "--enable-systemtap"
-    "--with-python2-bindings"
 )
 
 
-if [[ "$DISTRO_BRANCH" == -redhat-redhatenterprise*-6.*- ||
-      "$DISTRO_BRANCH" == -redhat-centos-6.*- ]]; then
+if [[ "$DISTRO_BRANCH" == -redhat-centos-8*- ||
+      "$DISTRO_BRANCH" == -redhat-redhatenterprise*-8.*- ]]; then
     CONFIGURE_ARG_LIST+=(
-        "--with-smb-idmap-interface-version=5"
-        "--disable-cifs-idmap-plugin"
-        "--with-syslog=syslog"
-        "--without-python3-bindings"
-        "--without-kcm"
+        "--with-python2-bindings"
+    )
+else
+    CONFIGURE_ARG_LIST+=(
+        "--without-python2-bindings"
     )
 fi
 
-if [[ "$DISTRO_BRANCH" == -redhat-fedora-2[0-2]* ]]; then
-    CONFIGURE_ARG_LIST+=(
-        "--without-kcm"
-    )
-fi
-
-if [[ "$DISTRO_BRANCH" == -redhat-redhatenterprise*-7.*- ||
-      "$DISTRO_BRANCH" == -redhat-centos-7.*- ]]; then
-    CONFIGURE_ARG_LIST+=(
-        "--without-python3-bindings"
-    )
-fi
 
 # Different versions of Debian might need different versions here but this is
 # sufficient to make the CI work
 if [[ "$DISTRO_BRANCH" == -debian-* ]]; then
     CONFIGURE_ARG_LIST+=(
-        "--without-python2-bindings"
         "--with-smb-idmap-interface-version=5"
     )
 fi
 
-if [[ "$DISTRO_BRANCH" == -redhat-fedora-4[0-9]* ||
-      "$DISTRO_BRANCH" == -redhat-fedora-3[2-9]* ||
-      "$DISTRO_BRANCH" == -redhat-centos*-9*- ||
-      "$DISTRO_BRANCH" == -redhat-redhatenterprise*-9.*- ]]; then
-    CONFIGURE_ARG_LIST+=(
-        "--without-python2-bindings"
-    )
-fi
-
-if [[ "$DISTRO_BRANCH" == -redhat-fedora-3[5-9]* ||
-      "$DISTRO_BRANCH" == -redhat-redhatenterprise*-9.*- ]]; then
+if [[ "$DISTRO_BRANCH" == -redhat-fedora-* ||
+      "$DISTRO_BRANCH" == -redhat-centos-9*- ||
+      "$DISTRO_BRANCH" == -redhat-centos-10*- ||
+      "$DISTRO_BRANCH" == -redhat-redhatenterprise*-9.*- ||
+      "$DISTRO_BRANCH" == -redhat-redhatenterprise*-10.*- ]]; then
     CONFIGURE_ARG_LIST+=(
         "--with-subid"
     )
@@ -84,7 +64,9 @@ fi
 
 if [[ "$DISTRO_BRANCH" == -redhat-fedora-* ||
       "$DISTRO_BRANCH" == -redhat-centos-9*- ||
-      "$DISTRO_BRANCH" == -redhat-centos-10*- ]]; then
+      "$DISTRO_BRANCH" == -redhat-centos-10*- ||
+      "$DISTRO_BRANCH" == -redhat-redhatenterprise*-9.*- ||
+      "$DISTRO_BRANCH" == -redhat-redhatenterprise*-10.*- ]]; then
     CONFIGURE_ARG_LIST+=(
         "--with-passkey"
     )

--- a/contrib/ci/deps.sh
+++ b/contrib/ci/deps.sh
@@ -48,8 +48,7 @@ if [[ "$DISTRO_BRANCH" == -redhat-* ]]; then
         libunistring-devel
     )
 
-    if [[ "$DISTRO_BRANCH" == -redhat-fedora-31* ||
-          "$DISTRO_BRANCH" == -redhat-redhatenterprise*-8.*- ||
+    if [[ "$DISTRO_BRANCH" == -redhat-redhatenterprise*-8.*- ||
           "$DISTRO_BRANCH" == -redhat-centos*-8*- ]]; then
         DEPS_LIST+=(
             python2
@@ -59,7 +58,7 @@ if [[ "$DISTRO_BRANCH" == -redhat-* ]]; then
     fi
 
     if [[ "$DISTRO_BRANCH" == -redhat-fedora-4[0-9]* ||
-          "$DISTRO_BRANCH" == -redhat-fedora-3[1-9]* ||
+          "$DISTRO_BRANCH" == -redhat-fedora-3[7-9]* ||
           "$DISTRO_BRANCH" == -redhat-redhatenterprise*-8.*- ||
           "$DISTRO_BRANCH" == -redhat-redhatenterprise*-9.*- ||
           "$DISTRO_BRANCH" == -redhat-centos*-8*- ||

--- a/contrib/ci/distro.sh
+++ b/contrib/ci/distro.sh
@@ -51,17 +51,7 @@ function distro_pkg_install()
 {
     declare prompt=$'Need root permissions to install packages.\n'
     prompt+="Enter sudo password for $USER: "
-    if [[ "$DISTRO_BRANCH" == -redhat-fedora-2[2-5]* ]]; then
-        # TODO switch fedora to DNF once
-        # https://bugzilla.redhat.com/show_bug.cgi?id=1215208 is fixed
-        [ $# != 0 ] && sudo -p "$prompt" \
-                            yum-deprecated --assumeyes install -- "$@" |&
-            # Pass input to output, fail if a missing package is reported
-            awk 'BEGIN {s=0}
-                 /^No package .* available.$/ {s=1}
-                 {print}
-                 END {exit s}'
-    elif [[ "$DISTRO_BRANCH" == -redhat-fedora-* ]]; then
+    if [[ "$DISTRO_BRANCH" == -redhat-fedora-* ]]; then
         [ $# != 0 ] && sudo -p "$prompt" \
                             /usr/bin/dnf --assumeyes --best \
                                          --setopt=install_weak_deps=False \


### PR DESCRIPTION
Support for Fedora 36-, RHEL/CentOS 6 and 7 in master branch ended, so
let's remove them. In addition, Python2 support also ended, so make
"--without-python2-bindings" the default for all distributions. Finally,
include RHEL/CentOS 10 for configurable features.

I would also have liked to update the [README.md](https://github.com/SSSD/sssd/blob/master/contrib/ci/README.md)
file in that folder, but apart from the supported versions I'm not sure what
else needs to be updated there. I think nobody updated it in the last years
and many things seem out of date.