### PR TITLE
SSS_CLIENT: replace `__thread` with `pthread_*specific()`  --  sssd-2.8 backport

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5273,13 +5273,15 @@ install-exec-hook: installsssddirs
 if BUILD_PYTHON2_BINDINGS
 	if [ "$(DESTDIR)" = "" ]; then \
 		cd $(builddir)/src/config; \
-		$(PYTHON2) setup.py build --build-base $(abs_builddir)/src/config \
-			install $(DISTSETUPOPTS) --prefix=$(PYTHON2_PREFIX) \
+		$(MKDIR_P) "$(python2dir)"; \
+		PYTHONPATH="$(PYTHONPATH):$(python2dir)" $(PYTHON2) setup.py build \
+			--build-base $(abs_builddir)/src/config install $(DISTSETUPOPTS) --prefix=$(PYTHON2_PREFIX) \
 			--record=$(abs_builddir)/src/config/.files2; \
 	else \
 		cd $(builddir)/src/config; \
-		$(PYTHON2) setup.py build --build-base $(abs_builddir)/src/config \
-			install $(DISTSETUPOPTS) --prefix=$(PYTHON2_PREFIX) \
+		$(MKDIR_P) "$(python2dir)"; \
+		PYTHONPATH="$(PYTHONPATH):$(python2dir)" $(PYTHON2) setup.py build \
+			--build-base $(abs_builddir)/src/config install $(DISTSETUPOPTS) --prefix=$(PYTHON2_PREFIX) \
 			--record=$(abs_builddir)/src/config/.files2 --root=$(DESTDIR); \
 	fi
 	cd $(DESTDIR)$(py2execdir) && \
@@ -5291,13 +5293,15 @@ endif
 if BUILD_PYTHON3_BINDINGS
 	if [ "$(DESTDIR)" = "" ]; then \
 		cd $(builddir)/src/config; \
-		$(PYTHON3) setup.py build --build-base $(abs_builddir)/src/config \
-			install $(DISTSETUPOPTS) --prefix=$(PYTHON3_PREFIX) \
+		$(MKDIR_P) "$(python3dir)"; \
+		PYTHONPATH="$(PYTHONPATH):$(python3dir)" $(PYTHON3) setup.py build \
+			--build-base $(abs_builddir)/src/config install $(DISTSETUPOPTS) --prefix=$(PYTHON3_PREFIX) \
 			--record=$(abs_builddir)/src/config/.files3; \
 	else \
 		cd $(builddir)/src/config; \
-		$(PYTHON3) setup.py build --build-base $(abs_builddir)/src/config \
-			install $(DISTSETUPOPTS) --prefix=$(PYTHON3_PREFIX) \
+		$(MKDIR_P) "$(python3dir)"; \
+		PYTHONPATH="$(PYTHONPATH):$(python3dir)" $(PYTHON3) setup.py build \
+			--build-base $(abs_builddir)/src/config install $(DISTSETUPOPTS) --prefix=$(PYTHON3_PREFIX) \
 			--record=$(abs_builddir)/src/config/.files3 --root=$(DESTDIR); \
 	fi
 	cd $(DESTDIR)$(py3execdir) && \
@@ -5361,10 +5365,16 @@ uninstall-hook:
 if BUILD_PYTHON2_BINDINGS
 	cd $(DESTDIR)$(py2execdir) && \
 		rm -f pysss.so pyhbac.so pysss_murmur.so pysss_nss_idmap.so
+	rm -fr "$(DESTDIR)$(python2dir)/easy-install.pth"
+	rm -fr "$(DESTDIR)$(python2dir)/__pycache__"
+	rm -fr "$(DESTDIR)$(python2dir)/site.py"
 endif
 if BUILD_PYTHON3_BINDINGS
 	cd $(DESTDIR)$(py3execdir) && \
 		rm -f pysss.so pyhbac.so pysss_murmur.so pysss_nss_idmap.so
+	rm -fr "$(DESTDIR)$(python3dir)/easy-install.pth"
+	rm -fr "$(DESTDIR)$(python3dir)/__pycache__"
+	rm -fr "$(DESTDIR)$(python3dir)/site.py"
 endif
 if BUILD_SAMBA
 	rm $(DESTDIR)/$(winbindplugindir)/sss.so

--- a/contrib/ci/configure.sh
+++ b/contrib/ci/configure.sh
@@ -66,7 +66,8 @@ if [[ "$DISTRO_BRANCH" == -debian-* ]]; then
     )
 fi
 
-if [[ "$DISTRO_BRANCH" == -redhat-fedora-3[2-9]* ||
+if [[ "$DISTRO_BRANCH" == -redhat-fedora-4[0-9]* ||
+      "$DISTRO_BRANCH" == -redhat-fedora-3[2-9]* ||
       "$DISTRO_BRANCH" == -redhat-centos*-9*- ||
       "$DISTRO_BRANCH" == -redhat-redhatenterprise*-9.*- ]]; then
     CONFIGURE_ARG_LIST+=(

--- a/contrib/ci/deps.sh
+++ b/contrib/ci/deps.sh
@@ -59,7 +59,8 @@ if [[ "$DISTRO_BRANCH" == -redhat-* ]]; then
         )
     fi
 
-    if [[ "$DISTRO_BRANCH" == -redhat-fedora-3[1-9]* ||
+    if [[ "$DISTRO_BRANCH" == -redhat-fedora-4[0-9]* ||
+          "$DISTRO_BRANCH" == -redhat-fedora-3[1-9]* ||
           "$DISTRO_BRANCH" == -redhat-redhatenterprise*-8.*- ||
           "$DISTRO_BRANCH" == -redhat-redhatenterprise*-9.*- ||
           "$DISTRO_BRANCH" == -redhat-centos*-8*- ||

--- a/contrib/ci/deps.sh
+++ b/contrib/ci/deps.sh
@@ -33,7 +33,6 @@ declare DEPS_INTGCHECK_SATISFIED=true
 if [[ "$DISTRO_BRANCH" == -redhat-* ]]; then
     declare _DEPS_LIST_SPEC
     DEPS_LIST+=(
-        clang-analyzer
         fakeroot
         libfaketime
         libcmocka-devel
@@ -107,7 +106,6 @@ if [[ "$DISTRO_BRANCH" == -debian-* ]]; then
         autopoint
         check
         cifs-utils
-        clang
         dh-apparmor
         dnsutils
         docbook-xml

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -135,6 +135,7 @@ BuildRequires: pcre2-devel
 BuildRequires: pkgconfig
 BuildRequires: popt-devel
 BuildRequires: python3-devel
+BuildRequires: python3-setuptools
 BuildRequires: samba-devel
 # required for idmap_sss.so
 BuildRequires: samba-winbind

--- a/src/config/setup.py.in
+++ b/src/config/setup.py.in
@@ -19,10 +19,10 @@
 #
 
 """
-Python-level packaging using distutils.
+Python-level packaging using setuptools.
 """
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='SSSDConfig',

--- a/src/external/pac_responder.m4
+++ b/src/external/pac_responder.m4
@@ -22,7 +22,8 @@ then
         Kerberos\ 5\ release\ 1.17* | \
         Kerberos\ 5\ release\ 1.18* | \
         Kerberos\ 5\ release\ 1.19* | \
-        Kerberos\ 5\ release\ 1.20*)
+        Kerberos\ 5\ release\ 1.20* | \
+        Kerberos\ 5\ release\ 1.21*)
             krb5_version_ok=yes
             AC_MSG_RESULT([yes])
             ;;

--- a/src/lib/certmap/sss_certmap_ldap_mapping.c
+++ b/src/lib/certmap/sss_certmap_ldap_mapping.c
@@ -228,14 +228,21 @@ int check_digest_conversion(const char *inp, const char **digest_list,
     bool colon = false;
     bool reverse = false;
     char *c;
+    size_t len = 0;
 
     sep = strchr(inp, '_');
+    if (sep != NULL) {
+        len = sep - inp;
+    }
 
     for (d = 0; digest_list[d] != NULL; d++) {
         if (sep == NULL) {
             cmp = strcasecmp(digest_list[d], inp);
         } else {
-            cmp = strncasecmp(digest_list[d], inp, (sep - inp -1));
+            if (strlen(digest_list[d]) != len) {
+                continue;
+            }
+            cmp = strncasecmp(digest_list[d], inp, len);
         }
 
         if (cmp == 0) {

--- a/src/sss_client/common.c
+++ b/src/sss_client/common.c
@@ -62,22 +62,31 @@
 
 /* common functions */
 
+static int sss_cli_sd_get(void);
+static void sss_cli_sd_set(int sd);
+static const struct stat *sss_cli_sb_get(void);
+static int sss_cli_sb_set_by_sd(int sd);
+
 #ifdef HAVE_PTHREAD_EXT
 static pthread_key_t sss_sd_key;
 static pthread_once_t sss_sd_key_init = PTHREAD_ONCE_INIT;
 static atomic_bool sss_sd_key_initialized = false;
-static __thread int sss_cli_sd = -1; /* the sss client socket descriptor */
-static __thread struct stat sss_cli_sb; /* the sss client stat buffer */
+struct sss_socket_descriptor_t {
+    int sd;
+    struct stat sb;
+};
 #else
-static int sss_cli_sd = -1; /* the sss client socket descriptor */
-static struct stat sss_cli_sb; /* the sss client stat buffer */
+static int _sss_cli_sd = -1; /* the sss client socket descriptor */
+static struct stat _sss_cli_sb; /* the sss client stat buffer */
 #endif
 
 void sss_cli_close_socket(void)
 {
-    if (sss_cli_sd != -1) {
-        close(sss_cli_sd);
-        sss_cli_sd = -1;
+    int sd = sss_cli_sd_get();
+
+    if (sd != -1) {
+        close(sd);
+        sss_cli_sd_set(-1);
     }
 }
 
@@ -85,25 +94,30 @@ void sss_cli_close_socket(void)
 static void sss_at_thread_exit(void *v)
 {
     sss_cli_close_socket();
+    free(v);
+    pthread_setspecific(sss_sd_key, NULL);
 }
 
 static void init_sd_key(void)
 {
-    pthread_key_create(&sss_sd_key, sss_at_thread_exit);
-    sss_sd_key_initialized = true;
+    if (pthread_key_create(&sss_sd_key, sss_at_thread_exit) == 0) {
+        sss_sd_key_initialized = true;
+    }
 }
 #endif
 
 #if HAVE_FUNCTION_ATTRIBUTE_DESTRUCTOR
 __attribute__((destructor)) void sss_at_lib_unload(void)
 {
+    sss_cli_close_socket();
 #ifdef HAVE_PTHREAD_EXT
     if (sss_sd_key_initialized) {
         sss_sd_key_initialized = false;
+        free(pthread_getspecific(sss_sd_key));
+        pthread_setspecific(sss_sd_key, NULL);
         pthread_key_delete(sss_sd_key);
     }
 #endif
-    sss_cli_close_socket();
 }
 #endif
 
@@ -137,7 +151,7 @@ static enum sss_status sss_cli_send_req(enum sss_cli_command cmd,
         int res, error;
 
         *errnop = 0;
-        pfd.fd = sss_cli_sd;
+        pfd.fd = sss_cli_sd_get();
         pfd.events = POLLOUT;
 
         do {
@@ -163,7 +177,7 @@ static enum sss_status sss_cli_send_req(enum sss_cli_command cmd,
                 *errnop = EPIPE;
             } else if (pfd.revents & POLLNVAL) {
                 /* Invalid request: fd is not opened */
-                sss_cli_sd = -1;
+                sss_cli_sd_set(-1);
                 *errnop = EPIPE;
             } else if (!(pfd.revents & POLLOUT)) {
                 *errnop = EBUSY;
@@ -180,13 +194,13 @@ static enum sss_status sss_cli_send_req(enum sss_cli_command cmd,
 
         errno = 0;
         if (datasent < SSS_NSS_HEADER_SIZE) {
-            res = send(sss_cli_sd,
+            res = send(sss_cli_sd_get(),
                        (char *)header + datasent,
                        SSS_NSS_HEADER_SIZE - datasent,
                        SSS_DEFAULT_WRITE_FLAGS);
         } else {
             rdsent = datasent - SSS_NSS_HEADER_SIZE;
-            res = send(sss_cli_sd,
+            res = send(sss_cli_sd_get(),
                        (const char *)rd->data + rdsent,
                        rd->len - rdsent,
                        SSS_DEFAULT_WRITE_FLAGS);
@@ -249,7 +263,7 @@ static enum sss_status sss_cli_recv_rep(enum sss_cli_command cmd,
         int bufrecv;
         int res, error;
 
-        pfd.fd = sss_cli_sd;
+        pfd.fd = sss_cli_sd_get();
         pfd.events = POLLIN;
 
         do {
@@ -278,7 +292,7 @@ static enum sss_status sss_cli_recv_rep(enum sss_cli_command cmd,
                 *errnop = EPIPE;
             } else if (pfd.revents & POLLNVAL) {
                 /* Invalid request: fd is not opened */
-                sss_cli_sd = -1;
+                sss_cli_sd_set(-1);
                 *errnop = EPIPE;
             } else if (!(pfd.revents & POLLIN)) {
                 *errnop = EBUSY;
@@ -296,12 +310,12 @@ static enum sss_status sss_cli_recv_rep(enum sss_cli_command cmd,
 
         errno = 0;
         if (datarecv < SSS_NSS_HEADER_SIZE) {
-            res = read(sss_cli_sd,
+            res = read(sss_cli_sd_get(),
                        (char *)header + datarecv,
                        SSS_NSS_HEADER_SIZE - datarecv);
         } else {
             bufrecv = datarecv - SSS_NSS_HEADER_SIZE;
-            res = read(sss_cli_sd,
+            res = read(sss_cli_sd_get(),
                        (char *) buf + bufrecv,
                        header[0] - datarecv);
         }
@@ -591,16 +605,6 @@ static int sss_cli_open_socket(int *errnop, const char *socket_name, int timeout
         return -1;
     }
 
-#ifdef HAVE_PTHREAD_EXT
-    pthread_once(&sss_sd_key_init, init_sd_key); /* once for all threads */
-
-    /* It actually doesn't matter what value to set for a key.
-     * The only important thing: key must be non-NULL to ensure
-     * destructor is executed at thread exit.
-     */
-    pthread_setspecific(sss_sd_key, &sss_cli_sd);
-#endif
-
     /* set as non-blocking, close on exec, and make sure standard
      * descriptors are not used */
     sd = make_safe_fd(sd);
@@ -670,7 +674,7 @@ static int sss_cli_open_socket(int *errnop, const char *socket_name, int timeout
         return -1;
     }
 
-    ret = fstat(sd, &sss_cli_sb);
+    ret = sss_cli_sb_set_by_sd(sd);
     if (ret != 0) {
         close(sd);
         return -1;
@@ -685,29 +689,65 @@ static enum sss_status sss_cli_check_socket(int *errnop,
 {
     static pid_t mypid;
     struct stat mysb;
+    const struct stat *sss_cli_sb = NULL;
     int mysd;
     int ret;
+#ifdef HAVE_PTHREAD_EXT
+    struct sss_socket_descriptor_t *descriptor = NULL;
+
+    ret = pthread_once(&sss_sd_key_init, init_sd_key); /* once for all threads */
+    if (ret != 0) {
+        *errnop = EFAULT;
+        return SSS_STATUS_UNAVAIL;
+    }
+    if (!sss_sd_key_initialized) {
+        /* pthread_once::init_sd_key::pthread_key_create failed  --  game over? */
+        *errnop = EFAULT;
+        return SSS_STATUS_UNAVAIL;
+    }
+
+    if (pthread_getspecific(sss_sd_key) == NULL) { /* for every thread */
+        descriptor = (struct sss_socket_descriptor_t *)
+                         calloc(1, sizeof(struct sss_socket_descriptor_t));
+        if (descriptor == NULL) {
+            *errnop = ENOMEM;
+            return SSS_STATUS_UNAVAIL;
+        }
+        descriptor->sd = -1;
+        ret = pthread_setspecific(sss_sd_key, descriptor);
+        if (ret != 0) {
+            free(descriptor);
+            *errnop = ENOMEM;
+            return SSS_STATUS_UNAVAIL;
+        }
+    }
+#endif
+    sss_cli_sb = sss_cli_sb_get();
+    if (sss_cli_sb == NULL) {
+        *errnop = EFAULT;
+        return SSS_STATUS_UNAVAIL;
+    }
 
     if (getpid() != mypid) {
-        ret = fstat(sss_cli_sd, &mysb);
+        ret = fstat(sss_cli_sd_get(), &mysb);
         if (ret == 0) {
             if (S_ISSOCK(mysb.st_mode) &&
-                mysb.st_dev == sss_cli_sb.st_dev &&
-                mysb.st_ino == sss_cli_sb.st_ino) {
+                mysb.st_dev == sss_cli_sb->st_dev &&
+                mysb.st_ino == sss_cli_sb->st_ino) {
                 sss_cli_close_socket();
             }
         }
-        sss_cli_sd = -1;
+        sss_cli_sd_set(-1);
         mypid = getpid();
     }
 
     /* check if the socket has been closed on the other side */
-    if (sss_cli_sd != -1) {
+    if (sss_cli_sd_get() != -1) {
         struct pollfd pfd;
         int res, error;
 
         *errnop = 0;
-        pfd.fd = sss_cli_sd;
+        pfd.fd = sss_cli_sd_get();
         pfd.events = POLLIN | POLLOUT;
 
         do {
@@ -733,7 +773,7 @@ static enum sss_status sss_cli_check_socket(int *errnop,
                 *errnop = EPIPE;
             } else if (pfd.revents & POLLNVAL) {
                 /* Invalid request: fd is not opened */
-                sss_cli_sd = -1;
+                sss_cli_sd_set(-1);
                 *errnop = EPIPE;
             } else if (!(pfd.revents & (POLLIN | POLLOUT))) {
                 *errnop = EBUSY;
@@ -755,7 +795,7 @@ static enum sss_status sss_cli_check_socket(int *errnop,
         return SSS_STATUS_UNAVAIL;
     }
 
-    sss_cli_sd = mysd;
+    sss_cli_sd_set(mysd);
 
     if (sss_cli_check_version(socket_name, timeout)) {
         return SSS_STATUS_SUCCESS;
@@ -1010,7 +1050,7 @@ int sss_pam_make_request(enum sss_cli_command cmd,
         goto out;
     }
 
-    error = check_server_cred(sss_cli_sd);
+    error = check_server_cred(sss_cli_sd_get());
     if (error != 0) {
         sss_cli_close_socket();
         *errnop = error;
@@ -1302,3 +1342,89 @@ errno_t sss_readrep_copy_string(const char *in,
 
     return EOK;
 }
+
+#ifdef HAVE_PTHREAD_EXT
+
+static int sss_cli_sd_get(void)
+{
+    if (!sss_sd_key_initialized) {
+        return -1;
+    }
+
+    struct sss_socket_descriptor_t *descriptor = pthread_getspecific(sss_sd_key);
+
+    if (descriptor == NULL) { /* sanity check */
+        return -1;
+    }
+
+    return descriptor->sd;
+}
+
+static void sss_cli_sd_set(int sd)
+{
+    if (!sss_sd_key_initialized) {
+        return;
+    }
+
+    struct sss_socket_descriptor_t *descriptor = pthread_getspecific(sss_sd_key);
+
+    if (descriptor == NULL) { /* sanity check */
+        return;
+    }
+
+    descriptor->sd = sd;
+}
+
+static const struct stat *sss_cli_sb_get(void)
+{
+    if (!sss_sd_key_initialized) {
+        return NULL;
+    }
+
+    struct sss_socket_descriptor_t *descriptor = pthread_getspecific(sss_sd_key);
+
+    if (descriptor == NULL) { /* sanity check */
+        return NULL;
+    }
+
+    return &descriptor->sb;
+}
+
+static int sss_cli_sb_set_by_sd(int sd)
+{
+    if (!sss_sd_key_initialized) {
+        return -1;
+    }
+
+    struct sss_socket_descriptor_t *descriptor = pthread_getspecific(sss_sd_key);
+
+    if (descriptor == NULL) { /* sanity check */
+        return -1;
+    }
+
+    return fstat(sd, &descriptor->sb);
+}
+
+#else
+
+static int sss_cli_sd_get(void)
+{
+    return _sss_cli_sd;
+}
+
+static void sss_cli_sd_set(int sd)
+{
+    _sss_cli_sd = sd;
+}
+
+static const struct stat *sss_cli_sb_get(void)
+{
+    return &_sss_cli_sb;
+}
+
+static int sss_cli_sb_set_by_sd(int sd)
+{
+    return fstat(sd, &_sss_cli_sb);
+}
+
+#endif

--- a/src/tests/cmocka/test_certmap.c
+++ b/src/tests/cmocka/test_certmap.c
@@ -2183,6 +2183,28 @@ static void test_sss_certmap_ldapu1_cert(void **state)
     assert_non_null(ctx);
     assert_null(ctx->prio_list);
 
+    /* cert!sha */
+    ret = sss_certmap_add_rule(ctx, 91,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule91={cert!sha}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 91,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule91={cert!sha}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    /* cert!sha_u */
+    ret = sss_certmap_add_rule(ctx, 90,
+                            "KRB5:<ISSUER>.*",
+                            "LDAP:rule90={cert!sha_u}", NULL);
+    assert_int_equal(ret, EINVAL);
+
+    ret = sss_certmap_add_rule(ctx, 99,
+                            "KRB5:<ISSUER>.*",
+                            "LDAPU1:rule90={cert!sha_u}", NULL);
+    assert_int_equal(ret, EINVAL);
+
     /* cert!sha555 */
     ret = sss_certmap_add_rule(ctx, 89,
                             "KRB5:<ISSUER>.*",

--- a/src/tests/system/conftest.py
+++ b/src/tests/system/conftest.py
@@ -7,6 +7,7 @@ from sssd_test_framework.config import SSSDMultihostConfig
 
 # Load additional plugins
 pytest_plugins = (
+    "pytest_importance",
     "pytest_mh",
     "pytest_ticket",
     "pytest_tier",

--- a/src/tests/system/requirements.txt
+++ b/src/tests/system/requirements.txt
@@ -1,4 +1,5 @@
 pytest
+git+https://github.com/next-actions/pytest-importance
 git+https://github.com/next-actions/pytest-mh
 git+https://github.com/next-actions/pytest-ticket
 git+https://github.com/next-actions/pytest-tier


### PR DESCRIPTION
in sss_client code to properly handle OOM condition (with `__thread` glibc terminates process in this case).

Solution relies on the fact that `sss_cli_check_socket()` is always executed first, before touching socket.
Nonetheless, there are sanity guards in setters/getters just in case.

It's possible to move context initialization code into a separate function and call it in every getter/setter, but probably not worth it.

Backported from ef5370e96bff79025cb9a0f9e62c4d3684f55512 with required amendments in `sss_cli_check_socket()`