### PR TITLE
Tests: Fix gating tests for 9.2

### DIFF
--- a/src/tests/multihost/alltests/test_automount_from_bash.py
+++ b/src/tests/multihost/alltests/test_automount_from_bash.py
@@ -670,7 +670,7 @@ class TestAutoFs(object):
         client.run_command("service autofs restart")
         time.sleep(10)
         with pytest.raises(subprocess.CalledProcessError):
-            client.run_command("cd /folder1/folder2/projects;cd -")
+            client.run_command("ls -d /folder1/folder2/projects")
         find_logs(multihost, log_sssd, f"Searching for automount map entries with base [ou=mount,{ds_suffix}]")
         # Adding the deleted direct map
         user_dn = f'cn=/folder1/folder2/projects,nisMapName=auto.direct,ou=mount,{ds_suffix}'
@@ -956,7 +956,7 @@ class TestAutoFs(object):
                          'nisMapEntry': f'-fstype=nfs,rw {master_server}:/export/foo/testkey{i}'.encode('utf-8')}
             ldap_inst.add_entry(user_info, user_dn)
         dumpmap_fixed_val = "automount - -dumpmaps | wc - l"
-        for i in range(1, 11):
+        for i in range(11):
             dumpmap_current_val = "automount - -dumpmaps | wc - l"
             assert dumpmap_fixed_val == dumpmap_current_val
 

--- a/src/tests/multihost/alltests/test_ldap_password_policy.py
+++ b/src/tests/multihost/alltests/test_ldap_password_policy.py
@@ -181,7 +181,7 @@ class TestPasswordPolicy():
         find_logs(multihost, file_ssd, "Password expired user must set a new password")
         ldap_modify_ds(multihost, ldap.MOD_REPLACE, cn_config, 'passwordExp', [b'off'])
         time.sleep(3)
-        assert tools.auth_client_ssh_password('ppuser1', 'NewPass_123')
+        assert tools.auth_client_ssh_password('ppuser1', 'Secret123')
         ldap_modify_ds(multihost, ldap.MOD_REPLACE, user_dn, 'userPassword', [b'Secret123'])
 
     @staticmethod


### PR DESCRIPTION
It fixes test from tire1_2 that is failling in gating

1. src/tests/multihost/alltests/test_automount.py   there is issue with autofs email thead: [CRASH] prep Package: autofs-1:5.1.7-36.el9
2. src/tests/multihost/alltests/test_automount_from_bash.py test did not rised error as last cd - command was successful, so i have remove cd - part(/folder1/folder2/projects does not exists)
3. src/tests/multihost/alltests/test_ldap_password_policy.py  password provied was wrong.
4. src/tests/multihost/alltests/test_backtrace.py ---  need to modify this test as per current log format

(cherry picked from 2096f45527d4513ae52547fafd383bd2542d7f79)