### PR TITLE
SSS_CLIENT: replace `__thread` with `pthread_*specific()`

### DIFF
--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -380,7 +380,7 @@ static void svc_child_info(struct mt_svc *svc, int wait_status)
                   pid, name, identity);
             sss_log(SSS_LOG_CRIT,
                     "Child [%d] ('%s':'%s') was terminated by own WATCHDOG. "
-                    "Consult corresponding logs to figure out the reason.",
+                    "Consult corresponding logs to figure out the reason. As a workaround consider increasing the timeout value",
                     pid, name, identity);
         } else {
             DEBUG(SSSDBG_OP_FAILURE,


### PR DESCRIPTION
in sss_client code to properly handle OOM condition (with `__thread` glibc terminates process in this case).

Solution relies on the fact that `sss_cli_check_socket()` is always executed first, before touching socket.
Nonetheless, there are sanity guards in setters/getters just in case.

It's possible to move context initialization code into a separate function and call it in every getter/setter, but probably not worth it.

Reviewed-by: Sumit Bose <sbose@redhat.com>
Reviewed-by: Carlos O'Donell <codonell@redhat.com>