### PR TITLE
Monitor: Improve log msg

### DIFF
--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -380,7 +380,7 @@ static void svc_child_info(struct mt_svc *svc, int wait_status)
                   pid, name, identity);
             sss_log(SSS_LOG_CRIT,
                     "Child [%d] ('%s':'%s') was terminated by own WATCHDOG. "
-                    "Consult corresponding logs to figure out the reason.",
+                    "Consult corresponding logs to figure out the reason. As a workaround consider increasing the timeout value",
                     pid, name, identity);
         } else {
             DEBUG(SSSDBG_OP_FAILURE,


### PR DESCRIPTION
If sssd is terminated by watchdog then we can try increasing the timeout value to workaround this issue temporarily hence I have added the suggestion of increasing timeout value.