### PR TITLE
KCM: Reduce the amount of memory allocated by KCM and avoid zeroing it when not necessary

### DIFF
--- a/src/responder/kcm/kcmsrv_ccache.c
+++ b/src/responder/kcm/kcmsrv_ccache.c
@@ -40,7 +40,9 @@ static int kcm_cc_destructor(struct kcm_ccache *cc)
         return 0;
     }
 
-    krb5_free_principal(NULL, cc->client);
+    if (cc->client != NULL) {
+        krb5_free_principal(NULL, cc->client);
+    }
     return 0;
 }
 

--- a/src/responder/kcm/kcmsrv_ccache.c
+++ b/src/responder/kcm/kcmsrv_ccache.c
@@ -233,7 +233,6 @@ struct kcm_cred *kcm_cred_new(TALLOC_CTX *mem_ctx,
     if (kcreds == NULL) {
         return NULL;
     }
-
     uuid_copy(kcreds->uuid, uuid);
     kcreds->cred_blob = talloc_steal(kcreds, cred_blob);
     return kcreds;

--- a/src/responder/kcm/kcmsrv_ccache.c
+++ b/src/responder/kcm/kcmsrv_ccache.c
@@ -411,7 +411,7 @@ krb5_creds **kcm_cc_unmarshal(TALLOC_CTX *mem_ctx,
         count++;
     }
 
-    cred_list = talloc_zero_array(tmp_ctx, krb5_creds *, count + 1);
+    cred_list = talloc_array(tmp_ctx, krb5_creds *, count + 1);
 
     for (cred = kcm_cc_get_cred(cc); cred != NULL; cred = kcm_cc_next_cred(cred), i++) {
         cred_list[i] = kcm_cred_to_krb5(krb_context, cred);
@@ -513,7 +513,7 @@ struct kcm_ccdb *kcm_ccdb_init(TALLOC_CTX *mem_ctx,
         ccdb->ops = &ccdb_secdb_ops;
         break;
     default:
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unknown ccache database\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unknown ccache database backend\n");
         break;
     }
 

--- a/src/responder/kcm/kcmsrv_ccache_binary.c
+++ b/src/responder/kcm/kcmsrv_ccache_binary.c
@@ -201,7 +201,7 @@ static errno_t bin_to_princ(TALLOC_CTX *mem_ctx,
         return ret;
     }
 
-    princ->data = talloc_zero_array(princ, krb5_data, princ->length);
+    princ->data = talloc_array(princ, krb5_data, princ->length);
     if (princ->length > 0 && princ->data == NULL) {
         return ENOMEM;
     }

--- a/src/responder/kcm/kcmsrv_ccache_pvt.h
+++ b/src/responder/kcm/kcmsrv_ccache_pvt.h
@@ -41,7 +41,6 @@ struct kcm_cred {
 };
 
 struct kcm_ccdb {
-    enum kcm_ccdb_be cc_be_type;
     struct tevent_context *ev;
 
     void *db_handle;

--- a/src/responder/kcm/kcmsrv_ccache_secdb.c
+++ b/src/responder/kcm/kcmsrv_ccache_secdb.c
@@ -531,13 +531,7 @@ static errno_t ccdb_secdb_init(struct kcm_ccdb *db,
     }
 
     if (kcm_quota->max_uid_secrets > 0) {
-        /* Even cn=default is considered a secret that adds up to
-         * the quota. To avoid off-by-one-confusion, increase
-         * the quota by two to 1) account for the cn=default object
-         * and 2) always allow writing to cn=defaults even if we
-         * are exactly at the quota limit
-         */
-       kcm_quota->max_uid_secrets += 2;
+       kcm_quota->max_uid_secrets += KCM_MAX_UID_EXTRA_SECRETS;
     }
 
     ret = sss_sec_init(db, kcm_quota, &secdb->sctx);

--- a/src/responder/kcm/kcmsrv_cmd.c
+++ b/src/responder/kcm/kcmsrv_cmd.c
@@ -275,7 +275,7 @@ static errno_t kcm_output_construct(TALLOC_CTX *mem_ctx,
     SAFEALIGN_SETMEM_UINT32(repbuf->rcbuf, 0, &c);
 
     if (replen > 0) {
-        rep = talloc_zero_array(mem_ctx, uint8_t, replen);
+        rep = talloc_array(mem_ctx, uint8_t, replen);
         if (rep == NULL) {
             DEBUG(SSSDBG_CRIT_FAILURE,
                   "Failed to allocate memory for the message\n");
@@ -437,7 +437,7 @@ static errno_t kcm_recv_data(TALLOC_CTX *mem_ctx,
         return E2BIG;
     }
 
-    msg = talloc_zero_array(mem_ctx, uint8_t, msglen);
+    msg = talloc_array(mem_ctx, uint8_t, msglen);
     if (msg == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Failed to allocate memory for the message\n");

--- a/src/responder/kcm/kcmsrv_cmd.c
+++ b/src/responder/kcm/kcmsrv_cmd.c
@@ -34,11 +34,6 @@
 /* The return code is 32bits */
 #define KCM_RETCODE_SIZE 4
 
-/* The maximum length of a request or reply as defined by the RPC
- * protocol. This is the same constant size as MIT KRB5 uses
- */
-#define KCM_PACKET_MAX_SIZE 10*1024*1024
-
 /* KCM operation, its raw input and raw output and result */
 struct kcm_op_io {
     struct kcm_op *op;

--- a/src/responder/kcm/kcmsrv_ops.c
+++ b/src/responder/kcm/kcmsrv_ops.c
@@ -161,7 +161,7 @@ struct tevent_req *kcm_cmd_send(TALLOC_CTX *mem_ctx,
                                         state,
                                         KCM_REPLY_MAX - 2*sizeof(uint32_t),
                                         KCM_REPLY_MAX - 2*sizeof(uint32_t));
-    if (state->reply == NULL) {
+    if (state->op_ctx->reply == NULL) {
         ret = ENOMEM;
         goto immediate;
     }

--- a/src/responder/kcm/kcmsrv_ops.h
+++ b/src/responder/kcm/kcmsrv_ops.h
@@ -29,6 +29,19 @@
 #include "util/sss_iobuf.h"
 #include "responder/kcm/kcmsrv_pvt.h"
 
+/* The initial packet size, which can later be grown up to KCM_PACKET_MAX_SIZE.
+ * The initial size is a trade off that is expected to best serve most of the
+ * cases (typical credentials size).
+ */
+#define KCM_PACKET_INITIAL_SIZE 4096
+
+/* The maximum length of a request or reply as defined by the RPC
+ * protocol. This is the same constant size as MIT KRB5 uses
+ * This limit comes from:
+ * https://github.com/krb5/krb5/blob/c20251dafd6120fa08c76b19315cb9deb1a1b24e/src/lib/krb5/ccache/cc_kcm.c#L54
+ */
+#define KCM_PACKET_MAX_SIZE 10*1024*1024
+
 struct kcm_op;
 struct kcm_op *kcm_get_opt(uint16_t opcode);
 const char *kcm_opt_name(struct kcm_op *op);

--- a/src/responder/kcm/secrets/secrets.c
+++ b/src/responder/kcm/secrets/secrets.c
@@ -381,12 +381,12 @@ static int local_db_check_peruid_number_of_secrets(TALLOC_CTX *mem_ctx,
         ret = local_db_remove_oldest_expired_secret(res, req);
         if (ret != EOK) {
             if (ret == ERR_NO_MATCHING_CREDS) {
-                /* max_uid_secrets is incremented by 2 for internal entries. */
+                /* max_uid_secrets is incremented for internal entries. */
                 DEBUG(SSSDBG_OP_FAILURE,
                       "Cannot store any more secrets for this client (basedn %s) "
                       "as the maximum allowed limit (%d) has been reached\n",
                       ldb_dn_get_linearized(cli_basedn),
-                      req->quota->max_uid_secrets - 2);
+                      req->quota->max_uid_secrets - KCM_MAX_UID_EXTRA_SECRETS);
                 ret = ERR_SEC_INVALID_TOO_MANY_SECRETS;
             }
             goto done;

--- a/src/responder/kcm/secrets/secrets.h
+++ b/src/responder/kcm/secrets/secrets.h
@@ -40,6 +40,14 @@
 #define DEFAULT_SEC_KCM_MAX_UID_SECRETS  64
 #define DEFAULT_SEC_KCM_MAX_PAYLOAD_SIZE 65536
 
+/* Even cn=default is considered a secret that adds up to
+ * the quota. To avoid off-by-one-confusion, increase
+ * the quota by two to 1) account for the cn=default object
+ * and 2) always allow writing to cn=defaults even if we
+ * are exactly at the quota limit
+ */
+#define KCM_MAX_UID_EXTRA_SECRETS  2
+
 struct sss_sec_ctx;
 
 struct sss_sec_req;

--- a/src/util/sss_iobuf.c
+++ b/src/util/sss_iobuf.c
@@ -30,7 +30,7 @@ struct sss_iobuf *sss_iobuf_init_empty(TALLOC_CTX *mem_ctx,
         return NULL;
     }
 
-    buf = talloc_zero_array(iobuf, uint8_t, size);
+    buf = talloc_array(iobuf, uint8_t, size);
     if (buf == NULL) {
         talloc_free(iobuf);
         return NULL;
@@ -43,7 +43,6 @@ struct sss_iobuf *sss_iobuf_init_empty(TALLOC_CTX *mem_ctx,
     iobuf->data = buf;
     iobuf->size = size;
     iobuf->capacity = capacity;
-    iobuf->dp = 0;
 
     return iobuf;
 }
@@ -80,7 +79,6 @@ struct sss_iobuf *sss_iobuf_init_steal(TALLOC_CTX *mem_ctx,
     iobuf->data = talloc_steal(iobuf, data);
     iobuf->size = size;
     iobuf->capacity = size;
-    iobuf->dp = 0;
 
     return iobuf;
 }

--- a/src/util/sss_iobuf.h
+++ b/src/util/sss_iobuf.h
@@ -23,6 +23,8 @@ struct sss_iobuf;
  *                          Use 0 for an 'unlimited' buffer that will grow
  *                          until SIZE_MAX/2.
  *
+ * @warning The allocated data storage will not be zeroed.
+ *
  * @return The newly created buffer on success or NULL on an error.
  *
  */
@@ -43,6 +45,8 @@ struct sss_iobuf *sss_iobuf_init_empty(TALLOC_CTX *mem_ctx,
  * @param[in]  data         The data to initialize the IO buffer with. This
  *                          data is copied into the iobuf-owned buffer.
  * @param[in]  size         The size of the data buffer
+ *
+ * @warning The allocated data storage will not be zeroed.
  *
  * @return The newly created buffer on success or NULL on an error.
  */


### PR DESCRIPTION
### Description
Resolves: https://github.com/SSSD/sssd/issues/7014

1. When the reply message's size is unknown, the initial size for packages is now set to 4KiB instead of 10MiB as before. If needed, they can still grow up to 10MiB. The reason for allocating 4KiB is that the kernel handles 4KiB-pages, even if less is requested, making it useless to allocate less than that size.
2. Some memory allocations are no longer zeroed as it is not really needed. After these allocations, the allocated structures are explicitly initialized overwriting the zeros. Not all zeroing allocations were removed. Only the previously identified ones and a few identified while fixing this issue. Some of the remaining are required and others were not analyzed yet.
3. Merged the `KCM_PACKET_MAX_SIZE` and `KCM_REPLY_MAX` macros.
4. Fixed a bad check I just happened to find.
5. Replaced the hard-coded value used to increase the size of the per-uid quota by a macro.
### Testing
I tested the improvement by running 2000 times in a row the `once` application provided in the downstream ticket. The `once` application measures and prints the time the function `gss_acquire_cred()` takes to execute once.
I ran the 2000-iteration loop several times, with and without the fix. This is a representative set of results:
#### sssd-2.9.1-1fc38
2000 loops
Total time: 26512708 usecs
Meantime: 13256 usecs
CPU consumption: About 70%

#### sssd-2.10.0-0.20231113.1726.gitaa9e1c908.fc38
2000 loops
Total time: 6354886 usecs
Mean time: 3177 usecs
CPU consumption: About 35%
