### PR TITLE
KCM: Fixing a problem when rotating the logs

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -82,6 +82,7 @@ Requires: sssd-krb5 = %{version}-%{release}
 Requires: sssd-ldap = %{version}-%{release}
 Requires: sssd-proxy = %{version}-%{release}
 Suggests: logrotate
+Suggests: procps-ng
 Suggests: python3-sssdconfig = %{version}-%{release}
 Suggests: sssd-dbus = %{version}-%{release}
 

--- a/src/examples/logrotate
+++ b/src/examples/logrotate
@@ -7,6 +7,7 @@
     compress
     delaycompress
     postrotate
-        /bin/kill -HUP `cat /var/run/sssd.pid  2>/dev/null`  2> /dev/null || true
+        /bin/kill -HUP `cat /var/run/sssd.pid 2>/dev/null` 2> /dev/null || true
+        /bin/pkill -HUP sssd_kcm 2> /dev/null || true
     endscript
 }


### PR DESCRIPTION
sssd_kcm is not registered with SSSD's monitor, so it is not signaled when it must restart the log. Adding this command will directly signal sssd_kcm (in addition to the monitor).
    
If sssd_kcm is also running in one or more containers, they will also receive the signal. Because only the log files in the host where rotated, the instances in the containers will go on using the same log files. Nothing will happen except for the "Received SIGHUP. Rotating logfiles." message in the log files. If we want to avoid this, we should implement a PID file.

Ticket: https://issues.redhat.com/browse/SSSD-5687
