### PR TITLE
SPEC: 'sssd-proxy' requires 'libsss_certmap.so'

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -370,6 +370,7 @@ identity data from and authenticate against an Active Directory server.
 Summary: The proxy back end of the SSSD
 License: GPLv3+
 Requires: sssd-common = %{version}-%{release}
+Requires: libsss_certmap = %{version}-%{release}
 
 %description proxy
 Provides the proxy back end which can be used to wrap an existing NSS and/or


### PR DESCRIPTION
Resolves following rpminspect warning:
```
Subpackage sssd-proxy carries 'Requires: libsss_certmap.so.0()(64bit)' which comes from
subpackage libsss_certmap but does not carry an explicit package version requirement.
Please add 'Requires: libsss_certmap = %{version}-%{release}' to the spec file to avoid
the need to test interoperability between various combinations of old and new subpackages.
```