### PR TITLE
ad: avoid printing backtrace on certain conditions

### DIFF
--- a/src/providers/ad/ad_domain_info.c
+++ b/src/providers/ad/ad_domain_info.c
@@ -225,7 +225,7 @@ ad_domain_info_send(TALLOC_CTX *mem_ctx,
      * the list if no matching domain was found since it is most probably
      * related to the configured domain. */
     if (state->sdom == NULL) {
-        DEBUG(SSSDBG_OP_FAILURE, "No internal domain data found for [%s], "
+        DEBUG(SSSDBG_TRACE_FUNC, "No internal domain data found for [%s], "
                                  "falling back to first domain.\n",
                                  state->dom_name);
         state->sdom = state->opts->sdom;

--- a/src/providers/ad/ad_gpo.c
+++ b/src/providers/ad/ad_gpo.c
@@ -3435,7 +3435,7 @@ ad_gpo_get_som_attrs_done(struct tevent_req *subreq)
         goto done;
     }
     if ((num_results < 1) || (results == NULL)) {
-        DEBUG(SSSDBG_OP_FAILURE, "no attrs found for SOM; try next SOM.\n");
+        DEBUG(SSSDBG_FUNC_DATA, "no attrs found for SOM; try next SOM.\n");
         state->som_index++;
         ret = ad_gpo_get_som_attrs_step(req);
         goto done;
@@ -3456,7 +3456,7 @@ ad_gpo_get_som_attrs_done(struct tevent_req *subreq)
     }
 
     if ((ret == ENOENT) || (el->num_values == 0)) {
-        DEBUG(SSSDBG_OP_FAILURE, "no attrs found for SOM; try next SOM\n");
+        DEBUG(SSSDBG_FUNC_DATA, "gpLink attr not found or has no values\n");
         state->som_index++;
         ret = ad_gpo_get_som_attrs_step(req);
         goto done;


### PR DESCRIPTION
This was found by test from https://github.com/SSSD/sssd/pull/6928.