### PR TITLE
passkey: Add krb5 preauthentication prompt support

### DIFF
--- a/src/krb5_plugin/passkey/passkey.h
+++ b/src/krb5_plugin/passkey/passkey.h
@@ -34,6 +34,9 @@
 #define SSSD_PASSKEY_QUESTION "passkey"
 #define SSSD_PASSKEY_PREFIX "passkey "
 #define SSSD_PASSKEY_REPLY_STATE "ipa_otpd state"
+#define SSSD_PASSKEY_PROMPT "Insert your passkey device, then press ENTER"
+#define SSSD_PASSKEY_PIN_PROMPT "Enter PIN"
+#define SSSD_PASSKEY_CHILD SSSD_LIBEXEC_PATH"/passkey_child"
 
 struct sss_passkey_config {
     char **indicators;
@@ -99,5 +102,9 @@ sss_passkey_message_decode_padata(krb5_pa_data *padata);
 
 krb5_pa_data **
 sss_passkey_message_encode_padata_array(const struct sss_passkey_message *data);
+
+krb5_error_code
+sss_passkey_concat_credentials(char **creds,
+                               char **_creds_str);
 
 #endif /* _PASSKEY_H_ */


### PR DESCRIPTION
Provide passkey support for plain kinit.

Setup: Add IPA user with `--user-auth-type=passkey` then add passkey mapping data with `ipa user-add-passkey`. PIN prompt will be skipped when no passkey PIN is set on the device and IPA passkey config `Require user verification: False`

~~~
$ kinit -n @IPA.TEST -c armor && kinit -T armor testuser1@IPA.TEST
Insert your passkey device, then press ENTER: 
Enter PIN: 

$ klist
Ticket cache: KEYRING:persistent:1000:krb_ccache_2nD3TEN
Default principal: testuser1@IPA.TEST

Valid starting       Expires              Service principal
11/20/2023 10:27:30  11/21/2023 09:40:35  krbtgt/IPA.TEST@IPA.TEST
