### PR TITLE
nssidmap: fix sss_nss_getgrouplist_timeout() with empty secondary group list

### DIFF
--- a/src/sss_client/idmap/sss_nss_ex.c
+++ b/src/sss_client/idmap/sss_nss_ex.c
@@ -241,8 +241,9 @@ static int sss_get_ex(struct nss_input *inp, uint32_t flags,
     /* Get number of results from repbuf. */
     SAFEALIGN_COPY_UINT32(&num_results, repbuf, NULL);
 
-    /* no results if not found */
-    if (num_results == 0) {
+    /* no results if not found, INITGR requests are handled separately */
+    if (num_results == 0 && inp->cmd != SSS_NSS_INITGR
+                         && inp->cmd != SSS_NSS_INITGR_EX) {
         ret = ENOENT;
         goto out;
     }


### PR DESCRIPTION
sss_nss_getgrouplist_timeout() is intended as a replacement for
getgrouplist() which only gets secondary groups from SSSD. Currently it
returns an ENOENT error if there are no secondary groups returned by
SSSD. However, as with getgrouplist(), there is the second parameter
which expects a single GID which will be added to the result. This means
that sss_nss_getgrouplist_timeout() will always return at least this GID
as a result and an ENOENT error does not make sense.

With this patch sss_nss_getgrouplist_timeout() will not return an error
anymore if there are no secondary groups but just a result with the
single GID from the second parameter.