### PR TITLE
pam: fix Smartcard auth with files provider

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -4030,7 +4030,9 @@ local_auth_policy = only
 </programlisting>
                         </para>
                         <para condition="with_files_provider">
-                            This option is ignored for the files provider.
+                            It is expected that the <quote>files</quote>
+                            provider ignores the local_auth_policy option and
+                            supports Smartcard authentication by default.
                         </para>
                         <para>
                             Default: match

--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -949,6 +949,16 @@ static errno_t pam_eval_local_auth_policy(TALLOC_CTX *mem_ctx,
     char **opts;
     size_t c;
 
+#ifdef BUILD_FILES_PROVIDER
+    if (is_files_provider(preq->domain)) {
+        *_sc_allow = true;
+        *_passkey_allow = false;
+        *_local_policy = NULL;
+
+        return EOK;
+    }
+#endif
+
     tmp_ctx = talloc_new(NULL);
     if (tmp_ctx == NULL) {
         return ENOMEM;

--- a/src/tests/intg/test_pam_responder.py
+++ b/src/tests/intg/test_pam_responder.py
@@ -41,7 +41,7 @@ LDAP_BASE_DN = "dc=example,dc=com"
 
 def provider_list():
      if os.environ['FILES_PROVIDER'] == "enabled":
-         return ('files', 'proxy')
+         return ('files', 'files_with_policy', 'proxy')
      else:
          # The comma is required to indicate a list with the string 'proxy' as
          # only item, without it the string 'proxy' will be interpreted as list
@@ -52,6 +52,8 @@ def provider_list():
 class provider_switch:
     def __init__(self, p):
         if p == 'files':
+            self.p = "id_provider = files\nfallback_to_nss = False\n"
+        elif p == 'files_with_policy':
             self.p = "id_provider = files\nfallback_to_nss = False\nlocal_auth_policy = enable:smartcard\n"
         elif p == 'proxy':
             self.p = "id_provider = proxy\nlocal_auth_policy = only\nproxy_lib_name = call\n"


### PR DESCRIPTION
It is expected that the files provider ignores the local_auth_policy
option and supports Smartcard authentication by default.