### PR TITLE
KCM: Securely erase memory used for secrets

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3726,6 +3726,7 @@ test_iobuf_CFLAGS = \
 test_iobuf_LDADD = \
     $(CMOCKA_LIBS) \
     $(SSSD_LIBS) \
+    $(SSSD_INTERNAL_LTLIBS) \
     $(NULL)
 
 test_confdb_SOURCES = \

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -167,6 +167,7 @@ BuildRequires: systemd-devel
 BuildRequires: systemtap-sdt-devel
 BuildRequires: uid_wrapper
 BuildRequires: po4a
+BuildRequires: valgrind-devel
 %if %{build_subid}
 BuildRequires: shadow-utils-subid-devel
 %endif

--- a/src/responder/kcm/kcmsrv_ccache.c
+++ b/src/responder/kcm/kcmsrv_ccache.c
@@ -308,6 +308,7 @@ kcm_cc_remove_duplicates(struct kcm_ccache *cc,
         }
 
         bret = sss_krb5_creds_compare(kctx, kcrd, kcrd_cc);
+        sss_erase_krb5_creds_securely(kcrd_cc);
         krb5_free_creds(kctx, kcrd_cc);
         if (!bret) {
             continue;
@@ -320,6 +321,7 @@ kcm_cc_remove_duplicates(struct kcm_ccache *cc,
     ret = EOK;
 
 done:
+    sss_erase_krb5_creds_securely(kcrd);
     krb5_free_creds(kctx, kcrd);
     krb5_free_context(kctx);
 
@@ -380,6 +382,7 @@ static int kcm_cc_unmarshal_destructor(krb5_creds **creds)
     }
 
     for (i = 0; creds[i] != NULL; i++) {
+        sss_erase_krb5_creds_securely(creds[i]);
         krb5_free_creds(krb_ctx, creds[i]);
     }
 

--- a/src/responder/kcm/kcmsrv_ccache_binary.c
+++ b/src/responder/kcm/kcmsrv_ccache_binary.c
@@ -109,7 +109,7 @@ errno_t kcm_ccache_to_sec_input_binary(TALLOC_CTX *mem_ctx,
     struct sss_iobuf *buf;
     errno_t ret;
 
-    buf = sss_iobuf_init_empty(mem_ctx, sizeof(krb5_principal_data), 0);
+    buf = sss_iobuf_init_empty(mem_ctx, sizeof(krb5_principal_data), 0, true);
     if (buf == NULL) {
         return ENOMEM;
     }

--- a/src/responder/kcm/kcmsrv_ccache_secdb.c
+++ b/src/responder/kcm/kcmsrv_ccache_secdb.c
@@ -61,7 +61,7 @@ static errno_t sec_get(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    buf = sss_iobuf_init_steal(tmp_ctx, data, len);
+    buf = sss_iobuf_init_steal(tmp_ctx, data, len, true);
     if (buf == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Cannot init the iobuf\n");
         ret = EIO;
@@ -683,7 +683,8 @@ static struct tevent_req *ccdb_secdb_set_default_send(TALLOC_CTX *mem_ctx,
 
     iobuf = sss_iobuf_init_readonly(state,
                                     (const uint8_t *) uuid_str,
-                                    UUID_STR_SIZE);
+                                    UUID_STR_SIZE,
+                                    false);
     if (iobuf == NULL) {
         ret = ENOMEM;
         goto immediate;

--- a/src/responder/kcm/kcmsrv_cmd.c
+++ b/src/responder/kcm/kcmsrv_cmd.c
@@ -443,6 +443,7 @@ static errno_t kcm_recv_data(TALLOC_CTX *mem_ctx,
               "Failed to allocate memory for the message\n");
         return ENOMEM;
     }
+    talloc_set_destructor((void *) msg, sss_erase_talloc_mem_securely);
 
     /* Set the buffer and its expected len to receive the data */
     reqbuf->v_msg.kiov_base = msg;

--- a/src/responder/kcm/kcmsrv_ops.c
+++ b/src/responder/kcm/kcmsrv_ops.c
@@ -110,7 +110,8 @@ struct tevent_req *kcm_cmd_send(TALLOC_CTX *mem_ctx,
 
     state->reply = sss_iobuf_init_empty(state,
                                         KCM_PACKET_INITIAL_SIZE,
-                                        KCM_PACKET_MAX_SIZE);
+                                        KCM_PACKET_MAX_SIZE,
+                                        true);
     if (state->reply == NULL) {
         ret = ENOMEM;
         goto immediate;
@@ -138,7 +139,8 @@ struct tevent_req *kcm_cmd_send(TALLOC_CTX *mem_ctx,
 
     state->op_ctx->input = sss_iobuf_init_readonly(state->op_ctx,
                                                    input->data,
-                                                   input->length);
+                                                   input->length,
+                                                   true);
     if (state->op_ctx->input == NULL) {
         ret = ENOMEM;
         goto immediate;
@@ -155,7 +157,8 @@ struct tevent_req *kcm_cmd_send(TALLOC_CTX *mem_ctx,
     state->op_ctx->reply = sss_iobuf_init_empty(
                                         state,
                                         KCM_PACKET_INITIAL_SIZE,
-                                        KCM_PACKET_MAX_SIZE - 2*sizeof(uint32_t));
+                                        KCM_PACKET_MAX_SIZE - 2*sizeof(uint32_t),
+                                        true);
     if (state->op_ctx->reply == NULL) {
         ret = ENOMEM;
         goto immediate;
@@ -882,7 +885,8 @@ static struct tevent_req *kcm_op_store_send(TALLOC_CTX *mem_ctx,
 
     state->cred_blob = sss_iobuf_init_empty(state,
                                             creds_len,
-                                            creds_len);
+                                            creds_len,
+                                            true);
     if (state->cred_blob == NULL) {
         ret = ENOMEM;
         goto immediate;

--- a/src/tests/cmocka/test_data_provider_be.c
+++ b/src/tests/cmocka/test_data_provider_be.c
@@ -32,8 +32,6 @@
 #define TEST_ID_PROVIDER "ldap"
 
 #define OFFLINE_TIMEOUT 2
-#define STR_HELPER(x) #x
-#define AS_STR(param) STR_HELPER(param)
 
 static TALLOC_CTX *global_mock_context = NULL;
 static bool global_timer_added;

--- a/src/tests/common.h
+++ b/src/tests/common.h
@@ -38,6 +38,9 @@
 #include "providers/ldap/sdap.h"
 
 
+#define STR_HELPER(x) #x
+#define AS_STR(param) STR_HELPER(param)
+
 #ifdef HAVE_FUNCTION_ATTRIBUTE_WARN_UNUSED_RESULT
 #define SSS_ATTRIBUTE_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
 #else

--- a/src/util/memory.c
+++ b/src/util/memory.c
@@ -41,6 +41,21 @@ static void explicit_bzero(void *s, size_t n)
 #endif
 
 
+void sss_erase_krb5_data_securely(krb5_data *data)
+{
+    if (data != NULL) {
+        sss_erase_mem_securely(data->data, data->length);
+    }
+}
+
+void sss_erase_krb5_creds_securely(krb5_creds *cred)
+{
+    if (cred != NULL) {
+        sss_erase_krb5_data_securely(&cred->ticket);
+        sss_erase_krb5_data_securely(&cred->second_ticket);
+    }
+}
+
 int sss_erase_talloc_mem_securely(void *p)
 {
     if (p == NULL) {

--- a/src/util/sss_iobuf.c
+++ b/src/util/sss_iobuf.c
@@ -88,7 +88,7 @@ void sss_iobuf_cursor_reset(struct sss_iobuf *iobuf)
     iobuf->dp = 0;
 }
 
-size_t sss_iobuf_get_len(struct sss_iobuf *iobuf)
+size_t sss_iobuf_get_len(const struct sss_iobuf *iobuf)
 {
     if (iobuf == NULL) {
         return 0;
@@ -97,7 +97,7 @@ size_t sss_iobuf_get_len(struct sss_iobuf *iobuf)
     return iobuf->dp;
 }
 
-size_t sss_iobuf_get_capacity(struct sss_iobuf *iobuf)
+size_t sss_iobuf_get_capacity(const struct sss_iobuf *iobuf)
 {
     if (iobuf == NULL) {
         return 0;
@@ -106,7 +106,7 @@ size_t sss_iobuf_get_capacity(struct sss_iobuf *iobuf)
     return iobuf->capacity;
 }
 
-size_t sss_iobuf_get_size(struct sss_iobuf *iobuf)
+size_t sss_iobuf_get_size(const struct sss_iobuf *iobuf)
 {
     if (iobuf == NULL) {
         return 0;
@@ -115,7 +115,7 @@ size_t sss_iobuf_get_size(struct sss_iobuf *iobuf)
     return iobuf->size;
 }
 
-uint8_t *sss_iobuf_get_data(struct sss_iobuf *iobuf)
+uint8_t *sss_iobuf_get_data(const struct sss_iobuf *iobuf)
 {
     if (iobuf == NULL) {
         return NULL;
@@ -124,7 +124,7 @@ uint8_t *sss_iobuf_get_data(struct sss_iobuf *iobuf)
     return iobuf->data;
 }
 
-static size_t iobuf_get_len(struct sss_iobuf *iobuf)
+static size_t iobuf_get_len(const struct sss_iobuf *iobuf)
 {
     if (iobuf == NULL) {
         return 0;

--- a/src/util/sss_iobuf.h
+++ b/src/util/sss_iobuf.h
@@ -2,6 +2,7 @@
 #define __SSS_IOBUF_H_
 
 #include <talloc.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <errno.h>
 
@@ -22,6 +23,8 @@ struct sss_iobuf;
  * @param[in]  capacity     The maximum capacity the buffer can grow into.
  *                          Use 0 for an 'unlimited' buffer that will grow
  *                          until SIZE_MAX/2.
+ * @param[in]  secure       Secure the data by erasing it before the memory is
+ *                          released.
  *
  * @warning The allocated data storage will not be zeroed.
  *
@@ -30,7 +33,8 @@ struct sss_iobuf;
  */
 struct sss_iobuf *sss_iobuf_init_empty(TALLOC_CTX *mem_ctx,
                                        size_t size,
-                                       size_t capacity);
+                                       size_t capacity,
+                                       bool secure);
 
 /*
  * @brief Allocate an IO buffer with a fixed size
@@ -45,6 +49,8 @@ struct sss_iobuf *sss_iobuf_init_empty(TALLOC_CTX *mem_ctx,
  * @param[in]  data         The data to initialize the IO buffer with. This
  *                          data is copied into the iobuf-owned buffer.
  * @param[in]  size         The size of the data buffer
+ * @param[in]  secure       Secure the data by erasing it before the memory is
+ *                          released.
  *
  * @warning The allocated data storage will not be zeroed.
  *
@@ -52,7 +58,8 @@ struct sss_iobuf *sss_iobuf_init_empty(TALLOC_CTX *mem_ctx,
  */
 struct sss_iobuf *sss_iobuf_init_readonly(TALLOC_CTX *mem_ctx,
                                           const uint8_t *data,
-                                          size_t size);
+                                          size_t size,
+                                          bool secure);
 
 /*
  * @brief Allocate an IO buffer with a fixed size, stealing input data.
@@ -65,12 +72,15 @@ struct sss_iobuf *sss_iobuf_init_readonly(TALLOC_CTX *mem_ctx,
  * @param[in]  mem_ctx      The talloc context that owns the iobuf
  * @param[in]  data         The data to initialize the IO buffer with.
  * @param[in]  size         The size of the data buffer
+ * @param[in]  secure       Secure the data by erasing it before the memory is
+ *                          released.
  *
  * @return The newly created buffer on success or NULL on an error.
  */
 struct sss_iobuf *sss_iobuf_init_steal(TALLOC_CTX *mem_ctx,
                                        uint8_t *data,
-                                       size_t size);
+                                       size_t size,
+                                       bool secure);
 
 /*
  * @brief Reset internal cursor of the IO buffer (seek to the start)
@@ -101,6 +111,11 @@ size_t sss_iobuf_get_size(const struct sss_iobuf *iobuf);
  * @brief Returns the data pointer of the IO buffer
  */
 uint8_t *sss_iobuf_get_data(const struct sss_iobuf *iobuf);
+
+/*
+ * @brief Returns whether the data is secured
+ */
+bool sss_iobuf_get_secure(const struct sss_iobuf *iobuf);
 
 /*
  * @brief Read from an IO buffer

--- a/src/util/sss_iobuf.h
+++ b/src/util/sss_iobuf.h
@@ -82,7 +82,7 @@ void sss_iobuf_cursor_reset(struct sss_iobuf *iobuf);
  *
  * @return The number of bytes (the data pointer offset)
  */
-size_t sss_iobuf_get_len(struct sss_iobuf *iobuf);
+size_t sss_iobuf_get_len(const struct sss_iobuf *iobuf);
 
 /*
  * @brief Returns the capacity of the IO buffer
@@ -90,17 +90,17 @@ size_t sss_iobuf_get_len(struct sss_iobuf *iobuf);
  * @return The capacity of the IO buffer. Returns zero
  * for an unlimited buffer.
  */
-size_t sss_iobuf_get_capacity(struct sss_iobuf *iobuf);
+size_t sss_iobuf_get_capacity(const struct sss_iobuf *iobuf);
 
 /*
  * @brief Returns the current size of the IO buffer
  */
-size_t sss_iobuf_get_size(struct sss_iobuf *iobuf);
+size_t sss_iobuf_get_size(const struct sss_iobuf *iobuf);
 
 /*
  * @brief Returns the data pointer of the IO buffer
  */
-uint8_t *sss_iobuf_get_data(struct sss_iobuf *iobuf);
+uint8_t *sss_iobuf_get_data(const struct sss_iobuf *iobuf);
 
 /*
  * @brief Read from an IO buffer

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -38,6 +38,7 @@
 #include <tevent.h>
 #include <ldb.h>
 #include <dhash.h>
+#include <krb5.h>
 
 #include "confdb/confdb.h"
 #include "shared/io.h"
@@ -243,6 +244,8 @@ int sss_mem_attach(TALLOC_CTX *mem_ctx, void *ptr, void_destructor_fn_t *fn);
  */
 int sss_erase_talloc_mem_securely(void *p);
 void sss_erase_mem_securely(void *p, size_t size);
+void sss_erase_krb5_data_securely(krb5_data *data);
+void sss_erase_krb5_creds_securely(krb5_creds *cred);
 
 /* from usertools.c */
 char *get_uppercase_realm(TALLOC_CTX *memctx, const char *name);


### PR DESCRIPTION
Make sure all the memory blocks allocated dynamically or statically by KCM to store credentials and messages (which might include credentials) are erased by calling `sss_erase_mem_securely()` or
`sss_erase_talloc_mem_securely()` before being freed.

`struct sss_iobuf` is the main structure used to store secrets. It's buffer will be cleaned when freed using a destructor. The destructor is associated to the buffer itself, in case it is stolen from one structure to another.

`struct kcm_ccache` doesn't need to be explicitly cleaned because, in the end, it uses `struct sss_iobuf`.

A unit test was added to check this functionality. `Valgrind`'s magic interfere with this test because the heap disappears. This makes the test incompatible avec `Valgrind`, so the test is skipped under these conditions. This added a new build dependency on the package `valgrind-devel`.

