### PR TITLE
Extension of #7038

### DIFF
--- a/src/p11_child/p11_child_openssl.c
+++ b/src/p11_child/p11_child_openssl.c
@@ -1991,28 +1991,16 @@ errno_t do_card(TALLOC_CTX *mem_ctx, struct p11_ctx *p11_ctx,
     /* login: do we need to check for Login Required? */
     if (mode == OP_AUTH) {
         DEBUG(SSSDBG_TRACE_ALL, "Login required.\n");
-
-        /* Check for protected authentication path */
         DEBUG(SSSDBG_TRACE_ALL, "Token flags [%lu].\n", token_info.flags);
-        if (token_info.flags & CKF_PROTECTED_AUTHENTICATION_PATH) {
-            DEBUG(SSSDBG_TRACE_ALL, "Protected authentication path.\n");
+        if ((pin != NULL)
+            || (token_info.flags & CKF_PROTECTED_AUTHENTICATION_PATH)) {
 
-            rv = module->C_Login(session, CKU_USER, NULL,
-                                 0);
-            if (rv == CKR_PIN_LOCKED) {
-                DEBUG(SSSDBG_OP_FAILURE, "C_Login failed: PIN locked\n");
-                ret = ERR_P11_PIN_LOCKED;
-                goto done;
-            } else if (rv != CKR_OK) {
-                DEBUG(SSSDBG_OP_FAILURE, "C_Login failed [%lu][%s].\n",
-                                 rv, p11_kit_strerror(rv));
-                ret = EIO;
-                goto done;
+            if (token_info.flags & CKF_PROTECTED_AUTHENTICATION_PATH) {
+                DEBUG(SSSDBG_TRACE_ALL, "Protected authentication path.\n");
+                pin = NULL;
             }
-            pkcs11_login = true;
-        } else if (pin != NULL) {
             rv = module->C_Login(session, CKU_USER, discard_const(pin),
-                                 strlen(pin));
+                                (pin != NULL) ? strlen(pin) : 0);
             if (rv == CKR_PIN_LOCKED) {
                 DEBUG(SSSDBG_OP_FAILURE, "C_Login failed: PIN locked\n");
                 ret = ERR_P11_PIN_LOCKED;


### PR DESCRIPTION
This is a pull request for issue https://github.com/SSSD/sssd/issues/7011

It checks if the flag CKF_PROTECTED_AUTHENTICATION_PATH is present,
and does C_Login with NULL if it is present, ignoring any pin passed from the user.