### PR TITLE
SYSTEM TESTS: run core set of tests against SSSD

### DIFF
--- a/src/tests/system/tests/test_autofs.py
+++ b/src/tests/system/tests/test_autofs.py
@@ -17,7 +17,12 @@ from sssd_test_framework.topology import KnownTopologyGroup
 @pytest.mark.ticket(gh=6739)
 @pytest.mark.parametrize("cache_first", [False, True])
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
-def test_autofs__cache_first(client: Client, nfs: NFS, provider: GenericProvider, cache_first: bool):
+@pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
+@pytest.mark.require(
+    lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
+    "SSSD was built without support for running under non-root"
+)
+def test_autofs__cache_first(client: Client, nfs: NFS, provider: GenericProvider, cache_first: bool, sssd_service_user: str):
     """
     :title: Autofs works correctly with any cache_first value
     :setup:
@@ -45,6 +50,7 @@ def test_autofs__cache_first(client: Client, nfs: NFS, provider: GenericProvider
     key = auto_export.key("export").add(info=nfs_export)
 
     # Start SSSD
+    client.sssd.set_service_user(sssd_service_user)
     client.sssd.common.autofs()
     client.sssd.autofs["cache_first"] = str(cache_first)
     client.sssd.start()

--- a/src/tests/system/tests/test_identity.py
+++ b/src/tests/system/tests/test_identity.py
@@ -14,7 +14,12 @@ from sssd_test_framework.topology import KnownTopologyGroup
 
 @pytest.mark.importance("critical")
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
-def test_identity__lookup_username_with_id(client: Client, provider: GenericProvider):
+@pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
+@pytest.mark.require(
+    lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
+    "SSSD was built without support for running under non-root"
+)
+def test_identity__lookup_username_with_id(client: Client, provider: GenericProvider, sssd_service_user: str):
     """
     :title: Resolve user by name with id
     :setup:
@@ -35,6 +40,7 @@ def test_identity__lookup_username_with_id(client: Client, provider: GenericProv
     for user, id in ids:
         provider.user(user).add(uid=id, gid=id + 500)
 
+    client.sssd.set_service_user(sssd_service_user)
     client.sssd.domain["ldap_id_mapping"] = "false"
     client.sssd.start()
 
@@ -47,7 +53,12 @@ def test_identity__lookup_username_with_id(client: Client, provider: GenericProv
 
 @pytest.mark.importance("critical")
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
-def test_identity__lookup_uid_with_id(client: Client, provider: GenericProvider):
+@pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
+@pytest.mark.require(
+    lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
+    "SSSD was built without support for running under non-root"
+)
+def test_identity__lookup_uid_with_id(client: Client, provider: GenericProvider, sssd_service_user: str):
     """
     :title: Resolve user by uid with id
     :setup:
@@ -68,6 +79,7 @@ def test_identity__lookup_uid_with_id(client: Client, provider: GenericProvider)
     for user, id in ids:
         provider.user(user).add(uid=id, gid=id + 500)
 
+    client.sssd.set_service_user(sssd_service_user)
     client.sssd.domain["ldap_id_mapping"] = "false"
     client.sssd.start()
 
@@ -228,7 +240,12 @@ def test_identity__lookup_user_by_group_with_getent(client: Client, provider: Ge
 
 @pytest.mark.importance("critical")
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
-def test_identity__lookup_group_membership_by_username_with_id(client: Client, provider: GenericProvider):
+@pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
+@pytest.mark.require(
+    lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
+    "SSSD was built without support for running under non-root"
+)
+def test_identity__lookup_group_membership_by_username_with_id(client: Client, provider: GenericProvider, sssd_service_user: str):
     """
     :title: Check membership of user by group name with id
     :setup:
@@ -251,6 +268,7 @@ def test_identity__lookup_group_membership_by_username_with_id(client: Client, p
 
     provider.group("group1").add().add_members([u1, u2, u3])
 
+    client.sssd.set_service_user(sssd_service_user)
     client.sssd.start()
 
     for name, groups in users:


### PR DESCRIPTION
running in two modes: under 'root' and under 'sssd' user (where supported)