### PR TITLE
SSS_CLIENT: MC: in case mem-cache file validation fails,

### DIFF
--- a/src/sss_client/common.c
+++ b/src/sss_client/common.c
@@ -767,6 +767,16 @@ static enum sss_status sss_cli_check_socket(int *errnop,
         myself_ino = myself_sb.st_ino;
     }
 
+    /* check if the socket has been hijacked */
+    if (sss_cli_sd_get() != -1) {
+        ret = fstat(sss_cli_sd_get(), &mypid_sb);
+        if ((ret != 0) || (!S_ISSOCK(mypid_sb.st_mode))
+            || (mypid_sb.st_dev != sss_cli_sb->st_dev)
+            || (mypid_sb.st_ino != sss_cli_sb->st_ino)) {
+            sss_cli_sd_set(-1);  /* don't ruin app even if it's misbehaving */
+        }
+    }
+
     /* check if the socket has been closed on the other side */
     if (sss_cli_sd_get() != -1) {
         struct pollfd pfd;

--- a/src/sss_client/nss_mc.h
+++ b/src/sss_client/nss_mc.h
@@ -53,6 +53,8 @@ struct sss_cli_mc_ctx {
     pthread_mutex_t *mutex;
 #endif
     int fd;
+    ino_t fd_inode;
+    dev_t fd_device;
 
     uint32_t seed;          /* seed from the tables header */
 
@@ -69,9 +71,9 @@ struct sss_cli_mc_ctx {
 };
 
 #if HAVE_PTHREAD
-#define SSS_CLI_MC_CTX_INITIALIZER(mtx) {UNINITIALIZED, (mtx), -1, 0, NULL, 0, NULL, 0, NULL, 0, 0}
+#define SSS_CLI_MC_CTX_INITIALIZER(mtx) {UNINITIALIZED, (mtx), -1, 0, 0, 0, NULL, 0, NULL, 0, NULL, 0, 0}
 #else
-#define SSS_CLI_MC_CTX_INITIALIZER {UNINITIALIZED, -1, 0, NULL, 0, NULL, 0, NULL, 0, 0}
+#define SSS_CLI_MC_CTX_INITIALIZER {UNINITIALIZED, -1, 0, 0, 0, NULL, 0, NULL, 0, NULL, 0, 0}
 #endif
 
 errno_t sss_nss_mc_get_ctx(const char *name, struct sss_cli_mc_ctx *ctx);

--- a/src/sss_client/nss_mc_common.c
+++ b/src/sss_client/nss_mc_common.c
@@ -79,17 +79,17 @@ static errno_t sss_nss_mc_validate(struct sss_cli_mc_ctx *ctx)
     }
 
     if (fstat(ctx->fd, &fdstat) == -1) {
-        return errno;
+        return EINVAL;
     }
 
     /* Memcache was removed. */
     if (fdstat.st_nlink == 0) {
-        return ENOENT;
+        return EINVAL;
     }
 
     /* Invalid size. */
     if (fdstat.st_size != ctx->mmap_size) {
-        return ERANGE;
+        return EINVAL;
     }
 
     return EOK;


### PR DESCRIPTION
don't return anything but EINVAL, because `_nss_sss_*()` functions can have a special handling for other error codes (for ERANGE in particular).