### PR TITLE
Coverity passkey fixes

### DIFF
--- a/src/krb5_plugin/passkey/passkey_clpreauth.c
+++ b/src/krb5_plugin/passkey/passkey_clpreauth.c
@@ -167,7 +167,7 @@ sss_passkeycl_exec_child(struct sss_passkey_challenge *data,
     int ret = 0;
     char *result_creds;
 
-    buf = malloc(CHILD_MSG_CHUNK);
+    buf = calloc(1, CHILD_MSG_CHUNK);
     if (buf == NULL) {
         ret = ENOMEM;
         return ret;
@@ -361,6 +361,7 @@ sss_passkeycl_process(krb5_context context,
 
 done:
     sss_passkey_message_free(reply_message);
+    sss_passkey_message_free(reply_msg);
     sss_passkey_message_free(input_message);
     free(reply);
     free(prompt_reply);

--- a/src/krb5_plugin/passkey/passkey_clpreauth.c
+++ b/src/krb5_plugin/passkey/passkey_clpreauth.c
@@ -269,7 +269,7 @@ sss_passkeycl_process(krb5_context context,
     const char *state;
     char prompt_answer[255] = {0};
     int answer_len;
-    const char *prompt_reply = NULL;
+    char *prompt_reply = NULL;
     uint8_t *reply = NULL;
     const char *answer;
 
@@ -362,9 +362,9 @@ sss_passkeycl_process(krb5_context context,
 done:
     sss_passkey_message_free(reply_message);
     sss_passkey_message_free(input_message);
-    if (reply != NULL) {
-        free(reply);
-    }
+    free(reply);
+    free(prompt_reply);
+
     return ret;
 }
 


### PR DESCRIPTION
Fixes for the below. I tested the fixes submitting a `scan.coverity.com` build with my fork and it fixes these 2 defects.

```

2 new defect(s) introduced to SSSD/sssd found with Coverity Scan.


New defect(s) Reported-by: Coverity Scan
Showing 2 of 2 defect(s)


** CID 470375:  Memory - corruptions  (OVERRUN)
/home/runner/work/sssd/sssd/src/krb5_plugin/passkey/passkey_utils.c: 629 in sss_passkey_concat_credentials()


________________________________________________________________________________________________________
*** CID 470375:  Memory - corruptions  (OVERRUN)
/home/runner/work/sssd/sssd/src/krb5_plugin/passkey/passkey_utils.c: 629 in sss_passkey_concat_credentials()
623                 free(result_creds);
624                 goto done;
625             }
626     
627             result_creds = tmp_creds;
628     
>>>     CID 470375:  Memory - corruptions  (OVERRUN)
>>>     Overrunning dynamic array "result_creds" by passing it to a function that accesses it at byte "creds_len".
629             strncat(result_creds, creds[i], creds_len);
630         }
631     
632         *_creds_str = result_creds;
633     
634         ret = 0;
635     done:
636         return ret;

** CID 470374:  Resource leaks  (RESOURCE_LEAK)
/home/runner/work/sssd/sssd/src/krb5_plugin/passkey/passkey_clpreauth.c: 368 in sss_passkeycl_process()


________________________________________________________________________________________________________
*** CID 470374:  Resource leaks  (RESOURCE_LEAK)
/home/runner/work/sssd/sssd/src/krb5_plugin/passkey/passkey_clpreauth.c: 368 in sss_passkeycl_process()
362     done:
363         sss_passkey_message_free(reply_message);
364         sss_passkey_message_free(input_message);
365         if (reply != NULL) {
366             free(reply);
367         }
>>>     CID 470374:  Resource leaks  (RESOURCE_LEAK)
>>>     Variable "prompt_reply" going out of scope leaks the storage it points to.
368         return ret;
369     }
370     
371     krb5_error_code
372     clpreauth_passkey_initvt(krb5_context context,
373                              int maj_ver,

```