### PR TITLE
Handle child-domain group membership

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2357,7 +2357,10 @@ ipa_ldap_opt_tests_LDADD = \
     $(LDB_LIBS) \
     $(SSSD_INTERNAL_LTLIBS) \
     $(OPENLDAP_LIBS) \
-    libsss_test_common.la
+    libsss_test_common.la \
+    libsss_ldap_common.la \
+    libdlopen_test_providers.la \
+    $(NULL)
 
 ad_ldap_opt_tests_SOURCES = \
     src/providers/ldap/ldap_opts.c \
@@ -2919,6 +2922,8 @@ nestedgroups_tests_LDADD = \
     $(SSSD_INTERNAL_LTLIBS) \
     libsss_idmap.la \
     libsss_test_common.la \
+    libsss_ldap_common.la \
+    libdlopen_test_providers.la \
     $(NULL)
 if BUILD_SYSTEMTAP
 nestedgroups_tests_LDADD += stap_generated_probes.lo
@@ -3165,6 +3170,8 @@ sdap_tests_LDADD = \
     $(SSSD_INTERNAL_LTLIBS) \
     $(OPENLDAP_LIBS) \
     libsss_test_common.la \
+    libsss_ldap_common.la \
+    libdlopen_test_providers.la \
     $(NULL)
 
 if BUILD_IFP

--- a/src/providers/ldap/sdap.h
+++ b/src/providers/ldap/sdap.h
@@ -707,6 +707,8 @@ errno_t sdap_get_primary_fqdn_list(struct sss_domain_info *domain,
                                    struct sysdb_attrs **attr_list,
                                    size_t attr_count,
                                    const char *ldap_attr,
+                                   const char *sid_attr,
+                                   struct sdap_idmap_ctx *idmap_ctx,
                                    char ***name_list);
 
 errno_t sdap_set_config_options_with_rootdse(struct sysdb_attrs *rootdse,

--- a/src/providers/ldap/sdap_async_groups.c
+++ b/src/providers/ldap/sdap_async_groups.c
@@ -2002,6 +2002,8 @@ static void sdap_get_groups_process(struct tevent_req *subreq)
         ret = sdap_get_primary_fqdn_list(state->dom, state,
                                 state->groups, state->count,
                                 state->opts->group_map[SDAP_AT_GROUP_NAME].name,
+                                state->opts->group_map[SDAP_AT_GROUP_OBJECTSID].name,
+                                state->opts->idmap_ctx,
                                 &sysdb_groupnamelist);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE,

--- a/src/providers/ldap/sdap_async_initgroups.c
+++ b/src/providers/ldap/sdap_async_initgroups.c
@@ -53,6 +53,7 @@ errno_t sdap_add_incomplete_groups(struct sysdb_ctx *sysdb,
     char *sid_str = NULL;
     bool use_id_mapping;
     bool need_filter;
+    struct sss_domain_info *subdomain;
 
     /* There are no groups in LDAP but we should add user to groups?? */
     if (ldap_groups_count == 0) return EOK;
@@ -68,7 +69,11 @@ errno_t sdap_add_incomplete_groups(struct sysdb_ctx *sysdb,
     mi = 0;
 
     for (i=0; sysdb_groupnames[i]; i++) {
-        ret = sysdb_search_group_by_name(tmp_ctx, domain, sysdb_groupnames[i], NULL,
+        subdomain = find_domain_by_object_name(domain, sysdb_groupnames[i]);
+        if (subdomain == NULL) {
+            subdomain = domain;
+        }
+        ret = sysdb_search_group_by_name(tmp_ctx, subdomain, sysdb_groupnames[i], NULL,
                                          &msg);
         if (ret == EOK) {
             continue;
@@ -222,7 +227,11 @@ errno_t sdap_add_incomplete_groups(struct sysdb_ctx *sysdb,
 
                 DEBUG(SSSDBG_TRACE_INTERNAL,
                       "Adding fake group %s to sysdb\n", groupname);
-                ret = sysdb_add_incomplete_group(domain, groupname, gid,
+                subdomain = find_domain_by_object_name(domain, groupname);
+                if (subdomain == NULL) {
+                    subdomain = domain;
+                }
+                ret = sysdb_add_incomplete_group(subdomain, groupname, gid,
                                                  original_dn, sid_str,
                                                  uuid, posix, now);
                 if (ret == ERR_GID_DUPLICATED) {
@@ -233,7 +242,7 @@ errno_t sdap_add_incomplete_groups(struct sysdb_ctx *sysdb,
                      *   removed from the memory cache
                      */
                     ret = sdap_handle_id_collision_for_incomplete_groups(
-                                            opts->dp, domain, groupname, gid,
+                                            opts->dp, subdomain, groupname, gid,
                                             original_dn, sid_str, uuid, posix,
                                             now);
                 }
@@ -667,6 +676,8 @@ sdap_nested_groups_store(struct sysdb_ctx *sysdb,
     if (count > 0) {
         ret = sdap_get_primary_fqdn_list(domain, tmp_ctx, groups, count,
                                        opts->group_map[SDAP_AT_GROUP_NAME].name,
+                                       opts->group_map[SDAP_AT_GROUP_OBJECTSID].name,
+                                       opts->idmap_ctx,
                                        &groupnamelist);
         if (ret != EOK) {
             DEBUG(SSSDBG_MINOR_FAILURE,
@@ -1447,6 +1458,8 @@ sdap_initgr_nested_get_membership_diff(TALLOC_CTX *mem_ctx,
         ret = sdap_get_primary_fqdn_list(dom, tmp_ctx, ldap_parentlist,
                                        parents_count,
                                        opts->group_map[SDAP_AT_GROUP_NAME].name,
+                                       opts->group_map[SDAP_AT_GROUP_OBJECTSID].name,
+                                       opts->idmap_ctx,
                                        &ldap_parent_names_list);
         if (ret != EOK) {
             DEBUG(SSSDBG_CRIT_FAILURE,
@@ -2105,6 +2118,8 @@ rfc2307bis_group_memberships_build(hash_entry_t *item, void *user_data)
         ret = sdap_get_primary_fqdn_list(mstate->dom, tmp_ctx,
                                group->ldap_parents, group->parents_count,
                                mstate->opts->group_map[SDAP_AT_GROUP_NAME].name,
+                               mstate->opts->group_map[SDAP_AT_GROUP_OBJECTSID].name,
+                               mstate->opts->idmap_ctx,
                                &ldap_parents_names_list);
         if (ret != EOK) {
             goto done;
@@ -2169,6 +2184,8 @@ errno_t save_rfc2307bis_user_memberships(
         ret = sdap_get_primary_fqdn_list(state->dom, tmp_ctx,
                                 state->direct_groups, state->num_direct_parents,
                                 state->opts->group_map[SDAP_AT_GROUP_NAME].name,
+                                state->opts->group_map[SDAP_AT_GROUP_OBJECTSID].name,
+                                state->opts->idmap_ctx,
                                 &ldap_grouplist);
         if (ret != EOK) {
             goto error;

--- a/src/providers/ldap/sdap_async_initgroups_ad.c
+++ b/src/providers/ldap/sdap_async_initgroups_ad.c
@@ -1333,6 +1333,8 @@ sdap_ad_get_domain_local_groups_parse_parents(TALLOC_CTX *mem_ctx,
         ret = sdap_get_primary_fqdn_list(dom, tmp_ctx, gr->ldap_parents,
                                        gr->parents_count,
                                        opts->group_map[SDAP_AT_GROUP_NAME].name,
+                                       opts->group_map[SDAP_AT_GROUP_OBJECTSID].name,
+                                       opts->idmap_ctx,
                                        &groupnamelist);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "sysdb_attrs_primary_fqdn_list failed.\n");


### PR DESCRIPTION
In AD, a user from a domain can be a member of a group that is from a child of the domain.

The old code did not account for this and created a cache object with incorrect DNs.

This patch looks up the correct domain before saving group and membership attributes.

Resolves: https://github.com/SSSD/sssd/issues/7084