### PR TITLE
Use LDB_NOSYNC to make domain cache faster

### DIFF
--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -1147,6 +1147,14 @@ static errno_t confdb_init_domain(struct sss_domain_info *domain,
         goto done;
     }
 
+    ret = get_entry_as_bool(res->msgs[0], &domain->cache_in_memory_transactions,
+                            CONFDB_DOMAIN_CACHE_IN_MEMORY_TRANSACTIONS, 0);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_FATAL_FAILURE,
+              "Invalid value for %s\n", CONFDB_DOMAIN_CACHE_IN_MEMORY_TRANSACTIONS);
+        goto done;
+    }
+
     ret = get_entry_as_uint32(res->msgs[0], &domain->override_gid,
                               CONFDB_DOMAIN_OVERRIDE_GID, 0);
     if (ret != EOK) {

--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -1148,7 +1148,7 @@ static errno_t confdb_init_domain(struct sss_domain_info *domain,
     }
 
     ret = get_entry_as_bool(res->msgs[0], &domain->cache_in_memory_transactions,
-                            CONFDB_DOMAIN_CACHE_IN_MEMORY_TRANSACTIONS, 0);
+                            CONFDB_DOMAIN_CACHE_IN_MEMORY_TRANSACTIONS, 1);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
               "Invalid value for %s\n", CONFDB_DOMAIN_CACHE_IN_MEMORY_TRANSACTIONS);

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -268,6 +268,7 @@
 #define CONFDB_DOMAIN_TYPE_APP "application"
 #define CONFDB_DOMAIN_INHERIT_FROM "inherit_from"
 #define CONFDB_DOMAIN_LOCAL_AUTH_POLICY "local_auth_policy"
+#define CONFDB_DOMAIN_CACHE_IN_MEMORY_TRANSACTIONS "cache_in_memory_transactions"
 
 /* Proxy Provider */
 #define CONFDB_PROXY_LIBNAME "proxy_lib_name"
@@ -374,6 +375,7 @@ struct sss_domain_info {
 
     bool cache_credentials;
     uint32_t cache_credentials_min_ff_length;
+    bool cache_in_memory_transactions;
     bool case_sensitive;
     bool case_preserve;
 

--- a/src/config/SSSDConfig/sssdoptions.py
+++ b/src/config/SSSDConfig/sssdoptions.py
@@ -227,6 +227,7 @@ class SSSDOptions(object):
                                                            'the first authentication factor (long term password) must '
                                                            'have to be saved as SHA512 hash into the cache.'),
         'local_auth_policy': _('Local authentication methods policy '),
+        'cache_in_memory_transactions': _('Perform cache transactions in memory.'),
 
         # [provider/ipa]
         'ipa_domain': _('IPA domain'),

--- a/src/config/SSSDConfigTest.py
+++ b/src/config/SSSDConfigTest.py
@@ -604,7 +604,8 @@ class SSSDConfigTestSSSDDomain(unittest.TestCase):
             'pam_gssapi_indicators_map',
             'refresh_expired_interval',
             'refresh_expired_interval_offset',
-            'local_auth_policy']
+            'local_auth_policy',
+            'cache_in_memory_transactions']
 
         self.assertTrue(type(options) == dict,
                         "Options should be a dictionary")
@@ -970,7 +971,8 @@ class SSSDConfigTestSSSDDomain(unittest.TestCase):
             'refresh_expired_interval_offset',
             'dyndns_refresh_interval',
             'dyndns_refresh_interval_offset',
-            'local_auth_policy']
+            'local_auth_policy',
+            'cache_in_memory_transactions']
 
         self.assertTrue(type(options) == dict,
                         "Options should be a dictionary")

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -379,6 +379,7 @@ option = offline_timeout_max
 option = offline_timeout_random_offset
 option = cache_credentials
 option = cache_credentials_minimal_first_factor_length
+option = cache_in_memory_transactions
 option = use_fully_qualified_names
 option = ignore_group_members
 option = entry_cache_timeout

--- a/src/config/etc/sssd.api.conf
+++ b/src/config/etc/sssd.api.conf
@@ -191,6 +191,7 @@ pam_gssapi_services = str, None, false
 pam_gssapi_check_upn = bool, None, false
 pam_gssapi_indicators_map = str, None, false
 local_auth_policy = str, None, false
+cache_in_memory_transactions = bool, None, false
 
 #Entry cache timeouts
 entry_cache_user_timeout = int, None, false

--- a/src/db/sysdb_init.c
+++ b/src/db/sysdb_init.c
@@ -614,12 +614,17 @@ static errno_t sysdb_cache_connect(TALLOC_CTX *mem_ctx,
     bool newly_created;
     bool ldb_file_exists;
     errno_t ret;
+    int ldb_flags = 0;
+
+    if (domain->cache_in_memory_transactions) {
+        ldb_flags |= LDB_FLG_NOSYNC;
+    }
 
     ldb_file_exists = !(access(sysdb->ldb_file, F_OK) == -1 && errno == ENOENT);
 
     ret = sysdb_cache_connect_helper(mem_ctx, domain, sysdb->ldb_file,
-                                      0, SYSDB_VERSION, SYSDB_BASE_LDIF,
-                                      &newly_created, ldb, version);
+                                     ldb_flags, SYSDB_VERSION, SYSDB_BASE_LDIF,
+                                     &newly_created, ldb, version);
 
     /* The cache has been newly created. */
     if (ret == EOK && newly_created && !ldb_file_exists) {

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2882,6 +2882,30 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                 </varlistentry>
 
                 <varlistentry>
+                    <term>cache_in_memory_transaction (boolean)</term>
+                    <listitem>
+                        <para>
+                            The cache can perform the update and hold the entire
+                            transaction in memory before it is written to the
+                            cache file.
+                        </para>
+                        <para>
+                            Cache performance with this option set to TRUE is
+                            much better. There is a negligible chance that data
+                            in the cache may become inconsistent when the entire
+                            computer is unexpectedly powered off while updating
+                            the cache.
+                        </para>
+                        <para>
+                            For this reason, it is not recommended to set this
+                            option to TRUE along with
+                            <emphasis>cache_credentials</emphasis> or when
+                            computer is expected to be used offline.
+                        </para>
+                    </listitem>
+                </varlistentry>
+
+                <varlistentry>
                     <term>cache_credentials (bool)</term>
                     <listitem>
                         <para>


### PR DESCRIPTION
Using LDB_NOSYNC option significantly improves the cache performance.

However, it still uses the cache recovery area, so the cache is still resilient when using this option even if SSSD is forcibly terminated.

There is small chance that cache become inconsistent, when computer is unexpectedly switched off while transaction is being written to cache file.

:config: New option 'cache_in_memory_transaction' to use fast transaction and improve cache performance.