### PR TITLE
Tests: alltests/test_config_validation converted

### DIFF
--- a/src/tests/multihost/alltests/test_config_validation.py
+++ b/src/tests/multihost/alltests/test_config_validation.py
@@ -22,6 +22,7 @@ from string import ascii_uppercase
 class TestConfigValidation(object):
     """ SSSD Config Validation """
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__check_typo_option_name')
     def test_0001_searchbase(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation: Verify typos in option
@@ -41,6 +42,7 @@ class TestConfigValidation(object):
         assert log_1.search(cmd.stdout_text)
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__check_typo_domain_name')
     def test_0002_domainname(self, multihost, backupsssdconf):
         """
         :title:  IDM-SSSD-TC: Configuration validation: Verify typos in domain
@@ -58,6 +60,7 @@ class TestConfigValidation(object):
         assert log_1.search(cmd.stdout_text)
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__check_invalid_option_name_in_snippet')
     def test_0003_snippetfile(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation: Verify typos in option
@@ -79,6 +82,7 @@ class TestConfigValidation(object):
         multihost.client[0].run_command(rm_snippet_file, raiseonerr=False)
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__check_invalid_domain_name_in_snippet')
     def test_0004_snippetfile(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation: Verify typos in domain
@@ -100,6 +104,7 @@ class TestConfigValidation(object):
         multihost.client[0].run_command(rm_snippet_file, raiseonerr=False)
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__check_misplaced_option')
     def test_0005_misplaced(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation: Verify misplaced
@@ -119,6 +124,7 @@ class TestConfigValidation(object):
         assert log.search(cmd.stdout_text)
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__check_typo_option_name')
     def test_0006_sameerrors(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation: Verify same error when
@@ -140,6 +146,7 @@ class TestConfigValidation(object):
             assert log_1.search(cmd.stdout_text)
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__missing_equal_sign')
     def test_0007_equalsign(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation: No equal sign between
@@ -157,6 +164,7 @@ class TestConfigValidation(object):
         print(log.search(cmd.stderr_text))
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__special_character_option_name')
     def test_0008_specialcharacter(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation: Option name contains
@@ -175,6 +183,7 @@ class TestConfigValidation(object):
         assert log_1.search(cmd.stdout_text)
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__check_typo_domain_name')
     def test_0009_sectionname(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation: Verify typos in
@@ -194,6 +203,7 @@ class TestConfigValidation(object):
         assert log_1.search(cmd.stdout_text)
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__special_character_section_name')
     def test_0010_splcharacters(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation: Verify typos
@@ -213,6 +223,7 @@ class TestConfigValidation(object):
         assert log_1.search(cmd.stdout_text)
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__special_character_domain_name')
     def test_0011_splcharacters(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation: Verify typos (special
@@ -232,6 +243,7 @@ class TestConfigValidation(object):
         assert log_1.search(cmd.stdout_text)
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__forward_slash_missing')
     def test_0012_forwardslash(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation: Forward slash is not
@@ -250,6 +262,7 @@ class TestConfigValidation(object):
         assert log_1.search(cmd.stdout_text)
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__sssd_section_name_typo')
     def test_0013_sectiontypos(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation:
@@ -267,6 +280,7 @@ class TestConfigValidation(object):
         assert log_1.search(cmd.stdout_text)
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__pam_section_name_typo')
     def test_0014_pamsection(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation: Typos in pam section
@@ -283,6 +297,7 @@ class TestConfigValidation(object):
         assert log.search(cmd.stdout_text)
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__nss_section_name_typo')
     def test_0015_nsssection(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation: Typos in nss section
@@ -299,6 +314,7 @@ class TestConfigValidation(object):
         assert log.search(cmd.stdout_text)
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__verify_permission')
     def test_0016_verifypermission(self, multihost):
         """
         :title: IDM-SSSD-TC: Configuration validation: Verify the permission
@@ -317,6 +333,7 @@ class TestConfigValidation(object):
         multihost.client[0].run_command(restore_mod, raiseonerr=False)
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__verify_ownership')
     def test_0017_verifyownership(self, multihost):
         """
         :title: IDM-SSSD-TC: Configuration validation: Verify the ownership
@@ -344,6 +361,7 @@ class TestConfigValidation(object):
         multihost.client[0].run_command(restore_chown, raiseonerr=False)
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__verify_missing_closing_bracket')
     def test_0018_closingbrackets(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation: Verify the closing
@@ -361,6 +379,7 @@ class TestConfigValidation(object):
         assert log_1.search(cmd.stderr_text)
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__verify_missing_opening_bracket')
     def test_0019_openingbracket(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation: Check starting square
@@ -378,6 +397,7 @@ class TestConfigValidation(object):
         log_1 = re.compile(r'.Equal\ssign\sis\smissing.*')
         assert log_1.search(cmd.stderr_text)
 
+# Useless?
     @pytest.mark.tier1
     def test_0020_fatalerror(self, multihost, backupsssdconf):
         """
@@ -401,6 +421,7 @@ class TestConfigValidation(object):
         assert log.search(cmd.stdout_text)
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__verify_typo_in_config_with_two_domains')
     def test_0021_twodomain(self, multihost, multidomain_sssd):
         """
         :title: IDM-SSSD-TC: Configuration validation: Verify typo in option
@@ -422,6 +443,7 @@ class TestConfigValidation(object):
         multihost.client[0].run_command(restore)
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__config_does_not_exist')
     def test_0022_fatalerror(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation: No sssctl commands can
@@ -436,6 +458,7 @@ class TestConfigValidation(object):
         assert cmd.returncode == 1 and log.search(cmd.stdout_text)
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__check_ldap_host_object_class_in_domain')
     def test_0023_checkldaphostobjectdomain(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation: Check
@@ -452,6 +475,7 @@ class TestConfigValidation(object):
         assert cmd.returncode == 0
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__check_ldap_host_object_class_in_sssd')
     def test_0024_checkldaphostobjectsssd(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation: Check
@@ -471,6 +495,7 @@ class TestConfigValidation(object):
         assert log.search(cmd.stdout_text)
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__enabling_2FA')
     def test_0025_check2FA(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation: Check false
@@ -496,6 +521,7 @@ class TestConfigValidation(object):
         assert cmd.returncode == 0
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__auto_private_groups_in_child_domain')
     def test_0026_checkchilddomain(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation: sssctl config-check
@@ -517,6 +543,7 @@ class TestConfigValidation(object):
         assert cmd.returncode == 0
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__non_default_config_location_snippet_directory')
     def test_0027_bz1723273(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration merging: sssctl config-check
@@ -537,6 +564,8 @@ class TestConfigValidation(object):
                sssctl_check.returncode == 1
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__non_default_config_location_permission')
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__non_default_config_location_ownership')
     def test_0028_bz1723273(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration merging: sssctl config-check
@@ -559,6 +588,7 @@ class TestConfigValidation(object):
                sssctl_check.returncode == 1
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__non_default_config_location_option_name_typo')
     def test_0029_bz1723273(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation: Verify typos in option
@@ -585,6 +615,7 @@ class TestConfigValidation(object):
                and sssctl_check.returncode == 1
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__non_default_config_location_snippet_is_present')
     def test_0030_bz1723273(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation: Does not complain
@@ -610,6 +641,7 @@ class TestConfigValidation(object):
                and sssctl_check.returncode == 1
 
     @pytest.mark.tier1
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__non_existing_snippet')
     def test_0031_bz1723273(self, multihost, backupsssdconf):
         """
         :title: IDM-SSSD-TC: Configuration validation: complains about non

--- a/src/tests/multihost/basic/test_sssctl_config_check.py
+++ b/src/tests/multihost/basic/test_sssctl_config_check.py
@@ -13,7 +13,7 @@ import pytest
 
 
 class TestSssctlConfigCheck(object):
-    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__typo_option_name')
+    @pytest.mark.converted('test_sssctl.py', 'test_sssctl__check_typo_option_name')
     def test_verify_typo_option_name(self, multihost):
         """
         :title: sssctl: Verify typos in option name (not value)

--- a/src/tests/system/tests/test_sssctl.py
+++ b/src/tests/system/tests/test_sssctl.py
@@ -196,7 +196,7 @@ def test_sssctl__check_typo_option_name(client: Client):
     :title: sssctl config-check detects mistyped option name
     :setup:
         1. Add wrong_option to domain section
-        2. Start SSSD, without config check
+        2. Apply config
     :steps:
         1. Call sssctl config-check
         2. Check error message
@@ -207,14 +207,11 @@ def test_sssctl__check_typo_option_name(client: Client):
     """
     client.sssd.common.local()
     client.sssd.dom("test")["wrong_option"] = "true"
-
-    client.sssd.start(check_config=False)
+    client.sssd.config_apply(check_config=False)
 
     result = client.sssctl.config_check()
-    assert result.rc != 0, "Config-check did not detect misconfigured config"
-
-    pattern = re.compile(r"Attribute 'wrong_option' is not allowed.*")
-    assert pattern.search(result.stdout), "Wrong error message was returned"
+    assert result.rc != 0, "Config-check did not detect misconfigured config, when SSSD is running"
+    assert "Attribute 'wrong_option' is not allowed" in result.stdout, "Wrong error message was returned"
 
 
 @pytest.mark.importance("high")
@@ -269,3 +266,681 @@ def test_sssctl__check_misplaced_option(client: Client):
 
     pattern = re.compile(r".Attribute 'services' is not allowed in section .*")
     assert pattern.search(result.stdout), "Wrong error message was returned"
+
+
+@pytest.mark.tools
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__check_invalid_option_name_in_snippet(client: Client):
+    """
+    :title: sssctl config-check detects invalid option name in snippet
+    :setup:
+        1. Create new conf snippet with invalid option name
+    :steps:
+        1. Call sssctl config-check
+        2. Check error message
+    :expectedresults:
+        1. config-check detects an error in config snippet
+        2. Error message is properly set
+    :customerscenario: False
+    """
+    client.sssd.common.local()
+    client.fs.write("/etc/sssd/conf.d/01_snippet.conf", "[domain/local]\ninvalid_option = True", mode="600")
+
+    result = client.sssctl.config_check()
+    assert result.rc != 0, "Config-check did not detect misconfigured config snippet"
+    assert "Attribute 'invalid_option' is not allowed" in result.stdout, "Wrong error message was returned"
+
+
+@pytest.mark.tools
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__check_invalid_domain_name_in_snippet(client: Client):
+    """
+    :title: sssctl config-check detects invalid domain name in snippet
+    :setup:
+        1. Create new conf snippet with invalid domain name
+    :steps:
+        1. Call sssctl config-check
+        2. Check error message
+    :expectedresults:
+        1. config-check detects an error in config snippet
+        2. Error message is properly set
+    :customerscenario: False
+    """
+    client.sssd.common.local()
+    client.fs.write("/etc/sssd/conf.d/01_snippet.conf", "[invalid/local]\ninvalid_option = True", mode="600")
+
+    result = client.sssctl.config_check()
+    assert result.rc != 0, "Config-check did not detect misconfigured config snippet"
+    assert "Section [invalid/local] is not allowed" in result.stdout, "Wrong error message was returned"
+
+
+@pytest.mark.tools
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__missing_equal_sign(client: Client):
+    """
+    :title: sssctl config-check detects missing equals sign
+    :setup:
+        1. Start SSSD, so default config is autimatically created
+        2. Edit config file so "=" is missing
+    :steps:
+        1. Call sssctl config-check
+        2. Check error message
+    :expectedresults:
+        1. config-check detects an error
+        2. Error messages are properly set
+    :customerscenario: False
+    """
+    client.sssd.common.local()
+    client.sssd.start()
+    conf = re.sub("id_provider = ", "id_provider ", client.fs.read("/etc/sssd/sssd.conf"))
+    client.fs.write("/etc/sssd/sssd.conf", conf, mode="600")
+
+    result = client.sssctl.config_check()
+    assert result.rc != 0, "Config-check did not detect misconfigured config"
+    assert "Equal sign is missing" in result.stderr, "Wrong error message on stderr"
+
+
+@pytest.mark.tools
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__special_character_option_name(client: Client):
+    """
+    :title: option name contains special character
+    :setup:
+        1. Start SSSD, so default config is autimatically created
+        2. Edit config file in a way that it contains special character
+    :steps:
+        1. Call sssctl config-check
+        2. Check error message
+    :expectedresults:
+        1. config-check detects an error
+        2. Error message is properly set
+    :customerscenario: False
+    """
+    client.sssd.common.local()
+    client.sssd.start()
+    conf = re.sub("id_provider", "id_@provider", client.fs.read("/etc/sssd/sssd.conf"))
+    client.fs.write("/etc/sssd/sssd.conf", conf, mode="600")
+
+    result = client.sssctl.config_check()
+    assert result.rc != 0, "Config-check did not detect misconfigured config"
+    assert "Attribute 'id_@provider' is not allowed in section" in result.stdout, "Wrong error message on stdout"
+
+
+@pytest.mark.tools
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__special_character_section_name(client: Client):
+    """
+    :title: section name contains special character
+    :setup:
+        1. Start SSSD, so default config is autimatically created
+        2. Edit config file in a way that it contains special character
+    :steps:
+        1. Call sssctl config-check
+        2. Check error message
+    :expectedresults:
+        1. config-check detects an error
+        2. Error message is properly set
+    :customerscenario: False
+    """
+    client.sssd.common.local()
+    client.sssd.start()
+    conf = re.sub("domain/", "d$main/", client.fs.read("/etc/sssd/sssd.conf"))
+    client.fs.write("/etc/sssd/sssd.conf", conf, mode="600")
+
+    result = client.sssctl.config_check()
+    assert result.rc != 0, "Config-check did not detect misconfigured config"
+    assert "Section [d$main/local] is not allowed" in result.stdout, "Wrong error message on stdout"
+
+
+@pytest.mark.tools
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__special_character_domain_name(client: Client):
+    """
+    :title: domain name contains special character
+    :setup:
+        1. Start SSSD, so default config is autimatically created
+        2. Edit config file in a way that it contains special character
+    :steps:
+        1. Call sssctl config-check
+        2. Check error message
+    :expectedresults:
+        1. config-check detects an error
+        2. Error message is properly set
+    :customerscenario: False
+    """
+    client.sssd.common.local()
+    client.sssd.start()
+    conf = re.sub("domain/local", "domain/local@", client.fs.read("/etc/sssd/sssd.conf"))
+    client.fs.write("/etc/sssd/sssd.conf", conf, mode="600")
+
+    result = client.sssctl.config_check()
+    assert result.rc != 0, "Config-check did not detect misconfigured config"
+    assert "Section [domain/local@] is not allowed" in result.stdout, "Wrong error message on stdout"
+
+
+@pytest.mark.tools
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__forward_slash_missing(client: Client):
+    """
+    :title: Forward slash is not present between domain name and section name
+    :setup:
+        1. Start SSSD, so default config is autimatically created
+        2. Edit config file in a way that forward slash is missing in section name
+    :steps:
+        1. Call sssctl config-check
+        2. Check error message
+    :expectedresults:
+        1. config-check detects an error
+        2. Error message is properly set
+    :customerscenario: False
+    """
+    client.sssd.common.local()
+    client.sssd.start()
+    conf = re.sub("domain/local", "domainlocal", client.fs.read("/etc/sssd/sssd.conf"))
+    client.fs.write("/etc/sssd/sssd.conf", conf, mode="600")
+
+    result = client.sssctl.config_check()
+    assert result.rc != 0, "Config-check did not detect misconfigured config"
+    assert "Section [domainlocal] is not allowed" in result.stdout, "Wrong error message on stdout"
+
+
+@pytest.mark.tools
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__sssd_section_name_typo(client: Client):
+    """
+    :title: Typo in sssd section name
+    :setup:
+        1. Start SSSD, so default config is autimatically created
+        2. Edit config file in a way that there is typo in sssd section name
+    :steps:
+        1. Call sssctl config-check
+        2. Check error message
+    :expectedresults:
+        1. config-check detects an error
+        2. Error message is properly set
+    :customerscenario: False
+    """
+    client.sssd.common.local()
+    client.sssd.start()
+    conf = re.sub(".sssd.", "[sssdx]", client.fs.read("/etc/sssd/sssd.conf"))
+    client.fs.write("/etc/sssd/sssd.conf", conf, mode="600")
+
+    result = client.sssctl.config_check()
+    assert result.rc != 0, "Config-check did not detect misconfigured config"
+    assert "Section [sssdx] is not allowed" in result.stdout, "Wrong error message on stdout"
+
+
+@pytest.mark.tools
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__pam_section_name_typo(client: Client):
+    """
+    :title: Typo in pam section name
+    :setup:
+        1. Start SSSD, so default config is autimatically created
+        2. Edit config file in a way that there is typo in sssd section name
+    :steps:
+        1. Call sssctl config-check
+        2. Check error message
+    :expectedresults:
+        1. config-check detects an error
+        2. Error message is properly set
+    :customerscenario: False
+    """
+    client.sssd.common.local()
+    client.sssd.start()
+    conf = re.sub(".pam.", "[pamx]", client.fs.read("/etc/sssd/sssd.conf"))
+    client.fs.write("/etc/sssd/sssd.conf", conf, mode="600")
+
+    result = client.sssctl.config_check()
+    assert result.rc != 0, "Config-check did not detect misconfigured config"
+    assert "Section [pamx] is not allowed" in result.stdout, "Wrong error message on stdout"
+
+
+@pytest.mark.tools
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__nss_section_name_typo(client: Client):
+    """
+    :title: Typo in nss section name
+    :setup:
+        1. Start SSSD, so default config is autimatically created
+        2. Edit config file in a way that there is typo in sssd section name
+    :steps:
+        1. Call sssctl config-check
+        2. Check error message
+    :expectedresults:
+        1. config-check detects an error
+        2. Error message is properly set
+    :customerscenario: False
+    """
+    client.sssd.common.local()
+    client.sssd.start()
+    conf = re.sub(".nss.", "[nssx]", client.fs.read("/etc/sssd/sssd.conf"))
+    client.fs.write("/etc/sssd/sssd.conf", conf, mode="600")
+
+    result = client.sssctl.config_check()
+    assert result.rc != 0, "Config-check did not detect misconfigured config"
+    assert "Section [nssx] is not allowed" in result.stdout, "Wrong error message on stdout"
+
+
+@pytest.mark.tools
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__verify_permission(client: Client):
+    """
+    :title: Verify the permission of default configuration file
+    :setup:
+        1. Start SSSD, so default config is autimatically created
+        2. Change permission of default config file
+    :steps:
+        1. Call sssctl config-check
+        2. Check error message
+    :expectedresults:
+        1. config-check detects an error
+        2. Error message is properly set
+    :customerscenario: False
+    """
+    client.sssd.common.local()
+    client.sssd.start()
+    client.fs.chmod("0777", "/etc/sssd/sssd.conf")
+    result = client.sssctl.config_check()
+    assert result.rc != 0, "Config-check did not detect misconfigured config"
+    assert "File ownership and permissions check failed" in result.stdout, "Wrong error message on stdout"
+
+
+@pytest.mark.tools
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__verify_ownership(client: Client):
+    """
+    :title: Verify the ownership of default configuration file
+    :setup:
+        1. Start SSSD, so default config is autimatically created
+        2. Change ownership of default config file
+    :steps:
+        1. Call sssctl config-check
+        2. Check error message
+    :expectedresults:
+        1. config-check detects an error
+        2. Error message is properly set
+    :customerscenario: False
+    """
+    client.local.user("user1").add()
+    client.local.group("group1").add()
+    client.sssd.common.local()
+    client.sssd.start()
+    client.fs.chown("/etc/sssd/sssd.conf", "user1", "group1")
+    result = client.sssctl.config_check()
+    assert result.rc != 0, "Config-check did not detect misconfigured config"
+    assert "File ownership and permissions check failed" in result.stdout, "Wrong error message on stdout"
+
+
+@pytest.mark.tools
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__verify_missing_closing_bracket(client: Client):
+    """
+    :title: Missing closing bracket in sssd section name
+    :setup:
+        1. Start SSSD, so default config is autimatically created
+        2. Edit config file in a way that there is missing closing bracket
+    :steps:
+        1. Call sssctl config-check
+        2. Check error message
+    :expectedresults:
+        1. config-check detects an error
+        2. Error message is properly set
+    :customerscenario: False
+    """
+    client.sssd.common.local()
+    client.sssd.start()
+    conf = re.sub(".nss.", "[nssx", client.fs.read("/etc/sssd/sssd.conf"))
+    client.fs.write("/etc/sssd/sssd.conf", conf, mode="600")
+
+    result = client.sssctl.config_check()
+    assert result.rc != 0, "Config-check did not detect misconfigured config"
+    assert "No closing bracket" in result.stderr, "Wrong error message on stderr"
+
+
+@pytest.mark.tools
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__verify_missing_opening_bracket(client: Client):
+    """
+    :title: Missing opening bracket in domain name
+    :setup:
+        1. Start SSSD, so default config is autimatically created
+        2. Edit config file in a way that there is missing opening bracket
+    :steps:
+        1. Call sssctl config-check
+        2. Check error message
+    :expectedresults:
+        1. config-check detects an error
+        2. Error message is properly set
+    :customerscenario: False
+    """
+    client.sssd.common.local()
+    client.sssd.start()
+    conf = re.sub(".domain/local.", "domain/local]", client.fs.read("/etc/sssd/sssd.conf"))
+    client.fs.write("/etc/sssd/sssd.conf", conf, mode="600")
+
+    result = client.sssctl.config_check()
+    assert result.rc != 0, "Config-check did not detect misconfigured config"
+    assert "Equal sign is missing" in result.stderr, "Wrong error message on stderr"
+    assert "Failed to parse configuration" in result.stderr, "Wrong error message on stderr"
+
+
+@pytest.mark.tools
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__verify_typo_in_config_with_two_domains(client: Client):
+    """
+    :title: Verify typo in option name with multiple domains in default configuration file
+    :setup:
+        1. Configure two ldap domains
+        2. Make typo in both domains
+    :steps:
+        1. Call sssctl config-check
+        2. Check error message
+    :expectedresults:
+        1. config-check detects an error
+        2. Error messages are properly set
+    :customerscenario: False
+    """
+    client.sssd.common.local()
+    client.sssd.dom("ldap1")["ldap_ri"] = "ldaps://invalid"
+    client.sssd.dom("ldap1")["id_provider"] = "ldap"
+    client.sssd.dom("ldap2")["ldap_ri"] = "ldaps://invalid"
+    client.sssd.dom("ldap2")["id_provider"] = "ldap"
+    client.sssd.sssd["domains"] = "ldap1, ldap2"
+    client.sssd.config_apply(check_config=False)
+
+    res = client.sssctl.config_check()
+    assert res.rc != 0, "Config-check did not detect misconfigured config"
+    assert "Issues identified by validators: 2" in res.stdout, "Wrong number of issues found by validators"
+    assert "Attribute 'ldap_ri' is not allowed in section 'domain/ldap1'" in res.stdout, "Wrong error message"
+    assert "Attribute 'ldap_ri' is not allowed in section 'domain/ldap2'" in res.stdout, "Wrong error message"
+
+
+@pytest.mark.tools
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__config_does_not_exist(client: Client):
+    """
+    :title: sssctl detects missing config
+    :setup:
+        1. Start SSSD, so default config is automatically created
+        2. Remove config
+    :steps:
+        1. Call sssctl config-check
+        2. Check error message
+    :expectedresults:
+        1. config-check detects an error
+        2. Error message is properly set
+    :customerscenario: False
+    """
+    client.sssd.common.local()
+    client.sssd.start()
+    client.fs.rm("/etc/sssd/sssd.conf")
+
+    result = client.sssctl.config_check()
+    assert result.rc != 0, "Config-check did not detect misconfigured config"
+    assert "File /etc/sssd/sssd.conf does not exist" in result.stdout, "Wrong error message on stdout"
+
+
+@pytest.mark.tools
+@pytest.mark.ticket(bz=1677994)
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__check_ldap_host_object_class_in_domain(client: Client):
+    """
+    :title: sssctl config-check allow ldap_host_object_class in domain section
+    :setup:
+        1. Add ldap_host_object_class to local domain section
+        2. Start SSSD
+    :steps:
+        1. Call sssctl config-check
+    :expectedresults:
+        1. config-check succeed
+    :customerscenario: True
+    """
+    client.sssd.default_domain = "local"
+    client.sssd.common.local()
+    client.sssd.domain["ldap_host_object_class"] = "ipService"
+    client.sssd.start(check_config=False)
+
+    result = client.sssctl.config_check()
+    assert result.rc == 0, "Config-check failed"
+
+
+@pytest.mark.tools
+@pytest.mark.ticket(bz=1677994)
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__check_ldap_host_object_class_in_sssd(client: Client):
+    """
+    :title: sssctl config-check do not allow ldap_host_object_class in sssd section
+    :setup:
+        1. Add ldap_host_object_class to sssd section
+        2. Start SSSD
+    :steps:
+        1. Call sssctl config-check
+    :expectedresults:
+        1. config-check succeed
+    :customerscenario: True
+    """
+    client.sssd.common.local()
+    client.sssd.sssd["ldap_host_object_class"] = "ipService"
+    client.sssd.start(check_config=False)
+
+    result = client.sssctl.config_check()
+    assert result.rc != 0, "Config-check did not detect misconfigured config"
+    assert (
+        "Attribute 'ldap_host_object_class' is not allowed in section 'sssd'" in result.stdout
+    ), "Wrong error message on stdout"
+
+
+@pytest.mark.tools
+@pytest.mark.ticket(bz=1856861)
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__enabling_2FA(client: Client):
+    """
+    :title: False warnings are logged in sssd.log file after enabling 2FA prompting
+    :setup:
+        1. Enable Two factor authentication
+        2. Start SSSD
+    :steps:
+        1. Call sssctl config-check
+    :expectedresults:
+        1. config-check succeed
+    :customerscenario: True
+    """
+    client.sssd.common.local()
+    client.sssd.section("prompting/2fa/sshd")["first_prompt"] = "Enter OTP Token Value:"
+    client.sssd.section("prompting/2fa/sshd")["single_prompt"] = "True"
+
+    client.sssd.section("prompting/2fa")["first_prompt"] = "prompt1"
+    client.sssd.section("prompting/2fa")["second_prompt"] = "prompt2"
+    client.sssd.section("prompting/2fa")["single_prompt"] = "True"
+
+    client.sssd.start(check_config=False)
+    result = client.sssctl.config_check()
+    assert result.rc == 0, "Config-check failed"
+
+
+@pytest.mark.tools
+@pytest.mark.ticket(bz=1791892)
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__auto_private_groups_in_child_domain(client: Client):
+    """
+    :title: sssctl config-check detects false positive when auto_private_groups is enabled or disabled in child domains
+    :setup:
+        1. Enable auto_private_groups in child domain
+        2. Disable auto_private_groups in second child domain
+        3. Start SSSD
+    :steps:
+        1. Call sssctl config-check
+    :expectedresults:
+        1. config-check succeed
+    :customerscenario: True
+    """
+    client.sssd.common.local()
+    client.sssd.sssd["domains"] = "td5f4f77.com"
+    client.sssd.subdom("td5f4f77.com", "one5f4f77.td5f4f77.com")["auto_private_groups"] = "True"
+    client.sssd.subdom("td5f4f77.com", "two5f4f77.td5f4f77.com")["auto_private_groups"] = "False"
+
+    client.sssd.start(check_config=False, debug_level=None)
+    result = client.sssctl.config_check()
+    assert result.rc == 0, "Config-check failed"
+
+
+@pytest.mark.tools
+@pytest.mark.ticket(bz=1723273)
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__non_default_config_location_snippet_directory(client: Client):
+    """
+    :title: sssctl config-check complains about non existing snippet directory when config is non default
+    :setup:
+        1. Copy sssd.conf file to different directory
+    :steps:
+        1. Call sssctl config-check on that different directory
+        2. Check error message
+    :expectedresults:
+        1. config-check failed
+        2. Error message is properly set
+    :customerscenario: True
+    """
+    client.sssd.common.local()
+    client.sssd.config_apply()
+    client.fs.mkdir("/tmp/test/")
+    client.fs.copy("/etc/sssd/sssd.conf", "/tmp/test/")
+
+    result = client.sssctl.config_check(config="/tmp/test/sssd.conf")
+    assert result.rc != 0, "Config-check successfully finished"
+    assert "Directory /tmp/test/conf.d does not exist" in result.stdout, "Wrong error message on stdout"
+
+
+@pytest.mark.tools
+@pytest.mark.ticket(bz=1723273)
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__non_default_config_location_permission(client: Client):
+    """
+    :title: sssctl config-check complains about proper permission when config is non default
+    :setup:
+        1. Copy sssd.conf file to different directory and set it wrong permission
+    :steps:
+        1. Call sssctl config-check on that different directory
+        2. Check error message
+    :expectedresults:
+        1. config-check failed
+        2. Error message is properly set
+    :customerscenario: True
+    """
+    client.sssd.common.local()
+    client.sssd.config_apply()
+    client.fs.mkdir("/tmp/test/")
+    client.fs.copy("/etc/sssd/sssd.conf", "/tmp/test/sssd.conf", mode="777")
+
+    result = client.sssctl.config_check(config="/tmp/test/sssd.conf")
+    assert result.rc != 0, "Config-check successfully finished"
+    assert "File ownership and permissions check failed" in result.stdout, "Wrong error message on stdout"
+
+
+@pytest.mark.tools
+@pytest.mark.ticket(bz=1723273)
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__non_default_config_location_ownership(client: Client):
+    """
+    :title: sssctl config-check complains about proper ownership when config is non default
+    :setup:
+        1. Copy sssd.conf file to different directory and set it wrong ownership
+    :steps:
+        1. Call sssctl config-check on that different directory
+        2. Check error message
+    :expectedresults:
+        1. config-check failed
+        2. Error message is properly set
+    :customerscenario: True
+    """
+    client.local.user("user1").add()
+    client.sssd.common.local()
+    client.sssd.config_apply()
+    client.fs.mkdir("/tmp/test/")
+    client.fs.copy("/etc/sssd/sssd.conf", "/tmp/test/sssd.conf", user="user1")
+
+    result = client.sssctl.config_check(config="/tmp/test/sssd.conf")
+    assert result.rc != 0, "Config-check successfully finished"
+    assert "File ownership and permissions check failed" in result.stdout, "Wrong error message on stdout"
+
+
+@pytest.mark.tools
+@pytest.mark.ticket(bz=1723273)
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__non_default_config_location_option_name_typo(client: Client):
+    """
+    :title: sssctl config-check detects typo in option name when config is non default
+    :setup:
+        1. Copy sssd.conf file to different directory and mistype option name
+    :steps:
+        1. Call sssctl config-check on that different directory
+        2. Check error message
+    :expectedresults:
+        1. config-check failed
+        2. Error message is properly set
+    :customerscenario: True
+    """
+    client.sssd.common.local()
+    client.sssd.default_domain = "local"
+    client.sssd.domain["search_base"] = "True"
+    client.sssd.config_apply(check_config=False)
+
+    client.fs.mkdir("/tmp/test/")
+    client.fs.copy("/etc/sssd/sssd.conf", "/tmp/test/")
+
+    result = client.sssctl.config_check(config="/tmp/test/sssd.conf")
+    assert result.rc != 0, "Config-check successfully finished"
+    assert (
+        "Attribute 'search_base' is not allowed in section 'domain/local'" in result.stdout
+    ), "Wrong error message on stdout"
+
+
+@pytest.mark.tools
+@pytest.mark.ticket(bz=1723273)
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__non_default_config_location_snippet_is_present(client: Client):
+    """
+    :title: sssctl config-check does not complain about missing snippet directory after adding with proper permission
+    :setup:
+        1. Copy sssd.conf file to different directory and create conf.d directory
+    :steps:
+        1. Call sssctl config-check on that different directory
+        2. Check error message
+    :expectedresults:
+        1. config-check failed
+        2. Error message is properly set
+    :customerscenario: True
+    """
+    client.sssd.common.local()
+    client.sssd.config_apply(check_config=False)
+
+    client.fs.mkdir("/tmp/test/")
+    client.fs.mkdir("/tmp/test/conf.d", mode="700")
+    client.fs.copy("/etc/sssd/sssd.conf", "/tmp/test/")
+
+    result = client.sssctl.config_check(config="/tmp/test/sssd.conf")
+    assert result.rc == 0, "Config-check failed"
+    assert "Directory /tmp/test/conf.d does not exist" not in result.stdout, "Wrong error message on stdout"
+
+
+@pytest.mark.tools
+@pytest.mark.ticket(bz=1723273)
+@pytest.mark.topology(KnownTopology.Client)
+def test_sssctl__non_existing_snippet(client: Client):
+    """
+    :title: sssctl config-check detects non existing snippet directory
+    :setup:
+        1. Start SSSD, so default config is autimatically created
+    :steps:
+        1. Call sssctl config-check with non existing snippet
+        2. Check error message
+    :expectedresults:
+        1. config-check failed
+        2. Error message is properly set
+    :customerscenario: True
+    """
+    client.sssd.common.local()
+    client.sssd.start()
+    result = client.sssctl.config_check(snippet="/does/not/exist")
+    assert result.rc != 0, "Config-check successfully finished"
+    assert "Directory /does/not/exist does not exist" in result.stdout, "Wrong error message on stdout"


### PR DESCRIPTION
`alltests/test_config_validation.py` converted to new framework. I did not convert test `test_0020_fatalerror` because I think it is already covered in other test cases.

I used only general description in assert failure messages and in docstrings. If you think I should be more descriptive, let me know.

If you have any other suggestions, just write them down.
Thanks in advance