### PR TITLE
KCM: Fix a memory "leak"

### DIFF
--- a/src/responder/kcm/kcmsrv_cmd.c
+++ b/src/responder/kcm/kcmsrv_cmd.c
@@ -350,7 +350,7 @@ static void kcm_send_reply(struct kcm_req_ctx *req_ctx)
 
     cctx = req_ctx->cctx;
 
-    ret = kcm_output_construct(cctx, &req_ctx->op_io, &req_ctx->repbuf);
+    ret = kcm_output_construct(req_ctx, &req_ctx->op_io, &req_ctx->repbuf);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Cannot construct the reply buffer, terminating client\n");


### PR DESCRIPTION
When an operation is processed, a buffer is allocated for the reply and its parent is the client context (`struct cli_ctx`). This buffer is not explicitly freed but it is released when the client context is freed. With each operation a new buffer is allocated and the previous one gets "lost."

This is not an actual leak because the lost buffers are released by `talloc` once the client context is freed, when the connection is closed. But on long-lived connections this can consume a large amount of memory before the connection is closed.

To solve this, the request context (`struct kcm_req_ctx`) is the new parent of the buffer. The request is freed as soon as the operation is completed and no buffer gets lost.

Resolves: https://github.com/SSSD/sssd/issues/7072