### PR TITLE
Tests: Revert change of retun type of realm_join

### DIFF
--- a/src/tests/multihost/sssd/testlib/common/utils.py
+++ b/src/tests/multihost/sssd/testlib/common/utils.py
@@ -439,7 +439,7 @@ class sssdTools(object):
             self.multihost.run_command("cat /etc/krb5.conf", raiseonerr=False)
             self.multihost.run_command("resolvectl dns", raiseonerr=False)
             raise SSSDException("Error: %s" % cmd.stderr_text)
-        return cmd.returncode == 0
+        return cmd.stderr_text
 
 
     def realm_leave(self, domainname, raiseonerr=True):


### PR DESCRIPTION
I looks like realm join return value was parsed in one place so I am reverting the mishap part of change (https://github.com/SSSD/sssd/pull/7075/files). 