### PR TITLE
Tests: fix flake8 issues

### DIFF
--- a/src/tests/system/tests/test_authentication.py
+++ b/src/tests/system/tests/test_authentication.py
@@ -16,7 +16,7 @@ from sssd_test_framework.topology import KnownTopologyGroup
 @pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
 @pytest.mark.require(
     lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
-    "SSSD was built without support for running under non-root"
+    "SSSD was built without support for running under non-root",
 )
 def test_authentication__login(client: Client, provider: GenericProvider, method: str, sssd_service_user: str):
     """
@@ -47,7 +47,7 @@ def test_authentication__login(client: Client, provider: GenericProvider, method
 @pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
 @pytest.mark.require(
     lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
-    "SSSD was built without support for running under non-root"
+    "SSSD was built without support for running under non-root",
 )
 def test_authentication__offline_login(client: Client, provider: GenericProvider, method: str, sssd_service_user: str):
     """

--- a/src/tests/system/tests/test_autofs.py
+++ b/src/tests/system/tests/test_autofs.py
@@ -20,9 +20,11 @@ from sssd_test_framework.topology import KnownTopologyGroup
 @pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
 @pytest.mark.require(
     lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
-    "SSSD was built without support for running under non-root"
+    "SSSD was built without support for running under non-root",
 )
-def test_autofs__cache_first(client: Client, nfs: NFS, provider: GenericProvider, cache_first: bool, sssd_service_user: str):
+def test_autofs__cache_first(
+    client: Client, nfs: NFS, provider: GenericProvider, cache_first: bool, sssd_service_user: str
+):
     """
     :title: Autofs works correctly with any cache_first value
     :setup:

--- a/src/tests/system/tests/test_identity.py
+++ b/src/tests/system/tests/test_identity.py
@@ -17,7 +17,7 @@ from sssd_test_framework.topology import KnownTopologyGroup
 @pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
 @pytest.mark.require(
     lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
-    "SSSD was built without support for running under non-root"
+    "SSSD was built without support for running under non-root",
 )
 def test_identity__lookup_username_with_id(client: Client, provider: GenericProvider, sssd_service_user: str):
     """
@@ -56,7 +56,7 @@ def test_identity__lookup_username_with_id(client: Client, provider: GenericProv
 @pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
 @pytest.mark.require(
     lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
-    "SSSD was built without support for running under non-root"
+    "SSSD was built without support for running under non-root",
 )
 def test_identity__lookup_uid_with_id(client: Client, provider: GenericProvider, sssd_service_user: str):
     """
@@ -243,9 +243,11 @@ def test_identity__lookup_user_by_group_with_getent(client: Client, provider: Ge
 @pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
 @pytest.mark.require(
     lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
-    "SSSD was built without support for running under non-root"
+    "SSSD was built without support for running under non-root",
 )
-def test_identity__lookup_group_membership_by_username_with_id(client: Client, provider: GenericProvider, sssd_service_user: str):
+def test_identity__lookup_group_membership_by_username_with_id(
+    client: Client, provider: GenericProvider, sssd_service_user: str
+):
     """
     :title: Check membership of user by group name with id
     :setup:

--- a/src/tests/system/tests/test_ldap.py
+++ b/src/tests/system/tests/test_ldap.py
@@ -21,7 +21,7 @@ from sssd_test_framework.topology import KnownTopology
 @pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
 @pytest.mark.require(
     lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
-    "SSSD was built without support for running under non-root"
+    "SSSD was built without support for running under non-root",
 )
 def test_ldap__change_password(client: Client, ldap: LDAP, modify_mode: str, use_ppolicy: str, sssd_service_user: str):
     """

--- a/src/tests/system/tests/test_sudo.py
+++ b/src/tests/system/tests/test_sudo.py
@@ -25,7 +25,7 @@ from sssd_test_framework.topology import KnownTopology, KnownTopologyGroup
 @pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
 @pytest.mark.require(
     lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
-    "SSSD was built without support for running under non-root"
+    "SSSD was built without support for running under non-root",
 )
 def test_sudo__user_allowed(client: Client, provider: GenericProvider, sssd_service_user: str):
     """
@@ -164,7 +164,7 @@ def test_sudo__case_sensitive_false(client: Client, provider: GenericProvider):
 @pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
 @pytest.mark.require(
     lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
-    "SSSD was built without support for running under non-root"
+    "SSSD was built without support for running under non-root",
 )
 def test_sudo__rules_refresh(client: Client, provider: GenericProvider, sssd_service_user: str):
     """
@@ -510,7 +510,7 @@ def test_sudo__prefer_full_refresh_over_smart_refresh(client: Client, full_inter
 @pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
 @pytest.mark.require(
     lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
-    "SSSD was built without support for running under non-root"
+    "SSSD was built without support for running under non-root",
 )
 def test_sudo__local_users_negative_cache(client: Client, provider: LDAP, sssd_service_user: str):
     """


### PR DESCRIPTION
I just used `black` to reformat test files to make `Static code analysis / python-system-tests (pull_request)`  succeed.
