### PR TITLE
CI: system: clean 'dnf.conf::tsflags'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,7 @@ jobs:
           #!/bin/bash
           set -ex
 
-          dnf install -y /dev/shm/sssd/rpmbuild/RPMS/*/*.rpm
+          dnf install --setopt=tsflags= -y /dev/shm/sssd/rpmbuild/RPMS/*/*.rpm
           rm -fr /dev/shm/sssd
 
           # We need to reenable sssd-kcm since it was disabled by removing sssd not not enabled again


### PR DESCRIPTION
to allow man pages installation. This is to enable proper feature detection that rely on man pages content.