### PR TITLE
CLIENT:NSS: never resolve initgroups for 'sssd' user

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -103,6 +103,8 @@ condconfigexists = ConditionPathExists=\|/etc/sssd/sssd.conf\nConditionDirectory
 # originally then it's addition to CapabilityBoundingSet doesn't matter.
 if SSSD_NON_ROOT_USER
 additional_caps = CAP_DAC_OVERRIDE
+nss_service_user_group = User=$(SSSD_USER)\nGroup=$(SSSD_USER)
+nss_socket_user_group = SocketUser=$(SSSD_USER)\nSocketGroup=$(SSSD_USER)
 endif
 else
 ifp_dbus_exec_comment = \# "sss_signal" is used to force SSSD monitor to trigger "sssd_ifp" reconnection to dbus
@@ -5270,7 +5272,9 @@ edit_cmd = $(SED) \
         -e 's|@prefix[@]|$(prefix)|g' \
         -e 's|@SSSD_USER[@]|$(SSSD_USER)|g' \
         -e 's|@condconfigexists[@]|$(condconfigexists)|g' \
-        -e 's|@additional_caps[@]|$(additional_caps)|g'
+        -e 's|@additional_caps[@]|$(additional_caps)|g' \
+        -e 's|@nss_service_user_group[@]|$(nss_service_user_group)|g' \
+        -e 's|@nss_socket_user_group[@]|$(nss_socket_user_group)|g'
 
 replace_script = \
     @rm -f $@ $@.tmp; \

--- a/src/sss_client/nss_group.c
+++ b/src/sss_client/nss_group.c
@@ -302,6 +302,14 @@ enum nss_status _nss_sss_initgroups_dyn(const char *user, gid_t group,
         return NSS_STATUS_NOTFOUND;
     }
 
+#ifdef SSSD_NON_ROOT_USER
+    /* Never resolve SSSD_USER */
+    if (strcmp(user, SSSD_USER) == 0) {
+        *errnop = 0;
+        return NSS_STATUS_NOTFOUND;
+    }
+#endif /* SSSD_NON_ROOT_USER */
+
     ret = sss_nss_mc_initgroups_dyn(user, user_len, group, start, size,
                                     groups, limit);
     switch (ret) {

--- a/src/sysv/systemd/sssd-nss.service.in
+++ b/src/sysv/systemd/sssd-nss.service.in
@@ -13,6 +13,10 @@ Environment=DEBUG_LOGGER=--logger=files
 EnvironmentFile=-@environment_file@
 ExecStart=@libexecdir@/sssd/sssd_nss ${DEBUG_LOGGER} --socket-activated
 Restart=on-failure
-# Currently SSSD NSS service ('sssd_nss') can't be started under 'sssd' user
-# via systemd due to NSS loop when systemd resolves getgrouplist(sssd).
-# Hence 'User=' and 'Group=' aren't set (defaults to root).
+# 'sssd_nss' is special in that it might be used for resolution of 'User='/'Group='/etc,
+# and this may cause the service to hang (loop).
+# In case SSSD needs to be configured to run as root, avoid adding 'User=root'/'Group=root' explicitly
+# here for this reason (use defaults instead).
+# In case SSSD was built with support of running under non-root user, there is a special
+# handling in 'libnss_sss' and it is allowed to use build time configured user in 'User='/'Group='
+@nss_service_user_group@

--- a/src/sysv/systemd/sssd-nss.socket.in
+++ b/src/sysv/systemd/sssd-nss.socket.in
@@ -10,6 +10,7 @@ Conflicts=shutdown.target
 [Socket]
 ExecStartPre=@libexecdir@/sssd/sssd_check_socket_activated_responders -r nss
 ListenStream=@pipepath@/nss
+@nss_socket_user_group@
 
 [Install]
 WantedBy=sssd.service


### PR DESCRIPTION
if built with non-root user support

This is an addition to 8c8702803263d6dbf2c39f5bca8fb33036806f35
It allows to avoid systemd hang while starting socket activated 'sssd_nss' under 'sssd' user.