### PR TITLE
Fleet commander: store deskprofiles under user running SSSD

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -3433,11 +3433,6 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                             Default: <quote>id_provider</quote> is used if it
                             is set and can perform session related tasks.
                         </para>
-                        <para>
-                            <emphasis>NOTE:</emphasis> In order to have this feature
-                            working as expected SSSD must be running as "root" and
-                            not as the unprivileged user.
-                        </para>
                     </listitem>
                 </varlistentry>
 

--- a/src/providers/ipa/ipa_deskprofile_rules_util.c
+++ b/src/providers/ipa/ipa_deskprofile_rules_util.c
@@ -219,10 +219,7 @@ done:
 }
 
 errno_t
-ipa_deskprofile_rules_create_user_dir(
-                                    const char *username, /* fully-qualified */
-                                    uid_t uid,
-                                    gid_t gid)
+ipa_deskprofile_rules_create_user_dir(const char *username /* fully-qualified */)
 {
     TALLOC_CTX *tmp_ctx;
     char *shortname;
@@ -245,8 +242,7 @@ ipa_deskprofile_rules_create_user_dir(
     }
 
     old_umask = umask(0026);
-    ret = sss_create_dir(IPA_DESKPROFILE_RULES_USER_DIR, domain, 0751,
-                         getuid(), getgid());
+    ret = sss_create_dir(IPA_DESKPROFILE_RULES_USER_DIR, domain, 0751);
     umask(old_umask);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
@@ -267,7 +263,7 @@ ipa_deskprofile_rules_create_user_dir(
     /* In order to read, create and traverse the directory, we need to have its
      * permissions set as 'rwx------' (700). */
     old_umask = umask(0077);
-    ret = sss_create_dir(domain_dir, shortname, 0700, uid, gid);
+    ret = sss_create_dir(domain_dir, shortname, 0700);
     umask(old_umask);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
@@ -684,9 +680,7 @@ ipa_deskprofile_rules_save_rule_to_disk(
                                     struct sysdb_attrs *rule,
                                     struct sss_domain_info *domain,
                                     const char *hostname,
-                                    const char *username, /* fully-qualified */
-                                    uid_t uid,
-                                    gid_t gid)
+                                    const char *username /* fully-qualified */)
 {
     TALLOC_CTX *tmp_ctx;
     const char *rule_name;
@@ -706,17 +700,12 @@ ipa_deskprofile_rules_save_rule_to_disk(
     const char *extension = "json";
     uint32_t prio;
     int fd = -1;
-    gid_t orig_gid;
-    uid_t orig_uid;
     errno_t ret;
 
     tmp_ctx = talloc_new(mem_ctx);
     if (tmp_ctx == NULL) {
         return ENOMEM;
     }
-
-    orig_gid = getegid();
-    orig_uid = geteuid();
 
     ret = sysdb_attrs_get_string(rule, IPA_CN, &rule_name);
     if (ret != EOK) {
@@ -880,26 +869,6 @@ ipa_deskprofile_rules_save_rule_to_disk(
         goto done;
     }
 
-    ret = setegid(gid);
-    if (ret == -1) {
-        ret = errno;
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Unable to set effective group id (%"PRIu32") of the domain's "
-              "process [%d]: %s\n",
-              gid, ret, sss_strerror(ret));
-        goto done;
-    }
-
-    ret = seteuid(uid);
-    if (ret == -1) {
-        ret = errno;
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Unable to set effective user id (%"PRIu32") of the domain's "
-              "process [%d]: %s\n",
-              uid, ret, sss_strerror(ret));
-        goto done;
-    }
-
     fd = open(filename_path, O_WRONLY | O_CREAT | O_TRUNC, 0400);
     if (fd == -1) {
         ret = errno;
@@ -920,119 +889,26 @@ ipa_deskprofile_rules_save_rule_to_disk(
         goto done;
     }
 
-    ret = seteuid(orig_uid);
-    if (ret == -1) {
-        ret = errno;
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Failed to set the effect user id (%"PRIu32") of the domain's "
-              "process [%d]: %s\n",
-              orig_uid, ret, sss_strerror(ret));
-        goto done;
-    }
-
-    ret = setegid(orig_gid);
-    if (ret == -1) {
-        ret = errno;
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Failed to set the effect group id (%"PRIu32") of the domain's "
-              "process [%d]: %s\n",
-              orig_gid, ret, sss_strerror(ret));
-        goto done;
-    }
-
     ret = EOK;
 
 done:
     if (fd != -1) {
         close(fd);
     }
-    if (geteuid() != orig_uid) {
-        ret = seteuid(orig_uid);
-        if (ret == -1) {
-            ret = errno;
-            DEBUG(SSSDBG_CRIT_FAILURE,
-                  "Unable to set effective user id (%"PRIu32") of the "
-                  "domain's process [%d]: %s\n",
-                  orig_uid, ret, sss_strerror(ret));
-            DEBUG(SSSDBG_CRIT_FAILURE,
-                  "Sending SIGUSR2 to the process: %d\n", getpid());
-            kill(getpid(), SIGUSR2);
-        }
-    }
-    if (getegid() != orig_gid) {
-        ret = setegid(orig_gid);
-        if (ret == -1) {
-            ret = errno;
-            DEBUG(SSSDBG_CRIT_FAILURE,
-                  "Unable to set effective group id (%"PRIu32") of the "
-                  "domain's process. Let's have the process restarted!\n",
-                  orig_gid);
-            DEBUG(SSSDBG_CRIT_FAILURE,
-                  "Sending SIGUSR2 to the process: %d\n", getpid());
-            kill(getpid(), SIGUSR2);
-        }
-    }
     talloc_free(tmp_ctx);
     return ret;
 }
 
 errno_t
-ipa_deskprofile_rules_remove_user_dir(const char *user_dir,
-                                      uid_t uid,
-                                      gid_t gid)
+ipa_deskprofile_rules_remove_user_dir(const char *user_dir)
 {
-    gid_t orig_gid;
-    uid_t orig_uid;
     errno_t ret;
-
-    orig_gid = getegid();
-    orig_uid = geteuid();
-
-    ret = setegid(gid);
-    if (ret == -1) {
-        ret = errno;
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Unable to set effective group id (%"PRIu32") of the domain's "
-              "process [%d]: %s\n",
-              gid, ret, sss_strerror(ret));
-        goto done;
-    }
-
-    ret = seteuid(uid);
-    if (ret == -1) {
-        ret = errno;
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Unable to set effective user id (%"PRIu32") of the domain's "
-              "process [%d]: %s\n",
-              uid, ret, sss_strerror(ret));
-        goto done;
-    }
 
     ret = sss_remove_subtree(user_dir);
     if (ret != EOK && ret != ENOENT) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Cannot remove \"%s\" directory [%d]: %s\n",
               user_dir, ret, sss_strerror(ret));
-        goto done;
-    }
-
-    ret = seteuid(orig_uid);
-    if (ret == -1) {
-        ret = errno;
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Failed to set the effect user id (%"PRIu32") of the domain's "
-              "process [%d]: %s\n",
-              orig_uid, ret, sss_strerror(ret));
-        goto done;
-    }
-
-    ret = setegid(orig_gid);
-    if (ret == -1) {
-        ret = errno;
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Failed to set the effect group id (%"PRIu32") of the domain's "
-              "process [%d]: %s\n",
-              orig_gid, ret, sss_strerror(ret));
         goto done;
     }
 
@@ -1047,32 +923,6 @@ ipa_deskprofile_rules_remove_user_dir(const char *user_dir,
     ret = EOK;
 
 done:
-    if (geteuid() != orig_uid) {
-        ret = seteuid(orig_uid);
-        if (ret == -1) {
-            ret = errno;
-            DEBUG(SSSDBG_CRIT_FAILURE,
-                  "unable to set effective user id (%"PRIu32") of the "
-                  "domain's process [%d]: %s\n",
-                  orig_uid, ret, sss_strerror(ret));
-            DEBUG(SSSDBG_CRIT_FAILURE,
-                  "Sending SIGUSR2 to the process: %d\n", getpid());
-            kill(getpid(), SIGUSR2);
-        }
-    }
-    if (getegid() != orig_gid) {
-        ret = setegid(orig_gid);
-        if (ret == -1) {
-            ret = errno;
-            DEBUG(SSSDBG_CRIT_FAILURE,
-                  "Unable to set effective user id (%"PRIu32") of the "
-                  "domain's process [%d]: %s\n",
-                  orig_uid, ret, sss_strerror(ret));
-            DEBUG(SSSDBG_CRIT_FAILURE,
-                  "Sending SIGUSR2 to the process: %d\n", getpid());
-            kill(getpid(), SIGUSR2);
-        }
-    }
     return ret;
 }
 

--- a/src/providers/ipa/ipa_deskprofile_rules_util.h
+++ b/src/providers/ipa/ipa_deskprofile_rules_util.h
@@ -45,10 +45,7 @@ ipa_deskprofile_get_filename_path(TALLOC_CTX *mem_ctx,
                                   char **_filename_path);
 
 errno_t
-ipa_deskprofile_rules_create_user_dir(
-                                    const char *username, /* fully-qualified */
-                                    uid_t uid,
-                                    gid_t gid);
+ipa_deskprofile_rules_create_user_dir(const char *username /* fully-qualified */);
 errno_t
 ipa_deskprofile_rules_save_rule_to_disk(
                                     TALLOC_CTX *mem_ctx,
@@ -56,13 +53,9 @@ ipa_deskprofile_rules_save_rule_to_disk(
                                     struct sysdb_attrs *rule,
                                     struct sss_domain_info *domain,
                                     const char *hostname,
-                                    const char *username, /* fully-qualified */
-                                    uid_t uid,
-                                    gid_t gid);
+                                    const char *username /* fully-qualified */);
 errno_t
-ipa_deskprofile_rules_remove_user_dir(const char *user_dir,
-                                      uid_t uid,
-                                      gid_t gid);
+ipa_deskprofile_rules_remove_user_dir(const char *user_dir);
 
 errno_t
 deskprofile_get_cached_priority(struct sss_domain_info *domain,

--- a/src/tests/files-tests.c
+++ b/src/tests/files-tests.c
@@ -40,8 +40,6 @@
 static char tpl_dir[] = "file-tests-dir-XXXXXX";
 static char *dir_path;
 static char *dst_path;
-static uid_t uid;
-static gid_t gid;
 static TALLOC_CTX *test_ctx = NULL;
 
 static void setup_files_test(void)
@@ -51,9 +49,6 @@ static void setup_files_test(void)
     mkdir(TESTS_PATH, 0700);
     dir_path = mkdtemp(talloc_asprintf(test_ctx, "%s/%s", TESTS_PATH, tpl_dir));
     dst_path = mkdtemp(talloc_asprintf(test_ctx, "%s/%s", TESTS_PATH, tpl_dir));
-
-    uid = getuid();
-    gid = getgid();
 }
 
 static void teardown_files_test(void)
@@ -217,7 +212,7 @@ START_TEST(test_create_dir)
     ck_assert_msg(errno == 0, "Cannot getcwd\n");
 
     /* create a dir */
-    ret = sss_create_dir(dir_path, "testdir", S_IRUSR | S_IXUSR, uid, gid);
+    ret = sss_create_dir(dir_path, "testdir", S_IRUSR | S_IXUSR);
     ck_assert_msg(ret == EOK, "cannot create dir: %s", strerror(ret));
 
     new_dir = talloc_asprintf(NULL, "%s/testdir", dir_path);
@@ -231,10 +226,6 @@ START_TEST(test_create_dir)
     ck_assert_msg((info.st_mode & S_IRUSR) != 0, "Read permission is not set\n");
     ck_assert_msg((info.st_mode & S_IWUSR) == 0, "Write permission is set\n");
     ck_assert_msg((info.st_mode & S_IXUSR) != 0, "Exec permission is not set\n");
-
-    /* check the owner is okay */
-    ck_assert_msg(info.st_uid == uid, "Dir created with the wrong uid\n");
-    ck_assert_msg(info.st_gid == gid, "Dir created with the wrong gid\n");
 
     talloc_free(new_dir);
 }

--- a/src/util/files.c
+++ b/src/util/files.c
@@ -213,14 +213,12 @@ fail:
 
 int sss_create_dir(const char *parent_dir_path,
                    const char *dir_name,
-                   mode_t mode,
-                   uid_t uid, gid_t gid)
+                   mode_t mode)
 {
     TALLOC_CTX *tmp_ctx;
     char *dir_path;
     int ret = EOK;
     int parent_dir_fd = -1;
-    int dir_fd = -1;
 
     tmp_ctx = talloc_new(NULL);
     if (tmp_ctx == NULL) {
@@ -257,32 +255,11 @@ int sss_create_dir(const char *parent_dir_path,
         }
     }
 
-    dir_fd = sss_open_cloexec(dir_path, O_RDONLY | O_DIRECTORY, &ret);
-    if (dir_fd == -1) {
-        DEBUG(SSSDBG_TRACE_FUNC,
-              "Cannot open() directory '%s' [%d]: %s\n",
-              dir_path, ret, sss_strerror(ret));
-        goto fail;
-    }
-
-    errno = 0;
-    ret = fchown(dir_fd, uid, gid);
-    if (ret == -1) {
-        ret = errno;
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Failed to own the newly created directory '%s' [%d]: %s\n",
-              dir_path, ret, sss_strerror(ret));
-        goto fail;
-    }
-
     ret = EOK;
 
 fail:
     if (parent_dir_fd != -1) {
         close(parent_dir_fd);
-    }
-    if (dir_fd != -1) {
-        close(dir_fd);
     }
     talloc_free(tmp_ctx);
     return ret;

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -820,8 +820,7 @@ int sss_remove_subtree(const char *root);
 
 int sss_create_dir(const char *parent_dir_path,
                    const char *dir_name,
-                   mode_t mode,
-                   uid_t uid, gid_t gid);
+                   mode_t mode);
 
 /* from selinux.c */
 int selinux_file_context(const char *dst_name);


### PR DESCRIPTION
Integrated feature was never oficially released, but the latest development status was:
```
org.freedesktop.FleetCommanderClient is run as root
```
and can read profiles doesn't matter files ownership ( https://lists.fedorahosted.org/archives/list/sssd-devel@lists.fedorahosted.org/message/IG3MIET5MILWJZRS3JQWMTVOPGNY6XWI/ )

Actual status is that 'FleetCommanderClient' isn't really maintained.

Storing profiles under user that runs SSSD doesn't break anything but removes the need for CAP_SET_?ID and CAP_CHOWN (in this code).