### PR TITLE
Tests: Add single retry for realm leave

### DIFF
--- a/src/tests/multihost/sssd/testlib/common/utils.py
+++ b/src/tests/multihost/sssd/testlib/common/utils.py
@@ -456,6 +456,11 @@ class sssdTools(object):
         # joining again and the error in log is misleading.
         cmd = self.multihost.run_command(
             f'realm leave {domainname} -v', log_stdout=raiseonerr, raiseonerr=False)
+        if cmd.returncode != 0 and "realm: Couldn't connect to realm service" in cmd.stderr_text:
+            print("WARNING: realm leave timed out, retrying!")
+            self.service_ctrl('restart', 'realmd')
+            cmd = self.multihost.run_command(
+                f'realm leave {domainname} -v', log_stdout=raiseonerr, raiseonerr=False)
         if cmd.returncode != 0 and raiseonerr:
             raise SSSDException("Error: %s", cmd.stderr_text)
         elif cmd.returncode != 0:


### PR DESCRIPTION
Realm leave is flaky in other arch tests (especially ppc64) so test stability can be improved there. This should help with this error that fails the test following the failed realm leave.

DEBUG - RUN realm leave DOMAIN-0EMF.COM -v
DEBUG - realm: Couldn't connect to realm service: Error calling StartServiceByName for org.freedesktop.realmd: Timeout was reached
DEBUG - Exit code: 1