### PR TITLE
contrib/sssd.spec.in: install udev rules to access security tokens by…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5641,6 +5641,7 @@ endif
 	rm -f $(builddir)/src/sysv/systemd/sssd-kcm.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-kcm.service
 	rm -f $(builddir)/src/tools/wrappers/sss_debuglevel
+	rm -Rf $(builddir)/contrib
 
 CLEANFILES += *.X */*.X */*/*.X
 
@@ -5669,6 +5670,7 @@ dist_noinst_DATA += \
     m4 \
     contrib/sssd.spec.in \
     contrib/sssd.sysusers \
+    contrib/90-sssd-token-access.rules \
     BUILD.txt \
     COPYING \
     src/tests/multihost/README.md \

--- a/configure.ac
+++ b/configure.ac
@@ -543,7 +543,7 @@ my_srcdir=`readlink -f $srcdir`
 AC_DEFINE_UNQUOTED([ABS_SRC_DIR], ["$my_srcdir"], [Absolute path to the source directory])
 
 AC_CONFIG_FILES([Makefile contrib/sssd.spec src/examples/rwtab src/doxy.config
-                 contrib/sssd-pcsc.rules
+                 contrib/sssd-pcsc.rules contrib/90-sssd-token-access.rules
                  src/sysv/sssd src/sysv/gentoo/sssd src/sysv/gentoo/sssd-kcm
                  po/Makefile.in src/man/Makefile src/tests/cwrap/Makefile
                  src/tests/intg/Makefile src/tests/test_CA/Makefile

--- a/contrib/90-sssd-token-access.rules.in
+++ b/contrib/90-sssd-token-access.rules.in
@@ -1,0 +1,7 @@
+# this udev file should be used with udev 188 and newer
+ACTION!="add|change", GOTO="sssd_end"
+
+# Allow SSSD to access security tokens
+SUBSYSTEM=="hidraw", ENV{ID_SECURITY_TOKEN}=="1", RUN{program}+="/usr/bin/setfacl -m u:@SSSD_USER@:rw $env{DEVNAME}"
+
+LABEL="sssd_end"

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -171,7 +171,7 @@ BuildRequires: shadow-utils-subid-devel
 %if %{build_kcm_renewals}
 BuildRequires: krb5-libs >= %{krb5_version}
 %endif
-%if %{use_sysusers}
+%if %{use_sysusers} || %{build_passkey}
 BuildRequires: systemd-rpm-macros
 %{?sysusers_requires_compat}
 %endif
@@ -529,6 +529,9 @@ Summary: SSSD helpers and plugins needed for authentication with passkey token
 License: GPLv3+
 Requires: sssd-common = %{version}-%{release}
 Requires: libfido2
+%if "%{sssd_user}" != "root"
+Requires: acl
+%endif
 
 %description passkey
 This package provides helper processes and Kerberos plugins that are required to
@@ -612,6 +615,9 @@ cp $RPM_BUILD_ROOT/%{_datadir}/sssd/krb5-snippets/sssd_enable_idp \
 %if %{build_passkey}
 cp $RPM_BUILD_ROOT/%{_datadir}/sssd/krb5-snippets/sssd_enable_passkey \
    $RPM_BUILD_ROOT/%{_sysconfdir}/krb5.conf.d/sssd_enable_passkey
+%if "%{sssd_user}" != "root"
+install -D -p -m 0644 contrib/90-sssd-token-access.rules %{buildroot}%{_udevrulesdir}/90-sssd-token-access.rules
+%endif
 %endif
 
 # krb5 configuration snippet
@@ -1020,6 +1026,9 @@ install -D -p -m 0644 contrib/sssd.sysusers %{buildroot}%{_sysusersdir}/sssd.con
 %attr(755,%{sssd_user},%{sssd_user}) %{_libexecdir}/%{servicename}/passkey_child
 %{_libdir}/%{name}/modules/sssd_krb5_passkey_plugin.so
 %{_datadir}/sssd/krb5-snippets/sssd_enable_passkey
+%if "%{sssd_user}" != "root"
+%{_udevrulesdir}/90-sssd-token-access.rules
+%endif
 %config(noreplace) %{_sysconfdir}/krb5.conf.d/sssd_enable_passkey
 %endif
 


### PR DESCRIPTION
… sssd-passkey

When SSSD runs unprivileged, passkey_child needs to be able to read and write a hardware FIDO2 token. Add a udev rule that allows SSSD group to do so.

Both GROUP and OWNER variables in udev rules a singular and cannot be used to extend permissions, thus use `setfacl` external utility to add POSIX ACL for the SSSD group access.