### PR TITLE
PROXY: strip SUID bit off 'proxy_child'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5536,8 +5536,6 @@ if SSSD_USER
 	chmod 4750 $(DESTDIR)$(sssdlibexecdir)/ldap_child
 	-chgrp $(SSSD_USER) $(DESTDIR)$(sssdlibexecdir)/krb5_child
 	chmod 4750 $(DESTDIR)$(sssdlibexecdir)/krb5_child
-	-chgrp $(SSSD_USER) $(DESTDIR)$(sssdlibexecdir)/proxy_child
-	chmod 4750 $(DESTDIR)$(sssdlibexecdir)/proxy_child
 if BUILD_SELINUX
 	-chgrp $(SSSD_USER) $(DESTDIR)$(sssdlibexecdir)/selinux_child
 	chmod 4750 $(DESTDIR)$(sssdlibexecdir)/selinux_child

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -877,7 +877,7 @@ install -D -p -m 0644 contrib/sssd.sysusers %{buildroot}%{_sysusersdir}/sssd.con
 
 %files proxy
 %license COPYING
-%attr(%{child_attrs},root,%{sssd_user}) %{_libexecdir}/%{servicename}/proxy_child
+%{_libexecdir}/%{servicename}/proxy_child
 %{_libdir}/%{name}/libsss_proxy.so
 
 %files dbus -f sssd_dbus.lang


### PR DESCRIPTION
'proxy' provider can be used to load arbitrary modules that might
(or might not) require specific capabilities.

Granting all capabilities unconditionally feels unjustified. One of
the widely used options is proxy around 'libnss_files' that doesn't
require any capabilities. Let administrator to set file capability
manually if required in esoteric use cases.