### PR TITLE
pam: fix SC auth with multiple certs and missing login name

### DIFF
--- a/src/responder/pam/pamsrv.h
+++ b/src/responder/pam/pamsrv.h
@@ -93,7 +93,17 @@ struct pam_auth_req {
     struct ldb_message *user_obj;
     struct cert_auth_info *cert_list;
     struct cert_auth_info *current_cert;
+    /* Switched to 'true' if the backend indicates that it cannot handle
+     * Smartcard authentication, but Smartcard authentication is
+     * possible and local Smartcard authentication is allowed. */
     bool cert_auth_local;
+    /* Switched to 'true' if authentication (not pre-authentication) was
+     * started without a login name and the name had to be lookup up with the
+     * certificate used for authentication. Since reading the certificate from
+     * the Smartcard already involves the PIN validation in this case there
+     * would be no need for an additional Smartcard interaction if only local
+     * Smartcard authentication is possible. */
+    bool initial_cert_auth_successful;
 
     bool passkey_data_exists;
     uint32_t client_id_num;

--- a/src/tests/intg/Makefile.am
+++ b/src/tests/intg/Makefile.am
@@ -199,6 +199,7 @@ clean-local:
 
 PAM_CERT_DB_PATH="$(abs_builddir)/../test_CA/SSSD_test_CA.pem"
 SOFTHSM2_CONF="$(abs_builddir)/../test_CA/softhsm2_one.conf"
+SOFTHSM2_TWO_CONF="$(abs_builddir)/../test_CA/softhsm2_two.conf"
 
 intgcheck-installed: config.py passwd group pam_sss_service pam_sss_alt_service pam_sss_sc_required pam_sss_try_sc pam_sss_allow_missing_name pam_sss_domains sss_netgroup_thread_test
 	pipepath="$(DESTDIR)$(pipepath)"; \
@@ -233,6 +234,7 @@ intgcheck-installed: config.py passwd group pam_sss_service pam_sss_alt_service 
 	PAM_CERT_DB_PATH=$(PAM_CERT_DB_PATH) \
 	ABS_SRCDIR=$(abs_srcdir) \
 	SOFTHSM2_CONF=$(SOFTHSM2_CONF) \
+	SOFTHSM2_TWO_CONF=$(SOFTHSM2_TWO_CONF) \
 	KCM_RENEW=$(KCM_RENEW) \
 	FILES_PROVIDER=$(FILES_PROVIDER) \
 	DBUS_SOCK_DIR="$(DESTDIR)$(runstatedir)/dbus/" \


### PR DESCRIPTION
While introducing the local_auth_policy option a quite specific use-case was not covered correctly. If there are multiple matching certificates on the Smartcard, 'local_auth_policy = only' is set and GDM's Smartcard mode was used for login, i.e. there is no user name given and the user has to be derived from the certificate used for login, authentication failed. The main reason for the failure is that in this case the Smartcard interaction and the user mapping has to be done first to determine the user before local_auth_policy is evaluated. As a result when checking if the authentication can be finished the request was in an unexpected state because the indicator for local Smartcard authentication was not enabled.

Resolves: https://github.com/SSSD/sssd/issues/7109