### PR TITLE
Tests: Set ciphers for kerberos

### DIFF
--- a/src/tests/multihost/sssd/testlib/common/libkrb5.py
+++ b/src/tests/multihost/sssd/testlib/common/libkrb5.py
@@ -33,17 +33,22 @@ class krb5srv(object):
         self.krb_acl_file = '%s/kadm5.acl' % (self.krb5_kdc_data_dir)
         self.admin_keytab = '%s/kadm5.keytab' % (self.krb5_kdc_data_dir)
         self.kdc_conf = '%s/kdc.conf' % (self.krb5_kdc_data_dir)
+        self.ciphers = "aes256-cts-hmac-sha384-192:normal "\
+            "aes128-cts-hmac-sha256-128:normal "\
+            "aes256-cts-hmac-sha1-96:normal "\
+            "aes128-cts-hmac-sha1-96:normal"
 
     def _config_krb5kdc(self):
         """ Configure kdc.conf and kadm5.acl
             :param: None
             :return str: Return Kerberos kdc.conf file path
         """
-        realm_def = """ {
-        acl_file = %s
-        admin_keytab = %s
-        } """ % (self.krb_acl_file,
-                 self.admin_keytab)
+
+        realm_def = f""" {{
+        acl_file = {self.krb_acl_file}
+        admin_keytab = {self.admin_keytab}
+        supported_enctypes = {self.ciphers}
+        }}"""
         config = ConfigParser.RawConfigParser()
         config.optionxform = str
         config.add_section('kdcdefaults')

--- a/src/tests/multihost/sssd/testlib/common/utils.py
+++ b/src/tests/multihost/sssd/testlib/common/utils.py
@@ -323,6 +323,7 @@ class sssdTools(object):
             self.multihost.transport.get_file(SSSD_DEFAULT_CONF, tmpconf.name)
         except IOError:
             config.add_section('sssd')
+            config.set('sssd', 'config_file_version', '2')
             config.set('sssd', 'services', 'nss, pam')
         else:
             try:
@@ -881,6 +882,20 @@ class sssdTools(object):
                            "edwards25519")
             krb5config.set("libdefaults", "default_ccache_name",
                            "KEYRING:persistent:%{uid}")
+            krb5config.set(
+                "libdefaults", "default_tgs_enctypes",
+                "aes256-cts-hmac-sha384-192 aes256-cts-hmac-sha1-96 "
+                "aes128-cts-hmac-sha256-128 aes128-cts-hmac-sha1-96 "
+                "aes256-cts des3-cbc-sha1 arcfour-hmac des-cbc-md5 "
+                "des-cbc-crc"
+            )
+            krb5config.set(
+                "libdefaults", "default_tkt_enctypes",
+                "aes256-cts-hmac-sha384-192 aes256-cts-hmac-sha1-96 "
+                "aes128-cts-hmac-sha256-128 aes128-cts-hmac-sha1-96 "
+                "aes256-cts des3-cbc-sha1 arcfour-hmac des-cbc-md5 "
+                "des-cbc-crc"
+            )
             krb5config.add_section("realms")
             krb5config.set("realms", "%s" % realm.upper(), realm_def)
             krb5config.add_section("domain_realm")


### PR DESCRIPTION
Fix kcm/krb5 tests in basic suite on fips by setting the allowed ciphers.
