### PR TITLE
Tests: Add pytest.ini with marker converted to basic suite

### DIFF
--- a/src/tests/multihost/basic/pytest.ini
+++ b/src/tests/multihost/basic/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    converted: Tests that are already converted to the new framework.


### PR DESCRIPTION
Fix "PytestUnknownMarkWarning: Unknown pytest.mark.converted - is this a typo?"