### PR TITLE
Tests: Fix OsError in test_kcm_debug_level_set

### DIFF
--- a/src/tests/multihost/basic/test_kcm.py
+++ b/src/tests/multihost/basic/test_kcm.py
@@ -39,7 +39,7 @@ class TestSanityKCM(object):
         try:
             multihost.master[0].transport.get_file(kcm_log_file,
                                                    local_kcm_log_file)
-        except FileNotFoundError:
+        except (FileNotFoundError, OSError):
             return 0
 
         nlines = sum(1 for line in open(local_kcm_log_file))


### PR DESCRIPTION
Resolve "OSError: File '/var/log/sssd/sssd_kcm.log' could not be read" ba catching and handling this exception as well.