### PR TITLE
Extend sssctl to manage cached GPOs

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -1497,6 +1497,7 @@ errno_t sysdb_remove_mapped_data(struct sss_domain_info *domain,
 #define SYSDB_GPO_GUID_ATTR "gpoGUID"
 #define SYSDB_GPO_VERSION_ATTR "gpoVersion"
 #define SYSDB_GPO_TIMEOUT_ATTR "gpoPolicyFileTimeout"
+#define SYSDB_GPO_PATH_ATTR "gpoPath"
 
 #define SYSDB_TMPL_GPO_BASE SYSDB_GPO_CONTAINER","SYSDB_DOM_BASE
 #define SYSDB_TMPL_GPO SYSDB_GPO_GUID_ATTR"=%s,"SYSDB_TMPL_GPO_BASE
@@ -1511,6 +1512,7 @@ errno_t sysdb_remove_mapped_data(struct sss_domain_info *domain,
 errno_t sysdb_gpo_store_gpo(struct sss_domain_info *domain,
                             const char *gpo_dpname,
                             const char *gpo_guid,
+                            const char *gpo_cache_path,
                             int gpo_version,
                             int cache_timeout,
                             time_t now);

--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -1509,6 +1509,7 @@ errno_t sysdb_remove_mapped_data(struct sss_domain_info *domain,
         NULL }
 
 errno_t sysdb_gpo_store_gpo(struct sss_domain_info *domain,
+                            const char *gpo_dpname,
                             const char *gpo_guid,
                             int gpo_version,
                             int cache_timeout,

--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -1529,6 +1529,11 @@ errno_t sysdb_gpo_get_gpos(TALLOC_CTX *mem_ctx,
 struct ldb_dn *sysdb_gpos_base_dn(TALLOC_CTX *mem_ctx,
                                   struct sss_domain_info *dom);
 
+errno_t
+sysdb_gpo_canon_guid(const char *gpo_guid,
+                     TALLOC_CTX *mem_ctx,
+                     char **canon_gpo_guid);
+
 /* === Functions related to GPO Result object === */
 
 #define SYSDB_GPO_RESULT_OC "gpo_result"

--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -1534,6 +1534,10 @@ sysdb_gpo_canon_guid(const char *gpo_guid,
                      TALLOC_CTX *mem_ctx,
                      char **canon_gpo_guid);
 
+errno_t sysdb_gpo_delete_gpo_by_guid(TALLOC_CTX *mem_ctx,
+                                     struct sss_domain_info *domain,
+                                     const char *gpo_guid);
+
 /* === Functions related to GPO Result object === */
 
 #define SYSDB_GPO_RESULT_OC "gpo_result"

--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -1523,6 +1523,9 @@ errno_t sysdb_gpo_get_gpos(TALLOC_CTX *mem_ctx,
                            struct sss_domain_info *domain,
                            struct ldb_result **_result);
 
+struct ldb_dn *sysdb_gpos_base_dn(TALLOC_CTX *mem_ctx,
+                                  struct sss_domain_info *dom);
+
 /* === Functions related to GPO Result object === */
 
 #define SYSDB_GPO_RESULT_OC "gpo_result"

--- a/src/db/sysdb_gpo.c
+++ b/src/db/sysdb_gpo.c
@@ -50,6 +50,7 @@ errno_t
 sysdb_gpo_store_gpo(struct sss_domain_info *domain,
                     const char *gpo_dpname,
                     const char *gpo_guid,
+                    const char *gpo_cache_path,
                     int gpo_version,
                     int cache_timeout,
                     time_t now)
@@ -138,6 +139,21 @@ sysdb_gpo_store_gpo(struct sss_domain_info *domain,
             goto done;
         }
 
+        /* Add the cache path */
+        lret = ldb_msg_add_empty(update_msg, SYSDB_GPO_PATH_ATTR,
+                                 LDB_FLAG_MOD_ADD,
+                                 NULL);
+        if (lret != LDB_SUCCESS) {
+            ret = sysdb_error_to_errno(lret);
+            goto done;
+        }
+
+        lret = ldb_msg_add_string(update_msg, SYSDB_GPO_PATH_ATTR, gpo_cache_path);
+        if (lret != LDB_SUCCESS) {
+            ret = sysdb_error_to_errno(lret);
+            goto done;
+        }
+
         /* Add the Version */
         lret = ldb_msg_add_empty(update_msg, SYSDB_GPO_VERSION_ATTR,
                                  LDB_FLAG_MOD_ADD,
@@ -199,6 +215,21 @@ sysdb_gpo_store_gpo(struct sss_domain_info *domain,
         /* Update the existing GPO */
 
         DEBUG(SSSDBG_TRACE_ALL, "Updating new GPO [%s][%s]\n", domain->name, gpo_guid);
+
+        /* Add the cache path */
+        lret = ldb_msg_add_empty(update_msg, SYSDB_GPO_PATH_ATTR,
+                                 LDB_FLAG_MOD_REPLACE,
+                                 NULL);
+        if (lret != LDB_SUCCESS) {
+            ret = sysdb_error_to_errno(lret);
+            goto done;
+        }
+
+        lret = ldb_msg_add_string(update_msg, SYSDB_GPO_PATH_ATTR, gpo_cache_path);
+        if (lret != LDB_SUCCESS) {
+            ret = sysdb_error_to_errno(lret);
+            goto done;
+        }
 
         /* Add the Version */
         lret = ldb_msg_add_empty(update_msg, SYSDB_GPO_VERSION_ATTR,

--- a/src/db/sysdb_gpo.c
+++ b/src/db/sysdb_gpo.c
@@ -683,3 +683,10 @@ done:
     return ret;
 
 }
+
+struct ldb_dn *sysdb_gpos_base_dn(TALLOC_CTX *mem_ctx,
+                                  struct sss_domain_info *dom)
+{
+    return ldb_dn_new_fmt(mem_ctx, dom->sysdb->ldb,
+                          SYSDB_TMPL_GPO_BASE, dom->name);
+}

--- a/src/db/sysdb_private.h
+++ b/src/db/sysdb_private.h
@@ -62,6 +62,7 @@
      "ipHostNumber: CASE_INSENSITIVE\n" \
      "ipNetworkNumber: CASE_INSENSITIVE\n" \
      "mail: CASE_INSENSITIVE\n" \
+     "gpoGUID: CASE_INSENSITIVE\n" \
      "\n" \
      "dn: @INDEXLIST\n" \
      "@IDXATTR: cn\n" \
@@ -90,6 +91,7 @@
      "@IDXATTR: ipHostNumber\n" \
      "@IDXATTR: ipNetworkNumber\n" \
      "@IDXATTR: originalADgidNumber\n" \
+     "@IDXATTR: gpoGUID\n" \
      "\n" \
      "dn: @MODULES\n" \
      "@LIST: asq,memberof\n" \

--- a/src/providers/ad/ad_gpo.c
+++ b/src/providers/ad/ad_gpo.c
@@ -4861,8 +4861,9 @@ static void gpo_cse_done(struct tevent_req *subreq)
 
     now = time(NULL);
     DEBUG(SSSDBG_TRACE_FUNC, "sysvol_gpt_version: %d\n", sysvol_gpt_version);
-    ret = sysdb_gpo_store_gpo(state->domain, state->gpo_guid, sysvol_gpt_version,
-                              state->gpo_timeout_option, now);
+    ret = sysdb_gpo_store_gpo(state->domain, state->gpo_dpname, state->gpo_guid,
+                              sysvol_gpt_version, state->gpo_timeout_option,
+                              now);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "Unable to store gpo cache entry: [%d](%s}\n",
               ret, sss_strerror(ret));

--- a/src/providers/ad/ad_gpo.c
+++ b/src/providers/ad/ad_gpo.c
@@ -2468,7 +2468,6 @@ ad_gpo_process_gpo_done(struct tevent_req *subreq)
     struct gp_gpo **candidate_gpos = NULL;
     int num_candidate_gpos = 0;
     int i = 0;
-    const char **cse_filtered_gpo_guids;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct ad_gpo_access_state);
@@ -2602,23 +2601,9 @@ ad_gpo_process_gpo_done(struct tevent_req *subreq)
         goto done;
     }
 
-    /* we create and populate an array of applicable gpo-guids */
-    cse_filtered_gpo_guids =
-        talloc_array(state, const char *, state->num_cse_filtered_gpos);
-    if (cse_filtered_gpo_guids == NULL) {
-        ret = ENOMEM;
-        goto done;
-    }
-
     for (i = 0; i < state->num_cse_filtered_gpos; i++) {
         DEBUG(SSSDBG_TRACE_FUNC, "cse_filtered_gpos[%d]->gpo_guid is %s\n", i,
                                   state->cse_filtered_gpos[i]->gpo_guid);
-        cse_filtered_gpo_guids[i] = talloc_steal(cse_filtered_gpo_guids,
-                                                 state->cse_filtered_gpos[i]->gpo_guid);
-        if (cse_filtered_gpo_guids[i] == NULL) {
-            ret = ENOMEM;
-            goto done;
-        }
     }
 
     DEBUG(SSSDBG_TRACE_FUNC, "num_cse_filtered_gpos: %d\n",

--- a/src/providers/ad/ad_gpo.h
+++ b/src/providers/ad/ad_gpo.h
@@ -27,7 +27,8 @@
 
 #define AD_GPO_CHILD_OUT_FILENO 3
 
-#define AD_GPO_ATTRS {AD_AT_NT_SEC_DESC, \
+#define AD_GPO_ATTRS {AD_AT_DISPLAY_NAME, \
+                      AD_AT_NT_SEC_DESC, \
                       AD_AT_CN, AD_AT_FILE_SYS_PATH, \
                       AD_AT_MACHINE_EXT_NAMES, \
                       AD_AT_FUNC_VERSION, \

--- a/src/tests/sysdb-tests.c
+++ b/src/tests/sysdb-tests.c
@@ -7162,6 +7162,7 @@ START_TEST(test_gpo_store_retrieve)
     const char *guid;
     int version;
     static const char *test_guid = "3610EDA5-77EF-11D2-8DC5-00C04FA31A66";
+    static const char *test_dpname = "TEST GPO";
 
     ret = setup_sysdb_tests(&test_ctx);
     sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
@@ -7174,7 +7175,7 @@ START_TEST(test_gpo_store_retrieve)
     ret = sysdb_gpo_get_gpos(test_ctx, test_ctx->domain, &result);
     sss_ck_fail_if_msg(ret != ENOENT, "GPO present in cache before store op");
 
-    ret = sysdb_gpo_store_gpo(test_ctx->domain,
+    ret = sysdb_gpo_store_gpo(test_ctx->domain, test_dpname,
                               test_guid, 1, 5, 0);
     sss_ck_fail_if_msg(ret != EOK, "Could not store a test GPO");
 
@@ -7209,6 +7210,7 @@ START_TEST(test_gpo_replace)
     const char *guid;
     int version;
     static const char *test_guid = "3610EDA5-77EF-11D2-8DC5-00C04FA31A66";
+    static const char *test_dpname = "TEST GPO";
 
     ret = setup_sysdb_tests(&test_ctx);
     sss_ck_fail_if_msg(ret != EOK, "Could not setup the test");
@@ -7228,7 +7230,7 @@ START_TEST(test_gpo_replace)
     ck_assert_int_eq(version, 1);
 
     /* Modify the version */
-    ret = sysdb_gpo_store_gpo(test_ctx->domain,
+    ret = sysdb_gpo_store_gpo(test_ctx->domain, test_dpname,
                               test_guid, 2, 5, 0);
     sss_ck_fail_if_msg(ret != EOK, "Could not store a test GPO");
 

--- a/src/tests/sysdb-tests.c
+++ b/src/tests/sysdb-tests.c
@@ -7164,6 +7164,7 @@ START_TEST(test_gpo_store_retrieve)
     static const char *test_guid = "3610EDA5-77EF-11D2-8DC5-00C04FA31A66";
     static const char *test_dpname = "TEST GPO";
     static const char *test_path = "/tmp/test/gpo";
+    char *canon_guid = NULL;
 
     ret = setup_sysdb_tests(&test_ctx);
     sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
@@ -7194,7 +7195,11 @@ START_TEST(test_gpo_store_retrieve)
 
     guid = ldb_msg_find_attr_as_string(result->msgs[0],
                                        SYSDB_GPO_GUID_ATTR, NULL);
-    ck_assert_str_eq(guid, test_guid);
+    ck_assert_str_ne(guid, test_guid);
+
+    ret = sysdb_gpo_canon_guid(test_guid, test_ctx, &canon_guid);
+    sss_ck_fail_if_msg(ret != EOK, "Failed to canonicalize guid");
+    ck_assert_str_eq(guid, canon_guid);
 
     version = ldb_msg_find_attr_as_uint(result->msgs[0],
                                         SYSDB_GPO_VERSION_ATTR, 0);
@@ -7213,9 +7218,13 @@ START_TEST(test_gpo_replace)
     static const char *test_guid = "3610EDA5-77EF-11D2-8DC5-00C04FA31A66";
     static const char *test_dpname = "TEST GPO";
     static const char *test_path = "/tmp/test/gpo";
+    char *canon_guid = NULL;
 
     ret = setup_sysdb_tests(&test_ctx);
     sss_ck_fail_if_msg(ret != EOK, "Could not setup the test");
+
+    ret = sysdb_gpo_canon_guid(test_guid, test_ctx, &canon_guid);
+    sss_ck_fail_if_msg(ret != EOK, "Failed to canonicalize guid");
 
     ret = sysdb_gpo_get_gpo_by_guid(test_ctx, test_ctx->domain,
                                     test_guid, &result);
@@ -7225,7 +7234,8 @@ START_TEST(test_gpo_replace)
 
     guid = ldb_msg_find_attr_as_string(result->msgs[0],
                                        SYSDB_GPO_GUID_ATTR, NULL);
-    ck_assert_str_eq(guid, test_guid);
+    ck_assert_str_ne(guid, test_guid);
+    ck_assert_str_eq(guid, canon_guid);
 
     version = ldb_msg_find_attr_as_uint(result->msgs[0],
                                         SYSDB_GPO_VERSION_ATTR, 0);
@@ -7244,7 +7254,8 @@ START_TEST(test_gpo_replace)
 
     guid = ldb_msg_find_attr_as_string(result->msgs[0],
                                        SYSDB_GPO_GUID_ATTR, NULL);
-    ck_assert_str_eq(guid, test_guid);
+    ck_assert_str_ne(guid, test_guid);
+    ck_assert_str_eq(guid, canon_guid);
 
     version = ldb_msg_find_attr_as_uint(result->msgs[0],
                                         SYSDB_GPO_VERSION_ATTR, 0);

--- a/src/tests/sysdb-tests.c
+++ b/src/tests/sysdb-tests.c
@@ -7163,6 +7163,7 @@ START_TEST(test_gpo_store_retrieve)
     int version;
     static const char *test_guid = "3610EDA5-77EF-11D2-8DC5-00C04FA31A66";
     static const char *test_dpname = "TEST GPO";
+    static const char *test_path = "/tmp/test/gpo";
 
     ret = setup_sysdb_tests(&test_ctx);
     sss_ck_fail_if_msg(ret != EOK, "Could not set up the test");
@@ -7176,7 +7177,7 @@ START_TEST(test_gpo_store_retrieve)
     sss_ck_fail_if_msg(ret != ENOENT, "GPO present in cache before store op");
 
     ret = sysdb_gpo_store_gpo(test_ctx->domain, test_dpname,
-                              test_guid, 1, 5, 0);
+                              test_guid, test_path, 1, 5, 0);
     sss_ck_fail_if_msg(ret != EOK, "Could not store a test GPO");
 
     ret = sysdb_gpo_get_gpos(test_ctx, test_ctx->domain, &result);
@@ -7211,6 +7212,7 @@ START_TEST(test_gpo_replace)
     int version;
     static const char *test_guid = "3610EDA5-77EF-11D2-8DC5-00C04FA31A66";
     static const char *test_dpname = "TEST GPO";
+    static const char *test_path = "/tmp/test/gpo";
 
     ret = setup_sysdb_tests(&test_ctx);
     sss_ck_fail_if_msg(ret != EOK, "Could not setup the test");
@@ -7231,7 +7233,7 @@ START_TEST(test_gpo_replace)
 
     /* Modify the version */
     ret = sysdb_gpo_store_gpo(test_ctx->domain, test_dpname,
-                              test_guid, 2, 5, 0);
+                              test_guid, test_path, 2, 5, 0);
     sss_ck_fail_if_msg(ret != EOK, "Could not store a test GPO");
 
     ret = sysdb_gpo_get_gpo_by_guid(test_ctx, test_ctx->domain,

--- a/src/tools/common/sss_tools.c
+++ b/src/tools/common/sss_tools.c
@@ -383,6 +383,7 @@ static struct poptOption *nonnull_popt_table(struct poptOption *options)
 
 errno_t sss_tool_popt_ex(struct sss_cmdline *cmdline,
                          struct poptOption *options,
+                         const char *extended_help,
                          enum sss_tool_opt require_option,
                          sss_popt_fn popt_fn,
                          void *popt_fn_pvt,
@@ -423,6 +424,14 @@ errno_t sss_tool_popt_ex(struct sss_cmdline *cmdline,
     if (help == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "talloc_asprintf() failed\n");
         return ENOMEM;
+    }
+
+    if (extended_help != NULL) {
+        help = talloc_asprintf_append(help, "\n\n%s", extended_help);
+        if (help == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "talloc_asprintf_append() failed\n");
+            return ENOMEM;
+        }
     }
 
     /* Create popt context. This function is supposed to be called on
@@ -525,7 +534,7 @@ errno_t sss_tool_popt(struct sss_cmdline *cmdline,
                       sss_popt_fn popt_fn,
                       void *popt_fn_pvt)
 {
-    return sss_tool_popt_ex(cmdline, options, require_option,
+    return sss_tool_popt_ex(cmdline, options, NULL, require_option,
                             popt_fn, popt_fn_pvt, NULL, NULL,
                             SSS_TOOL_OPT_REQUIRED, NULL, NULL);
 }

--- a/src/tools/common/sss_tools.h
+++ b/src/tools/common/sss_tools.h
@@ -74,6 +74,7 @@ enum sss_tool_opt {
 
 errno_t sss_tool_popt_ex(struct sss_cmdline *cmdline,
                          struct poptOption *options,
+                         const char *extended_help,
                          enum sss_tool_opt require_option,
                          sss_popt_fn popt_fn,
                          void *popt_fn_pvt,

--- a/src/tools/sss_override.c
+++ b/src/tools/sss_override.c
@@ -70,7 +70,7 @@ static errno_t parse_cmdline(struct sss_cmdline *cmdline,
     *_input_name = NULL;
     require = options == NULL ? SSS_TOOL_OPT_OPTIONAL : SSS_TOOL_OPT_REQUIRED;
 
-    ret = sss_tool_popt_ex(cmdline, options, require,
+    ret = sss_tool_popt_ex(cmdline, options, NULL, require,
                            NULL, NULL, "NAME", _("Specify name."),
                            SSS_TOOL_OPT_REQUIRED, &input_name, NULL);
     if (ret != EXIT_SUCCESS) {
@@ -171,7 +171,7 @@ static errno_t parse_cmdline_find(struct sss_cmdline *cmdline,
         POPT_TABLEEND
     };
 
-    ret = sss_tool_popt_ex(cmdline, options, SSS_TOOL_OPT_OPTIONAL,
+    ret = sss_tool_popt_ex(cmdline, options, NULL, SSS_TOOL_OPT_OPTIONAL,
                            NULL, NULL, NULL, NULL, SSS_TOOL_OPT_REQUIRED,
                            NULL, NULL);
     if (ret != EOK) {
@@ -201,7 +201,7 @@ static errno_t parse_cmdline_import(struct sss_cmdline *cmdline,
 {
     errno_t ret;
 
-    ret = sss_tool_popt_ex(cmdline, NULL, SSS_TOOL_OPT_OPTIONAL,
+    ret = sss_tool_popt_ex(cmdline, NULL, NULL, SSS_TOOL_OPT_OPTIONAL,
                            NULL, NULL, "FILE", "File to import the data from.",
                            SSS_TOOL_OPT_REQUIRED, _file, NULL);
     if (ret != EOK) {
@@ -217,7 +217,7 @@ static errno_t parse_cmdline_export(struct sss_cmdline *cmdline,
 {
     errno_t ret;
 
-    ret = sss_tool_popt_ex(cmdline, NULL, SSS_TOOL_OPT_OPTIONAL,
+    ret = sss_tool_popt_ex(cmdline, NULL, NULL, SSS_TOOL_OPT_OPTIONAL,
                            NULL, NULL, "FILE", "File to export the data to.",
                            SSS_TOOL_OPT_REQUIRED, _file, NULL);
     if (ret != EOK) {

--- a/src/tools/sssctl/sssctl.c
+++ b/src/tools/sssctl/sssctl.c
@@ -344,6 +344,7 @@ int main(int argc, const char **argv)
         SSS_TOOL_COMMAND("gpo-show", "Information about cached GPO", 0, sssctl_gpo_show),
         SSS_TOOL_COMMAND("gpo-list", "Enumerate cached GPOs", 0, sssctl_gpo_list),
         SSS_TOOL_COMMAND("gpo-remove", "Remove cached GPO", 0, sssctl_gpo_remove),
+        SSS_TOOL_COMMAND("gpo-purge", "Remove all cached GPOs", 0, sssctl_gpo_purge),
 #ifdef BUILD_PASSKEY
         SSS_TOOL_DELIMITER("Passkey related tools:"),
         SSS_TOOL_COMMAND_FLAGS("passkey-register", "Perform passkey registration", 0, sssctl_passkey_register, SSS_TOOL_FLAG_SKIP_CMD_INIT|SSS_TOOL_FLAG_SKIP_ROOT_CHECK),

--- a/src/tools/sssctl/sssctl.c
+++ b/src/tools/sssctl/sssctl.c
@@ -343,6 +343,7 @@ int main(int argc, const char **argv)
         SSS_TOOL_DELIMITER("GPOs related tools:"),
         SSS_TOOL_COMMAND("gpo-show", "Information about cached GPO", 0, sssctl_gpo_show),
         SSS_TOOL_COMMAND("gpo-list", "Enumerate cached GPOs", 0, sssctl_gpo_list),
+        SSS_TOOL_COMMAND("gpo-remove", "Remove cached GPO", 0, sssctl_gpo_remove),
 #ifdef BUILD_PASSKEY
         SSS_TOOL_DELIMITER("Passkey related tools:"),
         SSS_TOOL_COMMAND_FLAGS("passkey-register", "Perform passkey registration", 0, sssctl_passkey_register, SSS_TOOL_FLAG_SKIP_CMD_INIT|SSS_TOOL_FLAG_SKIP_ROOT_CHECK),

--- a/src/tools/sssctl/sssctl.c
+++ b/src/tools/sssctl/sssctl.c
@@ -340,6 +340,8 @@ int main(int argc, const char **argv)
         SSS_TOOL_COMMAND_FLAGS("cert-show", "Print information about the certificate", 0, sssctl_cert_show, SSS_TOOL_FLAG_SKIP_CMD_INIT|SSS_TOOL_FLAG_SKIP_ROOT_CHECK),
         SSS_TOOL_COMMAND("cert-map", "Show users mapped to the certificate", 0, sssctl_cert_map),
         SSS_TOOL_COMMAND_FLAGS("cert-eval-rule", "Check mapping and matching rule with a certificate", 0, sssctl_cert_eval_rule, SSS_TOOL_FLAG_SKIP_CMD_INIT|SSS_TOOL_FLAG_SKIP_ROOT_CHECK),
+        SSS_TOOL_DELIMITER("GPOs related tools:"),
+        SSS_TOOL_COMMAND("gpo-show", "Information about cached GPO", 0, sssctl_gpo_show),
 #ifdef BUILD_PASSKEY
         SSS_TOOL_DELIMITER("Passkey related tools:"),
         SSS_TOOL_COMMAND_FLAGS("passkey-register", "Perform passkey registration", 0, sssctl_passkey_register, SSS_TOOL_FLAG_SKIP_CMD_INIT|SSS_TOOL_FLAG_SKIP_ROOT_CHECK),

--- a/src/tools/sssctl/sssctl.c
+++ b/src/tools/sssctl/sssctl.c
@@ -342,6 +342,7 @@ int main(int argc, const char **argv)
         SSS_TOOL_COMMAND_FLAGS("cert-eval-rule", "Check mapping and matching rule with a certificate", 0, sssctl_cert_eval_rule, SSS_TOOL_FLAG_SKIP_CMD_INIT|SSS_TOOL_FLAG_SKIP_ROOT_CHECK),
         SSS_TOOL_DELIMITER("GPOs related tools:"),
         SSS_TOOL_COMMAND("gpo-show", "Information about cached GPO", 0, sssctl_gpo_show),
+        SSS_TOOL_COMMAND("gpo-list", "Enumerate cached GPOs", 0, sssctl_gpo_list),
 #ifdef BUILD_PASSKEY
         SSS_TOOL_DELIMITER("Passkey related tools:"),
         SSS_TOOL_COMMAND_FLAGS("passkey-register", "Perform passkey registration", 0, sssctl_passkey_register, SSS_TOOL_FLAG_SKIP_CMD_INIT|SSS_TOOL_FLAG_SKIP_ROOT_CHECK),

--- a/src/tools/sssctl/sssctl.h
+++ b/src/tools/sssctl/sssctl.h
@@ -158,4 +158,8 @@ errno_t sssctl_gpo_remove(struct sss_cmdline *cmdline,
                           struct sss_tool_ctx *tool_ctx,
                           void *pvt);
 
+errno_t sssctl_gpo_purge(struct sss_cmdline *cmdline,
+                         struct sss_tool_ctx *tool_ctx,
+                         void *pvt);
+
 #endif /* _SSSCTL_H_ */

--- a/src/tools/sssctl/sssctl.h
+++ b/src/tools/sssctl/sssctl.h
@@ -154,4 +154,8 @@ errno_t sssctl_gpo_list(struct sss_cmdline *cmdline,
                         struct sss_tool_ctx *tool_ctx,
                         void *pvt);
 
+errno_t sssctl_gpo_remove(struct sss_cmdline *cmdline,
+                          struct sss_tool_ctx *tool_ctx,
+                          void *pvt);
+
 #endif /* _SSSCTL_H_ */

--- a/src/tools/sssctl/sssctl.h
+++ b/src/tools/sssctl/sssctl.h
@@ -145,4 +145,9 @@ errno_t sssctl_passkey_register(struct sss_cmdline *cmdline,
 errno_t sssctl_cert_eval_rule(struct sss_cmdline *cmdline,
                               struct sss_tool_ctx *tool_ctx,
                               void *pvt);
+
+errno_t sssctl_gpo_show(struct sss_cmdline *cmdline,
+                        struct sss_tool_ctx *tool_ctx,
+                        void *pvt);
+
 #endif /* _SSSCTL_H_ */

--- a/src/tools/sssctl/sssctl.h
+++ b/src/tools/sssctl/sssctl.h
@@ -150,4 +150,8 @@ errno_t sssctl_gpo_show(struct sss_cmdline *cmdline,
                         struct sss_tool_ctx *tool_ctx,
                         void *pvt);
 
+errno_t sssctl_gpo_list(struct sss_cmdline *cmdline,
+                        struct sss_tool_ctx *tool_ctx,
+                        void *pvt);
+
 #endif /* _SSSCTL_H_ */

--- a/src/tools/sssctl/sssctl_access_report.c
+++ b/src/tools/sssctl/sssctl_access_report.c
@@ -391,7 +391,7 @@ errno_t sssctl_access_report(struct sss_cmdline *cmdline,
     sssctl_dom_access_reporter_fn reporter;
     struct sss_domain_info *dom;
 
-    ret = sss_tool_popt_ex(cmdline, NULL, SSS_TOOL_OPT_OPTIONAL,
+    ret = sss_tool_popt_ex(cmdline, NULL, NULL, SSS_TOOL_OPT_OPTIONAL,
                            NULL, NULL, "DOMAIN", _("Specify domain name."),
                            SSS_TOOL_OPT_REQUIRED, &domname, NULL);
     if (ret != EOK) {

--- a/src/tools/sssctl/sssctl_cache.c
+++ b/src/tools/sssctl/sssctl_cache.c
@@ -554,6 +554,7 @@ done:
 static errno_t parse_cmdline(struct sss_cmdline *cmdline,
                              struct sss_tool_ctx *tool_ctx,
                              struct poptOption *options,
+                             const char *extended_help,
                              const char **_orig_name,
                              struct sss_domain_info **_domain)
 {
@@ -562,7 +563,8 @@ static errno_t parse_cmdline(struct sss_cmdline *cmdline,
     struct sss_domain_info *domain;
     int ret;
 
-    ret = sss_tool_popt_ex(cmdline, options, SSS_TOOL_OPT_OPTIONAL,
+    ret = sss_tool_popt_ex(cmdline, options, extended_help,
+                           SSS_TOOL_OPT_OPTIONAL,
                            NULL, NULL, "NAME", _("Specify name."),
                            SSS_TOOL_OPT_REQUIRED, &input_name, NULL);
     if (ret != EOK) {
@@ -617,7 +619,8 @@ errno_t sssctl_user_show(struct sss_cmdline *cmdline,
         SSSCTL_CACHE_NULL
     };
 
-    ret = parse_cmdline(cmdline, tool_ctx, options, &opts.value, &opts.domain);
+    ret = parse_cmdline(cmdline, tool_ctx, options, NULL, &opts.value,
+                        &opts.domain);
     if (ret != EOK) {
         return ret;
     }
@@ -663,7 +666,8 @@ errno_t sssctl_group_show(struct sss_cmdline *cmdline,
         SSSCTL_CACHE_NULL
     };
 
-    ret = parse_cmdline(cmdline, tool_ctx, options, &opts.value, &opts.domain);
+    ret = parse_cmdline(cmdline, tool_ctx, options, NULL, &opts.value,
+                        &opts.domain);
     if (ret != EOK) {
         return ret;
     }
@@ -701,7 +705,8 @@ errno_t sssctl_netgroup_show(struct sss_cmdline *cmdline,
         SSSCTL_CACHE_NULL
     };
 
-    ret = parse_cmdline(cmdline, tool_ctx, NULL, &opts.value, &opts.domain);
+    ret = parse_cmdline(cmdline, tool_ctx, NULL, NULL, &opts.value,
+                        &opts.domain);
     if (ret != EOK) {
         return ret;
     }

--- a/src/tools/sssctl/sssctl_cert.c
+++ b/src/tools/sssctl/sssctl_cert.c
@@ -52,7 +52,7 @@ errno_t sssctl_cert_show(struct sss_cmdline *cmdline,
         POPT_TABLEEND
     };
 
-    ret = sss_tool_popt_ex(cmdline, options, SSS_TOOL_OPT_OPTIONAL,
+    ret = sss_tool_popt_ex(cmdline, options, NULL, SSS_TOOL_OPT_OPTIONAL,
                            NULL, NULL, "CERTIFICATE-BASE64-ENCODED",
                            _("Specify base64 encoded certificate."),
                            SSS_TOOL_OPT_REQUIRED, &cert_b64, NULL);
@@ -111,7 +111,7 @@ errno_t sssctl_cert_map(struct sss_cmdline *cmdline,
         POPT_TABLEEND
     };
 
-    ret = sss_tool_popt_ex(cmdline, options, SSS_TOOL_OPT_OPTIONAL,
+    ret = sss_tool_popt_ex(cmdline, options, NULL, SSS_TOOL_OPT_OPTIONAL,
                            NULL, NULL, "CERTIFICATE-BASE64-ENCODED",
                            _("Specify base64 encoded certificate."),
                            SSS_TOOL_OPT_REQUIRED, &cert_b64, NULL);
@@ -218,7 +218,7 @@ errno_t sssctl_cert_eval_rule(struct sss_cmdline *cmdline,
         POPT_TABLEEND
     };
 
-    ret = sss_tool_popt_ex(cmdline, options, SSS_TOOL_OPT_OPTIONAL,
+    ret = sss_tool_popt_ex(cmdline, options, NULL, SSS_TOOL_OPT_OPTIONAL,
                            NULL, NULL, "CERTIFICATE-BASE64-ENCODED",
                            _("Specify base64 encoded certificate."),
                            SSS_TOOL_OPT_REQUIRED, &cert_b64, NULL);

--- a/src/tools/sssctl/sssctl_data.c
+++ b/src/tools/sssctl/sssctl_data.c
@@ -436,7 +436,7 @@ errno_t sssctl_cache_index(struct sss_cmdline *cmdline,
         POPT_TABLEEND
     };
 
-    ret = sss_tool_popt_ex(cmdline, options, SSS_TOOL_OPT_OPTIONAL, NULL, NULL,
+    ret = sss_tool_popt_ex(cmdline, options, NULL, SSS_TOOL_OPT_OPTIONAL, NULL, NULL,
                            "ACTION", "create | delete | list",
                            SSS_TOOL_OPT_REQUIRED, &action_str, NULL);
     if (ret != EOK) {

--- a/src/tools/sssctl/sssctl_domains.c
+++ b/src/tools/sssctl/sssctl_domains.c
@@ -329,7 +329,7 @@ errno_t sssctl_domain_status(struct sss_cmdline *cmdline,
         POPT_TABLEEND
     };
 
-    ret = sss_tool_popt_ex(cmdline, options, SSS_TOOL_OPT_OPTIONAL,
+    ret = sss_tool_popt_ex(cmdline, options, NULL, SSS_TOOL_OPT_OPTIONAL,
                            NULL, NULL, "DOMAIN", _("Specify domain name."),
                            SSS_TOOL_OPT_REQUIRED, &opts.domain, &opt_set);
     if (ret != EOK) {

--- a/src/tools/sssctl/sssctl_logs.c
+++ b/src/tools/sssctl/sssctl_logs.c
@@ -480,7 +480,7 @@ errno_t sssctl_logs_fetch(struct sss_cmdline *cmdline,
     glob_t globbuf;
 
     /* Parse command line. */
-    ret = sss_tool_popt_ex(cmdline, NULL, SSS_TOOL_OPT_OPTIONAL, NULL, NULL,
+    ret = sss_tool_popt_ex(cmdline, NULL, NULL, SSS_TOOL_OPT_OPTIONAL, NULL, NULL,
                            "FILE", "Output file", SSS_TOOL_OPT_REQUIRED,
                            &file, NULL);
     if (ret != EOK) {
@@ -547,7 +547,7 @@ errno_t sssctl_debug_level(struct sss_cmdline *cmdline,
         goto fini;
     }
 
-    ret = sss_tool_popt_ex(cmdline, long_options, SSS_TOOL_OPT_OPTIONAL, NULL,
+    ret = sss_tool_popt_ex(cmdline, long_options, NULL, SSS_TOOL_OPT_OPTIONAL, NULL,
                            NULL, "DEBUG_LEVEL_TO_SET",
                            _("Specify debug level you want to set"),
                            SSS_TOOL_OPT_OPTIONAL, &debug_as_string, NULL);

--- a/src/tools/sssctl/sssctl_user_checks.c
+++ b/src/tools/sssctl/sssctl_user_checks.c
@@ -236,7 +236,7 @@ errno_t sssctl_user_checks(struct sss_cmdline *cmdline,
         POPT_TABLEEND
     };
 
-    ret = sss_tool_popt_ex(cmdline, options, SSS_TOOL_OPT_OPTIONAL,
+    ret = sss_tool_popt_ex(cmdline, options, NULL, SSS_TOOL_OPT_OPTIONAL,
                            NULL, NULL, "USERNAME", _("Specify user name."),
                            SSS_TOOL_OPT_REQUIRED, &user, NULL);
     if (ret != EOK) {


### PR DESCRIPTION
Extends the `sssctl` tool to show, list, remove and purge cached GPOs.

Fixes #4523 
