### PR TITLE
tests: Drop -extensions from openssl command if there is no -x509

### DIFF
--- a/src/tests/test_CA/intermediate_CA/Makefile.am
+++ b/src/tests/test_CA/intermediate_CA/Makefile.am
@@ -33,7 +33,7 @@ SSSD_test_CA.pem:
 	ln -s $(builddir)/../$@
 
 SSSD_test_intermediate_CA_req.pem: $(openssl_intermediate_ca_key) $(openssl_intermediate_ca_config) SSSD_test_CA.pem
-	$(OPENSSL) req -batch -config ${openssl_intermediate_ca_config} -new -nodes -key $< -sha256 -extensions v3_ca -out $@
+	$(OPENSSL) req -batch -config ${openssl_intermediate_ca_config} -new -nodes -key $< -sha256 -out $@
 
 SSSD_test_intermediate_CA.pem: SSSD_test_intermediate_CA_req.pem $(openssl_root_ca_config) $(openssl_root_ca_key)
 	cd .. && $(OPENSSL) ca -config ${openssl_root_ca_config} -batch -notext -keyfile $(openssl_root_ca_key) -in $(abs_builddir)/$< -days 200 -extensions v3_intermediate_ca -out $(abs_builddir)/$@


### PR DESCRIPTION
The 'openssl req' ignores the '-extensions' option without '-x509'. OpenSSL versions prior 3.2 simply ignored it. Starting with version 3.2 an error is generated:

| /usr/bin/openssl req -batch -config
| ../../../../../src/tests/test_CA/intermediate_CA/SSSD_test_intermediate_CA.config | -new -nodes -key
| …/build/../src/tests/test_CA/intermediate_CA/SSSD_test_intermediate_CA_key.pem -sha256 -extensions v3_ca -out SSSD_test_intermediate_CA_req.pem | Error adding request extensions from section v3_ca | 003163BAB27F0000:error:11000079:X509 V3 routines:v2i_AUTHORITY_KEYID:no issuer certificate:../crypto/x509/v3_akid.c:156: | 003163BAB27F0000:error:11000080:X509 V3 routines:X509V3_EXT_nconf_int:error in extension:../crypto/x509/v3_conf.c:48:section=v3_ca, name=authorityKeyIdentifier, value=keyid:always,issuer:always |

Remove the '-extensions' option.