### PR TITLE
Tests: remove id_provider = files for test_service.py

### DIFF
--- a/src/tests/multihost/alltests/test_services.py
+++ b/src/tests/multihost/alltests/test_services.py
@@ -52,7 +52,9 @@ class TestServices(object):
                        'domains': 'LOCAL'}
         tools.sssd_conf('sssd', sssd_params)
         domain_section = 'domain/LOCAL'
-        domain_params = {'id_provider': 'files'}
+        domain_params = {'id_provider': 'proxy',
+                        'proxy_lib_name': 'files',
+                        'proxy_pam_target': 'sssd-shadowutils'}
         tools.sssd_conf(domain_section, domain_params)
         multihost.client[0].service_sssd('restart')
         failures = []


### PR DESCRIPTION
    Tests: tier1/test_service: Remove files provider
    
    Tier1: for test_0002_1736796:
    
    Replacing the files provider to proxy provider,
    as here we are adding the local user and giving
    sudo permission to user to switch to root without password.
    Here, we are checking the authentication and also
    checking the sudo access for local user.