### PR TITLE
Tests: refactor sssd.conf backup and restore

### DIFF
--- a/src/tests/multihost/adsites/conftest.py
+++ b/src/tests/multihost/adsites/conftest.py
@@ -265,7 +265,7 @@ def joinad(session_multihost, request):
     try:
         session_multihost.client[0].service_sssd('restart')
     except SSSDException:
-        cmd = 'cat /etc/sssd/sssd.conf'
+        cmd = f'cat {SSSD_DEFAULT_CONF}'
         session_multihost.client[0].run_command(cmd)
         journal = 'journalctl -x -n 150 --no-pager'
         session_multihost.client[0].run_command(journal)
@@ -315,6 +315,6 @@ def setup_session(request, session_multihost, create_testdir):
     def teardown_session():
         """ Teardown session """
         session_multihost.client[0].service_sssd('stop')
-        remove_sssd_conf = 'rm -f /etc/sssd/sssd.conf'
+        remove_sssd_conf = f'rm -f {SSSD_DEFAULT_CONF}'
         session_multihost.client[0].run_command(remove_sssd_conf)
     request.addfinalizer(teardown_session)

--- a/src/tests/multihost/alltests/conftest.py
+++ b/src/tests/multihost/alltests/conftest.py
@@ -17,7 +17,6 @@ from sssd.testlib.common.utils import PkiTools, sssdTools, LdapOperations
 from sssd.testlib.common.libdirsrv import DirSrvWrap
 from sssd.testlib.common.exceptions import PkiLibException, LdapException
 
-
 pytest_plugins = (
     'sssd.testlib.common.fixtures',
     'pytest_importance',
@@ -42,9 +41,8 @@ def pytest_configure():
 def multidomain_sssd(session_multihost, request):
     """ Multidomain sssd configuration """
     session_multihost.client[0].service_sssd('stop')
-    bkup = 'cp %s %s.orig' % (SSSD_DEFAULT_CONF, SSSD_DEFAULT_CONF)
-    session_multihost.client[0].run_command(bkup)
     tools = sssdTools(session_multihost.client[0])
+    tools.backup_sssd_conf()
     tools.remove_sss_cache('/var/lib/sss/db')
     tools.remove_sss_cache('/var/lib/sss/mc')
 
@@ -113,8 +111,7 @@ def multidomain_sssd(session_multihost, request):
         """ Remove sssd configuration """
         stop_sssd = 'systemctl stop sssd'
         session_multihost.client[0].run_command(stop_sssd)
-        cmd = 'cp -f %s.orig %s' % (SSSD_DEFAULT_CONF, SSSD_DEFAULT_CONF)
-        session_multihost.client[0].run_command(cmd)
+        tools.restore_sssd_conf()
     request.addfinalizer(removesssd)
     return _modifysssd
 
@@ -244,15 +241,13 @@ def enable_sss_sudo_nsswitch(session_multihost, request):
 @pytest.fixture(scope='function')
 def backupsssdconf(session_multihost, request):
     """ Backup and restore sssd.conf """
-    bkup = 'cp -f %s %s.orig' % (SSSD_DEFAULT_CONF,
-                                 SSSD_DEFAULT_CONF)
-    session_multihost.client[0].run_command(bkup)
+    tools = sssdTools(session_multihost.client[0])
+    tools.backup_sssd_conf()
     session_multihost.client[0].service_sssd('stop')
 
     def restoresssdconf():
         """ Restore sssd.conf """
-        restore = 'cp -f %s.orig %s' % (SSSD_DEFAULT_CONF, SSSD_DEFAULT_CONF)
-        session_multihost.client[0].run_command(restore)
+        tools.restore_sssd_conf()
     request.addfinalizer(restoresssdconf)
 
 
@@ -836,13 +831,16 @@ base %s
 def template_sssdconf(session_multihost, request):
     """ Copy template sssd conf for multidomain tests """
     cwd = os.path.dirname(os.path.abspath(__file__))
-    remote = '/etc/sssd/sssd.conf'
+    remote = SSSD_DEFAULT_CONF
     source = posixpath.join(cwd, 'sssd_multidomain.conf')
     session_multihost.client[0].transport.put_file(source, remote)
+    tools = sssdTools(session_multihost.client[0])
+    tools.fix_sssd_conf_perms()
+
 
     def remove_template():
         """ Remove template sssd.conf """
-        cmd = 'rm -f /etc/sssd/sssd.conf'
+        cmd = f'rm -f {SSSD_DEFAULT_CONF}'
         session_multihost.client[0].run_command(cmd)
     request.addfinalizer(remove_template)
 
@@ -1276,7 +1274,9 @@ def default_sssd(session_multihost, request):
 services = nss, pam '''
     session_multihost.client[0].put_file_contents('%s' % (SSSD_DEFAULT_CONF),
                                                   contents)
-
+    tools = sssdTools(session_multihost.client[0])
+    tools.fix_sssd_conf_perms()
+    
     def remove_default_sssd():
         """ Remove default sssd.conf """
         session_multihost.client[0].service_sssd('stop')
@@ -1328,8 +1328,7 @@ def krb_connection_timeout(
     session_multihost.client[0].run_command(restore_selinux)
     sssd_tools = sssdTools(session_multihost.client[0])
     sssd_tools.remove_sss_cache('/var/lib/sss/db/')
-    chmod_cmd = "chmod 600 /etc/sssd/sssd.conf"
-    session_multihost.client[0].run_command(chmod_cmd)
+    sssd_tools.fix_sssd_conf_perms()
 
 
 @pytest.fixture(scope='class')
@@ -1419,10 +1418,8 @@ def setup_sshd_authorized_keys(session_multihost, request):
 @pytest.fixture(scope='class')
 def enable_ssh_responder(session_multihost, request):
     """ Enable ssh responder in sssd.conf """
-    backup_sssd = 'cp -f /etc/sssd/sssd.conf /etc/sssd/sssd.conf.backup'
-    restore_sssd_conf = 'cp -f /etc/sssd/sssd.conf.backup /etc/sssd/sssd.conf'
-    session_multihost.client[0].run_command(backup_sssd)
     tools = sssdTools(session_multihost.client[0])
+    tools.backup_sssd_conf()
     session_multihost.client[0].service_sssd('stop')
     tools.remove_sss_cache('/var/lib/sss/db')
     sssd_params = {'services': 'nss, pam, ssh'}
@@ -1431,7 +1428,7 @@ def enable_ssh_responder(session_multihost, request):
 
     def restore_sssd():
         """ Restore sssd.conf """
-        session_multihost.client[0].run_command(restore_sssd_conf)
+        tools.restore_sssd_conf()
     request.addfinalizer(restore_sssd)
 
 

--- a/src/tests/multihost/ipa/conftest.py
+++ b/src/tests/multihost/ipa/conftest.py
@@ -201,15 +201,13 @@ def add_group_member(session_multihost, request):
 @pytest.fixture(scope='function')
 def backupsssdconf(session_multihost, request):
     """ Backup and restore sssd.conf """
-    bkup = 'cp -f %s %s.orig' % (SSSD_DEFAULT_CONF,
-                                 SSSD_DEFAULT_CONF)
-    session_multihost.client[0].run_command(bkup)
+    tools = sssdTools(session_multihost.client[0])
+    tools.backup_sssd_conf()
     session_multihost.client[0].service_sssd('stop')
 
     def restoresssdconf():
         """ Restore sssd.conf """
-        restore = 'cp -f %s.orig %s' % (SSSD_DEFAULT_CONF, SSSD_DEFAULT_CONF)
-        session_multihost.client[0].run_command(restore)
+        tools.restore_sssd_conf()
     request.addfinalizer(restoresssdconf)
 
 # ====================  Class Scoped Fixtures ================


### PR DESCRIPTION
SSSD configuration backup and restore code was duplicated in multiple places moved in one place so we can easier change rights and owership of the file.