### PR TITLE
krb5: lower log level in sss_krb5_get_init_creds_password()

### DIFF
--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -2408,12 +2408,12 @@ static errno_t map_krb5_error(krb5_error_code kerr)
 {
     /* just pass SSSD's internal error codes */
     if (kerr > 0 && IS_SSSD_ERROR(kerr)) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "[%d][%s].\n", kerr, sss_strerror(kerr));
+        DEBUG(SSSDBG_OP_FAILURE, "[%d][%s].\n", kerr, sss_strerror(kerr));
         return kerr;
     }
 
     if (kerr != 0) {
-        KRB5_CHILD_DEBUG(SSSDBG_CRIT_FAILURE, kerr);
+        KRB5_CHILD_DEBUG(SSSDBG_OP_FAILURE, kerr);
     }
 
     switch (kerr) {


### PR DESCRIPTION
sss_krb5_get_init_creds_password() is called only with AD to be able to get
more specific error details and does the basic steps also done by 
krb5_get_init_creds_password() from libkrb5. In contrast to the libkrb5 
function it will return debug output. Unfortunately the log level is quite
low, i.e. messages are shown with the default debug level, and the messages
are send to syslog, too. This can get annoying during SSSD's pre-auth step
to determine the available authentication types since here, no credentials
are provided and errors are somewhat expected but will be ignored by the
callers.

This patch increases the log level during SSSD's pre-auth and only sends 
messages with the two lowest log levels to syslog.

   Resolves: https://github.com/SSSD/sssd/issues/7197