### PR TITLE
sbus: Fix codegen template for async client

### DIFF
--- a/src/sbus/codegen/templates/client_async.c.tpl
+++ b/src/sbus/codegen/templates/client_async.c.tpl
@@ -405,7 +405,7 @@
 
         TEVENT_REQ_RETURN_ON_ERROR(req);
 
-        *_value = <toggle line name="if-use-talloc">talloc_steal(mem_ctx, state->out->arg0);<or>state->out->arg0</toggle>;
+        *_value = <toggle line name="if-use-talloc">talloc_steal(mem_ctx, state->out->arg0)<or>state->out->arg0</toggle>;
 
         return EOK;
     }


### PR DESCRIPTION
Double semicolon is generated, thus test src/tests/double_semicolon_test fails for async client source code.

For example, we can generate code for IFP async client. To do this, add new async interface to src/responder/ifp/ifp_iface/ifp_iface.xml file:

    <interface name="org.freedesktop.sssd.infopipe.Tests.Test">
        <annotation name="codegen.Test" value="ifp_test" />
        <annotation name="codegen.AsyncCaller" value="true" />
        <property name="name" type="s" access="read" />
    </interface>

Then make check tests. Test fails with an error:
```
Double semicolon found:
../src/responder/ifp/ifp_iface/sbus_ifp_client_async.c:132:    *_value = talloc_steal(mem_ctx, state->out->arg0);;
```