### PR TITLE
Allow smart card authentication in vlock

### DIFF
--- a/src/responder/pam/pamsrv_p11.c
+++ b/src/responder/pam/pamsrv_p11.c
@@ -276,7 +276,7 @@ static errno_t get_sc_services(TALLOC_CTX *mem_ctx, struct pam_ctx *pctx,
 
     const char *default_sc_services[] = {
         "login", "su", "su-l", "gdm-smartcard", "gdm-password", "kdm", "sudo",
-        "sudo-i", "gnome-screensaver", "polkit-1", NULL,
+        "sudo-i", "gnome-screensaver", "polkit-1", "vlock", NULL,
     };
     const int default_sc_services_size =
         sizeof(default_sc_services) / sizeof(default_sc_services[0]);


### PR DESCRIPTION
I was made aware that there is something called vlock, allowing to lock tty, which would also make sense to use smart cards to unlock.

I was not able to test it works with sssd smart card authentication, but given that it is using pam, it should work.

I will update you when I will verify it works ok with a basic test (or if anyone can test the changes, it would be good).