### PR TITLE
Tests: Add oddjob package to master for multihost/alltests

### DIFF
--- a/src/tests/multihost/sssd/testlib/common/utils.py
+++ b/src/tests/multihost/sssd/testlib/common/utils.py
@@ -103,7 +103,8 @@ class sssdTools(object):
         """ Install common required packages on server"""
         pkgs = 'adcli realmd samba samba-common-tools krb5-workstation '\
                'samba-winbind-clients nfs-utils openldap-clients '\
-               'krb5-server cifs-utils expect 389-ds-base rsyslog'
+               'krb5-server cifs-utils expect 389-ds-base rsyslog '\
+               'oddjob oddjob-mkhomedir'
         sssd_pkgs = 'sssd sssd-tools sssd-proxy sssd-winbind-idmap '\
                     'libsss_autofs sssd-kcm sssd-dbus'
         # See comment in client_install_pkgs


### PR DESCRIPTION
The package is not pulled automatically as part of deps/packageset on fedora resulting in subprocess.CalledProcessError: Command 'systemctl restart oddjobd.service' returned non-zero exit status 5.