### PR TITLE
PAM: Print PAM Data once on incoming requests

### DIFF
--- a/src/responder/pam/pamsrv_dp.c
+++ b/src/responder/pam/pamsrv_dp.c
@@ -42,9 +42,6 @@ pam_dp_send_req(struct pam_auth_req *preq)
         return EIO;
     }
 
-    DEBUG(SSSDBG_CONF_SETTINGS, "Sending request with the following data:\n");
-    DEBUG_PAM_DATA(SSSDBG_CONF_SETTINGS, preq->pd);
-
     subreq = sbus_call_dp_dp_pamHandler_send(preq, preq->cctx->rctx->sbus_conn,
                  preq->domain->conn_name, SSS_BUS_PATH, preq->pd);
     if (subreq == NULL) {


### PR DESCRIPTION
Currently DEBUG_PAM_DATA is called twice in the PAM responder for incoming requests pam_sss -> PAM responder.

Drop the print_pam_data() logging done in PAM forwarder codepath.