### PR TITLE
man: fix default value for pam_passkey_auth

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -1679,7 +1679,7 @@ pam_account_locked_message = Account locked, please contact help desk.
                             Enable passkey device based authentication.
                         </para>
                         <para>
-                            Default: False
+                            Default: True
                         </para>
                     </listitem>
                 </varlistentry>


### PR DESCRIPTION
The default was changed to true, but the man page wasn't updated.

Fixes: https://github.com/SSSD/sssd/commit/c76ba343b783718468a3a108346d424f9a70eb76