### PR TITLE
Tests: Fix ipa/conftest.py for fedora.

### DIFF
--- a/src/tests/multihost/ipa/conftest.py
+++ b/src/tests/multihost/ipa/conftest.py
@@ -221,9 +221,11 @@ def environment_setup(session_multihost, request):
     Install necessary packages
     """
     client = session_multihost.client[0]
-    client.run_command("yum "
-                       "--enablerepo=*-CRB install"
-                       " -y shadow-utils*")
+    if "Fedora" in client.distro:
+        client.run_command("yum install -y shadow-utils*")
+    else:
+        client.run_command("yum --enablerepo=*-CRB install -y shadow-utils*")
+
     client.run_command("yum install -y gcc")
     client.run_command("yum install -y podman")
     with pytest.raises(subprocess.CalledProcessError):


### PR DESCRIPTION
The installation of shadow-utils fails on fedora as it tries to enable CRB repos.