### PR TITLE
MAN: sss_ssh_knownhosts.1 must also be translated

### DIFF
--- a/src/man/po/po4a.cfg
+++ b/src/man/po/po4a.cfg
@@ -20,6 +20,7 @@
 [type:docbook] sssd-ifp.5.xml $lang:$(builddir)/$lang/sssd-ifp.5.xml
 [type:docbook] sss_rpcidmapd.5.xml $lang:$(builddir)/$lang/sss_rpcidmapd.5.xml
 [type:docbook] sss_ssh_authorizedkeys.1.xml $lang:$(builddir)/$lang/sss_ssh_authorizedkeys.1.xml
+[type:docbook] sss_ssh_knownhosts.1.xml $lang:$(builddir)/$lang/sss_ssh_knownhosts.1.xml
 [type:docbook] sss_ssh_knownhostsproxy.1.xml $lang:$(builddir)/$lang/sss_ssh_knownhostsproxy.1.xml
 [type:docbook] idmap_sss.8.xml $lang:$(builddir)/$lang/idmap_sss.8.xml
 [type:docbook] sssctl.8.xml $lang:$(builddir)/$lang/sssctl.8.xml


### PR DESCRIPTION
The `sss_ssh_knownhosts.1.xml` file needs to be included in `po4a.cfg`.

Resolves: https://github.com/SSSD/sssd/issues/7232