### PR TITLE
pam: fix invalid #if condition

### DIFF
--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -1418,7 +1418,7 @@ void pam_reply(struct pam_auth_req *preq)
         goto done;
     }
 
-#if BUILD_PASSKEY
+#ifdef BUILD_PASSKEY
     if(pd->cmd == SSS_PAM_AUTHENTICATE &&
        pd->pam_status == PAM_NEW_AUTHTOK_REQD &&
        sss_authtok_get_type(pd->authtok) == SSS_AUTHTOK_TYPE_PASSKEY_REPLY) {


### PR DESCRIPTION
ifdef should be used as anywhere else, otherwise we hit a build
error if sssd is being built without passkey.