### PR TITLE
Tests: refactor sssd.conf backup and restore

### DIFF
--- a/src/tests/multihost/adsites/conftest.py
+++ b/src/tests/multihost/adsites/conftest.py
@@ -265,7 +265,7 @@ def joinad(session_multihost, request):
     try:
         session_multihost.client[0].service_sssd('restart')
     except SSSDException:
-        cmd = 'cat /etc/sssd/sssd.conf'
+        cmd = f'cat {SSSD_DEFAULT_CONF}'
         session_multihost.client[0].run_command(cmd)
         journal = 'journalctl -x -n 150 --no-pager'
         session_multihost.client[0].run_command(journal)
@@ -315,6 +315,6 @@ def setup_session(request, session_multihost, create_testdir):
     def teardown_session():
         """ Teardown session """
         session_multihost.client[0].service_sssd('stop')
-        remove_sssd_conf = 'rm -f /etc/sssd/sssd.conf'
+        remove_sssd_conf = f'rm -f {SSSD_DEFAULT_CONF}'
         session_multihost.client[0].run_command(remove_sssd_conf)
     request.addfinalizer(teardown_session)

--- a/src/tests/multihost/alltests/conftest.py
+++ b/src/tests/multihost/alltests/conftest.py
@@ -17,7 +17,6 @@ from sssd.testlib.common.utils import PkiTools, sssdTools, LdapOperations
 from sssd.testlib.common.libdirsrv import DirSrvWrap
 from sssd.testlib.common.exceptions import PkiLibException, LdapException
 
-
 pytest_plugins = (
     'sssd.testlib.common.fixtures',
     'pytest_importance',
@@ -42,9 +41,8 @@ def pytest_configure():
 def multidomain_sssd(session_multihost, request):
     """ Multidomain sssd configuration """
     session_multihost.client[0].service_sssd('stop')
-    bkup = 'cp %s %s.orig' % (SSSD_DEFAULT_CONF, SSSD_DEFAULT_CONF)
-    session_multihost.client[0].run_command(bkup)
     tools = sssdTools(session_multihost.client[0])
+    tools.backup_sssd_conf()
     tools.remove_sss_cache('/var/lib/sss/db')
     tools.remove_sss_cache('/var/lib/sss/mc')
 
@@ -113,8 +111,7 @@ def multidomain_sssd(session_multihost, request):
         """ Remove sssd configuration """
         stop_sssd = 'systemctl stop sssd'
         session_multihost.client[0].run_command(stop_sssd)
-        cmd = 'cp -f %s.orig %s' % (SSSD_DEFAULT_CONF, SSSD_DEFAULT_CONF)
-        session_multihost.client[0].run_command(cmd)
+        tools.restore_sssd_conf()
     request.addfinalizer(removesssd)
     return _modifysssd
 
@@ -244,15 +241,13 @@ def enable_sss_sudo_nsswitch(session_multihost, request):
 @pytest.fixture(scope='function')
 def backupsssdconf(session_multihost, request):
     """ Backup and restore sssd.conf """
-    bkup = 'cp -f %s %s.orig' % (SSSD_DEFAULT_CONF,
-                                 SSSD_DEFAULT_CONF)
-    session_multihost.client[0].run_command(bkup)
+    tools = sssdTools(session_multihost.client[0])
+    tools.backup_sssd_conf()
     session_multihost.client[0].service_sssd('stop')
 
     def restoresssdconf():
         """ Restore sssd.conf """
-        restore = 'cp -f %s.orig %s' % (SSSD_DEFAULT_CONF, SSSD_DEFAULT_CONF)
-        session_multihost.client[0].run_command(restore)
+        tools.restore_sssd_conf()
     request.addfinalizer(restoresssdconf)
 
 
@@ -836,13 +831,15 @@ base %s
 def template_sssdconf(session_multihost, request):
     """ Copy template sssd conf for multidomain tests """
     cwd = os.path.dirname(os.path.abspath(__file__))
-    remote = '/etc/sssd/sssd.conf'
     source = posixpath.join(cwd, 'sssd_multidomain.conf')
-    session_multihost.client[0].transport.put_file(source, remote)
+    session_multihost.client[0].transport.put_file(source, SSSD_DEFAULT_CONF)
+    tools = sssdTools(session_multihost.client[0])
+    tools.fix_sssd_conf_perms()
+
 
     def remove_template():
         """ Remove template sssd.conf """
-        cmd = 'rm -f /etc/sssd/sssd.conf'
+        cmd = f'rm -f {SSSD_DEFAULT_CONF}'
         session_multihost.client[0].run_command(cmd)
     request.addfinalizer(remove_template)
 
@@ -1277,6 +1274,8 @@ config_file_version = 2
 services = nss, pam '''
     session_multihost.client[0].put_file_contents('%s' % (SSSD_DEFAULT_CONF),
                                                   contents)
+    tools = sssdTools(session_multihost.client[0])
+    tools.fix_sssd_conf_perms()
 
     def remove_default_sssd():
         """ Remove default sssd.conf """
@@ -1329,8 +1328,7 @@ def krb_connection_timeout(
     session_multihost.client[0].run_command(restore_selinux)
     sssd_tools = sssdTools(session_multihost.client[0])
     sssd_tools.remove_sss_cache('/var/lib/sss/db/')
-    chmod_cmd = "chmod 600 /etc/sssd/sssd.conf"
-    session_multihost.client[0].run_command(chmod_cmd)
+    sssd_tools.fix_sssd_conf_perms()
 
 
 @pytest.fixture(scope='class')
@@ -1420,10 +1418,8 @@ def setup_sshd_authorized_keys(session_multihost, request):
 @pytest.fixture(scope='class')
 def enable_ssh_responder(session_multihost, request):
     """ Enable ssh responder in sssd.conf """
-    backup_sssd = 'cp -f /etc/sssd/sssd.conf /etc/sssd/sssd.conf.backup'
-    restore_sssd_conf = 'cp -f /etc/sssd/sssd.conf.backup /etc/sssd/sssd.conf'
-    session_multihost.client[0].run_command(backup_sssd)
     tools = sssdTools(session_multihost.client[0])
+    tools.backup_sssd_conf()
     session_multihost.client[0].service_sssd('stop')
     tools.remove_sss_cache('/var/lib/sss/db')
     sssd_params = {'services': 'nss, pam, ssh'}
@@ -1432,7 +1428,7 @@ def enable_ssh_responder(session_multihost, request):
 
     def restore_sssd():
         """ Restore sssd.conf """
-        session_multihost.client[0].run_command(restore_sssd_conf)
+        tools.restore_sssd_conf()
     request.addfinalizer(restore_sssd)
 
 

--- a/src/tests/multihost/basic/conftest.py
+++ b/src/tests/multihost/basic/conftest.py
@@ -5,6 +5,7 @@ from sssd.testlib.common.libdirsrv import DirSrvWrap
 from sssd.testlib.common.exceptions import PkiLibException
 from sssd.testlib.common.exceptions import LdapException
 from sssd.testlib.common.exceptions import SSSDException
+from sssd.testlib.common.paths import SSSD_DEFAULT_CONF
 
 import pytest
 try:
@@ -137,9 +138,8 @@ def setup_sssd(session_multihost, request):
     with open(temp_file_path, "w") as outfile:
         sssdConfig.write(outfile)
     session_multihost.master[0].transport.put_file(temp_file_path,
-                                                   '/etc/sssd/sssd.conf')
-    chg_perm = 'chmod 600 /etc/sssd/sssd.conf'
-    session_multihost.master[0].run_command(chg_perm)
+                                                   SSSD_DEFAULT_CONF)
+    sssdTools(session_multihost.master[0]).fix_sssd_conf_perms()
     os.close(temp_fd)
     try:
         session_multihost.master[0].service_sssd('restart')
@@ -230,9 +230,9 @@ def create_casesensitive_posix_user(session_multihost):
 @pytest.fixture
 def set_case_sensitive_false(session_multihost, request):
     """ Set case_sensitive to false in sssd domain section """
-    bkup_sssd = 'cp -f /etc/sssd/sssd.conf /etc/sssd/sssd.conf.orig'
-    session_multihost.master[0].run_command(bkup_sssd)
-    session_multihost.master[0].transport.get_file('/etc/sssd/sssd.conf',
+    tools = sssdTools(session_multihost.master[0])
+    tools.backup_sssd_conf()
+    session_multihost.master[0].transport.get_file(SSSD_DEFAULT_CONF,
                                                    '/tmp/sssd.conf')
     sssdconfig = ConfigParser.ConfigParser()
     sssdconfig.read('/tmp/sssd.conf')
@@ -242,23 +242,22 @@ def set_case_sensitive_false(session_multihost, request):
         with open('/tmp/sssd.conf', "w") as sssconf:
             sssdconfig.write(sssconf)
     session_multihost.master[0].transport.put_file('/tmp/sssd.conf',
-                                                   '/etc/sssd/sssd.conf')
+                                                   SSSD_DEFAULT_CONF)
+    tools.fix_sssd_conf_perms()
     session_multihost.master[0].service_sssd('restart')
 
     def restore_sssd():
         """ Restore sssd.conf """
-        restore_sssd = 'cp -f /etc/sssd/sssd.conf.orig /etc/sssd/sssd.conf'
-        session_multihost.master[0].run_command(restore_sssd)
-        session_multihost.master[0].service_sssd('restart')
+        tools.restore_sssd_conf()
     request.addfinalizer(restore_sssd)
 
 
 @pytest.fixture
 def set_entry_cache_sudo_timeout(session_multihost, request):
     """ Set entry cache sudo timeout in sssd.conf """
-    bkup_sssd = 'cp -f /etc/sssd/sssd.conf /etc/sssd/sssd.conf.orig'
-    session_multihost.master[0].run_command(bkup_sssd)
-    session_multihost.master[0].transport.get_file('/etc/sssd/sssd.conf',
+    tools = sssdTools(session_multihost.master[0])
+    tools.backup_sssd_conf()
+    session_multihost.master[0].transport.get_file(SSSD_DEFAULT_CONF,
                                                    '/tmp/sssd.conf')
     sssdconfig = ConfigParser.ConfigParser()
     sssdconfig.read('/tmp/sssd.conf')
@@ -268,14 +267,14 @@ def set_entry_cache_sudo_timeout(session_multihost, request):
         with open('/tmp/sssd.conf', "w") as sssconf:
             sssdconfig.write(sssconf)
     session_multihost.master[0].transport.put_file('/tmp/sssd.conf',
-                                                   '/etc/sssd/sssd.conf')
+                                                   SSSD_DEFAULT_CONF)
+    tools.fix_sssd_conf_perms()
+
     session_multihost.master[0].service_sssd('restart')
 
     def restore_sssd():
         """ Restore sssd.conf """
-        restore_sssd = 'cp -f /etc/sssd/sssd.conf.orig /etc/sssd/sssd.conf'
-        session_multihost.master[0].run_command(restore_sssd)
-        session_multihost.master[0].service_sssd('restart')
+        tools.restore_sssd_conf()
     request.addfinalizer(restore_sssd)
 
 
@@ -311,7 +310,7 @@ def enable_files_domain(session_multihost):
     """
     Enable the implicit files domain
     """
-    session_multihost.master[0].transport.get_file('/etc/sssd/sssd.conf',
+    session_multihost.master[0].transport.get_file(SSSD_DEFAULT_CONF,
                                                    '/tmp/sssd.conf')
     sssdconfig = ConfigParser.RawConfigParser(delimiters=('='))
     sssdconfig.read('/tmp/sssd.conf')
@@ -321,7 +320,8 @@ def enable_files_domain(session_multihost):
         with open('/tmp/sssd.conf', "w") as sssconf:
             sssdconfig.write(sssconf)
     session_multihost.master[0].transport.put_file('/tmp/sssd.conf',
-                                                   '/etc/sssd/sssd.conf')
+                                                   SSSD_DEFAULT_CONF)
+    sssdTools(session_multihost.master[0]).fix_sssd_conf_perms()
     session_multihost.master[0].service_sssd('restart')
 
 

--- a/src/tests/multihost/ipa/conftest.py
+++ b/src/tests/multihost/ipa/conftest.py
@@ -201,15 +201,13 @@ def add_group_member(session_multihost, request):
 @pytest.fixture(scope='function')
 def backupsssdconf(session_multihost, request):
     """ Backup and restore sssd.conf """
-    bkup = 'cp -f %s %s.orig' % (SSSD_DEFAULT_CONF,
-                                 SSSD_DEFAULT_CONF)
-    session_multihost.client[0].run_command(bkup)
+    tools = sssdTools(session_multihost.client[0])
+    tools.backup_sssd_conf()
     session_multihost.client[0].service_sssd('stop')
 
     def restoresssdconf():
         """ Restore sssd.conf """
-        restore = 'cp -f %s.orig %s' % (SSSD_DEFAULT_CONF, SSSD_DEFAULT_CONF)
-        session_multihost.client[0].run_command(restore)
+        tools.restore_sssd_conf()
     request.addfinalizer(restoresssdconf)
 
 # ====================  Class Scoped Fixtures ================

--- a/src/tests/multihost/sssd/testlib/common/utils.py
+++ b/src/tests/multihost/sssd/testlib/common/utils.py
@@ -74,6 +74,19 @@ class sssdTools(object):
         self._ad_conn = self.ad_ops.ad_conn()
         return self._ad_conn
 
+    @property
+    def sssd_user(self):
+        """Sssd user"""
+        if not hasattr(self, "_sssd_user"):
+            cmd = self.multihost.run_command(
+                'systemctl show sssd --value --property User', raiseonerr=False)
+            if cmd.returncode == 0:
+                self._sssd_user = cmd.stdout_text.strip()
+            else:
+                self._sssd_user = 'root'
+        return self._sssd_user
+
+
     def client_install_pkgs(self):
         """ Install common required packages """
         pkgs = 'adcli realmd samba samba-common-tools krb5-workstation '\
@@ -349,12 +362,16 @@ class sssdTools(object):
         self.multihost.transport.put_file(tmpconf.name, SSSD_DEFAULT_CONF)
         set_perms = 'chmod 600 /etc/sssd/sssd.conf'
         self.multihost.run_command(set_perms, raiseonerr=False)
+        self.multihost.run_command(
+            f'chown {self.sssd_user}:{self.sssd_user} {SSSD_DEFAULT_CONF}',
+            raiseonerr=False
+        )
         os.unlink(tmpconf.name)
 
     def get_domain_section_name(self):
         """ Get Domain section """
         tmpconf = tempfile.NamedTemporaryFile(suffix='sssd.conf', delete=False)
-        self.multihost.transport.get_file('/etc/sssd/sssd.conf', tmpconf.name)
+        self.multihost.transport.get_file(SSSD_DEFAULT_CONF, tmpconf.name)
         config = ConfigParser.ConfigParser()
         try:
             config.read(tmpconf.name)
@@ -1036,15 +1053,25 @@ class sssdTools(object):
         self.adhost.run_command(
             remove_automount, log_stdout=verbose, raiseonerr=False)
 
+    def fix_sssd_conf_perms(self):
+        """Restore ownership, permissions and selinux on sssd.conf"""
+        self.multihost.run_command(
+            f'chown {self.sssd_user}:{self.sssd_user} {SSSD_DEFAULT_CONF}',
+            raiseonerr=False
+        )
+        self.multihost.run_command(f'chmod 600 {SSSD_DEFAULT_CONF}', raiseonerr=False)
+        self.multihost.run_command(f'restorecon -v {SSSD_DEFAULT_CONF}', raiseonerr=False)
+
     def backup_sssd_conf(self):
         """ Backup sssd conf """
-        bkup_cmd = 'cp -af /etc/sssd/sssd.conf /etc/sssd/sssd.conf.orig'
+        bkup_cmd = f'cp -af {SSSD_DEFAULT_CONF} /etc/sssd/sssd.conf.orig'
         self.multihost.run_command(bkup_cmd)
 
     def restore_sssd_conf(self):
         """ Restore sssd conf """
-        restore_cmd = 'cp -af /etc/sssd/sssd.conf.orig /etc/sssd/sssd.conf'
+        restore_cmd = f'cp -af /etc/sssd/sssd.conf.orig {SSSD_DEFAULT_CONF}'
         self.multihost.run_command(restore_cmd)
+        self.fix_sssd_conf_perms()
 
     def add_service_principals(self, spn_list):
         """ Add service principal to Windows AD """


### PR DESCRIPTION
SSSD configuration backup and restore code was duplicated in multiple places moved in one place so we can easier change rights and owership of the file.

Reviewed-by: Madhuri Upadhye <mupadhye@redhat.com>