### PR TITLE
TESTS: Fix the ssh configuration - II

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,6 +339,17 @@ jobs:
 
           systemctl restart sssd || systemctl status sssd
 
+    - name: Patch the SSH configuration
+      uses: SSSD/sssd-ci-containers/actions/exec@master
+      with:
+        user: root
+        script: |
+          #!/bin/bash
+          test -x /usr/bin/sss_ssh_knownhosts && \
+              sed -e 's/GlobalKnownHostsFile/#GlobalKnownHostsFile/' \
+                  -e 's/ProxyCommand \/usr\/bin\/sss_ssh_knownhostsproxy -p %p %h/KnownHostsCommand \/usr\/bin\/sss_ssh_knownhosts %H/' \
+                  -i /etc/ssh/ssh_config.d/04-ipa.conf
+
     - name: Install system tests dependencies
       shell: bash
       working-directory: ./sssd/src/tests/system


### PR DESCRIPTION
The previous patch fixed the environment for the multihost tests, but system tests also need the fix.

Previous patch: https://github.com/SSSD/sssd/commit/e556bfd0d49d25301bf84efda72d27c6e0a5af68

These two patches need to be removed once FreeIPA has updated their tool `ipa-client-install` to use our new tool `sss_ssh_knownhosts`.

FreeIPA's PR: https://github.com/freeipa/freeipa/pull/7254