### PR TITLE
UTILS: inotify: avoid potential NULL deref

### DIFF
--- a/src/util/inotify.c
+++ b/src/util/inotify.c
@@ -233,9 +233,13 @@ static errno_t process_dir_event(struct snotify_ctx *snctx,
 {
     errno_t ret;
 
+    if (in_event->len == 0) {
+        DEBUG(SSSDBG_TRACE_FUNC, "Not interested in nameless event\n");
+        return EOK;
+    }
+
     DEBUG(SSSDBG_TRACE_ALL, "inotify name: %s\n", in_event->name);
-    if (in_event->len == 0 \
-            || strcmp(in_event->name, snctx->base_name) != 0) {
+    if (strcmp(in_event->name, snctx->base_name) != 0) {
         DEBUG(SSSDBG_TRACE_FUNC, "Not interested in %s\n", in_event->name);
         return EOK;
     }


### PR DESCRIPTION
Fixes following error:
```
Error: STRING_NULL (CWE-170):
sssd-2.9.1/src/util/inotify.c:298: string_null_source: Function ""read"" does not terminate string ""ev_buf"". [Note: The source code implementation of the function has been overridden by a builtin model.]
sssd-2.9.1/src/util/inotify.c:316: var_assign_var: Assigning: ""ptr"" = ""ev_buf"". Both now point to the same unterminated string.
sssd-2.9.1/src/util/inotify.c:320: var_assign_var: Assigning: ""in_event"" = ""ptr"". Both now point to the same unterminated string.
sssd-2.9.1/src/util/inotify.c:327: string_null: Passing unterminated string ""in_event->name"" to ""process_dir_event"", which expects a null-terminated string.
 #  325|
 #  326|               if (snctx->wctx->dir_wd == in_event->wd) {
 #  327|->                 ret = process_dir_event(snctx, in_event);
 #  328|               } else if (snctx->wctx->file_wd == in_event->wd) {
 #  329|                   ret = process_file_event(snctx, in_event);
```
  --  it might be unsafe to dereference `in_event->name`
if `in_event->len == 0`