### PR TITLE
ad: refresh root domain when read directly

### DIFF
--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -1395,7 +1395,7 @@ struct ad_get_root_domain_state {
 static void ad_get_root_domain_done(struct tevent_req *subreq);
 static void ad_check_root_domain_done(struct tevent_req *subreq);
 static errno_t
-ad_get_root_domain_refresh(struct ad_get_root_domain_state *state);
+ad_get_root_domain_refresh(struct ad_get_root_domain_state *state, bool refresh);
 
 struct tevent_req *
 ad_check_domain_send(TALLOC_CTX *mem_ctx,
@@ -1582,7 +1582,7 @@ static void ad_get_root_domain_done(struct tevent_req *subreq)
         return;
     }
 
-    ret = ad_get_root_domain_refresh(state);
+    ret = ad_get_root_domain_refresh(state, false);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "ad_get_root_domain_refresh() failed.\n");
     }
@@ -1682,7 +1682,7 @@ static void ad_check_root_domain_done(struct tevent_req *subreq)
 
     state->reply_count = 1;
 
-    ret = ad_get_root_domain_refresh(state);
+    ret = ad_get_root_domain_refresh(state, true);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "ad_get_root_domain_refresh() failed.\n");
     }
@@ -1697,7 +1697,7 @@ done:
 }
 
 static errno_t
-ad_get_root_domain_refresh(struct ad_get_root_domain_state *state)
+ad_get_root_domain_refresh(struct ad_get_root_domain_state *state, bool refresh)
 {
     struct sss_domain_info *root_domain;
     bool has_changes;
@@ -1713,7 +1713,7 @@ ad_get_root_domain_refresh(struct ad_get_root_domain_state *state)
         goto done;
     }
 
-    if (has_changes) {
+    if (has_changes || refresh) {
         ret = ad_subdom_reinit(state->sd_ctx);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "Could not reinitialize subdomains\n");


### PR DESCRIPTION
If the domain object of the forest root domain cannot be found in the
LDAP tree of the local AD domain SSSD tries to read the request data
from an LDAP server of the forest root domain directly. After reading
this data the information is stored in the cache but currently the
information about the domain store in memory is not updated with the
additional data. As a result e.g. the domain SID is missing in this data
and only becomes available after a restart where it is read from the
cache.

With this patch an unconditional refresh is triggered at the end of the
fallback code path.

Resolves: https://github.com/SSSD/sssd/issues/7250