### PR TITLE
INTG-TESTS: backport `sync_files_provider()` from b9c1d7d667d49080c27…

### DIFF
--- a/src/tests/intg/test_files_provider.py
+++ b/src/tests/intg/test_files_provider.py
@@ -456,6 +456,19 @@ def sssd_id_sync(name):
     return res, groups
 
 
+def sync_files_provider(name=None):
+    """
+    Tests with files provider can fail because files provider did not yet
+    finish updating its cache. Polling for presents of the canary user makes
+    sure that we wait until the cache is updated.
+    """
+    if name is None:
+        name = CANARY["name"]
+
+    ret = poll_canary(call_sssd_getpwnam, name)
+    assert ret
+
+
 # Helper functions
 def user_generator(seqnum):
     return dict(name='user%d' % seqnum,

--- a/src/tests/intg/test_pam_responder.py
+++ b/src/tests/intg/test_pam_responder.py
@@ -34,6 +34,7 @@ import kdc
 
 import pytest
 
+from .test_files_provider import sync_files_provider
 from intg.util import unindent
 
 LDAP_BASE_DN = "dc=example,dc=com"


### PR DESCRIPTION
…641fb4a800bd4c2612d43