### PR TITLE
Tests: sudo defaults rule 

### DIFF
--- a/src/tests/system/tests/test_identity.py
+++ b/src/tests/system/tests/test_identity.py
@@ -339,3 +339,4 @@ def test_identity__lookup_idmapping_of_posix_and_non_posix_user_and_group(client
     assert client.tools.getent.group("posix_group") is not None, "posix-group is not returned by sssd"
     assert client.tools.getent.group("nonposix_group") is None, "non-posix group is returned by sssd, it should not be"
     assert client.tools.getent.passwd("nonposix_user") is None, "non-posix user is returned by sssd, it should not be"
+    assert client.tools.getent.passwd("nonposix_user") is None, "non-posix user is returned by sssd, it should not be"


### PR DESCRIPTION
A sudo rule with specifically 'defaults' as cn is being tested. The addition option '!authenticate' has been added.
The man 5 sudoers.ldap says:
<snip>
       Sudo first looks for the ‘cn=defaults’ entry in the SUDOers container.  If found, the multi-valued sudoOption attribute is parsed in the same manner as a global Defaults line in /etc/sudoers.  In the
       following example, the SSH_AUTH_SOCK variable will be preserved in the environment for all users.

           dn: cn=defaults,ou=SUDOers,dc=my-domain,dc=com
           objectClass: top
           objectClass: sudoRole
           cn: defaults
           description: Default sudoOption's go here
           sudoOption: env_keep+=SSH_AUTH_SOCK

</snip>