### PR TITLE
tests: fixing typo in test_authentication.py

### DIFF
--- a/src/tests/system/tests/test_authentication.py
+++ b/src/tests/system/tests/test_authentication.py
@@ -126,7 +126,7 @@ def test_authentication__login_using_email_address(client: Client, ad: AD, metho
     """
     ad.user("user-1").add(password="Secret123", email=f"user-1@{ad.host.domain}")
     ad.user("user-2").add(password="Secret123", email="user-2@alias-domain.com")
-    ad.user("user-3").add(password="Secret123", email="user_3@alias-domain.com")
+    ad.user("user_3").add(password="Secret123", email="user_3@alias-domain.com")
 
     client.sssd.set_service_user(sssd_service_user)
     client.sssd.start()


### PR DESCRIPTION
 The assertion checks for user_3 but the user added is user-3. The value is different than the others because we are trying to try different  combinations.
