### PR TITLE
TESTS: don't use deprecated sssd.conf::user option

### DIFF
--- a/src/tests/system/tests/test_authentication.py
+++ b/src/tests/system/tests/test_authentication.py
@@ -15,12 +15,7 @@ from sssd_test_framework.topology import KnownTopology, KnownTopologyGroup
 
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
 @pytest.mark.parametrize("method", ["su", "ssh"])
-@pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
-@pytest.mark.require(
-    lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
-    "SSSD was built without support for running under non-root",
-)
-def test_authentication__login(client: Client, provider: GenericProvider, method: str, sssd_service_user: str):
+def test_authentication__login(client: Client, provider: GenericProvider, method: str):
     """
     :title: ssh/su login
     :setup:
@@ -37,7 +32,6 @@ def test_authentication__login(client: Client, provider: GenericProvider, method
     """
     provider.user("user1").add(password="Secret123")
 
-    client.sssd.set_service_user(sssd_service_user)
     client.sssd.start()
 
     assert client.auth.parametrize(method).password("user1", "Secret123"), "login with correct password failed"
@@ -46,12 +40,7 @@ def test_authentication__login(client: Client, provider: GenericProvider, method
 
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
 @pytest.mark.parametrize("method", ["su", "ssh"])
-@pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
-@pytest.mark.require(
-    lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
-    "SSSD was built without support for running under non-root",
-)
-def test_authentication__offline_login(client: Client, provider: GenericProvider, method: str, sssd_service_user: str):
+def test_authentication__offline_login(client: Client, provider: GenericProvider, method: str):
     """
     :title: Offline ssh/su login
     :setup:
@@ -80,7 +69,6 @@ def test_authentication__offline_login(client: Client, provider: GenericProvider
     wrong = "Wrong123"
     provider.user(user).add(password=correct)
 
-    client.sssd.set_service_user(sssd_service_user)
     client.sssd.domain["cache_credentials"] = "True"
     client.sssd.domain["krb5_store_password_if_offline"] = "True"
     client.sssd.pam["offline_credentials_expiration"] = "0"
@@ -103,12 +91,7 @@ def test_authentication__offline_login(client: Client, provider: GenericProvider
 @pytest.mark.topology(KnownTopology.AD)
 @pytest.mark.ticket(gh=7174)
 @pytest.mark.parametrize("method", ["su", "ssh"])
-@pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
-@pytest.mark.require(
-    lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
-    "SSSD was built without support for running under non-root",
-)
-def test_authentication__login_using_email_address(client: Client, ad: AD, method: str, sssd_service_user: str):
+def test_authentication__login_using_email_address(client: Client, ad: AD, method: str):
     """
     :title: Login using user's email address
     :description:
@@ -128,7 +111,6 @@ def test_authentication__login_using_email_address(client: Client, ad: AD, metho
     ad.user("user-2").add(password="Secret123", email="user-2@alias-domain.com")
     ad.user("user-3").add(password="Secret123", email="user_3@alias-domain.com")
 
-    client.sssd.set_service_user(sssd_service_user)
     client.sssd.start()
 
     assert client.auth.parametrize(method).password(

--- a/src/tests/system/tests/test_autofs.py
+++ b/src/tests/system/tests/test_autofs.py
@@ -17,14 +17,7 @@ from sssd_test_framework.topology import KnownTopologyGroup
 @pytest.mark.ticket(gh=6739)
 @pytest.mark.parametrize("cache_first", [False, True])
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
-@pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
-@pytest.mark.require(
-    lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
-    "SSSD was built without support for running under non-root",
-)
-def test_autofs__cache_first(
-    client: Client, nfs: NFS, provider: GenericProvider, cache_first: bool, sssd_service_user: str
-):
+def test_autofs__cache_first(client: Client, nfs: NFS, provider: GenericProvider, cache_first: bool):
     """
     :title: Autofs works correctly with any cache_first value
     :setup:
@@ -52,7 +45,6 @@ def test_autofs__cache_first(
     key = auto_export.key("export").add(info=nfs_export)
 
     # Start SSSD
-    client.sssd.set_service_user(sssd_service_user)
     client.sssd.common.autofs()
     client.sssd.autofs["cache_first"] = str(cache_first)
     client.sssd.start()

--- a/src/tests/system/tests/test_identity.py
+++ b/src/tests/system/tests/test_identity.py
@@ -14,12 +14,7 @@ from sssd_test_framework.topology import KnownTopologyGroup
 
 @pytest.mark.importance("critical")
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
-@pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
-@pytest.mark.require(
-    lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
-    "SSSD was built without support for running under non-root",
-)
-def test_identity__lookup_username_with_id(client: Client, provider: GenericProvider, sssd_service_user: str):
+def test_identity__lookup_username_with_id(client: Client, provider: GenericProvider):
     """
     :title: Resolve user by name with id
     :setup:
@@ -40,7 +35,6 @@ def test_identity__lookup_username_with_id(client: Client, provider: GenericProv
     for user, id in ids:
         provider.user(user).add(uid=id, gid=id + 500)
 
-    client.sssd.set_service_user(sssd_service_user)
     client.sssd.domain["ldap_id_mapping"] = "false"
     client.sssd.start()
 
@@ -53,12 +47,7 @@ def test_identity__lookup_username_with_id(client: Client, provider: GenericProv
 
 @pytest.mark.importance("critical")
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
-@pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
-@pytest.mark.require(
-    lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
-    "SSSD was built without support for running under non-root",
-)
-def test_identity__lookup_uid_with_id(client: Client, provider: GenericProvider, sssd_service_user: str):
+def test_identity__lookup_uid_with_id(client: Client, provider: GenericProvider):
     """
     :title: Resolve user by uid with id
     :setup:
@@ -79,7 +68,6 @@ def test_identity__lookup_uid_with_id(client: Client, provider: GenericProvider,
     for user, id in ids:
         provider.user(user).add(uid=id, gid=id + 500)
 
-    client.sssd.set_service_user(sssd_service_user)
     client.sssd.domain["ldap_id_mapping"] = "false"
     client.sssd.start()
 
@@ -240,14 +228,7 @@ def test_identity__lookup_user_by_group_with_getent(client: Client, provider: Ge
 
 @pytest.mark.importance("critical")
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
-@pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
-@pytest.mark.require(
-    lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
-    "SSSD was built without support for running under non-root",
-)
-def test_identity__lookup_group_membership_by_username_with_id(
-    client: Client, provider: GenericProvider, sssd_service_user: str
-):
+def test_identity__lookup_group_membership_by_username_with_id(client: Client, provider: GenericProvider):
     """
     :title: Check membership of user by group name with id
     :setup:
@@ -270,7 +251,6 @@ def test_identity__lookup_group_membership_by_username_with_id(
 
     provider.group("group1").add().add_members([u1, u2, u3])
 
-    client.sssd.set_service_user(sssd_service_user)
     client.sssd.start()
 
     for name, groups in users:

--- a/src/tests/system/tests/test_ldap.py
+++ b/src/tests/system/tests/test_ldap.py
@@ -18,12 +18,7 @@ from sssd_test_framework.topology import KnownTopology
 @pytest.mark.parametrize("modify_mode", ["exop", "ldap_modify"])
 @pytest.mark.parametrize("use_ppolicy", ["true", "false"])
 @pytest.mark.topology(KnownTopology.LDAP)
-@pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
-@pytest.mark.require(
-    lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
-    "SSSD was built without support for running under non-root",
-)
-def test_ldap__change_password(client: Client, ldap: LDAP, modify_mode: str, use_ppolicy: str, sssd_service_user: str):
+def test_ldap__change_password(client: Client, ldap: LDAP, modify_mode: str, use_ppolicy: str):
     """
     :title: Change password with "ldap_pwmodify_mode" set to @modify_mode
     :setup:
@@ -50,7 +45,6 @@ def test_ldap__change_password(client: Client, ldap: LDAP, modify_mode: str, use
     ldap.user(user).add(password=old_pass)
     ldap.aci.add('(targetattr="userpassword")(version 3.0; acl "pwp test"; allow (all) userdn="ldap:///self";)')
 
-    client.sssd.set_service_user(sssd_service_user)
     client.sssd.domain["ldap_pwmodify_mode"] = modify_mode
     client.sssd.domain["ldap_use_ppolicy"] = use_ppolicy
     client.sssd.start()

--- a/src/tests/system/tests/test_sudo.py
+++ b/src/tests/system/tests/test_sudo.py
@@ -22,12 +22,7 @@ from sssd_test_framework.topology import KnownTopology, KnownTopologyGroup
 @pytest.mark.importance("critical")
 @pytest.mark.authorization
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
-@pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
-@pytest.mark.require(
-    lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
-    "SSSD was built without support for running under non-root",
-)
-def test_sudo__user_allowed(client: Client, provider: GenericProvider, sssd_service_user: str):
+def test_sudo__user_allowed(client: Client, provider: GenericProvider):
     """
     :title: One user is allowed to run command, other user is not
     :setup:
@@ -52,7 +47,6 @@ def test_sudo__user_allowed(client: Client, provider: GenericProvider, sssd_serv
     provider.user("user-2").add()
     provider.sudorule("test").add(user=u, host="ALL", command="/bin/ls")
 
-    client.sssd.set_service_user(sssd_service_user)
     client.sssd.common.sudo()
     client.sssd.start()
 
@@ -161,12 +155,7 @@ def test_sudo__case_sensitive_false(client: Client, provider: GenericProvider):
 @pytest.mark.importance("critical")
 @pytest.mark.authorization
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
-@pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
-@pytest.mark.require(
-    lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
-    "SSSD was built without support for running under non-root",
-)
-def test_sudo__rules_refresh(client: Client, provider: GenericProvider, sssd_service_user: str):
+def test_sudo__rules_refresh(client: Client, provider: GenericProvider):
     """
     :title: Sudo rules refresh works
     :setup:
@@ -190,7 +179,6 @@ def test_sudo__rules_refresh(client: Client, provider: GenericProvider, sssd_ser
     u = provider.user("user-1").add()
     r = provider.sudorule("test").add(user=u, host="ALL", command="/bin/ls")
 
-    client.sssd.set_service_user(sssd_service_user)
     client.sssd.common.sudo()
     client.sssd.domain["entry_cache_sudo_timeout"] = "2"
     client.sssd.start()
@@ -507,12 +495,7 @@ def test_sudo__prefer_full_refresh_over_smart_refresh(client: Client, full_inter
 @pytest.mark.authorization
 @pytest.mark.ticket(bz=1294670, gh=3969)
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
-@pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
-@pytest.mark.require(
-    lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
-    "SSSD was built without support for running under non-root",
-)
-def test_sudo__local_users_negative_cache(client: Client, provider: LDAP, sssd_service_user: str):
+def test_sudo__local_users_negative_cache(client: Client, provider: LDAP):
     """
     :title: Sudo responder hits negative cache for local users
     :setup:
@@ -539,7 +522,6 @@ def test_sudo__local_users_negative_cache(client: Client, provider: LDAP, sssd_s
     client.local.user("user-1").add()
     client.fs.write("/etc/sudoers.d/test", "user-1 ALL=(ALL) NOPASSWD:ALL")
 
-    client.sssd.set_service_user(sssd_service_user)
     client.sssd.common.sudo()
     client.sssd.nss.update(
         entry_negative_timeout="0",  # disable standard negative cache to make sure we hit the local user case


### PR DESCRIPTION
Currently when SSSD is built '--with-sssd-user=sssd' it's also configured to run under 'sssd' user by default via sssd.service, so that sssd.conf::user option is ignored anyway.
Since sssd.conf::user is deprecated and will go away, it doesn't make much sense to put effort into testing it.
What makes sense is to test sssd.service::User option, but this is out of scope of this patch.