### PR TITLE
Fix format string used for time values

### DIFF
--- a/src/db/sysdb_gpo.c
+++ b/src/db/sysdb_gpo.c
@@ -154,7 +154,7 @@ sysdb_gpo_store_gpo(struct sss_domain_info *domain,
             goto done;
         }
 
-        lret = ldb_msg_add_fmt(update_msg, SYSDB_GPO_TIMEOUT_ATTR, "%lu",
+        lret = ldb_msg_add_fmt(update_msg, SYSDB_GPO_TIMEOUT_ATTR, "%"SPRItime,
                                ((cache_timeout) ? (now + cache_timeout) : 0));
         if (lret != LDB_SUCCESS) {
             ret = sysdb_error_to_errno(lret);
@@ -198,7 +198,7 @@ sysdb_gpo_store_gpo(struct sss_domain_info *domain,
             goto done;
         }
 
-        lret = ldb_msg_add_fmt(update_msg, SYSDB_GPO_TIMEOUT_ATTR, "%lu",
+        lret = ldb_msg_add_fmt(update_msg, SYSDB_GPO_TIMEOUT_ATTR, "%"SPRItime,
                                ((cache_timeout) ? (now + cache_timeout) : 0));
         if (lret != LDB_SUCCESS) {
             ret = sysdb_error_to_errno(lret);

--- a/src/providers/be_ptask.c
+++ b/src/providers/be_ptask.c
@@ -124,7 +124,7 @@ static void be_ptask_execute(struct tevent_context *ev,
         /* continue */
     }
 
-    DEBUG(SSSDBG_TRACE_FUNC, "Task [%s]: executing task, timeout %lu "
+    DEBUG(SSSDBG_TRACE_FUNC, "Task [%s]: executing task, timeout %"SPRItime" "
                               "seconds\n", task->name, task->timeout);
 
     task->last_execution = tv.tv_sec;
@@ -231,14 +231,14 @@ static void be_ptask_schedule(struct be_ptask *task,
     if(from & BE_PTASK_SCHEDULE_FROM_NOW) {
         tv = sss_tevent_timeval_current_ofs_time_t(delay);
 
-        DEBUG(SSSDBG_TRACE_FUNC, "Task [%s]: scheduling task %lu seconds "
-              "from now [%lu]\n", task->name, delay, tv.tv_sec);
+        DEBUG(SSSDBG_TRACE_FUNC, "Task [%s]: scheduling task %"SPRItime" seconds "
+              "from now [%"SPRItime"]\n", task->name, delay, tv.tv_sec);
     }
     else if (from & BE_PTASK_SCHEDULE_FROM_LAST) {
         tv = tevent_timeval_set(task->last_execution + delay, 0);
 
-        DEBUG(SSSDBG_TRACE_FUNC, "Task [%s]: scheduling task %lu seconds "
-                                  "from last execution time [%lu]\n",
+        DEBUG(SSSDBG_TRACE_FUNC, "Task [%s]: scheduling task %"SPRItime" seconds "
+                                  "from last execution time [%"SPRItime"]\n",
                                   task->name, delay, tv.tv_sec);
     }
 

--- a/src/responder/common/cache_req/plugins/cache_req_group_by_filter.c
+++ b/src/responder/common/cache_req/plugins/cache_req_group_by_filter.c
@@ -94,7 +94,7 @@ cache_req_group_by_filter_lookup(TALLOC_CTX *mem_ctx,
     if (is_files_provider(domain)) {
         recent_filter = NULL;
     } else {
-        recent_filter = talloc_asprintf(mem_ctx, "(%s>=%lu)", SYSDB_LAST_UPDATE,
+        recent_filter = talloc_asprintf(mem_ctx, "(%s>=%"SPRItime")", SYSDB_LAST_UPDATE,
                                         cr->req_start);
         if (recent_filter == NULL) {
             return ENOMEM;

--- a/src/responder/common/cache_req/plugins/cache_req_user_by_filter.c
+++ b/src/responder/common/cache_req/plugins/cache_req_user_by_filter.c
@@ -97,7 +97,7 @@ cache_req_user_by_filter_lookup(TALLOC_CTX *mem_ctx,
     if (is_files_provider(domain) || data->name.attr != NULL) {
         recent_filter = NULL;
     } else {
-        recent_filter = talloc_asprintf(mem_ctx, "(%s>=%lu)", SYSDB_LAST_UPDATE,
+        recent_filter = talloc_asprintf(mem_ctx, "(%s>=%"SPRItime")", SYSDB_LAST_UPDATE,
                                         cr->req_start);
         if (recent_filter == NULL) {
             return ENOMEM;

--- a/src/responder/kcm/secrets/secrets.c
+++ b/src/responder/kcm/secrets/secrets.c
@@ -513,7 +513,7 @@ static int local_db_create(struct sss_sec_req *req)
         goto done;
     }
 
-    ret = ldb_msg_add_fmt(msg, SEC_ATTR_CTIME, "%lu", time(NULL));
+    ret = ldb_msg_add_fmt(msg, SEC_ATTR_CTIME, "%"SPRItime"", time(NULL));
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
               "ldb_msg_add_string failed adding creationTime [%d]: %s\n",
@@ -1057,7 +1057,7 @@ errno_t sss_sec_put(struct sss_sec_req *req,
     }
     erase_msg = true;
 
-    ret = ldb_msg_add_fmt(msg, SEC_ATTR_CTIME, "%lu", time(NULL));
+    ret = ldb_msg_add_fmt(msg, SEC_ATTR_CTIME, "%"SPRItime"", time(NULL));
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
               "ldb_msg_add_string failed adding creationTime [%d]: %s\n",


### PR DESCRIPTION
When building for armhf with `_TIME_BITS=64`, the `%lu` format string used to represent `time_t` values as strings is no longer correct. Switch to `SPRItime` which takes into account the `time_t` size.