### PR TITLE
Tests: Update reference to polarion.yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,7 +393,7 @@ jobs:
           --mh-config=./mhc.yaml \
           --mh-log-path=$GITHUB_WORKSPACE/mh.log \
           --mh-artifacts-dir=$GITHUB_WORKSPACE/artifacts \
-          --polarion-config=./polarion.yaml \
+          --polarion-config=../polarion.yaml \
           --output-polarion-testcase=$GITHUB_WORKSPACE/artifacts/testcase.xml \
           --collect-only . |& tee $GITHUB_WORKSPACE/pytest-collect.log
 
@@ -410,7 +410,7 @@ jobs:
           --mh-config=./mhc.yaml \
           --mh-log-path=$GITHUB_WORKSPACE/mh.log \
           --mh-artifacts-dir=$GITHUB_WORKSPACE/artifacts \
-          --polarion-config=./polarion.yaml \
+          --polarion-config=../polarion.yaml \
           --output-polarion-testcase=$GITHUB_WORKSPACE/artifacts/testcase.xml \
           --output-polarion-testrun=$GITHUB_WORKSPACE/artifacts/testrun.xml \
           -vvv . |& tee $GITHUB_WORKSPACE/pytest.log


### PR DESCRIPTION
Despite PRCI should not be using polarion.yaml as it is used for an internal system, it still references it so the path has to be updated.