### PR TITLE
BUILD: link 'krb5_child' against 'libsystemd' if needed

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4737,6 +4737,10 @@ krb5_child_LDADD = \
     $(CAP_LIBS) \
     $(NULL)
 
+if HAVE_SYSTEMD_UNIT
+    krb5_child_LDADD += $(SYSTEMD_DAEMON_LIBS)
+endif
+
 ldap_child_SOURCES = \
     src/providers/ldap/ldap_child.c \
     src/providers/krb5/krb5_keytab.c \


### PR DESCRIPTION
This is addition to #7268

If SSSD is configured with
```
  --with-initscript=systemd
  --with-syslog=syslog
```
then 'krb5_child' need to be linked against 'libsystemd' due to `check_if_uid_is_active()` usage.

Resolves: https://github.com/SSSD/sssd/issues/7278