### PR TITLE
SPEC: suppress `chown` errors

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -1066,10 +1066,10 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d / -s /sbin/nologin -c "Us
 %__rm -f %{mcpath}/group
 %__rm -f %{mcpath}/initgroups
 %__rm -f %{mcpath}/sid
-%__chown %{sssd_user}:%{sssd_user} %{dbpath}/*
-%__chown %{sssd_user}:%{sssd_user} %{_sysconfdir}/sssd/sssd.conf
-%__chown -R %{sssd_user}:%{sssd_user} %{_sysconfdir}/sssd/conf.d
-%__chown %{sssd_user}:%{sssd_user} %{_var}/log/%{name}/*.log
+%__chown -f %{sssd_user}:%{sssd_user} %{dbpath}/* || true
+%__chown -f %{sssd_user}:%{sssd_user} %{_sysconfdir}/sssd/sssd.conf || true
+%__chown -f -R %{sssd_user}:%{sssd_user} %{_sysconfdir}/sssd/conf.d || true
+%__chown -f %{sssd_user}:%{sssd_user} %{_var}/log/%{name}/*.log || true
 
 %preun common
 %systemd_preun sssd.service


### PR DESCRIPTION
Files that package chown's during installation might not exist and that's totally fine (clean install).