### PR TITLE
Fixes #5536

### DIFF
--- a/src/monitor/monitor_bootstrap.c
+++ b/src/monitor/monitor_bootstrap.c
@@ -95,7 +95,7 @@ int bootstrap_monitor_process(void)
              */
             sss_log(SSS_LOG_WARNING, "'sssd.conf::"CONFDB_MONITOR_USER_RUNAS"' "
                     "option is deprecated. Run under '"SSSD_USER"' initially instead.");
-            ret = become_user(target_uid, target_gid); /* drops all caps */
+            ret = become_user(target_uid, target_gid, false); /* drops all caps */
             if (ret != 0) {
                 sss_log(SSS_LOG_ALERT, "Failed to change uid:gid");
                 return 1;

--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -152,7 +152,7 @@ static errno_t k5c_become_user(uid_t uid, gid_t gid, bool is_posix)
               "Will not drop privileges for a non-POSIX user\n");
         return EOK;
     }
-    return become_user(uid, gid);
+    return become_user(uid, gid, true);
 }
 
 static krb5_error_code set_lifetime_options(struct cli_opts *cli_opts,

--- a/src/providers/ldap/sdap_child_helpers.c
+++ b/src/providers/ldap/sdap_child_helpers.c
@@ -211,12 +211,6 @@ static errno_t create_child_req_send_buffer(TALLOC_CTX *mem_ctx,
     /* lifetime */
     SAFEALIGN_SET_UINT32(&buf->data[rp], lifetime, &rp);
 
-    /* UID and GID to drop privileges to, if needed. The ldap_child process runs as
-     * setuid if the back end runs unprivileged as it needs to access the keytab
-     */
-    SAFEALIGN_SET_UINT32(&buf->data[rp], geteuid(), &rp);
-    SAFEALIGN_SET_UINT32(&buf->data[rp], getegid(), &rp);
-
     *io_buf = buf;
     return EOK;
 }

--- a/src/tests/cwrap/test_become_user.c
+++ b/src/tests/cwrap/test_become_user.c
@@ -43,7 +43,7 @@ void test_become_user(void **state)
     pid = fork();
     if (pid == 0) {
         /* Change the UID in a child */
-        ret = become_user(sssd->pw_uid, sssd->pw_gid);
+        ret = become_user(sssd->pw_uid, sssd->pw_gid, false);
         assert_int_equal(ret, EOK);
 
         /* Make sure we have the requested UID and GID now and there
@@ -55,7 +55,7 @@ void test_become_user(void **state)
         assert_int_equal(getgid(), sssd->pw_gid);
 
         /* Another become_user is a no-op */
-        ret = become_user(sssd->pw_uid, sssd->pw_gid);
+        ret = become_user(sssd->pw_uid, sssd->pw_gid, false);
         assert_int_equal(ret, EOK);
 
         assert_int_equal(getgroups(0, NULL), 0);

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -744,7 +744,7 @@ errno_t mod_defaults_list(TALLOC_CTX *mem_ctx, const char **defaults_list,
                           char **mod_list, char ***_list);
 
 /* from become_user.c */
-errno_t become_user(uid_t uid, gid_t gid);
+errno_t become_user(uid_t uid, gid_t gid, bool keep_set_uid);
 struct sss_creds;
 errno_t switch_creds(TALLOC_CTX *mem_ctx,
                      uid_t uid, gid_t gid,


### PR DESCRIPTION
See commits comments for details.

Note about `keep 'set-user-ID' in k5c_become_user()`: this change potentially creates a way to regain `euid` back from `suid`. If SSSD runs under 'sssd' user it's not an issue at all. If SSSD runs under 'root' then it's worse - `man capabilities`:
```
If the effective user ID is changed from nonzero to 0, then the permitted set is copied to the effective set.
```
but:
 - 'permitted' set should be clean at this point (after `sss_drop_all_caps()`), but I didn't test it yet
 - frankly, if 'krb5_child' is compromised there are plenty of other (more simple) ways to exploit it than to regain capabilities from bounding set (that are present at startup anyway)
 - users looking for security hardening should run SSSD under 'sssd' user 