### PR TITLE
TESTS: 'config_file_version' option doesn't exist

### DIFF
--- a/src/tests/multihost/sssd/testlib/common/utils.py
+++ b/src/tests/multihost/sssd/testlib/common/utils.py
@@ -337,7 +337,6 @@ class sssdTools(object):
             self.multihost.transport.get_file(SSSD_DEFAULT_CONF, tmpconf.name)
         except IOError:
             config.add_section('sssd')
-            config.set('sssd', 'config_file_version', '2')
             config.set('sssd', 'services', 'nss, pam')
         else:
             try:


### PR DESCRIPTION
since e57093067665bb15c76cb88269fae93d44499bd5