### PR TITLE
scripts: add sssd.sysusers to srpm generated by make_srpm.sh

### DIFF
--- a/contrib/fedora/make_srpm.sh
+++ b/contrib/fedora/make_srpm.sh
@@ -176,6 +176,8 @@ add_patches "$RPMBUILD/SPECS/$PACKAGE_NAME.spec" \
             "$RPMBUILD/SOURCES" \
             "${patches[@]}"
 
+cp "$SRC_DIR"/contrib/sssd.sysusers "$RPMBUILD/SOURCES" 2>/dev/null
+
 cd $RPMBUILD
 rpmbuild --define "_topdir $RPMBUILD" \
          -bs SPECS/$PACKAGE_NAME.spec


### PR DESCRIPTION
This script is used by .copr/Makefile.