### PR TITLE
RESPONDER: use proper context for getDomains()

### DIFF
--- a/src/responder/pac/pacsrv_cmd.c
+++ b/src/responder/pac/pacsrv_cmd.c
@@ -146,7 +146,7 @@ static errno_t pac_add_pac_user(struct cli_ctx *cctx)
     ret = responder_get_domain_by_id(cctx->rctx, pr_ctx->user_dom_sid_str,
                                      &pr_ctx->dom);
     if (ret == EAGAIN || ret == ENOENT) {
-        req = sss_dp_get_domains_send(cctx->rctx, cctx->rctx, true,
+        req = sss_dp_get_domains_send(cctx, cctx->rctx, true,
                                       pr_ctx->domain_name);
         if (req == NULL) {
             ret = ENOMEM;

--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -1929,7 +1929,7 @@ static int pam_forwarder(struct cli_ctx *cctx, int pam_cmd)
 
     ret = pam_forwarder_parse_data(cctx, pd);
     if (ret == EAGAIN) {
-        req = sss_dp_get_domains_send(cctx->rctx, cctx->rctx, true, pd->domain);
+        req = sss_dp_get_domains_send(cctx, cctx->rctx, true, pd->domain);
         if (req == NULL) {
             ret = ENOMEM;
         } else {


### PR DESCRIPTION
Request was created on a long term responder context, but a callback for this request tries to access memory that is allocated on a short term client context. So if client disconnects before request is completed, then callback dereferences already freed memory.

Resolves: https://github.com/SSSD/sssd/issues/7319