### PR TITLE
Tests: Fix passkey non-root check for sssd service

### DIFF
--- a/src/tests/system/tests/test_passkey.py
+++ b/src/tests/system/tests/test_passkey.py
@@ -20,7 +20,7 @@ from sssd_test_framework.topology import KnownTopology, KnownTopologyGroup
 
 
 def passkey_requires_root(client: Client) -> tuple[bool, str] | bool:
-    if client.svc.get_property("sssd", "User") != "root":
+    if client.svc.get_property("sssd", "User") not in ("root", ""):
         return False, "Passkey tests don't work if SSSD runs under non-root"
 
     return True


### PR DESCRIPTION
In the system test_passkey.py module, the passkey_requires_root function only checked if root was returned.  However with older versions of SSSD, the systemctl show command did not return anything because there was no User variable defined.  In those cases, the check returned an empty string and the check failed and is skipping tests that should be run.