### PR TITLE
ci: explicitly set which topologies are already provisioned

### DIFF
--- a/src/tests/system/mhc.yaml
+++ b/src/tests/system/mhc.yaml
@@ -1,3 +1,9 @@
+provisioned_topologies:
+- client
+- ipa
+- ipa-trust-samba
+- ldap
+- samba
 domains:
 - id: sssd
   hosts:
@@ -34,12 +40,9 @@ domains:
       username: Administrator@ad.test
       password: vagrant
     config:
-      binddn: Administrator@ad.test
-      bindpw: vagrant
+      adminpw: vagrant
       client:
         ad_domain: ad.test
-        krb5_keytab: /enrollment/ad.test.keytab
-        ldap_krb5_keytab: /enrollment/ad.test.keytab
 
   - hostname: dc.samba.test
     role: samba


### PR DESCRIPTION
PRCI uses containers that already have multiple topologies provisioned
out of the box. pytest-mh and sssd-test-framework recently got the
ability to provision topology directly from pytest so in order to skip
this step in PRCI we need to set it explicitly.

Note that the client container is currently not enrolled in AD, so we
use topology setup there. Therefore if you run the tests locally with
AD running, you don't have to do a thing - client will automatically
join and leave the AD domain when AD/IPA-TRUST-AD topology is run.

---

Please note that this needs to be closed together with changes to other repositories:
* https://github.com/SSSD/sssd-test-framework/pull/103
* https://github.com/SSSD/sssd-ci-containers/pull/95
* https://github.com/next-actions/pytest-mh/pull/54