### PR TITLE
Use the DN from existing entry when updating a cached group

### DIFF
--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -2613,6 +2613,22 @@ int sysdb_store_user(struct sss_domain_info *domain,
         }
     } else {
         /* the user exists, let's just replace attributes when set */
+        /*
+         * The sysdb_search_user_by_name() function also matches lowercased
+         * aliases, saved when the domain is case-insensitive. This means that
+         * the stored entry name can differ in capitalization from the search
+         * name. Use the cached entry name to perform the modification because
+         * if name capitalization in entry's DN differs the modify operation
+         * will fail.
+         */
+        const char *entry_name =
+            ldb_msg_find_attr_as_string(msg, SYSDB_NAME, NULL);
+        if (entry_name != NULL) {
+            name = entry_name;
+        } else {
+            DEBUG(SSSDBG_MINOR_FAILURE, "User '%s' without a name?\n", name);
+        }
+
         ret = sysdb_store_user_attrs(domain, name, uid, gid, gecos, homedir,
                                      shell, orig_dn, attrs, remove_attrs,
                                      cache_timeout, now);
@@ -2847,6 +2863,22 @@ int sysdb_store_group(struct sss_domain_info *domain,
         ret = sysdb_store_new_group(domain, name, gid, attrs,
                                     cache_timeout, now);
     } else {
+        /*
+         * The sysdb_search_group_by_name() function also matches lowercased
+         * aliases, saved when the domain is case-insensitive. This means that
+         * the stored entry name can differ in capitalization from the search
+         * name. Use the cached entry name to perform the modification because
+         * if name capitalization in entry's DN differs the modify operation
+         * will fail.
+         */
+        const char *entry_name =
+            ldb_msg_find_attr_as_string(msg, SYSDB_NAME, NULL);
+        if (entry_name != NULL) {
+            name = entry_name;
+        } else {
+            DEBUG(SSSDBG_MINOR_FAILURE, "Group '%s' without a name?\n", name);
+        }
+
         ret = sysdb_store_group_attrs(domain, name, gid, attrs,
                                       cache_timeout, now);
     }


### PR DESCRIPTION
I have found an issue where storing a group fails with:

```
[sdap_save_group] (0x0400): Processing group lowercase@example.com
[sdap_check_ad_group_type] (0x4000): AD group [lowercase@example.com] has type flags 0x80000002
[sdap_save_group] (0x0400): Storing info for group lowercase@example.com.
[sysdb_check_ts_cache] (0x2000): Cannot find TS cache entry for [name=lowercase@example.com,cn=groups,cn=example.com,cn=sysdb]: [2]: No such file or directory
[ldb] (0x4000): Entry not found (name=lowercase@example.com,cn=groups,cn=example.com,cn=sysdb)
[sysdb_set_cache_entry_attr] (0x0080): ldb_modify failed: [No such object](32)[ldb_wait from ldb_modify with LDB_WAIT_ALL: No such object (32)]
[sysdb_set_entry_attr] (0x0080): Cannot set attrs for name=lowercase@example.com,cn=groups,cn=example.com,cn=sysdb, 2 [No such file or directory]
[sysdb_store_group] (0x0400): Error: 2 (No such file or directory)
[sdap_store_group_with_gid] (0x0040): Could not store group lowercase@example.com
[sdap_save_group] (0x0080): Could not store group with GID: [No such file or directory]
[sdap_save_group] (0x0080): Failed to save group [lowercase@example.com]: [No such file or directory]
```

The entry exists in the cache, although with different capitalization:

```
dn: name=UPPERCASE@example.com,cn=groups,cn=example.com,cn=sysdb
gidNumber: 123456
name: UPPERCASE@example.com
objectCategory: group
originalDN: CN=UPPERCASE,OU=xxx,OU=xxx,DC=example,DC=com
objectSIDString: S-1-5-21-1234567890-123456789-1234567890-123456
memberof: name=xxx@example.com,cn=groups,cn=example.com,cn=sysdb
orig_member: CN=xxx,OU=xxx,OU=xxx,DC=example,DC=com
orig_member: CN=yyy,OU=xxx,OU=xxx,DC=example,DC=com
nameAlias: lowercase@example.com
distinguishedName: name=UPPERCASE@example.com,cn=groups,cn=example.com,cn=sysdb
```

The problem is in that `sysdb_store_group()` searches the group including nameAlias, but subsequent modification fails because the DN is built based on the given name which may differ in case.

IMO if the first search finds the entry, its DN must be used to modify it.