### PR TITLE
LDAP: Trigger password change in case of grace login with expired password

### DIFF
--- a/src/config/SSSDConfig/sssdoptions.py
+++ b/src/config/SSSDConfig/sssdoptions.py
@@ -398,6 +398,7 @@ class SSSDOptions(object):
         'ldap_disable_paging': _('Disable the LDAP paging control'),
         'ldap_disable_range_retrieval': _('Disable Active Directory range retrieval'),
         'ldap_use_ppolicy': _('Use the ppolicy extension'),
+        'ldap_ppolicy_pwd_change_threshold': _('Force a password change when remaining grace logins reach or go below this threshold'),
 
         # [provider/ldap/id]
         'ldap_search_timeout': _('Length of time to wait for a search request'),

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -747,6 +747,7 @@ option = ldap_tls_key
 option = ldap_tls_reqcert
 option = ldap_uri
 option = ldap_use_ppolicy
+option = ldap_ppolicy_pwd_change_threshold
 option = ldap_user_ad_account_expires
 option = ldap_user_ad_user_account_control
 option = ldap_user_authorized_host

--- a/src/config/etc/sssd.api.d/sssd-ldap.conf
+++ b/src/config/etc/sssd.api.d/sssd-ldap.conf
@@ -44,6 +44,7 @@ ldap_disable_paging = bool, None, false
 ldap_disable_range_retrieval = bool, None, false
 wildcard_limit = int, None, false
 ldap_use_ppolicy = bool, None, false
+ldap_ppolicy_pwd_change_threshold = int, None, false
 
 [provider/ldap/id]
 ldap_search_timeout = int, None, false

--- a/src/man/sssd-ldap.5.xml
+++ b/src/man/sssd-ldap.5.xml
@@ -1488,7 +1488,8 @@ ldap_access_filter = (employeeType=admin)
                         <para>
                             Please note that 'access_provider = ldap' must
                             be set for this feature to work. Also 'ldap_pwd_policy'
-                            must be set to an appropriate password policy.
+                            must be set to shadow or mit_kerberos, these options
+                            do not work with server-side password policies.
                         </para>
                         <para>
                             <emphasis>authorized_service</emphasis>: use
@@ -1650,6 +1651,25 @@ ldap_access_filter = (employeeType=admin)
                         </para>
                         <para>
                             Default: true
+                        </para>
+                    </listitem>
+                </varlistentry>
+
+                <varlistentry>
+                    <term>ldap_ppolicy_pwd_change_threshold (integer)</term>
+                    <listitem>
+                        <para>
+                            Forces a password change when server side password
+                            policy controls are enabled and remaining grace
+                            logins returned by the server after the
+                            authentication reach or go below the threshold.
+                            Note that the minimum useful value is 2, as changing
+                            the password consumes 2 additional grace logins, one
+                            to verify the current password and a second one to
+                            perform the password change.
+                        </para>
+                        <para>
+                            Default: 0
                         </para>
                     </listitem>
                 </varlistentry>

--- a/src/providers/ad/ad_opts.c
+++ b/src/providers/ad/ad_opts.c
@@ -168,6 +168,7 @@ struct dp_option ad_def_ldap_opts[] = {
     { "wildcard_limit", DP_OPT_NUMBER, { .number = 1000 }, NULL_NUMBER},
     { "ldap_library_debug_level", DP_OPT_NUMBER, NULL_NUMBER, NULL_NUMBER},
     { "ldap_use_ppolicy", DP_OPT_BOOL, BOOL_TRUE, BOOL_TRUE },
+    { "ldap_ppolicy_pwd_change_threshold", DP_OPT_NUMBER, { .number = 0 }, NULL_NUMBER },
     DP_OPTION_TERMINATOR
 };
 

--- a/src/providers/ipa/ipa_opts.c
+++ b/src/providers/ipa/ipa_opts.c
@@ -178,6 +178,7 @@ struct dp_option ipa_def_ldap_opts[] = {
     { "wildcard_limit", DP_OPT_NUMBER, { .number = 1000 }, NULL_NUMBER},
     { "ldap_library_debug_level", DP_OPT_NUMBER, NULL_NUMBER, NULL_NUMBER},
     { "ldap_use_ppolicy", DP_OPT_BOOL, BOOL_TRUE, BOOL_TRUE },
+    { "ldap_ppolicy_pwd_change_threshold", DP_OPT_NUMBER, { .number = 0 }, NULL_NUMBER },
     DP_OPTION_TERMINATOR
 };
 

--- a/src/providers/ldap/ldap_auth.h
+++ b/src/providers/ldap/ldap_auth.h
@@ -43,7 +43,8 @@ int get_user_dn(TALLOC_CTX *memctx,
 errno_t check_pwexpire_policy(enum pwexpire pw_expire_type,
                               void *pw_expire_data,
                               struct pam_data *pd,
-                              errno_t checkb);
+                              int pwd_expiration_warning,
+                              struct sdap_options *opts);
 
 
 #endif /* _LDAP_AUTH_H_ */

--- a/src/providers/ldap/ldap_opts.c
+++ b/src/providers/ldap/ldap_opts.c
@@ -135,6 +135,7 @@ struct dp_option default_basic_opts[] = {
     { "wildcard_limit", DP_OPT_NUMBER, { .number = 1000 }, NULL_NUMBER},
     { "ldap_library_debug_level", DP_OPT_NUMBER, NULL_NUMBER, NULL_NUMBER},
     { "ldap_use_ppolicy", DP_OPT_BOOL, BOOL_TRUE, BOOL_TRUE },
+    { "ldap_ppolicy_pwd_change_threshold", DP_OPT_NUMBER, { .number = 0 }, NULL_NUMBER },
     DP_OPTION_TERMINATOR
 };
 

--- a/src/providers/ldap/sdap.h
+++ b/src/providers/ldap/sdap.h
@@ -238,6 +238,7 @@ enum sdap_basic_opt {
     SDAP_WILDCARD_LIMIT,
     SDAP_LIBRARY_DEBUG_LEVEL,
     SDAP_USE_PPOLICY,
+    SDAP_PPOLICY_PWD_CHANGE_THRESHOLD,
 
     SDAP_OPTS_BASIC /* opts counter */
 };

--- a/src/providers/ldap/sdap_access.c
+++ b/src/providers/ldap/sdap_access.c
@@ -807,7 +807,7 @@ static errno_t perform_pwexpire_policy(TALLOC_CTX *mem_ctx,
     }
 
     ret = check_pwexpire_policy(pw_expire_type, pw_expire_data, pd,
-                                domain->pwd_expiration_warning);
+                                domain->pwd_expiration_warning, opts);
     if (ret != EOK) {
         DEBUG(SSSDBG_MINOR_FAILURE,
               "check_pwexpire_policy returned %d:[%s].\n",


### PR DESCRIPTION
If LDAP server enforces password policies and the extended control is returned in the bind response, trigger a password change in the case of grace login.