### PR TITLE
MONITOR: tune startup logic a bit

### DIFF
--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -533,8 +533,10 @@ static int add_services_startup_timeout(struct mt_ctx *ctx)
     struct tevent_timer *to;
     struct timeval tv;
 
-    /* 5 seconds should be plenty */
-    tv = tevent_timeval_current_ofs(5, 0);
+    /* 7 seconds should be enough to accommodate for
+     * MONITOR_MAX_SVC_RESTARTS & MONITOR_MAX_RESTART_DELAY
+     */
+    tv = tevent_timeval_current_ofs(7, 0);
     to = tevent_add_timer(ctx->ev, ctx, tv, services_startup_timeout, ctx);
     if (!to) {
         DEBUG(SSSDBG_FATAL_FAILURE,"Out of memory?!\n");


### PR DESCRIPTION
Before those patches monitor performed several attempts to start a provider, then started responders, and then quit anyway because all attempt to start a provider were eventually exhausted.

This patch tunes timer so that all attempts to start a provider are exhausted before timer fires (and responders aren't even started).

User visible change is that SSSD now properly notifies systemd that service start failed (instead of reporting it started and then terminated).