### PR TITLE
SPEC: Add Requires: sssd-krb5-common for KCM ticket renewals

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -535,6 +535,7 @@ License: GPLv3+
 Requires: sssd-common = %{version}-%{release}
 %if %{build_kcm_renewals}
 Requires: krb5-libs >= %{krb5_version}
+Requires: sssd-krb5-common = %{version}-%{release}
 %endif
 %{?systemd_requires}
 


### PR DESCRIPTION
### Proposed change

The KCM ticket-renewal feature relies on the `/usr/libexec/ssd/krb5_child` binary for functionality. That binary is provided by the RPM package `sssd-krb5-common`. This commit fixes the dependency of `sssd-kcm` in the spec file.

### Steps to replicate the bug
On a fresh install of Fedora 40 via the Docker container image with `sssd-kcm` and `krb5-workstation` installed,
I ran into a bug where a renewable Kerberos TGT stored in the KCM fails to be renewed, even though I have set `tgt_renewal = true` in my `sssd.conf`. After enabling debug logging, here is what the log records when `sssd-kcm` attempts to renew the TGT:
```
(2024-05-09 16:13:25): [kcm] [kcm_child_req_setup] (0x2000): Setup for renewal of [REDACTED] for principal name [1000]
(2024-05-09 16:13:25): [kcm] [create_send_buffer] (0x0400): krb5_keytab not set for domain in sssd.conf
(2024-05-09 16:13:25): [kcm] [child_handler_setup] (0x2000): Setting up signal handler up for pid [682]
(2024-05-09 16:13:25): [kcm] [child_handler_setup] (0x2000): Signal handler set up for pid [682]
(2024-05-09 16:13:25): [kcm] [_write_pipe_handler] (0x0400): All data has been sent!
(2024-05-09 16:13:25): [kcm] [exec_child_ex] (0x0040): execv failed [2][No such file or directory].
(2024-05-09 16:13:25): [kcm] [kcm_responder_ctx_destructor] (0x0400): Responder is being shut down
(2024-05-09 16:13:25): [kcm] [_read_pipe_handler] (0x0020): read failed [5][Input/output error].
(2024-05-09 16:13:25): [kcm] [kcm_renew_tgt_done] (0x0010): Failed to receive krb5 child process request[5]: Input/output error
(2024-05-09 16:13:25): [kcm] [child_sig_handler] (0x1000): Waiting for child [682].
(2024-05-09 16:13:25): [kcm] [child_sig_handler] (0x0020): child [682] failed with status [1].
```
The result is that TGT renewal silently fails with no warning in the user-visible log.

### Steps to resolve the bug
Tracing the call stack indicated by the log, I found this relevant call to `exec_child_ex()` that generated the `execv()` failure:
https://github.com/SSSD/sssd/blob/7f48c7c448124dea68f2835c7e10742f48f8bc6c/src/providers/krb5/krb5_child_handler.c#L570-L574
The `KRB5_CHILD` constant evaluates to the binary `/usr/libexec/sssd/krb5_child` provided by the `sssd-krb5-common` package. Installing that package fixed the issue.

### Rationale for change
Given that `sssd-kcm` can be installed independently from the metapackage `sssd` or `sssd-krb5`, it makes sense to make it explicitly depend on `sssd-krb5-common` in order to allow the TGT renewal functionality to work as expected on a minimal installation that does not require the rest of `sssd` functionality.