### PR TITLE
TOOLS: don't overwrite config.ldb

### DIFF
--- a/src/tests/intg/test_sssctl.py
+++ b/src/tests/intg/test_sssctl.py
@@ -496,28 +496,28 @@ def test_debug_level_no_sssd(conf_stub_domain, portable_LC_ALL):
                         stderr_output=subprocess.STDOUT)
     except subprocess.CalledProcessError as cpe:
         assert cpe.returncode == 1
-        assert "SSSD is not running" in cpe.output
+        assert "SSSD isn't configured" in cpe.output
 
     try:
         get_call_output(["sssctl", "debug-level", "0x70"], check=True,
                         stderr_output=subprocess.STDOUT)
     except subprocess.CalledProcessError as cpe:
         assert cpe.returncode == 1
-        assert "SSSD is not running" in cpe.output
+        assert "SSSD isn't configured" in cpe.output
 
     try:
         get_call_output(["sssctl", "debug-level", "--nss"], check=True,
                         stderr_output=subprocess.STDOUT)
     except subprocess.CalledProcessError as cpe:
         assert cpe.returncode == 1
-        assert "SSSD is not running" in cpe.output
+        assert "SSSD isn't configured" in cpe.output
 
     try:
         get_call_output(["sssctl", "debug-level", "--nss", "0x70"], check=True,
                         stderr_output=subprocess.STDOUT)
     except subprocess.CalledProcessError as cpe:
         assert cpe.returncode == 1
-        assert "SSSD is not running" in cpe.output
+        assert "SSSD isn't configured" in cpe.output
 
 
 def test_invalidate_missing_specific_entry(ldap_conn, sanity_rfc2307, portable_LC_ALL):


### PR DESCRIPTION
This partially reverts d2d8f342cd5e90bb9fd947c448492225f959aa86 There should be no reason for 'sssctl' to run if SSSD itself isn't running (ir wasn't run so 'config.ldb' is absent).

Enforced recreation of 'config.ldb', on the other hand, might spoil file ownership, as 'sssct' is typically run under 'root', but SSSD itself might running under 'sssd' user.