### PR TITLE
oidc_child: fix wrong usage of '%*s'

### DIFF
--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -5741,7 +5741,7 @@ errno_t sysdb_ldb_list_indexes(TALLOC_CTX *mem_ctx,
             indexes = talloc_realloc(mem_ctx, indexes, const char *, j + 2);
             if (indexes == NULL) ERROR_OUT(ret, ENOMEM, done);
 
-            indexes[j] = talloc_asprintf(indexes, "%*s", length, data);
+            indexes[j] = talloc_asprintf(indexes, "%.*s", length, data);
             if (indexes[j] == NULL) ERROR_OUT(ret, ENOMEM, done);
 
             indexes[++j] = NULL;

--- a/src/oidc_child/oidc_child_curl.c
+++ b/src/oidc_child/oidc_child_curl.c
@@ -76,9 +76,9 @@ static size_t write_callback(char *ptr, size_t size, size_t nmemb,
     struct devicecode_ctx *dc_ctx = (struct devicecode_ctx *) userdata;
     char *tmp = NULL;
 
-    DEBUG(SSSDBG_TRACE_ALL, "%*s\n", (int) realsize, ptr);
+    DEBUG(SSSDBG_TRACE_ALL, "%.*s\n", (int) realsize, ptr);
 
-    tmp = talloc_asprintf(dc_ctx, "%s%*s",
+    tmp = talloc_asprintf(dc_ctx, "%s%.*s",
                           dc_ctx->http_data == NULL ? "" : dc_ctx->http_data,
                           (int) realsize, ptr);
     talloc_free(dc_ctx->http_data);


### PR DESCRIPTION
If it is not clear if a string is 0-terminated or not but the length is
known the '%.*s' template must be used to use only given numbers of
characters. '%*s' is a valid printf() template but only sets the minimal
width of the output.

This patch fixes an occurrence ion the sysdb code as well.