### PR TITLE
sss-client: handle key value in destructor

### DIFF
--- a/src/external/samba.m4
+++ b/src/external/samba.m4
@@ -4,6 +4,7 @@ AC_SUBST(SMBCLIENT_CFLAGS)
 AC_SUBST(SMBCLIENT_LIBS)
 AC_SUBST(NDR_KRB5PAC_CFLAGS)
 AC_SUBST(NDR_KRB5PAC_LIBS)
+AC_SUBST(IDMAP_SAMBA_LIBS)
 
 if test x"$with_samba" = xyes; then
     PKG_CHECK_MODULES(NDR_NBT, ndr_nbt, ,
@@ -62,13 +63,21 @@ them. In this case, you will need to execute configure script with argument
             AC_MSG_ERROR([Illegal value -$with_smb_idmap_interface_version- for option --with-smb-idmap-interface-version])
         fi
     else
-
-        AC_MSG_CHECKING([Samba's idmap plugin interface version])
         sambalibdir="`$PKG_CONFIG --variable=libdir smbclient`"/samba
+        AC_MSG_CHECKING([Samba's idmap library])
+        if test -f "${sambalibdir}/libidmap-private-samba.so"; then
+                IDMAP_SAMBA_LIBS=idmap-private-samba
+        elif test -f "${sambalibdir}/libidmap-samba4.so"; then
+                IDMAP_SAMBA_LIBS=idmap-samba4
+        else
+                AC_MSG_ERROR([Cannot find private idmap-samba library])
+        fi
+        AC_MSG_RESULT([found: $IDMAP_SAMBA_LIBS])
+        AC_MSG_CHECKING([Samba's idmap plugin interface version])
         SAVE_CFLAGS=$CFLAGS
         SAVE_LIBS=$LIBS
         CFLAGS="$CFLAGS $SMBCLIENT_CFLAGS $NDR_NBT_CFLAGS $NDR_KRB5PAC_CFLAGS"
-        LIBS="$LIBS -L${sambalibdir} -lidmap-samba4 -Wl,-rpath ${sambalibdir}"
+        LIBS="$LIBS -L${sambalibdir} -l${IDMAP_SAMBA_LIBS} -Wl,-rpath ${sambalibdir}"
         AC_RUN_IFELSE(
             [AC_LANG_SOURCE([
 #include <stdlib.h>

--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -1059,7 +1059,7 @@ static krb5_error_code create_empty_cred(krb5_context ctx, krb5_principal princ,
     krb5_creds *cred = NULL;
     krb5_data *krb5_realm;
 
-    cred = calloc(sizeof(krb5_creds), 1);
+    cred = calloc(1, sizeof(krb5_creds));
     if (cred == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "calloc failed.\n");
         return ENOMEM;

--- a/src/sss_client/common.c
+++ b/src/sss_client/common.c
@@ -93,8 +93,22 @@ void sss_cli_close_socket(void)
 #ifdef HAVE_PTHREAD_EXT
 static void sss_at_thread_exit(void *v)
 {
-    sss_cli_close_socket();
+    /* At this point the key value is already set to NULL and the only way to
+     * access the data from the value is via the argument passed to the
+     * destructor (sss_at_thread_exit). See e.g.
+     * https://www.man7.org/linux/man-pages/man3/pthread_key_create.3p.html
+     * for details. */
+
+    struct sss_socket_descriptor_t *descriptor = (struct sss_socket_descriptor_t *) v;
+
+    if (descriptor->sd != -1) {
+        close(descriptor->sd);
+        descriptor->sd = -1;
+    }
+
     free(v);
+
+    /* Most probably redudant, but better safe than sorry. */
     pthread_setspecific(sss_sd_key, NULL);
 }
 

--- a/src/tests/test_CA/intermediate_CA/Makefile.am
+++ b/src/tests/test_CA/intermediate_CA/Makefile.am
@@ -33,7 +33,7 @@ SSSD_test_CA.pem:
 	ln -s $(builddir)/../$@
 
 SSSD_test_intermediate_CA_req.pem: $(openssl_intermediate_ca_key) $(openssl_intermediate_ca_config) SSSD_test_CA.pem
-	$(OPENSSL) req -batch -config ${openssl_intermediate_ca_config} -new -nodes -key $< -sha256 -extensions v3_ca -out $@
+	$(OPENSSL) req -batch -config ${openssl_intermediate_ca_config} -new -nodes -key $< -sha256 -out $@
 
 SSSD_test_intermediate_CA.pem: SSSD_test_intermediate_CA_req.pem $(openssl_root_ca_config) $(openssl_root_ca_key)
 	cd .. && $(OPENSSL) ca -config ${openssl_root_ca_config} -batch -notext -keyfile $(openssl_root_ca_key) -in $(abs_builddir)/$< -days 200 -extensions v3_intermediate_ca -out $(abs_builddir)/$@


### PR DESCRIPTION
When the pthread key destructor is called the key value is already set to NULL by the caller. As a result the data stored in the value can only be accessed by the first argument passed to the destructor and not by pthread_getspecific() as the previous code did.

Resolves: https://github.com/SSSD/sssd/issues/7189

Reviewed-by: Alexey Tikhonov <atikhono@redhat.com>
Reviewed-by: Iker Pedrosa <ipedrosa@redhat.com>
(cherry picked from commit b439847bc88ad7b89f0596af822c0ffbf2a579df)