### PR TITLE
Tests: Improve logging of custom log plugin

### DIFF
--- a/src/tests/multihost/sssd/testlib/common/qe_class.py
+++ b/src/tests/multihost/sssd/testlib/common/qe_class.py
@@ -128,6 +128,8 @@ class QeHost(QeBaseHost):
             pkg_cmd = 'yum'
         pkg_install_cmd = f'{pkg_cmd} -y {action} {package}'
         cmd = self.run_command(pkg_install_cmd, raiseonerr=False)
+        if cmd.returncode != 0:
+            print(f"{pkg_install_cmd} failed.\nOUT:{cmd.stdout_text}\nERR:{cmd.stderr_text}")
         return bool(cmd.returncode == 0)
 
     def service_sssd(self, action):


### PR DESCRIPTION
Improve logging of failed package installation in session setup.
Change custom log plugin to enable capture=tee-sys for duplication of test output to console and file.