### PR TITLE
Fix OS detection and change default PAM service for sssctl user-checks for SUSE

### DIFF
--- a/src/external/platform.m4
+++ b/src/external/platform.m4
@@ -25,6 +25,11 @@ if test x"$osname" = x ; then
         osname="debian"
     elif test -f /etc/gentoo-release ; then
         osname="gentoo"
+    elif test -f /etc/os-release ; then
+        . /etc/os-release
+        if ([[ "${ID}" = "suse" ]]) || ([[ "${ID_LIKE#*suse*}" != "${ID_LIKE}" ]]); then
+            osname="suse"
+        fi
     fi
 
     AC_MSG_NOTICE([Detected operating system type: $osname])

--- a/src/tools/sssctl/sssctl_user_checks.c
+++ b/src/tools/sssctl/sssctl_user_checks.c
@@ -60,7 +60,11 @@ static struct pam_conv conv = {
 #endif
 
 #define DEFAULT_ACTION "acct"
+#ifdef HAVE_SUSE
+#define DEFAULT_SERVICE "login"
+#else
 #define DEFAULT_SERVICE "system-auth"
+#endif
 
 #define DEFAULT_BUFSIZE 4096
 


### PR DESCRIPTION
SUSE and openSUSE no longer ships /etc/SuSE-release [1], fallback to /etc/os-release.

Then, if building for SUSE, switch the default PAM service in `sssctl user-checks` from `system-auth` to `login`.

[1] https://en.opensuse.org/Etc_SuSE-release