### PR TITLE
CLIENT:idmap: fix coverity warning

### DIFF
--- a/src/sss_client/idmap/sss_nss_idmap.c
+++ b/src/sss_client/idmap/sss_nss_idmap.c
@@ -324,6 +324,11 @@ static int sss_nss_getyyybyxxx(union input inp, enum sss_cli_command cmd,
         goto done;
     }
 
+    if (replen < DATA_START) { /* make sure 'type' is present */
+        ret = EBADMSG;
+        goto done;
+    }
+
     /* Skip first two 32 bit values (number of results and
      * reserved padding) */
     SAFEALIGN_COPY_UINT32(&out->type, repbuf + 2 * sizeof(uint32_t), NULL);


### PR DESCRIPTION
Fixes following issue:
```
"Error: INTEGER_OVERFLOW (CWE-190):
sssd-2.10.0/src/sss_client/idmap/sss_nss_idmap.c:306:5: tainted_data_argument: The value returned in ""replen"" is considered tainted.
sssd-2.10.0/src/sss_client/idmap/sss_nss_idmap.c:331:5: overflow: The expression ""replen - 12UL"" might be negative, but is used in a context that treats it as unsigned.
sssd-2.10.0/src/sss_client/idmap/sss_nss_idmap.c:331:5: assign: Assigning: ""data_len"" = ""replen - 12UL"".
sssd-2.10.0/src/sss_client/idmap/sss_nss_idmap.c:347:9: overflow: The expression ""1UL * data_len"" is deemed underflowed because at least one of its arguments has underflowed.
sssd-2.10.0/src/sss_client/idmap/sss_nss_idmap.c:347:9: overflow_sink: ""1UL * data_len"", which might have underflowed, is passed to ""malloc(1UL * data_len)"".
 #  345|           }
 #  346|
 #  347|->         str = malloc(sizeof(char) * data_len);
 #  348|           if (str == NULL) {
 #  349|               ret = ENOMEM;"
```