### PR TITLE
SSH: sanity check to please coverity

### DIFF
--- a/src/util/sss_ssh.c
+++ b/src/util/sss_ssh.c
@@ -191,6 +191,10 @@ sss_ssh_format_pubkey(TALLOC_CTX *mem_ctx,
         }
 
         len = pubkey->data_len;
+        if (len == 0) {
+            ret = EINVAL;
+            goto done;
+        }
         if (pubkey->data[len - 1] == '\n') {
             len--;
         }


### PR DESCRIPTION
Fixes:
```
Error: INTEGER_OVERFLOW (CWE-190):
sssd-2.10.0/src/util/sss_ssh.c:195:13: underflow: The decrement operator on the unsigned variable ""len"" might result in an underflow.
sssd-2.10.0/src/util/sss_ssh.c:204:9: overflow_sink: ""len"", which might have underflowed, is passed to ""memcpy(out, pubkey->data, len)"". [Note: The source code implementation of the function has been overridden by a builtin model.]
 #  202|           }
 #  203|
 #  204|->         memcpy(out, pubkey->data, len);
 #  205|           out[len] = '\0';
 #  206|       }
```