### PR TITLE
Allow unknown operation system build

### DIFF
--- a/src/external/platform.m4
+++ b/src/external/platform.m4
@@ -1,5 +1,5 @@
 AC_ARG_WITH([os],
-            [AC_HELP_STRING([--with-os=OS_TYPE], [Type of your operation system (fedora|redhat|suse|gentoo)])]
+            [AC_HELP_STRING([--with-os=OS_TYPE], [Type of your operation system (fedora|redhat|suse|debian|gentoo)])]
            )
 osname=""
 if test x"$with_os" != x ; then

--- a/src/external/platform.m4
+++ b/src/external/platform.m4
@@ -1,17 +1,9 @@
 AC_ARG_WITH([os],
-            [AC_HELP_STRING([--with-os=OS_TYPE], [Type of your operation system (fedora|redhat|suse|debian|gentoo)])]
+            [AC_HELP_STRING([--with-os=OS_TYPE], [Type of your operation system (unknown|fedora|redhat|suse|debian|gentoo)])]
            )
 osname=""
 if test x"$with_os" != x ; then
-    if test x"$with_os" = xfedora || \
-       test x"$with_os" = xredhat || \
-       test x"$with_os" = xsuse || \
-       test x"$with_os" = xgentoo || \
-       test x"$with_os" = xdebian ; then
-        osname=$with_os
-    else
-        AC_MSG_ERROR([Illegal value -$with_os- for option --with-os])
-    fi
+    osname=$with_os
 fi
 
 if test x"$osname" = x ; then
@@ -30,6 +22,8 @@ if test x"$osname" = x ; then
         if ([[ "${ID}" = "suse" ]]) || ([[ "${ID_LIKE#*suse*}" != "${ID_LIKE}" ]]); then
             osname="suse"
         fi
+    else
+        osname="unknown"
     fi
 
     AC_MSG_NOTICE([Detected operating system type: $osname])


### PR DESCRIPTION
Dear Maintainers,

I faces an issue if I cross-compile the project for OpenEmbedded from a Debian build system, with python.

I get the following:

	error: option --install-layout not recognized

The `configure` script guesses the target system from the host if no `--with-os=` is set. It is untrue if cross-compiling.

Setting an operation system that is unsupported (i.e. not `fedora`, not `redhat` not `suse`, not `debian` or not `gentoo`) raises an error:

	configure: error: Illegal value -unknown- for option --with-os

In some circumstances, it is preferable to ignore an unsupported operation system and just do nothing.

This (second) patch adds the operation system `unknown` to avoid the `configure` script to guess for which operating system the project is build for; this also improve the incomplete output:

	configure: Detected operating system type:
	configure: Build with  config

Regards,
Gaël