### PR TITLE
ci: use python 3.11 for system tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,10 @@ jobs:
     permissions:
       contents: read
     steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
+
     - name: Checkout sssd repository
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -56,6 +56,10 @@ jobs:
     permissions:
       contents: read
     steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
+
     - name: Checkout repository
       uses: actions/checkout@v4
 


### PR DESCRIPTION
pytest-mh and sssd-test-framework started to require python 3.11 which
is not available on ubuntu runners by default.