### PR TITLE
configure: use runstatedir for default pid path

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -576,6 +576,7 @@ enable authentication with passkey token.
 autoreconf -ivf
 
 %configure \
+    --runstatedir=%{_rundir} \
     --disable-rpath \
     --disable-static \
     --enable-gss-spnego-for-zero-maxssf \

--- a/src/conf_macros.m4
+++ b/src/conf_macros.m4
@@ -39,8 +39,8 @@ AC_DEFUN([WITH_PID_PATH],
                                )
                 ]
                )
-    config_pidpath="/run/sssd"
-    pidpath="/run/sssd"
+    config_pidpath="$runstatedir/sssd"
+    pidpath="$runstatedir/sssd"
     if test x"$with_pid_path" != x; then
         config_pidpath=$with_pid_path
         pidpath=$with_pid_path


### PR DESCRIPTION
make distcheck yields the following error because pidpath is currently hardcoded to
/run/sssd (with the run directory hardcoded) and prefix is not correctly applied.

```
autoreconf -if && ./configure && make distcheck/usr/bin/mkdir: cannot create directory '/run/sssd': Permission denied
make[5]: *** [Makefile:47801: installsssddirs] Error 1
```

```
2024-06-04T16:35:23.1627995Z /usr/bin/mkdir -p \
2024-06-04T16:35:23.1628921Z     /__w/sssd/sssd/x86_64/sssd-2.10.0/_inst/include \
2024-06-04T16:35:23.1629987Z     /__w/sssd/sssd/x86_64/sssd-2.10.0/_inst/lib \
2024-06-04T16:35:23.1631024Z     /__w/sssd/sssd/x86_64/sssd-2.10.0/_inst/bin \
2024-06-04T16:35:23.1632011Z     /__w/sssd/sssd/x86_64/sssd-2.10.0/_inst/sbin \
2024-06-04T16:35:23.1632919Z     /__w/sssd/sssd/x86_64/sssd-2.10.0/_inst/share/man \
2024-06-04T16:35:23.1633620Z     /run/sssd \
2024-06-04T16:35:23.1634262Z     /__w/sssd/sssd/x86_64/sssd-2.10.0/_inst/lib/sssd \
2024-06-04T16:35:23.1635121Z     /__w/sssd/sssd/x86_64/sssd-2.10.0/_inst/lib/ldb \
2024-06-04T16:35:23.1635921Z     /__w/sssd/sssd/x86_64/sssd-2.10.0/_inst/share/dbus-1/system.d \
2024-06-04T16:35:23.1636710Z     /__w/sssd/sssd/x86_64/sssd-2.10.0/_inst/share/dbus-1/system-services \
2024-06-04T16:35:23.1637387Z     /__w/sssd/sssd/x86_64/sssd-2.10.0/_inst/lib/sssd \
2024-06-04T16:35:23.1637936Z     /__w/sssd/sssd/x86_64/sssd-2.10.0/_inst/lib/sssd \
2024-06-04T16:35:23.1638495Z     /__w/sssd/sssd/x86_64/sssd-2.10.0/_inst/share/sssd \
2024-06-04T16:35:23.1639022Z     /__w/sssd/sssd/x86_64/sssd-2.10.0/_inst/lib \
2024-06-04T16:35:23.1639592Z     /__w/sssd/sssd/x86_64/sssd-2.10.0/_inst/lib/sssd/modules \
2024-06-04T16:35:23.1640407Z     /__w/sssd/sssd/x86_64/sssd-2.10.0/_inst/var/lib/sss/pipes/private \
2024-06-04T16:35:23.1641288Z     /__w/sssd/sssd/x86_64/sssd-2.10.0/_inst/share/sssd/krb5-snippets \
```