### PR TITLE
version: replace dash with tilda

### DIFF
--- a/contrib/ci/distro.sh
+++ b/contrib/ci/distro.sh
@@ -55,9 +55,9 @@ function distro_pkg_install()
         [ $# != 0 ] && sudo -p "$prompt" \
                             /usr/bin/dnf --assumeyes --best \
                                          --setopt=install_weak_deps=False \
-                                         install -- "$@"
+                                         install "$@"
     elif [[ "$DISTRO_BRANCH" == -redhat-* ]]; then
-        [ $# != 0 ] && sudo -p "$prompt" yum --assumeyes install -- "$@" |&
+        [ $# != 0 ] && sudo -p "$prompt" yum --assumeyes install "$@" |&
             # Pass input to output, fail if a missing package is reported
             awk 'BEGIN {s=0}
                  /^No package .* available.$/ {s=1}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,7 +7,7 @@ function config()
 }
 
 SAVED_PWD=$PWD
-version=`grep '\[VERSION_NUMBER], \[.*\]' version.m4 | grep '[0-9]\+\.[0-9]\+\.[0-9]\+\(-[^]]\+\)\?' -o`
+version=`grep '\[VERSION_NUMBER], \[.*\]' version.m4 | grep '[0-9]\+\.[0-9]\+\.[0-9]\+\(~[^]]\+\)\?' -o`
 tag=${version}
 
 trap "cd $SAVED_PWD; rm -rf sssd-${version} sssd-${version}.tar" EXIT

--- a/src/config/setup.py.in
+++ b/src/config/setup.py.in
@@ -24,9 +24,21 @@ Python-level packaging using setuptools.
 
 from setuptools import setup
 
+def sanitize_version(version):
+    """
+    We need to convert Fedora version guidelines which we follow in version.m4
+    to Python guidelines. See:
+    * https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/
+    * https://packaging.python.org/en/latest/discussions/versioning/
+    """
+    # X.Y.Z~alpha1 -> X.Y.Za1
+    # X.Y.Z~beta1 -> X.Y.Zb1
+    # X.Y.Z~rc1 -> X.Y.Zrc1
+    return version.replace('~', '').replace('alpha', 'a').replace('beta', 'b')
+
 setup(
     name='SSSDConfig',
-    version='@VERSION@',
+    version=sanitize_version('@VERSION@'),
     license='GPLv3+',
     url='https://github.com/SSSD/sssd/',
     packages=['SSSDConfig'],

--- a/version.m4
+++ b/version.m4
@@ -1,5 +1,5 @@
 # Primary version number
-m4_define([VERSION_NUMBER], [2.10.0-beta1])
+m4_define([VERSION_NUMBER], [2.10.0~beta1])
 
 # If the PRERELEASE_VERSION_NUMBER is set, we'll append
 # it to the release tag when creating an RPM or SRPM


### PR DESCRIPTION
We released a new SSSD beta version as 2.10.0-beta1, unfortunately
this caused issues in the rpm build system as this value is set as
the Version field but dash is not allowed in this field therefore
`make rpms` was broken.

Fedora guidelines requires to use ~ as a prerelease separator so
two NVR versions compare correctly. For example:

* 2.10.0 < 2.10.0-beta1
* 2.10.0~beta1 < 2.10.0

We will follow this guideline to make `make rpms` work again and
to avoid any further rpm issues. Next GitHub release will also
follow this guideline.