### PR TITLE
ci: do not collect pytest-mh logs in separate file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,7 +395,6 @@ jobs:
         pytest \
           --color=yes \
           --mh-config=./mhc.yaml \
-          --mh-log-path=$GITHUB_WORKSPACE/mh.log \
           --mh-artifacts-dir=$GITHUB_WORKSPACE/artifacts \
           --polarion-config=../polarion.yaml \
           --output-polarion-testcase=$GITHUB_WORKSPACE/artifacts/testcase.xml \
@@ -412,7 +411,6 @@ jobs:
         pytest \
           --color=yes \
           --mh-config=./mhc.yaml \
-          --mh-log-path=$GITHUB_WORKSPACE/mh.log \
           --mh-artifacts-dir=$GITHUB_WORKSPACE/artifacts \
           --polarion-config=../polarion.yaml \
           --output-polarion-testcase=$GITHUB_WORKSPACE/artifacts/testcase.xml \
@@ -428,7 +426,6 @@ jobs:
         path: |
           sssd/ci-install-deps.log
           artifacts
-          mh.log
           build.log
           install.log
           pytest.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,6 +410,7 @@ jobs:
         source .venv/bin/activate
         pytest \
           --color=yes \
+          --show-capture=no \
           --mh-config=./mhc.yaml \
           --mh-artifacts-dir=$GITHUB_WORKSPACE/artifacts \
           --polarion-config=../polarion.yaml \


### PR DESCRIPTION
```
6abf7930d (Pavel Březina, 2 hours ago)
   ci: do not collect pytest-mh logs in separate file

   pytest-mh logs will be collected automatically per test on failure so there
   is no reason to collect everything in single file. Having logs per test
   will be easier to debug.

   The test log is stored in: artifacts/tests/$testname/test.log

c190e9777 (Pavel Březina, 3 minutes ago)
   ci: disable show-capture in system tests

   In case of failure, show-capture=yes (default) also prints all caputured 
   pytest-mh logs. Showing these logs in pytest output just makes it more 
   difficult to locate the failed assertion. The logs are stored in file for
   each failed test so we do not need to see them in pytest output to debug
   the issue.
```