### PR TITLE
ad: use right memory context in GPO code

### DIFF
--- a/src/providers/ad/ad_gpo.c
+++ b/src/providers/ad/ad_gpo.c
@@ -714,7 +714,7 @@ ad_gpo_get_sids(TALLOC_CTX *mem_ctx,
     }
     group_sids[i++] = talloc_strdup(group_sids, AD_AUTHENTICATED_USERS_SID);
     if (orig_gid_sid != NULL) {
-        group_sids[i++] = orig_gid_sid;
+        group_sids[i++] = talloc_steal(group_sids, orig_gid_sid);
     }
     group_sids[i] = NULL;
 


### PR DESCRIPTION
The original primary SID is allocated on a temporary context and must be
move to be longer living one to still be available when the SID is
evaluated later in the code.

Resolves: https://github.com/SSSD/sssd/issues/7411