### PR TITLE
SPEC: strip public rx bits from 'proxy_child'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5587,6 +5587,8 @@ if SSSD_USER
 	-chgrp $(SSSD_USER) $(DESTDIR)$(sssdlibexecdir)/krb5_child
 	chmod 750 $(DESTDIR)$(sssdlibexecdir)/krb5_child
 	-$(SETCAP) $(CHILD_CAPABILITIES) $(DESTDIR)$(sssdlibexecdir)/krb5_child
+	-chgrp $(SSSD_USER) $(DESTDIR)$(sssdlibexecdir)/proxy_child
+	chmod 750 $(DESTDIR)$(sssdlibexecdir)/proxy_child
 if BUILD_SELINUX
 	-chgrp $(SSSD_USER) $(DESTDIR)$(sssdlibexecdir)/selinux_child
 	chmod 750 $(DESTDIR)$(sssdlibexecdir)/selinux_child

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -921,7 +921,7 @@ install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/sssd.conf
 
 %files proxy
 %license COPYING
-%{_libexecdir}/%{servicename}/proxy_child
+%attr(0750,root,%{sssd_user}) %{_libexecdir}/%{servicename}/proxy_child
 %{_libdir}/%{name}/libsss_proxy.so
 
 %files dbus -f sssd_dbus.lang


### PR DESCRIPTION
as a safety measure for a case where administrator could be tempted to set SUID bit to support some legacy/3rd party PAM module.