### PR TITLE
configure: use prefix for systemd paths if needed and ${datadir}

### DIFF
--- a/src/conf_macros.m4
+++ b/src/conf_macros.m4
@@ -202,9 +202,14 @@ AC_DEFUN([WITH_SYSTEMD_UNIT_DIR],
   if test x"$with_systemdunitdir" != x; then
     systemdunitdir=$with_systemdunitdir
   else
-    systemdunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)
-    if test x"$systemdunitdir" = x; then
+    pkgconfigdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)
+    if test x"$pkgconfigdir" = x; then
       AC_MSG_ERROR([Could not detect systemd unit directory])
+    fi
+    if test "${pkgconfigdir:0:${#prefix}}" = "${prefix}"; then
+        systemdunitdir=${pkgconfigdir}
+    else
+        systemdunitdir=${prefix}${pkgconfigdir}
     fi
   fi
   AC_SUBST(systemdunitdir)
@@ -222,9 +227,14 @@ AC_DEFUN([WITH_SYSTEMD_CONF_DIR],
   if test x"$with_systemdconfdir" != x; then
     systemdconfdir=$with_systemdconfdir
   else
-    systemdconfdir=$($PKG_CONFIG --variable=systemdsystemconfdir systemd)
-    if test x"$systemdconfdir" = x; then
+    pkgconfigdir=${prefix}$($PKG_CONFIG --variable=systemdsystemconfdir systemd)
+    if test x"$pkgconfigdir" = x; then
       AC_MSG_ERROR([Could not detect systemd config directory])
+    fi
+    if test "${pkgconfigdir:0:${#prefix}}" = "${prefix}"; then
+        systemdconfdir=${pkgconfigdir}
+    else
+        systemdconfdir=${prefix}${pkgconfigdir}
     fi
   fi
   AC_SUBST(systemdconfdir, [$systemdconfdir/sssd.service.d])

--- a/src/conf_macros.m4
+++ b/src/conf_macros.m4
@@ -893,7 +893,7 @@ AC_DEFUN([WITH_CONF_SERVICE_USER_SUPPORT],
 
 AC_DEFUN([ENABLE_POLKIT_RULES_PATH],
   [
-    polkitdir="/usr/share/polkit-1/rules.d"
+    polkitdir="${datadir}/polkit-1/rules.d"
     AC_ARG_ENABLE([polkit-rules-path],
                   [AC_HELP_STRING([--enable-polkit-rules-path=PATH],
                                   [Path to store polkit rules at. Use --disable to not install the rules at all. [/usr/share/polkit-1/rules.d]]


### PR DESCRIPTION
'make distcheck' fails because those paths didn't respect the prefix. To 
avoid issues with standard prefixes like e.g. /usr, the prefix is only 
added if it does not match the start of the systemd path.

Instead of using the absolute path name '/usr/share' ${datadir} is used to
respect configure options and to make 'make distcheck' pass.

'polkitdir' is only used if SSSD was configured to run as 'sssd' user.