### PR TITLE
spec: change passkey_child owner

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -1079,7 +1079,7 @@ install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/sssd.conf
 
 %if %{build_passkey}
 %files passkey
-%attr(755,%{sssd_user},%{sssd_user}) %{_libexecdir}/%{servicename}/passkey_child
+%{_libexecdir}/%{servicename}/passkey_child
 %{_libdir}/%{name}/modules/sssd_krb5_passkey_plugin.so
 %{_datadir}/sssd/krb5-snippets/sssd_enable_passkey
 %if "%{sssd_user}" != "root"


### PR DESCRIPTION
passkey_child owner was incorrectly set to $sssd_user:$sssd_user, when it should be root:$sssd_user. Correcting it.

Fixes: 30daa0ccdae5 ("spec: update to include passkey")