### PR TITLE
tests: Add loading kernel module sch_netem for tc tool

### DIFF
--- a/src/tests/multihost/alltests/test_ldap_time_logging.py
+++ b/src/tests/multihost/alltests/test_ldap_time_logging.py
@@ -120,6 +120,7 @@ class TestLdapTimeLogging(object):
           6. Domain log has a warning message for long query time
         """
         section = f'domain/{ds_instance_name}'
+        multihost.client[0].run_command("modprobe sch_netem")
         tools = sssdTools(multihost.client[0])
         domain_params = {'debug_level': ''}
         tools.sssd_conf(section, domain_params, action="delete")

--- a/src/tests/multihost/alltests/test_misc.py
+++ b/src/tests/multihost/alltests/test_misc.py
@@ -544,6 +544,7 @@ class TestMisc(object):
             4. Network delay should be removed
         """
         client = multihost.client[0]
+        multihost.client[0].run_command("modprobe sch_netem")
         log_nss = '/var/log/sssd/sssd_nss.log'
         ldap_uri = 'ldap://%s' % (multihost.master[0].sys_hostname)
         ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)


### PR DESCRIPTION
Force module needed by tc to be loaded by modprobe.
Fixes tests alltests-tier1-4 and alltests-tier1_3
2024-06-11T15:07:08 src/tests/multihost/alltests/test_misc.py::TestMisc::test_bz822236 PASSED [ 66%]