### PR TITLE
Tests: automount segfault fix

### DIFF
--- a/src/tests/multihost/alltests/script/a1.cpp
+++ b/src/tests/multihost/alltests/script/a1.cpp
@@ -8,7 +8,8 @@ void *tr(void *) {
         char buf[8192];
         struct passwd *res;
 
-        getpwuid_r(getuid(), &pwd, buf, sizeof(buf), &res); }
+        getpwuid_r(getuid(), &pwd, buf, sizeof(buf), &res);
+        return NULL; }
 
 #define NTH 100
 pthread_t t[NTH];


### PR DESCRIPTION
C++ code compilation error due to the return value from void function . Adding 'return NULL'