### PR TITLE
test: Do not overwrite /etc/nsswitch.conf by authselect

### DIFF
--- a/src/tests/multihost/alltests/conftest.py
+++ b/src/tests/multihost/alltests/conftest.py
@@ -125,7 +125,10 @@ def setup_authselect(session_multihost):
     """
     Make sure to use sssd as authselect profile
     """
-    session_multihost.client[0].run_command("authselect select sssd --force")
+    # We should not overwrite nsswitch that is changed/pre-configured
+    session_multihost.client[0].run_command(
+        "test -L /etc/nsswitch.conf && authselect select sssd --force", raiseonerr=False
+    )
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
src/tests/multihost/alltests/test_hosts.py::TestHostMaps::test_more_than_one_cn PASSED [  2%]

The forced authselect was rewriting nsswitch configuration for the test.