### PR TITLE
initscripts: Allow Gentoo initscripts to work with sssd user

### DIFF
--- a/src/sysv/gentoo/sssd-kcm.in
+++ b/src/sysv/gentoo/sssd-kcm.in
@@ -6,6 +6,7 @@ description="SSSD Kerberos Cache Manager"
 command="@libexecdir@/sssd/sssd_kcm"
 command_background="true"
 command_args="--logger=files ${SSSD_KCM_OPTIONS}"
+command_user="@SSSD_USER@:@SSSD_USER@"
 pidfile="@pidpath@/sssd_kcm.pid"
 
 depend()

--- a/src/sysv/gentoo/sssd.in
+++ b/src/sysv/gentoo/sssd.in
@@ -5,6 +5,7 @@
 
 command="@sbindir@/sssd"
 command_args="-D --logger=files ${SSSD_OPTIONS}"
+command_user="@SSSD_USER@:@SSSD_USER@"
 description="System Security Services Daemon"
 pidfile="@pidpath@/sssd.pid"
 #sssd may take time time to TERMinate so allow som extra time


### PR DESCRIPTION
Current the sssd initscripts always start as root. Non-systemd users cannot use non-root mode. This allows the initscripts to run with --with-sssd-user option