### PR TITLE
PAM: grant 'cap_dac_read_search=p' to sssd_pam

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -99,8 +99,8 @@ ifp_systemdservice = SystemdService=sssd-ifp.service
 # or some snippet under /etc/sssd/sssd.conf.d/) to be present.
 condconfigexists = ConditionPathExists=\|/etc/sssd/sssd.conf\nConditionDirectoryNotEmpty=\|/etc/sssd/conf.d/
 
-# Bounding set needs to list capabilities required by ldap/krb5/selinux_childs, otherwise they can't gain it.
-capabilities = CapabilityBoundingSet= CAP_CHOWN CAP_DAC_OVERRIDE CAP_SETGID CAP_SETUID
+# Bounding set needs to list capabilities required by ldap/krb5/selinux_childs and sssd_pam, otherwise they can't gain it.
+capabilities = CapabilityBoundingSet= CAP_CHOWN CAP_DAC_OVERRIDE CAP_SETGID CAP_SETUID CAP_DAC_READ_SEARCH
 
 if BUILD_CONF_SERVICE_USER_SUPPORT
 # If non-root service user is supported, monitor might need SET-ID to switch user (deprecated 'sssd.conf::user' option)
@@ -5589,6 +5589,9 @@ if SSSD_USER
 	-$(SETCAP) $(CHILD_CAPABILITIES) $(DESTDIR)$(sssdlibexecdir)/krb5_child
 	-chgrp $(SSSD_USER) $(DESTDIR)$(sssdlibexecdir)/proxy_child
 	chmod 750 $(DESTDIR)$(sssdlibexecdir)/proxy_child
+	-chgrp $(SSSD_USER) $(DESTDIR)$(sssdlibexecdir)/sssd_pam
+	chmod 750 $(DESTDIR)$(sssdlibexecdir)/sssd_pam
+	-$(SETCAP) cap_dac_read_search=p $(DESTDIR)$(sssdlibexecdir)/sssd_pam
 if BUILD_SELINUX
 	-chgrp $(SSSD_USER) $(DESTDIR)$(sssdlibexecdir)/selinux_child
 	chmod 750 $(DESTDIR)$(sssdlibexecdir)/selinux_child

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -792,7 +792,7 @@ install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/sssd.conf
 %dir %{_libexecdir}/%{servicename}
 %{_libexecdir}/%{servicename}/sssd_be
 %{_libexecdir}/%{servicename}/sssd_nss
-%{_libexecdir}/%{servicename}/sssd_pam
+%attr(0750,root,%{sssd_user}) %caps(cap_dac_read_search=p) %{_libexecdir}/%{servicename}/sssd_pam
 %{_libexecdir}/%{servicename}/sssd_autofs
 %{_libexecdir}/%{servicename}/sssd_ssh
 %{_libexecdir}/%{servicename}/sssd_sudo

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -1759,9 +1759,13 @@ static void service_startup_handler(struct tevent_context *ev,
     }
 
     /* child */
-    if (mt_svc->type != MT_SVC_PROVIDER) {
-        /* providers are excluded becase they will need to execute
-         * child processes that elevate privs
+    if ((mt_svc->type != MT_SVC_PROVIDER) &&
+        ((mt_svc->name == NULL) || (strcmp(mt_svc->name, "pam") != 0))) {
+        /* Providers are excluded because they will need to execute
+         * child processes that elevate privs.
+         * 'sssd_pam' is excluded because it need to use 'cap_dac_read_search'
+         * to call `gss_acquire_cred_from()`/`gss_accept_sec_context()`
+         * that accesses a keytab.
          */
         ret = prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
         if (ret == -1) {

--- a/src/responder/pam/pamsrv_gssapi.c
+++ b/src/responder/pam/pamsrv_gssapi.c
@@ -698,9 +698,19 @@ static errno_t gssapi_get_creds(const char *keytab,
         }
     }
 
+    ret = sss_set_cap_effective(CAP_DAC_READ_SEARCH, true);
+    if (ret != 0) {
+        DEBUG(SSSDBG_IMPORTANT_INFO,
+              "Failed to elevate CAP_DAC_READ_SEARCH to effective set\n");
+    }
     major = gss_acquire_cred_from(&minor, name, GSS_C_INDEFINITE,
                                   GSS_C_NO_OID_SET, GSS_C_ACCEPT, &cstore,
                                   _creds, NULL, NULL);
+    sss_set_cap_effective(CAP_DAC_READ_SEARCH, false);
+    if (ret != 0) {
+        DEBUG(SSSDBG_IMPORTANT_INFO,
+              "Failed to drop CAP_DAC_READ_SEARCH from effective set\n");
+    }
     if (GSS_ERROR(major)) {
         DEBUG(SSSDBG_OP_FAILURE, "Unable to read credentials from [%s] "
               "[maj:0x%x, min:0x%x]\n", keytab ? keytab : "default",
@@ -747,9 +757,19 @@ gssapi_handshake(struct gssapi_state *state,
         return ret;
     }
 
+    ret = sss_set_cap_effective(CAP_DAC_READ_SEARCH, true);
+    if (ret != 0) {
+        DEBUG(SSSDBG_IMPORTANT_INFO,
+              "Failed to elevate CAP_DAC_READ_SEARCH to effective set\n");
+    }
     major = gss_accept_sec_context(&minor, &state->ctx, creds,
                                    &input, NULL, &client_name, &mech_type,
                                    &output, &ret_flags, NULL, NULL);
+    sss_set_cap_effective(CAP_DAC_READ_SEARCH, false);
+    if (ret != 0) {
+        DEBUG(SSSDBG_IMPORTANT_INFO,
+              "Failed to drop CAP_DAC_READ_SEARCH from effective set\n");
+    }
     if (major == GSS_S_CONTINUE_NEEDED || output.length > 0) {
         ret = sss_packet_set_body(pctx->creq->out, output.value, output.length);
         if (ret != EOK) {

--- a/src/sysv/systemd/sssd-pam.service.in
+++ b/src/sysv/systemd/sssd-pam.service.in
@@ -12,8 +12,8 @@ Also=sssd-pam.socket
 Environment=DEBUG_LOGGER=--logger=files
 EnvironmentFile=-@environment_file@
 ExecStart=@libexecdir@/sssd/sssd_pam ${DEBUG_LOGGER} --socket-activated
-# No capabilities:
-CapabilityBoundingSet=
+# 'CAP_DAC_READ_SEARCH' is granted as permitted file capability to be elevated to establish GSS API context
+CapabilityBoundingSet= CAP_DAC_READ_SEARCH
 Restart=on-failure
 User=@SSSD_USER@
 Group=@SSSD_USER@

--- a/src/util/capabilities.c
+++ b/src/util/capabilities.c
@@ -224,6 +224,42 @@ done:
     return ret;
 }
 
+errno_t sss_set_cap_effective(cap_value_t cap, bool effective)
+{
+    int ret;
+    cap_flag_value_t value = (effective ? CAP_SET : CAP_CLEAR);
+
+    cap_t caps = cap_get_proc();
+    if (caps == NULL) {
+        ret = errno;
+        DEBUG(SSSDBG_TRACE_FUNC, "cap_get_proc() failed: %d ('%s')\n",
+              ret, strerror(ret));
+        return ret;
+    }
+    if (cap_set_flag(caps, CAP_EFFECTIVE, 1, &cap, value) == -1) {
+        ret = errno;
+        DEBUG(SSSDBG_TRACE_FUNC,
+              "cap_set_flag(CAP_EFFECTIVE) failed: %d ('%s')\n",
+              ret, strerror(ret));
+        goto done;
+    }
+    if (cap_set_proc(caps) == -1) {
+        ret = errno;
+        DEBUG(SSSDBG_TRACE_FUNC, "cap_set_proc() failed: %d ('%s')\n",
+              ret, strerror(ret));
+        goto done;
+    }
+
+    ret = 0;
+
+done:
+    if (cap_free(caps) == -1) {
+        DEBUG(SSSDBG_TRACE_FUNC, "cap_free() failed\n");
+    }
+
+    return ret;
+}
+
 void sss_drop_all_caps(void)
 {
     size_t i;

--- a/src/util/server.c
+++ b/src/util/server.c
@@ -787,7 +787,8 @@ void server_loop(struct main_context *main_ctx)
               getuid(), geteuid(), getgid(), getegid(),
               prctl(PR_GET_KEEPCAPS, 0, 0, 0, 0),
               caps ? caps : "   (nothing)\n");
-        if (caps != NULL) {
+        if ((caps != NULL) && (strcmp(debug_prg_name, "pam") != 0)) {
+            /* 'sssd_pam' uses 'CAP_DAC_READ_SEARCH' file capability */
             DEBUG(SSSDBG_CRIT_FAILURE, "Non empty capabilities set!\n");
         }
         talloc_free(caps);

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -752,6 +752,7 @@ errno_t switch_creds(TALLOC_CTX *mem_ctx,
                      struct sss_creds **saved_creds);
 errno_t restore_creds(struct sss_creds *saved_creds);
 errno_t sss_log_caps_to_str(bool only_non_zero, char **_str);
+errno_t sss_set_cap_effective(cap_value_t cap, bool effective);
 errno_t sss_drop_cap(cap_value_t cap);
 void sss_drop_all_caps(void);
 


### PR DESCRIPTION
to allow `gss_acquire_cred_from()` that needs to read a keytab.