### PR TITLE
ENUMERATION: enable support for 'proxy' provider

### DIFF
--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -1080,7 +1080,9 @@ static errno_t confdb_init_domain_provider_and_enum(struct sss_domain_info *doma
     const char *tmp, *tmp_pam_target, *tmp_auth;
 
 #ifndef BUILD_EXTENDED_ENUMERATION_SUPPORT
-    if (domain->provider != NULL && strcasecmp(domain->provider, "ldap") == 0) {
+    if (domain->provider != NULL &&
+           ((strcasecmp(domain->provider, "ldap") == 0)
+         || (strcasecmp(domain->provider, "proxy") == 0)) ) {
 #endif
     /* TEMP: test if the old bitfield conf value is used and warn it has been
      * superseded. */

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2682,7 +2682,7 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                         </para>
                         <para condition="without_ext_enumeration">
                             Feature is only supported for domains with
-                            id_provider = ldap.
+                            id_provider = ldap or id_provider = proxy.
                         </para>
                         <para>
                             Note: Enabling enumeration has a severe
@@ -2716,6 +2716,12 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                             For the reasons cited above, enabling enumeration
                             is not recommended, especially in large
                             environments.
+                        </para>
+                        <para>
+                            Note: the proxy provider is tested with open source
+                            modules like 'libnss_files' and 'libnss_ldap'.
+                            3rd party modules must follow the documented
+                            behavior of nss modules to be used in this configuration.
                         </para>
                     </listitem>
                 </varlistentry>


### PR DESCRIPTION
even when built without '--with-extended-enumeration-support'