### PR TITLE
tests: housekeeping, test_identity.py

### DIFF
--- a/src/tests/system/tests/test_identity.py
+++ b/src/tests/system/tests/test_identity.py
@@ -1,7 +1,9 @@
 """
-SSSD Identity Lookup Test Cases
+Identity Tests
 
-:requirement: IDM-SSSD-REQ: Client side performance improvements
+These tests cover all the searches, queries, and lookups performed by SSSD.
+
+:requirement: Identity
 """
 
 from __future__ import annotations
@@ -9,6 +11,7 @@ from __future__ import annotations
 import pytest
 from sssd_test_framework.roles.client import Client
 from sssd_test_framework.roles.generic import GenericADProvider, GenericProvider
+from sssd_test_framework.roles.ipa import IPA
 from sssd_test_framework.topology import KnownTopologyGroup
 
 
@@ -19,21 +22,18 @@ from sssd_test_framework.topology import KnownTopologyGroup
     lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
     "SSSD was built without support for running under non-root",
 )
-def test_identity__lookup_username_with_id(client: Client, provider: GenericProvider, sssd_service_user: str):
+def test_identity__lookup_username_with_id_command(client: Client, provider: GenericProvider, sssd_service_user: str):
     """
-    :title: Resolve user by name with id
+    :title: Resolve user by name with "id"
     :setup:
-        1. Add 'user1', 'user2' and 'user3' to SSSD
-        2. Set users uids and gids
-        3. Start SSSD
+        1. Create the following users 'user1', 'user2' and 'user3' specifying the UIDs
+        2. Configure SSSD with "ldap_id_mapping = false" and start SSSD
     :steps:
-        1. Find 'user1', 'user2' and 'user3' with id(name)
-        2. Check that results have correct names
-        3. Check that results have correct ids
+        1. Lookup 'user1', 'user2' and 'user3' using the UID
+        2. Check the results
     :expectedresults:
         1. Users are found
-        2. Users have correct names
-        3. Users have correct ids
+        2. Results have the correct name and UIDs
     :customerscenario: False
     """
     ids = [("user1", 10001), ("user2", 10002), ("user3", 10003)]
@@ -46,9 +46,9 @@ def test_identity__lookup_username_with_id(client: Client, provider: GenericProv
 
     for name, uid in ids:
         result = client.tools.id(name)
-        assert result is not None, f"User {name} was not found using id"
-        assert result.user.name == name, f"Username {result.user.name} is incorrect, {name} expected"
-        assert result.user.id == uid, f"User id {result.user.id} is incorrect, {uid} expected"
+        assert result is not None, f"User {name} was not found using id!"
+        assert result.user.name == name, f"Username {result.user.name} is incorrect, {name} expected!"
+        assert result.user.id == uid, f"User id {result.user.id} is incorrect, {uid} expected!"
 
 
 @pytest.mark.importance("critical")
@@ -58,21 +58,18 @@ def test_identity__lookup_username_with_id(client: Client, provider: GenericProv
     lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
     "SSSD was built without support for running under non-root",
 )
-def test_identity__lookup_uid_with_id(client: Client, provider: GenericProvider, sssd_service_user: str):
+def test_identity__lookup_uid_with_id_command(client: Client, provider: GenericProvider, sssd_service_user: str):
     """
-    :title: Resolve user by uid with id
+    :title: Resolve user by uid with "id"
     :setup:
-        1. Add 'user1', 'user2' and 'user3' to SSSD
-        2. Set users uids and gids
-        3. Start SSSD
+        1. Create the following users 'user1', 'user2' and 'user3' specifying the UIDs and GIDs
+        2. Configure SSSD with "ldap_id_mapping = false" and start SSSD
     :steps:
-        1. Find 'user1', 'user2' and 'user3' with id(uid)
-        2. Check that users have correct names
-        3. Check that users have correct ids
+        1. Lookup 'user1', 'user2' and 'user3' using the UID
+        2. Check the results
     :expectedresults:
         1. Users are found
-        2. Users have correct names
-        3. Users have correct ids
+        2. Results have the correct name and UID
     :customerscenario: False
     """
     ids = [("user1", 10001), ("user2", 10002), ("user3", 10003)]
@@ -85,28 +82,25 @@ def test_identity__lookup_uid_with_id(client: Client, provider: GenericProvider,
 
     for name, uid in ids:
         result = client.tools.id(uid)
-        assert result is not None, f"User with uid {uid} was not found using id"
-        assert result.user.name == name, f"Username {result.user.name} is incorrect, {name} expected"
-        assert result.user.id == uid, f"User id {result.user.id} is incorrect, {uid} expected"
+        assert result is not None, f"User with uid {uid} was not found using id!"
+        assert result.user.name == name, f"Username {result.user.name} is incorrect, {name} expected!"
+        assert result.user.id == uid, f"User id {result.user.id} is incorrect, {uid} expected!"
 
 
 @pytest.mark.importance("critical")
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
 def test_identity__lookup_groupname_with_getent(client: Client, provider: GenericProvider):
     """
-    :title: Resolve group by name with getent.group
+    :title: Resolve group by name with getent
     :setup:
-        1. Add 'group1', 'group2' and 'group3' to SSSD
-        2. Set groups gids
-        3. Start SSSD
+        1. Create the following groups 'group1', 'group2' and 'group3' specifying the GIDs
+        2. Configure SSSD with "ldap_id_mapping = false" and start SSSD
     :steps:
-        1. Find 'group1', 'group2' and 'group3' with getent.group(name)
-        2. Check that groups have correct names
-        3. Check that groups have correct gids
+        1. Lookup the groups
+        2. Check the results
     :expectedresults:
         1. Groups are found
-        2. Groups have correct names
-        3. Groups have correct gids
+        2. Results have the correct names and GIDs
     :customerscenario: False
     """
     ids = [("group1", 10001), ("group2", 10002), ("group3", 10003)]
@@ -118,28 +112,25 @@ def test_identity__lookup_groupname_with_getent(client: Client, provider: Generi
 
     for name, gid in ids:
         result = client.tools.getent.group(name)
-        assert result is not None, f"Group {name} was not found using getent"
-        assert result.name == name, f"Groupname {result.name} is incorrect, {name} expected"
-        assert result.gid == gid, f"Group gid {result.gid} is incorrect, {gid} expected"
+        assert result is not None, f"Group {name} was not found using getent!"
+        assert result.name == name, f"Groupname {result.name} is incorrect, {name} expected!"
+        assert result.gid == gid, f"Group gid {result.gid} is incorrect, {gid} expected!"
 
 
 @pytest.mark.importance("critical")
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
-def test_identity__lookup_gid_with_getent(client: Client, provider: GenericProvider):
+def test_identity__lookup_group_gid_with_getent(client: Client, provider: GenericProvider):
     """
-    :title: Resolve group with by gid with getent.group
+    :title: Resolve group with by gid with getent
     :setup:
-        1. Add 'group1', 'group2' and 'group3' to SSSD
-        2. Set groups gids
-        3. Start SSSD
+        1. Create the following groups 'group1', 'group2' and 'group3' specifying the GIDs
+        2. Configure SSSD with "ldap_id_mapping = false" and start SSSD
     :steps:
-        1. Find 'group1', 'group2' and 'group3' with getent.group(gid)
-        2. Check that users have correct names
-        3. Check that users have correct gids
+        1. Lookup the groups using their GID with getent
+        2. Check the results
     :expectedresults:
         1. Groups are found
-        2. Groups have correct names
-        3. Groups have correct gids
+        2. Groups have the correct names and GIDs
     :customerscenario: False
     """
     ids = [("group1", 10001), ("group2", 10002), ("group3", 10003)]
@@ -151,32 +142,29 @@ def test_identity__lookup_gid_with_getent(client: Client, provider: GenericProvi
 
     for name, gid in ids:
         result = client.tools.getent.group(gid)
-        assert result is not None, f"Group with gid {gid} was not found using getent"
-        assert result.name == name, f"Groupname {result.name} is incorrect, {name} expected"
-        assert result.gid == gid, f"Group gid {result.gid} is incorrect, {gid} expected"
+        assert result is not None, f"Group with gid {gid} was not found using getent!"
+        assert result.name == name, f"Groupname {result.name} is incorrect, {name} expected!"
+        assert result.gid == gid, f"Group gid {result.gid} is incorrect, {gid} expected!"
 
 
 @pytest.mark.importance("critical")
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
 def test_identity__lookup_user_with_getent(client: Client, provider: GenericProvider):
     """
-    :title: Resolve user with getent.passwd
+    :title: Resolve user with getent
     :setup:
-        1. Add 'user1', 'user2' and 'user3' to SSSD
-        2. Set users uids and gids
-        3. Add 'group1', 'group2' and 'group3' to SSSD
-        4. Add users to groups
-        5. Start SSSD
+        1. Create the following users 'user1', 'user2' and 'user3' specifying the UIDs
+        2. Configure SSSD with "ldap_id_mapping = false" and start SSSD
     :steps:
-        1. Find 'user1', 'user2' and 'user3' with getent.passwd(name)
-        2. Find 'user1', 'user2' and 'user3' with getent.passwd(uid)
-        3. Check that users have correct names
-        4. Check that users have correct ids
+        1. Lookup the users using their name
+        2. Check the results
+        3. Lookup the users using their uid
+        4. Check the results
     :expectedresults:
         1. Users are found
-        2. Users are found
-        3. Users have correct names
-        4. Users have correct ids
+        2. Users have correct names and uids
+        3. Users are found
+        4. Users have correct names and uids
     :customerscenario: False
     """
     ids = [("user1", 10001), ("user2", 10002), ("user3", 10003)]
@@ -188,35 +176,34 @@ def test_identity__lookup_user_with_getent(client: Client, provider: GenericProv
 
     for name, uid in ids:
         result = client.tools.getent.passwd(name)
-        assert result is not None, f"User {name} was not found using getent"
-        assert result.name == name, f"Username {result.name} is incorrect, {name} expected"
-        assert result.uid == uid, f"User id {result.uid} is incorrect, {uid} expected"
+        assert result is not None, f"User {name} was not found using getent!"
+        assert result.name == name, f"Username {result.name} is incorrect, {name} expected!"
+        assert result.uid == uid, f"User id {result.uid} is incorrect, {uid} expected!"
 
         result = client.tools.getent.passwd(uid)
-        assert result is not None, f"User with uid {uid} was not found using getent"
-        assert result.name == name, f"Username {result.name} is incorrect, {name} expected"
-        assert result.uid == uid, f"User id {result.uid} is incorrect, {uid} expected"
+        assert result is not None, f"User with uid {uid} was not found using getent!"
+        assert result.name == name, f"Username {result.name} is incorrect, {name} expected!"
+        assert result.uid == uid, f"User id {result.uid} is incorrect, {uid} expected!"
 
 
 @pytest.mark.importance("critical")
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
-def test_identity__lookup_user_by_group_with_getent(client: Client, provider: GenericProvider):
+def test_identity__lookup_groups_by_name_and_gid_with_getent(client: Client, provider: GenericProvider):
     """
-    :title: Resolve user with getent.group
+    :title: Resolve groups with getent
     :setup:
-        1. Add 'group1', 'group2' and 'group3' to SSSD
-        2. Set groups gids
-        3. Start SSSD
+        1. Create the following groups 'group1', 'group2' and 'group3' specifying the GIDs
+        2. Configure SSSD with "ldap_id_mapping = false" and start SSSD
     :steps:
-        1. Find 'group1', 'group2' and 'group3' with getent.group(name)
-        2. Find 'group1', 'group2' and 'group3' with getent.group(gid)
-        3. Check that groups have correct names
-        4. Check that groups have correct gids
+        1. Lookup the groups using their name
+        2. Check the results
+        3. Lookup the groups using their gid
+        4. Check the results
     :expectedresults:
         1. Groups are found
-        2. Groups are found
-        3. Groups have correct names
-        4. Groups have correct gids
+        2. Groups have correct names and gids
+        3. Groups are found
+        4. Groups have correct names and gids
     :customerscenario: False
     """
     groups = [("group1", 10001), ("group2", 10002), ("group3", 10003)]
@@ -228,14 +215,14 @@ def test_identity__lookup_user_by_group_with_getent(client: Client, provider: Ge
 
     for group, id in groups:
         result = client.tools.getent.group(group)
-        assert result is not None, f"Group {group} was not found using getent"
-        assert result.name == group, f"Groupname {result.name} is incorrect, {group} expected"
-        assert result.gid == id, f"Group gid {result.gid} is incorrect, {id} expected"
+        assert result is not None, f"Group {group} was not found using getent!"
+        assert result.name == group, f"Groupname {result.name} is incorrect, {group} expected!"
+        assert result.gid == id, f"Group gid {result.gid} is incorrect, {id} expected!"
 
         result = client.tools.getent.group(id)
-        assert result is not None, f"Group with gid {id} was not found using getent"
-        assert result.name == group, f"Groupname {result.name} is incorrect, {group} expected"
-        assert result.gid == id, f"Group gid {result.gid} is incorrect, {id} expected"
+        assert result is not None, f"Group with gid {id} was not found using getent!"
+        assert result.name == group, f"Groupname {result.name} is incorrect, {group} expected!"
+        assert result.gid == id, f"Group gid {result.gid} is incorrect, {id} expected!"
 
 
 @pytest.mark.importance("critical")
@@ -245,28 +232,28 @@ def test_identity__lookup_user_by_group_with_getent(client: Client, provider: Ge
     lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
     "SSSD was built without support for running under non-root",
 )
-def test_identity__lookup_group_membership_by_username_with_id(
+def test_identity__lookup_group_membership_by_username_with_id_command(
     client: Client, provider: GenericProvider, sssd_service_user: str
 ):
     """
-    :title: Check membership of user by group name with id
+    :title: Check membership of user by group name with "id"
     :setup:
-        1. Add 'user1', 'user2' and 'user3' to SSSD
-        2. Add 'group1' to SSSD
-        3. Add members to group
-        4. Start SSSD
+        1. Create the following users 'user1', 'user2', 'user3', and 'user4'
+        2. Create 'group1' and add all users to group except for 'user4'
+        3. Configure SSSD with "ldap_id_mapping = false" and start SSSD
     :steps:
-        1. Find 'user1', 'user2' and 'user3' with id(name)
-        2. Check that users are members of correct group using memberof([name])
+        1. Lookup users by name
+        2. Check results
     :expectedresults:
         1. Users are found
-        2. Users are members of correct group
+        2. All users except 'user4' are members of 'group1'
     :customerscenario: False
     """
     users = [("user1", "group1"), ("user2", "group1"), ("user3", "group1")]
     u1 = provider.user("user1").add()
     u2 = provider.user("user2").add()
     u3 = provider.user("user3").add()
+    u4 = provider.user("user4").add()
 
     provider.group("group1").add().add_members([u1, u2, u3])
 
@@ -275,26 +262,29 @@ def test_identity__lookup_group_membership_by_username_with_id(
 
     for name, groups in users:
         result = client.tools.id(name)
-        assert result is not None, f"User {name} was not found using id"
-        assert result.memberof(groups), f"User {name} is member of wrong groups"
+        assert result is not None, f"User {name} was not found using id!"
+        assert result.memberof(groups), f"User {name} is a member of the wrong groups!"
+
+    result = client.tools.id(u4.name)
+    assert result is not None, "User not found!"
+    assert not result.memberof("group1"), f"User {u4.name} is a member of the wrong groups!"
 
 
 @pytest.mark.importance("critical")
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
-def test_identity__lookup_group_membership_by_group_with_id(client: Client, provider: GenericProvider):
+def test_identity__lookup_group_membership_by_group_with_id_command(client: Client, provider: GenericProvider):
     """
-    :title: Check membership of user by gid with id
+    :title: Check membership of user by gid with "id"
     :setup:
-        1. Add 'user1', 'user2' and 'user3' to SSSD
-        2. Add 'group1' to SSSD
-        3. Add members to group
-        4. Start SSSD
+        1. Create the following users 'user1', 'user2' and 'user3' specifying the UIDs and GIDs
+        2. Create 'group1' and add all users to group
+        3. Configure SSSD with "ldap_id_mapping = false" and start SSSD
     :steps:
-        1. Find 'user1', 'user2' and 'user3' with id(name)
-        2. Check that users are members of correct groups using memberof(gid)
+        1. Lookup users by name with "id"
+        2. Check results
     :expectedresults:
         1. Users are found
-        2. Users are members of correct group
+        2. Users are members of the group checked using the GID
     :customerscenario: False
     """
     users = [("user1", 1001), ("user2", 1001), ("user3", 1001)]
@@ -309,8 +299,8 @@ def test_identity__lookup_group_membership_by_group_with_id(client: Client, prov
 
     for name, gids in users:
         result = client.tools.id(name)
-        assert result is not None, f"User {name} was not found using id"
-        assert result.memberof(gids), f"User {name} is member of wrong groups"
+        assert result is not None, f"User {name} was not found using id!"
+        assert result.memberof(gids), f"User {name} is member of wrong groups!"
 
 
 @pytest.mark.importance("critical")
@@ -319,19 +309,15 @@ def test_identity__lookup_initgroups_with_getent(client: Client, provider: Gener
     """
     :title: Check initgroups of user
     :setup:
-        1. Add users to SSSD
-        2. Add groups to SSSD
-        3. Set groups gids
-        4. Add members to groups
-        5. Start SSSD
+        1. Create the following users 'user1', 'user2' and 'user3' specifying the UIDs and GIDs
+        2. Create the following groups 'group1', 'group2' and 'group3' and add all users to all groups
+        3. Configure SSSD with "ldap_id_mapping = false" and start SSSD
     :steps:
-        1. Find users with getent.initgroups(name)
-        2. Check that user has correct name
-        3. Check that user has correct initgroups
+        1. Lookup users using initgroups with getent
+        2. Check results
     :expectedresults:
         1. Users are found
-        2. User has correct names
-        3. User has correct initgroups
+        2. Users are in the groups checked by GIDs
     :customerscenario: False
     """
     users = ["user1", "user2", "user3"]
@@ -348,8 +334,8 @@ def test_identity__lookup_initgroups_with_getent(client: Client, provider: Gener
 
     for name in users:
         result = client.tools.getent.initgroups(name)
-        assert result.name == name, f"Username {result.name} is incorrect, {name} expected"
-        assert result.memberof([10001, 10002, 10003]), f"User {name} is member of wrong groups"
+        assert result.name == name, f"Username {result.name} is incorrect, {name} expected!"
+        assert result.memberof([10001, 10002, 10003]), f"User {name} is member of wrong groups!"
 
 
 @pytest.mark.importance("critical")
@@ -358,20 +344,16 @@ def test_identity__lookup_users_with_fully_qualified_name(client: Client, provid
     """
     :title: Resolve user when 'use_fully_qualified_names' is 'true'
     :setup:
-        1. Add 'user1' and 'user2' to SSSD
-        2. Set users uids and gids
-        3. In SSSD domain change 'use_fully_qualified_names' to 'true'
-        4. Start SSSD
+        1. Create the following users 'user1', 'user2' and 'user3' specifying the UIDs and GIDs
+        2. Configure SSSD with "ldap_id_mapping = false" and "use_fully_qualified_name = true" and start SSSD
     :steps:
-        1. Find 'user1' and 'user2' with id(name)
-        2. Find 'user1' and 'user2' with id(name@domain)
-        3. Check that users have correct full names
-        4. Check that users have correct ids
+        1. Lookup users with their username
+        2. Lookup users with their fully qualified name
+        3. Check results
     :expectedresults:
         1. Users are not found
         2. Users are found
-        3. Users have correct full names
-        4. Users have correct ids
+        3. Users have the correct names and UIDs
     :customerscenario: False
     """
     provider.user("user1").add(uid=10001, gid=19001)
@@ -381,38 +363,34 @@ def test_identity__lookup_users_with_fully_qualified_name(client: Client, provid
     client.sssd.domain["ldap_id_mapping"] = "false"
     client.sssd.start()
 
-    assert client.tools.id("user1") is None, "User user1 should be found only with fq name"
-    assert client.tools.id("user2") is None, "User user2 should be found only with fq name"
+    assert client.tools.id("user1") is None, "User user1 should be found only with fq name!"
+    assert client.tools.id("user2") is None, "User user2 should be found only with fq name!"
 
     result = client.tools.id("user1@test")
-    assert result is not None, "User user1@test was not found using id"
-    assert result.user.name == "user1@test", f"Username {result.user.name} is incorrect, user1@test expected"
-    assert result.user.id == 10001, f"User id {result.user.id} is incorrect, 10001 expected"
+    assert result is not None, "User user1@test was not found using id!"
+    assert result.user.name == "user1@test", f"Username {result.user.name} is incorrect, user1@test expected!"
+    assert result.user.id == 10001, f"User id {result.user.id} is incorrect, 10001 expected!"
 
     result = client.tools.id("user2@test")
-    assert result is not None, "User user2@test was not found using id"
-    assert result.user.name == "user2@test", f"Username {result.user.name} is incorrect, user2@test expected"
-    assert result.user.id == 10002, f"User id {result.user.id} is incorrect, 10002 expected"
+    assert result is not None, "User user2@test was not found using id!"
+    assert result.user.name == "user2@test", f"Username {result.user.name} is incorrect, user2@test expected!"
+    assert result.user.id == 10002, f"User id {result.user.id} is incorrect, 10002 expected!"
 
 
 @pytest.mark.importance("critical")
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
-def test_identity__lookup_users_when_case_insensitive(client: Client, provider: GenericProvider):
+def test_identity__lookup_users_when_case_sensitive_is_false(client: Client, provider: GenericProvider):
     """
-    :title: Search user with case insensitive name when 'case_sensitive' is 'false'
+    :title: Search user with case-sensitivity is false
     :setup:
-        1. Add 'user1', 'user2' and 'user3' to SSSD
-        2. Set users uids
-        3. In SSSD domain change 'case_sensitive' to 'false'
-        4. Start SSSD
+        1. Create the following users 'user1', 'user2' and 'user3' specifying the UIDs and GIDs
+        2. Configure SSSD with "ldap_id_mapping = false" and "case_sensitive = false" and start SSSD
     :steps:
-        1. Find users with id(name), where name is in random lower and upper case format
-        2. Check that usernames are correctly set
-        3. Check that users have correct ids
+        1. Lookup users by their name randomizing the capitalization of letters in the name
+        2. Check the results
     :expectedresults:
         1. Users are found
-        2. Users have correct names
-        3. Users have correct ids
+        2. Results have the correct name and UID
     :customerscenario: False
     """
     provider.user("user1").add(uid=10001, gid=19001)
@@ -435,34 +413,31 @@ def test_identity__lookup_users_when_case_insensitive(client: Client, provider: 
         ("USER3", 10003),
     ]:
         result = client.tools.id(name)
-        assert result is not None, f"User {name} was not found using id"
-        assert result.user.name == name.lower(), f"Username {result.user.name} is incorrect, {name.lower()} expected"
-        assert result.user.id == uid, f"User id {result.user.id} is incorrect, {uid} expected"
+        assert result is not None, f"User {name} was not found using id!"
+        assert result.user.name == name.lower(), f"Username {result.user.name} is incorrect, {name.lower()} expected!"
+        assert result.user.id == uid, f"User id {result.user.id} is incorrect, {uid} expected!"
 
 
 @pytest.mark.importance("critical")
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
-def test_identity__lookup_users_fully_qualified_name_and_case_insensitive(client: Client, provider: GenericProvider):
+def test_identity__lookup_users_fully_qualified_name_and_case_sensitive_is_false(
+    client: Client, provider: GenericProvider
+):
     """
-    :title: Search user with fq case insensitive name when
-            'case_sensitive' is 'false' and 'use_fully_qualified_names' is 'true'
+    :title: Search user with fully qualified name when case-sensitive is false
     :setup:
-        1. Add 'user1', 'user2' and 'user3' to SSSD
-        2. Set users gids and uids
-        3. Add 'group1', 'group2' and 'group3' to SSSD
-        4. Set groups gids
-        5. Add members to the groups
-        6. In SSSD domain change 'use_fully_qualified_names' to 'true'
-        7. In SSSD domain change 'case_sensitive' to 'false'
-        8. Start SSSD
+        1. Create the following users 'user1', 'user2' and 'user3' specifying the UIDs and GIDs
+        2. Create the following groups 'group1', 'group2' and 'group3' specifying the GIDs
+        3. Configure SSSD with "ldap_id_mapping = false", "case_sensitive = false" and
+           "use_fully_qualified_name = true" and start SSSD
     :steps:
-        1. Find users with id(name)
-        2. Find users with id(name@domain) - name is in random lower and upper case format
+        1. Lookup users by their name with id
+        2. Lookup users with their fully qualified name randomizing the capitalization of letters in the name
         3. Check that users have correct groups
     :expectedresults:
         1. Users are not found
         2. Users are found
-        3. Users are members of correct groups
+        3. Users are in the correct groups
     :customerscenario: False
     """
     u1 = provider.user("user1").add(gid=101, uid=10001)
@@ -478,51 +453,52 @@ def test_identity__lookup_users_fully_qualified_name_and_case_insensitive(client
     client.sssd.domain["ldap_id_mapping"] = "false"
     client.sssd.start()
 
-    assert client.tools.id("user1") is None, "User user1 should be found only with fq name"
-    assert client.tools.id("user2") is None, "User user2 should be found only with fq name"
-    assert client.tools.id("user3") is None, "User user3 should be found only with fq name"
+    assert client.tools.id("user1") is None, "User user1 should be found only with fully qualified name!"
+    assert client.tools.id("user2") is None, "User user2 should be found only with fully qualified name!"
+    assert client.tools.id("user3") is None, "User user3 should be found only with fully qualified name!"
 
     for name in ["User1@TesT", "UseR1@TesT", "UsER1@TesT"]:
         result = client.tools.id(name)
-        assert result is not None, f"User {name} was not found using id"
-        assert result.memberof([101, 1001, 1002, 1003]), f"User {name} is member of wrong groups"
+        assert result is not None, f"User {name} was not found using id!"
+        assert result.memberof([101, 1001, 1002, 1003]), f"User {name} is a member of the wrong groups!"
 
     for name in ["uSer2@TeST", "user2@TEsT", "uSER2@tesT"]:
         result = client.tools.id(name)
-        assert result is not None, f"User {name} was not found using id"
-        assert result.memberof([102, 1002, 1003]), f"User {name} is member of wrong groups"
+        assert result is not None, f"User {name} was not found using id!"
+        assert result.memberof([102, 1002, 1003]), f"User {name} is a member of the wrong groups!"
+        assert not result.memberof(1001), f"User {name} is in the wrong groups!"
 
     for name in ["USer3@TeST", "uSer3@TeST", "USER3@Test"]:
         result = client.tools.id(name)
-        assert result is not None, f"User {name} was not found using id"
-        assert result.memberof([103, 1003]), f"User {name} is member of wrong groups"
+        assert result is not None, f"User {name} was not found using id!"
+        assert result.memberof([103, 1003]), f"User {name} is a member of the wrong groups!"
+        assert not result.memberof([1001, 1002]), f"User {name} is in the wrong groups!"
 
 
 @pytest.mark.importance("critical")
-@pytest.mark.authentication
 @pytest.mark.topology(KnownTopologyGroup.AnyAD)
-def test_identity__lookup_idmapping_of_posix_and_non_posix_user_and_group(client: Client, provider: GenericADProvider):
+def test_identity__lookup_id_mapping_of_posix_and_non_posix_user_and_group(
+    client: Client, provider: GenericADProvider
+):
     """
-    :title: Check ID mapping of POSIX and non POSIX users in AD type directories when ldap_id_mapping is false
+    :title: Check ID mapping of POSIX and non-POSIX users in AD directories when id mapping is false
+    :note: This is a generic provider test, AD is a workaround to create users with no posix attributes
     :setup:
-        1. Create user with POSIX attriubtes
+        1. Create user with POSIX attributes
         2. Create group with POSIX attributes
         3. Create user with no POSIX attributes
         4. Create group with no POSIX attributes
-        5. Configure SSSD with "ldap_id_mapping" = false
-        6. Start SSSD
+        5. Configure SSSD with "ldap_id_mapping = false" and start SSSD
     :steps:
-        1. Query POSIX group information
-        2. Query POSIX user information
-        3. Query Non-POSIX group information
-        4. Query Non-POSIX user information
+        1. Query POSIX user information
+        2. Query Non-POSIX user information
+        3. Query POSIX group information
+        4. Query Non-POSIX group information
     :expectedresults:
-        1. POSIX group information should be returned and
-            gid matches the one supplied in creation
-        2. POSIX user information should be returned and
-            uid matches the one supplied in creation
-        3. Non-POSIX group information should not be returned
-        4. Non-POSIX user information should not be returned
+        1. POSIX user found with the correct values
+        2. User is not found
+        3. POSIX group found with the correct values
+        4. Group is not found
     :customerscenario: False
     """
 
@@ -537,46 +513,174 @@ def test_identity__lookup_idmapping_of_posix_and_non_posix_user_and_group(client
     client.sssd.domain["ldap_id_mapping"] = "false"
     client.sssd.start()
 
-    result = client.tools.id("posix_user")
-    assert result is not None, "posix-user is not returned by sssd"
-    assert result.group.id == 20001, "gid returned not matched the one provided"
-    assert result.user.id == 10001, "uid returned not matched the one provided"
+    user = client.tools.getent.passwd("posix_user")
+    assert user is not None, "posix-user not found!"
+    assert user.uid == 10001, "gid returned does not matched the one provided!"
+    assert user.gid == 20001, "uid returned does not matched the one provided!"
+    assert client.tools.getent.passwd("nonposix_user") is None, "nonposix-user found!"
 
-    assert client.tools.getent.group("posix_group") is not None, "posix-group is not returned by sssd"
-    assert client.tools.getent.group("nonposix_group") is None, "non-posix group is returned by sssd, it should not be"
+    group = client.tools.getent.group("posix_group")
+    assert group is not None, "posix-group not found!"
+    assert group.gid == 20001, "gid is not the correct value!"
+    assert client.tools.getent.group("nonposix_group") is None, "nonposix-group found!"
 
 
 @pytest.mark.ticket(bz=1695577)
+@pytest.mark.importance("critical")
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
-def test_identity__lookup_when_private_groups_set_to_hybrid(client: Client, provider: GenericProvider):
+def test_identity__lookup_when_auto_private_groups_is_set_to_true(client: Client, provider: GenericProvider):
     """
-    :title: auto_private_groups set to hybrid
+    :title: Look up users when auto private groups is set to true
+    :description:
+        When true, the user's gid will match the uid, even when the object isn't
+        a real group in the directory. If it is a real group, the user values will override
+        the name and gid. In this test, only the users exist in LDAP.
     :setup:
-        1. Add user "user_same" with uid equals to gid
-        2. Add user "user_different" with uid not equals to gid
-        3. Set auto_private_groups in sssd.conf to hybrid and turn of ldap_id_mapping
-        4. Start SSSD
+        1. Create the following users 'user_same_gid', 'user_diff_gid' and 'user_group_gid'.
+            Set the uids and gids to match the condition defined by in the username
+        2. Configure SSSD with "ldap_id_mapping = false" and "auto_private_groups = true" and start SSSD
     :steps:
-        1. getent passwd "user_same"
-        2. getent passwd "user_different"
+        1. Lookup all users and compare their uid to their gid
+        2. Lookup up the user's gid
     :expectedresults:
-        1. Uid equals to gid
-        2. Uid does not equal to gid
+        1. All users uid and gid match
+        2. All groups are found
     :customerscenario: True
     :requirement: IDM-SSSD-REQ: SSSD can automatically create user private groups for users
     """
-    provider.user("user_same").add(uid=111111, gid=111111)
-    provider.user("user_different").add(uid=111111, gid=100000)
+    provider.user("user_same_gid").add(uid=111111, gid=111111)
+    provider.user("user_diff_gid").add(uid=222222, gid=333333)
+    provider.user("user_no_gid").add(uid=444444)
+
+    client.sssd.domain["auto_private_groups"] = "true"
+    client.sssd.domain["ldap_id_mapping"] = "false"
+
+    client.sssd.start()
+
+    for i in [("user_same_gid", 111111), ("user_diff_gid", 222222), ("user_no_gid", 444444)]:
+        user = client.tools.getent.passwd(i[0])
+        assert user is not None, f"User '{i[0]}' is not found!"
+        assert user.uid == (i[1]), "uid does not match expected value!"
+        assert user.uid == user.gid, "uid does not match gid!"
+
+        group = client.tools.getent.group(i[0])
+        assert group is not None, f"{i[0]} group is not found!"
+
+
+@pytest.mark.ticket(bz=1695577)
+@pytest.mark.importance("high")
+@pytest.mark.topology(KnownTopologyGroup.AnyProvider)
+def test_identity__lookup_when_auto_private_groups_is_set_to_false(client: Client, provider: GenericProvider):
+    """
+    :title: Look up users when auto private groups is set to false
+    :description:
+        When false, to be able to look up the group, the group needs to exist
+        in the directory. In this test, only the 'user_group_gid' user has a valid LDAP group.
+    :setup:
+        1. Create a group
+        2. Create the following users 'user_same_gid', 'user_diff_gid' and 'user_group_gid'.
+            Set the uids and gids to match the condition defined by in the username
+        3. Configure SSSD with "ldap_id_mapping = false" and "auto_private_groups = false" and start SSSD
+    :steps:
+        1. Lookup 'user_same_gid' and look up the user's gid
+        2. Lookup 'user_diff_gid' and look up the user's gid
+        3. Lookup 'user_group_gid' and look up the user's gid
+    :expectedresults:
+        1. The user is found with the configured values, and the group is *NOT* found
+        2. The user is found with the configured values, and the group is *NOT* found
+        3. The user is found with the configured values, and the group is found
+    :customerscenario: True
+    :requirement: IDM-SSSD-REQ: SSSD can automatically create user private groups for users
+    """
+    provider.group("group").add(gid=444444)
+    provider.user("user_same_gid").add(uid=111111, gid=111111)
+    provider.user("user_diff_gid").add(uid=222222, gid=333333)
+    provider.user("user_group_gid").add(uid=444444, gid=444444)
+
+    client.sssd.domain["auto_private_groups"] = "false"
+    client.sssd.domain["ldap_id_mapping"] = "false"
+
+    client.sssd.start()
+
+    result = client.tools.getent.passwd("user_same_gid")
+    assert result is not None, "User 'user_same_gid' not found!"
+    assert result.gid == 111111, "gid does not match expected value!"
+
+    # IPA manages auto_private_groups on the server and is true by default
+    if isinstance(provider, IPA):
+        assert client.tools.getent.group(111111), "Group is not found!"
+    else:
+        assert not client.tools.getent.group(111111), "Group should not be found!"
+
+    result = client.tools.getent.passwd("user_diff_gid")
+    assert result is not None, "User 'user_diff_gid' is not found!"
+    assert result.gid == 333333, "gid does not match expected value!"
+    assert client.tools.getent.group(333333) is None, "group is found!"
+
+    result = client.tools.getent.passwd("user_group_gid")
+    assert result is not None, "User 'user_group_gid' is not found!"
+    assert result.gid == 444444, "gid does not match expected value!"
+    assert client.tools.getent.group(444444) is not None, "group is not found!"
+
+
+@pytest.mark.ticket(bz=1695577)
+@pytest.mark.importance("high")
+@pytest.mark.topology(KnownTopologyGroup.AnyProvider)
+def test_identity__lookup_when_auto_private_groups_is_set_to_hybrid(client: Client, provider: GenericProvider):
+    """
+    :title: Look up users when auto private groups is set to hybrid
+    :description:
+        When set to hybrid, if the uid and gid match for the user, it will act as if a
+        group exists similar to when the parameter is set to true. Like when it's set to false, if the
+        group exists in LDAP, it will look at whatever is existing for its values.
+    :setup:
+        1. Create a group
+        2. Create the following users 'user_same_gid', 'user_diff_gid', 'user_no_gid' and 'user_group_gid'.
+            Set the uids and gids to match the condition defined by in the username
+        3. Configure SSSD with "ldap_id_mapping = false" and "auto_private_groups = hybrid" start SSSD
+    :steps:
+        1. Lookup 'user_same_gid' and look up the user's gid
+        2. Lookup 'user_diff_gid' and look up the user's gid
+        3. Lookup 'user_no_gid' and look up the user's gid
+        4. Lookup 'user_group_gid' and look up the user's gid
+    :expectedresults:
+        1. The user is found with the configured values, and the group is found
+        2. The user is found with the configured values, and the group is *NOT* found
+        3. The user is found with the configured values, and the group is *NOT* found
+        4. The user is found with the configured values, and the group is found
+    :customerscenario: True
+    :requirement: IDM-SSSD-REQ: SSSD can automatically create user private groups for users
+    """
+    provider.group("group").add(gid=55555)
+    provider.user("user_same_gid").add(uid=111111, gid=111111)
+    provider.user("user_diff_gid").add(uid=222222, gid=333333)
+    provider.user("user_no_gid").add(uid=444444)
+    provider.user("user_group_gid").add(uid=555555, gid=555555)
 
     client.sssd.domain["auto_private_groups"] = "hybrid"
     client.sssd.domain["ldap_id_mapping"] = "false"
 
     client.sssd.start()
 
-    result = client.tools.getent.passwd("user_same@test")
-    assert result, "getent passwd failed on user_same"
-    assert result.uid == result.gid, "gid and uid for user_same are not same"
+    result = client.tools.getent.passwd("user_same_gid")
+    assert result is not None, "User 'user_same_gid' not found!"
+    assert result.gid == 111111, "gid does not match expected value!"
+    assert client.tools.getent.group(111111) is not None, "auto private group not found!"
 
-    result = client.tools.getent.passwd("user_different@test")
-    assert result, "getent passwd failed on user_different"
-    assert result.uid != result.gid, "gid and uid for user_different are same"
+    result = client.tools.getent.passwd("user_diff_gid")
+    assert result is not None, "User 'user_diff_gid' not found!"
+    assert result.gid == 333333, "gid does not match expected value!"
+    assert client.tools.getent.group(333333) is None, "auto private group should not be found!"
+
+    # IPA manages auto_private_groups on the server and is true by default
+    if isinstance(provider, IPA):
+        result = client.tools.getent.passwd("user_group_gid")
+        assert result is not None, "User 'user_group_gid' not found!"
+        assert result.gid == 555555, "gid is not found!"
+    else:
+        assert client.tools.getent.passwd("user_no_id") is None, "gid should not be found!"
+
+    result = client.tools.getent.passwd("user_group_gid")
+    assert result is not None, "User 'user_group_gid' not found!"
+    assert result.gid == 555555, "gid does not match expected value!"
+    assert client.tools.getent.group(555555) is not None, "auto private group not found!"


### PR DESCRIPTION
housekeeping, the following is looked at and may have been done:
* fixed typos and standardized formatting
* renamed test cases to improve the clarity of what the test does
* improved docstring language, setup, steps and expected results
* synced code with the docstring order
* removed necessary configuration relevant to the test
* added pytest.mark.importance to test cases

noteable changes:
 * auto_private_group tests reworked, adding two more test cases
