### PR TITLE
krb5_child: do not try passwords with OTP

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -4571,6 +4571,17 @@ ldap_user_extra_attrs = phone:telephoneNumber
                     to log in either only with the password or with both factors
                     two-step prompting has to be used.
                     </para>
+                    <para>
+                    Some clients, such as SSH with
+                    'PasswordAuthentication yes', generate their own prompts
+                    and do not use prompts provided by SSSD or other PAM
+                    modules. Additionally, for SSH with
+                    PasswordAuthentication, if two-factor authentication is
+                    available, SSSD expects that the
+                    credentials entered by the user at the SSH password prompt
+                    will always be the two factors in a single string, even if
+                    two-factor authentication is optional.
+                    </para>
                 </listitem>
             </varlistentry>
         </variablelist>

--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -541,15 +541,6 @@ static krb5_error_code tokeninfo_matches(TALLOC_CTX *mem_ctx,
     size_t fa2_len;
 
     switch (sss_authtok_get_type(auth_tok)) {
-    case SSS_AUTHTOK_TYPE_PASSWORD:
-        ret = sss_authtok_get_password(auth_tok, &pwd, &len);
-        if (ret != EOK) {
-            DEBUG(SSSDBG_OP_FAILURE, "sss_authtok_get_password failed.\n");
-            return ret;
-        }
-
-        return tokeninfo_matches_pwd(mem_ctx, ti, pwd, len, out_token, out_pin);
-        break;
     case SSS_AUTHTOK_TYPE_2FA_SINGLE:
         ret = sss_authtok_get_2fa_single(auth_tok, &pwd, &len);
         if (ret != EOK) {
@@ -574,7 +565,7 @@ static krb5_error_code tokeninfo_matches(TALLOC_CTX *mem_ctx,
               "Unsupported authtok type %d\n", sss_authtok_get_type(auth_tok));
     }
 
-    return EINVAL;
+    return EAGAIN;
 }
 
 static krb5_error_code answer_otp(krb5_context ctx,


### PR DESCRIPTION
During two-factor authentication (OTP) krb5_child should use use the
dedicated OTP auth types SSS_AUTHTOK_TYPE_2FA and
SSS_AUTHTOK_TYPE_2FA_SINGLE exclusively and should not try password or
other types.

Resolves: https://github.com/SSSD/sssd/issues/7456