### PR TITLE
Remove -f flag from sysv init script

### DIFF
--- a/src/sysv/sssd.in
+++ b/src/sysv/sssd.in
@@ -45,7 +45,7 @@ TIMEOUT=15
 start() {
     [ -x $SSSD ] || exit 5
     echo -n $"Starting $prog: "
-    daemon $SSSD -f -D
+    daemon $SSSD -D
     RETVAL=$?
     echo
     [ "$RETVAL" = 0 ] && touch $LOCK_FILE

--- a/src/sysv/sssd.in
+++ b/src/sysv/sssd.in
@@ -45,7 +45,7 @@ TIMEOUT=15
 start() {
     [ -x $SSSD ] || exit 5
     echo -n $"Starting $prog: "
-    daemon $SSSD -D
+    daemon $SSSD -D --logger=files
     RETVAL=$?
     echo
     [ "$RETVAL" = 0 ] && touch $LOCK_FILE


### PR DESCRIPTION
The `-f` flag no longer works with the sssd daemon (apologies I cannot find the exact commit where this option was removed). The systemd service removed this option in a7277fecf7a65ab6c83b36f009c558cdfbf997d2 but the sysv init script was not updated at that time.