### PR TITLE
Expose flat_name for use in homedir path

### DIFF
--- a/src/responder/nss/nss_protocol_pwent.c
+++ b/src/responder/nss/nss_protocol_pwent.c
@@ -123,6 +123,7 @@ sss_nss_get_homedir(TALLOC_CTX *mem_ctx,
     hd_ctx.uid = uid;
     hd_ctx.domain = domain->name;
     hd_ctx.upn = upn;
+    hd_ctx.flatname = domain->flat_name;
 
     homedir = sss_nss_get_homedir_override(mem_ctx, msg, nss_ctx, domain, &hd_ctx);
     if (homedir == NULL) {


### PR DESCRIPTION
The %F placeholder for subdomain_homedir doesn't work with the AD plugin, despite of what the manual says.

This patch let the use it and works also for trusted domains.