### PR TITLE
pam_sss: add missing optional 2nd factor handling

### DIFF
--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -2505,8 +2505,13 @@ static int prompt_by_config(pam_handle_t *pamh, struct pam_items *pi)
             ret = prompt_password(pamh, pi, pc_get_password_prompt(pi->pc[c]));
             break;
         case PC_TYPE_2FA:
-            ret = prompt_2fa(pamh, pi, false, pc_get_2fa_1st_prompt(pi->pc[c]),
-                             pc_get_2fa_2nd_prompt(pi->pc[c]));
+            if (pi->password_prompting) {
+                ret = prompt_2fa(pamh, pi, true, pc_get_2fa_1st_prompt(pi->pc[c]),
+                                 pc_get_2fa_2nd_prompt(pi->pc[c]));
+            } else {
+                ret = prompt_2fa(pamh, pi, false, pc_get_2fa_1st_prompt(pi->pc[c]),
+                                 pc_get_2fa_2nd_prompt(pi->pc[c]));
+            }
             break;
         case PC_TYPE_2FA_SINGLE:
             ret = prompt_2fa_single(pamh, pi,


### PR DESCRIPTION
This is a follow up to pull-request #7462 and adds the proper handling of
an optional second factor in case the prompting is configured.

Resolves: https://github.com/SSSD/sssd/issues/7456