### PR TITLE
test: housekeeping - sudo

### DIFF
--- a/src/tests/system/pytest.ini
+++ b/src/tests/system/pytest.ini
@@ -4,7 +4,6 @@ addopts = --strict-markers
 testpaths = tests
 markers =
     authentication:
-    authorization:
     cache:
     config:
     contains_workaround_for(gh=...,bz=...):


### PR DESCRIPTION
housekeeping, the following is looked at and may have been done:
* fixed typos and standardized formatting
* renamed test cases to improve the clarity of what the test does
* improved docstring language, setup, steps and expected results
* synced code with the docstring order
* removed necessary configuration relevant to the test
* added pytest.mark.importance to test cases
* added error messages to assertions

noteable changes:
* removed authorization pytest marker, it's no longer used