### PR TITLE
AD Provider: read sAMAccountName unconditionally

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -134,6 +134,7 @@
 #define SYSDB_CANONICAL_UPN "canonicalUserPrincipalName"
 #define SYSDB_CCACHE_FILE "ccacheFile"
 #define SYSDB_DN_FOR_MEMBER_HASH_TABLE "dnForMemberHashTable"
+#define SYSDB_AD_SAMACCOUNTNAME "adSAMAccountName"
 
 #define SYSDB_ORIG_DN "originalDN"
 #define SYSDB_ORIG_OBJECTCLASS "originalObjectClass"

--- a/src/providers/ad/ad_opts.c
+++ b/src/providers/ad/ad_opts.c
@@ -245,6 +245,7 @@ struct sdap_attr_map ad_2008r2_user_map[] = {
     { "ldap_user_auth_type", NULL, SYSDB_AUTH_TYPE, NULL },
     { "ldap_user_certificate", "userCertificate;binary", SYSDB_USER_CERT, NULL },
     { "ldap_user_email", "mail", SYSDB_USER_EMAIL, NULL },
+    { SDAP_ATTR_MAP_NO_OPT, "sAMAccountName", SYSDB_AD_SAMACCOUNTNAME, NULL },
     { "ldap_user_passkey", "altSecurityIdentities", SYSDB_USER_PASSKEY, NULL },
     SDAP_ATTR_MAP_TERMINATOR
 };

--- a/src/providers/ipa/ipa_opts.c
+++ b/src/providers/ipa/ipa_opts.c
@@ -228,6 +228,7 @@ struct sdap_attr_map ipa_user_map[] = {
     { "ldap_user_auth_type", "ipaUserAuthType", SYSDB_AUTH_TYPE, NULL },
     { "ldap_user_certificate", "userCertificate;binary", SYSDB_USER_CERT, NULL },
     { "ldap_user_email", "mail", SYSDB_USER_EMAIL, NULL },
+    { SDAP_ATTR_MAP_NO_OPT, "sAMAccountName", SYSDB_AD_SAMACCOUNTNAME, NULL },
     { "ldap_user_passkey", "ipaPassKey", SYSDB_USER_PASSKEY, NULL },
     SDAP_ATTR_MAP_TERMINATOR
 };

--- a/src/providers/ldap/ldap_common.h
+++ b/src/providers/ldap/ldap_common.h
@@ -388,6 +388,11 @@ char *sdap_combine_filters(TALLOC_CTX *mem_ctx,
                            const char *base_filter,
                            const char *extra_filter);
 
+char *principal_string_to_samaccountname(TALLOC_CTX *mem_ctx,
+                                         const char *attr_name,
+                                         const char *princ,
+                                         const char *realm);
+
 char *get_enterprise_principal_string_filter(TALLOC_CTX *mem_ctx,
                                              const char *attr_name,
                                              const char *princ,

--- a/src/providers/ldap/ldap_id.c
+++ b/src/providers/ldap/ldap_id.c
@@ -179,6 +179,7 @@ struct tevent_req *users_get_send(TALLOC_CTX *memctx,
     char *sid;
     char *user_filter = NULL;
     char *ep_filter;
+    char *sam_filter = NULL;
 
     req = tevent_req_create(memctx, &state, struct users_get_state);
     if (!req) return NULL;
@@ -230,13 +231,17 @@ struct tevent_req *users_get_send(TALLOC_CTX *memctx,
             ep_filter = get_enterprise_principal_string_filter(state,
                                    ctx->opts->user_map[SDAP_AT_USER_PRINC].name,
                                    clean_value, ctx->opts->basic);
+            sam_filter = principal_string_to_samaccountname(state,
+                                   ctx->opts->user_map[SDAP_AT_USER_SAMACCOUNTNAME].name,
+                                   clean_value, state->domain->realm);
             /* TODO: Do we have to check the attribute names more carefully? */
-            user_filter = talloc_asprintf(state, "(|(%s=%s)(%s=%s)%s)",
+            user_filter = talloc_asprintf(state, "(|(%s=%s)(%s=%s)%s%s)",
                                    ctx->opts->user_map[SDAP_AT_USER_PRINC].name,
                                    clean_value,
                                    ctx->opts->user_map[SDAP_AT_USER_EMAIL].name,
                                    clean_value,
-                                   ep_filter == NULL ? "" : ep_filter);
+                                   ep_filter == NULL ? "" : ep_filter,
+				   sam_filter == NULL ? "" : sam_filter);
             talloc_zfree(clean_value);
             if (user_filter == NULL) {
                 DEBUG(SSSDBG_OP_FAILURE, "talloc_asprintf failed.\n");

--- a/src/providers/ldap/ldap_opts.c
+++ b/src/providers/ldap/ldap_opts.c
@@ -197,6 +197,7 @@ struct sdap_attr_map rfc2307_user_map[] = {
     { "ldap_user_auth_type", NULL, SYSDB_AUTH_TYPE, NULL },
     { "ldap_user_certificate", "userCertificate;binary", SYSDB_USER_CERT, NULL },
     { "ldap_user_email", "mail", SYSDB_USER_EMAIL, NULL },
+    { SDAP_ATTR_MAP_NO_OPT, NULL, SYSDB_AD_SAMACCOUNTNAME, NULL },
     { "ldap_user_passkey", "passkey", SYSDB_USER_PASSKEY, NULL },
     SDAP_ATTR_MAP_TERMINATOR
 };
@@ -257,6 +258,7 @@ struct sdap_attr_map rfc2307bis_user_map[] = {
     { "ldap_user_auth_type", NULL, SYSDB_AUTH_TYPE, NULL },
     { "ldap_user_certificate", "userCertificate;binary", SYSDB_USER_CERT, NULL },
     { "ldap_user_email", "mail", SYSDB_USER_EMAIL, NULL },
+    { SDAP_ATTR_MAP_NO_OPT, NULL, SYSDB_AD_SAMACCOUNTNAME, NULL },
     { "ldap_user_passkey", "passkey", SYSDB_USER_PASSKEY, NULL },
     SDAP_ATTR_MAP_TERMINATOR
 };
@@ -317,6 +319,7 @@ struct sdap_attr_map gen_ad2008r2_user_map[] = {
     { "ldap_user_auth_type", NULL, SYSDB_AUTH_TYPE, NULL },
     { "ldap_user_certificate", "userCertificate;binary", SYSDB_USER_CERT, NULL },
     { "ldap_user_email", "mail", SYSDB_USER_EMAIL, NULL },
+    { SDAP_ATTR_MAP_NO_OPT, "sAMAccountName", SYSDB_AD_SAMACCOUNTNAME, NULL },
     { "ldap_user_passkey", "passkey", SYSDB_USER_PASSKEY, NULL },
     SDAP_ATTR_MAP_TERMINATOR
 };

--- a/src/providers/ldap/sdap.h
+++ b/src/providers/ldap/sdap.h
@@ -292,6 +292,7 @@ enum sdap_user_attrs {
     SDAP_AT_USER_AUTH_TYPE,
     SDAP_AT_USER_CERT,
     SDAP_AT_USER_EMAIL,
+    SDAP_AT_USER_SAMACCOUNTNAME,
     SDAP_AT_USER_PASSKEY,
 
     SDAP_OPTS_USER /* attrs counter */
@@ -421,6 +422,7 @@ struct sdap_attr_map {
     char *name;
 };
 #define SDAP_ATTR_MAP_TERMINATOR { NULL, NULL, NULL, NULL }
+#define SDAP_ATTR_MAP_NO_OPT "==NO OPTION=="
 
 struct sdap_search_base {
     const char *basedn;

--- a/src/providers/ldap/sdap_async_users.c
+++ b/src/providers/ldap/sdap_async_users.c
@@ -182,6 +182,7 @@ int sdap_save_user(TALLOC_CTX *memctx,
     int ret;
     const char *user_name = NULL;
     const char *fullname = NULL;
+    const char *samaccountname = NULL;
     const char *pwd;
     const char *gecos;
     const char *homedir;
@@ -203,6 +204,7 @@ int sdap_save_user(TALLOC_CTX *memctx,
     size_t c;
     char *p1;
     char *p2;
+    char *new_upn;
     bool is_posix = true;
 
     DEBUG(SSSDBG_TRACE_FUNC, "Save user\n");
@@ -269,7 +271,28 @@ int sdap_save_user(TALLOC_CTX *memctx,
     DEBUG(SSSDBG_TRACE_FUNC, "Processing user %s\n", user_name);
 
     if (opts->schema_type == SDAP_SCHEMA_AD) {
+        /* construct canonical UPN from sAMAccountName to help Samba and also
+         *  to allow us to lookup user via UPN */
         ret = sysdb_attrs_get_string(attrs,
+                    opts->user_map[SDAP_AT_USER_SAMACCOUNTNAME].sys_name,
+                                   &samaccountname);
+        if (ret == EOK) {
+            ret = ENOENT;
+            new_upn = talloc_asprintf(memctx, "%s@%s", samaccountname,
+                                      dom->realm);
+            if (new_upn != NULL){
+                ret = sysdb_attrs_add_string(user_attrs,
+                                             SYSDB_CANONICAL_UPN, new_upn);
+           	DEBUG(SSSDBG_TRACE_FUNC,
+                      "Storing Canonical UPN %s for user %s\n", new_upn,
+                      user_name);
+            }
+        }
+	if (ret != EOK) {
+           DEBUG(SSSDBG_MINOR_FAILURE,
+                 "Unable to obtain Canonical UPN for %s\n", user_name);
+	}
+	ret = sysdb_attrs_get_string(attrs,
                     opts->user_map[SDAP_AT_USER_FULLNAME].sys_name, &fullname);
         if (ret == EOK) {
             ret = sysdb_attrs_add_string(user_attrs, SYSDB_FULLNAME, fullname);


### PR DESCRIPTION
This is a follow up to pull request #7476 incorporating the changes as Simo requested.