### PR TITLE
cfg_rules.ini: Add missing ldap_user_passkey entry.

### DIFF
--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -772,6 +772,7 @@ option = ldap_user_nds_login_disabled
 option = ldap_user_nds_login_expiration_time
 option = ldap_user_object_class
 option = ldap_user_objectsid
+option = ldap_user_passkey
 option = ldap_user_primary_group
 option = ldap_user_principal
 option = ldap_user_search_base


### PR DESCRIPTION
This fixes the following message when using sssctl config-check and using the ldap_user_passkey config option:

[rule/allowed_domain_options]: Attribute 'ldap_user_passkey' is not allowed in section 'domain/EXAMPLE.COM'. Check for typos.