### PR TITLE
tests: housekeeping - test_trusts.py -> test_ipa_trusts.py

### DIFF
--- a/src/tests/system/tests/test_ipa_trusts.py
+++ b/src/tests/system/tests/test_ipa_trusts.py
@@ -1,5 +1,5 @@
 """
-Identity of trusted users and groups.
+IPA Trusts.
 
 :requirement: IDM-SSSD-REQ: Testing SSSD in IPA Provider
 """
@@ -15,24 +15,27 @@ from sssd_test_framework.topology import KnownTopologyGroup
 @pytest.mark.importance("low")
 @pytest.mark.ticket(jira="RHEL-3925", gh=6942)
 @pytest.mark.topology(KnownTopologyGroup.IPATrust)
-def test_trust_identity__group_without_sid(ipa: IPA, trusted: GenericADProvider):
+def test_ipa_trusts__lookup_group_without_sid(ipa: IPA, trusted: GenericADProvider):
     """
-    :title: Subdomain goes offline if IPA group is missing SID
+    :title: Subdomain stays online if IPA group is missing SID
+    :description: This test is to check a bug that made SSSD go offline when an expected attribute was missing.
+        This happens during applying overrides on cached group during initgroups of trusted user. If the group
+        does not have SID (it's GID is outside the sidgen range), SSSD goes offline.
     :setup:
         1. Create IPA external group "external-group" and add AD user "Administrator" as a member
         2. Create IPA posix group "posix-group" and add "external-group" as a member
         3. Clear SSSD cache and logs on IPA server
         4. Restart SSSD on IPA server
     :steps:
-        1. Resolve user "Administrator@addomain"
-        2. Expire user "Administrator@addomain"
-        3. Resolve user "Administrator@addomain"
-        4. Run "sssctl domain-status addomain"
+        1. Lookup AD administrator user
+        2. Clear user cache
+        3. Lookup AD administrator user
+        4. Check logs using sssctl for domain status
     :expectedresults:
-        1. User is resolved and member of posix-group
-        2. User is expired in SSSD cache
-        3. User is resolved and member of posix-group
-        4. The Active Directory domain is still online
+        1. User is found and is a member of 'posix-group'
+        2. User cache expired
+        3. User is found and is a member of 'posix-group'
+        4. No messages indicating AD went offline
     :customerscenario: True
     """
     username = trusted.fqn("administrator")
@@ -44,18 +47,16 @@ def test_trust_identity__group_without_sid(ipa: IPA, trusted: GenericADProvider)
 
     # Cache trusted user
     result = ipa.tools.id(username)
-    assert result is not None
-    assert result.user.name == username
-    assert result.memberof("posix-group")
+    assert result is not None, "User not found!"
+    assert result.memberof("posix-group"), "User is not a member of 'posix-group'!"
 
     # Expire the user and resolve it again, this will trigger the affected code path
     ipa.sssctl.cache_expire(user=username)
     result = ipa.tools.id(username)
-    assert result is not None
-    assert result.user.name == username
-    assert result.memberof("posix-group")
+    assert result is not None, "User not found!"
+    assert result.memberof("posix-group"), "User is not a member of 'posix-group'!"
 
     # Check that SSSD did not go offline
     status = ipa.sssctl.domain_status(trusted.domain, online=True)
-    assert "online status: offline" not in status.stdout.lower()
-    assert "online status: online" in status.stdout.lower()
+    assert "online status: offline" not in status.stdout.lower(), "AD domain went offline!"
+    assert "online status: online" in status.stdout.lower(), "AD domain was not online!"


### PR DESCRIPTION
* renamed file to test_ipa_trusts.py
* added assertion error messages
* removed redundant assertion
* clarified steps and results

Reviewed-by: Justin Stephenson <jstephen@redhat.com>
Reviewed-by: Madhuri Upadhye <mupadhye@redhat.com>
(cherry picked from commit f43dcc30a4534de1c8aaa141920db714bd503332)