### PR TITLE
tests: housekeeping, test_authentication.py

### DIFF
--- a/src/tests/system/tests/test_authentication.py
+++ b/src/tests/system/tests/test_authentication.py
@@ -1,7 +1,7 @@
 """
 SSSD Authentication Test Cases
 
-:requirement: offline
+:requirement: authentication
 """
 
 from __future__ import annotations
@@ -15,55 +15,60 @@ from sssd_test_framework.topology import KnownTopology, KnownTopologyGroup
 
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
 @pytest.mark.parametrize("method", ["su", "ssh"])
-def test_authentication__using_a_good_then_bad_password(client: Client, provider: GenericProvider, method: str):
+@pytest.mark.importance("critical")
+def test_authentication__with_default_settings(
+    client: Client,
+    provider: GenericProvider,
+    method: str,
+):
     """
-    :title: SSH and su authentication
+    :title: Authenticate with default settings
     :setup:
-        1. Add user to SSSD
-        2. Set password for user
-        3. Start SSSD
+        1. Create user
+        2. Start SSSD
     :steps:
         1. Authenticate user with correct password
         2. Authenticate user with incorrect password
     :expectedresults:
-        1. User is authenticated
-        2. User is not authenticated
+        1. Authentication is successful
+        2. Authentication is unsuccessful
     :customerscenario: False
     """
     provider.user("user1").add(password="Secret123")
 
     client.sssd.start()
 
-    assert client.auth.parametrize(method).password("user1", "Secret123"), "login with correct password failed"
-    assert not client.auth.parametrize(method).password("user1", "NOTSecret123"), "login with wrong password succeeded"
+    assert client.auth.parametrize(method).password("user1", "Secret123"), "User failed login!"
+    assert not client.auth.parametrize(method).password(
+        "user1", "NOTSecret123"
+    ), "User logged in with an invalid password!"
 
 
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
 @pytest.mark.parametrize("method", ["su", "ssh"])
-def test_authentication__using_a_good_then_bad_password_when_offline(
-    client: Client, provider: GenericProvider, method: str
+@pytest.mark.importance("critical")
+def test_authentication__default_settings_when_the_provider_is_offline(
+    client: Client,
+    provider: GenericProvider,
+    method: str,
 ):
     """
-    :title: Offline ssh/su login
+    :title: Authenticate with default settings when the provider is offline
     :setup:
-        1. Add user to SSSD and set its password
-        2. In SSSD domain change "cache_credentials" and "krb5_store_password_if_offline" to "True"
-        3. In SSSD pam change "offline_credentials_expiration" to "0"
-        4. Start SSSD
+        1. Create user
+        2. Configure SSSD with "cache_credentials = true" and "krb5_store_password_if_offline = true" and
+        "offline_credentials_expiration = 0"
+        3. Start SSSD
     :steps:
-        1. Authenticate user with wrong password
-        2. Authenticate user with correct password
-        3. Make server offline (by blocking traffic to the provider)
-        4. Bring SSSD offline explicitly
-        5. Offline authentication of user with correct password
-        6. Offline authentication of user with wrong password
+        1. Authenticate user with correct password
+        2. Block outbound traffic to the provider and force SSSD offline
+        3. Authenticate user with correct password
+        4. Authenticate user with incorrect password
     :expectedresults:
-        1. User is not authenticated
-        2. User is authenticated
-        3. Firewall rule added, traffic is dropped.
-        4. SSSD is offline
-        5. Offline authentication is successful
-        6. Offline authentication is not successful
+        1. User authentication is successful
+        2. No traffic is getting to the provider
+        3. User authentication is successful
+        4. User authentication is unsuccessful
     :customerscenario: False
     """
     user = "user1"
@@ -76,57 +81,50 @@ def test_authentication__using_a_good_then_bad_password_when_offline(
     client.sssd.pam["offline_credentials_expiration"] = "0"
     client.sssd.start()
 
-    assert not client.auth.parametrize(method).password(user, wrong), "login with wrong password succeeded"
-    assert client.auth.parametrize(method).password(user, correct), "login with correct password failed"
+    assert client.auth.parametrize(method).password(user, correct), "User failed login!"
 
-    # Block provider.
     client.firewall.outbound.reject_host(provider)
 
     # There might be active connections that are not terminated by creating firewall rule.
-    # We need to terminated it by bringing SSSD to offline state explicitly.
+    # We need to terminate it by forcing SSSD offline.
     client.sssd.bring_offline()
 
-    assert client.auth.parametrize(method).password(user, correct), "offline login with correct password failed"
-    assert not client.auth.parametrize(method).password(user, wrong), "offline login with wrong password succeeded"
+    assert client.auth.parametrize(method).password(user, correct), "User failed login!"
+    assert not client.auth.parametrize(method).password(user, wrong), "User logged in with an incorrect password!"
 
 
 @pytest.mark.topology(KnownTopology.AD)
 @pytest.mark.ticket(gh=7174)
 @pytest.mark.parametrize("method", ["su", "ssh"])
-@pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
-@pytest.mark.require(
-    lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
-    "SSSD was built without support for running under non-root",
-)
-def test_authentication__login_using_email_address(client: Client, ad: AD, method: str, sssd_service_user: str):
+@pytest.mark.importance("critical")
+def test_authentication__using_the_users_email_address(client: Client, ad: AD, method: str):
     """
-    :title: Login using user's email address
+    :title: Login using the user's email address
     :description:
-        Testing the feature to login using an email address instead of the userid. The username used, must match one of
-        directory attribute values for "EmailAddress". The login should be case insensitive and permit special
-        characters.
+        Testing the feature to login using an email address instead of the userid. The username used,
+        must match one of the user's LDAP attribute values, "EmailAddress". The login should be
+        case-insensitive and permit special characters.
     :setup:
         1. Add AD users with different email addresses
         2. Start SSSD
     :steps:
         1. Authenticate users using their email address and in different cases
     :expectedresults:
-        1. Authentication is successful using the email address and is case insensitive
+        1. Authentication is successful using the email address and is case-insensitive
     :customerscenario: False
     """
     ad.user("user-1").add(password="Secret123", email=f"user-1@{ad.host.domain}")
     ad.user("user-2").add(password="Secret123", email="user-2@alias-domain.com")
     ad.user("user_3").add(password="Secret123", email="user_3@alias-domain.com")
 
-    client.sssd.set_service_user(sssd_service_user)
     client.sssd.start()
 
     assert client.auth.parametrize(method).password(
         f"user-1@{ad.host.domain}", "Secret123"
-    ), "login with correct password failed"
+    ), f"User user-1@{ad.host.domain} failed login!"
     assert client.auth.parametrize(method).password(
         "user-2@alias-domain.com", "Secret123"
-    ), "login with correct password failed"
+    ), "User user-2@alias-domain.com failed login!"
     assert client.auth.parametrize(method).password(
         "uSEr_3@alias-dOMain.com", "Secret123"
-    ), "login with correct password failed"
+    ), "User uSEr_3@alias-dOMain.com failed login!"


### PR DESCRIPTION
housekeeping, the following is looked at and may have been done:
* fixed typos and standardized formatting
* renamed test cases to improve the clarity of what the test does
* improved docstring language, setup, steps and expected results
* synced code with the docstring order
* removed necessary configuration relevant to the test
* added pytest.mark.importance to test cases

noteable changes:
* big rename on the test case names, after discussing that some cases will have the positive and negative test, it no longers to be specified

(cherry picked from commit 7716d13c2a2364c76803f1e1360178f3385ec38d)