### PR TITLE
BUILD: configure logrotate to work with  non-root-group writable folder

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5706,6 +5706,7 @@ endif
 	rm -f $(builddir)/src/sysv/systemd/sssd-kcm.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-kcm.service
 	rm -f $(builddir)/src/tools/wrappers/sss_debuglevel
+	rm -Rf $(builddir)/src/examples
 	rm -Rf $(builddir)/contrib
 
 CLEANFILES += *.X */*.X */*/*.X

--- a/configure.ac
+++ b/configure.ac
@@ -563,6 +563,7 @@ AC_DEFINE_UNQUOTED([ABS_SRC_DIR], ["$my_srcdir"], [Absolute path to the source d
 AC_CONFIG_FILES([Makefile contrib/sssd.spec src/examples/rwtab src/doxy.config
                  contrib/sssd-pcsc.rules contrib/90-sssd-token-access.rules
                  contrib/sssd-tmpfiles.conf
+                 src/examples/logrotate
                  src/sysv/sssd src/sysv/gentoo/sssd src/sysv/gentoo/sssd-kcm
                  po/Makefile.in src/man/Makefile src/tests/cwrap/Makefile
                  src/tests/intg/Makefile src/tests/test_CA/Makefile

--- a/src/examples/logrotate.in
+++ b/src/examples/logrotate.in
@@ -6,6 +6,7 @@
     rotate 2
     compress
     delaycompress
+    su @SSSD_USER@ @SSSD_USER@
     postrotate
         /bin/kill -HUP `cat /var/run/sssd.pid 2>/dev/null` 2> /dev/null || true
         /bin/pkill -HUP sssd_kcm 2> /dev/null || true


### PR DESCRIPTION
Otherwise logrotate complains:
```
error: skipping "/var/log/sssd/sssd_kcm.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.
```

See https://bugzilla.redhat.com/show_bug.cgi?id=2299733 for details