### PR TITLE
backport 2.8 tests: use podman instead of ssh to speed up in PR CI

### DIFF
--- a/src/tests/system/mhc.yaml
+++ b/src/tests/system/mhc.yaml
@@ -3,6 +3,10 @@ domains:
   hosts:
   - hostname: client.test
     role: client
+    conn:
+      type: podman
+      container: client
+      sudo: True
     artifacts:
     - /etc/sssd/*
     - /var/log/sssd/*
@@ -10,6 +14,10 @@ domains:
 
   - hostname: master.ldap.test
     role: ldap
+    conn:
+      type: podman
+      container: ldap
+      sudo: True
     config:
       binddn: cn=Directory Manager
       bindpw: Secret123
@@ -20,6 +28,10 @@ domains:
 
   - hostname: master.ipa.test
     role: ipa
+    conn:
+      type: podman
+      container: ipa
+      sudo: True
     config:
       client:
         ipa_domain: ipa.test
@@ -30,7 +42,8 @@ domains:
     role: ad
     os:
       family: windows
-    ssh:
+    conn:
+      type: ssh
       username: Administrator@ad.test
       password: vagrant
     config:
@@ -43,6 +56,10 @@ domains:
 
   - hostname: dc.samba.test
     role: samba
+    conn:
+      type: podman
+      container: samba
+      sudo: True
     config:
       binddn: CN=Administrator,CN=Users,DC=samba,DC=test
       bindpw: Secret123
@@ -53,11 +70,19 @@ domains:
 
   - hostname: nfs.test
     role: nfs
+    conn:
+      type: podman
+      container: nfs
+      sudo: True
     config:
       exports_dir: /dev/shm/exports
 
   - hostname: kdc.test
     role: kdc
+    conn:
+      type: podman
+      container: kdc
+      sudo: True
     config:
       realm: TEST
       domain: test


### PR DESCRIPTION
We can now use podman instead of ssh run commands on the host. This
is quite faster so we can benefit from it in PR CI.

Reviewed-by: Dan Lavu <dlavu@redhat.com>
Reviewed-by: Tomáš Halman <thalman@redhat.com>
(cherry picked from commit 8e59f7700b83020308b8a7e203b2f437821b6f29)