### PR TITLE
backport 2.9 tests: use podman instead of ssh to speed up in PR CI

### DIFF
--- a/src/tests/system/mhc.yaml
+++ b/src/tests/system/mhc.yaml
@@ -9,6 +9,10 @@ domains:
   hosts:
   - hostname: client.test
     role: client
+    conn:
+      type: podman
+      container: client
+      sudo: True
     artifacts:
     - /etc/sssd/*
     - /var/log/sssd/*
@@ -16,6 +20,10 @@ domains:
 
   - hostname: master.ldap.test
     role: ldap
+    conn:
+      type: podman
+      container: ldap
+      sudo: True
     config:
       binddn: cn=Directory Manager
       bindpw: Secret123
@@ -26,6 +34,10 @@ domains:
 
   - hostname: master.ipa.test
     role: ipa
+    conn:
+      type: podman
+      container: ipa
+      sudo: True
     config:
       client:
         ipa_domain: ipa.test
@@ -36,7 +48,8 @@ domains:
     role: ad
     os:
       family: windows
-    ssh:
+    conn:
+      type: ssh
       username: Administrator@ad.test
       password: vagrant
     config:
@@ -46,6 +59,10 @@ domains:
 
   - hostname: dc.samba.test
     role: samba
+    conn:
+      type: podman
+      container: samba
+      sudo: True
     config:
       binddn: CN=Administrator,CN=Users,DC=samba,DC=test
       bindpw: Secret123
@@ -56,11 +73,19 @@ domains:
 
   - hostname: nfs.test
     role: nfs
+    conn:
+      type: podman
+      container: nfs
+      sudo: True
     config:
       exports_dir: /dev/shm/exports
 
   - hostname: kdc.test
     role: kdc
+    conn:
+      type: podman
+      container: kdc
+      sudo: True
     config:
       realm: TEST
       domain: test

--- a/src/tests/system/tests/test_files.py
+++ b/src/tests/system/tests/test_files.py
@@ -89,7 +89,7 @@ def test_files__enumeration_should_not_work(client: Client):
     client.sssd.sssd["enable_files_domain"] = "true"
     client.sssd.start()
 
-    assert not client.host.ssh.run("getent passwd -s sss").stdout, "Entries found!"
+    assert not client.host.conn.run("getent passwd -s sss").stdout, "Entries found!"
 
 
 @pytest.mark.importance("low")

--- a/src/tests/system/tests/test_kcm.py
+++ b/src/tests/system/tests/test_kcm.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import time
 
 import pytest
-from pytest_mh.ssh import SSHProcessError
+from pytest_mh.conn import ProcessError
 from sssd_test_framework.roles.client import Client
 from sssd_test_framework.roles.kdc import KDC
 from sssd_test_framework.roles.ldap import LDAP
@@ -423,7 +423,7 @@ def test_kcm__kinit_user_after_login(client: Client, kdc: KDC):
     with client.ssh(username, password) as ssh:
         with client.auth.kerberos(ssh) as krb:
             assert krb.kinit(username, password=password).rc == 0, "kinit failed!"
-            with pytest.raises(SSHProcessError):
+            with pytest.raises(ProcessError):
                 krb.kinit(username, password="wrong")
             assert krb.klist().rc == 0, "klist failed!"
 
@@ -462,7 +462,7 @@ def test_kcm__debug_log_enabled(client: Client, kdc: KDC):
         try:
             output = client.fs.wc(kcm_log_file, lines=True).stdout
             return int(output.split()[0])
-        except SSHProcessError:
+        except ProcessError:
             return 0
 
     user = "user1"
@@ -579,7 +579,7 @@ def test_kcm__configure_max_uid_ccaches_with_different_values(client: Client, kd
             client.sssd.config_apply()
             client.svc.restart("sssd-kcm")
             assert krb.kinit(user0, password=password).rc == 0, "max_uid_ccache = 1, kinit failed!"
-            with pytest.raises(SSHProcessError):
+            with pytest.raises(ProcessError):
                 krb.kinit(user1, password=password)
 
             # max_uid_ccaches set to default (64)
@@ -589,7 +589,7 @@ def test_kcm__configure_max_uid_ccaches_with_different_values(client: Client, kd
             for i in range(1, 64):
                 user = f"user{i}"
                 assert krb.kinit(user, password=password).rc == 0, "max_uid_ccache = 64, kinit failed!"
-            with pytest.raises(SSHProcessError):
+            with pytest.raises(ProcessError):
                 krb.kinit("user64", password=password)
 
             # max_uid_ccaches set to 65
@@ -597,7 +597,7 @@ def test_kcm__configure_max_uid_ccaches_with_different_values(client: Client, kd
             client.sssd.config_apply()
             client.svc.restart("sssd-kcm")
             assert krb.kinit("user64", password=password).rc == 0, "max_uid_ccache = 65, kinit failed!"
-            with pytest.raises(SSHProcessError):
+            with pytest.raises(ProcessError):
                 krb.kinit("user65", password=password)
 
     # kinit as another user

--- a/src/tests/system/tests/test_ldap.py
+++ b/src/tests/system/tests/test_ldap.py
@@ -120,7 +120,7 @@ def test_ldap__password_change_new_password_does_not_meet_complexity_requirement
 
     assert (
         "pam_sss(passwd:chauthtok): User info message: Password change failed."
-        in client.host.ssh.run("journalctl").stdout
+        in client.host.conn.run("journalctl").stdout
     )
 
 

--- a/src/tests/system/tests/test_logging.py
+++ b/src/tests/system/tests/test_logging.py
@@ -70,7 +70,7 @@ def test_logging__default_debug_level_check_with_login(client: Client):
 
     client.fs.copy("/var/log/sssd", "/tmp/copy")
     assert client.auth.ssh.password("user1", "Secret123"), "Authentication failed"
-    assert not client.host.ssh.run("diff /var/log/sssd /tmp/copy").stdout, "Debug messages were generated"
+    assert not client.host.conn.run("diff /var/log/sssd /tmp/copy").stdout, "Debug messages were generated"
 
 
 @pytest.mark.ticket(bz=1893159)

--- a/src/tests/system/tests/test_memcache.py
+++ b/src/tests/system/tests/test_memcache.py
@@ -1548,7 +1548,7 @@ def test_memcache__memcache_timeout_zero(client: Client, provider: GenericProvid
     client.sssd.domain["ldap_id_mapping"] = "false"
     client.sssd.start()
 
-    r = client.host.ssh.exec(["ls", "/var/lib/sss/mc"])
+    r = client.host.conn.exec(["ls", "/var/lib/sss/mc"])
     assert r.stdout == "", "Cache directory is not empty"
     assert r.stderr == "", "Ls command failed"
 
@@ -1616,9 +1616,9 @@ def test_memcache__removed_cache_without_invalidation(client: Client, provider: 
 
     client.sssd.stop()
 
-    r = client.host.ssh.exec(["ls", "/var/lib/sss/mc"])
+    r = client.host.conn.exec(["ls", "/var/lib/sss/mc"])
     for file in r.stdout.split():
-        check = client.host.ssh.exec(["rm", f"/var/lib/sss/mc/{file}"])
+        check = client.host.conn.exec(["rm", f"/var/lib/sss/mc/{file}"])
         assert check.rc == 0, "Cache file was not removed successfully"
 
     assert client.tools.id("user1") is None, "User user1 was found which is not expected"

--- a/src/tests/system/tests/test_sssctl.py
+++ b/src/tests/system/tests/test_sssctl.py
@@ -10,7 +10,8 @@ import re
 import time
 
 import pytest
-from pytest_mh.ssh import SSHAuthenticationError, SSHProcessError
+from pytest_mh.conn import ProcessError
+from pytest_mh.conn.ssh import SSHAuthenticationError
 from sssd_test_framework.roles.client import Client
 from sssd_test_framework.roles.ldap import LDAP
 from sssd_test_framework.topology import KnownTopology
@@ -41,7 +42,7 @@ def test_sssctl__check_missing_id_provider(client: Client):
     client.sssd.config_apply(check_config=False)
 
     # Check the error message in output of # sssctl config-check
-    output = client.host.ssh.run("sssctl config-check", raise_on_error=False)
+    output = client.host.conn.run("sssctl config-check", raise_on_error=False)
     assert "[rule/sssd_checks]: Attribute 'id_provider' is missing in section 'domain/test'." in output.stdout_lines[1]
 
 
@@ -71,7 +72,7 @@ def test_sssctl__check_invalid_id_provider(client: Client):
     client.sssd.config_apply(check_config=False)
 
     # Check the return code of # sssctl config-check command
-    output = client.host.ssh.run("sssctl config-check", raise_on_error=False)
+    output = client.host.conn.run("sssctl config-check", raise_on_error=False)
     assert (
         "[rule/sssd_checks]: Attribute 'id_provider' in section 'domain/test' has an invalid value: invalid"
         in output.stdout_lines[1]
@@ -234,7 +235,7 @@ def test_sssctl__check_missing_domain_name(client: Client):
     """
     client.sssd.dom("")["debug_level"] = "9"
 
-    with pytest.raises(SSHProcessError) as ex:
+    with pytest.raises(ProcessError) as ex:
         client.sssd.start(raise_on_error=True, check_config=True)
 
     assert ex.match(r"Section \[domain\/\] is not allowed. Check for typos.*"), "Wrong error message was returned"

--- a/src/tests/system/tests/test_tools.py
+++ b/src/tests/system/tests/test_tools.py
@@ -18,7 +18,7 @@ Tests pertaining to command line tools, some tools will have their own file.
 from __future__ import annotations
 
 import pytest
-from pytest_mh.ssh import SSHProcessError
+from pytest_mh.conn import ProcessError
 from sssd_test_framework.roles.client import Client
 from sssd_test_framework.topology import KnownTopology
 
@@ -46,16 +46,16 @@ def test_tools__sss_cache_expired_does_not_print_unrelated_message(client: Clien
     client.sssd.sssd["enable_files_domain"] = "false"
     client.local.user("user1").add()
 
-    with pytest.raises(SSHProcessError):
+    with pytest.raises(ProcessError):
         client.sssd.restart()
 
-    res = client.host.ssh.run("usermod -a -G wheel user1")
+    res = client.host.conn.run("usermod -a -G wheel user1")
     assert (
         "No domains configured, fatal error!" not in res.stdout
     ), "'No domains configured, fatal error!' printed to stdout!"
 
     for cmd in ("sss_cache -U", "sss_cache -G", "sss_cache -E", "sss_cache --user=nonexisting"):
-        res = client.host.ssh.run(cmd)
+        res = client.host.conn.run(cmd)
         assert (
             "No domains configured, fatal error!" not in res.stdout
         ), "'No domains configured, fatal error!' printed to stdout!"


### PR DESCRIPTION
We can now use podman instead of ssh run commands on the host. This is
quite faster so we can benefit from it in PR CI.

Reviewed-by: Dan Lavu <dlavu@redhat.com>
Reviewed-by: Tomáš Halman <thalman@redhat.com>
(cherry picked from commit 8e59f7700b83020308b8a7e203b2f437821b6f29)