### PR TITLE
New "DiscoverySite" Dbus method implementation and sssctl enhancement

### DIFF
--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -477,8 +477,8 @@ struct sss_domain_info {
     /* Counts how often the domain was not found during a refresh of the
      * domain list */
     size_t not_found_counter;
-    /* discovered netbios site */
-    const char *site;
+    /* Discovered site and forest names */
+    const char *current_site;
 };
 
 /**

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -477,6 +477,8 @@ struct sss_domain_info {
     /* Counts how often the domain was not found during a refresh of the
      * domain list */
     size_t not_found_counter;
+    /* discovered netbios site */
+    const char *site;
 };
 
 /**

--- a/src/providers/ad/ad_cldap_ping.c
+++ b/src/providers/ad/ad_cldap_ping.c
@@ -616,10 +616,10 @@ struct tevent_req *ad_cldap_ping_send(TALLOC_CTX *mem_ctx,
     }
 
     if (!srv_ctx->renew_site) {
-        state->site = talloc_strdup(state, srv_ctx->ad_options->current_site);
+        state->site = talloc_strdup(state, srv_ctx->be_ctx->domain->current_site);
         state->forest = talloc_strdup(state,
                                       srv_ctx->ad_options->current_forest);
-        if ((srv_ctx->ad_options->current_site != NULL && state->site == NULL)
+        if ((srv_ctx->be_ctx->domain->current_site != NULL && state->site == NULL)
                 || (srv_ctx->ad_options->current_forest != NULL
                                     && state->forest == NULL)) {
             DEBUG(SSSDBG_OP_FAILURE,
@@ -654,10 +654,10 @@ struct tevent_req *ad_cldap_ping_send(TALLOC_CTX *mem_ctx,
     state->discovery_domain = discovery_domain;
 
     /* If possible, lookup the information in the current site first. */
-    if (srv_ctx->ad_options->current_site != NULL) {
+    if (srv_ctx->be_ctx->domain->current_site != NULL) {
         state->all_tried = false;
         domain = ad_site_dns_discovery_domain(state,
-                                              srv_ctx->ad_options->current_site,
+                                              srv_ctx->be_ctx->domain->current_site,
                                               discovery_domain);
         if (domain == NULL) {
             DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!");

--- a/src/providers/ad/ad_common.c
+++ b/src/providers/ad/ad_common.c
@@ -1729,8 +1729,8 @@ ad_options_switch_site(struct ad_options *ad_options, struct be_ctx *be_ctx,
         return EOK;
     }
 
-    if (ad_options->current_site != NULL
-                    && strcmp(ad_options->current_site, new_site) == 0) {
+    if (be_ctx->domain->current_site != NULL
+                    && strcmp(be_ctx->domain->current_site, new_site) == 0) {
         return EOK;
     }
 
@@ -1739,10 +1739,10 @@ ad_options_switch_site(struct ad_options *ad_options, struct be_ctx *be_ctx,
         return ENOMEM;
     }
 
-    talloc_zfree(ad_options->current_site);
-    ad_options->current_site = site;
+    talloc_zfree(be_ctx->domain->current_site);
+    be_ctx->domain->current_site = site;
 
-    ret = sysdb_set_site(be_ctx->domain, ad_options->current_site);
+    ret = sysdb_set_site(be_ctx->domain, be_ctx->domain->current_site);
     if (ret != EOK) {
         /* Not fatal. */
         DEBUG(SSSDBG_MINOR_FAILURE, "Unable to store site information "

--- a/src/providers/ad/ad_common.h
+++ b/src/providers/ad/ad_common.h
@@ -113,7 +113,6 @@ struct ad_options {
     struct be_nsupdate_ctx *dyndns_ctx;
 
     /* Discovered site and forest names */
-    const char *current_site;
     const char *current_forest;
 };
 

--- a/src/providers/ad/ad_srv.c
+++ b/src/providers/ad/ad_srv.c
@@ -166,20 +166,20 @@ ad_srv_plugin_ctx_init(TALLOC_CTX *mem_ctx,
             goto fail;
         }
 
-        ctx->ad_options->current_site = talloc_strdup(ctx->ad_options,
+        be_ctx->domain->current_site = talloc_strdup(be_ctx->domain,
                                                       ad_site_override);
-        if (ctx->ad_options->current_site == NULL) {
+        if (be_ctx->domain->current_site == NULL) {
             goto fail;
         }
     } else {
         ret = sysdb_get_site(ctx->ad_options, be_ctx->domain,
-                             &ctx->ad_options->current_site);
+                             &be_ctx->domain->current_site);
         if (ret != EOK) {
             /* Not fatal. */
             DEBUG(SSSDBG_MINOR_FAILURE,
                   "Unable to get current site from cache [%d]: %s\n",
                   ret, sss_strerror(ret));
-            ctx->ad_options->current_site = NULL;
+            be_ctx->domain->current_site = NULL;
         }
     }
 
@@ -383,7 +383,6 @@ static void ad_srv_plugin_ping_done(struct tevent_req *subreq)
         goto done;
     }
 
-    state->ctx->be_ctx->domain->site = talloc_strdup(state->ctx->be_ctx->domain, state->site);
     DEBUG(SSSDBG_TRACE_FUNC, "About to discover primary and "
                               "backup servers\n");
 

--- a/src/providers/ad/ad_srv.c
+++ b/src/providers/ad/ad_srv.c
@@ -383,6 +383,7 @@ static void ad_srv_plugin_ping_done(struct tevent_req *subreq)
         goto done;
     }
 
+    state->ctx->be_ctx->domain->site = talloc_strdup(state->ctx->be_ctx->domain, state->site);
     DEBUG(SSSDBG_TRACE_FUNC, "About to discover primary and "
                               "backup servers\n");
 

--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -2134,7 +2134,7 @@ static void ad_subdomains_refresh_master_done(struct tevent_req *subreq)
     /* If the site was not discovered during the DNS discovery, e.g. because
      * the server name was given explicitly in sssd.conf, we try to set the
      * site here. */
-    if (state->ad_options->current_site == NULL) {
+    if (state->be_ctx->domain->current_site == NULL) {
         /* Ignore AD site found in netlogon attribute if specific site is set in
          * configuration file. */
         ad_site_override = dp_opt_get_string(state->ad_options->basic, AD_SITE);

--- a/src/providers/data_provider/dp.c
+++ b/src/providers/data_provider/dp.c
@@ -48,7 +48,8 @@ dp_init_interface(struct data_provider *provider)
         SBUS_METHODS(
             SBUS_SYNC(METHOD, sssd_DataProvider_Failover, ListServices, dp_failover_list_services, provider->be_ctx),
             SBUS_SYNC(METHOD, sssd_DataProvider_Failover, ListServers, dp_failover_list_servers, provider->be_ctx),
-            SBUS_SYNC(METHOD, sssd_DataProvider_Failover, ActiveServer, dp_failover_active_server, provider->be_ctx)
+            SBUS_SYNC(METHOD, sssd_DataProvider_Failover, ActiveServer, dp_failover_active_server, provider->be_ctx),
+            SBUS_SYNC(METHOD, sssd_DataProvider_Failover, DiscoverySite, dp_failover_discovery_site, provider->be_ctx)
         ),
         SBUS_SIGNALS(SBUS_NO_SIGNALS),
         SBUS_PROPERTIES(SBUS_NO_PROPERTIES)

--- a/src/providers/data_provider/dp_iface.h
+++ b/src/providers/data_provider/dp_iface.h
@@ -226,6 +226,12 @@ dp_failover_list_servers(TALLOC_CTX *mem_ctx,
                          const char *service_name,
                          const char ***_servers);
 
+errno_t
+dp_failover_discovery_site(TALLOC_CTX *mem_ctx,
+                         struct sbus_request *sbus_req,
+                         struct be_ctx *be_ctx,
+                         const char **_site);
+
 /* sssd.DataProvider.AccessControl */
 struct tevent_req *
 dp_access_control_refresh_rules_send(TALLOC_CTX *mem_ctx,

--- a/src/providers/data_provider/dp_iface_failover.c
+++ b/src/providers/data_provider/dp_iface_failover.c
@@ -334,7 +334,7 @@ dp_failover_discovery_site(TALLOC_CTX *mem_ctx,
                         struct be_ctx *be_ctx,
                         const char **_site)
 {
-    *_site = be_ctx->domain->site;
+    *_site = be_ctx->domain->current_site;
     return EOK;
 }
 

--- a/src/providers/data_provider/dp_iface_failover.c
+++ b/src/providers/data_provider/dp_iface_failover.c
@@ -25,6 +25,7 @@
 #include "providers/data_provider/dp_private.h"
 #include "providers/data_provider/dp_iface.h"
 #include "providers/backend.h"
+#include "providers/ad/ad_common.h"
 #include "util/util.h"
 
 static errno_t
@@ -326,3 +327,15 @@ dp_failover_list_servers(TALLOC_CTX *mem_ctx,
 
     return EOK;
 }
+
+errno_t
+dp_failover_discovery_site(TALLOC_CTX *mem_ctx,
+                        struct sbus_request *sbus_req,
+                        struct be_ctx *be_ctx,
+                        const char **_site)
+{
+    *_site = dp_opt_get_cstring(be_ctx->be_res->opts, AD_SITE);
+
+    return EOK;
+}
+

--- a/src/providers/data_provider/dp_iface_failover.c
+++ b/src/providers/data_provider/dp_iface_failover.c
@@ -334,8 +334,7 @@ dp_failover_discovery_site(TALLOC_CTX *mem_ctx,
                         struct be_ctx *be_ctx,
                         const char **_site)
 {
-    *_site = dp_opt_get_cstring(be_ctx->be_res->opts, AD_SITE);
-
+    *_site = be_ctx->domain->site;
     return EOK;
 }
 

--- a/src/responder/ifp/ifp_domains.h
+++ b/src/responder/ifp/ifp_domains.h
@@ -181,6 +181,17 @@ ifp_domains_domain_list_servers_recv(TALLOC_CTX *mem_ctx,
                                       const char ***_servers);
 
 struct tevent_req *
+ifp_domains_domain_discovery_site_send(TALLOC_CTX *mem_ctx,
+                                     struct tevent_context *ev,
+                                     struct sbus_request *sbus_req,
+                                     struct ifp_ctx *ifp_ctx);
+
+errno_t
+ifp_domains_domain_discovery_site_recv(TALLOC_CTX *mem_ctx,
+                                     struct tevent_req *req,
+                                     const char **_site);
+
+struct tevent_req *
 ifp_domains_domain_refresh_access_rules_send(TALLOC_CTX *mem_ctx,
                                              struct tevent_context *ev,
                                              struct sbus_request *sbus_req,

--- a/src/responder/ifp/ifp_iface/ifp_iface.c
+++ b/src/responder/ifp/ifp_iface/ifp_iface.c
@@ -138,6 +138,7 @@ ifp_register_sbus_interface(struct sbus_connection *conn,
             SBUS_ASYNC(METHOD, org_freedesktop_sssd_infopipe_Domains_Domain, ListServices, ifp_domains_domain_list_services_send, ifp_domains_domain_list_services_recv, ctx),
             SBUS_ASYNC(METHOD, org_freedesktop_sssd_infopipe_Domains_Domain, ActiveServer, ifp_domains_domain_active_server_send, ifp_domains_domain_active_server_recv, ctx),
             SBUS_ASYNC(METHOD, org_freedesktop_sssd_infopipe_Domains_Domain, ListServers, ifp_domains_domain_list_servers_send, ifp_domains_domain_list_servers_recv, ctx),
+            SBUS_ASYNC(METHOD, org_freedesktop_sssd_infopipe_Domains_Domain, DiscoverySite, ifp_domains_domain_discovery_site_send, ifp_domains_domain_discovery_site_recv, ctx),
             SBUS_ASYNC(METHOD, org_freedesktop_sssd_infopipe_Domains_Domain, RefreshAccessRules, ifp_domains_domain_refresh_access_rules_send, ifp_domains_domain_refresh_access_rules_recv, ctx)
         ),
         SBUS_SIGNALS(SBUS_NO_SIGNALS),

--- a/src/responder/ifp/ifp_iface/ifp_iface.xml
+++ b/src/responder/ifp/ifp_iface/ifp_iface.xml
@@ -117,6 +117,10 @@
             <arg name="servers" type="as" direction="out" />
         </method>
 
+        <method name="DiscoverySite" key="True">
+            <arg name="site" type="s" direction="out" />
+        </method>
+
         <method name="RefreshAccessRules" key="True" />
     </interface>
 

--- a/src/responder/ifp/ifp_iface/sbus_ifp_client_sync.h
+++ b/src/responder/ifp/ifp_iface/sbus_ifp_client_sync.h
@@ -164,6 +164,14 @@ sbus_call_ifp_domain_ActiveServer
      const char ** _arg_server);
 
 errno_t
+sbus_call_ifp_domain_DiscoverySite
+    (TALLOC_CTX *mem_ctx,
+     struct sbus_sync_connection *conn,
+     const char *busname,
+     const char *object_path,
+     const char ** _arg_site);
+
+errno_t
 sbus_call_ifp_domain_IsOnline
     (struct sbus_sync_connection *conn,
      const char *busname,

--- a/src/responder/ifp/ifp_iface/sbus_ifp_interface.h
+++ b/src/responder/ifp/ifp_iface/sbus_ifp_interface.h
@@ -1078,6 +1078,28 @@
         (handler_send), (handler_recv), (data)); \
 })
 
+/* Method: org.freedesktop.sssd.infopipe.Domains.Domain.DiscoverySite */
+#define SBUS_METHOD_SYNC_org_freedesktop_sssd_infopipe_Domains_Domain_DiscoverySite(handler, data) ({ \
+    SBUS_CHECK_SYNC((handler), (data), const char **); \
+    sbus_method_sync("DiscoverySite", \
+        &_sbus_ifp_args_org_freedesktop_sssd_infopipe_Domains_Domain_DiscoverySite, \
+        NULL, \
+        _sbus_ifp_invoke_in__out_s_send, \
+        _sbus_ifp_key_, \
+        (handler), (data)); \
+})
+
+#define SBUS_METHOD_ASYNC_org_freedesktop_sssd_infopipe_Domains_Domain_DiscoverySite(handler_send, handler_recv, data) ({ \
+    SBUS_CHECK_SEND((handler_send), (data)); \
+    SBUS_CHECK_RECV((handler_recv), const char **); \
+    sbus_method_async("DiscoverySite", \
+        &_sbus_ifp_args_org_freedesktop_sssd_infopipe_Domains_Domain_DiscoverySite, \
+        NULL, \
+        _sbus_ifp_invoke_in__out_s_send, \
+        _sbus_ifp_key_, \
+        (handler_send), (handler_recv), (data)); \
+})
+
 /* Method: org.freedesktop.sssd.infopipe.Domains.Domain.IsOnline */
 #define SBUS_METHOD_SYNC_org_freedesktop_sssd_infopipe_Domains_Domain_IsOnline(handler, data) ({ \
     SBUS_CHECK_SYNC((handler), (data), bool*); \

--- a/src/responder/ifp/ifp_iface/sbus_ifp_symbols.c
+++ b/src/responder/ifp/ifp_iface/sbus_ifp_symbols.c
@@ -206,6 +206,17 @@ _sbus_ifp_args_org_freedesktop_sssd_infopipe_Domains_Domain_ActiveServer = {
 };
 
 const struct sbus_method_arguments
+_sbus_ifp_args_org_freedesktop_sssd_infopipe_Domains_Domain_DiscoverySite = {
+    .input = (const struct sbus_argument[]){
+        {NULL}
+    },
+    .output = (const struct sbus_argument[]){
+        {.type = "s", .name = "site"},
+        {NULL}
+    }
+};
+
+const struct sbus_method_arguments
 _sbus_ifp_args_org_freedesktop_sssd_infopipe_Domains_Domain_IsOnline = {
     .input = (const struct sbus_argument[]){
         {NULL}

--- a/src/responder/ifp/ifp_iface/sbus_ifp_symbols.h
+++ b/src/responder/ifp/ifp_iface/sbus_ifp_symbols.h
@@ -71,6 +71,9 @@ extern const struct sbus_method_arguments
 _sbus_ifp_args_org_freedesktop_sssd_infopipe_Domains_Domain_ActiveServer;
 
 extern const struct sbus_method_arguments
+_sbus_ifp_args_org_freedesktop_sssd_infopipe_Domains_Domain_DiscoverySite;
+
+extern const struct sbus_method_arguments
 _sbus_ifp_args_org_freedesktop_sssd_infopipe_Domains_Domain_IsOnline;
 
 extern const struct sbus_method_arguments

--- a/src/sss_iface/sbus_sss_client_async.c
+++ b/src/sss_iface/sbus_sss_client_async.c
@@ -108,6 +108,106 @@ sbus_method_in__out__recv
     return EOK;
 }
 
+struct sbus_method_in__out_s_state {
+    struct _sbus_sss_invoker_args_s *out;
+};
+
+static void sbus_method_in__out_s_done(struct tevent_req *subreq);
+
+static struct tevent_req *
+sbus_method_in__out_s_send
+    (TALLOC_CTX *mem_ctx,
+     struct sbus_connection *conn,
+     sbus_invoker_keygen keygen,
+     const char *bus,
+     const char *path,
+     const char *iface,
+     const char *method)
+{
+    struct sbus_method_in__out_s_state *state;
+    struct tevent_req *subreq;
+    struct tevent_req *req;
+    errno_t ret;
+
+    req = tevent_req_create(mem_ctx, &state, struct sbus_method_in__out_s_state);
+    if (req == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
+        return NULL;
+    }
+
+    state->out = talloc_zero(state, struct _sbus_sss_invoker_args_s);
+    if (state->out == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Unable to allocate space for output parameters!\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+
+    subreq = sbus_call_method_send(state, conn, NULL, keygen, NULL,
+                                   bus, path, iface, method, NULL);
+    if (subreq == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    tevent_req_set_callback(subreq, sbus_method_in__out_s_done, req);
+
+    ret = EAGAIN;
+
+done:
+    if (ret != EAGAIN) {
+        tevent_req_error(req, ret);
+        tevent_req_post(req, conn->ev);
+    }
+
+    return req;
+}
+
+static void sbus_method_in__out_s_done(struct tevent_req *subreq)
+{
+    struct sbus_method_in__out_s_state *state;
+    struct tevent_req *req;
+    DBusMessage *reply;
+    errno_t ret;
+
+    req = tevent_req_callback_data(subreq, struct tevent_req);
+    state = tevent_req_data(req, struct sbus_method_in__out_s_state);
+
+    ret = sbus_call_method_recv(state, subreq, &reply);
+    talloc_zfree(subreq);
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    ret = sbus_read_output(state->out, reply, (sbus_invoker_reader_fn)_sbus_sss_invoker_read_s, state->out);
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    tevent_req_done(req);
+    return;
+}
+
+static errno_t
+sbus_method_in__out_s_recv
+    (TALLOC_CTX *mem_ctx,
+     struct tevent_req *req,
+     const char ** _arg0)
+{
+    struct sbus_method_in__out_s_state *state;
+    state = tevent_req_data(req, struct sbus_method_in__out_s_state);
+
+    TEVENT_REQ_RETURN_ON_ERROR(req);
+
+    *_arg0 = talloc_steal(mem_ctx, state->out->arg0);
+
+    return EOK;
+}
+
 struct sbus_method_in_pam_data_out_pam_response_state {
     struct _sbus_sss_invoker_args_pam_data in;
     struct _sbus_sss_invoker_args_pam_response *out;
@@ -1872,6 +1972,26 @@ sbus_call_dp_failover_ActiveServer_recv
      const char ** _server)
 {
     return sbus_method_in_s_out_s_recv(mem_ctx, req, _server);
+}
+
+struct tevent_req *
+sbus_call_dp_failover_DiscoverySite_send
+    (TALLOC_CTX *mem_ctx,
+     struct sbus_connection *conn,
+     const char *busname,
+     const char *object_path)
+{
+    return sbus_method_in__out_s_send(mem_ctx, conn, NULL,
+        busname, object_path, "sssd.DataProvider.Failover", "DiscoverySite");
+}
+
+errno_t
+sbus_call_dp_failover_DiscoverySite_recv
+    (TALLOC_CTX *mem_ctx,
+     struct tevent_req *req,
+     const char ** _site)
+{
+    return sbus_method_in__out_s_recv(mem_ctx, req, _site);
 }
 
 struct tevent_req *

--- a/src/sss_iface/sbus_sss_client_async.h
+++ b/src/sss_iface/sbus_sss_client_async.h
@@ -124,6 +124,19 @@ sbus_call_dp_failover_ActiveServer_recv
      const char ** _server);
 
 struct tevent_req *
+sbus_call_dp_failover_DiscoverySite_send
+    (TALLOC_CTX *mem_ctx,
+     struct sbus_connection *conn,
+     const char *busname,
+     const char *object_path);
+
+errno_t
+sbus_call_dp_failover_DiscoverySite_recv
+    (TALLOC_CTX *mem_ctx,
+     struct tevent_req *req,
+     const char ** _site);
+
+struct tevent_req *
 sbus_call_dp_failover_ListServers_send
     (TALLOC_CTX *mem_ctx,
      struct sbus_connection *conn,

--- a/src/sss_iface/sbus_sss_interface.h
+++ b/src/sss_iface/sbus_sss_interface.h
@@ -281,6 +281,28 @@
         (handler_send), (handler_recv), (data)); \
 })
 
+/* Method: sssd.DataProvider.Failover.DiscoverySite */
+#define SBUS_METHOD_SYNC_sssd_DataProvider_Failover_DiscoverySite(handler, data) ({ \
+    SBUS_CHECK_SYNC((handler), (data), const char **); \
+    sbus_method_sync("DiscoverySite", \
+        &_sbus_sss_args_sssd_DataProvider_Failover_DiscoverySite, \
+        NULL, \
+        _sbus_sss_invoke_in__out_s_send, \
+        NULL, \
+        (handler), (data)); \
+})
+
+#define SBUS_METHOD_ASYNC_sssd_DataProvider_Failover_DiscoverySite(handler_send, handler_recv, data) ({ \
+    SBUS_CHECK_SEND((handler_send), (data)); \
+    SBUS_CHECK_RECV((handler_recv), const char **); \
+    sbus_method_async("DiscoverySite", \
+        &_sbus_sss_args_sssd_DataProvider_Failover_DiscoverySite, \
+        NULL, \
+        _sbus_sss_invoke_in__out_s_send, \
+        NULL, \
+        (handler_send), (handler_recv), (data)); \
+})
+
 /* Method: sssd.DataProvider.Failover.ListServers */
 #define SBUS_METHOD_SYNC_sssd_DataProvider_Failover_ListServers(handler, data) ({ \
     SBUS_CHECK_SYNC((handler), (data), const char *, const char ***); \

--- a/src/sss_iface/sbus_sss_invokers.c
+++ b/src/sss_iface/sbus_sss_invokers.c
@@ -213,6 +213,173 @@ static void _sbus_sss_invoke_in__out__done(struct tevent_req *subreq)
     return;
 }
 
+struct _sbus_sss_invoke_in__out_s_state {
+    struct _sbus_sss_invoker_args_s out;
+    struct {
+        enum sbus_handler_type type;
+        void *data;
+        errno_t (*sync)(TALLOC_CTX *, struct sbus_request *, void *, const char **);
+        struct tevent_req * (*send)(TALLOC_CTX *, struct tevent_context *, struct sbus_request *, void *);
+        errno_t (*recv)(TALLOC_CTX *, struct tevent_req *, const char **);
+    } handler;
+
+    struct sbus_request *sbus_req;
+    DBusMessageIter *read_iterator;
+    DBusMessageIter *write_iterator;
+};
+
+static void
+_sbus_sss_invoke_in__out_s_step
+    (struct tevent_context *ev,
+     struct tevent_timer *te,
+     struct timeval tv,
+     void *private_data);
+
+static void
+_sbus_sss_invoke_in__out_s_done
+   (struct tevent_req *subreq);
+
+struct tevent_req *
+_sbus_sss_invoke_in__out_s_send
+   (TALLOC_CTX *mem_ctx,
+    struct tevent_context *ev,
+    struct sbus_request *sbus_req,
+    sbus_invoker_keygen keygen,
+    const struct sbus_handler *handler,
+    DBusMessageIter *read_iterator,
+    DBusMessageIter *write_iterator,
+    const char **_key)
+{
+    struct _sbus_sss_invoke_in__out_s_state *state;
+    struct tevent_req *req;
+    const char *key;
+    errno_t ret;
+
+    req = tevent_req_create(mem_ctx, &state, struct _sbus_sss_invoke_in__out_s_state);
+    if (req == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
+        return NULL;
+    }
+
+    state->handler.type = handler->type;
+    state->handler.data = handler->data;
+    state->handler.sync = handler->sync;
+    state->handler.send = handler->async_send;
+    state->handler.recv = handler->async_recv;
+
+    state->sbus_req = sbus_req;
+    state->read_iterator = read_iterator;
+    state->write_iterator = write_iterator;
+
+    ret = sbus_invoker_schedule(state, ev, _sbus_sss_invoke_in__out_s_step, req);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    ret = sbus_request_key(state, keygen, sbus_req, NULL, &key);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    if (_key != NULL) {
+        *_key = talloc_steal(mem_ctx, key);
+    }
+
+    ret = EAGAIN;
+
+done:
+    if (ret != EAGAIN) {
+        tevent_req_error(req, ret);
+        tevent_req_post(req, ev);
+    }
+
+    return req;
+}
+
+static void _sbus_sss_invoke_in__out_s_step
+   (struct tevent_context *ev,
+    struct tevent_timer *te,
+    struct timeval tv,
+    void *private_data)
+{
+    struct _sbus_sss_invoke_in__out_s_state *state;
+    struct tevent_req *subreq;
+    struct tevent_req *req;
+    errno_t ret;
+
+    req = talloc_get_type(private_data, struct tevent_req);
+    state = tevent_req_data(req, struct _sbus_sss_invoke_in__out_s_state);
+
+    switch (state->handler.type) {
+    case SBUS_HANDLER_SYNC:
+        if (state->handler.sync == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "Bug: sync handler is not specified!\n");
+            ret = ERR_INTERNAL;
+            goto done;
+        }
+
+        ret = state->handler.sync(state, state->sbus_req, state->handler.data, &state->out.arg0);
+        if (ret != EOK) {
+            goto done;
+        }
+
+        ret = _sbus_sss_invoker_write_s(state->write_iterator, &state->out);
+        goto done;
+    case SBUS_HANDLER_ASYNC:
+        if (state->handler.send == NULL || state->handler.recv == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "Bug: async handler is not specified!\n");
+            ret = ERR_INTERNAL;
+            goto done;
+        }
+
+        subreq = state->handler.send(state, ev, state->sbus_req, state->handler.data);
+        if (subreq == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
+            ret = ENOMEM;
+            goto done;
+        }
+
+        tevent_req_set_callback(subreq, _sbus_sss_invoke_in__out_s_done, req);
+        ret = EAGAIN;
+        goto done;
+    }
+
+    ret = ERR_INTERNAL;
+
+done:
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else if (ret != EAGAIN) {
+        tevent_req_error(req, ret);
+    }
+}
+
+static void _sbus_sss_invoke_in__out_s_done(struct tevent_req *subreq)
+{
+    struct _sbus_sss_invoke_in__out_s_state *state;
+    struct tevent_req *req;
+    errno_t ret;
+
+    req = tevent_req_callback_data(subreq, struct tevent_req);
+    state = tevent_req_data(req, struct _sbus_sss_invoke_in__out_s_state);
+
+    ret = state->handler.recv(state, subreq, &state->out.arg0);
+    talloc_zfree(subreq);
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    ret = _sbus_sss_invoker_write_s(state->write_iterator, &state->out);
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    tevent_req_done(req);
+    return;
+}
+
 struct _sbus_sss_invoke_in__out_u_state {
     struct _sbus_sss_invoker_args_u out;
     struct {

--- a/src/sss_iface/sbus_sss_invokers.h
+++ b/src/sss_iface/sbus_sss_invokers.h
@@ -40,6 +40,7 @@
          const char **_key)
 
 _sbus_sss_declare_invoker(, );
+_sbus_sss_declare_invoker(, s);
 _sbus_sss_declare_invoker(, u);
 _sbus_sss_declare_invoker(pam_data, pam_response);
 _sbus_sss_declare_invoker(raw, qus);

--- a/src/sss_iface/sbus_sss_symbols.c
+++ b/src/sss_iface/sbus_sss_symbols.c
@@ -147,6 +147,17 @@ _sbus_sss_args_sssd_DataProvider_Failover_ActiveServer = {
 };
 
 const struct sbus_method_arguments
+_sbus_sss_args_sssd_DataProvider_Failover_DiscoverySite = {
+    .input = (const struct sbus_argument[]){
+        {NULL}
+    },
+    .output = (const struct sbus_argument[]){
+        {.type = "s", .name = "site"},
+        {NULL}
+    }
+};
+
+const struct sbus_method_arguments
 _sbus_sss_args_sssd_DataProvider_Failover_ListServers = {
     .input = (const struct sbus_argument[]){
         {.type = "s", .name = "service_name"},

--- a/src/sss_iface/sbus_sss_symbols.h
+++ b/src/sss_iface/sbus_sss_symbols.h
@@ -53,6 +53,9 @@ extern const struct sbus_method_arguments
 _sbus_sss_args_sssd_DataProvider_Failover_ActiveServer;
 
 extern const struct sbus_method_arguments
+_sbus_sss_args_sssd_DataProvider_Failover_DiscoverySite;
+
+extern const struct sbus_method_arguments
 _sbus_sss_args_sssd_DataProvider_Failover_ListServers;
 
 extern const struct sbus_method_arguments

--- a/src/sss_iface/sss_iface.xml
+++ b/src/sss_iface/sss_iface.xml
@@ -69,6 +69,9 @@
             <arg name="service_name" type="s" direction="in" key="1" />
             <arg name="servers" type="as" direction="out" />
         </method>
+        <method name="DiscoverySite">
+            <arg name="site" type="s" direction="out" />
+        </method>
     </interface>
 
     <interface name="sssd.DataProvider.AccessControl">

--- a/src/tools/sssctl/sssctl_domains.c
+++ b/src/tools/sssctl/sssctl_domains.c
@@ -191,6 +191,7 @@ sssctl_domain_status_active_server(struct sbus_sync_connection *conn,
     TALLOC_CTX *tmp_ctx;
     const char *server;
     const char **services;
+    const char *site;
     errno_t ret;
     int i;
 
@@ -198,6 +199,21 @@ sssctl_domain_status_active_server(struct sbus_sync_connection *conn,
     if (tmp_ctx == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "talloc_new() failed\n");
         return ENOMEM;
+    }
+
+    ret = sbus_call_ifp_domain_DiscoverySite(tmp_ctx, conn, IFP_BUS,
+                                            domain_path, &site);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to get discovery site [%d]: %s\n",
+              ret, sss_strerror(ret));
+        PRINT_IFP_WARNING(ret);
+        goto done;
+    }
+
+    if (site == NULL) {
+        PRINT("No discovery site detected for this domain.\n");
+    } else {
+        PRINT("Discovery site: %s\n",site);
     }
 
     ret = sbus_call_ifp_domain_ListServices(tmp_ctx, conn, IFP_BUS,


### PR DESCRIPTION
SSSD commonly discovers and counts on AD(IPA?) dns/netbios **site** configured via AD sites and services plug in.
Unfortunately, this useful information is not shown via `sssctl domain-status` command so one has to crawl via sssd logs to figure/debug service discovery.

This is an attempt to improve the situation so we:
- implement new `DiscoverySite` DBus method
- extend `sss_domain_info` struct with a site variable which is then copied from the _ad_ responder (Unfortunately AD responder internals are quite well hidden and not directly available to the data provider, hence we have to use this trick)
- Enable data provider to serve this information via the additional site variable

This pull request is maybe bit "raw" because:
- no automatic tests are included (can anyone help with this?)
- not sure if it is not leaking memory (not sure about the talloc_strdup there)
- something can be perhaps done better (the site copy to DP) so suggestions are welcome

But still it seems to be working fine.