### PR TITLE
tests: change parameters for pytest.mark.flaky to max_runs

### DIFF
--- a/src/tests/multihost/ad/test_adparameters_ported.py
+++ b/src/tests/multihost/ad/test_adparameters_ported.py
@@ -189,7 +189,7 @@ def set_ssh_key_ldap(session_multihost, user, pubkey, operation="replace"):
     return cmd.returncode == 0
 
 
-@pytest.mark.flaky(reruns=3, reruns_delay=30)
+@pytest.mark.flaky(max_runs=3)
 @pytest.mark.adparameters
 @pytest.mark.usefixtures("change_client_hostname")
 class TestADParamsPorted:


### PR DESCRIPTION
Old python automation was using pytest-rerunfailures plugin providing pytest.mark.flaky with different parameters than flaky. Now we got both in idmci and flaky takes precendence so we need to use max_runs instead of reruns.