### PR TITLE
tests: fix test_ldap.py (add missing topology and remove skipif)

### DIFF
--- a/src/tests/system/tests/test_ldap.py
+++ b/src/tests/system/tests/test_ldap.py
@@ -20,14 +20,11 @@ from sssd_test_framework.topology import KnownTopology
 @pytest.mark.parametrize("use_ppolicy", ["true", "false"])
 @pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
 @pytest.mark.topology(KnownTopology.LDAP)
-@pytest.mark.skipif(
-    bool(lambda client, sssd_service_user: ((sssd_service_user != "root") and not client.features["non-privileged"])),
-    reason="SSSD was built without support for running under non-root",
+@pytest.mark.require(
+    lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
+    "SSSD was built without support for running under non-root",
 )
-@pytest.mark.skipif(
-    bool(lambda client: not client.features["ldap_use_ppolicy"]),
-    reason="SSSD is missing support for ldap_use_ppolicy.",
-)
+@pytest.mark.builtwith("ldap_use_ppolicy")
 def test_ldap__password_change_using_ppolicy(
     client: Client, ldap: LDAP, modify_mode: str, use_ppolicy: str, sssd_service_user: str
 ):
@@ -81,10 +78,7 @@ def test_ldap__password_change_using_ppolicy(
 @pytest.mark.parametrize("modify_mode", ["exop", "ldap_modify"])
 @pytest.mark.parametrize("use_ppolicy", ["true", "false"])
 @pytest.mark.topology(KnownTopology.LDAP)
-@pytest.mark.skipif(
-    bool(lambda client: not client.features["ldap_use_ppolicy"]),
-    reason="SSSD is missing support for ldap_use_ppolicy.",
-)
+@pytest.mark.builtwith("ldap_use_ppolicy")
 def test_ldap__password_change_new_passwords_do_not_match_using_ppolicy(
     client: Client, ldap: LDAP, modify_mode: str, use_ppolicy: str
 ):
@@ -118,10 +112,7 @@ def test_ldap__password_change_new_passwords_do_not_match_using_ppolicy(
 @pytest.mark.parametrize("modify_mode", ["exop", "ldap_modify"])
 @pytest.mark.parametrize("use_ppolicy", ["true", "false"])
 @pytest.mark.topology(KnownTopology.LDAP)
-@pytest.mark.skipif(
-    bool(lambda client: not client.features["ldap_use_ppolicy"]),
-    reason="SSSD is missing support for ldap_use_ppolicy.",
-)
+@pytest.mark.builtwith("ldap_use_ppolicy")
 def test_ldap__password_change_new_password_does_not_meet_complexity_requirements_using_ppolicy(
     client: Client, ldap: LDAP, modify_mode: str, use_ppolicy: str
 ):
@@ -164,10 +155,7 @@ def test_ldap__password_change_new_password_does_not_meet_complexity_requirement
 @pytest.mark.parametrize("modify_mode", ["exop", "ldap_modify"])
 @pytest.mark.parametrize("use_ppolicy", ["true", "false"])
 @pytest.mark.topology(KnownTopology.LDAP)
-@pytest.mark.skipif(
-    bool(lambda client: not client.features["ldap_use_ppolicy"]),
-    reason="SSSD is missing support for ldap_use_ppolicy.",
-)
+@pytest.mark.builtwith("ldap_use_ppolicy")
 def test_ldap__password_change_with_invalid_current_password_using_ppolicy(
     client: Client, ldap: LDAP, modify_mode: str, use_ppolicy: str
 ):

--- a/src/tests/system/tests/test_ldap.py
+++ b/src/tests/system/tests/test_ldap.py
@@ -19,6 +19,7 @@ from sssd_test_framework.topology import KnownTopology
 @pytest.mark.parametrize("modify_mode", ["exop", "ldap_modify"])
 @pytest.mark.parametrize("use_ppolicy", ["true", "false"])
 @pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
+@pytest.mark.topology(KnownTopology.LDAP)
 @pytest.mark.skipif(
     bool(lambda client, sssd_service_user: ((sssd_service_user != "root") and not client.features["non-privileged"])),
     reason="SSSD was built without support for running under non-root",


### PR DESCRIPTION
```
a18963f9a (Pavel Březina, 12 minutes ago)
   tests: avoid skipif in the system tests for feature detection

   @pytest.mark.skipif condition parameter only takes expressions that 
   evaluates to boolean or string that is eval'd by pytest. This happens way
   before the role objects are instantiated and it does not work.

   These lambda functions are not executed at all (and can not be executed
   because pytest does not support that). The reference to a function is just
   evaluated to True therefore the test is always skipped.

   This was broken by 4e95d6f6c1bdd90bd1ca666fa2989bcda443f0a4

---

83fb2c129 (Pavel Březina, 4 minutes ago)
   tests: add topology marker back to test_ldap__password_change_using_ppolicy

   This was accidentally removed by 8c19d7b6f0cf392cb4fa266a5933d4eebbb17090
```