### PR TITLE
Unit tests: use ".invalid" domain name for OCSP responder

### DIFF
--- a/src/tests/test_CA/SSSD_test_cert_0005.config
+++ b/src/tests/test_CA/SSSD_test_cert_0005.config
@@ -18,4 +18,4 @@ subjectKeyIdentifier = hash
 keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment
 extendedKeyUsage = clientAuth
 subjectAltName = email:sssd-devel@lists.fedorahosted.org,URI:https://github.com/SSSD/sssd//
-authorityInfoAccess = OCSP;URI:http://ocsp.my.server.test/
+authorityInfoAccess = OCSP;URI:http://ocsp.my.server.invalid/


### PR DESCRIPTION
to make DNS lookup fail faster.