### PR TITLE
BUILD: drop suppot of '--without-infopipe' ./configure option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -189,9 +189,7 @@ endif
 if BUILD_SSH
 sssdlibexec_PROGRAMS += sssd_ssh
 endif
-if BUILD_IFP
 sssdlibexec_PROGRAMS += sssd_ifp
-endif
 if BUILD_SAMBA
 sssdlibexec_PROGRAMS += gpo_child
 endif
@@ -319,12 +317,10 @@ if HAVE_LIBRESOLV
 non_interactive_cmocka_based_tests += test_resolv_fake
 endif   # HAVE_LIBRESOLV
 
-if BUILD_IFP
 non_interactive_cmocka_based_tests += ifp_tests
 if BUILD_LIBSIFP
 non_interactive_cmocka_based_tests += sss_sifp-tests
 endif   # BUILD_LIBSIFP
-endif   # BUILD_IFP
 
 if HAVE_INOTIFY
 non_interactive_cmocka_based_tests += test_inotify
@@ -946,11 +942,9 @@ SSSD_DOCS = \
     idmap_doc \
     nss_idmap_doc
 
-if BUILD_IFP
 if BUILD_LIBSIFP
     SSSD_DOCS += sss_simpleifp_doc
 endif  # BUILD_LIBSIFP
-endif  # BUILD_IFP
 
 CLIENT_LIBS = $(LTLIBINTL)
 
@@ -1443,7 +1437,6 @@ include_HEADERS = \
     src/lib/certmap/sss_certmap.h \
     $(NULL)
 
-if BUILD_IFP
 if BUILD_LIBSIFP
 lib_LTLIBRARIES += libsss_simpleifp.la
 pkgconfig_DATA += src/lib/sifp/sss_simpleifp.pc
@@ -1472,7 +1465,6 @@ include_HEADERS += \
     src/lib/sifp/sss_sifp.h \
     src/lib/sifp/sss_sifp_dbus.h
 endif  # BUILD_LIBSIFP
-endif  # BUILD_IFP
 
 #########################
 # Systemtap tracing     #
@@ -1673,7 +1665,6 @@ sssd_pac_LDADD = \
     libsss_sbus.la \
     $(NULL)
 
-if BUILD_IFP
 pkglib_LTLIBRARIES += libifp_iface.la
 libifp_iface_la_SOURCES = \
     src/responder/ifp/ifp_iface/sbus_ifp_arguments.c \
@@ -1780,8 +1771,6 @@ src/responder/ifp/org.freedesktop.sssd.infopipe.service: src/responder/ifp/org.f
 src/responder/ifp/org.freedesktop.sssd.infopipe.conf: src/responder/ifp/org.freedesktop.sssd.infopipe.conf.in Makefile
 	$(ifp_replace_script)
 
-
-endif
 
 if BUILD_KCM
 sssd_kcm_SOURCES = \
@@ -3201,7 +3190,6 @@ sdap_tests_LDADD = \
     libdlopen_test_providers.la \
     $(NULL)
 
-if BUILD_IFP
 ifp_tests_SOURCES = \
     $(TEST_MOCK_RESP_OBJ) \
     src/tests/cmocka/test_ifp.c \
@@ -3244,7 +3232,6 @@ sss_sifp_tests_LDADD = \
     $(POPT_LIBS) \
     $(SSSD_INTERNAL_LTLIBS)
 endif # BUILD_LIBSIFP
-endif # BUILD_IFP
 
 test_sysdb_views_SOURCES = \
     src/tests/cmocka/test_sysdb_views.c \
@@ -5238,11 +5225,9 @@ if BUILD_AUTOFS
         src/sysv/systemd/sssd-autofs.service \
         $(NULL)
 endif
-if BUILD_IFP
     systemdunit_DATA += \
         src/sysv/systemd/sssd-ifp.service \
         $(NULL)
-endif
 if BUILD_PAC_RESPONDER
     systemdunit_DATA += \
         src/sysv/systemd/sssd-pac.socket \
@@ -5368,11 +5353,9 @@ src/sysv/systemd/sssd-autofs.service: src/sysv/systemd/sssd-autofs.service.in Ma
 	$(replace_script)
 endif
 
-if BUILD_IFP
 src/sysv/systemd/sssd-ifp.service: src/sysv/systemd/sssd-ifp.service.in Makefile
 	@$(MKDIR_P) src/sysv/systemd/
 	$(ifp_replace_script)
-endif
 
 if BUILD_PAC_RESPONDER
 src/sysv/systemd/sssd-pac.socket: src/sysv/systemd/sssd-pac.socket.in Makefile
@@ -5491,11 +5474,9 @@ docs:
 	$(DOXYGEN) src/lib/idmap/sss_idmap.doxy
 	$(DOXYGEN) src/sss_client/idmap/sss_nss_idmap.doxy
 	$(DOXYGEN) src/lib/certmap/sss_certmap.doxy
-if BUILD_IFP
 if BUILD_LIBSIFP
 	$(DOXYGEN) src/lib/sifp/sss_simpleifp.doxy
 endif  # BUILD_LIBSIFP
-endif  # BUILD_IFP
 else !HAVE_DOXYGEN
 docs:
 	@echo "Doxygen not installed, cannot generate documentation"

--- a/src/conf_macros.m4
+++ b/src/conf_macros.m4
@@ -734,22 +734,6 @@ AC_DEFUN([WITH_SSH_KNOWN_HOSTS_PROXY],
     AM_CONDITIONAL([BUILD_SSH_KNOWN_HOSTS_PROXY], [test x"$with_ssh" = xyes -a x"$with_ssh_know_hosts_proxy" = xyes])
   ])
 
-AC_DEFUN([WITH_IFP],
-  [ AC_ARG_WITH([infopipe],
-                [AC_HELP_STRING([--with-infopipe],
-                                [Whether to build with InfoPipe support [yes]]
-                               )
-                ],
-                [with_infopipe=$withval],
-                with_infopipe=yes
-               )
-
-    if test x"$with_infopipe" = xyes; then
-        AC_DEFINE(BUILD_IFP, 1, [whether to build with InfoPipe support])
-    fi
-    AM_CONDITIONAL([BUILD_IFP], [test x"$with_infopipe" = xyes])
-  ])
-
 AC_DEFUN([WITH_LIBSIFP],
   [ AC_ARG_WITH([libsifp],
                 [AC_HELP_STRING([--with-libsifp],

--- a/src/man/Makefile.am
+++ b/src/man/Makefile.am
@@ -24,9 +24,6 @@ endif
 if BUILD_PAC_RESPONDER
 PAC_RESPONDER_CONDS = ;with_pac_responder
 endif
-if BUILD_IFP
-IFP_CONDS = ;with_ifp
-endif
 if BUILD_KCM
 KCM_CONDS = ;with_kcm
 endif
@@ -76,7 +73,7 @@ LIBNL_CONDS = ;have_libnl
 endif
 
 
-CONDS = with_false$(SUDO_CONDS)$(AUTOFS_CONDS)$(SSH_CONDS)$(SSH_KNOWN_HOSTS_PROXY_CONDS)$(PAC_RESPONDER_CONDS)$(IFP_CONDS)$(GPO_CONDS)$(SYSTEMD_CONDS)$(KCM_CONDS)$(STAP_CONDS)$(KCM_RENEWAL_CONDS)$(LOCKFREE_CLIENT_CONDS)$(HAVE_INOTIFY_CONDS)$(PASSKEY_CONDS)$(FILES_PROVIDER_CONDS)$(SSSD_NON_ROOT_USER_CONDS)$(SSSD_CONF_SERVICE_USER_CONDS)$(ENUM_CONDS)$(LIBNL_CONDS)
+CONDS = with_false$(SUDO_CONDS)$(AUTOFS_CONDS)$(SSH_CONDS)$(SSH_KNOWN_HOSTS_PROXY_CONDS)$(PAC_RESPONDER_CONDS)$(GPO_CONDS)$(SYSTEMD_CONDS)$(KCM_CONDS)$(STAP_CONDS)$(KCM_RENEWAL_CONDS)$(LOCKFREE_CLIENT_CONDS)$(HAVE_INOTIFY_CONDS)$(PASSKEY_CONDS)$(FILES_PROVIDER_CONDS)$(SSSD_NON_ROOT_USER_CONDS)$(SSSD_CONF_SERVICE_USER_CONDS)$(ENUM_CONDS)$(LIBNL_CONDS)
 
 
 #Special Rules:
@@ -93,7 +90,7 @@ endif
 EXTRA_DIST = $(wildcard $(srcdir)/*.xml) $(wildcard $(srcdir)/include/*.xml)
 man_MANS = \
     sssd.8 sssd.conf.5 sssd-ldap.5 sssd-ldap-attributes.5 \
-    sssd-krb5.5 sssd-simple.5 sss-certmap.5 \
+    sssd-krb5.5 sssd-simple.5 sss-certmap.5 sssd-ifp.5 \
     sssd_krb5_locator_plugin.8 sssd_krb5_localauth_plugin.8 \
     pam_sss.8 pam_sss_gss.8 sss_obfuscate.8 sss_cache.8 sss_debuglevel.8 \
 	sss_seed.8 sss_override.8 idmap_sss.8 sssctl.8 sssd-session-recording.5 \
@@ -113,10 +110,6 @@ endif
 
 if BUILD_SUDO
 man_MANS += sssd-sudo.5
-endif
-
-if BUILD_IFP
-man_MANS += sssd-ifp.5
 endif
 
 if BUILD_KCM

--- a/src/man/include/seealso.xml
+++ b/src/man/include/seealso.xml
@@ -65,12 +65,10 @@
                     <manvolnum>1</manvolnum>
                 </citerefentry>,
             </phrase>
-            <phrase condition="with_ifp">
-                <citerefentry>
-                    <refentrytitle>sssd-ifp</refentrytitle>
-                    <manvolnum>5</manvolnum>
-                </citerefentry>,
-            </phrase>
+            <citerefentry>
+                <refentrytitle>sssd-ifp</refentrytitle>
+                <manvolnum>5</manvolnum>
+            </citerefentry>,
             <citerefentry>
                 <refentrytitle>pam_sss</refentrytitle><manvolnum>8</manvolnum>
             </citerefentry>.

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -232,12 +232,11 @@
                                 </phrase>
                             </para>
                             <para>
-                                Supported services: nss, pam
+                                Supported services: nss, pam, ifp
                                 <phrase condition="with_sudo">, sudo</phrase>
                                 <phrase condition="with_autofs">, autofs</phrase>
                                 <phrase condition="with_ssh">, ssh</phrase>
                                 <phrase condition="with_pac_responder">, pac</phrase>
-                                <phrase condition="with_ifp">, ifp</phrase>
                             </para>
                             <para>
                                 <phrase condition="have_systemd">

--- a/src/tests/dlopen-tests.c
+++ b/src/tests/dlopen-tests.c
@@ -48,11 +48,9 @@ struct so {
     { "libsss_certmap.so", { LIBPFX"libsss_certmap.so", NULL } },
     { "pam_sss.so", { LIBPFX"pam_sss.so", NULL } },
     { "pam_sss_gss.so", { LIBPFX"pam_sss_gss.so", NULL } },
-#ifdef BUILD_IFP
 #ifdef BUILD_LIBSIFP
     { "libsss_simpleifp.so", { LIBPFX"libsss_simpleifp.so", NULL } },
 #endif /* BUILD_LIBSIFP */
-#endif /* BUILD_IFP */
 #ifdef BUILD_SUDO
     { "libsss_sudo.so", { LIBPFX"libsss_sudo.so", NULL } },
 #endif


### PR DESCRIPTION
:relnote: Support of '--without-infopipe' ./configure option was dropped. Feature is long time out of experimental state. Since building it doesn't require any additional dependencies, there is not much sense to keep option available. Those who not interested in feature can skip installing sssd-ifp sub-package.