### PR TITLE
Tests: Restart systemd-journald instead of stop/start

### DIFF
--- a/src/tests/multihost/alltests/conftest.py
+++ b/src/tests/multihost/alltests/conftest.py
@@ -1191,16 +1191,16 @@ def write_journalsssd(session_multihost, request):
     contents = "DEBUG_LOGGER=--logger=journald"
     session_multihost.client[0].put_file_contents('/etc/sysconfig/sssd',
                                                   contents)
-    start_journald = 'systemctl start systemd-journald'
-    session_multihost.client[0].run_command(start_journald)
+    restart_journald = 'systemctl restart systemd-journald'
+    session_multihost.client[0].run_command(restart_journald)
 
     def remove_journalsssd():
         """ Remove  /etc/sysconfig/sssd"""
         cmd = 'rm -f /etc/sysconfig/sssd'
-        stop_journald = 'systemctl stop systemd-journald'
+        restart_journald = 'systemctl restart systemd-journald'
         restart_sssd = 'systemctl restart sssd'
         session_multihost.client[0].run_command(cmd)
-        session_multihost.client[0].run_command(stop_journald)
+        session_multihost.client[0].run_command(restart_journald)
         session_multihost.client[0].run_command(restart_sssd)
     request.addfinalizer(remove_journalsssd)
 


### PR DESCRIPTION
systemd-journald service by default is in running state.
The tests should restart the service after modifying configurations.