### PR TITLE
Tests: Disable journald rate limiting during alltests pytest session

### DIFF
--- a/src/tests/multihost/alltests/conftest.py
+++ b/src/tests/multihost/alltests/conftest.py
@@ -1205,42 +1205,6 @@ def write_journalsssd(session_multihost, request):
     request.addfinalizer(remove_journalsssd)
 
 
-@pytest.fixture(scope='class')
-def update_journald_conf(session_multihost, request):
-    """
-    Update journald.conf
-    To turn off any kind of rate limiting, set RateLimitIntervalSec value to 0.
-    """
-    cmd = session_multihost.client[0].run_command(
-        'test -f /etc/systemd/journald.conf', raiseonerr=False)
-    if cmd.returncode == 0:
-        j_config = '/etc/systemd/journald.conf'
-    else:
-        j_config = '/usr/lib/systemd/journald.conf'
-
-    bkup_cmd = f'cp -f {j_config} /tmp/journald.conf.bkup'
-    session_multihost.client[0].run_command(bkup_cmd, raiseonerr=False)
-    up_ratelimit = 'RateLimitIntervalSec=0'
-    journald_conf = session_multihost.client[0].get_file_contents(
-        j_config)
-    if isinstance(journald_conf, bytes):
-        contents = journald_conf.decode('utf-8')
-    else:
-        contents = journald_conf
-    contents = contents.replace(up_ratelimit, '') + up_ratelimit
-    session_multihost.client[0].put_file_contents(j_config, contents)
-    session_multihost.client[0].run_command(
-        "systemctl daemon-reload", raiseonerr=False)
-    session_multihost.client[0].run_command(
-        "systemctl restart systemd-journald", raiseonerr=False)
-
-    def restore_journalsssd():
-        """ Restore journalsssd.conf """
-        bkup_cmd = f'cp -f /tmp/journald.conf.bkup {j_config}'
-        session_multihost.client[0].run_command(bkup_cmd)
-    request.addfinalizer(restore_journalsssd)
-
-
 @pytest.fixture(scope="class")
 def enable_autofs_schema(session_multihost, request):
     """ Enable autofs schema(rfc2307) to Windows AD.
@@ -1608,6 +1572,44 @@ def ns_account_lock(session_multihost, request):
     request.addfinalizer(restoresssdconf)
 
 # ====================  Session Scoped Fixtures ================
+
+
+@pytest.fixture(scope='session', autouse=True)
+def update_journald_conf(session_multihost, request):
+    """
+    Update journald.conf
+    To turn off any kind of rate limiting, set RateLimitIntervalSec value to 0.
+    """
+    cmd = session_multihost.client[0].run_command(
+        'test -f /etc/systemd/journald.conf', raiseonerr=False)
+    if cmd.returncode == 0:
+        j_config = '/etc/systemd/journald.conf'
+    else:
+        j_config = '/usr/lib/systemd/journald.conf'
+
+    bkup_cmd = f'cp -f {j_config} /tmp/journald.conf.bkup'
+    session_multihost.client[0].run_command(bkup_cmd, raiseonerr=False)
+    up_ratelimit = 'RateLimitIntervalSec=0'
+    journald_conf = session_multihost.client[0].get_file_contents(
+        j_config)
+    if isinstance(journald_conf, bytes):
+        contents = journald_conf.decode('utf-8')
+    else:
+        contents = journald_conf
+    contents = contents.replace(up_ratelimit, '') + up_ratelimit
+    session_multihost.client[0].put_file_contents(j_config, contents)
+    session_multihost.client[0].run_command(
+        "systemctl daemon-reload", raiseonerr=False)
+    session_multihost.client[0].run_command(
+        "systemctl restart systemd-journald", raiseonerr=False)
+
+    def restore_journalsssd():
+        """ Restore journalsssd.conf """
+        bkup_cmd = f'cp -f /tmp/journald.conf.bkup {j_config}'
+        session_multihost.client[0].run_command(bkup_cmd)
+    request.addfinalizer(restore_journalsssd)
+
+
 @pytest.fixture(scope="session", autouse=True)
 # pylint: disable=unused-argument
 def setup_session(session_multihost, request, create_testdir):

--- a/src/tests/multihost/alltests/test_journald.py
+++ b/src/tests/multihost/alltests/test_journald.py
@@ -14,7 +14,7 @@ from constants import ds_instance_name
 
 
 @pytest.mark.usefixtures('setup_sssd', 'create_posix_usersgroups',
-                         'update_journald_conf', 'write_journalsssd')
+                         'write_journalsssd')
 @pytest.mark.journald
 class TestJournald(object):
     """


### PR DESCRIPTION
Logging was paused as the journald rate limit was reached.
Disable rate limiting during the alltests pytest session.