### PR TITLE
sss_cache: remove a crutch

### DIFF
--- a/src/tools/sss_cache.c
+++ b/src/tools/sss_cache.c
@@ -147,23 +147,6 @@ int main(int argc, const char *argv[])
     bool skipped = true;
     struct sss_domain_info *dinfo;
 
-    /* If systemd is in offline mode,
-     * there's not going to be a sssd instance
-     * running.  This occurs for both e.g. yum --installroot
-     * as well as rpm-ostree offline updates.
-     *
-     * So let's just quickly do nothing.  (Though note today
-     * yum --installroot doesn't set this variable, rpm-ostree
-     * does)
-     *
-     * For more information on the variable, see:
-     * https://github.com/systemd/systemd/pull/7631
-     */
-    const char *systemd_offline = getenv ("SYSTEMD_OFFLINE");
-    if (systemd_offline && strcmp (systemd_offline, "1") == 0) {
-        return 0;
-    }
-
     ret = init_context(argc, argv, &tctx);
     if (ret == ERR_NO_DOMAIN_ENABLED) {
         /* nothing to invalidate; no reason to fail */


### PR DESCRIPTION
 - this thing is clumsy and just doesn't work (as reported by bootc project);
 - shadow-utils/SSSD integration goes away anyway on those rare platforms where it was enabled because 'files provider' went away;
 - finally, in general it's weird to condition sss_cache operability on a variable that sounds like "systemd doesn't run". There is no guarantee that this variable is only set by 'rpm-ostree' and won't break things in other situations.