### PR TITLE
Restart periodic tasks after detecting a clock shift

### DIFF
--- a/src/man/sssd.8.xml
+++ b/src/man/sssd.8.xml
@@ -204,6 +204,18 @@
                     </para>
                 </listitem>
             </varlistentry>
+            <varlistentry>
+                <term>SIGRTMIN+1</term>
+                <listitem>
+                    <para>
+                        Tells the SSSD to reschedule the periodic tasks. The
+                        internal watchdog sends this signal to the providers
+                        when a clock shift is detected although it can be sent
+                        to any sssd_be process directly.
+                    </para>
+                </listitem>
+            </varlistentry>
+
         </variablelist>
     </refsect1>
 

--- a/src/providers/backend.h
+++ b/src/providers/backend.h
@@ -117,6 +117,9 @@ struct be_ctx {
      * DP_ERR_OK or DP_ERR_OFFLINE. The only usage of this var, so far, is
      * to log the DP status without spamming the syslog/journal. */
     int last_dp_state;
+
+    /* List of periodic tasks */
+    struct be_ptask *tasks;
 };
 
 bool be_is_offline(struct be_ctx *ctx);

--- a/src/providers/be_ptask.h
+++ b/src/providers/be_ptask.h
@@ -143,6 +143,7 @@ errno_t be_ptask_create_sync(TALLOC_CTX *mem_ctx,
 void be_ptask_enable(struct be_ptask *task);
 void be_ptask_disable(struct be_ptask *task);
 void be_ptask_postpone(struct be_ptask *task);
+void be_ptask_postpone_all(struct be_ctx *be_ctx);
 void be_ptask_destroy(struct be_ptask **task);
 
 time_t be_ptask_get_period(struct be_ptask *task);

--- a/src/providers/be_ptask_private.h
+++ b/src/providers/be_ptask_private.h
@@ -42,6 +42,9 @@ struct be_ptask {
     struct tevent_timer *timer; /* active tevent timer */
     uint32_t flags;
     bool enabled;
+
+    struct be_ptask *prev;
+    struct be_ptask *next;
 };
 
 #endif /* DP_PTASK_PRIVATE_H_ */

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -218,6 +218,8 @@ int server_setup(const char *name, bool is_responder,
 void server_loop(struct main_context *main_ctx);
 void orderly_shutdown(int status);
 
+#define SSSSIG_RESET_WATCHDOG         SIGRTMIN
+
 /* from signal.c */
 void BlockSignals(bool block, int signum);
 void (*CatchSignal(int signum,void (*handler)(int )))(int);

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -219,6 +219,7 @@ void server_loop(struct main_context *main_ctx);
 void orderly_shutdown(int status);
 
 #define SSSSIG_RESET_WATCHDOG         SIGRTMIN
+#define SSSSIG_TIME_SHIFT_DETECTED    SIGRTMIN+1
 
 /* from signal.c */
 void BlockSignals(bool block, int signum);

--- a/src/util/util_watchdog.c
+++ b/src/util/util_watchdog.c
@@ -167,6 +167,8 @@ static void watchdog_fd_read_handler(struct tevent_context *ev,
     if (strncmp(debug_prg_name, "be[", sizeof("be[") - 1) == 0) {
         kill(getpid(), SIGUSR2);
         DEBUG(SSSDBG_IMPORTANT_INFO, "SIGUSR2 sent to %s\n", debug_prg_name);
+        kill(getpid(), SSSSIG_TIME_SHIFT_DETECTED);
+        DEBUG(SSSDBG_IMPORTANT_INFO, "SSSSIG_TIME_SHIFT_DETECTED sent to %s\n", debug_prg_name);
     }
 }
 

--- a/src/util/util_watchdog.c
+++ b/src/util/util_watchdog.c
@@ -175,7 +175,7 @@ int setup_watchdog(struct tevent_context *ev, int interval)
     struct sigevent sev;
     struct itimerspec its;
     struct tevent_fd *tfd;
-    int signum = SIGRTMIN;
+    int signum = SSSSIG_RESET_WATCHDOG;
     int ret;
 
     memset(&sev, 0, sizeof(sev));


### PR DESCRIPTION
If the system clock is backwards adjusted after SSSD has started the already scheduled periodic tasks won't be triggered at the expected interval.

This PR adds new handlers for signal SIGRTMIN+1 and a new SBUS method rescheduleTasks to reschedule the providers periodic tasks.