### PR TITLE
ci: Remove Fedora 41 and 42 from matrix for sssd-2-9.

### DIFF
--- a/.github/workflows/copr_build.yml
+++ b/.github/workflows/copr_build.yml
@@ -70,7 +70,7 @@ jobs:
       with:
         coprcfg: ${{ steps.copr.outputs.coprcfg }}
         filter: "fedora-.+-x86_64|centos-stream-.*-x86_64"
-        exclude: "fedora-eln-.+"
+        exclude: "fedora-eln-.+|fedora-38-x86_64|fedora-41-x86_64|fedora-42-x86_64|fedora-rawhide-x86_64|centos-stream-10-x86_64"
 
     - name: Create copr project
       uses: next-actions/copr/create-project@master

--- a/contrib/ci/get-matrix.py
+++ b/contrib/ci/get-matrix.py
@@ -25,14 +25,16 @@ def get_fedora_releases(type, exclude=[]):
 
 
 def get_fedora_matrix():
+    # Current fedora devel (41, 42) have sssd 2.10
+    # so it makes no sense to try to install sssd 2.9 there.
     fedora_stable = get_fedora_releases('current')
-    fedora_devel = get_fedora_releases('pending', exclude=['eln'])
-    fedora_frozen = get_fedora_releases('frozen', exclude=['eln'])
+    # fedora_devel = get_fedora_releases('pending', exclude=['eln'])
+    # fedora_frozen = get_fedora_releases('frozen', exclude=['eln'])
 
     matrix = []
     matrix.extend(['fedora-{0}'.format(x) for x in fedora_stable])
-    matrix.extend(['fedora-{0}'.format(x) for x in fedora_devel])
-    matrix.extend(['fedora-{0}'.format(x) for x in fedora_frozen])
+    # matrix.extend(['fedora-{0}'.format(x) for x in fedora_devel])
+    # matrix.extend(['fedora-{0}'.format(x) for x in fedora_frozen])
 
     return matrix
 

--- a/contrib/ci/get-matrix.py
+++ b/contrib/ci/get-matrix.py
@@ -13,34 +13,13 @@ import argparse
 import os
 
 
-def get_fedora_releases(type, exclude=[]):
-    r = requests.get(f'https://bodhi.fedoraproject.org/releases?state={type}')
-    r.raise_for_status()
-
-    versions = [x['version'] for x in r.json()['releases'] if x['id_prefix'] == 'FEDORA']
-    versions = list(set(versions) - set(exclude))
-    versions.sort()
-
-    return versions
-
-
 def get_fedora_matrix():
-    # Current fedora devel (41, 42) have sssd 2.10
-    # so it makes no sense to try to install sssd 2.9 there.
-    fedora_stable = get_fedora_releases('current')
-    # fedora_devel = get_fedora_releases('pending', exclude=['eln'])
-    # fedora_frozen = get_fedora_releases('frozen', exclude=['eln'])
-
-    matrix = []
-    matrix.extend(['fedora-{0}'.format(x) for x in fedora_stable])
-    # matrix.extend(['fedora-{0}'.format(x) for x in fedora_devel])
-    # matrix.extend(['fedora-{0}'.format(x) for x in fedora_frozen])
-
-    return matrix
+    # Fedora 41 and up are using 2.10, Fedora 38 and older are EOL
+    return ['fedora-39', 'fedora-40']
 
 
 def get_centos_matrix():
-    return ['centos-8', 'centos-9']
+    return ['centos-9']
 
 
 def get_other_matrix():


### PR DESCRIPTION
The current pending/devel Fedora versions contain sssd-2.10 so it does not make any sense to try install (unsuccessfully) sssd-2.9 on them.