### PR TITLE
oidc_child: use CURLOPT_PROTOCOLS_STR if available

### DIFF
--- a/src/external/libcurl.m4
+++ b/src/external/libcurl.m4
@@ -2,3 +2,15 @@ AC_SUBST(CURL_LIBS)
 AC_SUBST(CURL_CFLAGS)
 
 PKG_CHECK_MODULES([CURL], [libcurl], [found_libcurl=yes], [found_libcurl=no])
+
+AC_MSG_CHECKING([whether libcurl knows CURLOPT_PROTOCOLS_STR])
+
+AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([
+#include <curl/curl.h>
+int main () {
+    return CURLOPT_PROTOCOLS_STR;
+}])],
+    [AC_MSG_RESULT([yes]); AC_DEFINE_UNQUOTED([HAVE_CURLOPT_PROTOCOLS_STR], [1], [CURLOPT_PROTOCOLS_STR available]) ],
+    [AC_MSG_RESULT([no])]
+)

--- a/src/oidc_child/oidc_child_curl.c
+++ b/src/oidc_child/oidc_child_curl.c
@@ -122,7 +122,11 @@ static errno_t set_http_opts(CURL *curl_ctx, struct devicecode_ctx *dc_ctx,
     int ret;
 
     /* Only allow https */
+#ifdef HAVE_CURLOPT_PROTOCOLS_STR
+    res = curl_easy_setopt(curl_ctx, CURLOPT_PROTOCOLS_STR, "https");
+#else
     res = curl_easy_setopt(curl_ctx, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS);
+#endif
     if (res != CURLE_OK) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to enforce HTTPS.\n");
         ret = EIO;


### PR DESCRIPTION
Since curl version 7.85.0 CURLOPT_PROTOCOLS is deprecated and should be
replaced by CURLOPT_PROTOCOLS_STR.

Resolves: https://github.com/SSSD/sssd/issues/6922