### PR TITLE
RESOLV: supress deprecation warnings

### DIFF
--- a/src/resolv/async_resolv.c
+++ b/src/resolv/async_resolv.c
@@ -794,7 +794,7 @@ resolv_gethostbyname_dns_query_done(void *arg, int status, int timeouts,
                                     unsigned char *abuf, int alen);
 static int
 resolv_gethostbyname_dns_parse(struct gethostbyname_dns_state *state,
-                               int status, unsigned char *abuf, int alen);
+                               unsigned char *abuf, int alen);
 
 static struct tevent_req *
 resolv_gethostbyname_dns_send(TALLOC_CTX *mem_ctx, struct tevent_context *ev,
@@ -935,7 +935,7 @@ resolv_gethostbyname_dns_query_done(void *arg, int status, int timeouts,
         return;
     }
 
-    ret = resolv_gethostbyname_dns_parse(state, status, abuf, alen);
+    ret = resolv_gethostbyname_dns_parse(state, abuf, alen);
     if (ret != EOK) {
         tevent_req_error(req, ret);
         return;
@@ -946,11 +946,12 @@ resolv_gethostbyname_dns_query_done(void *arg, int status, int timeouts,
 
 static int
 resolv_gethostbyname_dns_parse(struct gethostbyname_dns_state *state,
-                               int status, unsigned char *abuf, int alen)
+                               unsigned char *abuf, int alen)
 {
     struct hostent *hostent = NULL;
     int naddrttls;
     errno_t ret;
+    int status;
     void *addr = NULL;
 
     naddrttls = DNS_HEADER_ANCOUNT(abuf);

--- a/src/resolv/async_resolv.c
+++ b/src/resolv/async_resolv.c
@@ -27,7 +27,6 @@
 #include <arpa/inet.h>
 #include <arpa/nameser.h>
 
-#include <ares.h>
 #include <talloc.h>
 #include <tevent.h>
 

--- a/src/resolv/async_resolv.h
+++ b/src/resolv/async_resolv.h
@@ -27,6 +27,7 @@
 #define __ASYNC_RESOLV_H__
 
 #include <netdb.h>
+#define CARES_NO_DEPRECATED
 #include <ares.h>
 
 #include "config.h"


### PR DESCRIPTION
In theory new API might be somewhat better.

But:

1) it's fairly new: `ares_search_dnsrec()` and `ares_query_dnsrec()`
were introduced in c-ares-1.28 while even CentOS Stream 10 has
c-ares-1.25, so SSSD would need to support (fallback) old API anyway.

2) SSSD doesn't make heavy use of DNS, so potential performance
improvements are really negligible.

On the other hand, old API/ABI will be available for a long time:
https://github.com/c-ares/c-ares/pull/732#issuecomment-2028454381

For those reasons it's not worth the effort to port code to new API
right now.
