### PR TITLE
sdap: Log hint for ignore unreadable references

### DIFF
--- a/src/providers/ldap/sdap_async_nested_groups.c
+++ b/src/providers/ldap/sdap_async_nested_groups.c
@@ -1633,6 +1633,8 @@ sdap_nested_group_single_step_process(struct tevent_req *subreq)
         } else {
             DEBUG(SSSDBG_OP_FAILURE, "Unknown entry type [%s]!\n",
                   state->current_member->dn);
+            DEBUG(SSSDBG_OP_FAILURE, "Consider enabling sssd-ldap option "
+                                     "ldap_ignore_unreadable_references\n");
             ret = EINVAL;
             goto done;
         }


### PR DESCRIPTION
in AD direct integration with `ldap_id_mapping = false` when adding a custom `ldap_user_search_base` I encountered this cryptic error when running `getent group posixgroup`

~~~
(2024-09-18 14:20:43): [be[ad.test]] [sdap_nested_group_single_step_process] (0x0040): [RID#3] Unknown entry type [CN=nonposixuser,CN=Users,DC=ad,DC=test]!
(2024-09-18 14:20:43): [be[ad.test]] [sdap_nested_group_single_step_done] (0x0020): [RID#3] Error processing direct membership [22]: Invalid argument
(2024-09-18 14:20:43): [be[ad.test]] [sdap_nested_done] (0x0020): [RID#3] Nested group processing failed: [22][Invalid argument]
(2024-09-18 14:20:43): [be[ad.test]] [sdap_id_op_destroy] (0x4000): [RID#3] releasing operation connection
(2024-09-18 14:20:43): [be[ad.test]] [sdap_id_op_done] (0x4000): [RID#3] releasing operation connection
(2024-09-18 14:20:43): [be[ad.test]] [sdap_id_conn_data_idle] (0x4000): [RID#3] Marking connection as idle
(2024-09-18 14:20:43): [be[ad.test]] [ad_account_info_done] (0x0040): [RID#3] ad_handle_acct_info_recv failed [22]: Invalid argument
~~~

It was only when I checked the code I realized that there is this `ldap_ignore_unreadable_references` boolean. Setting it to true (default is false) fixed this issue for me. I wanted to add a hint to help administrators.

~~~
    case SDAP_NESTED_GROUP_DN_UNKNOWN:
        if (state->ignore_unreadable_references) {
            DEBUG(SSSDBG_TRACE_FUNC, "Ignoring unreadable reference [%s]\n",
                  state->current_member->dn);
        } else {
            DEBUG(SSSDBG_OP_FAILURE, "Unknown entry type [%s]!\n",
                  state->current_member->dn);
            ret = EINVAL;
            goto done;
        }
        break;
    }
~~~