### PR TITLE
SPEC: keep 'sssd-polkit-rules' on RHEL9

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -210,8 +210,10 @@ License: GPL-3.0-or-later
 Obsoletes: libsss_simpleifp < 2.9.0
 Obsoletes: libsss_simpleifp-debuginfo < 2.9.0
 %endif
+%if 0%{?rhel} != 9
 %if %{use_sssd_user}
 Obsoletes: sssd-polkit-rules < 2.10.0
+%endif
 %endif
 # Requires
 # due to ABI changes in 1.1.30/1.2.0
@@ -474,6 +476,19 @@ Provides the D-Bus responder of the SSSD, called the InfoPipe, that allows
 the information from the SSSD to be transmitted over the system bus.
 
 %if 0%{?rhel} == 9
+%if %{use_sssd_user}
+%package polkit-rules
+Summary: Rules for polkit integration for SSSD
+Group: Applications/System
+License: GPL-3.0-or-later
+Requires: polkit >= 0.106
+Requires: sssd-common = %{version}-%{release}
+
+%description polkit-rules
+Provides rules for polkit integration with SSSD. This is required
+for smartcard support if SSSD service is running as user 'sssd'.
+%endif
+
 %package -n libsss_simpleifp
 Summary: The SSSD D-Bus responder helper library
 License: GPL-3.0-or-later
@@ -885,6 +900,9 @@ install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/sssd.conf
 %{_sysusersdir}/sssd.conf
 %endif
 %if %{use_sssd_user}
+%if 0%{?rhel} == 9
+%files polkit-rules
+%endif
 %{_datadir}/polkit-1/rules.d/*
 %endif
 


### PR DESCRIPTION
this partially reverts a7d0bbeb5a8a41e80fec91d7d38b5dcb35eebe8f

 - RHEL9 will keep default value of service user set to 'root', so polkit rules shouldn't be needed by default

 - it's undesirable to remove sub-package within a major release