### PR TITLE
SPEC: add CentOS Stream 9 / RHEL 9 only patch

### DIFF
--- a/contrib/0901-ldap-Switch-ldap_id_use_start_tls-default-to-False.patch
+++ b/contrib/0901-ldap-Switch-ldap_id_use_start_tls-default-to-False.patch
@@ -1,0 +1,37 @@
+Subject: [PATCH] ldap: Switch ldap_id_use_start_tls default to False
+
+CentOS Stream 9 / RHEL 9 only patch.
+---
+ src/man/sssd-ldap.5.xml        | 2 +-
+ src/providers/ldap/ldap_opts.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/man/sssd-ldap.5.xml b/src/man/sssd-ldap.5.xml
+index a6f9b1c97..5e7581809 100644
+--- a/src/man/sssd-ldap.5.xml
++++ b/src/man/sssd-ldap.5.xml
+@@ -917,7 +917,7 @@
+                             <emphasis>true</emphasis> is strongly recommended for security reasons.
+                         </para>
+                         <para>
+-                            Default: true
++                            Default: false
+                         </para>
+                     </listitem>
+                 </varlistentry>
+diff --git a/src/providers/ldap/ldap_opts.c b/src/providers/ldap/ldap_opts.c
+index d0d2b9e74..00a41aad3 100644
+--- a/src/providers/ldap/ldap_opts.c
++++ b/src/providers/ldap/ldap_opts.c
+@@ -75,7 +75,7 @@ struct dp_option default_basic_opts[] = {
+     { "ldap_tls_cert", DP_OPT_STRING, NULL_STRING, NULL_STRING },
+     { "ldap_tls_key", DP_OPT_STRING, NULL_STRING, NULL_STRING },
+     { "ldap_tls_cipher_suite", DP_OPT_STRING, NULL_STRING, NULL_STRING },
+-    { "ldap_id_use_start_tls", DP_OPT_BOOL, BOOL_TRUE, BOOL_TRUE },
++    { "ldap_id_use_start_tls", DP_OPT_BOOL, BOOL_FALSE, BOOL_FALSE },
+     { "ldap_id_mapping", DP_OPT_BOOL, BOOL_FALSE, BOOL_FALSE },
+     { "ldap_sasl_mech", DP_OPT_STRING, NULL_STRING, NULL_STRING },
+     { "ldap_sasl_authid", DP_OPT_STRING, NULL_STRING, NULL_STRING },
+-- 
+2.45.0
+

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -80,7 +80,9 @@ Source1: sssd.sysusers
 
 ### Downstream only patches ###
 # Place your downstream only patches here:
-# Patch0901: 0901-downstream-only-patch-file.patch
+%if 0%{?rhel} == 9
+Patch0901: 0901-ldap-Switch-ldap_id_use_start_tls-default-to-False.patch
+%endif
 
 ### Dependencies ###
 


### PR DESCRIPTION
to change default value of 'ldap_id_use_start_tls' to 'false'