### PR TITLE
tests: gpo link does not have args parameter

### DIFF
--- a/src/tests/system/tests/test_gpo.py
+++ b/src/tests/system/tests/test_gpo.py
@@ -365,7 +365,7 @@ def test_gpo__domain_and_sites_inheritance_when_site_is_enforcing(client: Client
         }
     ).link(target=f"{ad.host.naming_context}")
 
-    site_policy.link("Set", args=["-Enforced Yes"])
+    site_policy.link("Set", enforced=True)
 
     client.sssd.domain["ad_gpo_access_control"] = "enforcing"
     client.sssd.start()
@@ -537,7 +537,7 @@ def test_gpo__sites_inheritance_using_gpo_link_order(client: Client, ad: AD, met
             "SeInteractiveLogonRight": [user2, ad.group("Domain Admins")],
             "SeDenyInteractiveLogonRight": [user1],
         }
-    ).link(args=["-Order 1"])
+    ).link(order=1)
 
     client.sssd.domain["ad_gpo_access_control"] = "enforcing"
     client.sssd.start()


### PR DESCRIPTION
This parameter was removed by
https://github.com/SSSD/sssd-test-framework/commit/83d7b28ea060c16354a26cc05a5ae650bd5614f9

Fix
```
tests/test_gpo.py:368: error: Unexpected keyword argument "args" for "link" of "GPO"  [call-arg]
.venv/lib/python3.11/site-packages/sssd_test_framework/roles/ad.py:1741: note: "link" of "GPO" defined here
tests/test_gpo.py:535: error: Unexpected keyword argument "args" for "link" of "GPO"  [call-arg]
.venv/lib/python3.11/site-packages/sssd_test_framework/roles/ad.py:1741: note: "link" of "GPO" defined here
```