### PR TITLE
sbus: terminate ongoing chained requests if backend is restarted

### DIFF
--- a/src/sbus/connection/sbus_connection.c
+++ b/src/sbus/connection/sbus_connection.c
@@ -471,3 +471,20 @@ void sbus_connection_free(struct sbus_connection *conn)
               conn);
     }
 }
+
+void
+sbus_connection_terminate_member_requests(struct sbus_connection *conn,
+                                          const char *member)
+{
+    DEBUG(SSSDBG_TRACE_FUNC, "Terminating outgoing chained requests for: %s\n",
+          member);
+
+    sbus_requests_terminate_member(conn->requests->outgoing, member,
+                                   ERR_TERMINATED);
+
+    DEBUG(SSSDBG_TRACE_FUNC, "Terminating incoming chained requests from: %s\n",
+          member);
+
+    sbus_requests_terminate_member(conn->requests->incoming, member,
+                                   ERR_TERMINATED);
+}

--- a/src/sbus/connection/sbus_dispatcher.c
+++ b/src/sbus/connection/sbus_dispatcher.c
@@ -38,6 +38,7 @@ sbus_dispatch_reconnect(struct sbus_connection *conn)
     /* Terminate all outgoing requests associated with this connection. */
     DEBUG(SSSDBG_TRACE_FUNC, "Connection lost. Terminating active requests.\n");
     sbus_requests_terminate_all(conn->requests->outgoing, ERR_TERMINATED);
+    sbus_requests_terminate_all(conn->requests->incoming, ERR_TERMINATED);
 
     switch (conn->type) {
     case SBUS_CONNECTION_CLIENT:

--- a/src/sbus/interface/sbus_std_signals.c
+++ b/src/sbus/interface/sbus_std_signals.c
@@ -37,6 +37,11 @@ sbus_name_owner_changed(TALLOC_CTX *mem_ctx,
     /* Delete any existing sender information since it is now obsolete. */
     sbus_senders_delete(conn->senders, name);
 
+    /* Terminate active request if the owner has disconnected. */
+    if (new_owner == NULL || new_owner[0] == '\0') {
+        sbus_connection_terminate_member_requests(sbus_req->conn, old_owner);
+    }
+
     return EOK;
 }
 

--- a/src/sbus/sbus.h
+++ b/src/sbus/sbus.h
@@ -337,6 +337,16 @@ sbus_connection_add_path_map(struct sbus_connection *conn,
                              struct sbus_path *map);
 
 /**
+ * Terminate all outgoing requests for given member.
+ *
+ * @param conn      An sbus connection.
+ * @param member D-Bus member name (destination)
+ */
+void
+sbus_connection_terminate_member_requests(struct sbus_connection *conn,
+                                          const char *member);
+
+/**
  * Add new signal listener to the router.
  *
  * Create a new listener with @SBUS_LISTEN_SYNC or @SBUS_LISTEN_ASYNC.

--- a/src/sbus/sbus_private.h
+++ b/src/sbus/sbus_private.h
@@ -431,6 +431,9 @@ struct sbus_request_list {
     struct tevent_req *req;
     struct sbus_connection *conn;
 
+    /* Member part of the key. Destination for outgoing, sender for incoming.*/
+    const char *member;
+
     bool is_invalid;
     bool is_dbus;
 
@@ -462,6 +465,7 @@ sbus_requests_add(hash_table_t *table,
                   const char *key,
                   struct sbus_connection *conn,
                   struct tevent_req *req,
+                  const char *member,
                   bool is_dbus,
                   bool *_key_exists);
 
@@ -483,6 +487,12 @@ sbus_requests_finish(struct sbus_request_list *item,
 void
 sbus_requests_terminate_all(hash_table_t *table,
                             errno_t error);
+
+/* Terminate requests associated with given member. */
+void
+sbus_requests_terminate_member(hash_table_t *table,
+                               const char *member,
+                               errno_t error);
 
 /* Create new sbus request. */
 struct sbus_request *


### PR DESCRIPTION
If there is an outgoing request already chained and backend is
restarted, a new outgoing request is chained but not processed,
it waits for a timeout.

This patch makes sure that all outgoing requests are gracefully
terminated if backend restarts.

Resolves: https://github.com/SSSD/sssd/issues/7503