### PR TITLE
ssh: do not use default_domain_suffix

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -420,6 +420,10 @@
                         <term>default_domain_suffix (string)</term>
                         <listitem>
                             <para>
+                                Please note that this option is deprecated and
+                                domain_resolution_order should be used.
+                            </para>
+                            <para>
                                 This string will be used as a default domain
                                 name for all names without a domain name
                                 component. The main use case is environments

--- a/src/responder/ssh/ssh_cmd.c
+++ b/src/responder/ssh/ssh_cmd.c
@@ -87,8 +87,7 @@ static errno_t ssh_cmd_get_user_pubkeys(struct cli_ctx *cli_ctx)
 
     cmd_ctx->cli_ctx = cli_ctx;
 
-    ret = ssh_protocol_parse_user(cli_ctx, cli_ctx->rctx->default_domain,
-                                  &cmd_ctx->name, &cmd_ctx->domain);
+    ret = ssh_protocol_parse_user(cli_ctx, &cmd_ctx->name, &cmd_ctx->domain);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Invalid request message!\n");
         goto done;

--- a/src/responder/ssh/ssh_private.h
+++ b/src/responder/ssh/ssh_private.h
@@ -50,7 +50,6 @@ struct sss_cmd_table *get_ssh_cmds(void);
 
 errno_t
 ssh_protocol_parse_user(struct cli_ctx *cli_ctx,
-                        const char *default_domain,
                         const char **_name,
                         const char **_domain);
 

--- a/src/responder/ssh/ssh_protocol.c
+++ b/src/responder/ssh/ssh_protocol.c
@@ -136,7 +136,6 @@ done:
 
 static errno_t
 ssh_protocol_parse_request(struct cli_ctx *cli_ctx,
-                           const char *default_domain,
                            const char **_name,
                            const char **_alias,
                            const char **_domain)
@@ -209,8 +208,6 @@ ssh_protocol_parse_request(struct cli_ctx *cli_ctx,
                 return EINVAL;
             }
             c += domain_len;
-        } else {
-            domain = default_domain;
         }
 
         DEBUG(SSSDBG_TRACE_FUNC,
@@ -234,12 +231,10 @@ ssh_protocol_parse_request(struct cli_ctx *cli_ctx,
 
 errno_t
 ssh_protocol_parse_user(struct cli_ctx *cli_ctx,
-                        const char *default_domain,
                         const char **_name,
                         const char **_domain)
 {
-    return ssh_protocol_parse_request(cli_ctx, default_domain,
-                                      _name, NULL, _domain);
+    return ssh_protocol_parse_request(cli_ctx, _name, NULL, _domain);
 }
 
 errno_t
@@ -248,5 +243,5 @@ ssh_protocol_parse_host(struct cli_ctx *cli_ctx,
                         const char **_alias,
                         const char **_domain)
 {
-    return ssh_protocol_parse_request(cli_ctx, NULL, _name, _alias, _domain);
+    return ssh_protocol_parse_request(cli_ctx, _name, _alias, _domain);
 }


### PR DESCRIPTION
The default_domain_suffix is already handled in the generic cache
request code and the additional enforcement in the ssh responder might
cause issue if fully-qualified names are used as input.

With this change the ssh responder handles request data similar to the
nss responder e.g. in sss_nss_protocol_parse_name().

Resolves: https://github.com/SSSD/sssd/issues/7671