### PR TITLE
Monitor attaches service destructor to a wrong sbus connection

### DIFF
--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -261,7 +261,12 @@ monitor_sbus_RegisterService(TALLOC_CTX *mem_ctx,
     }
 
     /* Fill in svc structure with connection data */
-    svc->conn = sbus_req->conn;
+    svc->conn = sbus_server_find_connection(mt_ctx->sbus_server, svc->busname);
+    if (svc->conn == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Bug: No connection found for '%s'\n", svc->busname);
+        return ERR_SBUS_KILL_CONNECTION;
+    }
 
     /* For {dbus,socket}-activated services we will have to unregister then
      * when the sbus_connection is freed. That's the reason we have to

--- a/src/sbus/server/sbus_server.c
+++ b/src/sbus/server/sbus_server.c
@@ -405,7 +405,7 @@ sbus_server_new_connection(DBusServer *dbus_server,
 
     sbus_server = talloc_get_type(data, struct sbus_server);
 
-    DEBUG(SSSDBG_FUNC_DATA, "Adding connection %p.\n", dbus_conn);
+    DEBUG(SSSDBG_FUNC_DATA, "New dbus connection %p.\n", dbus_conn);
 
     /* First, add a message filter that will take care of routing messages
      * between connections. */
@@ -429,6 +429,7 @@ sbus_server_new_connection(DBusServer *dbus_server,
         dbus_connection_close(dbus_conn);
         return;
     }
+    DEBUG(SSSDBG_FUNC_DATA, "Adding sbus connection %p.\n", sbus_conn);
 
     dbret = dbus_connection_set_data(dbus_conn, sbus_server->data_slot,
                                      sbus_conn, NULL);


### PR DESCRIPTION
#### First and Main Problem
When the monitor receives a `sssd.monitor.RegisterService` D-Bus method, it is received on the listening connection and not on the client's connection. Because of this, the destructor is set for to the listening connection (taken from the sbus_request) and instead of the client connection.

The client connection is now retrieved by searching it by the sender's name in the `sbus_server` accessible from the `mt_ctx`, to set the destructor for the correct connection in the function `monitor_sbus_RegisterService()`.

#### Second Problem
The mysterious connection `0x11fe700` is nothing more than the pointer to the `DBusConnection` on top of which the new `struct sbus_connection` is created on `0x11e4a90`, but nowadays nothing permits to establish a relationship between them. I just added a new message that allows to establish that relationship.

Messages used to be:
```
[sbus_server_new_connection] (0x0200): Adding connection 0x11fe700.
...
[sbus_server_bus_hello] (0x4000): Assigning unique name :1.3 to connection 0x11e4a90
```

And now they are:
```
[sbus_server_new_connection] (0x0200): New dbus connection 0x11fe700.
...
[sbus_server_new_connection] (0x0200): Adding sbus connection 0x11e4a90.
...
[sbus_server_bus_hello] (0x4000): Assigning unique name :1.3 to connection 0x11e4a90
```

The new sbus connection is created on top of the preceding dbus connection.