### PR TITLE
man: add `sssd-passkey.5`

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -759,6 +759,9 @@ do
         sss-certmap*)
             echo \%lang\(${lang}\) \%{_mandir}/${man}\* >> libsss_certmap.lang
             ;;
+        sssd-passkey*)
+            echo \%lang\(${lang}\) \%{_mandir}/${man}\* >> sssd_passkey.lang
+            ;;
         *)
             echo \%lang\(${lang}\) \%{_mandir}/${man}\* >> sssd.lang
             ;;
@@ -1111,6 +1114,7 @@ install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/sssd.conf
 %{_udevrulesdir}/90-sssd-token-access.rules
 %endif
 %config(noreplace) %{_sysconfdir}/krb5.conf.d/sssd_enable_passkey
+%{_mandir}/man5/sssd-passkey.5*
 %endif
 
 %if %{use_sssd_user}

--- a/src/man/Makefile.am
+++ b/src/man/Makefile.am
@@ -130,6 +130,10 @@ man_MANS += sssd-files.5
 endif # BUILD_FILES_PROVIDER
 endif
 
+if BUILD_PASSKEY
+man_MANS += sssd-passkey.5
+endif
+
 $(builddir)/src/man/sssd_user_name.include:
 	@mkdir -p $(builddir)/src/man
 	@echo -n $(SSSD_USER) > $(builddir)/src/man/sssd_user_name.include

--- a/src/man/po/po4a.cfg
+++ b/src/man/po/po4a.cfg
@@ -30,6 +30,7 @@
 [type:docbook] sssd-systemtap.5.xml $lang:$(builddir)/$lang/sssd-systemtap.5.xml
 [type:docbook] sssd-ldap-attributes.5.xml $lang:$(builddir)/$lang/sssd-ldap-attributes.5.xml
 [type:docbook] sssd_krb5_localauth_plugin.8.xml $lang:$(builddir)/$lang/sssd_krb5_localauth_plugin.8.xml
+[type:docbook] sssd-passkey.5.xml $lang:$(builddir)/$lang/sssd-passkey.5.xml
 [type:docbook] include/autofs_attributes.xml $lang:$(builddir)/$lang/include/autofs_attributes.xml opt:"-k 0"
 [type:docbook] include/service_discovery.xml $lang:$(builddir)/$lang/include/service_discovery.xml opt:"-k 0"
 [type:docbook] include/upstream.xml $lang:$(builddir)/$lang/include/upstream.xml opt:"-k 0"

--- a/src/man/sssd-passkey.5.xml
+++ b/src/man/sssd-passkey.5.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DocBook V4.5//EN"
+"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<reference>
+<title>SSSD Manual pages</title>
+<refentry>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="include/upstream.xml" />
+
+    <refmeta>
+        <refentrytitle>sssd-passkey</refentrytitle>
+        <manvolnum>5</manvolnum>
+        <refmiscinfo class="manual">File Formats and Conventions</refmiscinfo>
+    </refmeta>
+
+    <refnamediv id='name'>
+        <refname>sssd-passkey</refname>
+        <refpurpose>SSSD passkey options</refpurpose>
+    </refnamediv>
+
+    <refsect1 id='description'>
+        <title>DESCRIPTION</title>
+        <para>
+            This manual page describes the specifics for configuration of
+            passkey for
+            <citerefentry>
+                <refentrytitle>sssd</refentrytitle>
+                <manvolnum>8</manvolnum>
+            </citerefentry>.
+            Refer to the <quote>FILE FORMAT</quote> section of the
+            <citerefentry>
+                <refentrytitle>sssd.conf</refentrytitle>
+                <manvolnum>5</manvolnum>
+            </citerefentry> manual page for detailed syntax information.</para>
+    </refsect1>
+
+    <refsect1 id='configuration-options'>
+        <title>CONFIGURATION OPTIONS</title>
+        <para>
+            <variablelist>
+                <varlistentry>
+                    <term>user_verification (boolean)</term>
+                    <listitem>
+                        <para>
+                            Enable or disable the requirement for user
+                            verification (i.e. PIN, fingerprint) on the passkey
+                            device during authentication.
+                        </para>
+                        <para>
+                            Three different actors come into play when deciding
+                            whether to request user verification: LDAP server,
+                            <citerefentry><refentrytitle>sssd.conf
+                            </refentrytitle><manvolnum>5</manvolnum></citerefentry>
+                            option and the passkey device itself.
+                        </para>
+                        <para>
+                            If the IPA provider is used and online, Kerberos
+                            based passkey authentication is available, the
+                            server-side settings are applied for all passkey
+                            usages. For other cases the settings in
+                            <filename>sssd.conf</filename> are used. This
+                            includes passkey authentication with any other
+                            provider; and the IPA provider in case online
+                            authentication is not available and local passkey
+                            is allowed by the option
+                            <emphasis>local_auth_policy = enable:passkey</emphasis>.
+                        </para>
+                        <para>
+                            The interaction of the
+                            <emphasis>user_verification</emphasis> option and
+                            the passkey device option is explained in the
+                            following table:
+                        </para>
+                        <informaltable frame='all'>
+                        <tgroup cols='3'>
+                        <colspec colname='c1' align='center'/>
+                        <colspec colname='c2' align='center'/>
+                        <colspec colname='c3' align='center'/>
+
+                        <thead>
+                        <row><entry>user_verification</entry><entry>Device</entry>
+                            <entry>Result</entry></row>
+                        </thead>
+                        <tbody>
+                        <row>
+                            <entry>True</entry>
+                            <entry>User verification is configured</entry>
+                            <entry>User verification is requested</entry>
+                        </row>
+                        <row>
+                            <entry>True</entry>
+                            <entry>User verification is not configured</entry>
+                            <entry><para>
+                            User verification is requested; however, the
+                            authentication is expected to fail if the device is
+                            not replaced with a device where authentication is
+                            configured during the authentication process.
+                            </para></entry>
+                        </row>
+                        <row>
+                            <entry>False</entry>
+                            <entry>User verification is configured</entry>
+                            <entry><para>
+                            sssd automatically detects it during device query
+                            and user verification is requested
+                            </para></entry>
+                        </row>
+                        <row>
+                            <entry>False</entry>
+                            <entry>User verification is not configured</entry>
+                            <entry>User verification is not requested</entry>
+                        </row>
+                        </tbody></tgroup></informaltable>
+                        <para>
+                            If 'enter' is pressed at the PIN prompt for user
+                            verification without typing any characters, then
+                            SSSD falls back from passkey to password
+                            authentication.
+                        </para>
+                    </listitem>
+                </varlistentry>
+            </variablelist>
+        </para>
+    </refsect1>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="include/seealso.xml" />
+
+</refentry>
+</reference>

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -727,15 +727,16 @@
                                     <listitem>
                                         <para> Enable or disable the user
                                         verification (i.e. PIN, fingerprint)
-                                        during authentication. If enabled, the
-                                        PIN will always be requested.
+                                        during authentication.
                                         </para>
                                         <para>
-                                        The default is that the key settings
-                                        decide what to do. In the IPA or
-                                        kerberos pre-authentication case,
-                                        this value will be overwritten by the
-                                        server.
+                                        See
+                                        <citerefentry>
+                                            <refentrytitle>sssd-passkey</refentrytitle>
+                                            <manvolnum>5</manvolnum>
+                                        </citerefentry> to
+                                        understand the behaviour of this option
+                                        in the different scenarios.
                                         </para>
                                     </listitem>
                                 </varlistentry>


### PR DESCRIPTION
Include a new man page for passkey to explain the behaviour of `user_verification` option in the different scenarios. It is a complex option, so it has been decided to add a table to simplify its understanding.