### PR TITLE
rpm: drop the --remote argument from git-archive call

### DIFF
--- a/contrib/fedora/make_srpm.sh
+++ b/contrib/fedora/make_srpm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 #    Authors:
 #        Lukas Slebodnik <lslebodn@redhat.com>
@@ -169,7 +169,6 @@ NAME="$PACKAGE_NAME-$PACKAGE_VERSION"
 TARBALL="$RPMBUILD/SOURCES/$NAME.tar.gz"
 
 git archive --format=tar --prefix="$NAME"/ \
-            --remote="file://$SRC_DIR" \
             HEAD | gzip > "$TARBALL"
 
 # fallback to tar if git archive failed


### PR DESCRIPTION
It seems that current (autumn 2024) git releases somehow dislike
the use of `--remote=file://` when it applies the [safe] directory
checks.  The option doesn't seem to be useful though, so let's drop
it to fix the Copr builds.

Relates: https://github.com/fedora-copr/copr/issues/3421
