### PR TITLE
sssd: always print path when config object is rejected

### DIFF
--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -1931,9 +1931,9 @@ int main(int argc, const char *argv[])
     ret = confdb_read_ini(tmp_ctx, config_file, CONFDB_DEFAULT_CONFIG_DIR, false,
                           &config);
     if (ret != EOK) {
-        ERROR("Can't read config: '%s'\n", sss_strerror(ret));
+        ERROR("Cannot read config %s: '%s'\n", config_file, sss_strerror(ret));
         sss_log(SSS_LOG_ALERT,
-                "Failed to read configuration: '%s'", sss_strerror(ret));
+                "Failed to read configuration %s: '%s'", config_file, sss_strerror(ret));
         ret = 3;
         goto out;
     }

--- a/src/util/sss_ini.c
+++ b/src/util/sss_ini.c
@@ -888,7 +888,7 @@ int sss_ini_read_sssd_conf(struct sss_ini *self,
     ret = sss_ini_open(self, config_file, "[sssd]\n");
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "The sss_ini_open failed %s: %d\n",
+              "sss_ini_open on %s failed: %d\n",
               config_file,
               ret);
         return ERR_INI_OPEN_FAILED;
@@ -898,26 +898,28 @@ int sss_ini_read_sssd_conf(struct sss_ini *self,
         ret = sss_ini_access_check(self);
         if (ret != EOK) {
             DEBUG(SSSDBG_CRIT_FAILURE,
-                  "Permission check on config file failed.\n");
+                  "Permission check on config file %s failed: %d\n",
+                  config_file, ret);
             return ERR_INI_INVALID_PERMISSION;
         }
     } else {
         DEBUG(SSSDBG_CONF_SETTINGS,
-              "File %1$s does not exist.\n",
-              (config_file ? config_file : "NULL"));
+              "File %s does not exist.\n", config_file);
     }
 
     ret = sss_ini_parse(self);
     if (ret != EOK) {
         sss_ini_config_print_errors(self->error_list);
-        DEBUG(SSSDBG_FATAL_FAILURE, "Failed to parse configuration.\n");
+        DEBUG(SSSDBG_FATAL_FAILURE, "Failed to parse configuration file %s: %d\n",
+              config_file, ret);
         return ERR_INI_PARSE_FAILED;
     }
 
     ret = sss_ini_add_snippets(self, config_dir);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
-              "Error while reading configuration directory.\n");
+              "Error while reading configuration directory %s: %d\n",
+              config_dir, ret);
         return ERR_INI_ADD_SNIPPETS_FAILED;
     }
 


### PR DESCRIPTION
Observed:

```
Oct 16 09:44:04 a4 sssd[28717]: [sssd] [sss_ini_read_sssd_conf] (0x0020): Permission check on config file failed.
Oct 16 09:44:04 a4 sssd[28717]: Can't read config: 'File ownership and permissions check failed'
Oct 16 09:44:04 a4 sssd[28717]: Failed to read configuration: 'File ownership and permissions check failed'
```

Expected:

_Well yes, but **which one**_!?