### PR TITLE
build: fix spellos in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -300,9 +300,9 @@ AS_IF([! $PKG_CONFIG --atleast-version 1.0.0 dbus-1], [
 ])
 
 AS_IF([test x$has_dbus != xno], [
-    SAFE_LIBS="$LIBS"
+    SAVED_LIBS="$LIBS"
     LIBS="$DBUS_LIBS"
-    SAFE_CFLAGS=$CFLAGS
+    SAVED_CFLAGS=$CFLAGS
     CFLAGS="$CFLAGS $DBUS_CFLAGS"
 
     AC_CHECK_FUNC([dbus_watch_get_unix_fd],
@@ -313,8 +313,8 @@ AS_IF([test x$has_dbus != xno], [
                    [],
                    [ #include <dbus/dbus.h> ])
 
-    LIBS="$SAFE_LIBS"
-    CFLAGS=$SAFE_CFLAGS
+    LIBS="$SAVED_LIBS"
+    CFLAGS=$SAVED_CFLAGS
 ])
 
 # work around a bug in cov-build from Coverity
@@ -479,7 +479,7 @@ AS_IF([test x"$sss_cv_attribute_warn_unused_result" = xyes], [
              [whether compiler supports __attribute__((warn_unused_result))])
 ])
 
-SAFE_CFLAGS=$CFLAGS
+SAVED_CFLAGS=$CFLAGS
 CFLAGS="-Werror"
 AC_CACHE_CHECK(
     [whether compiler supports __attribute__((fallthrough))],
@@ -505,7 +505,7 @@ AC_CACHE_CHECK(
              sss_cv_attribute_fallthrough_val="((void)0)"
          ])
     ])
-CFLAGS=$SAFE_CFLAGS
+CFLAGS=$SAVED_CFLAGS
 
 AC_DEFINE_UNQUOTED(
     [SSS_ATTRIBUTE_FALLTHROUGH],


### PR DESCRIPTION
"safe" is the antonym to "unsafe", but it's not like CFLAGS is unsafe. You really want "saved" here.

Fixes: sssd-1_13_1-169-g6b01dae73