### PR TITLE
build: unbreak detection for x400Address

### DIFF
--- a/src/external/crypto.m4
+++ b/src/external/crypto.m4
@@ -5,8 +5,6 @@ AC_DEFUN([AM_CHECK_LIBCRYPTO],
 ])
 
 AC_MSG_CHECKING([whether OpenSSL's x400Address is ASN1_STRING])
-SAVE_CFLAGS=$CFLAGS
-CFLAGS="$CFLAGS -Werror -Wall -Wextra"
 AC_COMPILE_IFELSE(
                   [AC_LANG_SOURCE([
                       #include <openssl/x509v3.h>
@@ -14,8 +12,9 @@ AC_COMPILE_IFELSE(
                       int main(void)
                       {
                           GENERAL_NAME gn = { 0 };
-
-                          return ASN1_STRING_length(gn.d.x400Address);
+                          /* If the types are different, the compiler will error out. */
+                          gn.d.x400Address - (ASN1_STRING *)0;
+                          return 0;
                       }
                   ])],
                   [
@@ -27,5 +26,3 @@ AC_COMPILE_IFELSE(
                       AC_MSG_RESULT([no])
                       AC_MSG_WARN([OpenSSL's x400Address is not of ASN1_STRING type])
                   ])
-
-CFLAGS=$SAVE_CFLAGS


### PR DESCRIPTION
Observed:

```
./configure CFLAGS="-O0 -D_FORTIFY_SOURCE=3"
…
checking whether OpenSSL's x400Address is ASN1_STRING... no
configure: WARNING: OpenSSL's x400Address is not of ASN1_STRING type
```

Expected:

```
checking whether OpenSSL's x400Address is ASN1_STRING... yes
```

Relying on warnings alone is terrible; rewrite the C code to provoke compile error in all cases. [N.B.: I just noticed that the use of the subtraction operator is conveniently portable, and one need not use typeof(), which is merely a language extension prior to C23.]

Fixes: 2.8.0-164-gced32c44e