### PR TITLE
Make failover work over IP families

### DIFF
--- a/src/providers/backend.h
+++ b/src/providers/backend.h
@@ -56,6 +56,7 @@ struct be_svc_data {
 
     char *last_good_srv;
     int last_good_port;
+    int last_good_family;
     time_t last_status_change;
     bool run_callbacks;
 

--- a/src/providers/fail_over.c
+++ b/src/providers/fail_over.c
@@ -23,6 +23,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <sys/socket.h>
 #include <sys/time.h>
 
 #include <errno.h>
@@ -30,6 +31,7 @@
 #include <strings.h>
 #include <talloc.h>
 #include <netdb.h>
+#include <arpa/inet.h>
 
 #include "util/dlinklist.h"
 #include "util/refcount.h"
@@ -268,6 +270,8 @@ str_server_status(enum server_status status)
         return "working";
     case SERVER_NOT_WORKING:
         return "not working";
+    case SERVER_SECOND_FAMILY:
+        return "second family";
     }
 
     return "unknown server status";
@@ -479,6 +483,74 @@ service_destructor(struct fo_service *service)
 {
     DLIST_REMOVE(service->ctx->service_list, service);
     return 0;
+}
+
+static bool fo_is_ip_address(char *name)
+{
+    struct sockaddr_in sa;
+    int result;
+
+    result = inet_pton(AF_INET, name, &(sa.sin_addr));
+    if (result == 1) {
+        return true;
+    }
+    result = inet_pton(AF_INET6, name, &(sa.sin_addr));
+    return (result == 1);
+}
+
+static bool
+try_another_family(struct fo_server *server) {
+    enum restrict_family family_order;
+
+    if (
+        server == NULL ||
+        server->common == NULL ||
+        server->common->rhostent == NULL ||
+        server->service == NULL ||
+        server->service->ctx == NULL ||
+        server->service->ctx->opts == NULL) {
+        return false;
+    }
+
+    if (fo_is_ip_address(server->common->name)) {
+        return false;
+    }
+
+    family_order = server->service->ctx->opts->family_order;
+
+    if (server->common->rhostent->family == AF_INET &&
+        family_order == IPV4_FIRST) {
+
+        return true;
+    }
+
+    if (server->common->rhostent->family == AF_INET6 &&
+        family_order == IPV6_FIRST) {
+
+        return true;
+    }
+
+    return false;
+}
+
+int
+fo_get_server_secondary_family(struct fo_server *server) {
+    if (
+        server == NULL ||
+        server->service == NULL ||
+        server->service->ctx == NULL ||
+        server->service->ctx->opts == NULL) {
+        return 0;
+    }
+
+    switch (server->service->ctx->opts->family_order) {
+    case IPV4_FIRST:
+        return AF_INET6;
+    case IPV6_FIRST:
+        return AF_INET;
+    default:
+        return 0;
+    }
 }
 
 int
@@ -1193,13 +1265,28 @@ fo_resolve_service_server(struct tevent_req *req)
                                         struct resolve_service_state);
     struct tevent_req *subreq;
     int ret;
+    enum restrict_family family_restriction;
 
+    family_restriction = state->fo_ctx->opts->family_order;
     switch (get_server_status(state->server)) {
+    case SERVER_SECOND_FAMILY:
+        switch (family_restriction) {
+        case IPV4_FIRST:
+            family_restriction = IPV6_ONLY;
+            break;
+        case IPV6_FIRST:
+            family_restriction = IPV4_ONLY;
+            break;
+        default:
+            break;
+        }
+        /* FALLTHROUGH */
+        SSS_ATTRIBUTE_FALLTHROUGH;
     case SERVER_NAME_NOT_RESOLVED: /* Request name resolution. */
         subreq = resolv_gethostbyname_send(state->server->common,
                                            state->ev, state->resolv,
                                            state->server->common->name,
-                                           state->fo_ctx->opts->family_order,
+                                           family_restriction,
                                            default_host_dbs);
         if (subreq == NULL) {
             tevent_req_error(req, ENOMEM);
@@ -1603,12 +1690,16 @@ fo_set_port_status(struct fo_server *server, enum port_status status)
     }
 
     if (!server->common || !server->common->name) return;
-
+    if (status == PORT_NOT_WORKING && try_another_family(server)) {
+        set_server_common_status(server->common, SERVER_SECOND_FAMILY);
+        server->port_status = PORT_NEUTRAL;
+        status = PORT_NEUTRAL;
+    }
     /* It is possible to introduce duplicates when expanding SRV results
      * into fo_server structures. Find the duplicates and set the same
      * status */
     DLIST_FOR_EACH(siter, server->service->server_list) {
-        if (fo_server_cmp(siter, server)) {
+        if (fo_server_cmp(siter, server) && siter != server) {
             DEBUG(SSSDBG_TRACE_FUNC,
                   "Marking port %d of duplicate server '%s' as '%s'\n",
                    siter->port, SERVER_NAME(siter),
@@ -1655,6 +1746,17 @@ int
 fo_get_server_port(struct fo_server *server)
 {
     return server->port;
+}
+
+int
+fo_get_server_family(struct fo_server *server)
+{
+    if (server != NULL &&
+        server->common != NULL &&
+        server->common->rhostent != NULL) {
+        return server->common->rhostent->family;
+    }
+    return 0;
 }
 
 const char *

--- a/src/providers/fail_over.h
+++ b/src/providers/fail_over.h
@@ -49,6 +49,7 @@ enum server_status {
     SERVER_NAME_NOT_RESOLVED, /* We didn't yet resolved the host name. */
     SERVER_RESOLVING_NAME,    /* Name resolving is in progress. */
     SERVER_NAME_RESOLVED,     /* We resolved the host name but didn't try to connect. */
+    SERVER_SECOND_FAMILY,    /* We should try second protocol */
     SERVER_WORKING,           /* We successfully connected to the server. */
     SERVER_NOT_WORKING        /* We tried and failed to connect to the server. */
 };
@@ -197,6 +198,21 @@ void fo_try_next_server(struct fo_service *service);
 void *fo_get_server_user_data(struct fo_server *server);
 
 int fo_get_server_port(struct fo_server *server);
+
+/*
+ * Get curently used/resolved inet family.
+ * Function returns AF_INET, AF_INET6 or 0 in case that
+ * name is not resolved yet.
+ */
+int fo_get_server_family(struct fo_server *server);
+
+/*
+ * Get secondary inet family if exists.
+ * Function returns AF_INET, AF_INET6 or 0 in case that there is no
+ * secondary family (for example if IPV4_ONLY is set). Note that
+ * this function returns what is configured, not what is actually used.
+ */
+int fo_get_server_secondary_family(struct fo_server *server);
 
 const char *fo_get_server_name(struct fo_server *server);
 

--- a/src/providers/fail_over_srv.c
+++ b/src/providers/fail_over_srv.c
@@ -440,6 +440,7 @@ struct fo_resolve_srv_dns_ctx {
     char *hostname;
     char *sssd_domain;
     char *detected_domain;
+    bool last_family_tried;
 };
 
 struct fo_resolve_srv_dns_state {

--- a/src/tests/system/tests/test_failover.py
+++ b/src/tests/system/tests/test_failover.py
@@ -80,3 +80,29 @@ def test_failover__reactivation_timeout_is_honored(
     assert (
         f"Primary server reactivation timeout set to {expected} seconds" in log
     ), f"'Primary server reactivation timeout set to {expected} seconds' not found in logs!"
+
+
+@pytest.mark.importance("low")
+@pytest.mark.topology(KnownTopologyGroup.AnyProvider)
+def test_failover__connect_using_ipv4_second_family(client: Client, provider: GenericProvider):
+    """
+    :title: Make sure that we can connect using secondary protocol
+    :setup:
+        1. Create user
+        2. Set family_order to "ipv6_first"
+        3. Set IPv6 address in /etc/hosts so it resolves but it
+           points to non-exesting machine
+        4. Start SSSD
+    :steps:
+        1. Resolve user
+    :expectedresults:
+        1. SSSD goes online and the user is resolved
+    :customerscenario: False
+    """
+    user = provider.user("testuser").add()
+    client.sssd.domain["lookup_family_order"] = "ipv6_first"
+    client.fs.append("/etc/hosts", "cafe:cafe::3 %s" % provider.host.hostname)
+    client.sssd.start()
+
+    result = client.tools.id(user.name)
+    assert result is not None, f"{user.name} was not found, SSSD did not switch to IPv4 family!"


### PR DESCRIPTION
Originally the option ipv4_first and ipv6_first was taken into account
when resolving IP address.

When both families are resolvable but the primary is blocked on
firewall, the SSSD must switch to the socondary family.