### PR TITLE
sssd: rework sss_ini_access_check

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -1137,8 +1137,9 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d /run/sssd -s /sbin/nologi
 %__rm -f %{mcpath}/initgroups
 %__rm -f %{mcpath}/sid
 %__chown -f %{sssd_user}:%{sssd_user} %{dbpath}/* || true
-%__chown -f %{sssd_user}:%{sssd_user} %{_sysconfdir}/sssd/sssd.conf || true
-%__chown -f -R %{sssd_user}:%{sssd_user} %{_sysconfdir}/sssd/conf.d || true
+%__chown -f root:%{sssd_user} %{_sysconfdir}/sssd/sssd.conf || true
+%__chown -f -R root:%{sssd_user} %{_sysconfdir}/sssd/conf.d || true
+find %{_sysconfdir}/sssd/sssd.conf %{_sysconfdir}/sssd/conf.d -type f -exec %__chmod 0640 {} +
 %__chown -f %{sssd_user}:%{sssd_user} %{_var}/log/%{name}/*.log || true
 %__chown -f %{sssd_user}:%{sssd_user} %{secdbpath}/*.ldb || true
 %__chown -f %{sssd_user}:%{sssd_user} %{gpocachepath}/* || true

--- a/src/external/libini_config.m4
+++ b/src/external/libini_config.m4
@@ -1,9 +1,9 @@
 PKG_CHECK_MODULES(INI_CONFIG_V1_3, [
-    ini_config >= 1.3.0], [
+    ini_config >= 1.3.2], [
         INI_CONFIG_CFLAGS="$INI_CONFIG_V1_3_CFLAGS"
         INI_CONFIG_LIBS="$INI_CONFIG_V1_3_LIBS"
     ], [
-        AC_MSG_ERROR([Please install libini_config-devel version 1.3.0 or greater])
+        AC_MSG_ERROR([Please install libini_config-devel version 1.3.2 or greater])
     ]
 )
 

--- a/src/sysv/systemd/sssd-kcm.service.in
+++ b/src/sysv/systemd/sssd-kcm.service.in
@@ -9,11 +9,12 @@ Also=sssd-kcm.socket
 
 [Service]
 Environment=DEBUG_LOGGER=--logger=files
-ExecStartPre=+-/bin/chown -f @SSSD_USER@:@SSSD_USER@ @sssdconfdir@
-ExecStartPre=+-/bin/chown -f @SSSD_USER@:@SSSD_USER@ @sssdconfdir@/sssd.conf
-ExecStartPre=+-/bin/chown -f -R @SSSD_USER@:@SSSD_USER@ @sssdconfdir@/conf.d
+ExecStartPre=+-/bin/chown -f root:@SSSD_USER@ @sssdconfdir@
+ExecStartPre=+-/bin/chown -f root:@SSSD_USER@ @sssdconfdir@/sssd.conf
+ExecStartPre=+-/bin/chown -fRh root:@SSSD_USER@ @sssdconfdir@/conf.d
+ExecStartPre=+-/bin/find @sssdconfdir@/sssd.conf @sssdconfdir@/conf.d -type f -exec chmod 0640 {} +
 ExecStartPre=+-/bin/sh -c "/bin/chown -f @SSSD_USER@:@SSSD_USER@ @secdbpath@/*.ldb"
-ExecStartPre=+-/bin/chown -f @SSSD_USER@:@SSSD_USER@ @logpath@/sssd_kcm.log
+ExecStartPre=+-/bin/chown -fh @SSSD_USER@:@SSSD_USER@ @logpath@/sssd_kcm.log
 ExecStart=@libexecdir@/sssd/sssd_kcm ${DEBUG_LOGGER}
 CapabilityBoundingSet= CAP_DAC_OVERRIDE CAP_CHOWN CAP_SETGID CAP_SETUID
 SecureBits=noroot noroot-locked

--- a/src/sysv/systemd/sssd.service.in
+++ b/src/sysv/systemd/sssd.service.in
@@ -10,13 +10,14 @@ StartLimitBurst=5
 [Service]
 Environment=DEBUG_LOGGER=--logger=files
 EnvironmentFile=-@environment_file@
-ExecStartPre=+-/bin/chown -f @SSSD_USER@:@SSSD_USER@ @sssdconfdir@
-ExecStartPre=+-/bin/chown -f @SSSD_USER@:@SSSD_USER@ @sssdconfdir@/sssd.conf
-ExecStartPre=+-/bin/chown -f -R @SSSD_USER@:@SSSD_USER@ @sssdconfdir@/conf.d
-ExecStartPre=+-/bin/chown -f -R @SSSD_USER@:@SSSD_USER@ @sssdconfdir@/pki
-ExecStartPre=+-/bin/sh -c "/bin/chown -f @SSSD_USER@:@SSSD_USER@ @dbpath@/*.ldb"
-ExecStartPre=+-/bin/sh -c "/bin/chown -f @SSSD_USER@:@SSSD_USER@ @gpocachepath@/*"
-ExecStartPre=+-/bin/sh -c "/bin/chown -f @SSSD_USER@:@SSSD_USER@ @logpath@/*.log"
+ExecStartPre=+-/bin/chown -f root:@SSSD_USER@ @sssdconfdir@
+ExecStartPre=+-/bin/chown -f root:@SSSD_USER@ @sssdconfdir@/sssd.conf
+ExecStartPre=+-/bin/chown -fRh root:@SSSD_USER@ @sssdconfdir@/conf.d
+ExecStartPre=+-/bin/chown -fRh root:@SSSD_USER@ @sssdconfdir@/pki
+ExecStartPre=+-/bin/find @sssdconfdir@/sssd.conf @sssdconfdir@/conf.d @sssdconfdir@/pki -type f -exec chmod 0640 {} +
+ExecStartPre=+-/bin/sh -c "/bin/chown -fh @SSSD_USER@:@SSSD_USER@ @dbpath@/*.ldb"
+ExecStartPre=+-/bin/sh -c "/bin/chown -fh @SSSD_USER@:@SSSD_USER@ @gpocachepath@/*"
+ExecStartPre=+-/bin/sh -c "/bin/chown -fh @SSSD_USER@:@SSSD_USER@ @logpath@/*.log"
 ExecStart=@sbindir@/sssd -i ${DEBUG_LOGGER}
 Type=notify
 NotifyAccess=main


### PR DESCRIPTION
When sssd runs in unprivileged mode, the config file should, from a security perspective, ideally be owned by root:sssd and have mode rw-r-----, such that sssd can read, but not write to it.

The current implementation of sss_ini_access_check rejects this security-conscious choice, so rewrite it.

Fixes: 2.9.0-132-gae3bac934