### PR TITLE
sssd: fix faulty program detection inside is_running_sssd

### DIFF
--- a/src/util/sss_ini.c
+++ b/src/util/sss_ini.c
@@ -158,8 +158,8 @@ static bool is_running_sssd(void)
     ret = readlink("/proc/self/exe", exe, sizeof(exe) - 1);
     if ((ret > 0) && (ret < 1024)) {
         exe[ret] = 0;
-        s = strstr(exe, debug_prg_name);
-        if ((s != NULL) && (strlen(s) == strlen(debug_prg_name))) {
+        s = strrchr(exe, '/');
+        if (s != NULL && strcmp(s + 1, debug_prg_name) == 0) {
             return true;
         }
     }


### PR DESCRIPTION
The ``is_running_sssd`` function erroneously returns false even though the program binary is called ``sssd``. This is because it looks at the wrong portion of the filename.

Observed:

```
…
(gdb) r
…
is_running_sssd () at src/util/sss_ini.c:156
156         const char *s = NULL;
(gdb) n
158         ret = readlink("/proc/self/exe", exe, sizeof(exe) - 1);
159         if ((ret > 0) && (ret < 1024)) {
160             exe[ret] = 0;
161             s = strstr(exe, debug_prg_name);
(gdb) p exe
$6 = "/home/ej/repos/sssd/.libs/sssd", '\000' <repeats 993 times>
(gdb) p debug_prg_name
$7 = 0x7ffff77fc110 "sssd"
(gdb) p s
$8 = 0x7ffff7fa72cf <exe+15> "sssd/.libs/sssd"
```

Expected:

```
(gdb) p s
$8 = 0x7ffff7fa72da <exe+26> "sssd"
```

Fixes: 2.9.0-453-g9fbaf6d74