### PR TITLE
SPEC: require systemtap-sdt-dtrace on ELN

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -175,7 +175,7 @@ BuildRequires: softhsm >= 2.1.0
 BuildRequires: bc
 BuildRequires: systemd-devel
 BuildRequires: systemtap-sdt-devel
-%if 0%{?fedora} >= 41
+%if 0%{?fedora} >= 41 || 0%{?rhel} >= 11
 BuildRequires: systemtap-sdt-dtrace
 %endif
 BuildRequires: uid_wrapper


### PR DESCRIPTION
ELN (the future RHEL 11) tracks rawhide and therefore also includes a systemtap with a separate dtrace subpackage.  As a result, sssd-2.10.0 failed to build in ELN.

ELN scratch build: https://koji.fedoraproject.org/koji/taskinfo?taskID=125095605