### PR TITLE
INI: relax config files checks

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -1136,9 +1136,9 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d /run/sssd -s /sbin/nologi
 %__rm -f %{mcpath}/group
 %__rm -f %{mcpath}/initgroups
 %__rm -f %{mcpath}/sid
+%__chown -f -R root:%{sssd_user} %{_sysconfdir}/sssd || true
+%__chmod -f -R g+r %{_sysconfdir}/sssd || true
 %__chown -f %{sssd_user}:%{sssd_user} %{dbpath}/* || true
-%__chown -f %{sssd_user}:%{sssd_user} %{_sysconfdir}/sssd/sssd.conf || true
-%__chown -f -R %{sssd_user}:%{sssd_user} %{_sysconfdir}/sssd/conf.d || true
 %__chown -f %{sssd_user}:%{sssd_user} %{_var}/log/%{name}/*.log || true
 %__chown -f %{sssd_user}:%{sssd_user} %{secdbpath}/*.ldb || true
 %__chown -f %{sssd_user}:%{sssd_user} %{gpocachepath}/* || true

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -57,9 +57,8 @@
             readable, and writeable only by 'root'.
         </para>
         <para condition="with_non_root_user_support">
-            <filename>sssd.conf</filename> must be a regular file that is owned,
-            readable, and writeable by the same user as configured to run SSSD
-            service.
+            <filename>sssd.conf</filename> must be a regular file that is
+            accessible only by the user used to run SSSD service or root.
         </para>
     </refsect1>
 

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -1934,6 +1934,9 @@ int main(int argc, const char *argv[])
         ERROR("Can't read config: '%s'\n", sss_strerror(ret));
         sss_log(SSS_LOG_ALERT,
                 "Failed to read configuration: '%s'", sss_strerror(ret));
+        sss_log(SSS_LOG_ALERT,
+                "Make sure configuration is readable by the user used to run service"
+                " and doesn't have public rwx bits set.");
         ret = 3;
         goto out;
     }

--- a/src/sysv/systemd/sssd-kcm.service.in
+++ b/src/sysv/systemd/sssd-kcm.service.in
@@ -9,9 +9,8 @@ Also=sssd-kcm.socket
 
 [Service]
 Environment=DEBUG_LOGGER=--logger=files
-ExecStartPre=+-/bin/chown -f @SSSD_USER@:@SSSD_USER@ @sssdconfdir@
-ExecStartPre=+-/bin/chown -f @SSSD_USER@:@SSSD_USER@ @sssdconfdir@/sssd.conf
-ExecStartPre=+-/bin/chown -f -R @SSSD_USER@:@SSSD_USER@ @sssdconfdir@/conf.d
+ExecStartPre=+-/bin/chown -f -R root:@SSSD_USER@ @sssdconfdir@
+ExecStartPre=+-/bin/chmod -f -R g+r @sssdconfdir@
 ExecStartPre=+-/bin/sh -c "/bin/chown -f @SSSD_USER@:@SSSD_USER@ @secdbpath@/*.ldb"
 ExecStartPre=+-/bin/chown -f @SSSD_USER@:@SSSD_USER@ @logpath@/sssd_kcm.log
 ExecStart=@libexecdir@/sssd/sssd_kcm ${DEBUG_LOGGER}

--- a/src/sysv/systemd/sssd.service.in
+++ b/src/sysv/systemd/sssd.service.in
@@ -10,10 +10,8 @@ StartLimitBurst=5
 [Service]
 Environment=DEBUG_LOGGER=--logger=files
 EnvironmentFile=-@environment_file@
-ExecStartPre=+-/bin/chown -f @SSSD_USER@:@SSSD_USER@ @sssdconfdir@
-ExecStartPre=+-/bin/chown -f @SSSD_USER@:@SSSD_USER@ @sssdconfdir@/sssd.conf
-ExecStartPre=+-/bin/chown -f -R @SSSD_USER@:@SSSD_USER@ @sssdconfdir@/conf.d
-ExecStartPre=+-/bin/chown -f -R @SSSD_USER@:@SSSD_USER@ @sssdconfdir@/pki
+ExecStartPre=+-/bin/chown -f -R root:@SSSD_USER@ @sssdconfdir@
+ExecStartPre=+-/bin/chmod -f -R g+r @sssdconfdir@
 ExecStartPre=+-/bin/sh -c "/bin/chown -f @SSSD_USER@:@SSSD_USER@ @dbpath@/*.ldb"
 ExecStartPre=+-/bin/sh -c "/bin/chown -f @SSSD_USER@:@SSSD_USER@ @gpocachepath@/*"
 ExecStartPre=+-/bin/sh -c "/bin/chown -f @SSSD_USER@:@SSSD_USER@ @logpath@/*.log"

--- a/src/tests/cmocka/test_config_check.c
+++ b/src/tests/cmocka/test_config_check.c
@@ -35,7 +35,6 @@ struct sss_ini {
     struct ref_array *ra_error_list;
     struct ini_cfgobj *sssd_config;
     struct value_obj *obj;
-    const struct stat *cstat;
     struct ini_cfgfile *file;
     bool main_config_exists;
 };

--- a/src/tools/sssctl/sssctl_config.c
+++ b/src/tools/sssctl/sssctl_config.c
@@ -117,7 +117,8 @@ errno_t sssctl_config_check(struct sss_cmdline *cmdline,
         goto done;
     }
     else if (ret != EOK) {
-        PRINT("Failed to read '%s': %s\n", config_path, sss_strerror(ret));
+        PRINT("Configuration validation failed: %s\n", sss_strerror(ret));
+        PRINT("Run with high debug level to see details.\n");
         goto done;
     }
 

--- a/src/util/sss_ini.c
+++ b/src/util/sss_ini.c
@@ -239,13 +239,6 @@ static int sss_ini_add_snippets(struct sss_ini *self,
               ret);
     }
 
-    while (ref_array_get(self->ra_success_list, i, &msg) != NULL) {
-        DEBUG(SSSDBG_TRACE_FUNC,
-              "Config merge success: %s\n", msg);
-        i++;
-    }
-
-    i = 0;
     while (ref_array_get(self->ra_error_list, i, &msg) != NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Config merge error: %s\n", msg);

--- a/src/util/sss_ini.c
+++ b/src/util/sss_ini.c
@@ -235,8 +235,8 @@ static int sss_ini_add_snippets(struct sss_ini *self,
                              &self->ra_success_list);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "Failed to augment configuration: Error %d",
-              ret);
+              "Failed to augment configuration [%d]: %s\n",
+              ret, sss_strerror(ret));
     }
 
     while (ref_array_get(self->ra_error_list, i, &msg) != NULL) {
@@ -613,14 +613,14 @@ static int sss_ini_call_validators_errobj(struct sss_ini *data,
     ret = ini_rules_read_from_file(rules_path, &rules_cfgobj);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
-              "Failed to read sssd.conf schema %d [%s]\n", ret, strerror(ret));
+              "Failed to read sssd.conf schema [%d]: %s\n", ret, strerror(ret));
         goto done;
     }
 
     ret = ini_rules_check(rules_cfgobj, data->sssd_config, sss_validators, errobj);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
-              "ini_rules_check failed %d [%s]\n", ret, strerror(ret));
+              "ini_rules_check failed [%d]: %s\n", ret, strerror(ret));
         goto done;
     }
 
@@ -761,14 +761,14 @@ int sss_ini_open(struct sss_ini *self,
                                            strlen(fallback_cfg));
         if (ret != EOK) {
             DEBUG(SSSDBG_FATAL_FAILURE,
-                  "sss_ini_config_file_from_mem failed. Error %d\n",
-                  ret);
+                  "sss_ini_config_file_from_mem() failed [%d]: %s\n",
+                  ret, sss_strerror(ret));
         }
         break;
     default:
         DEBUG(SSSDBG_CONF_SETTINGS,
-              "sss_ini_config_file_open failed: Error %d\n",
-              ret);
+              "sss_ini_config_file_open() failed [%d]: %s\n",
+              ret, sss_strerror(ret));
         sss_ini_config_print_errors(self->error_list);
         break;
     }
@@ -860,9 +860,8 @@ int sss_ini_read_sssd_conf(struct sss_ini *self,
     ret = sss_ini_open(self, config_file, "[sssd]\n");
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
-              "sss_ini_open on %s failed: %d\n",
-              config_file,
-              ret);
+              "sss_ini_open() on '%s' failed [%d]: %s\n",
+              config_file, ret, sss_strerror(ret));
         return ERR_INI_OPEN_FAILED;
     }
 
@@ -882,8 +881,8 @@ int sss_ini_read_sssd_conf(struct sss_ini *self,
     ret = sss_ini_add_snippets(self, config_dir);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE,
-              "Error while reading configuration directory %s: %d\n",
-              config_dir, ret);
+              "Error while reading configuration directory '%s' [%d]: %s\n",
+              config_dir, ret, sss_strerror(ret));
         return ERR_INI_ADD_SNIPPETS_FAILED;
     }
 

--- a/src/util/sss_ini.c
+++ b/src/util/sss_ini.c
@@ -43,7 +43,6 @@ struct sss_ini {
     struct ref_array *ra_error_list;
     struct ini_cfgobj *sssd_config;
     struct value_obj *obj;
-    const struct stat *cstat;
     struct ini_cfgfile *file;
     bool main_config_exists;
 };
@@ -191,29 +190,6 @@ static int sss_ini_access_check(struct sss_ini *self)
 }
 
 
-
-/* Get cstat */
-
-int sss_ini_get_stat(struct sss_ini *self)
-{
-    self->cstat = ini_config_get_stat(self->file);
-
-    if (!self->cstat) return EIO;
-
-    return EOK;
-}
-
-
-
-/* Get mtime */
-
-int sss_ini_get_mtime(struct sss_ini *self,
-                      size_t timestr_len,
-                      char *timestr)
-{
-    return snprintf(timestr, timestr_len, "%llu",
-                    (long long unsigned)self->cstat->st_mtime);
-}
 
 /* Get file_exists */
 

--- a/src/util/sss_ini.h
+++ b/src/util/sss_ini.h
@@ -93,18 +93,6 @@ int sss_ini_open(struct sss_ini *self,
 bool sss_ini_exists(struct sss_ini *self);
 
 /**
- * @brief get Cstat structure of the ini file
- */
-int sss_ini_get_stat(struct sss_ini *self);
-
-/**
- * @brief Get mtime of the ini file
- */
-int sss_ini_get_mtime(struct sss_ini *self,
-                      size_t timestr_len,
-                      char *timestr);
-
-/**
  * @brief Get pointer to list of snippet parsing errors
  */
 struct ref_array *

--- a/src/util/sss_ini.h
+++ b/src/util/sss_ini.h
@@ -81,18 +81,6 @@ int sss_ini_open(struct sss_ini *self,
                  const char *fallback_cfg);
 
 /**
- * @brief Check whether sss_ini_open() reported that ini file is
- *        not present
- *
- * @param[in] self  pointer to sss_ini structure
- *
- * @return
- *   - true   we are using ini file
- *   - false  file was not found
- */
-bool sss_ini_exists(struct sss_ini *self);
-
-/**
  * @brief Get pointer to list of snippet parsing errors
  */
 struct ref_array *


### PR DESCRIPTION
Only make sure:
 - user is root or sssd
 - group is root or sssd
 - other can't access it

Don't make any assumptions wrt user/group read/write-ability.
