### PR TITLE
SERVICE: set domain name at startup

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -179,6 +179,7 @@ sssdlibexec_PROGRAMS = \
     ldap_child \
     proxy_child \
     sss_signal \
+    setdomainname \
     $(NULL)
 if BUILD_SUDO
 sssdlibexec_PROGRAMS += sssd_sudo
@@ -220,6 +221,7 @@ if BUILD_PAC_RESPONDER
 endif
 if HAVE_SYSTEMD_UNIT
 sssdlibexec_PROGRAMS += sssd_check_socket_activated_responders
+sssdlibexec_SCRIPTS = src/sysv/systemd/set-nis-domainname
 endif
 
 if HAVE_CHECK
@@ -1915,6 +1917,8 @@ sss_signal_SOURCES = \
 sss_signal_LDADD = \
     libsss_debug.la \
     $(NULL)
+
+setdomainname_SOURCES = src/tools/setdomainname.c $(NULL)
 
 sss_override_SOURCES = \
     src/tools/sss_override.c \
@@ -5407,6 +5411,14 @@ src/sysv/systemd/sssd-kcm.service: src/sysv/systemd/sssd-kcm.service.in Makefile
 endif
 
 EXTRA_DIST += \
+    src/sysv/systemd/set-nis-domainname.in \
+    $(NULL)
+
+src/sysv/systemd/set-nis-domainname: src/sysv/systemd/set-nis-domainname.in Makefile
+	@$(MKDIR_P) src/sysv/systemd/
+	$(replace_script)
+
+EXTRA_DIST += \
     src/tools/wrappers/sss_debuglevel.in \
     $(NULL)
 
@@ -5695,6 +5707,7 @@ endif
 	rm -f $(builddir)/src/sysv/systemd/sssd-sudo.service
 	rm -f $(builddir)/src/sysv/systemd/sssd-kcm.socket
 	rm -f $(builddir)/src/sysv/systemd/sssd-kcm.service
+	rm -f $(builddir)/src/sysv/systemd/set-nis-domainname
 	rm -f $(builddir)/src/tools/wrappers/sss_debuglevel
 	rm -Rf $(builddir)/src/examples
 	rm -Rf $(builddir)/contrib

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -218,6 +218,7 @@ Obsoletes: sssd-polkit-rules < 2.10.0
 # Requires
 # due to ABI changes in 1.1.30/1.2.0
 Requires: libldb >= %{ldb_version}
+Requires: libcap >= 2.48
 Requires: sssd-client%{?_isa} = %{version}-%{release}
 Requires: (libsss_sudo = %{version}-%{release} if sudo)
 Requires: (libsss_autofs%{?_isa} = %{version}-%{release} if autofs)
@@ -845,6 +846,8 @@ install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/sssd.conf
 %{_bindir}/sss_ssh_knownhostsproxy
 %{_sbindir}/sss_cache
 %{_libexecdir}/%{servicename}/sss_signal
+%{_libexecdir}/%{servicename}/setdomainname
+%{_libexecdir}/%{servicename}/set-nis-domainname
 
 %attr(775,%{sssd_user},%{sssd_user}) %dir %{sssdstatedir}
 %dir %{_localstatedir}/cache/krb5rcache

--- a/src/sysv/systemd/set-nis-domainname.in
+++ b/src/sysv/systemd/set-nis-domainname.in
@@ -1,0 +1,15 @@
+#!/usr/bin/sh
+
+NETWORK=/etc/sysconfig/network
+
+if [ ! -f $NETWORK ]; then
+    exit 0
+fi
+
+DOMAIN=$(capsh --mode=NOPRIV -- -c "source $NETWORK; echo \$NISDOMAIN")
+
+if [ -n "${DOMAIN}" ] && [ -x @libexecdir@/sssd/setdomainname ]; then
+    capsh --inh=cap_sys_admin --drop=all -- -c "@libexecdir@/sssd/setdomainname ${DOMAIN}"
+fi
+
+exit 0

--- a/src/sysv/systemd/sssd.service.in
+++ b/src/sysv/systemd/sssd.service.in
@@ -10,6 +10,7 @@ StartLimitBurst=5
 [Service]
 Environment=DEBUG_LOGGER=--logger=files
 EnvironmentFile=-@environment_file@
+ExecStartPre=+-@libexecdir@/sssd/set-nis-domainname
 ExecStartPre=+-/bin/chown -f -R root:@SSSD_USER@ @sssdconfdir@
 ExecStartPre=+-/bin/chmod -f -R g+r @sssdconfdir@
 ExecStartPre=+-/bin/sh -c "/bin/chown -f @SSSD_USER@:@SSSD_USER@ @dbpath@/*.ldb"

--- a/src/tools/setdomainname.c
+++ b/src/tools/setdomainname.c
@@ -1,0 +1,38 @@
+/*
+    Copyright (C) 2024 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stddef.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+
+
+int main(int argc, const char *argv[])
+{
+    if (argc != 2) {
+        return EINVAL;
+    }
+
+    if ((argv[1] == NULL) || (argv[1][0] == 0)) {
+        return EINVAL;
+    }
+
+    errno = 0;
+    setdomainname(argv[1], strlen(argv[1]));
+
+    return errno;
+}


### PR DESCRIPTION
:relnote: SSSD service will set `NISDOMAIN` value from `/etc/sysconfig/network`
as a domain name at service startup. This is required to support netgroups in
LDAP-stored SUDO rules.

Resolves: https://github.com/SSSD/sssd/issues/7224