### PR TITLE
pam_sss: add some missing cleanup calls.

### DIFF
--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -3037,6 +3037,7 @@ static int pam_sss(enum sss_cli_command task, pam_handle_t *pamh,
                 if (ret != PAM_SUCCESS) {
                     D(("failed to get authentication token: %s",
                        pam_strerror(pamh, ret)));
+                    overwrite_and_free_pam_items(&pi);
                     return ret;
                 }
                 break;
@@ -3091,6 +3092,7 @@ static int pam_sss(enum sss_cli_command task, pam_handle_t *pamh,
                          * would be invalid for the actual password change. So
                          * we are done. */
 
+                        overwrite_and_free_pam_items(&pi);
                         return PAM_SUCCESS;
                     }
                     task = SSS_PAM_CHAUTHTOK_PRELIM;
@@ -3103,6 +3105,7 @@ static int pam_sss(enum sss_cli_command task, pam_handle_t *pamh,
                 break;
             default:
                 D(("Illegal task [%#x]", task));
+                overwrite_and_free_pam_items(&pi);
                 return PAM_SYSTEM_ERR;
         }
 


### PR DESCRIPTION
This patch should avoid Coverity warnings like:

./src/sss_client/pam_sss.c:3075:17: alloc_arg: "get_authtok_for_password_change" allocates memory that is stored into "pi.first_factor".
./src/sss_client/pam_sss.c:3090:25: leaked_storage: Variable "pi" going out of scope leaks the storage "pi.first_factor" points to.