### PR TITLE
Initial support for IDM IDM Trust

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3452,10 +3452,13 @@ test_ipa_subdom_server_SOURCES = \
     src/tests/cmocka/common_mock_sdap.c \
     src/tests/cmocka/common_mock_be.c \
     src/tests/cmocka/common_mock_krb5.c \
+    src/tests/cmocka/data_provider/mock_dp.c \
     src/tests/cmocka/test_ipa_subdomains_server.c \
     src/providers/ipa/ipa_subdomains_server.c \
     src/providers/ipa/ipa_subdomains_utils.c \
+    src/providers/ipa/ipa_common.c \
     src/providers/ipa/ipa_opts.c \
+    src/providers/ipa/ipa_srv.c \
     src/providers/ldap/ldap_common.c \
     $(NULL)
 test_ipa_subdom_server_CFLAGS = \

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -413,6 +413,7 @@ struct sss_domain_info {
     char *dns_name;
     char *domain_id;
     uint32_t trust_direction;
+    uint32_t trust_type;
     struct timeval subdomains_last_checked;
 
     bool has_views;

--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -173,6 +173,7 @@
 #define SYSDB_SUBDOMAIN_ENUM "enumerate"
 #define SYSDB_SUBDOMAIN_FOREST "memberOfForest"
 #define SYSDB_SUBDOMAIN_TRUST_DIRECTION "trustDirection"
+#define SYSDB_SUBDOMAIN_TRUST_TYPE "trustType"
 #define SYSDB_UPN_SUFFIXES "upnSuffixes"
 #define SYSDB_SITE "site"
 #define SYSDB_ENABLED "enabled"
@@ -566,6 +567,7 @@ errno_t sysdb_subdomain_store(struct sysdb_ctx *sysdb,
                               enum sss_domain_mpg_mode mpg_mode,
                               bool enumerate, const char *forest,
                               uint32_t trust_direction,
+                              uint32_t trust_type,
                               struct ldb_message_element *upn_suffixes);
 
 errno_t sysdb_update_subdomains(struct sss_domain_info *domain,
@@ -607,6 +609,7 @@ struct sss_domain_info *new_subdomain(TALLOC_CTX *mem_ctx,
                                       const char *forest,
                                       const char **upn_suffixes,
                                       uint32_t trust_direction,
+                                      uint32_t trust_type,
                                       struct confdb_ctx *confdb,
                                       bool enabled);
 

--- a/src/man/sssd-ipa.5.xml
+++ b/src/man/sssd-ipa.5.xml
@@ -936,6 +936,12 @@ ad_server = dc.ad.domain.com
                         <para>ad_site</para>
                     </listitem>
                     <listitem>
+                        <para>ipa_server</para>
+                    </listitem>
+                    <listitem>
+                        <para>ipa_backup_server</para>
+                    </listitem>
+                    <listitem>
                         <para>ldap_search_base</para>
                     </listitem>
                     <listitem>
@@ -949,11 +955,15 @@ ad_server = dc.ad.domain.com
                     </listitem>
                 </itemizedlist>
             </para>
+            <para>
+                Options prefixed with 'ad_' or 'ipa_' only apply to
+                their respective subdomain type.
+            </para>
         </refsect2>
         <refsect2 id='client_configuration'>
             <title>OPTIONS TUNABLE ON IPA CLIENTS</title>
             <para>
-                The following options can be set in a subdomain
+                The following options can be set in an AD subdomain
                 section on an IPA client:
                 <itemizedlist>
                     <listitem>

--- a/src/providers/ad/ad_common.c
+++ b/src/providers/ad/ad_common.c
@@ -1621,11 +1621,11 @@ ad_user_conn_list(TALLOC_CTX *mem_ctx,
     return clist;
 }
 
-errno_t ad_inherit_opts_if_needed(struct dp_option *parent_opts,
-                                  struct dp_option *subdom_opts,
-                                  struct confdb_ctx *cdb,
-                                  const char *subdom_conf_path,
-                                  int opt_id)
+errno_t subdom_inherit_opts_if_needed(struct dp_option *parent_opts,
+                                      struct dp_option *subdom_opts,
+                                      struct confdb_ctx *cdb,
+                                      const char *subdom_conf_path,
+                                      int opt_id)
 {
     int ret;
     bool is_default = true;

--- a/src/providers/ad/ad_common.h
+++ b/src/providers/ad/ad_common.h
@@ -135,23 +135,15 @@ struct ad_options *ad_create_options(TALLOC_CTX *mem_ctx,
                                      struct data_provider *dp,
                                      struct sss_domain_info *subdom);
 
-struct ad_options *ad_create_2way_trust_options(TALLOC_CTX *mem_ctx,
-                                                struct confdb_ctx *cdb,
-                                                const char *conf_path,
-                                                struct data_provider *dp,
-                                                const char *realm,
-                                                struct sss_domain_info *subdom,
-                                                const char *hostname,
-                                                const char *keytab);
-
-struct ad_options *ad_create_1way_trust_options(TALLOC_CTX *mem_ctx,
-                                                struct confdb_ctx *cdb,
-                                                const char *conf_path,
-                                                struct data_provider *dp,
-                                                struct sss_domain_info *subdom,
-                                                const char *hostname,
-                                                const char *keytab,
-                                                const char *sasl_authid);
+struct ad_options *ad_create_trust_options(TALLOC_CTX *mem_ctx,
+                                           struct confdb_ctx *cdb,
+                                           const char *conf_path,
+                                           struct data_provider *dp,
+                                           struct sss_domain_info *subdom,
+                                           const char *realm,
+                                           const char *hostname,
+                                           const char *keytab,
+                                           const char *sasl_authid);
 
 errno_t ad_set_search_bases(struct sdap_options *id_opts,
                             struct sdap_domain *sdap);

--- a/src/providers/ad/ad_common.h
+++ b/src/providers/ad/ad_common.h
@@ -237,11 +237,11 @@ errno_t netlogon_get_domain_info(TALLOC_CTX *mem_ctx,
                                  char **_site,
                                  char **_forest);
 
-errno_t ad_inherit_opts_if_needed(struct dp_option *parent_opts,
-                                  struct dp_option *suddom_opts,
-                                  struct confdb_ctx *cdb,
-                                  const char *subdom_conf_path,
-                                  int opt_id);
+errno_t subdom_inherit_opts_if_needed(struct dp_option *parent_opts,
+                                      struct dp_option *suddom_opts,
+                                      struct confdb_ctx *cdb,
+                                      const char *subdom_conf_path,
+                                      int opt_id);
 
 errno_t ad_refresh_init(struct be_ctx *be_ctx,
                         struct ad_id_ctx *id_ctx);

--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -327,10 +327,10 @@ ad_subdom_ad_ctx_new(struct be_ctx *be_ctx,
         return ENOMEM;
     }
 
-    ret = ad_inherit_opts_if_needed(id_ctx->ad_options->basic,
-                                    ad_options->basic,
-                                    be_ctx->cdb, subdom_conf_path,
-                                    AD_USE_LDAPS);
+    ret = subdom_inherit_opts_if_needed(id_ctx->ad_options->basic,
+                                        ad_options->basic,
+                                        be_ctx->cdb, subdom_conf_path,
+                                        AD_USE_LDAPS);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Failed to inherit option [%s] to sub-domain [%s]. "
@@ -344,10 +344,10 @@ ad_subdom_ad_ctx_new(struct be_ctx *be_ctx,
         ad_set_ssf_and_mech_for_ldaps(ad_options->id);
     }
 
-    ret = ad_inherit_opts_if_needed(id_ctx->sdap_id_ctx->opts->basic,
-                                    ad_options->id->basic,
-                                    be_ctx->cdb, subdom_conf_path,
-                                    SDAP_SASL_MECH);
+    ret = subdom_inherit_opts_if_needed(id_ctx->sdap_id_ctx->opts->basic,
+                                        ad_options->id->basic,
+                                        be_ctx->cdb, subdom_conf_path,
+                                        SDAP_SASL_MECH);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Failed to inherit option [%s] to sub-domain [%s]. "

--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -43,7 +43,6 @@
 /* Attributes of AD trusted domains */
 #define AD_AT_FLATNAME      "flatName"
 #define AD_AT_SID           "securityIdentifier"
-#define AD_AT_TRUST_TYPE    "trustType"
 #define AD_AT_TRUST_PARTNER "trustPartner"
 #define AD_AT_TRUST_ATTRS   "trustAttributes"
 #define AD_AT_DOMAIN_NAME   "cn"
@@ -1224,7 +1223,7 @@ static void ad_get_slave_domain_connect_done(struct tevent_req *subreq)
     int dp_error;
     errno_t ret;
     const char *attrs[] = { AD_AT_FLATNAME, AD_AT_TRUST_PARTNER,
-                            AD_AT_SID, AD_AT_TRUST_TYPE, AD_AT_DOMAIN_NAME,
+                            AD_AT_SID, AD_AT_DOMAIN_NAME,
                             AD_AT_TRUST_ATTRS, AD_AT_TRUST_DIRECTION, NULL };
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
@@ -1433,7 +1432,7 @@ ad_get_root_domain_send(TALLOC_CTX *mem_ctx,
     struct sdap_options *opts;
     errno_t ret;
     const char *attrs[] = { AD_AT_FLATNAME, AD_AT_TRUST_PARTNER,
-                            AD_AT_SID, AD_AT_TRUST_TYPE, AD_AT_TRUST_DIRECTION,
+                            AD_AT_SID, AD_AT_TRUST_DIRECTION,
                             AD_AT_TRUST_ATTRS, AD_AT_DOMAIN_NAME, NULL };
 
     req = tevent_req_create(mem_ctx, &state, struct ad_get_root_domain_state);

--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -27,6 +27,7 @@
 #include "providers/ad/ad_domain_info.h"
 #include "providers/ad/ad_srv.h"
 #include "providers/ad/ad_common.h"
+#include "providers/ipa/ipa_subdomains.h"
 
 #include "providers/ldap/sdap_idmap.h"
 #include "providers/ldap/sdap_ops.h"
@@ -582,6 +583,7 @@ ad_subdom_store(struct confdb_ctx *cdb,
     char *realm;
     const char *flat;
     const char *dns;
+    uint32_t trust_type;
     errno_t ret;
     enum idmap_error_code err;
     struct ldb_message_element *el;
@@ -594,6 +596,9 @@ ad_subdom_store(struct confdb_ctx *cdb,
         ret = ENOMEM;
         goto done;
     }
+
+    /* AD trust type */
+    trust_type = IPA_TRUST_AD;
 
     ret = sysdb_attrs_get_string(subdom_attrs, AD_AT_TRUST_PARTNER, &name);
     if (ret != EOK) {
@@ -645,7 +650,8 @@ ad_subdom_store(struct confdb_ctx *cdb,
                                 name, str_domain_mpg_mode(mpg_mode));
 
     ret = sysdb_subdomain_store(domain->sysdb, name, realm, flat, dns, sid_str,
-                                mpg_mode, enumerate, domain->forest, 0, NULL);
+                                mpg_mode, enumerate, domain->forest, 0, trust_type,
+                                NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "sysdb_subdomain_store failed.\n");
         goto done;
@@ -2587,6 +2593,7 @@ ad_check_domain_send(TALLOC_CTX *mem_ctx,
                      const char *parent_dom_name)
 {
     errno_t ret;
+    uint32_t trust_type;
     struct tevent_req *req;
     struct tevent_req *subreq;
     struct ad_check_domain_state *state;
@@ -2604,6 +2611,9 @@ ad_check_domain_send(TALLOC_CTX *mem_ctx,
     state->parent = NULL;
     state->sdom = NULL;
 
+    /* AD trust type */
+    trust_type = IPA_TRUST_AD;
+
     state->dom = find_domain_by_name(be_ctx->domain, dom_name, true);
     if (state->dom == NULL) {
         state->parent = find_domain_by_name(be_ctx->domain, parent_dom_name,
@@ -2619,7 +2629,7 @@ ad_check_domain_send(TALLOC_CTX *mem_ctx,
         state->dom = new_subdomain(state->parent, state->parent, dom_name,
                                    dom_name, NULL, NULL, NULL, MPG_DISABLED, false,
                                    state->parent->forest,
-                                   NULL, 0, be_ctx->cdb, true);
+                                   NULL, 0, trust_type, be_ctx->cdb, true);
         if (state->dom == NULL) {
             DEBUG(SSSDBG_OP_FAILURE, "new_subdomain() failed.\n");
             ret = EINVAL;

--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -311,13 +311,15 @@ ad_subdom_ad_ctx_new(struct be_ctx *be_ctx,
         return ENOMEM;
     }
 
-    ad_options = ad_create_2way_trust_options(id_ctx,
-                                              be_ctx->cdb,
-                                              subdom_conf_path,
-                                              be_ctx->provider,
-                                              realm,
-                                              subdom,
-                                              hostname, keytab);
+    ad_options = ad_create_trust_options(id_ctx,
+                                         be_ctx->cdb,
+                                         subdom_conf_path,
+                                         be_ctx->provider,
+                                         subdom,
+                                         realm,
+                                         hostname,
+                                         keytab,
+                                         NULL);
     if (ad_options == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Cannot initialize AD options\n");
         talloc_free(ad_options);

--- a/src/providers/ipa/ipa_common.h
+++ b/src/providers/ipa/ipa_common.h
@@ -255,6 +255,7 @@ int ipa_get_id_options(struct ipa_options *ipa_opts,
                        struct confdb_ctx *cdb,
                        const char *conf_path,
                        struct data_provider *dp,
+                       bool sdom_add,
                        struct sdap_options **_opts);
 
 int ipa_get_auth_options(struct ipa_options *ipa_opts,
@@ -270,6 +271,15 @@ int ipa_get_autofs_options(struct ipa_options *ipa_opts,
 
 errno_t ipa_get_dyndns_options(struct be_ctx *be_ctx,
                                struct ipa_options *ctx);
+
+errno_t ipa_set_sdap_options(struct ipa_options *ipa_opts,
+                             struct sdap_options *sdap_opts);
+
+errno_t ipa_set_search_bases(struct ipa_options *ipa_opts,
+                             struct confdb_ctx *cdb,
+                             const char *basedn,
+                             const char *conf_path,
+                             struct sdap_domain *sdap_dom);
 
 errno_t ipa_hostid_init(TALLOC_CTX *mem_ctx,
                         struct be_ctx *be_ctx,
@@ -324,5 +334,16 @@ errno_t ipa_get_host_attrs(struct dp_option *ipa_options,
 
 errno_t ipa_refresh_init(struct be_ctx *be_ctx,
                          struct ipa_id_ctx *id_ctx);
+
+
+struct ipa_options *
+ipa_create_trust_options(TALLOC_CTX *mem_ctx,
+                         struct be_ctx *be_ctx,
+                         struct confdb_ctx *cdb,
+                         const char *subdom_conf_path,
+                         struct data_provider *dp,
+                         struct sss_domain_info *subdom,
+                         const char *keytab,
+                         const char *sasl_authid);
 
 #endif /* _IPA_COMMON_H_ */

--- a/src/providers/ipa/ipa_common.h
+++ b/src/providers/ipa/ipa_common.h
@@ -284,6 +284,8 @@ errno_t ipa_autofs_init(TALLOC_CTX *mem_ctx,
 int ipa_service_init(TALLOC_CTX *memctx, struct be_ctx *ctx,
                      const char *primary_servers,
                      const char *backup_servers,
+                     const char *realm,
+                     const char *ipa_service,
                      struct ipa_options *options,
                      struct ipa_service **_service);
 

--- a/src/providers/ipa/ipa_id.c
+++ b/src/providers/ipa/ipa_id.c
@@ -334,14 +334,14 @@ static int ipa_initgr_get_overrides_step(struct tevent_req *req)
 
         DEBUG(SSSDBG_TRACE_LIBS, "Fetching group %s: %s\n", dn, ipa_uuid);
 
-        subreq = ipa_get_ad_override_send(state, state->ev,
+        subreq = ipa_get_trusted_override_send(state, state->ev,
                                           state->ipa_ctx->sdap_id_ctx,
                                           state->ipa_ctx->ipa_options,
                                           state->realm,
                                           state->ipa_ctx->view_name,
                                           state->ar);
         if (subreq == NULL) {
-            DEBUG(SSSDBG_OP_FAILURE, "ipa_get_ad_override_send failed.\n");
+            DEBUG(SSSDBG_OP_FAILURE, "ipa_get_trusted_override_send failed.\n");
             return ENOMEM;
         }
         tevent_req_set_callback(subreq,
@@ -361,7 +361,7 @@ static void ipa_initgr_get_overrides_override_done(struct tevent_req *subreq)
     int ret;
     struct sysdb_attrs *override_attrs = NULL;
 
-    ret = ipa_get_ad_override_recv(subreq, &state->dp_error, state,
+    ret = ipa_get_trusted_override_recv(subreq, &state->dp_error, state,
                                    &override_attrs);
     talloc_zfree(subreq);
     if (ret != EOK) {
@@ -605,11 +605,11 @@ static void ipa_id_get_account_info_connected(struct tevent_req *subreq)
         goto fail;
     }
 
-    subreq = ipa_get_ad_override_send(state, state->ev, state->ctx,
-                                      state->ipa_ctx->ipa_options, state->realm,
-                                      state->ipa_ctx->view_name, state->ar);
+    subreq = ipa_get_trusted_override_send(state, state->ev, state->ctx,
+                                           state->ipa_ctx->ipa_options, state->realm,
+                                           state->ipa_ctx->view_name, state->ar);
     if (subreq == NULL) {
-        DEBUG(SSSDBG_OP_FAILURE, "ipa_get_ad_override_send failed.\n");
+        DEBUG(SSSDBG_OP_FAILURE, "ipa_get_trusted_override_send failed.\n");
         ret = ENOMEM;
         goto fail;
     }
@@ -636,8 +636,8 @@ static void ipa_id_get_account_info_got_override(struct tevent_req *subreq)
     char *anchor_domain;
     char *ipa_uuid;
 
-    ret = ipa_get_ad_override_recv(subreq, &dp_error, state,
-                                   &state->override_attrs);
+    ret = ipa_get_trusted_override_recv(subreq, &dp_error, state,
+                                        &state->override_attrs);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
@@ -903,14 +903,14 @@ static int ipa_id_get_account_info_post_proc_step(struct tevent_req *req)
             goto done;
         }
 
-        subreq = ipa_get_ad_override_send(state, state->ev,
-                                          state->ipa_ctx->sdap_id_ctx,
-                                          state->ipa_ctx->ipa_options,
-                                          state->realm,
-                                          state->ipa_ctx->view_name,
-                                          state->ar);
+        subreq = ipa_get_trusted_override_send(state, state->ev,
+                                               state->ipa_ctx->sdap_id_ctx,
+                                               state->ipa_ctx->ipa_options,
+                                               state->realm,
+                                               state->ipa_ctx->view_name,
+                                               state->ar);
         if (subreq == NULL) {
-            DEBUG(SSSDBG_OP_FAILURE, "ipa_get_ad_override_send failed.\n");
+            DEBUG(SSSDBG_OP_FAILURE, "ipa_get_trusted_override_send failed.\n");
             ret = ENOMEM;
             goto done;
         }
@@ -987,8 +987,8 @@ static void ipa_id_get_account_info_done(struct tevent_req *subreq)
     const char *class;
     enum sysdb_member_type type;
 
-    ret = ipa_get_ad_override_recv(subreq, &dp_error, state,
-                                   &state->override_attrs);
+    ret = ipa_get_trusted_override_recv(subreq, &dp_error, state,
+                                        &state->override_attrs);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "IPA override lookup failed: %d\n", ret);

--- a/src/providers/ipa/ipa_id.h
+++ b/src/providers/ipa/ipa_id.h
@@ -98,17 +98,17 @@ errno_t get_dp_id_data_for_user_name(TALLOC_CTX *mem_ctx,
                                       const char *domain_name,
                                       struct dp_id_data **_ar);
 
-struct tevent_req *ipa_get_ad_override_send(TALLOC_CTX *mem_ctx,
-                                            struct tevent_context *ev,
-                                            struct sdap_id_ctx *sdap_id_ctx,
-                                            struct ipa_options *ipa_options,
-                                            const char *ipa_realm,
-                                            const char *view_name,
-                                            struct dp_id_data *ar);
+struct tevent_req *ipa_get_trusted_override_send(TALLOC_CTX *mem_ctx,
+                                                 struct tevent_context *ev,
+                                                 struct sdap_id_ctx *sdap_id_ctx,
+                                                 struct ipa_options *ipa_options,
+                                                 const char *ipa_realm,
+                                                 const char *view_name,
+                                                 struct dp_id_data *ar);
 
-errno_t ipa_get_ad_override_recv(struct tevent_req *req, int *dp_error_out,
-                                 TALLOC_CTX *mem_ctx,
-                                 struct sysdb_attrs **override_attrs);
+errno_t ipa_get_trusted_override_recv(struct tevent_req *req, int *dp_error_out,
+                                      TALLOC_CTX *mem_ctx,
+                                      struct sysdb_attrs **override_attrs);
 
 struct tevent_req *ipa_subdomain_account_send(TALLOC_CTX *memctx,
                                               struct tevent_context *ev,

--- a/src/providers/ipa/ipa_init.c
+++ b/src/providers/ipa/ipa_init.c
@@ -111,6 +111,7 @@ static errno_t ipa_init_options(TALLOC_CTX *mem_ctx,
     struct ipa_options *ipa_options;
     const char *ipa_servers;
     const char *ipa_backup_servers;
+    const char *realm;
     errno_t ret;
 
     ret = ipa_get_options(mem_ctx, be_ctx->cdb, be_ctx->conf_path,
@@ -121,9 +122,10 @@ static errno_t ipa_init_options(TALLOC_CTX *mem_ctx,
 
     ipa_servers = dp_opt_get_string(ipa_options->basic, IPA_SERVER);
     ipa_backup_servers = dp_opt_get_string(ipa_options->basic, IPA_BACKUP_SERVER);
+    realm = dp_opt_get_string(ipa_options->basic, IPA_KRB5_REALM);
 
     ret = ipa_service_init(ipa_options, be_ctx, ipa_servers,
-                           ipa_backup_servers, ipa_options,
+                           ipa_backup_servers, realm, "IPA", ipa_options,
                            &ipa_options->service);
     if (ret != EOK) {
         DEBUG(SSSDBG_FATAL_FAILURE, "Failed to init IPA service [%d]: %s\n",

--- a/src/providers/ipa/ipa_s2n_exop.c
+++ b/src/providers/ipa/ipa_s2n_exop.c
@@ -2468,7 +2468,6 @@ static errno_t ipa_s2n_save_objects(struct sss_domain_info *dom,
     time_t now;
     struct sss_nss_homedir_ctx homedir_ctx;
     char *name = NULL;
-    char *upn = NULL;
     gid_t gid;
     gid_t orig_gid = 0;
     TALLOC_CTX *tmp_ctx;
@@ -2540,22 +2539,6 @@ static errno_t ipa_s2n_save_objects(struct sss_domain_info *dom,
                 goto done;
             }
         } else if (ret != ENOENT) {
-            DEBUG(SSSDBG_OP_FAILURE, "sysdb_attrs_get_string failed.\n");
-            goto done;
-        }
-
-        ret = sysdb_attrs_get_string(attrs->sysdb_attrs, SYSDB_UPN, &tmp_str);
-        if (ret == EOK) {
-            upn = talloc_strdup(tmp_ctx, tmp_str);
-            if (upn == NULL) {
-                DEBUG(SSSDBG_OP_FAILURE, "talloc_strdup failed.\n");
-                ret = ENOMEM;
-                goto done;
-            }
-            DEBUG(SSSDBG_TRACE_ALL, "Found original AD upn [%s].\n", upn);
-        } else if (ret == ENOENT) {
-            upn = NULL;
-        } else {
             DEBUG(SSSDBG_OP_FAILURE, "sysdb_attrs_get_string failed.\n");
             goto done;
         }

--- a/src/providers/ipa/ipa_s2n_exop.c
+++ b/src/providers/ipa/ipa_s2n_exop.c
@@ -1501,15 +1501,15 @@ static void ipa_s2n_get_list_next(struct tevent_req *subreq)
         goto fail;
     }
 
-    subreq = ipa_get_ad_override_send(state, state->ev,
-                           state->ipa_ctx->sdap_id_ctx,
-                           state->ipa_ctx->ipa_options,
-                           dp_opt_get_string(state->ipa_ctx->ipa_options->basic,
-                                             IPA_KRB5_REALM),
-                           state->ipa_ctx->view_name,
-                           ar);
+    subreq = ipa_get_trusted_override_send(state, state->ev,
+                                           state->ipa_ctx->sdap_id_ctx,
+                                           state->ipa_ctx->ipa_options,
+                                           dp_opt_get_string(state->ipa_ctx->ipa_options->basic,
+                                                             IPA_KRB5_REALM),
+                                           state->ipa_ctx->view_name,
+                                           ar);
     if (subreq == NULL) {
-        DEBUG(SSSDBG_OP_FAILURE, "ipa_get_ad_override_send failed.\n");
+        DEBUG(SSSDBG_OP_FAILURE, "ipa_get_trusted_override_send failed.\n");
         ret = ENOMEM;
         goto fail;
     }
@@ -1566,7 +1566,7 @@ static void ipa_s2n_get_list_get_override_done(struct tevent_req *subreq)
     struct ipa_s2n_get_list_state *state = tevent_req_data(req,
                                                struct ipa_s2n_get_list_state);
 
-    ret = ipa_get_ad_override_recv(subreq, NULL, state, &state->override_attrs);
+    ret = ipa_get_trusted_override_recv(subreq, NULL, state, &state->override_attrs);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "IPA override lookup failed: %d\n", ret);
@@ -2318,15 +2318,15 @@ static void ipa_s2n_get_user_done(struct tevent_req *subreq)
             goto done;
         }
 
-        subreq = ipa_get_ad_override_send(state, state->ev,
-                           state->ipa_ctx->sdap_id_ctx,
-                           state->ipa_ctx->ipa_options,
-                           dp_opt_get_string(state->ipa_ctx->ipa_options->basic,
-                                             IPA_KRB5_REALM),
-                           state->ipa_ctx->view_name,
-                           ar);
+        subreq = ipa_get_trusted_override_send(state, state->ev,
+                                               state->ipa_ctx->sdap_id_ctx,
+                                               state->ipa_ctx->ipa_options,
+                                               dp_opt_get_string(state->ipa_ctx->ipa_options->basic,
+                                                                 IPA_KRB5_REALM),
+                                               state->ipa_ctx->view_name,
+                                               ar);
         if (subreq == NULL) {
-            DEBUG(SSSDBG_OP_FAILURE, "ipa_get_ad_override_send failed.\n");
+            DEBUG(SSSDBG_OP_FAILURE, "ipa_get_trusted_override_send failed.\n");
             ret = ENOMEM;
             goto done;
         }
@@ -2979,15 +2979,15 @@ static void ipa_s2n_get_list_done(struct tevent_req  *subreq)
 
     if (state->override_attrs == NULL
             && !is_default_view(state->ipa_ctx->view_name)) {
-        subreq = ipa_get_ad_override_send(state, state->ev,
-                           state->ipa_ctx->sdap_id_ctx,
-                           state->ipa_ctx->ipa_options,
-                           dp_opt_get_string(state->ipa_ctx->ipa_options->basic,
-                                             IPA_KRB5_REALM),
-                           state->ipa_ctx->view_name,
-                           ar);
+        subreq = ipa_get_trusted_override_send(state, state->ev,
+                                               state->ipa_ctx->sdap_id_ctx,
+                                               state->ipa_ctx->ipa_options,
+                                               dp_opt_get_string(state->ipa_ctx->ipa_options->basic,
+                                                                 IPA_KRB5_REALM),
+                                               state->ipa_ctx->view_name,
+                                               ar);
         if (subreq == NULL) {
-            DEBUG(SSSDBG_OP_FAILURE, "ipa_get_ad_override_send failed.\n");
+            DEBUG(SSSDBG_OP_FAILURE, "ipa_get_trusted_override_send failed.\n");
             ret = ENOMEM;
             goto fail;
         }
@@ -3023,7 +3023,7 @@ static void ipa_s2n_get_user_get_override_done(struct tevent_req *subreq)
                                                 struct ipa_s2n_get_user_state);
     struct sysdb_attrs *override_attrs = NULL;
 
-    ret = ipa_get_ad_override_recv(subreq, NULL, state, &override_attrs);
+    ret = ipa_get_trusted_override_recv(subreq, NULL, state, &override_attrs);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "IPA override lookup failed: %d\n", ret);

--- a/src/providers/ipa/ipa_subdomains.c
+++ b/src/providers/ipa/ipa_subdomains.c
@@ -3199,9 +3199,9 @@ errno_t ipa_subdomains_init(TALLOC_CTX *mem_ctx,
         /* Ignore this error and try to discover the subdomains later */
     }
 
-    ret = ipa_ad_subdom_init(be_ctx, ipa_id_ctx);
+    ret = ipa_trusted_subdom_init(be_ctx, ipa_id_ctx);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "ipa_ad_subdom_init() failed.\n");
+        DEBUG(SSSDBG_CRIT_FAILURE, "ipa_trusted_subdom_init() failed.\n");
         return ret;
     }
 

--- a/src/providers/ipa/ipa_subdomains.h
+++ b/src/providers/ipa/ipa_subdomains.h
@@ -111,7 +111,7 @@ void ipa_ad_subdom_remove(struct be_ctx *be_ctx,
                           struct ipa_id_ctx *id_ctx,
                           struct sss_domain_info *subdom);
 
-int ipa_ad_subdom_init(struct be_ctx *be_ctx,
+int ipa_trusted_subdom_init(struct be_ctx *be_ctx,
                        struct ipa_id_ctx *id_ctx);
 
 errno_t ipa_server_get_trust_direction(struct sysdb_attrs *sd,
@@ -150,7 +150,7 @@ struct ipa_server_mode_ctx {
     uid_t kt_owner_gid;
 };
 
-int ipa_ad_subdom_init(struct be_ctx *be_ctx,
+int ipa_trusted_subdom_init(struct be_ctx *be_ctx,
                        struct ipa_id_ctx *id_ctx);
 
 enum req_input_type {
@@ -170,15 +170,15 @@ struct req_input {
     } inp;
 };
 
-struct tevent_req *ipa_get_ad_memberships_send(TALLOC_CTX *mem_ctx,
-                                        struct tevent_context *ev,
-                                        struct dp_id_data *ar,
-                                        struct ipa_server_mode_ctx *server_mode,
-                                        struct sss_domain_info *user_dom,
-                                        struct sdap_id_ctx *sdap_id_ctx,
-                                        const char *domain);
+struct tevent_req *ipa_get_trusted_memberships_send(TALLOC_CTX *mem_ctx,
+                                                    struct tevent_context *ev,
+                                                    struct dp_id_data *ar,
+                                                    struct ipa_server_mode_ctx *server_mode,
+                                                    struct sss_domain_info *user_dom,
+                                                    struct sdap_id_ctx *sdap_id_ctx,
+                                                    const char *domain);
 
-errno_t ipa_get_ad_memberships_recv(struct tevent_req *req, int *dp_error_out);
+errno_t ipa_get_trusted_memberships_recv(struct tevent_req *req, int *dp_error_out);
 
 struct tevent_req *ipa_ext_group_member_send(TALLOC_CTX *mem_ctx,
                                              struct tevent_context *ev,

--- a/src/providers/ipa/ipa_subdomains.h
+++ b/src/providers/ipa/ipa_subdomains.h
@@ -69,8 +69,15 @@ errno_t ipa_subdomains_init(TALLOC_CTX *mem_ctx,
                             struct dp_method *dp_methods);
 
 /* The following are used in server mode only */
+enum ipa_trust_type {
+    IPA_TRUST_UNKNOWN = 0,
+    IPA_TRUST_AD = 1,
+    IPA_TRUST_IPA = 2,
+};
+
 struct ipa_ad_server_ctx {
     struct sss_domain_info *dom;
+    enum ipa_trust_type type;
     struct ad_id_ctx *ad_id_ctx;
 
     struct ipa_ad_server_ctx *next, *prev;
@@ -108,10 +115,16 @@ errno_t ipa_server_get_trust_direction(struct sysdb_attrs *sd,
                                        struct ldb_context *ldb_ctx,
                                        uint32_t *_direction);
 
+errno_t ipa_server_get_trust_type(struct sysdb_attrs *sd,
+                                  struct ldb_context *ldb_ctx,
+                                  uint32_t *_type);
+
 const char *ipa_trust_dir2str(uint32_t direction);
+const char *ipa_trust_type2str(uint32_t type);
 
 /* Utilities */
 #define IPA_TRUST_DIRECTION "ipaNTTrustDirection"
+#define IPA_PARTNER_TRUST_TYPE "ipaPartnerTrustType"
 
 struct ldb_dn *ipa_subdom_ldb_dn(TALLOC_CTX *mem_ctx,
                                  struct ldb_context *ldb_ctx,

--- a/src/providers/ipa/ipa_subdomains.h
+++ b/src/providers/ipa/ipa_subdomains.h
@@ -75,12 +75,15 @@ enum ipa_trust_type {
     IPA_TRUST_IPA = 2,
 };
 
-struct ipa_ad_server_ctx {
+struct ipa_subdom_server_ctx {
     struct sss_domain_info *dom;
     enum ipa_trust_type type;
-    struct ad_id_ctx *ad_id_ctx;
+    union {
+        struct ad_id_ctx *ad_id_ctx;
+        struct ipa_id_ctx *ipa_id_ctx;
+    } id_ctx;
 
-    struct ipa_ad_server_ctx *next, *prev;
+    struct ipa_subdom_server_ctx *next, *prev;
 };
 
 /* Can be used to set up trusted subdomain, for example fetch
@@ -140,7 +143,7 @@ struct ipa_server_mode_ctx {
     const char *realm;
     const char *hostname;
 
-    struct ipa_ad_server_ctx *trusts;
+    struct ipa_subdom_server_ctx *trusts;
     struct ipa_ext_groups *ext_groups;
 
     uid_t kt_owner_uid;

--- a/src/providers/ipa/ipa_subdomains_id.c
+++ b/src/providers/ipa/ipa_subdomains_id.c
@@ -802,6 +802,9 @@ static errno_t ipa_get_ad_ipa_membership_step(struct tevent_req *req);
 static void ipa_id_get_groups_overrides_done(struct tevent_req *subreq);
 static void ipa_get_ad_acct_done(struct tevent_req *subreq);
 
+static enum ipa_trust_type
+ipa_get_trust_type(struct ipa_id_ctx *ipa_ctx,
+                   struct sss_domain_info *dom);
 static struct tevent_req *
 ipa_get_ad_acct_send(TALLOC_CTX *mem_ctx,
                      struct tevent_context *ev,
@@ -900,6 +903,19 @@ ipa_get_ad_id_ctx(struct ipa_id_ctx *ipa_ctx,
     }
 
     return (iter) ? iter->ad_id_ctx : NULL;
+}
+
+static enum ipa_trust_type
+ipa_get_trust_type(struct ipa_id_ctx *ipa_ctx,
+                   struct sss_domain_info *dom)
+{
+    struct ipa_subdom_server_ctx *iter;
+
+    DLIST_FOR_EACH(iter, ipa_ctx->server_mode->trusts) {
+        if (iter->dom == dom) break;
+    }
+
+    return iter->type;
 }
 
 static errno_t

--- a/src/providers/ipa/ipa_subdomains_id.c
+++ b/src/providers/ipa/ipa_subdomains_id.c
@@ -896,13 +896,13 @@ static struct ad_id_ctx *
 ipa_get_ad_id_ctx(struct ipa_id_ctx *ipa_ctx,
                   struct sss_domain_info *dom)
 {
-    struct ipa_ad_server_ctx *iter;
+    struct ipa_subdom_server_ctx *iter;
 
     DLIST_FOR_EACH(iter, ipa_ctx->server_mode->trusts) {
         if (iter->dom == dom) break;
     }
 
-    return (iter) ? iter->ad_id_ctx : NULL;
+    return (iter) ? iter->id_ctx.ad_id_ctx : NULL;
 }
 
 static enum ipa_trust_type

--- a/src/providers/ipa/ipa_subdomains_id.c
+++ b/src/providers/ipa/ipa_subdomains_id.c
@@ -783,7 +783,7 @@ ipa_ad_gc_conn_list(TALLOC_CTX *mem_ctx, struct ipa_id_ctx *ipa_ctx,
     return clist;
 }
 
-/* IPA lookup for server mode. Directly to AD. */
+/* IPA lookup for server mode. AD or IPA subdomain */
 struct ipa_get_acct_state {
     int dp_error;
     struct tevent_context *ev;
@@ -793,6 +793,7 @@ struct ipa_get_acct_state {
     char *object_sid;
     struct sysdb_attrs *override_attrs;
     struct ldb_message *obj_msg;
+    enum ipa_trust_type type;
 };
 
 static void ipa_get_trusted_acct_part_done(struct tevent_req *subreq);
@@ -810,7 +811,8 @@ ipa_get_ad_acct_send(TALLOC_CTX *mem_ctx,
                      struct tevent_context *ev,
                      struct ipa_id_ctx *ipa_ctx,
                      struct sysdb_attrs *override_attrs,
-                     struct dp_id_data *ar)
+                     struct dp_id_data *ar,
+                     enum ipa_trust_type type)
 {
     errno_t ret;
     struct tevent_req *req;
@@ -829,6 +831,7 @@ ipa_get_ad_acct_send(TALLOC_CTX *mem_ctx,
     state->ipa_ctx = ipa_ctx;
     state->ar = ar;
     state->obj_msg = NULL;
+    state->type = type;
     state->override_attrs = override_attrs;
 
     /* This can only be a subdomain request, verify subdomain */
@@ -905,6 +908,19 @@ ipa_get_ad_id_ctx(struct ipa_id_ctx *ipa_ctx,
     return (iter) ? iter->id_ctx.ad_id_ctx : NULL;
 }
 
+static struct ipa_id_ctx *
+ipa_get_ipa_id_ctx(struct ipa_id_ctx *ipa_ctx,
+                   struct sss_domain_info *dom)
+{
+    struct ipa_subdom_server_ctx *iter;
+
+    DLIST_FOR_EACH(iter, ipa_ctx->server_mode->trusts) {
+        if (iter->dom == dom) break;
+    }
+
+    return (iter) ? iter->id_ctx.ipa_id_ctx : NULL;
+}
+
 static enum ipa_trust_type
 ipa_get_trust_type(struct ipa_id_ctx *ipa_ctx,
                    struct sss_domain_info *dom)
@@ -917,6 +933,76 @@ ipa_get_trust_type(struct ipa_id_ctx *ipa_ctx,
 
     return iter->type;
 }
+
+static struct ipa_id_ctx *ipa_get_ipa_id_ctx(struct ipa_id_ctx *ipa_ctx,
+                                             struct sss_domain_info *dom);
+
+static struct tevent_req *
+ipa_get_ipa_acct_send(TALLOC_CTX *mem_ctx,
+                      struct tevent_context *ev,
+                      struct ipa_id_ctx *ipa_ctx,
+                      struct sysdb_attrs *override_attrs,
+                      struct dp_id_data *ar,
+                      enum ipa_trust_type type)
+{
+    errno_t ret;
+    struct tevent_req *req;
+    struct tevent_req *subreq;
+    struct ipa_get_acct_state *state;
+    struct sdap_domain *sdom;
+    struct sdap_id_ctx *sdap_id_ctx;
+    struct ipa_id_ctx *ipa_id_ctx;
+
+    req = tevent_req_create(mem_ctx, &state, struct ipa_get_acct_state);
+    if (req == NULL) return NULL;
+
+    state->dp_error = -1;
+    state->ev = ev;
+    state->ipa_ctx = ipa_ctx;
+    state->ar = ar;
+    state->obj_msg = NULL;
+    state->type = type;
+    state->override_attrs = override_attrs;
+
+    /* This can only be a subdomain request, verify subdomain */
+    state->obj_dom = find_domain_by_name(ipa_ctx->sdap_id_ctx->be->domain,
+                                         ar->domain, true);
+    if (state->obj_dom == NULL) {
+        ret = EINVAL;
+        goto fail;
+    }
+
+    /* Let's see if this subdomain has a ipa_id_ctx */
+    ipa_id_ctx = ipa_get_ipa_id_ctx(ipa_ctx, state->obj_dom);
+    if (ipa_id_ctx == NULL) {
+        ret = EINVAL;
+        goto fail;
+    }
+    sdap_id_ctx = ipa_id_ctx->sdap_id_ctx;
+
+    /* Now we already need ipa_id_ctx in particular sdap_id_conn_ctx */
+    sdom = sdap_domain_get(sdap_id_ctx->opts, state->obj_dom);
+    if (sdom == NULL) {
+        ret = EIO;
+        goto fail;
+    }
+
+    ipa_id_ctx->sdap_id_ctx->opts->sdom = sdom;
+    subreq = ipa_id_get_account_info_send(req, ev, ipa_id_ctx, ar);
+    if (subreq == NULL) {
+        ret = ENOMEM;
+        goto fail;
+    }
+    tevent_req_set_callback(subreq, ipa_get_trusted_acct_part_done, req);
+    return req;
+
+fail:
+    state->dp_error = DP_ERR_FATAL;
+    tevent_req_error(req, ret);
+    tevent_req_post(req, ev);
+    return req;
+}
+
 
 static errno_t
 get_subdomain_homedir_of_user(TALLOC_CTX *mem_ctx, struct sss_domain_info *dom,
@@ -1285,7 +1371,14 @@ ipa_get_trusted_acct_part_done(struct tevent_req *subreq)
     const char *sid;
     struct dp_id_data *ar;
 
-    ret = ad_handle_acct_info_recv(subreq, &state->dp_error, NULL);
+    if (state->type == IPA_TRUST_AD) {
+        ret = ad_handle_acct_info_recv(subreq, &state->dp_error, NULL);
+    } else if (state->type == IPA_TRUST_IPA) {
+        ret = ipa_id_get_account_info_recv(subreq, &state->dp_error);
+    } else {
+        ret = EINVAL;
+    }
+
     talloc_zfree(subreq);
     if (ret == ERR_SUBDOM_INACTIVE) {
         tevent_req_error(req, ret);
@@ -1673,6 +1766,7 @@ struct ipa_srv_acct_state {
 
     struct sss_domain_info *obj_dom;
     struct be_ctx *be_ctx;
+    enum ipa_trust_type type;
     bool retry;
 
     int dp_error;
@@ -1715,6 +1809,8 @@ ipa_srv_acct_send(TALLOC_CTX *mem_ctx,
         goto fail;
     }
 
+    state->type = ipa_get_trust_type(state->ipa_ctx, state->obj_dom);
+
     ret = ipa_srv_acct_lookup_step(req);
     if (ret != EOK) {
         goto fail;
@@ -1734,10 +1830,21 @@ static int ipa_srv_acct_lookup_step(struct tevent_req *req)
     struct ipa_srv_acct_state *state = tevent_req_data(req,
                                             struct ipa_srv_acct_state);
 
-    DEBUG(SSSDBG_TRACE_FUNC, "Looking up AD account\n");
-    subreq = ipa_get_ad_acct_send(state, state->ev, state->ipa_ctx,
-                                  state->override_attrs,
-                                  state->ar);
+    if (state->type == IPA_TRUST_AD) {
+        DEBUG(SSSDBG_TRACE_FUNC, "Looking up AD account\n");
+        subreq = ipa_get_ad_acct_send(state, state->ev, state->ipa_ctx,
+                                      state->override_attrs,
+                                      state->ar, state->type);
+    } else if (state->type == IPA_TRUST_IPA) {
+        DEBUG(SSSDBG_TRACE_FUNC, "Looking up IPA account\n");
+        subreq = ipa_get_ipa_acct_send(state, state->ev, state->ipa_ctx,
+                                       state->override_attrs,
+                                       state->ar, state->type);
+    } else {
+        DEBUG(SSSDBG_TRACE_FUNC, "Trust type is unknown\n");
+        subreq = NULL;
+    }
+
     if (subreq == NULL) {
         return ENOMEM;
     }

--- a/src/providers/ipa/ipa_subdomains_id.c
+++ b/src/providers/ipa/ipa_subdomains_id.c
@@ -23,11 +23,13 @@
 */
 
 #include <errno.h>
+#include <ldb.h>
 
 #include "util/util.h"
 #include "util/sss_nss.h"
 #include "util/strtonum.h"
 #include "db/sysdb.h"
+#include "db/sysdb_private.h"
 #include "providers/ldap/ldap_common.h"
 #include "providers/ldap/sdap_async.h"
 #include "providers/ldap/sdap_async_ad.h"
@@ -1360,6 +1362,102 @@ done:
     return ret;
 }
 
+static void ipa_get_sid_ipa_next(struct tevent_req *subreq)
+{
+    int ret;
+    int dp_error = DP_ERR_FATAL;
+    const char *sid;
+    const char *user;
+    struct ldb_message *user_msg;
+    struct dp_id_data *ar;
+    struct dp_id_data *user_ar;
+    struct tevent_req *req = tevent_req_callback_data(subreq,
+                                                      struct tevent_req);
+    struct ipa_get_acct_state *state = tevent_req_data(req,
+                                                struct ipa_get_acct_state);
+
+    ret = ipa_subdomain_account_recv(subreq, &state->dp_error);
+    talloc_zfree(subreq);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "ipa_id_get_account_info failed: %d %d\n", ret,
+                                 dp_error);
+        goto done;
+    }
+
+    /* Get username object and id data */
+    user = ldb_msg_find_attr_as_string(state->obj_msg, SYSDB_NAME, NULL);
+    if (user == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Cannot find SYSDB_NAME.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    DEBUG(SSSDBG_TRACE_INTERNAL,
+          "Looking up IPA object [%s] from LDAP.\n",
+          user);
+    ret = get_dp_id_data_for_user_name(state,
+                                       user,
+                                       state->obj_dom->name,
+                                       &user_ar);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Failed to create lookup data for IPA object [%s].\n",
+              user);
+        goto done;
+    }
+
+    /* Get user object */
+    ret = get_object_from_cache(state, state->obj_dom, user_ar,
+                                &user_msg);
+    if (ret == ENOENT) {
+        DEBUG(SSSDBG_MINOR_FAILURE, "Object not found, ending request\n");
+        tevent_req_done(req);
+        return;
+    } else if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "get_object_from_cache failed.\n");
+        goto done;
+    }
+
+    /* Retrieve SID from user object */
+    sid = ldb_msg_find_attr_as_string(user_msg, SYSDB_SID_STR, NULL);
+    if (sid == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Cannot find a SID.\n");
+    }
+
+    state->object_sid = talloc_strdup(state, sid);
+    if (state->object_sid == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "talloc_strdup failed.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = get_dp_id_data_for_sid(state, state->object_sid,
+                                 state->obj_dom->name, &ar);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "get_dp_id_data_for_sid failed.\n");
+        goto done;
+    }
+
+    subreq = ipa_get_trusted_override_send(state, state->ev,
+                                           state->ipa_ctx->sdap_id_ctx,
+                                           state->ipa_ctx->ipa_options,
+                                           state->ipa_ctx->server_mode->realm,
+                                           state->ipa_ctx->view_name,
+                                           ar);
+    if (subreq == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "ipa_get_ad_override_send failed.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+    tevent_req_set_callback(subreq, ipa_get_trusted_override_done, req);
+
+    return;
+
+done:
+    tevent_req_error(req,ret);
+    return;
+}
+
 static void
 ipa_get_trusted_acct_part_done(struct tevent_req *subreq)
 {
@@ -1369,7 +1467,9 @@ ipa_get_trusted_acct_part_done(struct tevent_req *subreq)
                                                 struct ipa_get_acct_state);
     errno_t ret;
     const char *sid;
+    const char *user;
     struct dp_id_data *ar;
+    struct dp_id_data *user_ar;
 
     if (state->type == IPA_TRUST_AD) {
         ret = ad_handle_acct_info_recv(subreq, &state->dp_error, NULL);
@@ -1412,9 +1512,45 @@ ipa_get_trusted_acct_part_done(struct tevent_req *subreq)
     if (state->override_attrs == NULL) {
         sid = ldb_msg_find_attr_as_string(state->obj_msg, SYSDB_SID_STR, NULL);
         if (sid == NULL) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "Cannot find a SID.\n");
-            ret = EINVAL;
-            goto fail;
+            DEBUG(SSSDBG_MINOR_FAILURE, "Cannot find a SID.\n");
+            /* In IPA-IPA trust, user private groups do not contain a SID. Lookup the
+             * equivalent user object of the same name in IPA and use this SID instead */
+            if (state->type == IPA_TRUST_IPA) {
+                user = ldb_msg_find_attr_as_string(state->obj_msg, SYSDB_NAME, NULL);
+                if (user == NULL) {
+                    DEBUG(SSSDBG_CRIT_FAILURE, "Cannot find SYSDB_NAME.\n");
+                    ret = ENOMEM;
+                    goto fail;
+                }
+
+                DEBUG(SSSDBG_TRACE_INTERNAL,
+                      "Looking up IPA object [%s] from LDAP.\n",
+                      user);
+                ret = get_dp_id_data_for_user_name(state,
+                                                   user,
+                                                   state->obj_dom->name,
+                                                   &user_ar);
+                if (ret != EOK) {
+                    DEBUG(SSSDBG_OP_FAILURE,
+                          "Failed to create lookup data for IPA object [%s].\n",
+                          user);
+                    goto fail;
+                }
+
+                subreq = ipa_subdomain_account_send(state, state->ev, state->ipa_ctx, user_ar);
+                if (subreq == NULL) {
+                    DEBUG(SSSDBG_OP_FAILURE,
+                          "ipa_id_get_account_info_send failed.\n");
+                    ret = ENOMEM;
+                    goto fail;
+                }
+                tevent_req_set_callback(subreq, ipa_get_sid_ipa_next, req);
+            } else {
+                ret = EINVAL;
+                goto fail;
+            }
+
+            return;
         }
 
         state->object_sid = talloc_strdup(state, sid);

--- a/src/providers/ipa/ipa_subdomains_id.c
+++ b/src/providers/ipa/ipa_subdomains_id.c
@@ -37,13 +37,13 @@
 #include "providers/ipa/ipa_subdomains.h"
 
 static struct tevent_req *
-ipa_srv_ad_acct_send(TALLOC_CTX *mem_ctx,
-                     struct tevent_context *ev,
-                     struct ipa_id_ctx *ipa_ctx,
-                     struct sysdb_attrs *override_attrs,
-                     struct dp_id_data *ar);
+ipa_srv_acct_send(TALLOC_CTX *mem_ctx,
+                  struct tevent_context *ev,
+                  struct ipa_id_ctx *ipa_ctx,
+                  struct sysdb_attrs *override_attrs,
+                  struct dp_id_data *ar);
 static errno_t
-ipa_srv_ad_acct_recv(struct tevent_req *req, int *dp_error_out);
+ipa_srv_acct_recv(struct tevent_req *req, int *dp_error_out);
 
 struct ipa_subdomain_account_state {
     struct tevent_context *ev;
@@ -169,13 +169,13 @@ static void ipa_subdomain_account_connected(struct tevent_req *subreq)
         goto fail;
     }
 
-    subreq = ipa_get_ad_override_send(state, state->ev, state->ctx,
+    subreq = ipa_get_trusted_override_send(state, state->ev, state->ctx,
                           state->ipa_ctx->ipa_options,
                           dp_opt_get_string(state->ipa_ctx->ipa_options->basic,
                                             IPA_KRB5_REALM),
                           state->ipa_ctx->view_name, state->ar);
     if (subreq == NULL) {
-        DEBUG(SSSDBG_OP_FAILURE, "ipa_get_ad_override_send failed.\n");
+        DEBUG(SSSDBG_OP_FAILURE, "ipa_get_trusted_override_send failed.\n");
         ret = ENOMEM;
         goto fail;
     }
@@ -204,8 +204,8 @@ static void ipa_subdomain_account_got_override(struct tevent_req *subreq)
     const char *anchor = NULL;
     struct dp_id_data *ar;
 
-    ret = ipa_get_ad_override_recv(subreq, &dp_error, state,
-                                   &state->override_attrs);
+    ret = ipa_get_trusted_override_recv(subreq, &dp_error, state,
+                                        &state->override_attrs);
     talloc_zfree(subreq);
     if (ret != EOK) {
         ret = sdap_id_op_done(state->op, ret, &dp_error);
@@ -337,8 +337,8 @@ static errno_t ipa_subdomain_account_get_original_step(struct tevent_req *req,
     struct tevent_req *subreq;
 
     if (state->ipa_server_mode) {
-        subreq = ipa_srv_ad_acct_send(state, state->ev, state->ipa_ctx,
-                                      state->override_attrs, ar);
+        subreq = ipa_srv_acct_send(state, state->ev, state->ipa_ctx,
+                                   state->override_attrs, ar);
     } else {
         subreq = ipa_get_subdom_acct_send(state, state->ev, state->ipa_ctx,
                                           state->override_attrs, ar);
@@ -367,7 +367,7 @@ static void ipa_subdomain_account_done(struct tevent_req *subreq)
     struct sss_domain_info *object_dom;
 
     if (state->ipa_server_mode) {
-        ret = ipa_srv_ad_acct_recv(subreq, &dp_error);
+        ret = ipa_srv_acct_recv(subreq, &dp_error);
     } else {
         ret = ipa_get_subdom_acct_recv(subreq, &dp_error);
     }
@@ -784,7 +784,7 @@ ipa_ad_gc_conn_list(TALLOC_CTX *mem_ctx, struct ipa_id_ctx *ipa_ctx,
 }
 
 /* IPA lookup for server mode. Directly to AD. */
-struct ipa_get_ad_acct_state {
+struct ipa_get_acct_state {
     int dp_error;
     struct tevent_context *ev;
     struct ipa_id_ctx *ipa_ctx;
@@ -795,12 +795,12 @@ struct ipa_get_ad_acct_state {
     struct ldb_message *obj_msg;
 };
 
-static void ipa_get_ad_acct_ad_part_done(struct tevent_req *subreq);
-static void ipa_get_ad_override_done(struct tevent_req *subreq);
-static errno_t ipa_get_ad_apply_override_step(struct tevent_req *req);
-static errno_t ipa_get_ad_ipa_membership_step(struct tevent_req *req);
+static void ipa_get_trusted_acct_part_done(struct tevent_req *subreq);
+static void ipa_get_trusted_override_done(struct tevent_req *subreq);
+static errno_t ipa_get_trusted_apply_override_step(struct tevent_req *req);
+static errno_t ipa_get_trusted_ipa_membership_step(struct tevent_req *req);
 static void ipa_id_get_groups_overrides_done(struct tevent_req *subreq);
-static void ipa_get_ad_acct_done(struct tevent_req *subreq);
+static void ipa_get_trusted_acct_done(struct tevent_req *subreq);
 
 static enum ipa_trust_type
 ipa_get_trust_type(struct ipa_id_ctx *ipa_ctx,
@@ -815,13 +815,13 @@ ipa_get_ad_acct_send(TALLOC_CTX *mem_ctx,
     errno_t ret;
     struct tevent_req *req;
     struct tevent_req *subreq;
-    struct ipa_get_ad_acct_state *state;
+    struct ipa_get_acct_state *state;
     struct sdap_domain *sdom;
     struct sdap_id_conn_ctx **clist;
     struct sdap_id_ctx *sdap_id_ctx;
     struct ad_id_ctx *ad_id_ctx;
 
-    req = tevent_req_create(mem_ctx, &state, struct ipa_get_ad_acct_state);
+    req = tevent_req_create(mem_ctx, &state, struct ipa_get_acct_state);
     if (req == NULL) return NULL;
 
     state->dp_error = -1;
@@ -882,7 +882,7 @@ ipa_get_ad_acct_send(TALLOC_CTX *mem_ctx,
         ret = ENOMEM;
         goto fail;
     }
-    tevent_req_set_callback(subreq, ipa_get_ad_acct_ad_part_done, req);
+    tevent_req_set_callback(subreq, ipa_get_trusted_acct_part_done, req);
     return req;
 
 fail:
@@ -1275,12 +1275,12 @@ done:
 }
 
 static void
-ipa_get_ad_acct_ad_part_done(struct tevent_req *subreq)
+ipa_get_trusted_acct_part_done(struct tevent_req *subreq)
 {
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                 struct tevent_req);
-    struct ipa_get_ad_acct_state *state = tevent_req_data(req,
-                                                struct ipa_get_ad_acct_state);
+    struct ipa_get_acct_state *state = tevent_req_data(req,
+                                                struct ipa_get_acct_state);
     errno_t ret;
     const char *sid;
     struct dp_id_data *ar;
@@ -1338,23 +1338,23 @@ ipa_get_ad_acct_ad_part_done(struct tevent_req *subreq)
             goto fail;
         }
 
-        subreq = ipa_get_ad_override_send(state, state->ev,
-                                          state->ipa_ctx->sdap_id_ctx,
-                                          state->ipa_ctx->ipa_options,
-                                          state->ipa_ctx->server_mode->realm,
-                                          state->ipa_ctx->view_name,
-                                          ar);
+        subreq = ipa_get_trusted_override_send(state, state->ev,
+                                               state->ipa_ctx->sdap_id_ctx,
+                                               state->ipa_ctx->ipa_options,
+                                               state->ipa_ctx->server_mode->realm,
+                                               state->ipa_ctx->view_name,
+                                               ar);
         if (subreq == NULL) {
-            DEBUG(SSSDBG_OP_FAILURE, "ipa_get_ad_override_send failed.\n");
+            DEBUG(SSSDBG_OP_FAILURE, "ipa_get_trusted_override_send failed.\n");
             ret = ENOMEM;
             goto fail;
         }
-        tevent_req_set_callback(subreq, ipa_get_ad_override_done, req);
+        tevent_req_set_callback(subreq, ipa_get_trusted_override_done, req);
     } else {
-        ret = ipa_get_ad_apply_override_step(req);
+        ret = ipa_get_trusted_apply_override_step(req);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE,
-                  "ipa_get_ad_apply_override_step failed.\n");
+                  "ipa_get_trusted_apply_override_step failed.\n");
             goto fail;
         }
     }
@@ -1369,15 +1369,15 @@ fail:
 
 
 static void
-ipa_get_ad_override_done(struct tevent_req *subreq)
+ipa_get_trusted_override_done(struct tevent_req *subreq)
 {
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                 struct tevent_req);
-    struct ipa_get_ad_acct_state *state = tevent_req_data(req,
-                                                struct ipa_get_ad_acct_state);
+    struct ipa_get_acct_state *state = tevent_req_data(req,
+                                                struct ipa_get_acct_state);
     errno_t ret;
 
-    ret = ipa_get_ad_override_recv(subreq, &state->dp_error, state,
+    ret = ipa_get_trusted_override_recv(subreq, &state->dp_error, state,
                                    &state->override_attrs);
     talloc_zfree(subreq);
     if (ret != EOK) {
@@ -1387,9 +1387,9 @@ ipa_get_ad_override_done(struct tevent_req *subreq)
 
     }
 
-    ret = ipa_get_ad_apply_override_step(req);
+    ret = ipa_get_trusted_apply_override_step(req);
     if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "ipa_get_ad_apply_override_step failed.\n");
+        DEBUG(SSSDBG_OP_FAILURE, "ipa_get_trusted_apply_override_step failed.\n");
         goto fail;
     }
 
@@ -1404,8 +1404,8 @@ fail:
 static void ipa_check_ghost_members_done(struct tevent_req *subreq);
 static errno_t ipa_check_ghost_members(struct tevent_req *req)
 {
-    struct ipa_get_ad_acct_state *state = tevent_req_data(req,
-                                                struct ipa_get_ad_acct_state);
+    struct ipa_get_acct_state *state = tevent_req_data(req,
+                                                struct ipa_get_acct_state);
     errno_t ret;
     struct tevent_req *subreq;
     struct ldb_message_element *ghosts = NULL;
@@ -1462,10 +1462,10 @@ static void ipa_check_ghost_members_done(struct tevent_req *subreq)
     return;
 }
 
-static errno_t ipa_get_ad_apply_override_step(struct tevent_req *req)
+static errno_t ipa_get_trusted_apply_override_step(struct tevent_req *req)
 {
-    struct ipa_get_ad_acct_state *state = tevent_req_data(req,
-                                                struct ipa_get_ad_acct_state);
+    struct ipa_get_acct_state *state = tevent_req_data(req,
+                                                struct ipa_get_acct_state);
     errno_t ret;
     struct tevent_req *subreq;
     const char *obj_name;
@@ -1571,9 +1571,9 @@ static errno_t ipa_get_ad_apply_override_step(struct tevent_req *req)
         return EOK;
     }
 
-    ret = ipa_get_ad_ipa_membership_step(req);
+    ret = ipa_get_trusted_ipa_membership_step(req);
     if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "ipa_get_ad_ipa_membership_step failed.\n");
+        DEBUG(SSSDBG_OP_FAILURE, "ipa_get_trusted_ipa_membership_step failed.\n");
         return ret;
     }
 
@@ -1595,9 +1595,9 @@ static void ipa_id_get_groups_overrides_done(struct tevent_req *subreq)
         return;
     }
 
-    ret = ipa_get_ad_ipa_membership_step(req);
+    ret = ipa_get_trusted_ipa_membership_step(req);
     if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "ipa_get_ad_ipa_membership_step failed.\n");
+        DEBUG(SSSDBG_OP_FAILURE, "ipa_get_trusted_ipa_membership_step failed.\n");
         tevent_req_error(req, ret);
         return;
     }
@@ -1605,39 +1605,39 @@ static void ipa_id_get_groups_overrides_done(struct tevent_req *subreq)
     return;
 }
 
-static errno_t ipa_get_ad_ipa_membership_step(struct tevent_req *req)
+static errno_t ipa_get_trusted_ipa_membership_step(struct tevent_req *req)
 {
-    struct ipa_get_ad_acct_state *state = tevent_req_data(req,
-                                                struct ipa_get_ad_acct_state);
+    struct ipa_get_acct_state *state = tevent_req_data(req,
+                                                struct ipa_get_acct_state);
     struct tevent_req *subreq;
 
-    /* For initgroups request we have to check IPA group memberships of AD
+    /* For initgroups request we have to check IPA group memberships of trusted
      * users. This has to be done for other user-request as well to make sure
      * IPA related attributes are not overwritten. */
-    subreq = ipa_get_ad_memberships_send(state, state->ev, state->ar,
-                                         state->ipa_ctx->server_mode,
-                                         state->obj_dom,
-                                         state->ipa_ctx->sdap_id_ctx,
-                                         state->ipa_ctx->server_mode->realm);
+    subreq = ipa_get_trusted_memberships_send(state, state->ev, state->ar,
+                                              state->ipa_ctx->server_mode,
+                                              state->obj_dom,
+                                              state->ipa_ctx->sdap_id_ctx,
+                                              state->ipa_ctx->server_mode->realm);
     if (subreq == NULL) {
-        DEBUG(SSSDBG_OP_FAILURE, "ipa_get_ad_memberships_send failed.\n");
+        DEBUG(SSSDBG_OP_FAILURE, "ipa_get_trusted_memberships_send failed.\n");
         return ENOMEM;
     }
-    tevent_req_set_callback(subreq, ipa_get_ad_acct_done, req);
+    tevent_req_set_callback(subreq, ipa_get_trusted_acct_done, req);
 
     return EOK;
 }
 
 static void
-ipa_get_ad_acct_done(struct tevent_req *subreq)
+ipa_get_trusted_acct_done(struct tevent_req *subreq)
 {
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                 struct tevent_req);
-    struct ipa_get_ad_acct_state *state = tevent_req_data(req,
-                                                struct ipa_get_ad_acct_state);
+    struct ipa_get_acct_state *state = tevent_req_data(req,
+                                                struct ipa_get_acct_state);
     errno_t ret;
 
-    ret = ipa_get_ad_memberships_recv(subreq, &state->dp_error);
+    ret = ipa_get_trusted_memberships_recv(subreq, &state->dp_error);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "IPA external groups lookup failed: %d\n",
@@ -1651,10 +1651,10 @@ ipa_get_ad_acct_done(struct tevent_req *subreq)
 }
 
 static errno_t
-ipa_get_ad_acct_recv(struct tevent_req *req, int *dp_error_out)
+ipa_get_acct_recv(struct tevent_req *req, int *dp_error_out)
 {
-    struct ipa_get_ad_acct_state *state = tevent_req_data(req,
-                                                struct ipa_get_ad_acct_state);
+    struct ipa_get_acct_state *state = tevent_req_data(req,
+                                                struct ipa_get_acct_state);
 
     if (dp_error_out) {
         *dp_error_out = state->dp_error;
@@ -1665,7 +1665,7 @@ ipa_get_ad_acct_recv(struct tevent_req *req, int *dp_error_out)
     return EOK;
 }
 
-struct ipa_srv_ad_acct_state {
+struct ipa_srv_acct_state {
     struct tevent_context *ev;
     struct ipa_id_ctx *ipa_ctx;
     struct sysdb_attrs *override_attrs;
@@ -1678,22 +1678,22 @@ struct ipa_srv_ad_acct_state {
     int dp_error;
 };
 
-static int ipa_srv_ad_acct_lookup_step(struct tevent_req *req);
-static void ipa_srv_ad_acct_lookup_done(struct tevent_req *subreq);
-static void ipa_srv_ad_acct_retried(struct tevent_req *subreq);
+static int ipa_srv_acct_lookup_step(struct tevent_req *req);
+static void ipa_srv_acct_lookup_done(struct tevent_req *subreq);
+static void ipa_srv_acct_retried(struct tevent_req *subreq);
 
 static struct tevent_req *
-ipa_srv_ad_acct_send(TALLOC_CTX *mem_ctx,
-                     struct tevent_context *ev,
-                     struct ipa_id_ctx *ipa_ctx,
-                     struct sysdb_attrs *override_attrs,
-                     struct dp_id_data *ar)
+ipa_srv_acct_send(TALLOC_CTX *mem_ctx,
+                  struct tevent_context *ev,
+                  struct ipa_id_ctx *ipa_ctx,
+                  struct sysdb_attrs *override_attrs,
+                  struct dp_id_data *ar)
 {
     errno_t ret;
     struct tevent_req *req;
-    struct ipa_srv_ad_acct_state *state;
+    struct ipa_srv_acct_state *state;
 
-    req = tevent_req_create(mem_ctx, &state, struct ipa_srv_ad_acct_state);
+    req = tevent_req_create(mem_ctx, &state, struct ipa_srv_acct_state);
     if (req == NULL) {
         return NULL;
     }
@@ -1715,7 +1715,7 @@ ipa_srv_ad_acct_send(TALLOC_CTX *mem_ctx,
         goto fail;
     }
 
-    ret = ipa_srv_ad_acct_lookup_step(req);
+    ret = ipa_srv_acct_lookup_step(req);
     if (ret != EOK) {
         goto fail;
     }
@@ -1728,11 +1728,11 @@ fail:
     return req;
 }
 
-static int ipa_srv_ad_acct_lookup_step(struct tevent_req *req)
+static int ipa_srv_acct_lookup_step(struct tevent_req *req)
 {
     struct tevent_req *subreq;
-    struct ipa_srv_ad_acct_state *state = tevent_req_data(req,
-                                            struct ipa_srv_ad_acct_state);
+    struct ipa_srv_acct_state *state = tevent_req_data(req,
+                                            struct ipa_srv_acct_state);
 
     DEBUG(SSSDBG_TRACE_FUNC, "Looking up AD account\n");
     subreq = ipa_get_ad_acct_send(state, state->ev, state->ipa_ctx,
@@ -1741,21 +1741,21 @@ static int ipa_srv_ad_acct_lookup_step(struct tevent_req *req)
     if (subreq == NULL) {
         return ENOMEM;
     }
-    tevent_req_set_callback(subreq, ipa_srv_ad_acct_lookup_done, req);
+    tevent_req_set_callback(subreq, ipa_srv_acct_lookup_done, req);
 
     return EOK;
 }
 
-static void ipa_srv_ad_acct_lookup_done(struct tevent_req *subreq)
+static void ipa_srv_acct_lookup_done(struct tevent_req *subreq)
 {
     errno_t ret;
     int dp_error = DP_ERR_FATAL;
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                 struct tevent_req);
-    struct ipa_srv_ad_acct_state *state = tevent_req_data(req,
-                                            struct ipa_srv_ad_acct_state);
+    struct ipa_srv_acct_state *state = tevent_req_data(req,
+                                            struct ipa_srv_acct_state);
 
-    ret = ipa_get_ad_acct_recv(subreq, &dp_error);
+    ret = ipa_get_acct_recv(subreq, &dp_error);
     talloc_free(subreq);
     if (ret == ERR_SUBDOM_INACTIVE && state->retry == true) {
 
@@ -1770,7 +1770,7 @@ static void ipa_srv_ad_acct_lookup_done(struct tevent_req *subreq)
         if (subreq == NULL) {
             goto fail;
         }
-        tevent_req_set_callback(subreq, ipa_srv_ad_acct_retried, req);
+        tevent_req_set_callback(subreq, ipa_srv_acct_retried, req);
         return;
     } else if (ret != EOK) {
         be_mark_dom_offline(state->obj_dom, state->be_ctx);
@@ -1789,14 +1789,14 @@ fail:
     tevent_req_error(req, ret);
 }
 
-static void ipa_srv_ad_acct_retried(struct tevent_req *subreq)
+static void ipa_srv_acct_retried(struct tevent_req *subreq)
 {
     errno_t ret;
     struct ad_id_ctx *ad_id_ctx;
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                 struct tevent_req);
-    struct ipa_srv_ad_acct_state *state = tevent_req_data(req,
-                                            struct ipa_srv_ad_acct_state);
+    struct ipa_srv_acct_state *state = tevent_req_data(req,
+                                            struct ipa_srv_acct_state);
 
     ret = ipa_server_trusted_dom_setup_recv(subreq);
     talloc_free(subreq);
@@ -1819,7 +1819,7 @@ static void ipa_srv_ad_acct_retried(struct tevent_req *subreq)
 
     ad_failover_reset(state->be_ctx, ad_id_ctx->ad_options->service);
 
-    ret = ipa_srv_ad_acct_lookup_step(req);
+    ret = ipa_srv_acct_lookup_step(req);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
               "Failed to look up AD acct [%d]: %s\n", ret, sss_strerror(ret));
@@ -1830,10 +1830,10 @@ static void ipa_srv_ad_acct_retried(struct tevent_req *subreq)
 }
 
 static errno_t
-ipa_srv_ad_acct_recv(struct tevent_req *req, int *dp_error_out)
+ipa_srv_acct_recv(struct tevent_req *req, int *dp_error_out)
 {
-    struct ipa_srv_ad_acct_state *state = tevent_req_data(req,
-                                                struct ipa_srv_ad_acct_state);
+    struct ipa_srv_acct_state *state = tevent_req_data(req,
+                                                struct ipa_srv_acct_state);
 
     if (dp_error_out) {
         *dp_error_out = state->dp_error;

--- a/src/providers/ipa/ipa_subdomains_server.c
+++ b/src/providers/ipa/ipa_subdomains_server.c
@@ -1136,7 +1136,7 @@ void ipa_ad_subdom_remove(struct be_ctx *be_ctx,
     talloc_zfree(sdom);
 }
 
-struct ipa_ad_subdom_reinit_state {
+struct ipa_trusted_subdom_reinit_state {
     struct tevent_context *ev;
     struct be_ctx *be_ctx;
     struct ipa_id_ctx *id_ctx;
@@ -1161,9 +1161,9 @@ static void create_trusts_at_startup(struct tevent_context *ev,
                                      void *pvt)
 {
     struct tevent_req *req;
-    struct ipa_ad_subdom_reinit_state *state;
+    struct ipa_trusted_subdom_reinit_state *state;
 
-    state = talloc_get_type(pvt, struct ipa_ad_subdom_reinit_state);
+    state = talloc_get_type(pvt, struct ipa_trusted_subdom_reinit_state);
 
     req = ipa_server_create_trusts_send(state, state->ev, state->be_ctx,
                                         state->id_ctx, state->parent);
@@ -1177,16 +1177,16 @@ static void create_trusts_at_startup(struct tevent_context *ev,
     return;
 }
 
-static errno_t ipa_ad_subdom_reinit(TALLOC_CTX *mem_ctx,
-                                    struct tevent_context *ev,
-                                    struct be_ctx *be_ctx,
-                                    struct ipa_id_ctx *id_ctx,
-                                    struct sss_domain_info *parent)
+static errno_t ipa_trusted_subdom_reinit(TALLOC_CTX *mem_ctx,
+                                         struct tevent_context *ev,
+                                         struct be_ctx *be_ctx,
+                                         struct ipa_id_ctx *id_ctx,
+                                         struct sss_domain_info *parent)
 {
     struct tevent_immediate *imm;
-    struct ipa_ad_subdom_reinit_state *state;
+    struct ipa_trusted_subdom_reinit_state *state;
 
-    state = talloc(mem_ctx, struct ipa_ad_subdom_reinit_state);
+    state = talloc(mem_ctx, struct ipa_trusted_subdom_reinit_state);
     if (state == NULL) {
         return ENOMEM;
     }
@@ -1211,8 +1211,8 @@ static errno_t ipa_ad_subdom_reinit(TALLOC_CTX *mem_ctx,
     return EOK;
 }
 
-int ipa_ad_subdom_init(struct be_ctx *be_ctx,
-                       struct ipa_id_ctx *id_ctx)
+int ipa_trusted_subdom_init(struct be_ctx *be_ctx,
+                            struct ipa_id_ctx *id_ctx)
 {
     char *realm;
     char *hostname;
@@ -1275,10 +1275,10 @@ int ipa_ad_subdom_init(struct be_ctx *be_ctx,
         }
     }
 
-    ret = ipa_ad_subdom_reinit(be_ctx, be_ctx->ev,
+    ret = ipa_trusted_subdom_reinit(be_ctx, be_ctx->ev,
                                be_ctx, id_ctx, be_ctx->domain);
     if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "ipa_ad_subdom_refresh failed.\n");
+        DEBUG(SSSDBG_OP_FAILURE, "ipa_trusted_subdom_reinit failed.\n");
         return ret;
     }
 

--- a/src/providers/ipa/ipa_subdomains_server.c
+++ b/src/providers/ipa/ipa_subdomains_server.c
@@ -216,14 +216,15 @@ ipa_create_1way_trust_ctx(struct ipa_id_ctx *id_ctx,
         return NULL;
     }
 
-    ad_options = ad_create_1way_trust_options(id_ctx,
-                                              be_ctx->cdb,
-                                              subdom_conf_path,
-                                              be_ctx->provider,
-                                              subdom,
-                                              id_ctx->server_mode->hostname,
-                                              keytab,
-                                              principal);
+    ad_options = ad_create_trust_options(id_ctx,
+                                         be_ctx->cdb,
+                                         subdom_conf_path,
+                                         be_ctx->provider,
+                                         subdom,
+                                         NULL,
+                                         id_ctx->server_mode->hostname,
+                                         keytab,
+                                         principal);
     if (ad_options == NULL) {
         talloc_free(keytab);
         talloc_free(principal);

--- a/src/providers/ipa/ipa_subdomains_server.c
+++ b/src/providers/ipa/ipa_subdomains_server.c
@@ -263,12 +263,12 @@ ipa_create_ipa_trust_ctx(struct ipa_id_ctx *id_ctx,
 }
 
 static struct ad_options *
-ipa_create_ad_1way_trust_ctx(struct ipa_id_ctx *id_ctx,
-                             struct be_ctx *be_ctx,
-                             const char *subdom_conf_path,
-                             const char *forest,
-                             const char *forest_realm,
-                             struct sss_domain_info *subdom)
+ipa_create_ad_trust_ctx(struct ipa_id_ctx *id_ctx,
+                        struct be_ctx *be_ctx,
+                        const char *subdom_conf_path,
+                        const char *forest,
+                        const char *forest_realm,
+                        struct sss_domain_info *subdom)
 {
     char *keytab;
     char *principal;
@@ -325,9 +325,9 @@ static struct ad_options *ipa_ad_options_new(struct be_ctx *be_ctx,
      * thus we always should be initializing principals/keytabs
      * as if we are running one-way trust */
     if (direction & LSA_TRUST_DIRECTION_MASK) {
-        ad_options = ipa_create_ad_1way_trust_ctx(id_ctx, be_ctx,
-                                                  subdom_conf_path, forest,
-                                                  forest_realm, subdom);
+        ad_options = ipa_create_ad_trust_ctx(id_ctx, be_ctx,
+                                             subdom_conf_path, forest,
+                                             forest_realm, subdom);
     } else {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unsupported trust direction!\n");
         ad_options = NULL;

--- a/src/providers/ipa/ipa_views.c
+++ b/src/providers/ipa/ipa_views.c
@@ -379,7 +379,7 @@ errno_t get_dp_id_data_for_user_name(TALLOC_CTX *mem_ctx,
                                    _ar);
 }
 
-struct ipa_get_ad_override_state {
+struct ipa_get_trusted_override_state {
     struct tevent_context *ev;
     struct sdap_id_ctx *sdap_id_ctx;
     struct ipa_options *ipa_options;
@@ -393,12 +393,12 @@ struct ipa_get_ad_override_state {
     char *filter;
 };
 
-static void ipa_get_ad_override_connect_done(struct tevent_req *subreq);
-static errno_t ipa_get_ad_override_qualify_name(
-                                struct ipa_get_ad_override_state *state);
-static void ipa_get_ad_override_done(struct tevent_req *subreq);
+static void ipa_get_trusted_override_connect_done(struct tevent_req *subreq);
+static errno_t ipa_get_trusted_override_qualify_name(
+                                struct ipa_get_trusted_override_state *state);
+static void ipa_get_trusted_override_done(struct tevent_req *subreq);
 
-struct tevent_req *ipa_get_ad_override_send(TALLOC_CTX *mem_ctx,
+struct tevent_req *ipa_get_trusted_override_send(TALLOC_CTX *mem_ctx,
                                             struct tevent_context *ev,
                                             struct sdap_id_ctx *sdap_id_ctx,
                                             struct ipa_options *ipa_options,
@@ -409,9 +409,9 @@ struct tevent_req *ipa_get_ad_override_send(TALLOC_CTX *mem_ctx,
     int ret;
     struct tevent_req *req;
     struct tevent_req *subreq;
-    struct ipa_get_ad_override_state *state;
+    struct ipa_get_trusted_override_state *state;
 
-    req = tevent_req_create(mem_ctx, &state, struct ipa_get_ad_override_state);
+    req = tevent_req_create(mem_ctx, &state, struct ipa_get_trusted_override_state);
     if (req == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "tevent_req_create failed.\n");
         return NULL;
@@ -453,7 +453,7 @@ struct tevent_req *ipa_get_ad_override_send(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    tevent_req_set_callback(subreq, ipa_get_ad_override_connect_done, req);
+    tevent_req_set_callback(subreq, ipa_get_trusted_override_connect_done, req);
 
     return req;
 
@@ -470,12 +470,12 @@ done:
     return req;
 }
 
-static void ipa_get_ad_override_connect_done(struct tevent_req *subreq)
+static void ipa_get_trusted_override_connect_done(struct tevent_req *subreq)
 {
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                       struct tevent_req);
-    struct ipa_get_ad_override_state *state = tevent_req_data(req,
-                                              struct ipa_get_ad_override_state);
+    struct ipa_get_trusted_override_state *state = tevent_req_data(req,
+                                              struct ipa_get_trusted_override_state);
     int ret;
     char *basedn;
     char *search_base;
@@ -536,7 +536,7 @@ static void ipa_get_ad_override_connect_done(struct tevent_req *subreq)
         goto fail;
     }
 
-    tevent_req_set_callback(subreq, ipa_get_ad_override_done, req);
+    tevent_req_set_callback(subreq, ipa_get_trusted_override_done, req);
     return;
 
 fail:
@@ -545,12 +545,12 @@ fail:
     return;
 }
 
-static void ipa_get_ad_override_done(struct tevent_req *subreq)
+static void ipa_get_trusted_override_done(struct tevent_req *subreq)
 {
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                       struct tevent_req);
-    struct ipa_get_ad_override_state *state = tevent_req_data(req,
-                                              struct ipa_get_ad_override_state);
+    struct ipa_get_trusted_override_state *state = tevent_req_data(req,
+                                              struct ipa_get_trusted_override_state);
     int ret;
     size_t reply_count = 0;
     struct sysdb_attrs **reply = NULL;
@@ -558,7 +558,7 @@ static void ipa_get_ad_override_done(struct tevent_req *subreq)
     ret = sdap_get_generic_recv(subreq, state, &reply_count, &reply);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "ipa_get_ad_override request failed.\n");
+        DEBUG(SSSDBG_OP_FAILURE, "ipa_get_trusted_override request failed.\n");
         goto fail;
     }
 
@@ -590,7 +590,7 @@ static void ipa_get_ad_override_done(struct tevent_req *subreq)
                             state->filter);
     state->override_attrs = reply[0];
 
-    ret = ipa_get_ad_override_qualify_name(state);
+    ret = ipa_get_trusted_override_qualify_name(state);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Cannot qualify object name\n");
         goto fail;
@@ -606,8 +606,8 @@ fail:
     return;
 }
 
-static errno_t ipa_get_ad_override_qualify_name(
-                                struct ipa_get_ad_override_state *state)
+static errno_t ipa_get_trusted_override_qualify_name(
+                                struct ipa_get_trusted_override_state *state)
 {
     int ret;
     struct ldb_message_element *name;
@@ -633,12 +633,12 @@ static errno_t ipa_get_ad_override_qualify_name(
     return EOK;
 }
 
-errno_t ipa_get_ad_override_recv(struct tevent_req *req, int *dp_error_out,
+errno_t ipa_get_trusted_override_recv(struct tevent_req *req, int *dp_error_out,
                                  TALLOC_CTX *mem_ctx,
                                  struct sysdb_attrs **override_attrs)
 {
-    struct ipa_get_ad_override_state *state = tevent_req_data(req,
-                                              struct ipa_get_ad_override_state);
+    struct ipa_get_trusted_override_state *state = tevent_req_data(req,
+                                              struct ipa_get_trusted_override_state);
 
     if (dp_error_out != NULL) {
         *dp_error_out = state->dp_error;

--- a/src/tests/cmocka/test_ad_common.c
+++ b/src/tests/cmocka/test_ad_common.c
@@ -749,15 +749,15 @@ static void test_ad_create_1way_trust_options(void **state)
     mock_keytab_with_contents(test_ctx, ONEWAY_KEYTAB_PATH, ONEWAY_TEST_PRINC);
 
     test_ctx->subdom->name = discard_const(ONEWAY_DOMNAME);
-    test_ctx->ad_ctx->ad_options = ad_create_1way_trust_options(
-                                                            test_ctx->ad_ctx,
-                                                            NULL,
-                                                            NULL,
-                                                            NULL,
-                                                            test_ctx->subdom,
-                                                            ONEWAY_HOST_NAME,
-                                                            ONEWAY_KEYTAB_PATH,
-                                                            ONEWAY_AUTHID);
+    test_ctx->ad_ctx->ad_options = ad_create_trust_options(test_ctx->ad_ctx,
+                                                          NULL,
+                                                          NULL,
+                                                          NULL,
+                                                          test_ctx->subdom,
+                                                          NULL,
+                                                          ONEWAY_HOST_NAME,
+                                                          ONEWAY_KEYTAB_PATH,
+                                                          ONEWAY_AUTHID);
     assert_non_null(test_ctx->ad_ctx->ad_options);
 
     assert_int_equal(test_ctx->ad_ctx->ad_options->id->schema_type,
@@ -816,14 +816,15 @@ static void test_ad_create_2way_trust_options(void **state)
     mock_keytab_with_contents(test_ctx, KEYTAB_PATH, KEYTAB_TEST_PRINC);
     test_ctx->subdom->name = discard_const(DOMNAME);
 
-    test_ctx->ad_ctx->ad_options = ad_create_2way_trust_options(
+    test_ctx->ad_ctx->ad_options = ad_create_trust_options(
                                         test_ctx->ad_ctx,
                                         NULL,
                                         NULL,
                                         NULL,
-                                        REALMNAME,
                                         test_ctx->subdom,
+                                        REALMNAME,
                                         HOST_NAME,
+                                        NULL,
                                         NULL);
 
     assert_non_null(test_ctx->ad_ctx->ad_options);
@@ -887,14 +888,15 @@ test_ldap_conn_setup(void **state)
 
     ad_ctx = test_ctx->ad_ctx;
 
-    test_ctx->ad_ctx->ad_options = ad_create_2way_trust_options(
+    test_ctx->ad_ctx->ad_options = ad_create_trust_options(
                                         ad_ctx,
                                         NULL,
                                         NULL,
                                         NULL,
-                                        REALMNAME,
                                         test_ctx->subdom,
+                                        REALMNAME,
                                         HOST_NAME,
+                                        NULL,
                                         NULL);
 
     assert_non_null(ad_ctx->ad_options);

--- a/src/tests/cmocka/test_fqnames.c
+++ b/src/tests/cmocka/test_fqnames.c
@@ -23,6 +23,7 @@
 #include <popt.h>
 
 #include "db/sysdb_private.h"
+#include "providers/ipa/ipa_subdomains.h"
 #include "tests/cmocka/common_mock.h"
 
 #define NAME        "name"
@@ -308,7 +309,8 @@ static int parse_name_test_setup_re(void **state, const char *regexp)
      */
     test_ctx->subdom = new_subdomain(dom, dom, SUBDOMNAME, NULL, SUBFLATNAME,
                                      SUBDOMNAME, NULL, MPG_DISABLED, false,
-                                     NULL, NULL, 0, NULL, true);
+                                     NULL, NULL, 0, IPA_TRUST_UNKNOWN,
+                                     NULL, true);
     assert_non_null(test_ctx->subdom);
 
     check_leaks_push(test_ctx);

--- a/src/tests/cmocka/test_ipa_subdomains_server.c
+++ b/src/tests/cmocka/test_ipa_subdomains_server.c
@@ -549,7 +549,7 @@ static void test_ipa_server_trust_init(void **state)
 
     add_test_2way_subdomains(test_ctx);
 
-    ret = ipa_ad_subdom_init(test_ctx->be_ctx, test_ctx->ipa_ctx);
+    ret = ipa_trusted_subdom_init(test_ctx->be_ctx, test_ctx->ipa_ctx);
     assert_int_equal(ret, EOK);
 
     tv = tevent_timeval_current_ofs(1, 0);
@@ -905,7 +905,7 @@ static void test_ipa_server_trust_oneway_init(void **state)
 
     add_test_1way_subdomains(test_ctx);
 
-    ret = ipa_ad_subdom_init(test_ctx->be_ctx, test_ctx->ipa_ctx);
+    ret = ipa_trusted_subdom_init(test_ctx->be_ctx, test_ctx->ipa_ctx);
     assert_int_equal(ret, EOK);
 
     tv = tevent_timeval_current_ofs(1, 0);

--- a/src/tests/cmocka/test_ipa_subdomains_server.c
+++ b/src/tests/cmocka/test_ipa_subdomains_server.c
@@ -399,7 +399,7 @@ static void test_ipa_server_create_trusts_none(struct tevent_req *req)
 
 }
 
-static void assert_trust_object(struct ipa_ad_server_ctx *trust,
+static void assert_trust_object(struct ipa_subdom_server_ctx *trust,
                                 const char *dom_name,
                                 const char *dom_realm,
                                 const char *sid,
@@ -414,7 +414,7 @@ static void assert_trust_object(struct ipa_ad_server_ctx *trust,
     assert_string_equal(trust->dom->name, dom_name);
     assert_string_equal(trust->dom->domain_id, sid);
 
-    s = dp_opt_get_string(trust->ad_id_ctx->ad_options->basic,
+    s = dp_opt_get_string(trust->id_ctx.ad_id_ctx->ad_options->basic,
                           AD_KRB5_REALM);
     if (dom_realm != NULL) {
         assert_non_null(s);
@@ -423,7 +423,7 @@ static void assert_trust_object(struct ipa_ad_server_ctx *trust,
         assert_null(s);
     }
 
-    s = dp_opt_get_string(trust->ad_id_ctx->ad_options->basic,
+    s = dp_opt_get_string(trust->id_ctx.ad_id_ctx->ad_options->basic,
                           AD_DOMAIN);
     if (dom_name != NULL) {
         assert_non_null(s);
@@ -433,7 +433,7 @@ static void assert_trust_object(struct ipa_ad_server_ctx *trust,
     }
 
     /* both one-way and two-way trust uses specialized keytab */
-    s = dp_opt_get_string(trust->ad_id_ctx->ad_options->id->basic,
+    s = dp_opt_get_string(trust->id_ctx.ad_id_ctx->ad_options->id->basic,
                           SDAP_KRB5_KEYTAB);
     if (keytab != NULL) {
         assert_non_null(s);
@@ -442,7 +442,7 @@ static void assert_trust_object(struct ipa_ad_server_ctx *trust,
         assert_null(s);
     }
 
-    s = dp_opt_get_string(trust->ad_id_ctx->ad_options->id->basic,
+    s = dp_opt_get_string(trust->id_ctx.ad_id_ctx->ad_options->id->basic,
                           SDAP_SASL_REALM);
     if (sdap_realm != NULL) {
         assert_non_null(s);
@@ -451,7 +451,7 @@ static void assert_trust_object(struct ipa_ad_server_ctx *trust,
         assert_null(s);
     }
 
-    s = dp_opt_get_string(trust->ad_id_ctx->ad_options->id->basic,
+    s = dp_opt_get_string(trust->id_ctx.ad_id_ctx->ad_options->id->basic,
                           SDAP_SASL_AUTHID);
     if (authid != NULL) {
         assert_non_null(s);
@@ -467,8 +467,8 @@ static void test_ipa_server_create_trusts_twoway(struct tevent_req *req)
         tevent_req_callback_data(req, struct trust_test_ctx);
     errno_t ret;
     struct sss_domain_info *child_dom;
-    struct ipa_ad_server_ctx *s_trust;
-    struct ipa_ad_server_ctx *c_trust;
+    struct ipa_subdom_server_ctx *s_trust;
+    struct ipa_subdom_server_ctx *c_trust;
 
     ret = ipa_server_create_trusts_recv(req);
     talloc_zfree(req);
@@ -544,8 +544,8 @@ static void test_ipa_server_trust_init(void **state)
     errno_t ret;
     struct tevent_timer *timeout_handler;
     struct timeval tv;
-    struct ipa_ad_server_ctx *s_trust;
-    struct ipa_ad_server_ctx *c_trust;
+    struct ipa_subdom_server_ctx *s_trust;
+    struct ipa_subdom_server_ctx *c_trust;
 
     add_test_2way_subdomains(test_ctx);
 
@@ -736,8 +736,8 @@ static void test_ipa_server_create_trusts_oneway(struct tevent_req *req)
     struct trust_test_ctx *test_ctx = \
         tevent_req_callback_data(req, struct trust_test_ctx);
     errno_t ret;
-    struct ipa_ad_server_ctx *s_trust;
-    struct ipa_ad_server_ctx *c_trust;
+    struct ipa_subdom_server_ctx *s_trust;
+    struct ipa_subdom_server_ctx *c_trust;
 
     ret = ipa_server_create_trusts_recv(req);
     talloc_zfree(req);

--- a/src/tests/cmocka/test_ipa_subdomains_server.c
+++ b/src/tests/cmocka/test_ipa_subdomains_server.c
@@ -266,14 +266,14 @@ static void add_test_subdomains(struct trust_test_ctx *test_ctx,
                                 SUBDOM_NAME, SUBDOM_REALM,
                                 NULL, SUBDOM_NAME, SUBDOM_SID,
                                 MPG_ENABLED, false, SUBDOM_REALM,
-                                direction, NULL);
+                                direction, IPA_TRUST_AD, NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_subdomain_store(test_ctx->tctx->sysdb,
                                 CHILD_NAME, CHILD_REALM,
                                 CHILD_FLAT, CHILD_NAME, CHILD_SID,
                                 MPG_ENABLED, false, SUBDOM_REALM,
-                                direction, NULL);
+                                direction, IPA_TRUST_AD, NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_update_subdomains(test_ctx->tctx->dom, test_ctx->tctx->confdb);

--- a/src/tests/cmocka/test_negcache.c
+++ b/src/tests/cmocka/test_negcache.c
@@ -40,6 +40,7 @@
 #include "util/util.h"
 #include "responder/common/responder.h"
 #include "responder/common/negcache.h"
+#include "providers/ipa/ipa_subdomains.h"
 
 int test_ncache_setup(void **state);
 int test_ncache_teardown(void **state);
@@ -657,12 +658,13 @@ static void test_sss_ncache_prepopulate(void **state)
     subdomain = new_subdomain(tc, tc->dom,
                               testdom[0], testdom[1], testdom[2], testdom[0],
                               testdom[3], false, false, NULL, NULL, 0,
-                              tc->confdb, true);
+                              IPA_TRUST_UNKNOWN, tc->confdb, true);
     assert_non_null(subdomain);
 
     ret = sysdb_subdomain_store(tc->sysdb,
                                 testdom[0], testdom[1], testdom[2], testdom[0],
-                                testdom[3], false, false, NULL, 0, NULL);
+                                testdom[3], false, false, NULL, 0,
+                                IPA_TRUST_UNKNOWN, NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_update_subdomains(tc->dom, tc->confdb);

--- a/src/tests/cmocka/test_nss_srv.c
+++ b/src/tests/cmocka/test_nss_srv.c
@@ -31,6 +31,7 @@
 #include "responder/common/negcache.h"
 #include "responder/nss/nss_private.h"
 #include "responder/nss/nss_protocol.h"
+#include "providers/ipa/ipa_subdomains.h"
 #include "sss_client/idmap/sss_nss_idmap.h"
 #include "util/util_sss_idmap.h"
 #include "util/crypto/sss_crypto.h"
@@ -3688,12 +3689,14 @@ static int sss_nss_subdom_test_setup_common(void **state, bool nonfqnames)
     subdomain = new_subdomain(sss_nss_test_ctx, sss_nss_test_ctx->tctx->dom,
                               testdom[0], testdom[1], testdom[2], testdom[0],
                               testdom[3], false, false, NULL, NULL, 0,
-                              sss_nss_test_ctx->tctx->confdb, true);
+                              IPA_TRUST_UNKNOWN, sss_nss_test_ctx->tctx->confdb,
+                              true);
     assert_non_null(subdomain);
 
     ret = sysdb_subdomain_store(sss_nss_test_ctx->tctx->sysdb,
                                 testdom[0], testdom[1], testdom[2], testdom[0],
-                                testdom[3], MPG_DISABLED, false, NULL, 0, NULL);
+                                testdom[3], MPG_DISABLED, false, NULL, 0,
+                                IPA_TRUST_UNKNOWN, NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_update_subdomains(sss_nss_test_ctx->tctx->dom,

--- a/src/tests/cmocka/test_responder_cache_req.c
+++ b/src/tests/cmocka/test_responder_cache_req.c
@@ -27,6 +27,7 @@
 #include "tests/cmocka/common_mock_resp.h"
 #include "db/sysdb.h"
 #include "responder/common/cache_req/cache_req.h"
+#include "providers/ipa/ipa_subdomains.h"
 
 #define LDAP_ID_PROVIDER "ldap"
 #define TESTS_PATH "tp_" BASE_FILE_STEM
@@ -728,12 +729,13 @@ int test_subdomain_setup(void **state)
     test_ctx->subdomain = new_subdomain(test_ctx, test_ctx->tctx->dom,
                               testdom[0], testdom[1], testdom[2], testdom[0],
                               testdom[3], MPG_DISABLED, false, NULL, NULL, 0,
-                              test_ctx->tctx->confdb, true);
+                              IPA_TRUST_UNKNOWN, test_ctx->tctx->confdb, true);
     assert_non_null(test_ctx->subdomain);
 
     ret = sysdb_subdomain_store(test_ctx->tctx->sysdb,
                                 testdom[0], testdom[1], testdom[2], testdom[0],
-                                testdom[3], MPG_DISABLED, false, NULL, 0, NULL);
+                                testdom[3], MPG_DISABLED, false, NULL, 0,
+                                IPA_TRUST_UNKNOWN, NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_update_subdomains(test_ctx->tctx->dom,

--- a/src/tests/cmocka/test_sysdb_subdomains.c
+++ b/src/tests/cmocka/test_sysdb_subdomains.c
@@ -30,6 +30,7 @@
 
 #include "tests/cmocka/common_mock.h"
 #include "tests/common.h"
+#include "providers/ipa/ipa_subdomains.h"
 #include "db/sysdb_private.h" /* for sysdb->ldb member */
 
 #define TESTS_PATH "tp_" BASE_FILE_STEM
@@ -100,7 +101,8 @@ static void test_sysdb_subdomain_create(void **state)
 
     ret = sysdb_subdomain_store(test_ctx->tctx->sysdb,
                                 dom1[0], dom1[1], dom1[2], dom1[0], dom1[3],
-                                MPG_DISABLED, false, NULL, 0, NULL);
+                                MPG_DISABLED, false, NULL, 0, IPA_TRUST_UNKNOWN,
+                                NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_update_subdomains(test_ctx->tctx->dom, test_ctx->tctx->confdb);
@@ -113,7 +115,8 @@ static void test_sysdb_subdomain_create(void **state)
 
     ret = sysdb_subdomain_store(test_ctx->tctx->sysdb,
                                 dom2[0], dom2[1], dom2[2], dom2[0], dom2[3],
-                                MPG_DISABLED, false, NULL, 1, NULL);
+                                MPG_DISABLED, false, NULL, 1, IPA_TRUST_UNKNOWN,
+                                NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_update_subdomains(test_ctx->tctx->dom, test_ctx->tctx->confdb);
@@ -127,12 +130,14 @@ static void test_sysdb_subdomain_create(void **state)
     /* Reverse the trust directions */
     ret = sysdb_subdomain_store(test_ctx->tctx->sysdb,
                                 dom1[0], dom1[1], dom1[2], dom1[0], dom1[3],
-                                MPG_DISABLED, false, NULL, 1, NULL);
+                                MPG_DISABLED, false, NULL, 1, IPA_TRUST_UNKNOWN,
+                                NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_subdomain_store(test_ctx->tctx->sysdb,
                                 dom2[0], dom2[1], dom2[2], dom2[0], dom2[3],
-                                MPG_DISABLED, false, NULL, 0, NULL);
+                                MPG_DISABLED, false, NULL, 0, IPA_TRUST_UNKNOWN,
+                                NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_update_subdomains(test_ctx->tctx->dom, test_ctx->tctx->confdb);
@@ -159,12 +164,14 @@ static void test_sysdb_subdomain_create(void **state)
     /* Test that changing the MPG status works */
     ret = sysdb_subdomain_store(test_ctx->tctx->sysdb,
                                 dom1[0], dom1[1], dom1[2], dom1[0], dom1[3],
-                                MPG_ENABLED, false, NULL, 1, NULL);
+                                MPG_ENABLED, false, NULL, 1, IPA_TRUST_UNKNOWN,
+                                NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_subdomain_store(test_ctx->tctx->sysdb,
                                 dom2[0], dom2[1], dom2[2], dom2[0], dom2[3],
-                                MPG_ENABLED, false, NULL, 0, NULL);
+                                MPG_ENABLED, false, NULL, 0, IPA_TRUST_UNKNOWN,
+                                NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_update_subdomains(test_ctx->tctx->dom, test_ctx->tctx->confdb);
@@ -175,12 +182,14 @@ static void test_sysdb_subdomain_create(void **state)
 
     ret = sysdb_subdomain_store(test_ctx->tctx->sysdb,
                                 dom1[0], dom1[1], dom1[2], dom1[0], dom1[3],
-                                MPG_HYBRID, false, NULL, 1, NULL);
+                                MPG_HYBRID, false, NULL, 1, IPA_TRUST_UNKNOWN,
+                                NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_subdomain_store(test_ctx->tctx->sysdb,
                                 dom2[0], dom2[1], dom2[2], dom2[0], dom2[3],
-                                MPG_HYBRID, false, NULL, 0, NULL);
+                                MPG_HYBRID, false, NULL, 0, IPA_TRUST_UNKNOWN,
+                                NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_update_subdomains(test_ctx->tctx->dom, test_ctx->tctx->confdb);
@@ -247,27 +256,28 @@ static void test_sysdb_link_forest_root_ipa(void **state)
 
     ret = sysdb_subdomain_store(test_ctx->tctx->sysdb,
                                 dom1[0], dom1[1], dom1[2], dom1[0], dom1[3],
-                                MPG_DISABLED, false, dom1[4], 0, NULL);
+                                MPG_DISABLED, false, dom1[4], 0, IPA_TRUST_UNKNOWN,
+                                NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_subdomain_store(test_ctx->tctx->sysdb,
                                 child_dom1[0], child_dom1[1],
                                 child_dom1[2], child_dom1[0], child_dom1[3],
                                 MPG_DISABLED, false, child_dom1[4],
-                                0, NULL);
+                                0, IPA_TRUST_UNKNOWN, NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_subdomain_store(test_ctx->tctx->sysdb,
                                 dom2[0], dom2[1], dom2[2], dom2[0], dom2[3],
                                 MPG_DISABLED, false, dom2[4],
-                                0, NULL);
+                                0, IPA_TRUST_UNKNOWN, NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_subdomain_store(test_ctx->tctx->sysdb,
                                 child_dom2[0], child_dom2[1],
                                 child_dom2[2], child_dom2[0], child_dom2[3],
                                 MPG_DISABLED, false, child_dom2[4],
-                                0, NULL);
+                                0, IPA_TRUST_UNKNOWN, NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_update_subdomains(test_ctx->tctx->dom, test_ctx->tctx->confdb);
@@ -341,14 +351,14 @@ static void test_sysdb_link_forest_root_ad(void **state)
                                 child_dom[0], child_dom[1],
                                 child_dom[2], child_dom[0], child_dom[3],
                                 MPG_DISABLED, false, child_dom[4],
-                                0, NULL);
+                                0, IPA_TRUST_UNKNOWN, NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_subdomain_store(test_ctx->tctx->sysdb,
                                 sub_dom[0], sub_dom[1],
                                 sub_dom[2], sub_dom[0], sub_dom[3],
                                 MPG_DISABLED, false, sub_dom[4],
-                                0, NULL);
+                                0, IPA_TRUST_UNKNOWN, NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_update_subdomains(test_ctx->tctx->dom, test_ctx->tctx->confdb);
@@ -419,14 +429,14 @@ static void test_sysdb_link_forest_member_ad(void **state)
                                 sub_dom[0], sub_dom[1],
                                 sub_dom[2], sub_dom[0], sub_dom[3],
                                 MPG_DISABLED, false, sub_dom[4],
-                                0, NULL);
+                                0, IPA_TRUST_UNKNOWN, NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_subdomain_store(test_ctx->tctx->sysdb,
                                 forest_root[0], forest_root[1],
                                 forest_root[2], forest_root[0], forest_root[3],
                                 MPG_DISABLED, false, forest_root[4],
-                                0, NULL);
+                                0, IPA_TRUST_UNKNOWN, NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_master_domain_update(test_ctx->tctx->dom);
@@ -505,7 +515,7 @@ static void test_sysdb_link_ad_multidom(void **state)
                                 child_dom[0], child_dom[1],
                                 child_dom[2], child_dom[0], child_dom[3],
                                 MPG_DISABLED, false, child_dom[4],
-                                0, NULL);
+                                0, IPA_TRUST_UNKNOWN, NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_master_domain_update(main_dom1);
@@ -526,7 +536,8 @@ static void test_sysdb_link_ad_multidom(void **state)
     ret = sysdb_subdomain_store(main_dom2->sysdb,
                                 dom2_forest_root[0], dom2_forest_root[1],
                                 dom2_forest_root[2], dom2_forest_root[0], dom2_forest_root[3],
-                                MPG_DISABLED, false, dom2_forest_root[4], 0, NULL);
+                                MPG_DISABLED, false, dom2_forest_root[4], 0, IPA_TRUST_UNKNOWN,
+                                NULL);
     assert_int_equal(ret, EOK);
 
     ret = sysdb_master_domain_update(main_dom2);

--- a/src/tests/sysdb-tests.c
+++ b/src/tests/sysdb-tests.c
@@ -30,6 +30,7 @@
 #include <arpa/inet.h>
 #include "util/util.h"
 #include "util/crypto/sss_crypto.h"
+#include "providers/ipa/ipa_subdomains.h"
 #include "db/sysdb_private.h"
 #include "db/sysdb_services.h"
 #include "db/sysdb_autofs.h"
@@ -1601,7 +1602,7 @@ START_TEST (test_sysdb_get_user_attr_subdomain)
     /* Create subdomain */
     subdomain = new_subdomain(test_ctx, test_ctx->domain,
                               "test.sub", "TEST.SUB", "test", "test.sub", "S-3",
-                              MPG_DISABLED, false, NULL, NULL, 0, NULL, true);
+                              MPG_DISABLED, false, NULL, NULL, 0, IPA_TRUST_UNKNOWN, NULL, true);
     sss_ck_fail_if_msg(subdomain == NULL, "Failed to create new subdomain.");
 
     ret = sss_names_init_from_args(test_ctx,
@@ -6401,11 +6402,11 @@ START_TEST(test_sysdb_subdomain_store_user)
 
     subdomain = new_subdomain(test_ctx, test_ctx->domain,
                               testdom[0], testdom[1], testdom[2], testdom[0],
-                              testdom[3], MPG_DISABLED, false, NULL, NULL, 0, NULL, true);
+                              testdom[3], MPG_DISABLED, false, NULL, NULL, 0, IPA_TRUST_UNKNOWN, NULL, true);
     ck_assert_msg(subdomain != NULL, "Failed to create new subdomain.");
     ret = sysdb_subdomain_store(test_ctx->sysdb,
                                 testdom[0], testdom[1], testdom[2], testdom[0], testdom[3],
-                                false, false, NULL, 0, NULL);
+                                false, false, NULL, 0, IPA_TRUST_UNKNOWN, NULL);
     sss_ck_fail_if_msg(ret != EOK, "Could not set up the test (test subdom)");
 
     ret = sysdb_update_subdomains(test_ctx->domain, NULL);
@@ -6479,11 +6480,11 @@ START_TEST(test_sysdb_subdomain_content_delete)
 
     subdomain = new_subdomain(test_ctx, test_ctx->domain,
                               testdom[0], testdom[1], testdom[2], testdom[0],
-                              testdom[3], MPG_DISABLED, false, NULL, NULL, 0, NULL, true);
+                              testdom[3], MPG_DISABLED, false, NULL, NULL, 0, IPA_TRUST_UNKNOWN, NULL, true);
     ck_assert_msg(subdomain != NULL, "Failed to create new subdomain.");
     ret = sysdb_subdomain_store(test_ctx->sysdb,
                                 testdom[0], testdom[1], testdom[2], testdom[0], testdom[3],
-                                false, false, NULL, 0, NULL);
+                                false, false, NULL, 0, IPA_TRUST_UNKNOWN, NULL);
     sss_ck_fail_if_msg(ret != EOK, "Could not set up the test (test subdom)");
 
     ret = sysdb_update_subdomains(test_ctx->domain, NULL);
@@ -6567,11 +6568,11 @@ START_TEST(test_sysdb_subdomain_user_ops)
 
     subdomain = new_subdomain(test_ctx, test_ctx->domain,
                               testdom[0], testdom[1], testdom[2], testdom[0],
-                              testdom[3], MPG_DISABLED, false, NULL, NULL, 0, NULL, true);
+                              testdom[3], MPG_DISABLED, false, NULL, NULL, 0, IPA_TRUST_UNKNOWN, NULL, true);
     ck_assert_msg(subdomain != NULL, "Failed to create new subdomain.");
     ret = sysdb_subdomain_store(test_ctx->sysdb,
                                 testdom[0], testdom[1], testdom[2], testdom[0], testdom[3],
-                                false, false, NULL, 0, NULL);
+                                false, false, NULL, 0, IPA_TRUST_UNKNOWN, NULL);
     sss_ck_fail_if_msg(ret != EOK, "Could not set up the test (test subdom)");
 
     ret = sysdb_update_subdomains(test_ctx->domain, NULL);
@@ -6640,11 +6641,11 @@ START_TEST(test_sysdb_subdomain_group_ops)
 
     subdomain = new_subdomain(test_ctx, test_ctx->domain,
                               testdom[0], testdom[1], testdom[2], testdom[0],
-                              testdom[3], MPG_DISABLED, false, NULL, NULL, 0, NULL, true);
+                              testdom[3], MPG_DISABLED, false, NULL, NULL, 0, IPA_TRUST_UNKNOWN, NULL, true);
     ck_assert_msg(subdomain != NULL, "Failed to create new subdomain.");
     ret = sysdb_subdomain_store(test_ctx->sysdb,
                                 testdom[0], testdom[1], testdom[2], testdom[0], testdom[3],
-                                false, false, NULL, 0, NULL);
+                                false, false, NULL, 0, IPA_TRUST_UNKNOWN, NULL);
     sss_ck_fail_if_msg(ret != EOK, "Could not set up the test (test subdom)");
 
     ret = sysdb_update_subdomains(test_ctx->domain, NULL);


### PR DESCRIPTION
This PR adds support for IDM subdomains, enabling IDM IDM Trust functionality in SSSD. These are building blocks in SSSD to incorporate the IDM IDM Trust feature. Note however that on the freeIPA side development is still ongoing, this means the entire IDM IDM Trust feature (freeIPA + SSSD) is not yet available, and full integration cannot be tested yet. Current testing is being done using COPR packages.