### PR TITLE
CLIENT: don't try to lookup `getservbyport(0, ...)`

### DIFF
--- a/src/sss_client/nss_services.c
+++ b/src/sss_client/nss_services.c
@@ -292,6 +292,11 @@ _nss_sss_getservbyport_r(int port, const char *protocol,
 	return NSS_STATUS_TRYAGAIN;
     }
 
+    if (port == 0) {
+        *errnop = EINVAL;
+        return NSS_STATUS_NOTFOUND;
+    }
+
     if (protocol) {
         ret = sss_strnlen(protocol, SSS_NAME_MAX, &proto_len);
         if (ret != 0) {


### PR DESCRIPTION
'sssd_nss' won't handle this request anyway.

https://issues.redhat.com/browse/RHEL-66935