### PR TITLE
Add the option for `DP_OPT_DYNDNS_REFRESH_OFFSET`

### DIFF
--- a/src/providers/be_dyndns.c
+++ b/src/providers/be_dyndns.c
@@ -1201,6 +1201,7 @@ static struct dp_option default_dyndns_opts[] = {
     { "dyndns_update", DP_OPT_BOOL, BOOL_FALSE, BOOL_FALSE },
     { "dyndns_update_per_family", DP_OPT_BOOL, BOOL_TRUE, BOOL_TRUE },
     { "dyndns_refresh_interval", DP_OPT_NUMBER, NULL_NUMBER, NULL_NUMBER },
+    { "dyndns_refresh_interval_offset", DP_OPT_NUMBER, NULL_NUMBER, NULL_NUMBER },
     { "dyndns_iface", DP_OPT_STRING, NULL_STRING, NULL_STRING },
     { "dyndns_ttl", DP_OPT_NUMBER, { .number = 1200 }, NULL_NUMBER },
     { "dyndns_update_ptr", DP_OPT_BOOL, BOOL_TRUE, BOOL_FALSE },

--- a/src/providers/be_dyndns.c
+++ b/src/providers/be_dyndns.c
@@ -1197,7 +1197,7 @@ be_nsupdate_check(void)
     return ret;
 }
 
-static struct dp_option default_dyndns_opts[] = {
+struct dp_option default_dyndns_opts[] = {
     { "dyndns_update", DP_OPT_BOOL, BOOL_FALSE, BOOL_FALSE },
     { "dyndns_update_per_family", DP_OPT_BOOL, BOOL_TRUE, BOOL_TRUE },
     { "dyndns_refresh_interval", DP_OPT_NUMBER, NULL_NUMBER, NULL_NUMBER },

--- a/src/providers/be_dyndns.h
+++ b/src/providers/be_dyndns.h
@@ -63,6 +63,7 @@ enum dp_dyndns_opts {
 
     DP_OPT_DYNDNS /* attrs counter */
 };
+extern struct dp_option default_dyndns_opts[DP_OPT_DYNDNS + 1];
 
 #define DYNDNS_REMOVE_A     0x1
 #define DYNDNS_REMOVE_AAAA  0x2

--- a/src/tests/ipa_ldap_opt-tests.c
+++ b/src/tests/ipa_ldap_opt-tests.c
@@ -103,6 +103,10 @@ START_TEST(test_compare_opts)
     ret = compare_dp_options(ipa_dyndns_opts, DP_OPT_DYNDNS,
                              ad_dyndns_opts);
     ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
+
+    ret = compare_dp_options(ipa_dyndns_opts, DP_OPT_DYNDNS,
+                             default_dyndns_opts);
+    ck_assert_msg(ret == EOK, "[%s]", strerror(ret));
 }
 END_TEST
 
@@ -199,6 +203,8 @@ START_TEST(test_dp_opt_sentinel)
     fail_unless_dp_opt_is_terminator(&default_basic_opts[SDAP_OPTS_BASIC]);
 
     fail_unless_dp_opt_is_terminator(&default_krb5_opts[KRB5_OPTS]);
+
+    fail_unless_dp_opt_is_terminator(&default_dyndns_opts[DP_OPT_DYNDNS]);
 
     fail_unless_dp_opt_is_terminator(&ad_basic_opts[AD_OPTS_BASIC]);
     fail_unless_dp_opt_is_terminator(&ad_def_ldap_opts[SDAP_OPTS_BASIC]);


### PR DESCRIPTION
The label `DP_OPT_DYNDNS_REFRESH_OFFSET` was introduced in https://github.com/SSSD/sssd/blob/fb91349cfeba653942b32141f890e3de78b3fb13/src/providers/be_dyndns.h#L55 but the corresponding option is missing in https://github.com/SSSD/sssd/blob/fb91349cfeba653942b32141f890e3de78b3fb13/src/providers/be_dyndns.c#L1200

This error was introduced by https://github.com/SSSD/sssd/commit/35c35de42012481a6bd2690d12d5d11a4ae23ea5

Also modified a test to compare the structure `default_dyndns_opts` to `ipa_dyndns_opts`, which is already compared
to `ad_dyndns_opts`; and another test to check the structure's terminator.