### PR TITLE
dyndns: collect nsupdate debug output

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2890,7 +2890,8 @@ dyndns_tests_SOURCES = \
      $(SSSD_RESOLV_OBJ) \
      src/tests/cmocka/common_mock_be.c \
      src/tests/cmocka/test_dyndns.c \
-     src/providers/data_provider_opts.c
+     src/providers/data_provider_opts.c \
+     src/util/child_common.c
 dyndns_tests_CFLAGS = \
     $(AM_CFLAGS) \
     $(CMOCKA_CFLAGS) \


### PR DESCRIPTION
It looks like in current code the assumption is that the nsupdate
command can just send its debug output into the backend log by
duplicating the file descriptor. This won't work since the logs file is
opened with O_CLOEXEC so that it is closed when nsupdate is started.

Additionally it is questionable if this approach is a good idea because
it would lead to a random intermixing of debug information. This patch
collects the output on strderr of nsupdate separately and adds it into
the backend log similar to the input send to nsupdate.