### PR TITLE
test: authentication, adding generic password policy tests

### DIFF
--- a/src/tests/system/tests/test_authentication.py
+++ b/src/tests/system/tests/test_authentication.py
@@ -21,20 +21,18 @@ from sssd_test_framework.topology import KnownTopologyGroup
     lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
     "SSSD was built without support for running under non-root",
 )
-def test_authentication__with_default_settings(
-    client: Client, provider: GenericProvider, method: str, sssd_service_user: str
-):
+def test_authentication__user_login(client: Client, provider: GenericProvider, method: str, sssd_service_user: str):
     """
     :title: Authenticate with default settings
     :setup:
         1. Create user
         2. Start SSSD
     :steps:
-        1. Authenticate user with correct password
-        2. Authenticate user with incorrect password
+        1. Login as user
+        2. Login as user with bad password
     :expectedresults:
-        1. Authentication is successful
-        2. Authentication is unsuccessful
+        1. User can log in
+        2. User cannot log in
     :customerscenario: False
     """
     provider.user("user1").add(password="Secret123")
@@ -49,6 +47,92 @@ def test_authentication__with_default_settings(
 
 
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
+@pytest.mark.importance("critical")
+def test_authentication__user_login_then_changes_password(
+    client: Client,
+    provider: GenericProvider,
+):
+    """
+    :title: User issues a password change after login
+    :setup:
+        1. Create user 'user'
+        2. Start SSSD
+    :steps:
+        1. Login as user
+        2. Issue password change and enter a bad confirmation password
+        3. Issue password change and enter a good confirmation password
+        4. Login with old password
+        5. Login with new password
+    :expectedresults:
+        1. User is authenticated
+        2. Password change is unsuccessful
+        3. Password change is successful
+        4. User cannot log in
+        5. User can log in
+    :customerscenario: True
+    """
+    old_password = "Secret123"
+    invalid_password = "secret"
+    new_password = "New_Secret123"
+
+    provider.user("user1").add(password=old_password)
+
+    client.sssd.start()
+
+    assert not client.auth.passwd.password(
+        "user1", old_password, new_password, retyped=invalid_password
+    ), "Password should not have been able to be changed!"
+    assert client.auth.passwd.password("user1", old_password, new_password), "'user1' password change failed!"
+
+    assert not client.auth.ssh.password("user1", old_password), "'user1' shouldn't have been able to log in!"
+    assert client.auth.ssh.password("user1", new_password), "'user1' failed to log in!"
+
+
+@pytest.mark.topology(KnownTopologyGroup.AnyProvider)
+@pytest.mark.importance("critical")
+def test_authentication__user_login_then_changes_password_with_complexity_requirement(
+    client: Client,
+    provider: GenericProvider,
+):
+    """
+    :title: User issues a password change after login with password policy complexity enabled
+    :setup:
+        1. Create user 'user'
+        2. Enable password complexity requirements
+        3. Start SSSD
+    :steps:
+        1. Login as user
+        2. Issue password change as user with password that does not meet complexity requirements
+        3. Issue password change as user with password meeting complexity requirements and logout
+        4. Login with old password
+        5. Login with new password
+    :expectedresults:
+        1. User is authenticated
+        2. Password change is unsuccessful
+        3. Password change is successful
+        4. User cannot log in
+        5. User can log in
+    :customerscenario: True
+    """
+    old_password = "Secret123"
+    invalid_password = "secret"
+    new_password = "Secret123**%%"
+
+    provider.user("user1").add(password=old_password)
+    provider.password_policy.complexity(enable=True)
+
+    client.sssd.start()
+
+    assert not client.auth.passwd.password(
+        "user1", old_password, invalid_password
+    ), "Password should not have been able to be changed!"
+
+    assert client.auth.passwd.password("user1", old_password, new_password), "'user1' password change failed!"
+    assert not client.auth.ssh.password("user1", old_password), "'user1' shouldn't have been able to log in!"
+    assert client.auth.ssh.password("user1", new_password), "'user1' failed to log in!"
+
+
+@pytest.mark.topology(KnownTopologyGroup.AnyProvider)
 @pytest.mark.parametrize("method", ["su", "ssh"])
 @pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
 @pytest.mark.importance("critical")
@@ -56,7 +140,54 @@ def test_authentication__with_default_settings(
     lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
     "SSSD was built without support for running under non-root",
 )
-def test_authentication__default_settings_when_the_provider_is_offline(
+def test_authentication__user_is_forced_to_change_expired_password_before_login(
+    client: Client, provider: GenericProvider, sssd_service_user: str, method: str
+):
+    """
+    :title: User must change their password during the login prompt
+    :setup:
+        1. Create user and expire their password
+        2. Start SSSD
+    :steps:
+        1. Login as user and user forced to change password
+        2. Enter the current password, new password and then wrong password during confirmation
+        3. Login as user and user forced to change password
+        4. Enter the current password and the same new password
+        5. Login with the new password
+        6. Login with the old password
+    :expectedresults:
+        1. User is authenticated, user is forced to change its password
+        2. User is not able to change its password
+        3. User is authenticated, user is forced to change its password
+        4. Password change succeeds
+        5. User can log in
+        6. User cannot log in
+    :customerscenario: True
+    """
+    old_pass = "Secret123"
+    new_pass = "Password123"
+
+    user = provider.user("user1").add(password=old_pass)
+    client.sssd.start(service_user=sssd_service_user)
+
+    assert client.auth.ssh.password(user.name, old_pass), "User failed to authenticate!"
+    user.password_change_at_logon(password=old_pass)
+
+    assert client.auth.parametrize(method).password_expired(user.name, old_pass, new_pass), "Password change failed!"
+
+    assert client.auth.parametrize(method).password(user.name, new_pass), "User login failed!"
+    assert not client.auth.parametrize(method).password(user.name, old_pass), "Login with old password passed!"
+
+
+@pytest.mark.topology(KnownTopologyGroup.AnyProvider)
+@pytest.mark.parametrize("method", ["su", "ssh"])
+@pytest.mark.parametrize("sssd_service_user", ("root", "sssd"))
+@pytest.mark.importance("critical")
+@pytest.mark.require(
+    lambda client, sssd_service_user: ((sssd_service_user == "root") or client.features["non-privileged"]),
+    "SSSD was built without support for running under non-root",
+)
+def test_authentication__user_login_when_the_provider_is_offline(
     client: Client, provider: GenericProvider, method: str, sssd_service_user: str
 ):
     """
@@ -64,16 +195,16 @@ def test_authentication__default_settings_when_the_provider_is_offline(
     :setup:
         1. Create user
         2. Configure SSSD with "cache_credentials = true" and "krb5_store_password_if_offline = true" and
-        "offline_credentials_expiration = 0"
+            "offline_credentials_expiration = 0"
         3 Start SSSD
     :steps:
-        1. Authenticate user with correct password
-        2. Offline user authentication with correct password
-        3. Offline user authentication with incorrect password
+        1. Login as user
+        2. Offline, login as user
+        3. Offline, login as user with bad password
     :expectedresults:
-        1. User authentication is successful
-        2. User authentication is successful
-        3. User authentication is unsuccessful
+        1. User can log in
+        2. User can log in
+        3. User cannot log in
     :customerscenario: False
     """
     user = "user1"
@@ -105,7 +236,9 @@ def test_authentication__default_settings_when_the_provider_is_offline(
     ["user", "uid", "fqn", "domain", "first_char", "upn", "default", "lowercase", "substring", "literal%"],
 )
 @pytest.mark.importance("medium")
-def test_authentication__with_overriding_home_directory(client: Client, provider: GenericProvider, home_key: str):
+def test_authentication__user_login_with_overriding_home_directory(
+    client: Client, provider: GenericProvider, home_key: str
+):
     """
     :title: Override the user's home directory
     :description:


### PR DESCRIPTION
* depends on https://github.com/SSSD/sssd-test-framework/pull/139
* added generic password change tests
* removed generic password change tests in test_ldap and made them only ppolicy tests, since generic now covers ldap
* renamed test_ldap names. 
* updated assertions, _client.auth.ssh.password_with_output_, now returns a different value because of the mentioned pull request

