### PR TITLE
branch sssd-2-10 build with OpenSSL 1.1 is broken

### DIFF
--- a/src/util/cert/libcrypto/cert.c
+++ b/src/util/cert/libcrypto/cert.c
@@ -20,7 +20,9 @@
 #include <openssl/x509.h>
 #include <openssl/bio.h>
 #include <openssl/pem.h>
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
 #include <openssl/core_names.h>
+#endif
 
 #include "util/util.h"
 #include "util/sss_endian.h"
@@ -177,14 +179,18 @@ done:
 #define IDENTIFIER_NISTP384 "nistp384"
 #define IDENTIFIER_NISTP521 "nistp521"
 
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+static int sss_ec_get_key(BN_CTX *bn_ctx, EVP_PKEY *cert_pub_key,
+#else
 static int sss_ec_get_key(BN_CTX *bn_ctx, const EVP_PKEY *cert_pub_key,
+#endif
                           EC_GROUP **_ec_group, EC_POINT **_ec_public_key)
 {
     EC_GROUP *ec_group = NULL;
     EC_POINT *ec_public_key = NULL;
+    int ret;
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
-    int ret;
     static char curve_name[4096];
     static unsigned char pubkey[4096];
     size_t len;
@@ -373,7 +379,11 @@ done:
 #define SSH_RSA_HEADER "ssh-rsa"
 #define SSH_RSA_HEADER_LEN (sizeof(SSH_RSA_HEADER) - 1)
 
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+static int sss_rsa_get_key(EVP_PKEY *cert_pub_key,
+#else
 static int sss_rsa_get_key(const EVP_PKEY *cert_pub_key,
+#endif
                            BIGNUM **_n, BIGNUM **_e)
 {
     int ret;
@@ -396,7 +406,7 @@ static int sss_rsa_get_key(const EVP_PKEY *cert_pub_key,
 #else
 
     const BIGNUM *tmp_n;
-    const BIGNUM *tmp_e:
+    const BIGNUM *tmp_e;
     const RSA *rsa_pub_key = NULL;
     rsa_pub_key = EVP_PKEY_get0_RSA(cert_pub_key);
     if (rsa_pub_key == NULL) {
@@ -406,16 +416,16 @@ static int sss_rsa_get_key(const EVP_PKEY *cert_pub_key,
 
     RSA_get0_key(rsa_pub_key, tmp_n, tmp_e, NULL);
 
-    *n = BN_dup(tmp_n);
-    if (*n == NULL) {
+    n = BN_dup(tmp_n);
+    if (n == NULL) {
         ret = ENOMEM;
         goto done;
     }
 
-    *e = BN_dup(tmp_e);
-    if (*e == NULL) {
+    e = BN_dup(tmp_e);
+    if (e == NULL) {
         BN_clear_free(n);
-        ret = ENOME;
+        ret = ENOMEM;
         goto done;
     }
 


### PR DESCRIPTION
cert util: add support build with OpenSSL older than 3.0:
* Don't include <openssl/core_names.h> header if OpenSSL older 3.0 is used.
* Fix compile typos for build with OpenSSL 1.1.
