### PR TITLE
Assume that callbacks are not broken in OpenLDAP when cross-compiling

### DIFF
--- a/src/external/ldap.m4
+++ b/src/external/ldap.m4
@@ -78,9 +78,10 @@ AC_CHECK_MEMBERS([struct ldap_conncb.lc_arg],
                        return ldap_set_option(NULL, LDAP_OPT_CONNECT_CB, &cb);
                      ]] )],
                    [AC_DEFINE([HAVE_LDAP_CONNCB], [1],
-                     [Define if LDAP connection callbacks are available])],
+                     [Define if LDAP connection callbacks are available, always set when cross-compiling])],
                    [AC_MSG_WARN([Found broken callback implementation])],
-                   [])],
+                   [AC_DEFINE([HAVE_LDAP_CONNCB], [1],
+                     [Define if LDAP connection callbacks are available, always set when cross-compiling])])],
                  [], [[#include <ldap.h>]])
 
 AC_CHECK_TYPE([LDAPDerefRes],


### PR DESCRIPTION
~This adds a LDAP_HAVE_CONNCB_CROSS variable that will be used instead of the runtime check for a broken connection callbacks in ldap library. Set it to yes to assume that connection callbacks are working.~

~This allows the project to be configured successfully when cross-compiling.~

If we do cross-compiling against a known broken version of OpenLDAP, we can do `export ac_cv_member_struct_ldap_conncb_lc_arg=no` before running configure. This is rather unlikely now, as the test was done to detect a bug that was fixed 16 years ago.

This allows the project to be configured successfully when cross-compiling, without disabling connection callbacks.

Tested locally in Flatcar (https://github.com/flatcar/scripts/pull/2501)