### PR TITLE
KRB5: mistype fix

### DIFF
--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -2432,7 +2432,7 @@ static krb5_error_code get_and_save_tgt(struct krb5_req *kr,
     /* Make sure ccache is created and written as the user */
     kerr = switch_to_user();
     if (kerr != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Failed to switch to user IDs: %d\n", ret);
+        DEBUG(SSSDBG_CRIT_FAILURE, "Failed to switch to user IDs: %d\n", kerr);
         goto done;
     }
 


### PR DESCRIPTION
Fixes:
```
 *** CID 515655:  Uninitialized variables  (UNINIT)
 /home/runner/work/sssd/sssd/src/providers/krb5/krb5_child.c: 2435 in
 get_and_save_tgt()
 2429             goto done;
 2430         }
 2431
 2432         /* Make sure ccache is created and written as the user */
 2433         kerr = switch_to_user();
 2434         if (kerr != EOK) {
  >>>     CID 515655:  Uninitialized variables  (UNINIT)
  >>>     Using uninitialized value "ret" when calling "sss_debug_fn".
 2435             DEBUG(SSSDBG_CRIT_FAILURE, "Failed to switch to user
 IDs: %d\n", ret);
 2436             goto done;
 2437         }
 2438
 2439         log_process_caps("Saving ccache");
 2440
```