### PR TITLE
Ignore '--dumpable' argument in 'krb5_child' and 'ldap_child'

### DIFF
--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -4120,7 +4120,7 @@ int main(int argc, const char *argv[])
     uint32_t offline;
     int opt;
     poptContext pc;
-    int dumpable = 1;
+    int dummy = 1;
     int backtrace = 1;
     int debug_fd = -1;
     const char *opt_logger = NULL;
@@ -4135,8 +4135,8 @@ int main(int argc, const char *argv[])
     struct poptOption long_options[] = {
         POPT_AUTOHELP
         SSSD_DEBUG_OPTS
-        {"dumpable", 0, POPT_ARG_INT, &dumpable, 0,
-         _("Allow core dumps"), NULL },
+        {"dumpable", 0, POPT_ARG_INT, &dummy, 0,
+         _("Ignored, /proc/sys/fs/suid_dumpable setting is in force"), NULL },
         {"backtrace", 0, POPT_ARG_INT, &backtrace, 0,
          _("Enable debug backtrace"), NULL },
         {"debug-fd", 0, POPT_ARG_INT, &debug_fd, 0,
@@ -4201,11 +4201,11 @@ int main(int argc, const char *argv[])
 
     poptFreeContext(pc);
 
-    /* This call is more for the sake of consistency than
-     * anything else. Any change of euid will reset DUMPABLE
-     * to the value of '/proc/sys/fs/suid_dumpable'
+    /* Don't touch PR_SET_DUMPABLE as 'krb5_child' handles host keytab.
+     * Rely on system settings instead: this flag "is reset to the
+     * current value contained in the file /proc/sys/fs/suid_dumpable"
+     * when "the process executes a program that has file capabilities".
      */
-    prctl(PR_SET_DUMPABLE, (dumpable == 0) ? 0 : 1);
 
     debug_prg_name = talloc_asprintf(NULL, "krb5_child[%d]", getpid());
     if (!debug_prg_name) {

--- a/src/providers/ldap/ldap_child.c
+++ b/src/providers/ldap/ldap_child.c
@@ -977,7 +977,7 @@ int main(int argc, const char *argv[])
 {
     int ret;
     int opt;
-    int dumpable = 1;
+    int dummy = 1;
     int backtrace = 1;
     int debug_fd = -1;
     const char *opt_logger = NULL;
@@ -993,8 +993,8 @@ int main(int argc, const char *argv[])
     struct poptOption long_options[] = {
         POPT_AUTOHELP
         SSSD_DEBUG_OPTS
-        {"dumpable", 0, POPT_ARG_INT, &dumpable, 0,
-         _("Allow core dumps"), NULL },
+        {"dumpable", 0, POPT_ARG_INT, &dummy, 0,
+         _("Ignored, /proc/sys/fs/suid_dumpable setting is in force"), NULL },
         {"backtrace", 0, POPT_ARG_INT, &backtrace, 0,
          _("Enable debug backtrace"), NULL },
         {"debug-fd", 0, POPT_ARG_INT, &debug_fd, 0,
@@ -1019,7 +1019,11 @@ int main(int argc, const char *argv[])
 
     poptFreeContext(pc);
 
-    prctl(PR_SET_DUMPABLE, (dumpable == 0) ? 0 : 1);
+    /* Don't touch PR_SET_DUMPABLE as 'ldap_child' handles host keytab.
+     * Rely on system settings instead: this flag "is reset to the
+     * current value contained in the file /proc/sys/fs/suid_dumpable"
+     * when "the process executes a program that has file capabilities".
+     */
 
     debug_prg_name = talloc_asprintf(NULL, "ldap_child[%d]", getpid());
     if (!debug_prg_name) {

--- a/src/util/child_common.c
+++ b/src/util/child_common.c
@@ -809,6 +809,10 @@ static errno_t prepare_child_argv(TALLOC_CTX *mem_ctx,
             goto fail;
         }
 
+        /* Some helpers, namely 'krb5_child' and 'ldap_child',
+         * will ignore '--dumpable' argument to avoid leaking
+         * host keytab accidentially.
+         */
         argv[--argc] = talloc_asprintf(argv, "--dumpable=%d",
                                            prctl(PR_GET_DUMPABLE));
         if (argv[argc] == NULL) {


### PR DESCRIPTION
to avoid leaking host keytab accidentially.

Take a note that this is rather a general precaution than a fix of a real threat since normally those coredumps wouldn't be accessible to non-privileged user anyway.