### PR TITLE
pam: Do not prevent root from changing auth token

### DIFF
--- a/src/man/pam_sss.8.xml
+++ b/src/man/pam_sss.8.xml
@@ -56,6 +56,9 @@
             <arg choice='opt'>
                 <replaceable>require_cert_auth</replaceable>
             </arg>
+            <arg choice='opt'>
+                <replaceable>allow_chauthtok_by_root</replaceable>
+            </arg>
         </cmdsynopsis>
     </refsynopsisdiv>
 
@@ -246,6 +249,22 @@ auth sufficient pam_sss.so allow_missing_name
                         If no Smartcard is available after the timeout or
                         certificate based authentication is not allowed for the
                         current service PAM_AUTHINFO_UNAVAIL is returned.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term>
+                    <option>allow_chauthtok_by_root</option>
+                </term>
+                <listitem>
+                    <para>
+                        By default the chauthtok PAM action will short-circuit to
+                        returning PAM_SUCCESS when pam_sss.so is invoked by root
+                        user.
+                    </para>
+                    <para>
+                        This option disables this behavior allowing to change
+                        auth tokens when running as root.
                     </para>
                 </listitem>
             </varlistentry>

--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -2472,6 +2472,8 @@ static void eval_argv(pam_handle_t *pamh, int argc, const char **argv,
             }
         } else if (strcmp(*argv, "quiet") == 0) {
             *quiet_mode = true;
+        } else if (strcmp(*argv, "allow_chauthtok_by_root") == 0) {
+            *flags |= PAM_CLI_FLAGS_ALLOW_CHAUTHTOK_BY_ROOT;
         } else if (strcmp(*argv, "ignore_unknown_user") == 0) {
             *flags |= PAM_CLI_FLAGS_IGNORE_UNKNOWN_USER;
         } else if (strcmp(*argv, "ignore_authinfo_unavail") == 0) {
@@ -2756,7 +2758,7 @@ static int get_authtok_for_password_change(pam_handle_t *pamh,
     }
 
     if (pam_flags & PAM_PRELIM_CHECK) {
-        if (getuid() == 0 && !exp_data )
+        if (!(flags & PAM_CLI_FLAGS_ALLOW_CHAUTHTOK_BY_ROOT) && getuid() == 0 && !exp_data )
             return PAM_SUCCESS;
 
         if (flags & PAM_CLI_FLAGS_USE_2FA

--- a/src/sss_client/sss_cli.h
+++ b/src/sss_client/sss_cli.h
@@ -429,6 +429,7 @@ enum pam_item_type {
 #define PAM_CLI_FLAGS_PROMPT_ALWAYS (1 << 7)
 #define PAM_CLI_FLAGS_TRY_CERT_AUTH (1 << 8)
 #define PAM_CLI_FLAGS_REQUIRE_CERT_AUTH (1 << 9)
+#define PAM_CLI_FLAGS_ALLOW_CHAUTHTOK_BY_ROOT (1 << 10)
 
 #define SSS_NSS_MAX_ENTRIES 256
 #define SSS_NSS_HEADER_SIZE (sizeof(uint32_t) * 4)


### PR DESCRIPTION
In my workflow I use pam_sss to change passwords of AD domain users. It works fine when user changes his password himself, but it doesn't work I do the same with, for example, `pamtester` program running as root.

The history of this `getuid() == 0` check traces down to 15 years ago and it still doesn't give a clear rationale.

The proposed patch fixes the problem for me.