### PR TITLE
'selinux_child' return code

### DIFF
--- a/src/providers/ipa/selinux_child.c
+++ b/src/providers/ipa/selinux_child.c
@@ -377,8 +377,8 @@ int main(int argc, const char *argv[])
         ret = setresuid(0, 0, -1);
         if (ret == -1) {
             ret = errno;
-            DEBUG(SSSDBG_CRIT_FAILURE,
-                  "setuid() failed: %d, selinux_child might not work!\n", ret);
+            DEBUG(SSSDBG_CRIT_FAILURE, "setresuid() failed: %d\n", ret);
+            goto fail;
         }
     }
     if (getgid() != 0) {
@@ -387,8 +387,8 @@ int main(int argc, const char *argv[])
         ret = setresgid(0, 0, -1);
         if (ret == -1) {
             ret = errno;
-            DEBUG(SSSDBG_CRIT_FAILURE,
-                  "setgid() failed: %d, selinux_child might not work!\n", ret);
+            DEBUG(SSSDBG_CRIT_FAILURE, "setresgid() failed: %d\n", ret);
+            goto fail;
         }
     }
     sss_drop_all_caps();

--- a/src/providers/ipa/selinux_child.c
+++ b/src/providers/ipa/selinux_child.c
@@ -414,7 +414,7 @@ int main(int argc, const char *argv[])
 
     sss_log_process_caps("Sending response");
 
-    ret = prepare_response(main_ctx, ret, &resp);
+    ret = prepare_response(main_ctx, EOK, &resp);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Failed to prepare response buffer.\n");
         goto fail;

--- a/src/util/child_common.c
+++ b/src/util/child_common.c
@@ -896,13 +896,16 @@ void exec_child_ex(TALLOC_CTX *mem_ctx,
         exit(EXIT_FAILURE);
     }
 
-    close(pipefd_from_child[0]);
-    ret = dup2(pipefd_from_child[1], child_out_fd);
-    if (ret == -1) {
-        err = errno;
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "dup2 failed [%d][%s].\n", err, strerror(err));
-        exit(EXIT_FAILURE);
+    /* some helpers, like 'selinux_child', do not write a response */
+    if (pipefd_from_child != NULL) {
+        close(pipefd_from_child[0]);
+        ret = dup2(pipefd_from_child[1], child_out_fd);
+        if (ret == -1) {
+            err = errno;
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "dup2 failed [%d][%s].\n", err, strerror(err));
+            exit(EXIT_FAILURE);
+        }
     }
 
     ret = prepare_child_argv(mem_ctx, debug_fd,


### PR DESCRIPTION
 - fail immediately if set-id fails
 - make it explicit that currently `prepare_response()` always sends '0' as a return code