### PR TITLE
Fix missing sys/types.h on musl libc

### DIFF
--- a/src/sss_client/nss_mc.h
+++ b/src/sss_client/nss_mc.h
@@ -26,6 +26,7 @@
 #include <stdbool.h>
 #include <pwd.h>
 #include <grp.h>
+#include <sys/types.h>
 
 #include "config.h"
 #if HAVE_PTHREAD


### PR DESCRIPTION
Fixes https://github.com/SSSD/sssd/commit/0344c41aca0d6fcaa33e081ed77297607e48ced4