### PR TITLE
SPEC: conf files are owned by 'root:sssd'

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -854,9 +854,9 @@ install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/sssd.conf
 %attr(775,%{sssd_user},%{sssd_user}) %dir %{pubconfpath}
 %attr(770,%{sssd_user},%{sssd_user}) %dir %{gpocachepath}
 %attr(770,%{sssd_user},%{sssd_user}) %dir %{_var}/log/%{name}
-%attr(750,%{sssd_user},%{sssd_user}) %dir %{_sysconfdir}/sssd
-%attr(750,%{sssd_user},%{sssd_user}) %dir %{_sysconfdir}/sssd/conf.d
-%attr(750,%{sssd_user},%{sssd_user}) %dir %{_sysconfdir}/sssd/pki
+%attr(750,root,%{sssd_user}) %dir %{_sysconfdir}/sssd
+%attr(750,root,%{sssd_user}) %dir %{_sysconfdir}/sssd/conf.d
+%attr(750,root,%{sssd_user}) %dir %{_sysconfdir}/sssd/pki
 %ghost %attr(0600,%{sssd_user},%{sssd_user}) %config(noreplace) %{_sysconfdir}/sssd/sssd.conf
 %dir %{_sysconfdir}/logrotate.d
 %config(noreplace) %{_sysconfdir}/logrotate.d/sssd


### PR DESCRIPTION
518db322fdd5a4de41813fbe5bc35fc20392ce67 updated service files but missed spec-file.
This results in
```
$ rpm --verify sssd-common-0:2.10.1-1.el10.x86_64
.....U...    /etc/sssd
.....U...    /etc/sssd/conf.d
.....U...    /etc/sssd/pki
```