### PR TITLE
SYSTEMD SERVICE: use "--no-dereference" for 'chown'

### DIFF
--- a/src/sysv/systemd/sssd-kcm.service.in
+++ b/src/sysv/systemd/sssd-kcm.service.in
@@ -9,10 +9,10 @@ Also=sssd-kcm.socket
 
 [Service]
 Environment=DEBUG_LOGGER=--logger=files
-ExecStartPre=+-/bin/chown -f -R root:@SSSD_USER@ @sssdconfdir@
+ExecStartPre=+-/bin/chown -f -R -h root:@SSSD_USER@ @sssdconfdir@
 ExecStartPre=+-/bin/chmod -f -R g+r @sssdconfdir@
-ExecStartPre=+-/bin/sh -c "/bin/chown -f @SSSD_USER@:@SSSD_USER@ @secdbpath@/*.ldb"
-ExecStartPre=+-/bin/chown -f @SSSD_USER@:@SSSD_USER@ @logpath@/sssd_kcm.log
+ExecStartPre=+-/bin/sh -c "/bin/chown -f -h @SSSD_USER@:@SSSD_USER@ @secdbpath@/*.ldb"
+ExecStartPre=+-/bin/chown -f -h @SSSD_USER@:@SSSD_USER@ @logpath@/sssd_kcm.log
 ExecStart=@libexecdir@/sssd/sssd_kcm ${DEBUG_LOGGER}
 CapabilityBoundingSet= CAP_DAC_READ_SEARCH CAP_SETGID CAP_SETUID
 SecureBits=noroot noroot-locked

--- a/src/sysv/systemd/sssd.service.in
+++ b/src/sysv/systemd/sssd.service.in
@@ -10,11 +10,11 @@ StartLimitBurst=5
 [Service]
 Environment=DEBUG_LOGGER=--logger=files
 EnvironmentFile=-@environment_file@
-ExecStartPre=+-/bin/chown -f -R root:@SSSD_USER@ @sssdconfdir@
+ExecStartPre=+-/bin/chown -f -R -h root:@SSSD_USER@ @sssdconfdir@
 ExecStartPre=+-/bin/chmod -f -R g+r @sssdconfdir@
-ExecStartPre=+-/bin/sh -c "/bin/chown -f @SSSD_USER@:@SSSD_USER@ @dbpath@/*.ldb"
-ExecStartPre=+-/bin/chown -f -R @SSSD_USER@:@SSSD_USER@ @gpocachepath@
-ExecStartPre=+-/bin/sh -c "/bin/chown -f @SSSD_USER@:@SSSD_USER@ @logpath@/*.log"
+ExecStartPre=+-/bin/sh -c "/bin/chown -f -h @SSSD_USER@:@SSSD_USER@ @dbpath@/*.ldb"
+ExecStartPre=+-/bin/chown -f -R -h @SSSD_USER@:@SSSD_USER@ @gpocachepath@
+ExecStartPre=+-/bin/sh -c "/bin/chown -f -h @SSSD_USER@:@SSSD_USER@ @logpath@/*.log"
 ExecStart=@sbindir@/sssd -i ${DEBUG_LOGGER}
 Type=notify
 NotifyAccess=main


### PR DESCRIPTION
to avoid following accidential symbolic links in those dirs.