### PR TITLE
Parametrize sssctl tests.

### DIFF
--- a/src/tests/system/tests/test_sssctl.py
+++ b/src/tests/system/tests/test_sssctl.py
@@ -178,7 +178,7 @@ def test_sssctl__check_invalid_option_name_in_snippet(client: Client, contents, 
     :customerscenario: False
     """
     client.sssd.common.local()
-    client.fs.write("/etc/sssd/conf.d/01_snippet.conf", contents, mode="600")
+    client.fs.write("/etc/sssd/conf.d/01_snippet.conf", contents, mode="640")
 
     result = client.sssctl.config_check()
     assert result.rc != 0, "Config-check did not detect misconfigured config snippet"


### PR DESCRIPTION
- Combine various sssctl tests to the single parametrized tests.

1) `test_sssctl__check_invalid_option_name_in_snippet` merges tests:

test_sssctl__check_invalid_option_name_in_snippet
test_sssctl__check_invalid_section_in_name_in_snippet 

2) `test_sssctl__check_invalid_section_name` merges tests:

test_sssctl__check_missing_equal_sign 
test_sssctl__check_invalid_id_provider 
test_sssctl__check_missing_id_provider
test_sssctl__check_special_character_in_option_name
test_sssctl__check_special_character_in_section_name
test_sssctl__check_special_character_in_domain_name
test_sssctl__check_forward_slash_missing_in_domain_section
test_sssctl__check_invalid_sssd_section_name
test_sssctl__check_missing_closing_bracket
test_sssctl__check_missing_opening_bracket

3) `test_sssctl__check_attribute_not_allowed_in_sssd` merges tests:

test_sssctl__check_misplaced_option
test_sssctl__check_ldap_host_object_class_not_allowed_in_sssd

4) `test_sssctl__check_config_location_permissions` merges tests:

test_sssctl__check_non_existing_snippet
test_sssctl__check_non_default_config_location_missing_snippet_directory
test_sssctl__check_invalid_permission
test_sssctl__check_non_default_config_location_invalid_permission
test_sssctl__check_non_default_config_location_invalid_option_name


5) Dropped tests:
test_sssctl__check_invalid_pam_section_name (duplicate test_sssctl__check_invalid_sssd_section_name)
test_sssctl__check_invalid_nss_section_name (duplicate test_sssctl__check_invalid_sssd_section_name)