### PR TITLE
Fixing sssd.service:

### DIFF
--- a/src/sysv/systemd/sssd-kcm.service.in
+++ b/src/sysv/systemd/sssd-kcm.service.in
@@ -13,6 +13,9 @@ Environment=DEBUG_LOGGER=--logger=files
 # '-H' only allows following a command line argument itself, everything else encountered due to '-R' isn't followed.
 ExecStartPre=+-/bin/chown -f -R -H root:@SSSD_USER@ @sssdconfdir@
 ExecStartPre=+-/bin/chmod -f -R g+r @sssdconfdir@
+ExecStartPre=+-/bin/chmod -f g+x @sssdconfdir@
+ExecStartPre=+-/bin/chmod -f g+x @sssdconfdir@/conf.d
+ExecStartPre=+-/bin/chmod -f g+x @sssdconfdir@/pki
 ExecStartPre=+-/bin/sh -c "/bin/chown -f -h @SSSD_USER@:@SSSD_USER@ @secdbpath@/*.ldb"
 ExecStartPre=+-/bin/chown -f -h @SSSD_USER@:@SSSD_USER@ @logpath@/sssd_kcm.log
 ExecStart=@libexecdir@/sssd/sssd_kcm ${DEBUG_LOGGER}

--- a/src/sysv/systemd/sssd-kcm.service.in
+++ b/src/sysv/systemd/sssd-kcm.service.in
@@ -9,7 +9,9 @@ Also=sssd-kcm.socket
 
 [Service]
 Environment=DEBUG_LOGGER=--logger=files
-ExecStartPre=+-/bin/chown -f -R -h root:@SSSD_USER@ @sssdconfdir@
+# '-H' is used with @sssdconfdir@ to support use case where /etc/sssd is a symlink.
+# '-H' only allows following a command line argument itself, everything else encountered due to '-R' isn't followed.
+ExecStartPre=+-/bin/chown -f -R -H root:@SSSD_USER@ @sssdconfdir@
 ExecStartPre=+-/bin/chmod -f -R g+r @sssdconfdir@
 ExecStartPre=+-/bin/sh -c "/bin/chown -f -h @SSSD_USER@:@SSSD_USER@ @secdbpath@/*.ldb"
 ExecStartPre=+-/bin/chown -f -h @SSSD_USER@:@SSSD_USER@ @logpath@/sssd_kcm.log

--- a/src/sysv/systemd/sssd.service.in
+++ b/src/sysv/systemd/sssd.service.in
@@ -14,6 +14,9 @@ EnvironmentFile=-@environment_file@
 # '-H' only allows following a command line argument itself, everything else encountered due to '-R' isn't followed.
 ExecStartPre=+-/bin/chown -f -R -H root:@SSSD_USER@ @sssdconfdir@
 ExecStartPre=+-/bin/chmod -f -R g+r @sssdconfdir@
+ExecStartPre=+-/bin/chmod -f g+x @sssdconfdir@
+ExecStartPre=+-/bin/chmod -f g+x @sssdconfdir@/conf.d
+ExecStartPre=+-/bin/chmod -f g+x @sssdconfdir@/pki
 ExecStartPre=+-/bin/sh -c "/bin/chown -f -h @SSSD_USER@:@SSSD_USER@ @dbpath@/*.ldb"
 ExecStartPre=+-/bin/chown -f -R -h @SSSD_USER@:@SSSD_USER@ @gpocachepath@
 ExecStartPre=+-/bin/sh -c "/bin/chown -f -h @SSSD_USER@:@SSSD_USER@ @logpath@/*.log"

--- a/src/sysv/systemd/sssd.service.in
+++ b/src/sysv/systemd/sssd.service.in
@@ -10,7 +10,9 @@ StartLimitBurst=5
 [Service]
 Environment=DEBUG_LOGGER=--logger=files
 EnvironmentFile=-@environment_file@
-ExecStartPre=+-/bin/chown -f -R -h root:@SSSD_USER@ @sssdconfdir@
+# '-H' is used with @sssdconfdir@ to support use case where /etc/sssd is a symlink.
+# '-H' only allows following a command line argument itself, everything else encountered due to '-R' isn't followed.
+ExecStartPre=+-/bin/chown -f -R -H root:@SSSD_USER@ @sssdconfdir@
 ExecStartPre=+-/bin/chmod -f -R g+r @sssdconfdir@
 ExecStartPre=+-/bin/sh -c "/bin/chown -f -h @SSSD_USER@:@SSSD_USER@ @dbpath@/*.ldb"
 ExecStartPre=+-/bin/chown -f -R -h @SSSD_USER@:@SSSD_USER@ @gpocachepath@


### PR DESCRIPTION
 - traverse 'sssdconfdir' symlink while chown-ing (#7781)
 - fix missing 'g+x' on /etc/sssd and subdirs