### PR TITLE
SSH: sss_ssh_knownhost must succeed if the responder is stopped

### DIFF
--- a/src/man/sss_ssh_knownhosts.1.xml
+++ b/src/man/sss_ssh_knownhosts.1.xml
@@ -50,6 +50,9 @@
             <refentrytitle>ssh_config</refentrytitle><manvolnum>5</manvolnum>
             </citerefentry> man page for more details about this option.
         </para>
+        <para>
+            This tool requires that SSSD's ssh service is enabled to work properly.
+        </para>
     </refsect1>
 
     <refsect1 id='options'>
@@ -112,8 +115,9 @@
     <refsect1 id='exit_status'>
         <title>EXIT STATUS</title>
         <para>
-            In case of successful execution, even if no key was found, 0 is
-            returned. 1 is returned in case of error.
+            In case of successful execution, even if no key was found for that
+            host or if the ssh responder could not be contacted, 0 is returned.
+            1 is returned in case of any other error.
         </para>
     </refsect1>
 


### PR DESCRIPTION
`sss_ssh_knownhosts` requires that SSSD's 'ssh' service is launched to work properly. But if it is not launched or it is anyhow stopped, the tool MUST NOT fail and let the ssh client continue its job.

