### PR TITLE
PAM: don't set PR_SET_DUMPABLE

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -713,6 +713,14 @@
                                 prctl:PR_SET_DUMPABLE for details.
                             </para>
                             <para>
+                                Take a note that this setting has no effect
+                                for 'ldap_child', 'krb5_child' and 'sssd_pam'
+                                as those privileged binaries can have a copy
+                                of a host keytab data in a memory and their
+                                behavior in this regards is governed by
+                                /proc/sys/fs/suid_dumpable system setting.
+                            </para>
+                            <para>
                                 Default: true
                             </para>
                         </listitem>


### PR DESCRIPTION
to avoid leaking host keytab accidentially.

Take a note that this is rather a general precaution than a fix of a real threat since normally those coredumps wouldn't be accessible to non-privileged user anyway.

This is an addition to https://github.com/SSSD/sssd/pull/7755