### PR TITLE
PAM: fix issue found by Coverity

### DIFF
--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -1612,7 +1612,7 @@ static int send_and_receive(pam_handle_t *pamh, struct pam_items *pi,
             break;
         default:
             D(("Illegal task [%#x]", task));
-            return PAM_SYSTEM_ERR;
+            pam_status = PAM_SYSTEM_ERR;
     }
 
 done:


### PR DESCRIPTION
```
1614            D(("Illegal task [%#x]", task));
       9. out_of_scope: Variable buf goes out of scope.

CID 530049: (#1 of 1): Resource leak (RESOURCE_LEAK)
10. leaked_storage: Variable rd going out of scope leaks the storage rd.data points to.
1615            return PAM_SYSTEM_ERR;
1616    }
```