### PR TITLE
CI: Fix coverity label multiline conditional

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -19,8 +19,8 @@ concurrency:
 jobs:
   coverity:
     if: |
-      ${{ github.event_name == 'schedule' }} ||
-      ${{ github.event.label.name == 'coverity' && github.event_name == 'pull_request_target' }}
+      github.event_name == 'schedule' ||
+      (github.event.label.name == 'coverity' && github.event_name == 'pull_request_target')
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Coverity job is currently triggered when any label is added, unexpectedly.

Per https://github.com/orgs/community/discussions/25641#discussioncomment-3248571

`Note: if you use “${{ }}” to surround the condition, this will not work.`

Multi-line if conditional does not work with ${{ }} expansion:

