### PR TITLE
doc: improve description of ldap_disable_range_retrieval

### DIFF
--- a/src/man/sssd-ldap.5.xml
+++ b/src/man/sssd-ldap.5.xml
@@ -692,13 +692,17 @@
                             Disable Active Directory range retrieval.
                         </para>
                         <para>
-                            Active Directory limits the number of members to be
+                            Active Directory limits the number of members that can be
                             retrieved in a single lookup using the MaxValRange
-                            policy (which defaults to 1500 members). If a group
-                            contains more members, the reply would include an
-                            AD-specific range extension. This option disables
-                            parsing of the range extension, therefore large
-                            groups will appear as having no members.
+                            policy, which defaults to 1500 members. If a group
+                            contains more than 1500 members, the reply includes
+                            an AD-specific range extension. When enabled,
+                            this option prevents SSSD from parsing the range
+                            extension. As a result large groups will appear as they
+                            have no members.
+                            This option does not enable SSSD to read subsequent
+                            ranges. To retrieve all members of a group, you must
+                            increase the MaxValRange setting in Active Directory.
                         </para>
                         <para>
                             Default: False


### PR DESCRIPTION
Revised the description of the `ldap_disable_range_retrieval` option to clarify the how to get a full group member list when groups exceed 1500 members.