### PR TITLE
KCM: fix memory leak

### DIFF
--- a/src/responder/kcm/secrets/secrets.c
+++ b/src/responder/kcm/secrets/secrets.c
@@ -1030,7 +1030,7 @@ errno_t sss_sec_put(struct sss_sec_req *req,
     }
 
     secret_val.length = secret_len;
-    secret_val.data = talloc_memdup(req->sctx, secret, secret_len);
+    secret_val.data = talloc_memdup(msg, secret, secret_len);
     if (!secret_val.data) {
         ret = ENOMEM;
         goto done;
@@ -1135,7 +1135,7 @@ errno_t sss_sec_update(struct sss_sec_req *req,
     }
 
     secret_val.length = secret_len;
-    secret_val.data = talloc_memdup(req->sctx, secret, secret_len);
+    secret_val.data = talloc_memdup(msg, secret, secret_len);
     if (!secret_val.data) {
         ret = ENOMEM;
         goto done;


### PR DESCRIPTION
`ldb_msg_add_value()` makes a copy under the hood, so `secret_val.data` was left hanging on `sss_sec_ctx`.