### PR TITLE
RESPONDER: remove unreachable code

### DIFF
--- a/src/responder/common/responder_get_domains.c
+++ b/src/responder/common/responder_get_domains.c
@@ -144,7 +144,6 @@ struct tevent_req *sss_dp_get_domains_send(TALLOC_CTX *mem_ctx,
     struct tevent_req *req;
     struct tevent_req *subreq;
     struct sss_dp_get_domains_state *state;
-    bool refresh_timeout = false;
 
     req = tevent_req_create(mem_ctx, &state, struct sss_dp_get_domains_state);
     if (req == NULL) {
@@ -169,7 +168,6 @@ struct tevent_req *sss_dp_get_domains_send(TALLOC_CTX *mem_ctx,
             goto immediately;
         }
     }
-    refresh_timeout = true;
 
     state->rctx = rctx;
     if (hint != NULL) {
@@ -195,9 +193,6 @@ struct tevent_req *sss_dp_get_domains_send(TALLOC_CTX *mem_ctx,
 
 immediately:
     if (ret == EOK) {
-        if (refresh_timeout) {
-            set_time_of_last_request(rctx);
-        }
         tevent_req_done(req);
     } else {
         tevent_req_error(req, ret);


### PR DESCRIPTION
At 'immediately:' when condition (ret == EOK) is met, 'refresh_timeout' can't be 'true', so code can't be reached.

It was different before 827a9bffacc500fbfc71c6454285298dc99982a3