### PR TITLE
BUILD: introduce "--with-syslog=stderr" option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,10 @@ if WITH_JOURNALD
     extra_distcheck_flags += --with-syslog=journald
 endif
 
+if WITH_STDERR_SYSLOG
+    extra_distcheck_flags += --with-syslog=stderr
+endif
+
 DISTCHECK_CONFIGURE_FLAGS = --with-ldb-lib-dir="$$dc_install_base"/lib/ldb \
                             $(extra_distcheck_flags) \
                             $(AUX_DISTCHECK_CONFIGURE_FLAGS)

--- a/src/conf_macros.m4
+++ b/src/conf_macros.m4
@@ -144,7 +144,7 @@ AC_DEFUN([WITH_INITSCRIPT],
 AC_DEFUN([WITH_SYSLOG],
   [ AC_ARG_WITH([syslog],
                 [AC_HELP_STRING([--with-syslog=SYSLOG_TYPE],
-                                [Type of your system logger (syslog|journald). [syslog]]
+                                [Type of your system logger (syslog|journald|stderr). [syslog]]
                                )
                 ],
                 [],
@@ -152,13 +152,18 @@ AC_DEFUN([WITH_SYSLOG],
                )
 
   if test x"$with_syslog" = xsyslog || \
-     test x"$with_syslog" = xjournald; then
+     test x"$with_syslog" = xjournald || \
+     test x"$with_syslog" = xstderr; then
         syslog=$with_syslog
   else
-      AC_MSG_ERROR([Unknown syslog type, supported types are syslog and journald])
+      AC_MSG_ERROR([Unknown syslog type, supported types are syslog, journald and stderr])
   fi
 
   AM_CONDITIONAL([WITH_JOURNALD], [test x"$syslog" = xjournald])
+  AM_CONDITIONAL([WITH_STDERR_SYSLOG], [test x"$syslog" = xstderr])
+  if test x"$with_syslog" = xstderr; then
+      AC_DEFINE_UNQUOTED([WITH_STDERR_SYSLOG], 1, [Send syslog to stderr])
+  fi
   ])
 
 AC_DEFUN([WITH_ENVIRONMENT_FILE],


### PR DESCRIPTION
to be used in containers-like environments where
no system wide logger is available.