### PR TITLE
ldap: Fix nesting level comparison, again

### DIFF
--- a/src/providers/ldap/sdap_async_initgroups.c
+++ b/src/providers/ldap/sdap_async_initgroups.c
@@ -2288,7 +2288,7 @@ struct tevent_req *rfc2307bis_nested_groups_send(
     if (!req) return NULL;
 
     if ((num_groups == 0) ||
-        (nesting > dp_opt_get_int(opts->basic, SDAP_NESTING_LEVEL))) {
+        (nesting >= dp_opt_get_int(opts->basic, SDAP_NESTING_LEVEL))) {
         /* No parent groups to process or too deep*/
         ret = EOK;
         goto done;


### PR DESCRIPTION
This was reverted previously due to:

It broke a test for enumerate nested groups if they are part
 of non POSIX groups https://pagure.io/SSSD/sssd/issue/2406

Users are still having issues with the nesting level however for rfc2307bis