### PR TITLE
CI: update list of target platforms

### DIFF
--- a/.github/workflows/copr_build.yml
+++ b/.github/workflows/copr_build.yml
@@ -69,8 +69,7 @@ jobs:
       uses: next-actions/copr/filter-chroots@master
       with:
         coprcfg: ${{ steps.copr.outputs.coprcfg }}
-        filter: "fedora-.+-x86_64|centos-stream-.*-x86_64"
-        exclude: "fedora-eln-.+|fedora-38-x86_64|fedora-41-x86_64|fedora-42-x86_64|fedora-rawhide-x86_64|centos-stream-10-x86_64"
+        filter: "fedora-40-x86_64|centos-stream-9-x86_64"
 
     - name: Create copr project
       uses: next-actions/copr/create-project@master
@@ -94,12 +93,6 @@ jobs:
       env:
         coprcfg: ${{ steps.copr.outputs.coprcfg }}
       run: |
-        # CentOS Stream 8
-        copr-cli --config "$coprcfg" edit-chroot                                                        \
-          --repos 'https://kojihub.stream.centos.org/kojifiles/repos/c8s-build/latest/$basearch'        \
-          --modules idm:DL1                                                                             \
-          $COPR_ACCOUNT/$COPR_PROJECT/centos-stream-8-x86_64
-
         # CentOS Stream 9
         copr-cli --config "$coprcfg" edit-chroot                                                  \
           --repos 'https://kojihub.stream.centos.org/kojifiles/repos/c9s-build/latest/$basearch/' \

--- a/contrib/ci/get-matrix.py
+++ b/contrib/ci/get-matrix.py
@@ -15,7 +15,7 @@ import os
 
 def get_fedora_matrix():
     # Fedora 41 and up are using 2.10, Fedora 38 and older are EOL
-    return ['fedora-39', 'fedora-40']
+    return ['fedora-40']
 
 
 def get_centos_matrix():


### PR DESCRIPTION
C8S buildroot isn't available and F39 isn't supported.