### PR TITLE
configure: Require valgrind-devel when valgrind is enabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -537,6 +537,13 @@ AM_CHECK_PAM_WRAPPER
 AM_CHECK_TEST_CA
 AX_VALGRIND_CHECK
 
+AS_IF([test x$VALGRIND_ENABLED = xyes], [
+    AC_CHECK_HEADERS([valgrind/valgrind.h],,AC_MSG_ERROR([valgrind-devel required with valgrind enabled]))
+], [
+    AC_CHECK_HEADERS([valgrind/valgrind.h])
+])
+
+
 # Check if the user wants SSSD to be compiled with systemtap probes
 AM_CHECK_SYSTEMTAP
 

--- a/src/tests/cmocka/test_iobuf.c
+++ b/src/tests/cmocka/test_iobuf.c
@@ -20,6 +20,8 @@
 */
 #define _GNU_SOURCE                /* For memmem() */
 
+#include "config.h"
+
 #include <stdio.h>
 #include <fcntl.h>
 #include <errno.h>
@@ -28,7 +30,9 @@
 #include <string.h>
 #include <stddef.h>
 #include <setjmp.h>
+#ifdef HAVE_VALGRIND_VALGRIND_H
 #include <valgrind/valgrind.h>
+#endif
 #include <cmocka.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
@@ -187,11 +191,13 @@ static void test_sss_iobuf_secure(void **state)
     struct sss_iobuf *iobuf_secret_2;
     struct sss_iobuf *iobuf_nosecret;
 
+#ifdef HAVE_VALGRIND_VALGRIND_H
     /* Valgrind interferes with this test by somehow making disappear the heap.
      * So don't run it on Valgrind. */
     if (RUNNING_ON_VALGRIND) {
         skip();
     }
+#endif
 
 
     mem_ctx = talloc_new(NULL);


### PR DESCRIPTION
Currently we include `<valgrind/valgrind.h>` unconditionally to access the `RUNNING_ON_VALGRIND` macro, which allows us to skip one of the tests which is known not to work correctly under valgrind.

However, if only the runtime part of valgrind in installed on the system and the devel part is missing, this will result in a very late compilation error. Checking for the header's presence at configure time allows us to provide better diagnostics, earlier.

More importantly, this makes it possible to build sssd at all on architectures where valgrind is not yet available, such as riscv64.