### PR TITLE
ipa: Set proper SDAP_KRB5_REALM for subdomain options

### DIFF
--- a/src/providers/ipa/ipa_common.c
+++ b/src/providers/ipa/ipa_common.c
@@ -1499,10 +1499,6 @@ ipa_create_trust_options(TALLOC_CTX *mem_ctx,
         }
     }
 
-    /* Set IPA KRB5 realm */
-    ret = dp_opt_set_string(ipa_options->id->basic,
-                            IPA_KRB5_REALM, subdom->realm);
-
     /* Set SDAP_SASL_AUTHID to the trust principal */
     ret = dp_opt_set_string(ipa_options->id->basic,
                             SDAP_SASL_AUTHID, sasl_authid);

--- a/src/providers/ipa/ipa_subdomains_server.c
+++ b/src/providers/ipa/ipa_subdomains_server.c
@@ -697,7 +697,7 @@ ipa_ctx_new(struct be_ctx *be_ctx,
     }
 
     ret = domain_to_basedn(be_ctx,
-                           dp_opt_get_string(ipa_options->id->basic, IPA_KRB5_REALM),
+                           dp_opt_get_string(ipa_options->basic, IPA_DOMAIN),
                            &basedn);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "domain_to_basedn failure\n");


### PR DESCRIPTION
Creating this as draft so I can test this does not break IPA IPA trust