### PR TITLE
Pattern support for dyndns_iface option

### DIFF
--- a/src/man/sssd-ad.5.xml
+++ b/src/man/sssd-ad.5.xml
@@ -1227,15 +1227,16 @@ ad_gpo_map_deny = +my_pam_service
                             Optional. Applicable only when dyndns_update
                             is true. Choose the interface or a list of interfaces
                             whose IP addresses should be used for dynamic DNS
-                            updates. Special value <quote>*</quote> implies that
-                            IPs from all interfaces should be used.
+                            updates. The name of interface can be a wildcard
+                            pattern. See <emphasis>man 7 glob</emphasis> for
+                            details about patterns.
                         </para>
                         <para>
                             Default: Use the IP addresses of the interface which
                             is used for AD LDAP connection
                         </para>
                         <para>
-                            Example: dyndns_iface = em1, vnet1, vnet2
+                            Example: dyndns_iface = em1, vnet?, vpn*
                         </para>
                     </listitem>
                 </varlistentry>

--- a/src/man/sssd-ipa.5.xml
+++ b/src/man/sssd-ipa.5.xml
@@ -181,8 +181,9 @@
                             Optional. Applicable only when dyndns_update
                             is true. Choose the interface or a list of interfaces
                             whose IP addresses should be used for dynamic DNS
-                            updates. Special value <quote>*</quote> implies that
-                            IPs from all interfaces should be used.
+                            updates. The name of interface can be a wildcard
+                            pattern. See <emphasis>man 7 glob</emphasis> for
+                            details about patterns.
                         </para>
                         <para>
                             NOTE: While it is still possible to use the old

--- a/src/providers/be_dyndns.c
+++ b/src/providers/be_dyndns.c
@@ -30,6 +30,7 @@
 #include <arpa/inet.h>
 #include <net/if.h>
 #include <ifaddrs.h>
+#include <fnmatch.h>
 #include <ctype.h>
 #include "util/debug.h"
 #include "util/util.h"
@@ -43,9 +44,6 @@
 #ifndef DYNDNS_TIMEOUT
 #define DYNDNS_TIMEOUT 15
 #endif /* DYNDNS_TIMEOUT */
-
-/* MASK represents special value for matching all interfaces */
-#define MASK "*"
 
 struct sss_iface_addr {
     struct sss_iface_addr *next;
@@ -189,9 +187,9 @@ static bool supported_address_family(sa_family_t sa_family)
     return sa_family == AF_INET || sa_family == AF_INET6;
 }
 
-static bool matching_name(const char *ifname, const char *ifname2)
+static bool matching_name(const char *ifname, const char *ifname_pattern)
 {
-    return (strcmp(MASK, ifname) == 0) || (strcasecmp(ifname, ifname2) == 0);
+    return fnmatch(ifname_pattern, ifname, 0) == 0;
 }
 
 /* Collect IP addresses associated with an interface */
@@ -224,7 +222,7 @@ sss_iface_addr_list_get(TALLOC_CTX *mem_ctx, const char *ifname,
 
         /* Add IP addresses to the list */
         if (supported_address_family(ifa->ifa_addr->sa_family)
-                && matching_name(ifname, ifa->ifa_name)
+                && matching_name(ifa->ifa_name, ifname)
                 && ok_for_dns(ifa->ifa_addr)) {
 
             /* Add this address to the IP address list */


### PR DESCRIPTION
:config:Until now dyndns_iface option supported only "*" for all interfaces or exact names. With this update it is possible to use shell wildcard patterns (e. g. eth*, eth[01], ...).