### PR TITLE
Properly check valgrind arches

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -169,7 +169,9 @@ BuildRequires: systemtap-sdt-dtrace
 %endif
 BuildRequires: uid_wrapper
 BuildRequires: po4a
+%ifarch %{valgrind_arches}
 BuildRequires: valgrind-devel
+%endif
 %if %{build_subid}
 BuildRequires: shadow-utils-subid-devel
 %endif


### PR DESCRIPTION
Needed to build successfully on riscv64.

Same as https://src.fedoraproject.org/rpms/sssd/pull-request/64