### PR TITLE
SYSDB: perf improvements in sysdb_add_group_member_overrides(), part 2

### DIFF
--- a/src/db/sysdb_views.c
+++ b/src/db/sysdb_views.c
@@ -1661,7 +1661,7 @@ errno_t sysdb_add_group_member_overrides(struct sss_domain_info *domain,
     struct ldb_result *res_members;
     TALLOC_CTX *tmp_ctx;
     struct ldb_result *override_obj;
-    static const char *member_attrs[] = SYSDB_PW_ATTRS;
+    static const char *member_attrs[] = { SYSDB_NAME, NULL };
     struct ldb_dn *override_dn = NULL;
     const char *memberuid;
     const char *val;

--- a/src/db/sysdb_views.c
+++ b/src/db/sysdb_views.c
@@ -1773,7 +1773,7 @@ errno_t sysdb_add_group_member_overrides(struct sss_domain_info *domain,
 
         val = talloc_steal(obj, memberuid);
         if (val == NULL) {
-            DEBUG(SSSDBG_OP_FAILURE, "talloc_strdup failed.\n");
+            DEBUG(SSSDBG_OP_FAILURE, "talloc_steal() failed.\n");
             ret = ENOMEM;
             goto done;
         }

--- a/src/db/sysdb_views.c
+++ b/src/db/sysdb_views.c
@@ -1584,8 +1584,8 @@ static errno_t get_user_members_recursively(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    ret = sysdb_search_entry(tmp_ctx, dom->sysdb, base_dn, LDB_SCOPE_SUBTREE,
-                             filter, attrs, &count, &msgs);
+    ret = sysdb_cache_search_entry(tmp_ctx, dom->sysdb->ldb, base_dn, LDB_SCOPE_SUBTREE,
+                                   filter, attrs, &count, &msgs);
     if (ret != EOK) {
         goto done;
     }

--- a/src/db/sysdb_views.c
+++ b/src/db/sysdb_views.c
@@ -1760,7 +1760,8 @@ errno_t sysdb_add_group_member_overrides(struct sss_domain_info *domain,
             }
 
             if (memberuid == NULL) {
-                DEBUG(SSSDBG_TRACE_ALL, "No override name available.\n");
+                DEBUG_CONDITIONAL(SSSDBG_TRACE_ALL, "No override name available for %s.\n",
+                                  orig_name);
                 memberuid = orig_name;
             } else {
                 /* add domain name if memberuid is a short name */
@@ -1784,9 +1785,9 @@ errno_t sysdb_add_group_member_overrides(struct sss_domain_info *domain,
             ret = sysdb_error_to_errno(ret);
             goto done;
         }
-        DEBUG(SSSDBG_TRACE_ALL, "Added [%s] to [%s].\n", memberuid,
-                                OVERRIDE_PREFIX SYSDB_MEMBERUID);
-
+        DEBUG_CONDITIONAL(SSSDBG_TRACE_ALL,
+                          "Added [%s] to ["OVERRIDE_PREFIX SYSDB_MEMBERUID"].\n",
+                          memberuid);
     }
 
     ret = EOK;

--- a/src/db/sysdb_views.c
+++ b/src/db/sysdb_views.c
@@ -1670,6 +1670,15 @@ errno_t sysdb_add_group_member_overrides(struct sss_domain_info *domain,
         return EOK;
     }
 
+    if (ldb_msg_find_element(obj, SYSDB_MEMBERUID) == NULL) {
+        /* empty memberUid list means there are no user objects in
+         * the cache that would have 'memberOf = obj->dn',
+         * so get_user_members_recursively() will return an empty list
+         * anyway (but may consume a lot of CPU in case of a large cache)
+         */
+        return EOK;
+    }
+
     tmp_ctx = talloc_new(NULL);
     if (tmp_ctx == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "talloc_new failed.\n");

--- a/src/responder/common/cache_req/plugins/cache_req_group_by_filter.c
+++ b/src/responder/common/cache_req/plugins/cache_req_group_by_filter.c
@@ -32,7 +32,7 @@ cache_req_group_by_filter_prepare_domain_data(struct cache_req *cr,
                                               struct sss_domain_info *domain)
 {
     TALLOC_CTX *tmp_ctx;
-    const char *name;
+    char *name;
     errno_t ret;
 
     if (cr->data->name.name == NULL) {
@@ -52,11 +52,7 @@ cache_req_group_by_filter_prepare_domain_data(struct cache_req *cr,
         goto done;
     }
 
-    name = sss_reverse_replace_space(tmp_ctx, name, cr->rctx->override_space);
-    if (name == NULL) {
-        ret = ENOMEM;
-        goto done;
-    }
+    sss_reverse_replace_space_inplace(name, cr->rctx->override_space);
 
     talloc_zfree(data->name.lookup);
     data->name.lookup = talloc_steal(data, name);

--- a/src/responder/common/cache_req/plugins/cache_req_group_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_group_by_name.c
@@ -32,7 +32,7 @@ cache_req_group_by_name_prepare_domain_data(struct cache_req *cr,
                                             struct sss_domain_info *domain)
 {
     TALLOC_CTX *tmp_ctx;
-    const char *name;
+    char *name;
     errno_t ret;
 
     if (cr->data->name.name == NULL) {
@@ -52,11 +52,7 @@ cache_req_group_by_name_prepare_domain_data(struct cache_req *cr,
         goto done;
     }
 
-    name = sss_reverse_replace_space(tmp_ctx, name, cr->rctx->override_space);
-    if (name == NULL) {
-        ret = ENOMEM;
-        goto done;
-    }
+    sss_reverse_replace_space_inplace(name, cr->rctx->override_space);
 
     name = sss_create_internal_fqname(tmp_ctx, name, domain->name);
     if (name == NULL) {

--- a/src/responder/common/cache_req/plugins/cache_req_initgroups_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_initgroups_by_name.c
@@ -32,7 +32,7 @@ cache_req_initgroups_by_name_prepare_domain_data(struct cache_req *cr,
                                                  struct sss_domain_info *domain)
 {
     TALLOC_CTX *tmp_ctx;
-    const char *name;
+    char *name;
     errno_t ret;
 
     if (cr->data->name.name == NULL) {
@@ -52,11 +52,7 @@ cache_req_initgroups_by_name_prepare_domain_data(struct cache_req *cr,
         goto done;
     }
 
-    name = sss_reverse_replace_space(tmp_ctx, name, cr->rctx->override_space);
-    if (name == NULL) {
-        ret = ENOMEM;
-        goto done;
-    }
+    sss_reverse_replace_space_inplace(name, cr->rctx->override_space);
 
     name = sss_create_internal_fqname(tmp_ctx, name, domain->name);
     if (name == NULL) {

--- a/src/responder/common/cache_req/plugins/cache_req_object_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_object_by_name.c
@@ -76,7 +76,7 @@ cache_req_object_by_name_prepare_domain_data(struct cache_req *cr,
                                              struct sss_domain_info *domain)
 {
     TALLOC_CTX *tmp_ctx;
-    const char *name;
+    char *name;
     errno_t ret;
 
     if (cr->data->name.name == NULL) {
@@ -96,11 +96,7 @@ cache_req_object_by_name_prepare_domain_data(struct cache_req *cr,
         goto done;
     }
 
-    name = sss_reverse_replace_space(tmp_ctx, name, cr->rctx->override_space);
-    if (name == NULL) {
-        ret = ENOMEM;
-        goto done;
-    }
+    sss_reverse_replace_space_inplace(name, cr->rctx->override_space);
 
     name = sss_create_internal_fqname(tmp_ctx, name, domain->name);
     if (name == NULL) {

--- a/src/responder/common/cache_req/plugins/cache_req_subid_ranges_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_subid_ranges_by_name.c
@@ -30,7 +30,7 @@ cache_req_subid_ranges_by_name_prepare_domain_data(struct cache_req *cr,
                                                    struct sss_domain_info *domain)
 {
     TALLOC_CTX *tmp_ctx;
-    const char *name;
+    char *name;
     errno_t ret;
 
     if (cr->data->name.name == NULL) {
@@ -50,11 +50,7 @@ cache_req_subid_ranges_by_name_prepare_domain_data(struct cache_req *cr,
         goto done;
     }
 
-    name = sss_reverse_replace_space(tmp_ctx, name, cr->rctx->override_space);
-    if (name == NULL) {
-        ret = ENOMEM;
-        goto done;
-    }
+    sss_reverse_replace_space_inplace(name, cr->rctx->override_space);
 
     talloc_zfree(data->name.lookup);
     data->name.lookup = talloc_steal(data, name);

--- a/src/responder/common/cache_req/plugins/cache_req_user_by_filter.c
+++ b/src/responder/common/cache_req/plugins/cache_req_user_by_filter.c
@@ -32,7 +32,7 @@ cache_req_user_by_filter_prepare_domain_data(struct cache_req *cr,
                                              struct sss_domain_info *domain)
 {
     TALLOC_CTX *tmp_ctx;
-    const char *name;
+    char *name;
     errno_t ret;
 
     if (cr->data->name.name == NULL) {
@@ -52,11 +52,7 @@ cache_req_user_by_filter_prepare_domain_data(struct cache_req *cr,
         goto done;
     }
 
-    name = sss_reverse_replace_space(tmp_ctx, name, cr->rctx->override_space);
-    if (name == NULL) {
-        ret = ENOMEM;
-        goto done;
-    }
+    sss_reverse_replace_space_inplace(name, cr->rctx->override_space);
 
     talloc_zfree(data->name.lookup);
     data->name.lookup = talloc_steal(data, name);

--- a/src/responder/common/cache_req/plugins/cache_req_user_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_user_by_name.c
@@ -32,7 +32,7 @@ cache_req_user_by_name_prepare_domain_data(struct cache_req *cr,
                                            struct sss_domain_info *domain)
 {
     TALLOC_CTX *tmp_ctx;
-    const char *name;
+    char *name;
     errno_t ret;
 
     if (cr->data->name.name == NULL) {
@@ -52,11 +52,7 @@ cache_req_user_by_name_prepare_domain_data(struct cache_req *cr,
         goto done;
     }
 
-    name = sss_reverse_replace_space(tmp_ctx, name, cr->rctx->override_space);
-    if (name == NULL) {
-        ret = ENOMEM;
-        goto done;
-    }
+    sss_reverse_replace_space_inplace(name, cr->rctx->override_space);
 
     name = sss_create_internal_fqname(tmp_ctx, name, domain->name);
     if (name == NULL) {

--- a/src/responder/common/negcache.c
+++ b/src/responder/common/negcache.c
@@ -96,7 +96,7 @@ static int sss_ncache_check_str(struct sss_nc_ctx *ctx, char *str)
     char *ep;
     int ret;
 
-    DEBUG(SSSDBG_TRACE_INTERNAL, "Checking negative cache for [%s]\n", str);
+    DEBUG_CONDITIONAL(SSSDBG_TRACE_INTERNAL, "Checking negative cache for [%s]\n", str);
 
     data.dptr = NULL;
 

--- a/src/responder/common/responder.h
+++ b/src/responder/common/responder.h
@@ -362,12 +362,6 @@ errno_t sss_parse_inp_recv(struct tevent_req *req, TALLOC_CTX *mem_ctx,
 const char **parse_attr_list_ex(TALLOC_CTX *mem_ctx, const char *conf_str,
                                 const char **defaults);
 
-char *sss_resp_create_fqname(TALLOC_CTX *mem_ctx,
-                             struct resp_ctx *rctx,
-                             struct sss_domain_info *dom,
-                             bool name_is_upn,
-                             const char *orig_name);
-
 errno_t sss_resp_populate_cr_domains(struct resp_ctx *rctx);
 
 const char *

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -1692,37 +1692,20 @@ int sized_domain_name(TALLOC_CTX *mem_ctx,
                       const char *member_name,
                       struct sized_string **_name)
 {
-    TALLOC_CTX *tmp_ctx = NULL;
-    errno_t ret;
-    char *domname;
+    const char *domain;
     struct sss_domain_info *member_dom;
 
-    tmp_ctx = talloc_new(NULL);
-    if (tmp_ctx == NULL) {
-        return ENOMEM;
-    }
-
-    ret = sss_parse_internal_fqname(tmp_ctx, member_name, NULL, &domname);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "sss_parse_internal_fqname failed\n");
-        goto done;
-    }
-
-    if (domname == NULL) {
-        ret = ERR_WRONG_NAME_FORMAT;
-        goto done;
+    domain = sss_get_domain_internal_fqname(member_name);
+    if (domain == NULL) {
+        return ERR_WRONG_NAME_FORMAT;
     }
 
     member_dom = find_domain_by_name(get_domains_head(rctx->domains),
-                                     domname, true);
+                                     domain, true);
     if (member_dom == NULL) {
-        ret = ERR_DOMAIN_NOT_FOUND;
-        goto done;
+        return ERR_DOMAIN_NOT_FOUND;
     }
 
-    ret = sized_output_name(mem_ctx, rctx, member_name,
-                            member_dom, _name);
-done:
-    talloc_free(tmp_ctx);
-    return ret;
+    return sized_output_name(mem_ctx, rctx, member_name,
+                             member_dom, _name);
 }

--- a/src/responder/common/responder_common.c
+++ b/src/responder/common/responder_common.c
@@ -1657,20 +1657,13 @@ int sized_output_name(TALLOC_CTX *mem_ctx,
                       struct sss_domain_info *name_dom,
                       struct sized_string **_name)
 {
-    TALLOC_CTX *tmp_ctx = NULL;
     errno_t ret;
     char *name_str;
     struct sized_string *name;
 
-    tmp_ctx = talloc_new(NULL);
-    if (tmp_ctx == NULL) {
-        return ENOMEM;
-    }
-
-    name = talloc_zero(tmp_ctx, struct sized_string);
+    name = talloc_zero(mem_ctx, struct sized_string);
     if (name == NULL) {
-        ret = ENOMEM;
-        goto done;
+        return ENOMEM;
     }
 
     ret = sss_output_fqname(name, name_dom, orig_name,
@@ -1680,10 +1673,15 @@ int sized_output_name(TALLOC_CTX *mem_ctx,
     }
 
     to_sized_string(name, name_str);
-    *_name = talloc_steal(mem_ctx, name);
     ret = EOK;
+
 done:
-    talloc_zfree(tmp_ctx);
+    if (ret == EOK) {
+        *_name = name;
+    } else {
+        talloc_free(name);
+    }
+
     return ret;
 }
 

--- a/src/responder/common/responder_utils.c
+++ b/src/responder/common/responder_utils.c
@@ -155,49 +155,6 @@ done:
     return res;
 }
 
-char *sss_resp_create_fqname(TALLOC_CTX *mem_ctx,
-                             struct resp_ctx *rctx,
-                             struct sss_domain_info *dom,
-                             bool name_is_upn,
-                             const char *orig_name)
-{
-    TALLOC_CTX *tmp_ctx;
-    char *name;
-
-    tmp_ctx = talloc_new(NULL);
-    if (tmp_ctx == NULL) {
-        return NULL;
-    }
-
-    name = sss_get_cased_name(tmp_ctx, orig_name, dom->case_sensitive);
-    if (name == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "sss_get_cased_name failed\n");
-        talloc_free(tmp_ctx);
-        return NULL;
-    }
-
-    name = sss_reverse_replace_space(tmp_ctx, name, rctx->override_space);
-    if (name == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "sss_reverse_replace_space failed\n");
-        talloc_free(tmp_ctx);
-        return NULL;
-    }
-
-
-    if (name_is_upn == false) {
-        name = sss_create_internal_fqname(tmp_ctx, name, dom->name);
-        if (name == NULL) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "sss_create_internal_fqname failed\n");
-            talloc_free(tmp_ctx);
-            return NULL;
-        }
-    }
-
-    name = talloc_steal(mem_ctx, name);
-    talloc_free(tmp_ctx);
-    return name;
-}
-
 struct resp_resolve_group_names_state {
     struct tevent_context *ev;
     struct resp_ctx *rctx;

--- a/src/tests/cmocka/test_fqnames.c
+++ b/src/tests/cmocka/test_fqnames.c
@@ -110,8 +110,6 @@ void test_default(void **state)
     errno_t ret;
 
     char *fqdn;
-    const int fqdn_size = 255;
-    char fqdn_s[fqdn_size];
 
     if (test_ctx == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Type mismatch\n");
@@ -128,10 +126,6 @@ void test_default(void **state)
     assert_string_equal(fqdn, NAME"@"DOMNAME);
     talloc_free(fqdn);
 
-    ret = sss_fqname(fqdn_s, fqdn_size, test_ctx->nctx, test_ctx->dom, NAME);
-    assert_int_equal(ret + 1, sizeof(NAME"@"DOMNAME));
-    assert_string_equal(fqdn_s, NAME"@"DOMNAME);
-
     talloc_free(test_ctx->nctx);
 }
 
@@ -142,8 +136,6 @@ void test_all(void **state)
     errno_t ret;
 
     char *fqdn;
-    const int fqdn_size = 255;
-    char fqdn_s[fqdn_size];
 
     if (test_ctx == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Type mismatch\n");
@@ -160,10 +152,6 @@ void test_all(void **state)
     assert_string_equal(fqdn, NAME"@"DOMNAME"@"FLATNAME);
     talloc_free(fqdn);
 
-    ret = sss_fqname(fqdn_s, fqdn_size, test_ctx->nctx, test_ctx->dom, NAME);
-    assert_int_equal(ret + 1, sizeof(NAME"@"DOMNAME"@"FLATNAME));
-    assert_string_equal(fqdn_s, NAME"@"DOMNAME"@"FLATNAME);
-
     talloc_free(test_ctx->nctx);
 }
 
@@ -174,8 +162,6 @@ void test_flat(void **state)
     errno_t ret;
 
     char *fqdn;
-    const int fqdn_size = 255;
-    char fqdn_s[fqdn_size];
 
     if (test_ctx == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Type mismatch\n");
@@ -192,10 +178,6 @@ void test_flat(void **state)
     assert_string_equal(fqdn, NAME"@"FLATNAME);
     talloc_free(fqdn);
 
-    ret = sss_fqname(fqdn_s, fqdn_size, test_ctx->nctx, test_ctx->dom, NAME);
-    assert_int_equal(ret + 1, sizeof(NAME"@"FLATNAME));
-    assert_string_equal(fqdn_s, NAME"@"FLATNAME);
-
     talloc_free(test_ctx->nctx);
 }
 
@@ -206,8 +188,6 @@ void test_flat_fallback(void **state)
     errno_t ret;
 
     char *fqdn;
-    const int fqdn_size = 255;
-    char fqdn_s[fqdn_size];
 
     if (test_ctx == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Type mismatch\n");
@@ -228,10 +208,6 @@ void test_flat_fallback(void **state)
     assert_non_null(fqdn);
     assert_string_equal(fqdn, NAME"@"DOMNAME);
     talloc_free(fqdn);
-
-    ret = sss_fqname(fqdn_s, fqdn_size, test_ctx->nctx, test_ctx->dom, NAME);
-    assert_int_equal(ret + 1, sizeof(NAME"@"DOMNAME));
-    assert_string_equal(fqdn_s, NAME"@"DOMNAME);
 
     talloc_free(test_ctx->nctx);
 }

--- a/src/tests/cmocka/test_string_utils.c
+++ b/src/tests/cmocka/test_string_utils.c
@@ -23,10 +23,8 @@
 
 void test_replace_whitespaces(void **state)
 {
-    TALLOC_CTX *mem_ctx;
-    const char *input_str = "Lorem ipsum dolor sit amet";
-    const char *res;
     size_t i;
+    char *input;
 
     struct {
         const char *input;
@@ -51,36 +49,18 @@ void test_replace_whitespaces(void **state)
         { NULL, NULL, '\0' },
     };
 
-    mem_ctx = talloc_new(NULL);
-    assert_non_null(mem_ctx);
-    check_leaks_push(mem_ctx);
-
-    res = sss_replace_space(mem_ctx, input_str, '\0');
-    assert_string_equal(res, input_str);
-    talloc_zfree(res);
-
-    res = sss_replace_space(mem_ctx, input_str, '\0');
-    assert_string_equal(res, input_str);
-    talloc_zfree(res);
-
     for (i=0; data_set[i].input != NULL; ++i) {
-        res = sss_replace_space(mem_ctx, data_set[i].input,
-                                data_set[i].replace_char);
-        assert_non_null(res);
-        assert_string_equal(res, data_set[i].output);
-        talloc_zfree(res);
+        input = strdup(data_set[i].input);
+        sss_replace_space_inplace(input, data_set[i].replace_char);
+        assert_string_equal(input, data_set[i].output);
+        free(input);
     }
-
-    assert_true(check_leaks_pop(mem_ctx) == true);
-    talloc_free(mem_ctx);
 }
 
 void test_reverse_replace_whitespaces(void **state)
 {
-    TALLOC_CTX *mem_ctx;
-    char *input_str = discard_const_p(char, "Lorem ipsum dolor sit amet");
-    char *res;
     size_t i;
+    char *input;
 
     struct {
         const char *input;
@@ -109,29 +89,12 @@ void test_reverse_replace_whitespaces(void **state)
         { NULL, NULL, '\0' },
     };
 
-    mem_ctx = talloc_new(NULL);
-    assert_non_null(mem_ctx);
-    check_leaks_push(mem_ctx);
-
-    res = sss_reverse_replace_space(mem_ctx, input_str, '\0');
-    assert_string_equal(res, input_str);
-    talloc_free(res);
-
-    res = sss_reverse_replace_space(mem_ctx, input_str, '\0');
-    assert_string_equal(res, input_str);
-    talloc_free(res);
-
     for (i=0; data_set[i].input != NULL; ++i) {
-        input_str = discard_const_p(char, data_set[i].input);
-        res = sss_reverse_replace_space(mem_ctx, input_str,
-                                        data_set[i].replace_char);
-        assert_non_null(res);
-        assert_string_equal(res, data_set[i].output);
-        talloc_zfree(res);
+        input = strdup(data_set[i].input);
+        sss_reverse_replace_space_inplace(input, data_set[i].replace_char);
+        assert_string_equal(input, data_set[i].output);
+        free(input);
     }
-
-    assert_true(check_leaks_pop(mem_ctx) == true);
-    talloc_free(mem_ctx);
 }
 
 void test_guid_blob_to_string_buf(void **state)

--- a/src/util/debug.h
+++ b/src/util/debug.h
@@ -194,6 +194,18 @@ void sss_debug_fn(const char *file,
                                             (level & (SSSDBG_FATAL_FAILURE | \
                                                       SSSDBG_CRIT_FAILURE))))
 
+/* The same as DEBUG but does nothing if requested debug level isn't set,
+ * thus avoiding logging to the backtrace in this case.
+ * Meant to be used in hot (performance sensitive) code paths only.
+ */
+#define DEBUG_CONDITIONAL(level, format, ...) do { \
+    if (DEBUG_IS_SET(level)) { \
+        sss_debug_fn(__FILE__, __LINE__, __FUNCTION__, \
+                     level, \
+                     format, ##__VA_ARGS__); \
+    } \
+} while (0)
+
 
 /* not to be used explictly, use 'DEBUG_INIT' instead */
 void _sss_debug_init(int dbg_lvl, const char *logger);

--- a/src/util/domain_info_utils.c
+++ b/src/util/domain_info_utils.c
@@ -910,8 +910,8 @@ static const char *domain_state_str(struct sss_domain_info *dom)
 
 enum sss_domain_state sss_domain_get_state(struct sss_domain_info *dom)
 {
-    DEBUG(SSSDBG_TRACE_LIBS,
-          "Domain %s is %s\n", dom->name, domain_state_str(dom));
+    DEBUG_CONDITIONAL(SSSDBG_TRACE_INTERNAL,
+                      "Domain %s is %s\n", dom->name, domain_state_str(dom));
     return dom->state;
 }
 

--- a/src/util/sss_tc_utf8.c
+++ b/src/util/sss_tc_utf8.c
@@ -28,7 +28,7 @@
 #include "util/util.h"
 
 /* Expects and returns NULL-terminated string;
- * result must be freed with sss_utf8_free()
+ * result must be freed with free()
  */
 static inline char *sss_utf8_tolower(const char *s)
 {

--- a/src/util/string_utils.c
+++ b/src/util/string_utils.c
@@ -22,12 +22,20 @@
 
 #include "util/util.h"
 
+static inline void replace_char_inplace(char *p, char match, char sub)
+{
+    for (; *p != '\0'; ++p) {
+        if (*p == match) {
+            *p = sub;
+        }
+    }
+}
+
 char *sss_replace_char(TALLOC_CTX *mem_ctx,
                        const char *in,
                        const char match,
                        const char sub)
 {
-    char *p;
     char *out;
 
     out = talloc_strdup(mem_ctx, in);
@@ -35,21 +43,16 @@ char *sss_replace_char(TALLOC_CTX *mem_ctx,
         return NULL;
     }
 
-    for (p = out; *p != '\0'; ++p) {
-        if (*p == match) {
-            *p = sub;
-        }
-    }
+    replace_char_inplace(out, match, sub);
 
     return out;
 }
 
-char * sss_replace_space(TALLOC_CTX *mem_ctx,
-                         const char *orig_name,
-                         const char subst)
+void sss_replace_space_inplace(char *orig_name,
+                               const char subst)
 {
     if (subst == '\0' || subst == ' ') {
-        return talloc_strdup(mem_ctx, orig_name);
+        return;
     }
 
     if (strchr(orig_name, subst) != NULL) {
@@ -60,28 +63,27 @@ char * sss_replace_space(TALLOC_CTX *mem_ctx,
                 "Name [%s] already contains replacement character [%c]. " \
                 "No replacement will be done.\n",
                 orig_name, subst);
-        return talloc_strdup(mem_ctx, orig_name);
+        return;
     }
 
-    return sss_replace_char(mem_ctx, orig_name, ' ', subst);
+    replace_char_inplace(orig_name, ' ', subst);
 }
 
-char * sss_reverse_replace_space(TALLOC_CTX *mem_ctx,
-                                 const char *orig_name,
-                                 const char subst)
+void sss_reverse_replace_space_inplace(char *orig_name,
+                                       const char subst)
 {
     if (subst == '\0' || subst == ' ') {
-        return talloc_strdup(mem_ctx, orig_name);
+        return;
     }
 
     if (strchr(orig_name, subst) != NULL && strchr(orig_name, ' ') != NULL) {
         DEBUG(SSSDBG_TRACE_FUNC,
               "Input [%s] contains replacement character [%c] and space.\n",
               orig_name, subst);
-        return talloc_strdup(mem_ctx, orig_name);
+        return;
     }
 
-    return sss_replace_char(mem_ctx, orig_name, subst, ' ');
+    replace_char_inplace(orig_name, subst, ' ');
 }
 
 errno_t guid_blob_to_string_buf(const uint8_t *blob, char *str_buf,

--- a/src/util/usertools.c
+++ b/src/util/usertools.c
@@ -723,11 +723,15 @@ char *sss_output_name(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    outname = sss_get_cased_name(tmp_ctx, shortname, case_sensitive);
-    if (outname == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE,
-                "sss_get_cased_name failed, skipping\n");
-        goto done;
+    if (!case_sensitive) {
+        outname = sss_get_cased_name(tmp_ctx, shortname, false);
+        if (outname == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                    "sss_get_cased_name failed, skipping\n");
+            goto done;
+        }
+    } else { /* avoid talloc_strdup() inside sss_get_cased_name() */
+        outname = shortname;
     }
 
     outname = sss_replace_space(tmp_ctx, outname, replace_space);

--- a/src/util/usertools.c
+++ b/src/util/usertools.c
@@ -629,7 +629,7 @@ errno_t sss_parse_internal_fqname(TALLOC_CTX *mem_ctx,
     }
 
     if (_shortname != NULL) {
-        shortname_len = strlen(fqname) - strlen(separator);
+        shortname_len = (size_t)(separator - fqname);
         *_shortname = talloc_strndup(mem_ctx, fqname, shortname_len);
         if (*_shortname == NULL) {
             return ENOMEM;

--- a/src/util/usertools.c
+++ b/src/util/usertools.c
@@ -552,16 +552,6 @@ sss_tc_fqname2(TALLOC_CTX *mem_ctx, struct sss_names_ctx *nctx,
     return output;
 }
 
-int
-sss_fqname(char *str, size_t size, struct sss_names_ctx *nctx,
-           struct sss_domain_info *domain, const char *name)
-{
-    if (domain == NULL || nctx == NULL) return -EINVAL;
-
-    return safe_format_string(str, size, nctx->fq_fmt,
-                              name, domain->name, calc_flat_name (domain), NULL);
-}
-
 errno_t sss_user_by_name_or_uid(const char *input, uid_t *_uid, gid_t *_gid)
 {
     uid_t uid;

--- a/src/util/usertools.c
+++ b/src/util/usertools.c
@@ -508,8 +508,6 @@ calc_flat_name(struct sss_domain_info *domain)
 
     s = domain->flat_name;
     if (s == NULL) {
-        DEBUG(SSSDBG_FUNC_DATA, "Domain has no flat name set,"
-              "using domain name instead\n");
         s = domain->name;
     }
 

--- a/src/util/usertools.c
+++ b/src/util/usertools.c
@@ -734,11 +734,7 @@ char *sss_output_name(TALLOC_CTX *mem_ctx,
         outname = shortname;
     }
 
-    outname = sss_replace_space(tmp_ctx, outname, replace_space);
-    if (outname == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "sss_replace_space failed\n");
-        goto done;
-    }
+    sss_replace_space_inplace(outname, replace_space);
 
     outname = talloc_steal(mem_ctx, outname);
 done:

--- a/src/util/usertools.c
+++ b/src/util/usertools.c
@@ -608,54 +608,35 @@ errno_t sss_parse_internal_fqname(TALLOC_CTX *mem_ctx,
                                   char **_shortname,
                                   char **_dom_name)
 {
-    errno_t ret;
-    char *separator;
-    char *shortname = NULL;
-    char *dom_name = NULL;
+    const char *separator;
     size_t shortname_len;
-    TALLOC_CTX *tmp_ctx;
 
     if (fqname == NULL) {
         return EINVAL;
     }
 
-    tmp_ctx = talloc_new(NULL);
-    if (tmp_ctx == NULL) {
-        return ENOMEM;
-    }
-
     separator = strrchr(fqname, '@');
     if (separator == NULL || *(separator + 1) == '\0' || separator == fqname) {
         /*The name does not contain name or domain component. */
-        ret = ERR_WRONG_NAME_FORMAT;
-        goto done;
+        return ERR_WRONG_NAME_FORMAT;
     }
 
     if (_dom_name != NULL) {
-        dom_name = talloc_strdup(tmp_ctx, separator + 1);
-        if (dom_name == NULL) {
-            ret = ENOMEM;
-            goto done;
+        *_dom_name = talloc_strdup(mem_ctx, separator + 1);
+        if (*_dom_name == NULL) {
+            return ENOMEM;
         }
-
-        *_dom_name = talloc_steal(mem_ctx, dom_name);
     }
 
     if (_shortname != NULL) {
         shortname_len = strlen(fqname) - strlen(separator);
-        shortname = talloc_strndup(tmp_ctx, fqname, shortname_len);
-        if (shortname == NULL) {
-            ret = ENOMEM;
-            goto done;
+        *_shortname = talloc_strndup(mem_ctx, fqname, shortname_len);
+        if (*_shortname == NULL) {
+            return ENOMEM;
         }
-
-        *_shortname = talloc_steal(mem_ctx, shortname);
     }
 
-    ret = EOK;
-done:
-    talloc_free(tmp_ctx);
-    return ret;
+    return EOK;
 }
 
 /* Creates internal fqname in format shortname@domname.

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -319,6 +319,22 @@ errno_t sss_parse_internal_fqname(TALLOC_CTX *mem_ctx,
                                   char **_shortname,
                                   char **_dom_name);
 
+/* Accepts fqname in the format shortname@domname only
+ * and returns a pointer to domain part or NULL if not found.
+ */
+__attribute__((always_inline))
+static inline const char *sss_get_domain_internal_fqname(const char *fqname)
+{
+    const char *separator = strrchr(fqname, '@');
+
+    if (separator == NULL || *(separator + 1) == '\0' || separator == fqname) {
+        /*The name does not contain name or domain component. */
+        return NULL;
+    }
+
+    return (separator + 1);
+}
+
 /* Creates internal fqname in format shortname@domname.
  * The domain portion is lowercased. */
 char *sss_create_internal_fqname(TALLOC_CTX *mem_ctx,

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -712,12 +712,10 @@ char *sss_replace_char(TALLOC_CTX *mem_ctx,
                        const char match,
                        const char sub);
 
-char * sss_replace_space(TALLOC_CTX *mem_ctx,
-                         const char *orig_name,
-                         const char replace_char);
-char * sss_reverse_replace_space(TALLOC_CTX *mem_ctx,
-                                 const char *orig_name,
-                                 const char replace_char);
+void sss_replace_space_inplace(char *orig_name,
+                               const char replace_char);
+void sss_reverse_replace_space_inplace(char *orig_name,
+                                       const char replace_char);
 
 #define GUID_BIN_LENGTH 16
 /* 16 2-digit hex values + 4 dashes + terminating 0 */


### PR DESCRIPTION
 * Most impactful patch is "Replaced `sysdb_search_entry()` with `sysdb_cache_search_entry()`
to avoid `sysdb_merge_msg_list_ts_attrs()`"
 * Second impactful is "Avoid logging to the backtrace unconditionally in hot paths"
 * All other patches optimize code under `sss_nss_protocol_fill_members()` (those helpers are also used in other cases), but I admit impact is pretty contained (2..3% of time in my test setup), so if you think some of patches make code readability worse - I'm fine to drop those.


Testing with the same setup as in https://github.com/SSSD/sssd/pull/7841#issuecomment-2675248906 but default debug settings:

`time SSS_NSS_USE_MEMCACHE=NO getent -s sss group final-g5050002@ldap.test > /dev/null`

2.11.0-0.250306.171312 (**vanilla**) : 2.207 .. 2.434

sssd-9.pr7866-06233 (don't read ts) : 1.142 .. 1.271
sssd-9.pr7866-06235 (debug)       : 1.035 .. 1.119
sssd-9.pr7866-06249 (fill-members): 1.007 .. 1.086

