### PR TITLE
SYSDB: perf improvements in sysdb_add_group_member_overrides(), part 3

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -759,8 +759,7 @@ errno_t sysdb_add_overrides_to_object(struct sss_domain_info *domain,
                                       const char **req_attrs);
 
 errno_t sysdb_add_group_member_overrides(struct sss_domain_info *domain,
-                                         struct ldb_message *obj,
-                                         bool expect_override_dn);
+                                         struct ldb_message *obj);
 
 errno_t sysdb_getpwnam_with_views(TALLOC_CTX *mem_ctx,
                                   struct sss_domain_info *domain,

--- a/src/db/sysdb_search.c
+++ b/src/db/sysdb_search.c
@@ -1150,8 +1150,7 @@ int sysdb_getgrnam_with_views(TALLOC_CTX *mem_ctx,
 
         /* Must be called even without views to check to
          * SYSDB_DEFAULT_OVERRIDE_NAME */
-        ret = sysdb_add_group_member_overrides(domain, orig_obj->msgs[0],
-                                               DOM_HAS_VIEWS(domain));
+        ret = sysdb_add_group_member_overrides(domain, orig_obj->msgs[0]);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE,
                   "sysdb_add_group_member_overrides failed.\n");
@@ -1345,8 +1344,7 @@ int sysdb_getgrgid_with_views(TALLOC_CTX *mem_ctx,
 
         /* Must be called even without views to check to
          * SYSDB_DEFAULT_OVERRIDE_NAME */
-        ret = sysdb_add_group_member_overrides(domain, orig_obj->msgs[0],
-                                               DOM_HAS_VIEWS(domain));
+        ret = sysdb_add_group_member_overrides(domain, orig_obj->msgs[0]);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE,
                   "sysdb_add_group_member_overrides failed.\n");
@@ -1639,8 +1637,7 @@ int sysdb_enumgrent_filter_with_views(TALLOC_CTX *mem_ctx,
             }
         }
 
-        ret = sysdb_add_group_member_overrides(domain, res->msgs[c],
-                                               DOM_HAS_VIEWS(domain));
+        ret = sysdb_add_group_member_overrides(domain, res->msgs[c]);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE,
                   "sysdb_add_group_member_overrides failed.\n");

--- a/src/db/sysdb_views.c
+++ b/src/db/sysdb_views.c
@@ -1653,9 +1653,9 @@ static inline int add_domain_name(TALLOC_CTX *mem_ctx,
 }
 
 errno_t sysdb_add_group_member_overrides(struct sss_domain_info *domain,
-                                         struct ldb_message *obj,
-                                         bool expect_override_dn)
+                                         struct ldb_message *obj)
 {
+    bool expect_override_dn;
     int ret;
     size_t c;
     struct ldb_result *res_members;
@@ -1669,6 +1669,8 @@ errno_t sysdb_add_group_member_overrides(struct sss_domain_info *domain,
     if (domain->ignore_group_members) {
         return EOK;
     }
+
+    expect_override_dn = DOM_HAS_VIEWS(domain);
 
     if (!expect_override_dn
         && ((domain->provider == NULL) || (strcasecmp(domain->provider, "ipa") != 0))) {

--- a/src/db/sysdb_views.c
+++ b/src/db/sysdb_views.c
@@ -1670,6 +1670,12 @@ errno_t sysdb_add_group_member_overrides(struct sss_domain_info *domain,
         return EOK;
     }
 
+    if (!expect_override_dn
+        && ((domain->provider == NULL) || (strcasecmp(domain->provider, "ipa") != 0))) {
+        /* (no view defined) and (not IPA hence no SYSDB_DEFAULT_OVERRIDE_NAME) */
+        return EOK;
+    }
+
     if (ldb_msg_find_element(obj, SYSDB_MEMBERUID) == NULL) {
         /* empty memberUid list means there are no user objects in
          * the cache that would have 'memberOf = obj->dn',


### PR DESCRIPTION
(to be rebased on top of #7866)

Since this patch completely skips `sysdb_add_group_member_overrides()` in the setup described in https://github.com/SSSD/sssd/pull/7841#issuecomment-2675248906 (and used for testing in #7866), sure thing it makes lookup ~ x10..15 times faster - 62..82 msec.