### PR TITLE
SPEC: package 'enable_sssd_conf_dir' as a part of 'sssd-krb5-common'

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -856,14 +856,14 @@ install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/sssd.conf
 %attr(775,%{sssd_user},%{sssd_user}) %dir %{pubconfpath}/krb5.include.d
 %attr(0750,root,%{sssd_user}) %caps(cap_dac_read_search=p) %{_libexecdir}/%{servicename}/ldap_child
 %attr(0750,root,%{sssd_user}) %caps(cap_dac_read_search,cap_setuid,cap_setgid=p) %{_libexecdir}/%{servicename}/krb5_child
+%config(noreplace) %{_sysconfdir}/krb5.conf.d/enable_sssd_conf_dir
+%dir %{_datadir}/sssd/krb5-snippets
+%{_datadir}/sssd/krb5-snippets/enable_sssd_conf_dir
 
 %files krb5 -f sssd_krb5.lang
 %license COPYING
 %{_libdir}/%{name}/libsss_krb5.so
 %{_mandir}/man5/sssd-krb5.5*
-%config(noreplace) %{_sysconfdir}/krb5.conf.d/enable_sssd_conf_dir
-%dir %{_datadir}/sssd/krb5-snippets
-%{_datadir}/sssd/krb5-snippets/enable_sssd_conf_dir
 
 %files common-pac
 %license COPYING


### PR DESCRIPTION
This is needed by sssd-ad/sssd-ipa that do not pull 'sssd-krb5'