### PR TITLE
tests: Update mock date to postpone timezone related failures

### DIFF
--- a/src/tests/util-tests.c
+++ b/src/tests/util-tests.c
@@ -1081,7 +1081,7 @@ static void convert_time_tz(const char* tz)
                 "setenv failed with errno: %d", errno);
     }
 
-    ret = sss_utc_to_time_t("20140801115742Z", "%Y%m%d%H%M%SZ", &unix_time);
+    ret = sss_utc_to_time_t("20250101115742Z", "%Y%m%d%H%M%SZ", &unix_time);
 
     /* restore */
     if (orig_tz != NULL) {
@@ -1089,8 +1089,8 @@ static void convert_time_tz(const char* tz)
         sss_ck_fail_if_msg(ret2 == -1,
                 "setenv failed with errno: %d", errno);
     }
-    ck_assert_msg(ret == EOK && difftime(1406894262, unix_time) == 0,
-                "Expecting 1406894262 got: ret[%d] unix_time[%"SPRItime"]",
+    ck_assert_msg(ret == EOK && difftime(1735732662, unix_time) == 0,
+                "Expecting 1735732662 got: ret[%d] unix_time[%"SPRItime"]",
                 ret, unix_time);
 }
 


### PR DESCRIPTION
Because timezones can change throughout the years, mktime calculates timestamp according to a timezone valid at that date, but tzset uses current timezone and that can lead to an incorrect result.

I've decided on a more recent date to cover timezone changes that happened in other countries (see [tzdata-meta](https://tzdata-meta.timtimeonline.com/) for a list of changes).

As soon as there appears a better and tested solution to fix/rewrite `sss_utc_to_time_t` to properly work with timezones, this date will not need constant updates.

See https://github.com/SSSD/sssd/issues/7209 for more information.