### PR TITLE
ci: include build description for covscan

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -29,6 +29,15 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: false
 
+    - name: Set description
+      run: |
+        if [ ${{ github.event_name }} == 'pull_request' ]; then
+          echo "DESCRIPTION=Pull Request number ${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+        else
+          echo "DESCRIPTION=Daily scheduled run ${{ github.ref }}" >> $GITHUB_ENV
+        fi
+      shell: bash
+
     - name: Install dependencies
       uses: ./.github/actions/install-dependencies
 
@@ -41,3 +50,4 @@ jobs:
         email: "sssd-maint@redhat.com"
         token: ${{ secrets.COVERITY_SCAN_TOKEN }}
         working-directory: x86_64
+        description: ${{ env.DESCRIPTION }}


### PR DESCRIPTION
Add a description to make it easier to identify which build (snapshot) associates with a certain PR.

Description is a field visible in the covscan webUI - go to `Snapshots -> All in Project`