### PR TITLE
p11_child: Add timeout parameter

### DIFF
--- a/src/p11_child/p11_child.h
+++ b/src/p11_child/p11_child.h
@@ -27,6 +27,7 @@
 
 /* for CK_MECHANISM_TYPE */
 #include <p11-kit/pkcs11.h>
+#include <time.h>
 
 /* Time to wait for new slot events. */
 #define PKCS11_SLOT_EVENT_WAIT_TIME 1
@@ -59,7 +60,8 @@ enum pin_mode {
 };
 
 errno_t init_p11_ctx(TALLOC_CTX *mem_ctx, const char *ca_db,
-                     bool wait_for_card, struct p11_ctx **p11_ctx);
+                     bool wait_for_card, time_t timeout,
+                     struct p11_ctx **p11_ctx);
 
 errno_t init_verification(struct p11_ctx *p11_ctx,
                           struct cert_verify_opts *cert_verify_opts);

--- a/src/responder/ifp/ifp_users.c
+++ b/src/responder/ifp/ifp_users.c
@@ -1128,7 +1128,7 @@ ifp_users_find_by_valid_cert_send(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    state->extra_args = talloc_zero_array(state, const char *, 8);
+    state->extra_args = talloc_zero_array(state, const char *, 10);
     if (state->extra_args == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "talloc_zero_array failed.\n");
         ret = ENOMEM;
@@ -1143,6 +1143,16 @@ ifp_users_find_by_valid_cert_send(TALLOC_CTX *mem_ctx,
         state->extra_args[arg_c++] = "--verify";
     }
     state->extra_args[arg_c++] = "--verification";
+    if (state->timeout > 0) {
+        state->extra_args[arg_c++] = talloc_asprintf(state, "%d",
+                                                     state->timeout);
+        if (state->extra_args[arg_c - 1] == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE, "talloc_asprintf failed.\n");
+            ret = ENOMEM;
+            goto done;
+        }
+        state->extra_args[arg_c++] = "--timeout";
+    }
 
     ret = p11_child_exec(req);
 

--- a/src/responder/pam/pamsrv_p11.c
+++ b/src/responder/pam/pamsrv_p11.c
@@ -746,7 +746,7 @@ struct tevent_req *pam_check_cert_send(TALLOC_CTX *mem_ctx,
     struct timeval tv;
     int pipefd_to_child[2] = PIPE_INIT;
     int pipefd_from_child[2] = PIPE_INIT;
-    const char *extra_args[20] = { NULL };
+    const char *extra_args[22] = { NULL };
     uint8_t *write_buf = NULL;
     size_t write_buf_len = 0;
     size_t arg_c;
@@ -777,6 +777,16 @@ struct tevent_req *pam_check_cert_send(TALLOC_CTX *mem_ctx,
 
     /* extra_args are added in revers order */
     arg_c = 0;
+
+    if (timeout > 0) {
+        extra_args[arg_c++] = talloc_asprintf(mem_ctx, "%lu", timeout);
+        if (extra_args[arg_c - 1] == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "talloc_asprintf failed.\n");
+            ret = ENOMEM;
+            goto done;
+        }
+        extra_args[arg_c++] = "--timeout";
+    }
 
     chain_id = sss_chain_id_get();
 

--- a/src/responder/ssh/ssh_cert_to_ssh_key.c
+++ b/src/responder/ssh/ssh_cert_to_ssh_key.c
@@ -91,7 +91,7 @@ struct tevent_req *cert_to_ssh_key_send(TALLOC_CTX *mem_ctx,
     }
     state->valid_keys = 0;
 
-    state->extra_args = talloc_zero_array(state, const char *, 8);
+    state->extra_args = talloc_zero_array(state, const char *, 10);
     if (state->extra_args == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "talloc_zero_array failed.\n");
         ret = ENOMEM;
@@ -108,6 +108,14 @@ struct tevent_req *cert_to_ssh_key_send(TALLOC_CTX *mem_ctx,
         state->extra_args[arg_c++] = "--verify";
     }
     state->extra_args[arg_c++] = "--verification";
+    if (timeout > 0) {
+        state->extra_args[arg_c++] = talloc_asprintf(state, "%lu", timeout);
+        if (state->extra_args[arg_c - 1] == NULL) {
+            ret = ENOMEM;
+            goto done;
+        }
+        state->extra_args[arg_c++] = "--timeout";
+    }
 
     state->certs = talloc_zero_array(state, const char *, cert_count);
     if (state->certs == NULL) {


### PR DESCRIPTION
p11_child communication with OCSP server may take a long time because of network issues. Then p11_child is killed after `p11_child_timeout` and the authentication fails.

This is not desirable when `certificate_verification` is set to `soft_ocsp`. This update will pass the timeout to the child process so it can cancel the OCSP verification before it is terminated.

Resolves: https://github.com/SSSD/sssd/issues/6601