### PR TITLE
Revert "Enumerate object with escaped characters in name"

### DIFF
--- a/src/db/sysdb_search.c
+++ b/src/db/sysdb_search.c
@@ -814,7 +814,6 @@ static errno_t sysdb_enum_dn_filter(TALLOC_CTX *mem_ctx,
 {
     TALLOC_CTX *tmp_ctx = NULL;
     char *dn_filter;
-    char *sanitized_dn;
     const char *fqname;
     errno_t ret;
 
@@ -845,18 +844,11 @@ static errno_t sysdb_enum_dn_filter(TALLOC_CTX *mem_ctx,
     }
 
     for (size_t i = 0; i < ts_res->count; i++) {
-        ret = sss_filter_sanitize_dn(tmp_ctx,
-                                     ldb_dn_get_linearized(ts_res->msgs[i]->dn),
-                                     &sanitized_dn);
-        if (ret != EOK) {
-            goto done;
-        }
         dn_filter = talloc_asprintf_append(
                                   dn_filter,
                                   "(%s=%s)",
                                   SYSDB_DN,
-                                  sanitized_dn);
-        talloc_free(sanitized_dn);
+                                  ldb_dn_get_linearized(ts_res->msgs[i]->dn));
         if (dn_filter == NULL) {
             ret = ENOMEM;
             goto done;


### PR DESCRIPTION
This reverts commit 158b4cdb7ac62fde1280f50a5d678f80d0e99015.