### PR TITLE
SPEC: relax Samba version req a bit

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -46,7 +46,7 @@
 %global ldb_modulesdir %(pkg-config --variable=modulesdir ldb)
 %global ldb_version 1.2.0
 
-%global samba_package_version %(rpm -q samba-devel --queryformat %{version}-%{release})
+%global samba_package_version %(rpm -q samba-devel --queryformat %{version})
 
 Name: @PACKAGE_NAME@
 Version: %{downstream_version}


### PR DESCRIPTION
Samba version check is there to avoid cases when users upgrade SSSD but do not upgrade samba-libs. Sometimes this can result in difficult-to-debug issues when the gap is too wide.

On the other hand, too strict check often bites: when a buildroot has a new Samba that isn't yet available otherwise, it becomes impossible to install SSSD due to unsatisfied deps.

Requiring for %{version} part only looks like a reasonable compromise.