### PR TITLE
ci: grab all logs from ipa host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,7 @@ jobs:
         mkdir -p $GITHUB_WORKSPACE/artifacts
         source .venv/bin/activate
         pytest \
+          --durations=0 \
           --color=yes \
           --show-capture=no \
           --mh-config=./mhc.yaml \

--- a/src/tests/system/mhc.yaml
+++ b/src/tests/system/mhc.yaml
@@ -31,6 +31,14 @@ domains:
         ipa_domain: ipa.test
         krb5_keytab: /var/enrollment/ipa.test.keytab
         ldap_krb5_keytab: /var/enrollment/ipa.test.keytab
+    artifacts:
+    - /etc/sssd/*
+    - /var/log/dirsrv/*
+    - /var/log/httpd/*
+    - /var/log/ipa/*
+    - /var/log/krb5kdc.log
+    - /var/log/sssd/*
+    - /var/lib/sss/db/*
 
   - hostname: dc.ad.test
     role: ad


### PR DESCRIPTION
Fetch IPA logs and gather test duration.

```
9f50021c7 (Pavel Březina, 23 hours ago)
   ci: print duration of each test case

   We recently stumbled on very slow test runs on Fedora 42 where it finished
   hours later then other distrubitions or timed out completely. Pytest with
   --durations=0 prints duration of each test case which can help us identify
   problematic test in the future, if the slow down is caused by specific test
   cases.

7e5d2cfe3 (Pavel Březina, 6 days ago)
   ci: grab ipa logs from ipa host

   ...to allow debugging IPA failures.
```

Requires: https://github.com/SSSD/sssd-test-framework/pull/174