### PR TITLE
 Autofs imagemode #7917 cherry-pick to 2.8

### DIFF
--- a/src/tests/system/mhc.yaml
+++ b/src/tests/system/mhc.yaml
@@ -21,7 +21,7 @@ domains:
       bindpw: Secret123
       client:
         ldap_tls_reqcert: demand
-        ldap_tls_cacert: /data/certs/ca.crt
+        ldap_tls_cacert: /var/data/certs/ca.crt
         dns_discovery_domain: ldap.test
 
   - hostname: master.ipa.test
@@ -29,8 +29,8 @@ domains:
     config:
       client:
         ipa_domain: ipa.test
-        krb5_keytab: /enrollment/ipa.test.keytab
-        ldap_krb5_keytab: /enrollment/ipa.test.keytab
+        krb5_keytab: /var/enrollment/ipa.test.keytab
+        ldap_krb5_keytab: /var/enrollment/ipa.test.keytab
 
   - hostname: dc.ad.test
     role: ad
@@ -52,8 +52,8 @@ domains:
       bindpw: Secret123
       client:
         ad_domain: samba.test
-        krb5_keytab: /enrollment/samba.test.keytab
-        ldap_krb5_keytab: /enrollment/samba.test.keytab
+        krb5_keytab: /var/enrollment/samba.test.keytab
+        ldap_krb5_keytab: /var/enrollment/samba.test.keytab
 
   - hostname: nfs.test
     role: nfs

--- a/src/tests/system/tests/test_autofs.py
+++ b/src/tests/system/tests/test_autofs.py
@@ -1,0 +1,160 @@
+"""
+Automount Test Cases
+
+:requirement: autofs
+"""
+
+from __future__ import annotations
+
+import pytest
+from sssd_test_framework.roles.client import Client
+from sssd_test_framework.roles.generic import GenericProvider
+from sssd_test_framework.roles.nfs import NFS
+from sssd_test_framework.topology import KnownTopologyGroup
+
+
+@pytest.mark.importance("medium")
+@pytest.mark.topology(KnownTopologyGroup.AnyProvider)
+def test_autofs__propagate_offline_status_for_a_single_domain(client: Client, provider: GenericProvider):
+    """
+    :title: Autofs propagates offline status if a domain is offline
+    :setup:
+        1. Block traffic to the provider
+        2. Enable autofs responder
+        3. Start SSSD
+        4. Reload autofs daemon
+    :steps:
+        1. Read autofs responder logs
+    :expectedresults:
+        1. cache_req returns "SSSD is offline" when data provider is offline for auto.master search
+    :customerscenario: False
+    """
+    # Render the provider offline
+    client.firewall.outbound.reject_host(provider)
+
+    # Start SSSD
+    client.sssd.common.autofs()
+    client.sssd.start()
+
+    # Reload automounter in order fetch updated maps
+    client.automount.reload()
+
+    # Check that offline status was returned from cache req
+    log = client.fs.read(client.sssd.logs.autofs).splitlines()
+    offline_status_propagated = False
+    for index, line in enumerate(log):
+        if "cache_req_process_result" in line and "Finished: Error" in line and "SSSD is offline" in line:
+            if "Object [auto.master] was not found in cache" in log[index - 1]:
+                offline_status_propagated = True
+                break
+
+    assert offline_status_propagated, "Offline status not propagated!"
+
+
+@pytest.mark.importance("critical")
+@pytest.mark.topology(KnownTopologyGroup.AnyProvider)
+def test_autofs__propagate_offline_status_for_multiple_domains(client: Client):
+    """
+    :title: Autofs propagates offline status if a domain is offline in multi domain environment
+    :setup:
+        1. Create two fake LDAP domains that will be offline (the provider is online but does not have autofs maps)
+        2. Enable autofs responder
+        3. Start SSSD
+        4. Reload autofs daemon
+    :steps:
+        1. Read autofs responder logs
+    :expectedresults:
+        1. cache_req returns "SSSD is offline" when data provider is offline for auto.master search
+    :customerscenario: False
+    """
+    # Create fake domains, these will be offline
+    client.sssd.dom("fake1").update(
+        enabled="true",
+        id_provider="ldap",
+        ldap_uri="ldap://fake1.test",
+    )
+
+    client.sssd.dom("fake2").update(
+        enabled="true",
+        id_provider="ldap",
+        ldap_uri="ldap://fake2.test",
+    )
+
+    # Start SSSD
+    client.sssd.common.autofs()
+    client.sssd.start()
+
+    # Reload automounter in order fetch updated maps
+    client.automount.reload()
+
+    # Check that offline status was returned from cache req
+    log = client.fs.read(client.sssd.logs.autofs).splitlines()
+    offline_status_propagated = False
+    for index, line in enumerate(log):
+        if "cache_req_process_result" in line and "Finished: Error" in line and "SSSD is offline" in line:
+            if "Object [auto.master] was not found in cache" in log[index - 1]:
+                offline_status_propagated = True
+                break
+
+    assert offline_status_propagated, "Offline status not propagated!"
+
+
+@pytest.mark.importance("critical")
+@pytest.mark.topology(KnownTopologyGroup.AnyProvider)
+def test_autofs__works_with_some_offline_domains(client: Client, nfs: NFS, provider: GenericProvider):
+    """
+    :title: Autofs works if some domain is offline in multi domain environment
+    :setup:
+        1. Create NFS export
+        2. Create auto.master map
+        3. Create auto.export map
+        4. Add /var/export (auto.export) key to auto.master
+        5. Add "NFS export" key as "export" to auto.export
+        6. Create two fake LDAP domains that will be offline (the provider is online)
+        7. Enable autofs responder
+        8. Start SSSD
+        9. Reload autofs daemon
+    :steps:
+        1. Access /var/export/export
+        2. Dump automount maps "automount -m"
+    :expectedresults:
+        1. Directory can be accessed and it is correctly mounted to the NFS share
+        2. /var/export contains auto.export map and "export" key
+    :customerscenario: False
+    """
+
+    # Create autofs maps
+    nfs_export = nfs.export("export").add()
+    auto_master = provider.automount.map("auto.master").add()
+    auto_export = provider.automount.map("auto.export").add()
+    auto_master.key("/var/export").add(info=auto_export)
+    key = auto_export.key("export").add(info=nfs_export)
+
+    # Create fake domains, these will be offline
+    client.sssd.dom("fake1").update(
+        enabled="true",
+        id_provider="ldap",
+        ldap_uri="ldap://fake1.test",
+    )
+
+    client.sssd.dom("fake2").update(
+        enabled="true",
+        id_provider="ldap",
+        ldap_uri="ldap://fake2.test",
+    )
+
+    # Start SSSD
+    client.sssd.sssd["domain_resolution_order"] = f"fake1, fake2, {client.sssd.default_domain}"
+    client.sssd.common.autofs()
+    client.sssd.start()
+
+    # Reload automounter in order fetch updated maps
+    client.automount.reload()
+
+    # Check that we can mount the exported directory
+    assert client.automount.mount("/var/export/export", nfs_export), "Unable to mount /var/export/export!"
+
+    # Check that the maps are correctly fetched
+    assert client.automount.dumpmaps() == {
+        "/var/export": {"map": "auto.export", "keys": [str(key)]},
+    }, "Automount maps do not match!"


### PR DESCRIPTION
We need move things from / to /var for image move with read only /.
Retried PR for https://github.com/SSSD/sssd/pull/7829.
Note that this introduces the suite to 2.8.