### PR TITLE
Support for ID Override Templates

### DIFF
--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -374,6 +374,9 @@ struct sss_domain_info {
     const char *homedir_substr;
     const char *override_shell;
     const char *default_shell;
+    /* Domain specific ID override template attributes */
+    const char *template_homedir;
+    const char *template_shell;
 
     uint32_t user_timeout;
     uint32_t group_timeout;

--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -207,12 +207,15 @@
 #define SYSDB_VIEW_NAME "viewName"
 #define SYSDB_OVERRIDE_CLASS "override"
 #define SYSDB_OVERRIDE_ANCHOR_UUID "overrideAnchorUUID"
+#define SYSDB_OVERRIDE_ANCHOR "overrideAnchor"
 #define SYSDB_OVERRIDE_USER_CLASS "userOverride"
 #define SYSDB_OVERRIDE_GROUP_CLASS "groupOverride"
 #define SYSDB_OVERRIDE_DN "overrideDN"
 #define SYSDB_OVERRIDE_OBJECT_DN "overrideObjectDN"
 #define SYSDB_USE_DOMAIN_RESOLUTION_ORDER "useDomainResolutionOrder"
 #define SYSDB_DOMAIN_RESOLUTION_ORDER "domainResolutionOrder"
+#define SYSDB_DOMAIN_TEMPLATE_SHELL "templateLoginShell"
+#define SYSDB_DOMAIN_TEMPLATE_HOMEDIR "templateHomeDirectory"
 #define SYSDB_PASSKEY_USER_VERIFICATION "passkeyUserVerification"
 #define SYSDB_SESSION_RECORDING "sessionRecording"
 
@@ -655,6 +658,23 @@ errno_t sysdb_update_view_name(struct sysdb_ctx *sysdb, const char *view_name);
 errno_t sysdb_get_view_name(TALLOC_CTX *mem_ctx, struct sysdb_ctx *sysdb,
                             char **view_name);
 
+errno_t sysdb_update_override_template(struct sysdb_ctx *sysdb,
+                                       const char *view_name,
+                                       const char *anchor,
+                                       const char *home_dir,
+                                       const char *login_shell);
+
+errno_t sysdb_domain_update_domain_template(struct sss_domain_info *parent,
+                                            struct sysdb_ctx *sysdb,
+                                            const char *subdom_name,
+                                            const char *home_dir,
+                                            const char *login_shell);
+
+errno_t sysdb_update_domain_template(struct sysdb_ctx *sysdb,
+                                     struct ldb_dn *dn,
+                                     const char *home_dir,
+                                     const char *login_shell);
+
 errno_t sysdb_update_view_domain_resolution_order(
                                         struct sysdb_ctx *sysdb,
                                         const char *domain_resolution_order);
@@ -692,6 +712,8 @@ errno_t sysdb_invalidate_overrides(struct sysdb_ctx *sysdb);
 
 errno_t sysdb_apply_default_override(struct sss_domain_info *domain,
                                      struct sysdb_attrs *override_attrs,
+                                     const char *global_template_homedir,
+                                     const char *global_template_shell,
                                      struct ldb_dn *obj_dn);
 
 errno_t sysdb_search_by_orig_dn(TALLOC_CTX *mem_ctx,
@@ -1230,6 +1252,13 @@ errno_t sysdb_store_override(struct sss_domain_info *domain,
                              const char *view_name,
                              enum sysdb_member_type type,
                              struct sysdb_attrs *attrs, struct ldb_dn *obj_dn);
+
+errno_t sysdb_store_override_template(struct sss_domain_info *domain,
+                                      struct sysdb_attrs *attrs,
+                                      const char *global_template_homedir,
+                                      const char *global_template_shell,
+                                      const char *view_name,
+                                      struct ldb_dn *obj_dn);
 
 /*
  * Cache the time of last initgroups invocation. Typically this is not done when

--- a/src/db/sysdb_subdomains.c
+++ b/src/db/sysdb_subdomains.c
@@ -1622,6 +1622,84 @@ done:
 }
 
 errno_t
+sysdb_domain_update_domain_template(struct sss_domain_info *parent,
+                                    struct sysdb_ctx *sysdb,
+                                    const char *subdom_name,
+                                    const char *home_dir,
+                                    const char *login_shell)
+{
+
+    TALLOC_CTX *tmp_ctx;
+    struct ldb_dn *dn;
+    struct sss_domain_info *subdom;
+    errno_t ret;
+
+    if (home_dir == NULL && login_shell == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Either login shell or home directory must be provided\n");
+        return EINVAL;
+    }
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    dn = ldb_dn_new_fmt(tmp_ctx, sysdb->ldb, SYSDB_DOM_BASE, subdom_name);
+    if (dn == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = sysdb_update_domain_template(sysdb, dn,
+                                       home_dir, login_shell);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "sysdb_update_domain_template() failed [%d]: [%s].\n",
+              ret, sss_strerror(ret));
+        goto done;
+    }
+
+    /* Update sss_domain_info struct to have templates available in memory */
+    subdom = find_domain_by_name(parent, subdom_name, true);
+    if (!subdom) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Could not find domain matching [%s]\n",
+              subdom_name);
+        ret = EIO;
+        goto done;
+    }
+
+    if (home_dir != NULL) {
+        subdom->template_homedir = talloc_strdup(subdom, home_dir);
+        if (subdom->template_homedir == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE, "Failed to copy homedir template.\n");
+            ret = ENOMEM;
+            goto done;
+        }
+    } else {
+        subdom->template_homedir = NULL;
+    }
+
+    if (login_shell != NULL) {
+        subdom->template_shell = talloc_strdup(subdom, login_shell);
+        if (subdom->template_shell == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE, "Failed to copy shell template.\n");
+            ret = ENOMEM;
+            goto done;
+        }
+    } else {
+        subdom->template_shell = NULL;
+    }
+
+    ret = EOK;
+
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+errno_t
 sysdb_domain_update_domain_resolution_order(struct sysdb_ctx *sysdb,
                                             const char *domain_name,
                                             const char *domain_resolution_order)

--- a/src/db/sysdb_views.c
+++ b/src/db/sysdb_views.c
@@ -25,6 +25,9 @@
 #include "db/sysdb_domain_resolution_order.h"
 
 #define SYSDB_VIEWS_BASE "cn=views,cn=sysdb"
+#define SYSDB_DOMAIN_TEMPLATE_OVERRIDE_FILTER "(templateType=domain)"
+#define SYSDB_GLOBAL_TEMPLATE_OVERRIDE_FILTER "(templateType=global)"
+#define SYSDB_GLOBAL_TEMPLATE_SID "S-1-5-11"
 
 /* In general is should not be possible that there is a view container without
  * a view name set. But to be on the safe side we return both information
@@ -486,62 +489,108 @@ add_name_and_aliases_for_name_override(struct sss_domain_info *domain,
     return EOK;
 }
 
-errno_t sysdb_store_override(struct sss_domain_info *domain,
-                             const char *view_name,
-                             enum sysdb_member_type type,
-                             struct sysdb_attrs *attrs, struct ldb_dn *obj_dn)
+static errno_t sysdb_add_template_values(struct sysdb_attrs *attrs,
+                                         struct sss_domain_info *domain,
+                                         const char *global_template_homedir,
+                                         const char *global_template_shell,
+                                         const char *override_dn,
+                                         bool has_override)
 {
-    TALLOC_CTX *tmp_ctx;
-    const char *anchor;
     int ret;
-    struct ldb_dn *override_dn;
+    const char *classes[] = {"ipaOverrideAnchor", "top", "ipaUserOverride", "ipasshuser",
+                             "ipaSshGroupOfPubKeys", NULL};
+
+    if (attrs == NULL) {
+        DEBUG(SSSDBG_MINOR_FAILURE, "Expected sysdb attrs to populate\n");
+        ret = EINVAL;
+        goto done;
+    }
+
+    /* originalDN */
+    ret = sysdb_attrs_add_string(attrs, SYSDB_ORIG_DN, override_dn);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_MINOR_FAILURE, "Error setting SYSDB_ORIG_DN: [%s]\n",
+                                 strerror(ret));
+        goto done;
+    }
+
+    /* Original objectClass, existing override attrs already has these classes */
+    if (!has_override) {
+        for (int i = 0; classes[i] != NULL; i++) {
+            ret = sysdb_attrs_add_string(attrs, SYSDB_ORIG_OBJECTCLASS, classes[i]);
+            if (ret != EOK) {
+                DEBUG(SSSDBG_MINOR_FAILURE, "Error setting SYSDB_ORIG_OBJECTCLASS: [%s]\n",
+                                         strerror(ret));
+                goto done;
+            }
+        }
+    }
+
+    /* Apply homedir template values */
+    if (domain->template_homedir != NULL) {
+        ret = sysdb_attrs_add_string(attrs, SYSDB_HOMEDIR, domain->template_homedir);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE, "Error setting domain template homedir: [%s]\n",
+                                     strerror(ret));
+            goto done;
+        }
+    } else if (global_template_homedir != NULL) {
+        ret = sysdb_attrs_add_string(attrs, SYSDB_HOMEDIR, global_template_homedir);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE, "Error setting global template homedir: [%s]\n",
+                                     strerror(ret));
+            goto done;
+        }
+    }
+
+    /* Apply shell template values */
+    if (domain->template_shell != NULL) {
+        ret = sysdb_attrs_add_string(attrs, SYSDB_SHELL, domain->template_shell);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE, "Error setting domain template shell: [%s]\n",
+                                     strerror(ret));
+            goto done;
+        }
+    } else if (global_template_shell != NULL ) {
+        ret = sysdb_attrs_add_string(attrs, SYSDB_SHELL, global_template_shell);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE, "Error setting global template shell: [%s]\n",
+                                     strerror(ret));
+            goto done;
+        }
+    }
+
+    ret = EOK;
+
+done:
+    return ret;
+}
+
+errno_t sysdb_update_override_object(TALLOC_CTX *mem_ctx,
+                                     struct sss_domain_info *domain,
+                                     struct sysdb_attrs *attrs,
+                                     enum sysdb_member_type type,
+                                     struct ldb_dn *override_dn,
+                                     struct ldb_dn *obj_dn,
+                                     bool has_override,
+                                     bool template)
+{
     const char *override_dn_str;
     const char *obj_dn_str;
+    int ret;
+    size_t count = 0;
     const char *obj_attrs[] = { SYSDB_OBJECTCLASS,
                                 SYSDB_OVERRIDE_DN,
                                 NULL};
-    size_t count = 0;
     struct ldb_message **msgs;
     struct ldb_message *msg = NULL;
     const char *obj_override_dn;
     bool add_ref = true;
-    size_t c;
     bool in_transaction = false;
-    bool has_override = true;
+    size_t c;
     const char *name_override;
 
-    tmp_ctx = talloc_new(NULL);
-    if (tmp_ctx == NULL) {
-        ret = ENOMEM;
-        goto done;
-    }
-
-    if (attrs != NULL) {
-        has_override = true;
-        ret = sysdb_attrs_get_string(attrs, SYSDB_OVERRIDE_ANCHOR_UUID,
-                                     &anchor);
-        if (ret != EOK) {
-            DEBUG(SSSDBG_CRIT_FAILURE,
-                  "Missing anchor in override attributes.\n");
-            ret = EINVAL;
-            goto done;
-        }
-
-        override_dn = ldb_dn_new_fmt(tmp_ctx, domain->sysdb->ldb,
-                                     SYSDB_TMPL_OVERRIDE, anchor, view_name);
-        if (override_dn == NULL) {
-            DEBUG(SSSDBG_OP_FAILURE, "ldb_dn_new_fmt failed.\n");
-            ret = ENOMEM;
-            goto done;
-        }
-    } else {
-        /* if there is no override for the given object, just store the DN of
-         * the object iself in the SYSDB_OVERRIDE_DN attribute to indicate
-         * that it was checked if an override exists and none was found. */
-        has_override = false;
-        override_dn = obj_dn;
-    }
-
+    /* Add/Update override object in cache */
     override_dn_str = ldb_dn_get_linearized(override_dn);
     obj_dn_str = ldb_dn_get_linearized(obj_dn);
     if (override_dn_str == NULL || obj_dn_str == NULL) {
@@ -550,7 +599,7 @@ errno_t sysdb_store_override(struct sss_domain_info *domain,
         goto done;
     }
 
-    ret = sysdb_search_entry(tmp_ctx, domain->sysdb, obj_dn, LDB_SCOPE_BASE,
+    ret = sysdb_search_entry(mem_ctx, domain->sysdb, obj_dn, LDB_SCOPE_BASE,
                              NULL, obj_attrs, &count, &msgs);
     if (ret != EOK) {
         if (ret == ENOENT) {
@@ -601,21 +650,23 @@ errno_t sysdb_store_override(struct sss_domain_info *domain,
                   "ldb_delete failed, maybe object did not exist. Ignoring.\n");
         }
 
-        ret = sysdb_attrs_get_string(attrs, SYSDB_NAME, &name_override);
-        if (ret == EOK) {
-            ret = add_name_and_aliases_for_name_override(domain, attrs, false,
-                                                         name_override);
-            if (ret != EOK) {
-                DEBUG(SSSDBG_OP_FAILURE,
-                      "add_name_and_aliases_for_name_override failed.\n");
+        if (!template) {
+            ret = sysdb_attrs_get_string(attrs, SYSDB_NAME, &name_override);
+            if (ret == EOK) {
+                ret = add_name_and_aliases_for_name_override(domain, attrs, false,
+                                                             name_override);
+                if (ret != EOK) {
+                    DEBUG(SSSDBG_OP_FAILURE,
+                          "add_name_and_aliases_for_name_override failed.\n");
+                    goto done;
+                }
+            } else if (ret != ENOENT) {
+                DEBUG(SSSDBG_OP_FAILURE, "sysdb_attrs_get_string failed.\n");
                 goto done;
             }
-        } else if (ret != ENOENT) {
-            DEBUG(SSSDBG_OP_FAILURE, "sysdb_attrs_get_string failed.\n");
-            goto done;
         }
 
-        msg = ldb_msg_new(tmp_ctx);
+        msg = ldb_msg_new(mem_ctx);
         if (msg == NULL) {
             ret = ENOMEM;
             goto done;
@@ -693,9 +744,10 @@ errno_t sysdb_store_override(struct sss_domain_info *domain,
         }
     }
 
+    /* Update overrideDN value of actual user or group object to point to override */
     if (add_ref) {
         talloc_free(msg);
-        msg = ldb_msg_new(tmp_ctx);
+        msg = ldb_msg_new(mem_ctx);
         if (msg == NULL) {
             ret = ENOMEM;
             goto done;
@@ -730,7 +782,6 @@ errno_t sysdb_store_override(struct sss_domain_info *domain,
     }
 
     ret = EOK;
-
 done:
     if (in_transaction) {
         if (ret != EOK) {
@@ -742,6 +793,172 @@ done:
         }
     }
 
+    return ret;
+}
+
+errno_t sysdb_store_override_template(struct sss_domain_info *domain,
+                                      struct sysdb_attrs *override_attrs,
+                                      const char *global_template_homedir,
+                                      const char *global_template_shell,
+                                      const char *view_name,
+                                      struct ldb_dn *obj_dn)
+{
+    TALLOC_CTX *tmp_ctx;
+    int ret;
+    struct ldb_dn *override_dn;
+    struct sysdb_attrs *attrs;
+    const char *override_dn_str;
+    const char *anchor;
+    bool has_override = false;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    if (override_attrs != NULL) {
+        has_override = true;
+    }
+
+    if (domain->template_homedir == NULL && domain->template_shell == NULL
+        && global_template_homedir == NULL && global_template_shell == NULL) {
+        DEBUG(SSSDBG_MINOR_FAILURE, "No template values to update.\n");
+        ret = EOK;
+        goto done;
+    }
+
+    /* If normal non-template ID override exists for this user, then update
+     * the existing ID override object (adding template values ) */
+    if (has_override) {
+        ret = sysdb_attrs_get_string(override_attrs, SYSDB_OVERRIDE_ANCHOR_UUID,
+                                     &anchor);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Missing anchor in override attributes.\n");
+            ret = EINVAL;
+            goto done;
+        }
+    /* Use domain SID for override DN, or global template SID */
+    } else if (domain->template_homedir != NULL || domain->template_shell != NULL) {
+        anchor = talloc_asprintf(tmp_ctx, "%s-545", domain->domain_id);
+        if (anchor == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE, "talloc_asprintf failed.\n");
+            ret = ENOMEM;
+            goto done;
+        }
+    } else {
+        anchor = SYSDB_GLOBAL_TEMPLATE_SID;
+    }
+
+    override_dn = ldb_dn_new_fmt(tmp_ctx, domain->sysdb->ldb,
+                                 SYSDB_TMPL_OVERRIDE, anchor,
+                                 domain->view_name);
+
+    if (!has_override) {
+        attrs = sysdb_new_attrs(tmp_ctx);
+        if (attrs == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE, "sysdb_new_attrs failed.\n");
+            ret = ENOMEM;
+            goto done;
+        }
+    } else {
+        attrs = override_attrs;
+    }
+
+    override_dn_str = ldb_dn_get_linearized(override_dn);
+    if (override_dn_str == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "override_dn_str == NULL.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = sysdb_add_template_values(attrs, domain,
+                                    global_template_homedir, global_template_shell,
+                                    override_dn_str, has_override);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_MINOR_FAILURE, "Error adding template values: [%s]\n",
+                                    strerror(ret));
+        goto done;
+    }
+
+    ret = sysdb_update_override_object(tmp_ctx, domain, attrs,
+                                       SYSDB_MEMBER_USER, override_dn,
+                                       obj_dn, true, true);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "sysdb_update_override_object failed.\n");
+    }
+
+
+    ret = EOK;
+
+done:
+    if (ret != EOK) {
+        DEBUG(SSSDBG_TRACE_FUNC, "Error: %d (%s)\n", ret, strerror(ret));
+    }
+
+    talloc_zfree(tmp_ctx);
+    return ret;
+}
+
+
+errno_t sysdb_store_override(struct sss_domain_info *domain,
+                             const char *view_name,
+                             enum sysdb_member_type type,
+                             struct sysdb_attrs *attrs, struct ldb_dn *obj_dn)
+{
+    TALLOC_CTX *tmp_ctx;
+    const char *anchor;
+    int ret;
+    struct ldb_dn *override_dn;
+    bool has_override = true;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    if (attrs != NULL) {
+        has_override = true;
+        ret = sysdb_attrs_get_string(attrs, SYSDB_OVERRIDE_ANCHOR_UUID,
+                                     &anchor);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Missing anchor in override attributes.\n");
+            ret = EINVAL;
+            goto done;
+        }
+
+        override_dn = ldb_dn_new_fmt(tmp_ctx, domain->sysdb->ldb,
+                                     SYSDB_TMPL_OVERRIDE, anchor, view_name);
+        if (override_dn == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE, "ldb_dn_new_fmt failed.\n");
+            ret = ENOMEM;
+            goto done;
+        }
+
+    } else {
+        /* if there is no override for the given object, and no override
+         * template, just store the DN of the object iself in the
+         * SYSDB_OVERRIDE_DN attribute to indicate that it was checked
+         * if an override exists and none was found. */
+        has_override = false;
+        override_dn = obj_dn;
+    }
+
+    ret = sysdb_update_override_object(tmp_ctx, domain, attrs, type,
+                                       override_dn, obj_dn, has_override,
+                                       false);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "sysdb_update_override_object failed.\n");
+    }
+
+    ret = EOK;
+
+done:
     talloc_zfree(tmp_ctx);
     return ret;
 }
@@ -821,6 +1038,8 @@ done:
 
 errno_t sysdb_apply_default_override(struct sss_domain_info *domain,
                                      struct sysdb_attrs *override_attrs,
+                                     const char *global_template_homedir,
+                                     const char *global_template_shell,
                                      struct ldb_dn *obj_dn)
 {
     int ret;
@@ -844,16 +1063,40 @@ errno_t sysdb_apply_default_override(struct sss_domain_info *domain,
     bool is_cert = false;
     struct ldb_message_element el_del = { 0, SYSDB_SSH_PUBKEY, 0, NULL };
     struct sysdb_attrs del_attrs = { 1, &el_del };
-
-    if (override_attrs == NULL) {
-        /* nothing to do */
-        return EOK;
-    }
+    bool has_override = false;
 
     tmp_ctx = talloc_new(NULL);
     if (tmp_ctx == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "talloc_new failed.\n");
         return ENOMEM;
+    }
+
+    if (override_attrs != NULL) {
+        has_override = true;
+    } else {
+        override_attrs = sysdb_new_attrs(tmp_ctx);
+        if (override_attrs == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE, "sysdb_new_attrs failed.\n");
+            ret = ENOMEM;
+            goto done;
+        }
+    }
+
+    /* No overrides exist for the user, check templates */
+    if (domain->template_homedir != NULL || domain->template_shell != NULL
+        || global_template_homedir != NULL || global_template_shell != NULL) {
+        ret = sysdb_add_template_values(override_attrs, domain, global_template_homedir,
+                                        global_template_shell, ldb_dn_get_linearized(obj_dn),
+                                        has_override);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE, "Error adding template values: [%s]\n",
+                                        strerror(ret));
+            goto done;
+        }
+    /* No templates, nothing to do */
+    } else {
+        ret = EOK;
+        goto done;
     }
 
     attrs = sysdb_new_attrs(tmp_ctx);
@@ -1937,4 +2180,260 @@ const char *sss_view_ldb_msg_find_attr_as_string(struct sss_domain_info *dom,
 {
     return sss_view_ldb_msg_find_attr_as_string_ex(dom, msg, attr_name,
                                                    default_value, NULL);
+}
+
+static errno_t sysdb_create_override_template(struct sysdb_ctx *sysdb,
+                                              const char *template_dn,
+                                              const char *anchor,
+                                              const char *homedir,
+                                              const char *shell)
+{
+    struct ldb_message *msg = NULL;
+    bool domain_template;
+    bool global_template;
+    errno_t ret;
+
+    msg = ldb_msg_new(sysdb);
+    if (msg == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+    msg->dn = ldb_dn_new(msg, sysdb->ldb, template_dn);
+    if (msg->dn == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = ldb_msg_add_string(msg, SYSDB_OBJECTCLASS,
+                             SYSDB_OVERRIDE_ANCHOR);
+
+    ret = ldb_msg_add_string(msg, SYSDB_OBJECTCLASS,
+                             SYSDB_OVERRIDE_USER_CLASS);
+
+    /* global templates always have anchor :SID:S-1-5-11 */
+    ret = string_ends_with(anchor, SYSDB_GLOBAL_TEMPLATE_SID, &global_template);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_TRACE_FUNC, "string_ends_with() failure.\n");
+        goto done;
+    }
+
+    /* domain template examples below in format :SID:$domainpart-545
+     *     :SID:S-1-5-21-3044487217-4285925784-991641718-545
+     *     :SID:S-1-5-21-644878228-3836315275-1841415914-545
+     */
+    ret = string_ends_with(anchor, "-545", &domain_template);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_TRACE_FUNC, "string_ends_with() failure.\n");
+        goto done;
+    }
+
+    if (global_template) {
+        ret = ldb_msg_add_string(msg, "templateType", "global");
+        if (ret != LDB_SUCCESS) {
+            ret = sysdb_error_to_errno(ret);
+            goto done;
+        }
+    } else if (domain_template) {
+        ret = ldb_msg_add_string(msg, "templateType", "domain");
+        if (ret != LDB_SUCCESS) {
+            ret = sysdb_error_to_errno(ret);
+            goto done;
+        }
+    }
+
+    if (homedir != NULL) {
+        ret = ldb_msg_add_string(msg, SYSDB_HOMEDIR, homedir);
+        if (ret != LDB_SUCCESS) {
+            ret = sysdb_error_to_errno(ret);
+            goto done;
+        }
+    }
+
+    if (shell != NULL) {
+        ret = ldb_msg_add_string(msg, SYSDB_SHELL, shell);
+        if (ret != LDB_SUCCESS) {
+            ret = sysdb_error_to_errno(ret);
+            goto done;
+        }
+    }
+
+    ret = ldb_msg_add_string(msg, SYSDB_OVERRIDE_ANCHOR_UUID, anchor);
+    if (ret != LDB_SUCCESS) {
+        ret = sysdb_error_to_errno(ret);
+        goto done;
+    }
+
+    /* do a synchronous add */
+    ret = ldb_add(sysdb->ldb, msg);
+    if (ret != LDB_SUCCESS) {
+        DEBUG(SSSDBG_FATAL_FAILURE,
+              "Failed to add domain template container (%d, [%s])!\n",
+               ret, ldb_errstring(sysdb->ldb));
+        ret = EIO;
+        goto done;
+    }
+
+    ret = EOK;
+
+done:
+    talloc_free(msg);
+
+    return ret;
+}
+
+errno_t
+sysdb_update_domain_template(struct sysdb_ctx *sysdb,
+                             struct ldb_dn *dn,
+                             const char *home_dir,
+                             const char *login_shell)
+{
+    TALLOC_CTX *tmp_ctx;
+    struct ldb_message *msg;
+    errno_t ret;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    msg = ldb_msg_new(tmp_ctx);
+    if (msg == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    msg->dn = dn;
+
+    if (login_shell != NULL) {
+        ret = ldb_msg_add_empty(msg, SYSDB_DOMAIN_TEMPLATE_SHELL,
+                                LDB_FLAG_MOD_REPLACE, NULL);
+        if (ret != LDB_SUCCESS) {
+            ret = sysdb_error_to_errno(ret);
+            goto done;
+        }
+
+        ret = ldb_msg_add_string(msg, SYSDB_DOMAIN_TEMPLATE_SHELL,
+                                 login_shell);
+        if (ret != LDB_SUCCESS) {
+            ret = sysdb_error_to_errno(ret);
+            goto done;
+        }
+    }
+
+    if (home_dir != NULL) {
+        ret = ldb_msg_add_empty(msg, SYSDB_DOMAIN_TEMPLATE_HOMEDIR,
+                                LDB_FLAG_MOD_REPLACE, NULL);
+        if (ret != LDB_SUCCESS) {
+            ret = sysdb_error_to_errno(ret);
+            goto done;
+        }
+
+        ret = ldb_msg_add_string(msg, SYSDB_DOMAIN_TEMPLATE_HOMEDIR,
+                                 home_dir);
+        if (ret != LDB_SUCCESS) {
+            ret = sysdb_error_to_errno(ret);
+            goto done;
+        }
+    }
+
+    ret = ldb_modify(sysdb->ldb, msg);
+    if (ret != LDB_SUCCESS) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "ldb_modify()_failed: [%s][%d][%s]\n",
+              ldb_strerror(ret), ret, ldb_errstring(sysdb->ldb));
+        ret = sysdb_error_to_errno(ret);
+        goto done;
+    }
+
+
+    ret = EOK;
+
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+errno_t sysdb_update_override_template(struct sysdb_ctx *sysdb,
+                                       const char *view_name,
+                                       const char *anchor,
+                                       const char *homedir,
+                                       const char *shell)
+{
+    struct ldb_dn *container_dn = NULL;
+    TALLOC_CTX *tmp_ctx = NULL;
+    bool in_transaction = false;
+    int ret;
+    const char *anchor_chopped;
+    const char *template_dn;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    template_dn = talloc_asprintf(tmp_ctx, SYSDB_TMPL_OVERRIDE,
+                                  anchor,
+                                  view_name);
+    if (template_dn == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "talloc_asprintf failed.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    /* anchor begins with a : character, ldb treats strings beginning
+     * with : as base64 so we need to remove it */
+    if (anchor == NULL || anchor[0] != ':') {
+        DEBUG(SSSDBG_OP_FAILURE, "NULL or Invalid anchor format\n");
+        ret = EINVAL;
+        goto done;
+    }
+    anchor_chopped = anchor + 1;
+
+    DEBUG(SSSDBG_TRACE_FUNC, "Preparing to add [%s] to sysdb\n",
+                             template_dn);
+
+    container_dn = ldb_dn_new(sysdb, sysdb->ldb, template_dn);
+    if (container_dn == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "ldb_dn_new failed.\n");
+        return ENOMEM;
+    }
+
+    ret = sysdb_transaction_start(sysdb);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sysdb_transaction_start failed.\n");
+        goto done;
+    }
+    in_transaction = true;
+
+    ret = sysdb_delete_recursive(sysdb, container_dn, true);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sysdb_delete_recursive failed.\n");
+        goto done;
+    }
+    ret = sysdb_create_override_template(sysdb, template_dn,
+                                         anchor_chopped, homedir, shell);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sysdb_create_certmap_container failed.\n");
+        goto done;
+    }
+
+    ret = sysdb_transaction_commit(sysdb);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "sysdb_transaction_commit failed.\n");
+        goto done;
+    }
+    in_transaction = false;
+
+done:
+    if (in_transaction) {
+        ret = sysdb_transaction_cancel(sysdb);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "Could not cancel transaction.\n");
+        }
+    }
+
+    talloc_free(container_dn);
+    talloc_free(tmp_ctx);
+
+    return ret;
 }

--- a/src/providers/ipa/ipa_common.h
+++ b/src/providers/ipa/ipa_common.h
@@ -210,6 +210,8 @@ struct ipa_id_ctx {
     char *view_name;
     /* Only used with server mode */
     struct ipa_server_mode_ctx *server_mode;
+    const char *global_template_homedir;
+    const char *global_template_shell;
 };
 
 struct ipa_options {

--- a/src/providers/ipa/ipa_s2n_exop.c
+++ b/src/providers/ipa/ipa_s2n_exop.c
@@ -946,6 +946,7 @@ static errno_t ipa_s2n_save_objects(struct sss_domain_info *dom,
                                     struct req_input *req_input,
                                     struct resp_attrs *attrs,
                                     struct resp_attrs *simple_attrs,
+                                    struct ipa_id_ctx *ipa_ctx,
                                     const char *view_name,
                                     struct sysdb_attrs *override_attrs,
                                     struct sysdb_attrs *mapped_attrs,
@@ -1611,7 +1612,7 @@ static errno_t ipa_s2n_get_list_save_step(struct tevent_req *req)
                                                struct ipa_s2n_get_list_state);
 
     ret = ipa_s2n_save_objects(state->dom, &state->req_input, state->attrs,
-                               NULL, state->ipa_ctx->view_name,
+                               NULL, state->ipa_ctx, state->ipa_ctx->view_name,
                                state->override_attrs, state->mapped_attrs,
                                false);
     if (ret != EOK) {
@@ -2322,7 +2323,8 @@ static void ipa_s2n_get_user_done(struct tevent_req *subreq)
 
     if (ret == ENOENT || is_default_view(state->ipa_ctx->view_name)) {
         ret = ipa_s2n_save_objects(state->dom, state->req_input, state->attrs,
-                                   state->simple_attrs, NULL, NULL, NULL, true);
+                                   state->simple_attrs, state->ipa_ctx,
+                                   NULL, NULL, NULL, true);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "ipa_s2n_save_objects failed.\n");
             goto done;
@@ -2475,6 +2477,7 @@ static errno_t ipa_s2n_save_objects(struct sss_domain_info *dom,
                                     struct req_input *req_input,
                                     struct resp_attrs *attrs,
                                     struct resp_attrs *simple_attrs,
+                                    struct ipa_id_ctx *ipa_ctx,
                                     const char *view_name,
                                     struct sysdb_attrs *override_attrs,
                                     struct sysdb_attrs *mapped_attrs,
@@ -2905,10 +2908,25 @@ static errno_t ipa_s2n_save_objects(struct sss_domain_info *dom,
         /* For the default view the data return by the extdom plugin already
          * contains all needed data and it is not expected to have a separate
          * override object. */
-        ret = sysdb_store_override(dom, view_name, type, override_attrs,
-                                   res->msgs[0]->dn);
+        ret = sysdb_store_override(dom,
+                                   view_name,
+                                   type,
+                                   override_attrs, res->msgs[0]->dn);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "sysdb_store_override failed.\n");
+            goto done;
+        }
+
+        /* Individual user ID override should supersede template values,
+         * Don't add template values if normal ID override is found */
+        ret = sysdb_store_override_template(dom,
+                                            override_attrs,
+                                            ipa_ctx->global_template_homedir,
+                                            ipa_ctx->global_template_shell,
+                                            ipa_ctx->view_name,
+                                            res->msgs[0]->dn);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_OP_FAILURE, "sysdb_store_override_template failed.\n");
             goto done;
         }
     }
@@ -2958,7 +2976,8 @@ static void ipa_s2n_get_list_done(struct tevent_req  *subreq)
                                  &sid_str);
     if (ret == ENOENT) {
         ret = ipa_s2n_save_objects(state->dom, state->req_input, state->attrs,
-                                   state->simple_attrs, NULL, NULL, NULL, true);
+                                   state->simple_attrs, state->ipa_ctx,
+                                   NULL, NULL, NULL, true);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "ipa_s2n_save_objects failed.\n");
             goto fail;
@@ -2995,6 +3014,7 @@ static void ipa_s2n_get_list_done(struct tevent_req  *subreq)
     } else {
         ret = ipa_s2n_save_objects(state->dom, state->req_input, state->attrs,
                                    state->simple_attrs,
+                                   state->ipa_ctx,
                                    state->ipa_ctx->view_name,
                                    state->override_attrs, NULL, true);
         if (ret != EOK) {
@@ -3031,7 +3051,8 @@ static void ipa_s2n_get_user_get_override_done(struct tevent_req *subreq)
     }
 
     ret = ipa_s2n_save_objects(state->dom, state->req_input, state->attrs,
-                               state->simple_attrs, state->ipa_ctx->view_name,
+                               state->simple_attrs, state->ipa_ctx,
+                               state->ipa_ctx->view_name,
                                override_attrs, NULL, true);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "ipa_s2n_save_objects failed.\n");

--- a/src/providers/ipa/ipa_subdomains.c
+++ b/src/providers/ipa/ipa_subdomains.c
@@ -48,6 +48,7 @@
 #define OBJECTCLASS "objectClass"
 
 #define IPA_ASSIGNED_ID_VIEW "ipaAssignedIDView"
+#define IPA_ANCHOR_UUID "ipaAnchorUUID"
 
 #define IPA_DOMAIN_RESOLUTION_ORDER "ipaDomainResolutionOrder"
 
@@ -1779,6 +1780,272 @@ static errno_t ipa_subdomains_view_name_recv(struct tevent_req *req)
     return EOK;
 }
 
+struct ipa_subdomains_view_template_state {
+    struct ipa_subdomains_ctx *sd_ctx;
+    struct sysdb_attrs *override_attrs;
+    struct sss_domain_info *domain;
+    const char *view_name;
+    const char *ipa_view_name;
+};
+
+static void ipa_subdomains_view_template_done(struct tevent_req *subreq);
+
+static struct tevent_req *
+ipa_subdomains_view_template_send(TALLOC_CTX *mem_ctx,
+                                  struct tevent_context *ev,
+                                  struct ipa_subdomains_ctx *sd_ctx,
+                                  struct sdap_handle *sh)
+{
+    struct ipa_subdomains_view_template_state *state;
+    struct tevent_req *subreq;
+    struct tevent_req *req;
+    const char *attrs[] = { IPA_ANCHOR_UUID, SYSDB_HOMEDIR, SYSDB_SHELL, NULL };
+    char *base;
+    char *ldap_basedn;
+    char *filter;
+    char *domain_name;
+    struct sss_domain_info *d = NULL;
+    errno_t ret;
+
+    req = tevent_req_create(mem_ctx, &state,
+                            struct ipa_subdomains_view_template_state);
+    if (req == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "tevent_req_create() failed\n");
+        return NULL;
+    }
+
+    state->sd_ctx = sd_ctx;
+    state->override_attrs = NULL;
+    state->domain = sd_ctx->be_ctx->domain;
+    state->view_name = sd_ctx->ipa_id_ctx->view_name;
+
+    if (is_default_view(state->view_name)) {
+        state->ipa_view_name = IPA_DEFAULT_VIEW_NAME;
+    } else {
+        state->ipa_view_name = state->view_name;
+    }
+
+    /* Create search filter including trusted domain SIDs, skip parent domain
+     * Only retrieve override templates by searching for global
+     * (ipaanchoruuid=:SID:S-1-5-11) or domain
+     * (ipaanchoruuid=:SID:$domain_id-545) template SID values explicitly */
+    filter = talloc_asprintf(state, "(|");
+    if (filter == NULL) {
+        ret = ENOMEM;
+        goto immediately;
+    }
+
+    for (d = get_next_domain(state->domain, SSS_GND_DESCEND);
+         d && IS_SUBDOMAIN(d);
+         d = get_next_domain(d, 0)) {
+        filter = talloc_asprintf_append(filter, "(%s=:SID:%s-545)",
+                                        IPA_ANCHOR_UUID, d->domain_id);
+    }
+
+    /* Add the global SID */
+    filter = talloc_asprintf_append(filter, "(%s=:SID:S-1-5-11))", IPA_ANCHOR_UUID);
+
+    domain_name = dp_opt_get_string(sd_ctx->ipa_id_ctx->ipa_options->basic,
+                                    IPA_KRB5_REALM);
+
+    ret = domain_to_basedn(state, domain_name, &ldap_basedn);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "domain_to_basedn failed.\n");
+        goto immediately;
+    }
+
+    DEBUG(SSSDBG_TRACE_ALL,
+          "Searching for overrides in view [%s] with filter [%s].\n",
+          state->ipa_view_name, filter);
+
+    base = talloc_asprintf(state, "cn=%s,cn=views,cn=accounts,%s",
+                           state->ipa_view_name, ldap_basedn);
+    if (base == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "talloc_asprintf failed.\n");
+        ret = ENOMEM;
+        goto immediately;
+    }
+
+    subreq = sdap_get_generic_send(state, ev, sd_ctx->sdap_id_ctx->opts,
+                                 sh, base,
+                                 LDAP_SCOPE_SUBTREE,
+                                 filter, attrs,
+                                 NULL,
+                                 0,
+                                 dp_opt_get_int(state->sd_ctx->sdap_id_ctx->opts->basic,
+                                                SDAP_SEARCH_TIMEOUT),
+                                 false);
+    if (subreq == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "sdap_get_generic_send failed.\n");
+        ret = ENOMEM;
+        goto immediately;
+    }
+
+    tevent_req_set_callback(subreq, ipa_subdomains_view_template_done, req);
+
+    return req;
+
+immediately:
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else {
+        tevent_req_error(req, ret);
+    }
+    tevent_req_post(req, ev);
+
+    return req;
+}
+
+static void ipa_subdomains_view_template_done(struct tevent_req *subreq)
+{
+    struct ipa_subdomains_view_template_state *state;
+    struct tevent_req *req;
+    size_t reply_count;
+    struct sysdb_attrs **reply;
+    struct sss_domain_info *trusted_dom = NULL;
+    const char *homedir = NULL;
+    const char *shell = NULL;
+    const char *anchor = NULL;
+    char **anchor_sid = NULL;
+    int anchor_num;
+    bool domain_template;
+    bool global_template;
+    errno_t ret;
+
+    req = tevent_req_callback_data(subreq, struct tevent_req);
+    state = tevent_req_data(req, struct ipa_subdomains_view_template_state);
+
+    ret = sdap_get_generic_recv(subreq, state, &reply_count, &reply);
+    talloc_zfree(subreq);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "ipa_subdomains_view_template request failed.\n");
+        goto done;
+    }
+
+    if (reply_count == 0) {
+        DEBUG(SSSDBG_TRACE_ALL, "No override template found.\n");
+        tevent_req_done(req);
+        return;
+    }
+
+    DEBUG(SSSDBG_TRACE_FUNC,
+          "Found [%zu] overrides\n",
+          reply_count);
+
+    for (int c = 0; c < reply_count; c++) {
+        homedir = NULL;
+        shell = NULL;
+
+        ret = sysdb_attrs_get_string(reply[c], SYSDB_HOMEDIR, &homedir);
+        if (ret != EOK && ret != ENOENT) {
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "sysdb_attrs_get_string failed(SYSDB_HOMEDIR): [%d](%s)\n",
+                  ret, sss_strerror(ret));
+            goto done;
+        }
+
+        ret = sysdb_attrs_get_string(reply[c], SYSDB_SHELL, &shell);
+        if (ret != EOK && ret != ENOENT) {
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "sysdb_attrs_get_string failed(SYSDB_SHELL): [%d](%s)\n",
+                  ret, sss_strerror(ret));
+            goto done;
+        }
+
+        ret = sysdb_attrs_get_string(reply[c], "ipaAnchorUUID", &anchor);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "sysdb_attrs_get_string failed(ipaAnchorUUID): [%d](%s)\n",
+                  ret, sss_strerror(ret));
+            goto done;
+        }
+
+        /* Add override templates into cache */
+        ret = sysdb_update_override_template(state->domain->sysdb, state->ipa_view_name,
+                                             anchor, homedir, shell);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_OP_FAILURE, "Unable to update override templates in sysdb.\n");
+            goto done;
+        }
+
+        /* Add any domain templates to the cache objects for the domains */
+        ret = string_ends_with(anchor, "-545", &domain_template);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_OP_FAILURE, "string_ends_with() failure.\n");
+            goto done;
+        }
+
+        ret = string_ends_with(anchor, "-1-5-11", &global_template);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_OP_FAILURE, "string_ends_with() failure.\n");
+            goto done;
+        }
+
+        if (domain_template) {
+            /* Get domain name from anchor */
+            ret = split_on_separator(state, anchor, ':', true, true, &anchor_sid, &anchor_num);
+            if (ret != EOK) {
+                DEBUG(SSSDBG_OP_FAILURE,
+                      "split_on_separator failed: [%d](%s)\n",
+                      ret, sss_strerror(ret));
+                goto done;
+            }
+
+            trusted_dom = find_domain_by_sid(state->domain, anchor_sid[1]);
+            if (trusted_dom == NULL) {
+                DEBUG(SSSDBG_MINOR_FAILURE, "No subdomain found with SID [%s], skipping.\n",
+                                            anchor_sid[1]);
+                continue;
+            }
+
+            ret = sysdb_domain_update_domain_template(state->domain, state->domain->sysdb, trusted_dom->name,
+                                                      homedir, shell);
+            if (ret != EOK) {
+                DEBUG(SSSDBG_OP_FAILURE, "sysdb_domain_update_domain_template failed.\n");
+                goto done;
+            }
+        /* Copy global template values into memory to be read in sysdb_store_override() */
+        } else if (global_template) {
+            if (homedir != NULL) {
+                state->sd_ctx->ipa_id_ctx->global_template_homedir = talloc_strdup(state->sd_ctx->ipa_id_ctx, homedir);
+                if (state->sd_ctx->ipa_id_ctx->global_template_homedir == NULL) {
+                    DEBUG(SSSDBG_OP_FAILURE, "talloc_strdup failed.\n");
+                    ret = ENOMEM;
+                    goto done;
+                }
+            } else {
+                state->sd_ctx->ipa_id_ctx->global_template_homedir = NULL;
+            }
+
+            if (shell != NULL) {
+                state->sd_ctx->ipa_id_ctx->global_template_shell = talloc_strdup(state->sd_ctx->ipa_id_ctx, shell);
+                if (state->sd_ctx->ipa_id_ctx->global_template_shell == NULL) {
+                    DEBUG(SSSDBG_OP_FAILURE, "talloc_strdup failed.\n");
+                    ret = ENOMEM;
+                    goto done;
+                }
+            } else {
+                state->sd_ctx->ipa_id_ctx->global_template_shell = NULL;
+            }
+        }
+    }
+
+done:
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    tevent_req_done(req);
+}
+
+static errno_t ipa_subdomains_view_template_recv(struct tevent_req *req)
+{
+    TEVENT_REQ_RETURN_ON_ERROR(req);
+
+    return EOK;
+}
+
 struct ipa_subdomains_view_domain_resolution_order_state {
     struct sss_domain_info *domain;
     const char *view_name;
@@ -2647,6 +2914,7 @@ static void ipa_subdomains_refresh_passkey_done(struct tevent_req *subreq);
 static void ipa_subdomains_refresh_master_done(struct tevent_req *subreq);
 static void ipa_subdomains_refresh_slave_done(struct tevent_req *subreq);
 static void ipa_subdomains_refresh_view_name_done(struct tevent_req *subreq);
+static void ipa_subdomains_refresh_view_template_done(struct tevent_req *subreq);
 static void ipa_subdomains_refresh_view_domain_resolution_order_done(
                                                     struct tevent_req *subreq);
 static void ipa_domain_refresh_resolution_order_done(struct tevent_req *subreq);
@@ -2912,6 +3180,36 @@ static void ipa_subdomains_refresh_view_name_done(struct tevent_req *subreq)
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Unable to get view name [%d]: %s\n",
+              ret, sss_strerror(ret));
+        /* Not good, but let's try to continue with other server side options */
+    }
+
+    subreq = ipa_subdomains_view_template_send(state, state->ev, state->sd_ctx,
+                                           sdap_id_op_handle(state->sdap_op));
+    if (subreq == NULL) {
+        tevent_req_error(req, ENOMEM);
+        return;
+    }
+
+    tevent_req_set_callback(subreq, ipa_subdomains_refresh_view_template_done,
+                            req);
+    return;
+}
+
+static void ipa_subdomains_refresh_view_template_done(struct tevent_req *subreq)
+{
+    struct ipa_subdomains_refresh_state *state;
+    struct tevent_req *req;
+    errno_t ret;
+
+    req = tevent_req_callback_data(subreq, struct tevent_req);
+    state = tevent_req_data(req, struct ipa_subdomains_refresh_state);
+
+    ret = ipa_subdomains_view_template_recv(subreq);
+    talloc_zfree(subreq);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Unable to get ID override templates [%d]: %s\n",
               ret, sss_strerror(ret));
         /* Not good, but let's try to continue with other server side options */
     }

--- a/src/providers/ipa/ipa_subdomains_id.c
+++ b/src/providers/ipa/ipa_subdomains_id.c
@@ -1701,13 +1701,23 @@ static errno_t ipa_get_trusted_apply_override_step(struct tevent_req *req)
     int entry_type;
     size_t groups_count = 0;
     struct ldb_message **groups = NULL;
+    bool has_template = false;
     const char *attrs[] = SYSDB_INITGR_ATTRS;
 
-    if (state->override_attrs != NULL) {
+    if (state->obj_dom->template_homedir != NULL ||
+        state->obj_dom->template_shell != NULL ||
+        state->ipa_ctx->global_template_homedir != NULL ||
+        state->ipa_ctx->global_template_shell != NULL) {
+        has_template = true;
+    }
+
+    if (state->override_attrs != NULL || has_template) {
         /* We are in ipa-server-mode, so the view is the default view by
          * definition. */
         ret = sysdb_apply_default_override(state->obj_dom,
                                            state->override_attrs,
+                                           state->ipa_ctx->global_template_homedir,
+                                           state->ipa_ctx->global_template_shell,
                                            state->obj_msg->dn);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "sysdb_apply_default_override failed.\n");

--- a/src/tests/cmocka/test_string_utils.c
+++ b/src/tests/cmocka/test_string_utils.c
@@ -184,6 +184,26 @@ void test_get_last_x_chars(void **state)
     assert_string_equal(s, "abc");
 }
 
+void test_string_ends_with(void **state)
+{
+    errno_t ret;
+    bool result;
+
+    ret = string_ends_with("abc-def", "def", &result);
+    assert_int_equal(ret, EOK);
+    assert_true(result);
+
+    ret = string_ends_with("abc-def", "de", &result);
+    assert_int_equal(ret, EOK);
+    assert_false(result);
+
+    ret = string_ends_with("abc", "abcdef", &result);
+    assert_int_equal(ret, EINVAL);
+
+    ret = string_ends_with(NULL, "abcdef", &result);
+    assert_int_equal(ret, EINVAL);
+}
+
 void test_concatenate_string_array(void **state)
 {
     TALLOC_CTX *mem_ctx;

--- a/src/tests/cmocka/test_utils.c
+++ b/src/tests/cmocka/test_utils.c
@@ -2494,6 +2494,7 @@ int main(int argc, const char *argv[])
         cmocka_unit_test(test_reverse_replace_whitespaces),
         cmocka_unit_test(test_guid_blob_to_string_buf),
         cmocka_unit_test(test_get_last_x_chars),
+        cmocka_unit_test(test_string_ends_with),
         cmocka_unit_test(test_concatenate_string_array),
         cmocka_unit_test_setup_teardown(test_add_strings_lists,
                                         setup_leak_tests,

--- a/src/tests/cmocka/test_utils.h
+++ b/src/tests/cmocka/test_utils.h
@@ -31,6 +31,7 @@ void test_replace_whitespaces(void **state);
 void test_reverse_replace_whitespaces(void **state);
 void test_guid_blob_to_string_buf(void **state);
 void test_get_last_x_chars(void **state);
+void test_string_ends_with(void **state);
 void test_concatenate_string_array(void **state);
 void test_mod_defaults_list(void **state);
 

--- a/src/util/string_utils.c
+++ b/src/util/string_utils.c
@@ -128,6 +128,34 @@ const char *get_last_x_chars(const char *str, size_t x)
     return (str + len - x);
 }
 
+errno_t string_ends_with(const char *str,
+                         const char *suffix,
+                         bool *_result)
+{
+    int res;
+    size_t len;
+    size_t suffix_len;
+
+    *_result = false;
+
+    if (str == NULL) {
+        return EINVAL;
+    }
+
+    len = strlen(str);
+    suffix_len = strlen(suffix);
+
+    if (suffix_len > len) {
+        return EINVAL;
+    }
+
+    res = strcmp(str + (len - suffix_len), suffix);
+
+    *_result = !res;
+
+    return EOK;
+}
+
 char **concatenate_string_array(TALLOC_CTX *mem_ctx,
                                 char **arr1, size_t len1,
                                 char **arr2, size_t len2)

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -730,6 +730,7 @@ errno_t guid_blob_to_string_buf(const uint8_t *blob, char *str_buf,
                                 size_t buf_size);
 
 const char *get_last_x_chars(const char *str, size_t x);
+errno_t string_ends_with(const char *str, const char *suffix, bool *_result);
 
 char **concatenate_string_array(TALLOC_CTX *mem_ctx,
                                 char **arr1, size_t len1,


### PR DESCRIPTION
Add support for ID override templates for Trusted AD/IPA users.

Testing this PR can be done with https://copr.fedorainfracloud.org/coprs/abbra/wip-ipa-trust/ which contains FreeIPA ID override templates code, and SSSD build with these code changes.


=====================

Add functionality for SSSD to apply domain templates and global templates as fallback override values to trusted IDM and AD users.

Templates are only assigned loginShell and/or homeDirectory attribute values. On the FreeIPA server, templates are added to ID views (Default trust view, or other) and will be used as fallback in ID override lookups. ID override templates can be set for user home directory(SSSD ‘override_homedir’ template syntax), or default login shell.

 Two types of templates will exist, domain templates and global templates. Allow specifying a template entry for trusted domain users.

```
--template <domain> – specify per-domain templates that apply to all users in the trusted domain <domain>
--global-template – specify a global template that applies to any authenticated user from a trusted domain
```

=====================

Domain template can be added with:

`# ipa idoverrideuser-add 'example_for_c1' '*' --template ipa2demo.test --homedir /home/%d/%u-DOMAIN --shell /bin/ksh`

Global template can be added with:

`# ipa idoverrideuser-add 'example_for_c1' '*' --global-template --homedir /home/%d/%u-GLOBAL --shell /bin/csh`