### PR TITLE
UTIL: mark non string array properly

### DIFF
--- a/src/util/crypto/libcrypto/crypto_sha512crypt.c
+++ b/src/util/crypto/libcrypto/crypto_sha512crypt.c
@@ -44,7 +44,7 @@ const char sha512_rounds_prefix[] = "rounds=";
 #define ROUNDS_MAX 999999999
 
 /* Table with characters for base64 transformation.  */
-const char b64t[64] =
+__attribute__ ((nonstring)) const char b64t[64] =
     "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
 /* base64 conversion function */


### PR DESCRIPTION
Fixes:
```
../src/util/crypto/libcrypto/crypto_sha512crypt.c:48:5: error: initializer-string
for array of 'char' truncates NUL terminator but destination lacks 'nonstring'
attribute (65 chars into 64 available) [-Werror=unterminated-string-initialization]
   48 |     "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```