### PR TITLE
IPA: return ENOENT if `ipa_get_config` yields nothing

### DIFF
--- a/src/providers/ipa/ipa_auth.c
+++ b/src/providers/ipa/ipa_auth.c
@@ -100,6 +100,7 @@ static void get_password_migration_flag_auth_done(struct tevent_req *subreq)
                                                       struct tevent_req);
     struct get_password_migration_flag_state *state = tevent_req_data(req,
                                       struct get_password_migration_flag_state);
+    static const char *attrs[] = {IPA_CONFIG_MIGRATION_ENABLED, NULL};
     int ret, dp_error;
 
     ret = sdap_id_op_connect_recv(subreq, &dp_error);
@@ -122,7 +123,7 @@ static void get_password_migration_flag_auth_done(struct tevent_req *subreq)
     subreq = ipa_get_config_send(state, state->ev,
                                  sdap_id_op_handle(state->sdap_op),
                                  state->sdap_id_ctx->opts, state->ipa_realm,
-                                 NULL, NULL, NULL);
+                                 attrs, NULL, NULL);
 
     tevent_req_set_callback(subreq, get_password_migration_flag_done, req);
 }

--- a/src/providers/ipa/ipa_config.c
+++ b/src/providers/ipa/ipa_config.c
@@ -57,18 +57,11 @@ ipa_get_config_send(TALLOC_CTX *mem_ctx,
     }
 
     if (attrs == NULL) {
-        state->attrs = talloc_zero_array(state, const char *, 4);
-        if (state->attrs == NULL) {
-            ret = ENOMEM;
-            goto done;
-        }
-        state->attrs[0] = IPA_CONFIG_MIGRATION_ENABLED;
-        state->attrs[1] = IPA_CONFIG_SELINUX_DEFAULT_USER_CTX;
-        state->attrs[2] = IPA_CONFIG_SELINUX_MAP_ORDER;
-        state->attrs[3] = NULL;
-    } else {
-        state->attrs = attrs;
+        DEBUG(SSSDBG_OP_FAILURE, "Requested attributes must be provided.\n");
+        ret = EINVAL;
+        goto done;
     }
+    state->attrs = attrs;
 
     if (filter == NULL) {
         filter = IPA_CONFIG_FILTER;

--- a/src/providers/ipa/ipa_config.c
+++ b/src/providers/ipa/ipa_config.c
@@ -131,10 +131,13 @@ static void ipa_get_config_done(struct tevent_req *subreq)
         goto done;
     }
 
-    if (reply_count != 1) {
-        DEBUG(SSSDBG_MINOR_FAILURE, "Unexpected number of results, expected 1, "
-                                    "got %zu.\n", reply_count);
+    if (reply_count > 1) {
+        DEBUG(SSSDBG_MINOR_FAILURE, "Unexpected number of results: %zu.\n",
+              reply_count);
         ret = EINVAL;
+        goto done;
+    } else if (reply_count == 0) {
+        ret = ENOENT;
         goto done;
     }
 

--- a/src/providers/ipa/ipa_selinux.c
+++ b/src/providers/ipa/ipa_selinux.c
@@ -1090,8 +1090,8 @@ static void ipa_get_selinux_config_done(struct tevent_req *subreq)
 
     ret = ipa_get_config_recv(subreq, state, &state->defaults);
     talloc_free(subreq);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_IMPORTANT_INFO, "Could not get IPA config\n");
+    if (ret != EOK) { /* Expected to be configured so ENOENT is a real error */
+        DEBUG(SSSDBG_OP_FAILURE, "Could not get IPA config\n");
         goto done;
     }
 

--- a/src/providers/ipa/ipa_selinux.c
+++ b/src/providers/ipa/ipa_selinux.c
@@ -1066,13 +1066,15 @@ static void ipa_get_config_step(struct tevent_req *req)
     struct ipa_get_selinux_state *state = tevent_req_data(req,
                                                   struct ipa_get_selinux_state);
     struct ipa_id_ctx *id_ctx = state->selinux_ctx->id_ctx;
+    static const char *attrs[] = {IPA_CONFIG_SELINUX_DEFAULT_USER_CTX,
+                                  IPA_CONFIG_SELINUX_MAP_ORDER, NULL};
 
     domain = dp_opt_get_string(state->selinux_ctx->id_ctx->ipa_options->basic,
                                IPA_KRB5_REALM);
     subreq = ipa_get_config_send(state, state->be_ctx->ev,
                                  sdap_id_op_handle(state->op),
                                  id_ctx->sdap_id_ctx->opts,
-                                 domain, NULL, NULL, NULL);
+                                 domain, attrs, NULL, NULL);
     if (subreq == NULL) {
         tevent_req_error(req, ENOMEM);
     }

--- a/src/providers/ipa/ipa_subdomains.c
+++ b/src/providers/ipa/ipa_subdomains.c
@@ -1939,7 +1939,7 @@ ipa_domain_resolution_order_send(TALLOC_CTX *mem_ctx,
     struct ipa_domain_resolution_order_state *state;
     struct tevent_req *subreq;
     struct tevent_req *req;
-    const char *attrs[] = {IPA_DOMAIN_RESOLUTION_ORDER, NULL};
+    static const char *attrs[] = {IPA_DOMAIN_RESOLUTION_ORDER, NULL};
     errno_t ret;
 
     req = tevent_req_create(mem_ctx, &state,

--- a/src/providers/ipa/ipa_subdomains.c
+++ b/src/providers/ipa/ipa_subdomains.c
@@ -1977,8 +1977,10 @@ static void ipa_domain_resolution_order_done(struct tevent_req *subreq)
 
     ret = ipa_get_config_recv(subreq, state, &config);
     talloc_zfree(subreq);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_IMPORTANT_INFO,
+    if (ret == ENOENT) {
+        config = NULL;
+    } else if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
               "Failed to get the domains' resolution order configuration "
               "from the server [%d]: %s\n",
               ret, sss_strerror(ret));
@@ -1989,7 +1991,7 @@ static void ipa_domain_resolution_order_done(struct tevent_req *subreq)
         ret = sysdb_attrs_get_string(config, IPA_DOMAIN_RESOLUTION_ORDER,
                                      &domain_resolution_order);
         if (ret != EOK && ret != ENOENT) {
-            DEBUG(SSSDBG_IMPORTANT_INFO,
+            DEBUG(SSSDBG_OP_FAILURE,
                   "Failed to get the domains' resolution order configuration "
                   "value [%d]: %s\n",
                   ret, sss_strerror(ret));
@@ -2974,7 +2976,7 @@ ipa_domain_refresh_resolution_order_done(struct tevent_req *subreq)
     ret = ipa_domain_resolution_order_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        DEBUG(SSSDBG_MINOR_FAILURE,
+        DEBUG(SSSDBG_OP_FAILURE,
               "Unable to get the domains order resolution [%d]: %s\n",
               ret, sss_strerror(ret));
         /* Not good, but let's try to continue with other server side options */

--- a/src/providers/ipa/ipa_subdomains_passkey.c
+++ b/src/providers/ipa/ipa_subdomains_passkey.c
@@ -93,8 +93,10 @@ void ipa_subdomains_passkey_done(struct tevent_req *subreq)
 
     ret = ipa_get_config_recv(subreq, state, &config);
     talloc_zfree(subreq);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_MINOR_FAILURE, "Unable to get data from LDAP [%d]: %s\n",
+    if (ret == ENOENT) {
+        config = NULL;
+    } if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "Unable to get data from LDAP [%d]: %s\n",
                         ret, sss_strerror(ret));
         goto done;
     }

--- a/src/providers/ipa/ipa_subdomains_passkey.c
+++ b/src/providers/ipa/ipa_subdomains_passkey.c
@@ -49,7 +49,7 @@ ipa_subdomains_passkey_send(TALLOC_CTX *mem_ctx,
     struct tevent_req *subreq;
     struct tevent_req *req;
     errno_t ret;
-    const char *attrs[] = { IPA_PASSKEY_VERIFICATION, NULL };
+    static const char *attrs[] = { IPA_PASSKEY_VERIFICATION, NULL };
 
     req = tevent_req_create(mem_ctx, &state,
                             struct ipa_subdomains_passkey_state);


### PR DESCRIPTION
and handle this error code properly.