### PR TITLE
certmap: allow prefix in rule in sssd.conf

### DIFF
--- a/src/tests/intg/test_pam_responder.py
+++ b/src/tests/intg/test_pam_responder.py
@@ -159,8 +159,9 @@ def format_pam_cert_auth_conf(config, provider):
         debug_level = 10
         {provider.p}
 
-        [certmap/auth_only/user1]
+        [certmap/auth_only/abc]
         matchrule = <SUBJECT>.*CN=SSSD test cert 000[12].*
+        maprule = LDAPU1:(user1)
     """).format(**locals())
 
 


### PR DESCRIPTION
The current check for certificate mapping rules coming from sssd.conf is
too strict. Only rules which starts and ends with '(' and ')'
respectively are allowed. As a result new mapping templates with the
LDAPU1 prefix cannot be used.

With this patch prefixes are allowed as well. An existing integration
was was updated to cover this.

Resolves: https://github.com/SSSD/sssd/issues/7931