### PR TITLE
ipa: improve handling of external group memberships

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -1418,7 +1418,7 @@ errno_t sysdb_remove_attrs(struct sss_domain_info *domain,
                            char **remove_attrs);
 
 /**
- * @brief Return direct parents of an object in the cache
+ * @brief Return name of direct parents of an object in the cache
  *
  * @param[in]  mem_ctx         Memory context the result should be allocated
  *                             on
@@ -1443,6 +1443,37 @@ errno_t sysdb_get_direct_parents(TALLOC_CTX *mem_ctx,
                                  enum sysdb_member_type mtype,
                                  const char *name,
                                  char ***_direct_parents);
+
+/**
+ * @brief Return requested attribute of direct parents of an object in the cache
+ *
+ * @param[in]  mem_ctx         Memory context the result should be allocated
+ *                             on
+ * @param[in]  dom             domain the object is in
+ * @param[in]  parent_dom      domain which should be searched for direct
+ *                             parents if NULL all domains in the given cache
+ *                             are searched
+ * @param[in]  mtype           Type of the object, SYSDB_MEMBER_USER or
+ *                             SYSDB_MEMBER_GROUP
+ * @param[in]  name            Name of the object
+ * @param[in]  attr_name       Name of the attribute to return, if NULL
+ *                             SYSDB_NAME will be used
+ * @param[out] _direct_parents List of the requested attribute of the direct
+ *                             parent groups
+ *
+ *
+ * @return
+ *  - EOK:    success
+ *  - EINVAL: wrong mtype
+ *  - ENOMEM: Memory allocation failed
+ */
+errno_t sysdb_get_direct_parents_ex(TALLOC_CTX *mem_ctx,
+                                    struct sss_domain_info *dom,
+                                    struct sss_domain_info *parent_dom,
+                                    enum sysdb_member_type mtype,
+                                    const char *name,
+                                    const char *attr_name,
+                                    char ***_direct_parents);
 
 /* === Functions related to ID-mapping === */
 

--- a/src/db/sysdb_search.c
+++ b/src/db/sysdb_search.c
@@ -2430,18 +2430,19 @@ done:
     return ret;
 }
 
-errno_t sysdb_get_direct_parents(TALLOC_CTX *mem_ctx,
-                                 struct sss_domain_info *dom,
-                                 struct sss_domain_info *parent_dom,
-                                 enum sysdb_member_type mtype,
-                                 const char *name,
-                                 char ***_direct_parents)
+errno_t sysdb_get_direct_parents_ex(TALLOC_CTX *mem_ctx,
+                                    struct sss_domain_info *dom,
+                                    struct sss_domain_info *parent_dom,
+                                    enum sysdb_member_type mtype,
+                                    const char *name,
+                                    const char *attr_name,
+                                    char ***_direct_parents)
 {
     errno_t ret;
     const char *dn;
     char *sanitized_dn;
     struct ldb_dn *basedn;
-    static const char *group_attrs[] = { SYSDB_NAME, NULL };
+    const char *group_attrs[] = { NULL, NULL };
     const char *member_filter;
     size_t direct_sysdb_count = 0;
     struct ldb_message **direct_sysdb_groups = NULL;
@@ -2494,6 +2495,11 @@ errno_t sysdb_get_direct_parents(TALLOC_CTX *mem_ctx,
     DEBUG(SSSDBG_TRACE_INTERNAL,
           "searching sysdb with filter [%s]\n", member_filter);
 
+    if (attr_name == NULL) {
+        attr_name = SYSDB_NAME;
+    }
+    group_attrs[0] = attr_name;
+
     ret = sysdb_search_entry(tmp_ctx, dom->sysdb, basedn,
                              LDB_SCOPE_SUBTREE, member_filter, group_attrs,
                              &direct_sysdb_count, &direct_sysdb_groups);
@@ -2515,10 +2521,11 @@ errno_t sysdb_get_direct_parents(TALLOC_CTX *mem_ctx,
 
     pi = 0;
     for(i = 0; i < direct_sysdb_count; i++) {
-        tmp_str = ldb_msg_find_attr_as_string(direct_sysdb_groups[i],
-                                                SYSDB_NAME, NULL);
+        tmp_str = ldb_msg_find_attr_as_string(direct_sysdb_groups[i], attr_name,
+                                              NULL);
         if (!tmp_str) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "A group with no name?\n");
+            DEBUG(SSSDBG_CRIT_FAILURE, "A group with no attribute [%s]?\n",
+                                       attr_name);
             /* This should never happen, but if it does, just continue */
             continue;
         }
@@ -2540,6 +2547,17 @@ errno_t sysdb_get_direct_parents(TALLOC_CTX *mem_ctx,
 done:
     talloc_free(tmp_ctx);
     return ret;
+}
+
+errno_t sysdb_get_direct_parents(TALLOC_CTX *mem_ctx,
+                                 struct sss_domain_info *dom,
+                                 struct sss_domain_info *parent_dom,
+                                 enum sysdb_member_type mtype,
+                                 const char *name,
+                                 char ***_direct_parents)
+{
+    return sysdb_get_direct_parents_ex(mem_ctx, dom, parent_dom, mtype, name,
+                                       NULL, _direct_parents);
 }
 
 errno_t sysdb_get_real_name(TALLOC_CTX *mem_ctx,


### PR DESCRIPTION
Currently add_ad_user_to_cached_groups() expects that all IPA 
group-memberships of users from a trusted domain are removed when the 
group-memberships from the trusted domain are updated. This is currently 
only true for the code path where the tokenGroups request is used. The code
path without tokenGroups does not remove the IPA group-memberships.

Removing the IPA group-memberships is also not very efficient especially if
there are no changes to those at all. With this patch in 
add_ad_user_to_cached_groups() it is checked which group-memberships have
to be added or removed. In this function the SYSDB_ORIG_MEMBEROF attribute
of the user is handled as well for the IPA group-memberships. Since this
attribute is removed in all code paths all IPA group-memberships are added
here again. But instead of doing it one by one as in the previous version,
the attribute is added for all groups in a single operation which should
help to improved the performance as well.