### PR TITLE
PAM: fixes following issue:

### DIFF
--- a/src/responder/pam/pamsrv_gssapi.c
+++ b/src/responder/pam/pamsrv_gssapi.c
@@ -741,7 +741,7 @@ gssapi_handshake(struct gssapi_state *state,
     OM_uint32 flags = GSS_C_MUTUAL_FLAG;
     gss_buffer_desc output = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc input;
-    gss_name_t client_name;
+    gss_name_t client_name = GSS_C_NO_NAME;
     gss_cred_id_t creds;
     OM_uint32 ret_flags;
     gss_OID mech_type;
@@ -822,6 +822,7 @@ gssapi_handshake(struct gssapi_state *state,
 done:
     gss_release_cred(&minor, &creds);
     gss_release_buffer(&minor, &output);
+    gss_release_name(&minor, &client_name);
 
     return ret;
 }


### PR DESCRIPTION
```
 Error: RESOURCE_LEAK (CWE-772):
 sssd-2.9.1/src/responder/pam/pamsrv_gssapi.c:750: alloc_arg: ""gss_accept_sec_context"" allocates memory that is stored into ""client_name"".
 sssd-2.9.1/src/responder/pam/pamsrv_gssapi.c:806: leaked_storage: Variable ""client_name"" going out of scope leaks the storage it points to.
 #  804|       gss_release_buffer(&minor, &output);
 #  805|
 #  806|->     return ret;
 #  807|   }
 #  808|
```

Note: PR CI job 'Coverity scan / coverity' have settings that do not catch this issue, so can't be used to verify issue is resolved. But the fix is quite trivial.