### PR TITLE
oidc_child: fallback to ID and access tokens when looking up configured user identity

### DIFF
--- a/src/oidc_child/oidc_child.c
+++ b/src/oidc_child/oidc_child.c
@@ -592,7 +592,7 @@ int main(int argc, const char *argv[])
         DEBUG(SSSDBG_TRACE_ALL, "id_token: [%s].\n", dc_ctx->td->id_token_str);
 
         if (dc_ctx->jwks_uri != NULL) {
-            ret = verify_token(dc_ctx);
+            ret = decode_token(dc_ctx, true);
             if (ret != EOK) {
                 DEBUG(SSSDBG_OP_FAILURE, "Failed to verify tokens.\n");
                 goto done;
@@ -626,7 +626,7 @@ int main(int argc, const char *argv[])
             if (dc_ctx->jwks_uri == NULL) {
                 /* Up to here the tokens are only decoded into JSON if
                  * verification keys were provided. */
-                ret = verify_token(dc_ctx);
+                ret = decode_token(dc_ctx, false);
                 if (ret != EOK) {
                     DEBUG(SSSDBG_OP_FAILURE, "Failed to decode tokens, ignored.\n");
                 }

--- a/src/oidc_child/oidc_child.c
+++ b/src/oidc_child/oidc_child.c
@@ -616,7 +616,41 @@ int main(int argc, const char *argv[])
         trace_tokens(dc_ctx);
 
         user_identifier = get_user_identifier(dc_ctx, dc_ctx->td->userinfo,
-                                              opts.user_identifier_attr);
+                                              opts.user_identifier_attr,
+                                              "userinfo token");
+        if (user_identifier == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "User identifier not found in user info data, "
+                  "checking id token.\n");
+
+            if (dc_ctx->jwks_uri == NULL) {
+                /* Up to here the tokens are only decoded into JSON if
+                 * verification keys were provided. */
+                ret = verify_token(dc_ctx);
+                if (ret != EOK) {
+                    DEBUG(SSSDBG_OP_FAILURE, "Failed to decode tokens, ignored.\n");
+                }
+            }
+
+            if (dc_ctx->td->id_token_payload != NULL) {
+                user_identifier = get_user_identifier(dc_ctx, dc_ctx->td->id_token_payload,
+                                                      opts.user_identifier_attr,
+                                                      "id token");
+            }
+        }
+
+        if (user_identifier == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "User identifier not found in user info data or id token, "
+                  "checking access token.\n");
+
+            if (dc_ctx->td->access_token_payload != NULL) {
+                user_identifier = get_user_identifier(dc_ctx, dc_ctx->td->access_token_payload,
+                                                      opts.user_identifier_attr,
+                                                      "access token");
+            }
+        }
+
         if (user_identifier == NULL) {
             DEBUG(SSSDBG_OP_FAILURE, "Failed to get user identifier.\n");
             goto done;

--- a/src/oidc_child/oidc_child_json.c
+++ b/src/oidc_child/oidc_child_json.c
@@ -471,7 +471,8 @@ static const char *get_id_string(TALLOC_CTX *mem_ctx, json_t *id_object)
 }
 
 const char *get_user_identifier(TALLOC_CTX *mem_ctx, json_t *userinfo,
-                                const char *user_identifier_attr)
+                                const char *user_identifier_attr,
+                                const char *user_info_type)
 {
     json_t *id_object = NULL;
     const char *user_identifier = NULL;
@@ -494,8 +495,9 @@ const char *get_user_identifier(TALLOC_CTX *mem_ctx, json_t *userinfo,
             break;
         } else {
             DEBUG(SSSDBG_CRIT_FAILURE,
-                  "Failed to read attribute [%s] from userinfo data.\n",
-                  id_attr_list[c]);
+                  "Failed to read attribute [%s] from %s data.\n",
+                  id_attr_list[c],
+                  user_info_type != NULL ? user_info_type : "userinfo");
         }
     }
 

--- a/src/oidc_child/oidc_child_util.h
+++ b/src/oidc_child/oidc_child_util.h
@@ -94,6 +94,7 @@ errno_t parse_token_result(struct devicecode_ctx *dc_ctx,
 errno_t verify_token(struct devicecode_ctx *dc_ctx);
 
 const char *get_user_identifier(TALLOC_CTX *mem_ctx, json_t *userinfo,
-                                const char *user_identifier_attr);
+                                const char *user_identifier_attr,
+                                const char *user_info_type);
 
 #endif /* __OIDC_CHILD_UTIL_H__ */

--- a/src/oidc_child/oidc_child_util.h
+++ b/src/oidc_child/oidc_child_util.h
@@ -91,7 +91,7 @@ errno_t parse_result(struct devicecode_ctx *dc_ctx);
 errno_t parse_token_result(struct devicecode_ctx *dc_ctx,
                            char **error_description);
 
-errno_t verify_token(struct devicecode_ctx *dc_ctx);
+errno_t decode_token(struct devicecode_ctx *dc_ctx, bool verify);
 
 const char *get_user_identifier(TALLOC_CTX *mem_ctx, json_t *userinfo,
                                 const char *user_identifier_attr,


### PR DESCRIPTION
oidc_child: fallback to ID and access tokens when looking up configured user identity

Some IdPs do not provide all attributes as requested by the claims in userinfo response. They, however, provide them in either ID or access tokens. Fall back to one of those if possible, in order to find the user identity based on the attribute specified by the caller.

One example of such behavior is Entra ID:
https://learn.microsoft.com/en-us/entra/identity-platform/userinfo#userinfo-response

  > You can't add to or customize the information returned by the UserInfo endpoint.

