### PR TITLE
Revert "sdap: include sub-domain memberships in updates"

### DIFF
--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -3055,8 +3055,8 @@ sysdb_group_membership_mod(struct sss_domain_info *domain,
 
     if (!is_dn) {
         /* To create a correct DN we have to check if the group belongs to */
-        /* child or parent domain */
-        group_dom = find_domain_by_object_name(get_domains_head(domain), group);
+        /* child domain */
+        group_dom = find_domain_by_object_name(domain, group);
         if (group_dom == NULL) {
             DEBUG(SSSDBG_OP_FAILURE,
                   "The right (sub)domain for the group [%s] was not found\n",

--- a/src/providers/ldap/sdap_async_initgroups.c
+++ b/src/providers/ldap/sdap_async_initgroups.c
@@ -1347,7 +1347,7 @@ sdap_initgr_store_user_memberships(struct sdap_initgr_nested_state *state)
         }
     }
 
-    ret = sysdb_get_direct_parents(tmp_ctx, state->dom, NULL,
+    ret = sysdb_get_direct_parents(tmp_ctx, state->dom, state->dom,
                                    SYSDB_MEMBER_USER,
                                    state->username, &sysdb_parent_name_list);
     if (ret) {
@@ -1435,7 +1435,7 @@ sdap_initgr_nested_get_membership_diff(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    ret = sysdb_get_direct_parents(tmp_ctx, dom, NULL, SYSDB_MEMBER_GROUP,
+    ret = sysdb_get_direct_parents(tmp_ctx, dom, dom, SYSDB_MEMBER_GROUP,
                                    group_name, &sysdb_parents_names_list);
     if (ret) {
         DEBUG(SSSDBG_CRIT_FAILURE,
@@ -2110,7 +2110,7 @@ rfc2307bis_group_memberships_build(hash_entry_t *item, void *user_data)
         goto done;
     }
 
-    ret = sysdb_get_direct_parents(tmp_ctx, mstate->dom, NULL,
+    ret = sysdb_get_direct_parents(tmp_ctx, mstate->dom, mstate->dom,
                                    SYSDB_MEMBER_GROUP,
                                    group_name, &sysdb_parents_names_list);
     if (ret) {
@@ -2173,7 +2173,7 @@ errno_t save_rfc2307bis_user_memberships(
     }
     in_transaction = true;
 
-    ret = sysdb_get_direct_parents(tmp_ctx, state->dom, NULL,
+    ret = sysdb_get_direct_parents(tmp_ctx, state->dom, state->dom,
                                    SYSDB_MEMBER_USER,
                                    state->name, &sysdb_parent_name_list);
     if (ret) {


### PR DESCRIPTION
The reverted patch causes performance issues for AD users with a large
number of IPA group memberships.

This reverts commit 596bc5fb8e0760c26293304f404069c0e986f534.