### PR TITLE
SSSCTL: config-check: do not return an error if snippets directory does not exists

### DIFF
--- a/src/tools/sssctl/sssctl_config.c
+++ b/src/tools/sssctl/sssctl_config.c
@@ -163,7 +163,14 @@ errno_t sssctl_config_check(struct sss_cmdline *cmdline,
         i++;
     }
 
-    if (num_errors != 0 || num_ra_error != 0) {
+    /*
+     * When the snippets directory does not exit ra_error contains only one
+     * element (the directory open error). Do not return an error in this case
+     * as sssd does not consider it as such, it just prints a warning.
+     * When the directory exists and there is an error parsing a file,
+     * ra_error contains at least two elements.
+     */
+    if (num_errors != 0 || num_ra_error >= 2) {
         ret = EINVAL;
     } else {
         ret = EOK;


### PR DESCRIPTION
There is a discrepancy between sssd and sssctl config-check regarding the absence of the snippets directory.

The sssctl config-check command exits with code 1, but sssd does not consider it a hard error, it just logs a warning and then runs fine.

When there is a real error parsing the snippets, the ra_error array contains at least two elements.