### PR TITLE
CLIENT:MC: fix potential free of NULL pointer

### DIFF
--- a/src/sss_client/nss_mc_common.c
+++ b/src/sss_client/nss_mc_common.c
@@ -239,7 +239,9 @@ done:
     if (ret) {
         sss_nss_mc_destroy_ctx(ctx);
     }
-    free(file);
+    if (file) {
+        free(file);
+    }
     sss_mt_unlock(ctx);
 
     return ret;


### PR DESCRIPTION
This patch avoids free() of NULL pointer by failures in sss_nss_mc_init_ctx()