### PR TITLE
NSS: Reject empty name lookups in client library

### DIFF
--- a/src/sss_client/nss_passwd.c
+++ b/src/sss_client/nss_passwd.c
@@ -156,6 +156,11 @@ enum nss_status _nss_sss_getpwnam_r(const char *name, struct passwd *result,
         return NSS_STATUS_NOTFOUND;
     }
 
+    if (name_len == 0) {
+        *errnop = EINVAL;
+        return NSS_STATUS_NOTFOUND;
+    }
+
 #ifdef SSSD_NON_ROOT_USER
     /* Never resolve SSSD_USER */
     if (strcmp(name, SSSD_USER) == 0) {


### PR DESCRIPTION
Don't send a request to SSSD for lookups like `getent passwd ""`, reject them locally in libnss_sss.so

Resolves: https://github.com/SSSD/sssd/issues/7970