### PR TITLE
sss_prctl: avoid redefinition of prctl_mm_map

### DIFF
--- a/src/util/sss_prctl.c
+++ b/src/util/sss_prctl.c
@@ -21,7 +21,6 @@
 #include "util/sss_prctl.h"
 
 #ifdef HAVE_PRCTL
-#include <linux/prctl.h>
 #include <sys/prctl.h>
 
 int sss_prctl_set_dumpable(int dumpable)


### PR DESCRIPTION
prctl_mm_map is provided by linux's prctl.h and libc's prctl.h. libc's headers should be preferred.