### PR TITLE
Provide the struct spwd definition if shadow.h isn't available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,7 @@ AM_CONDITIONAL([HAVE_GCC], [test "$ac_cv_prog_gcc" = yes])
 
 AC_CHECK_HEADERS(stdint.h dlfcn.h)
 AC_CHECK_HEADERS([stdatomic.h],,AC_MSG_ERROR([C11 atomic types are not supported]))
+AC_CHECK_HEADERS(shadow.h)
 AC_CONFIG_HEADER(config.h)
 
 AC_CHECK_TYPES([errno_t], [], [], [[#include <errno.h>]])

--- a/src/providers/ldap/ldap_auth.c
+++ b/src/providers/ldap/ldap_auth.c
@@ -37,7 +37,21 @@
 #include <sys/time.h>
 #include <strings.h>
 
+#ifdef HAVE_SHADOW_H
 #include <shadow.h>
+#else
+struct spwd {
+    char          *sp_namp;
+    char          *sp_pwdp;
+    long int       sp_lstchg;
+    long int       sp_min;
+    long int       sp_max;
+    long int       sp_warn;
+    long int       sp_inact;
+    long int       sp_expire;
+    unsigned long int   sp_flag;
+};
+#endif
 #include <security/pam_modules.h>
 
 #include "util/util.h"


### PR DESCRIPTION
shadow.h is missing on FreeBSD, but luckily this structure is used as an internal struct inside ldap_auth.c