### PR TITLE
Tests: Move test_ldap_referrals from gating (tier1)

### DIFF
--- a/src/tests/multihost/alltests/test_multidomain.py
+++ b/src/tests/multihost/alltests/test_multidomain.py
@@ -19,7 +19,8 @@ from sssd.testlib.common.ssh2_python import check_login_client
 @pytest.mark.multidomain
 class TestMultiDomain(object):
     @staticmethod
-    @pytest.mark.tier1
+    @pytest.mark.ticket(jira="RHEL-87352")
+    @pytest.mark.tier2
     def test_ldap_referrals(multihost, multidomain_sssd):
         """
         :title: Ldap referrals feature of two ldap server with


### PR DESCRIPTION
The test is failing due to DS ldap bug RHEL-87352. Moving it out from gating.