### PR TITLE
Tests: Add missing markers for ticket plugin

### DIFF
--- a/src/tests/multihost/ad/pytest.ini
+++ b/src/tests/multihost/ad/pytest.ini
@@ -28,4 +28,6 @@ markers =
    tier1_4: tier1 test cases split to keep runtime upto 60 minutes
    tier2: All tier2 test cases
    tier3: All tier3 test cases
+   contains_workaround_for(gh=...,bz=...,jira=...):
+ticket_tools = bz,gh,jira
 

--- a/src/tests/multihost/admultidomain/pytest.ini
+++ b/src/tests/multihost/admultidomain/pytest.ini
@@ -9,3 +9,5 @@ markers =
    tier1: All tier1 test cases
    tier2: All tier2 test cases
    tier3: All tier3 test cases
+   contains_workaround_for(gh=...,bz=...,jira=...):
+ticket_tools = bz,gh,jira

--- a/src/tests/multihost/adsites/pytest.ini
+++ b/src/tests/multihost/adsites/pytest.ini
@@ -5,3 +5,5 @@ markers =
    dropped: Tests that are been dropped.
    covered: Tests that are covered by another test.
    system: Tests that are done, rewritten and merged as a system test.
+   contains_workaround_for(gh=...,bz=...,jira=...):
+ticket_tools = bz,gh,jira

--- a/src/tests/multihost/alltests/pytest.ini
+++ b/src/tests/multihost/alltests/pytest.ini
@@ -48,3 +48,5 @@ markers =
     tier2: tier2 test cases
     tier3: tier3 test cases
     timelog: Test time is logged for ldap queries in the domain logs
+    contains_workaround_for(gh=...,bz=...,jira=...):
+ticket_tools = bz,gh,jira

--- a/src/tests/multihost/ipa/pytest.ini
+++ b/src/tests/multihost/ipa/pytest.ini
@@ -10,3 +10,5 @@ markers =
     trust: Tests related to IPA AD Trust
     adhbac: Test related to HBAC in IPA-AD Trust environment
     converted: Tests that are already converted to the new framework.
+    contains_workaround_for(gh=...,bz=...,jira=...):
+ticket_tools = bz,gh,jira

--- a/src/tests/system/pytest.ini
+++ b/src/tests/system/pytest.ini
@@ -6,7 +6,7 @@ markers =
     authentication:
     cache:
     config:
-    contains_workaround_for(gh=...,bz=...):
+    contains_workaround_for(gh=...,bz=...,jira=...):
     identity:
     integration:
     slow:


### PR DESCRIPTION
The markers for pytest ticket plugin are missing from multihost tests.