### PR TITLE
spec: simplify the spec file and target f41+ and rhel10+

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -7,16 +7,6 @@
 %global upstream_version @PACKAGE_VERSION@
 %global downstream_version %(echo "@PACKAGE_VERSION@" | sed 's/-/~/g')
 
-%if 0%{?fedora} >= 34
-%global build_kcm_renewals 1
-%global krb5_version 1.19.1
-%elif 0%{?rhel} >= 8
-%global build_kcm_renewals 1
-%global krb5_version 1.18.2
-%else
-%global build_kcm_renewals 0
-%endif
-
 %global build_passkey 1
 
 %global build_idp 1
@@ -151,9 +141,7 @@ BuildRequires: po4a
 BuildRequires: valgrind-devel
 %endif
 BuildRequires: shadow-utils-subid-devel
-%if %{build_kcm_renewals}
-BuildRequires: krb5-libs >= %{krb5_version}
-%endif
+BuildRequires: krb5-libs
 BuildRequires: systemd-rpm-macros
 %{?sysusers_requires_compat}
 
@@ -465,10 +453,8 @@ Library to map certificates to users based on rules
 Summary: An implementation of a Kerberos KCM server
 License: GPL-3.0-or-later
 Requires: sssd-common = %{version}-%{release}
-%if %{build_kcm_renewals}
-Requires: krb5-libs >= %{krb5_version}
+Requires: krb5-libs
 Requires: sssd-krb5-common = %{version}-%{release}
-%endif
 %{?systemd_requires}
 
 %description kcm

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -18,7 +18,6 @@
 
 # Determine the location of the LDB modules directory
 %global ldb_modulesdir %(pkg-config --variable=modulesdir ldb)
-%global ldb_version 1.2.0
 
 %global samba_package_version %(rpm -q samba-devel --queryformat %{version})
 
@@ -90,7 +89,7 @@ BuildRequires: libcmocka-devel >= 1.0.0
 BuildRequires: libdhash-devel >= 0.4.2
 BuildRequires: libfido2-devel
 BuildRequires: libini_config-devel >= 1.3
-BuildRequires: libldb-devel >= %{ldb_version}
+BuildRequires: libldb-devel
 BuildRequires: libnfsidmap-devel
 BuildRequires: libnl3-devel
 BuildRequires: libselinux-devel
@@ -156,9 +155,7 @@ the existing back ends.
 %package common
 Summary: Common files for the SSSD
 License: GPL-3.0-or-later
-# Requires
-# due to ABI changes in 1.1.30/1.2.0
-Requires: libldb >= %{ldb_version}
+Requires: libldb
 Requires: sssd-client%{?_isa} = %{version}-%{release}
 Requires: (libsss_sudo = %{version}-%{release} if sudo)
 Requires: (libsss_autofs%{?_isa} = %{version}-%{release} if autofs)

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -7,13 +7,6 @@
 %global upstream_version @PACKAGE_VERSION@
 %global downstream_version %(echo "@PACKAGE_VERSION@" | sed 's/-/~/g')
 
-# sysusers depends on presence of sssd user
-%if 0%{?fedora} >= 41 || 0%{?rhel} >= 10
-%global use_sysusers 1
-%else
-%global use_sysusers 0
-%endif
-
 %global build_subid 1
 
 %if 0%{?fedora} >= 34
@@ -165,10 +158,8 @@ BuildRequires: shadow-utils-subid-devel
 %if %{build_kcm_renewals}
 BuildRequires: krb5-libs >= %{krb5_version}
 %endif
-%if %{use_sysusers} || %{build_passkey}
 BuildRequires: systemd-rpm-macros
 %{?sysusers_requires_compat}
-%endif
 
 %description
 Provides a set of daemons to manage access to remote directories and
@@ -696,9 +687,7 @@ do
     cat $subpackage.lang
 done
 
-%if %{use_sysusers}
 install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/sssd.conf
-%endif
 
 %files
 %license COPYING
@@ -802,9 +791,7 @@ install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/sssd.conf
 %{_datadir}/systemtap/tapset/sssd.stp
 %{_datadir}/systemtap/tapset/sssd_functions.stp
 %{_mandir}/man5/sssd-systemtap.5*
-%if %{use_sysusers}
 %{_sysusersdir}/sssd.conf
-%endif
 %{_datadir}/polkit-1/rules.d/*
 
 
@@ -1006,12 +993,7 @@ install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/sssd.conf
 
 %pre common
 ! getent passwd sssd >/dev/null || usermod sssd -d /run/sssd >/dev/null 2>&1 || true
-%if %{use_sysusers}
 %sysusers_create_compat %{SOURCE1}
-%else
-getent group sssd >/dev/null || groupadd -r sssd
-getent passwd sssd >/dev/null || useradd -r -g sssd -d /run/sssd -s /sbin/nologin -c "User for sssd" sssd
-%endif
 
 %post common
 %systemd_post sssd.service

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -7,8 +7,6 @@
 %global upstream_version @PACKAGE_VERSION@
 %global downstream_version %(echo "@PACKAGE_VERSION@" | sed 's/-/~/g')
 
-%global build_subid 1
-
 %if 0%{?fedora} >= 34
 %global build_kcm_renewals 1
 %global krb5_version 1.19.1
@@ -152,9 +150,7 @@ BuildRequires: po4a
 %ifarch %{valgrind_arches}
 BuildRequires: valgrind-devel
 %endif
-%if %{build_subid}
 BuildRequires: shadow-utils-subid-devel
-%endif
 %if %{build_kcm_renewals}
 BuildRequires: krb5-libs >= %{krb5_version}
 %endif
@@ -530,9 +526,7 @@ autoreconf -ivf
     --with-sssd-user=sssd \
     --with-syslog=journald \
     --with-test-dir=/dev/shm \
-%if %{build_subid}
     --with-subid \
-%endif
 %if %{build_passkey}
     --with-passkey \
 %endif
@@ -849,9 +843,7 @@ install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/sssd.conf
 %files client -f sssd_client.lang
 %license src/sss_client/COPYING src/sss_client/COPYING.LESSER
 %{_libdir}/libnss_sss.so.2
-%if %{build_subid}
 %{_libdir}/libsubid_sss.so
-%endif
 %{_libdir}/security/pam_sss.so
 %{_libdir}/security/pam_sss_gss.so
 %{_libdir}/krb5/plugins/libkrb5/sssd_krb5_locator_plugin.so

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -5,7 +5,7 @@
 # RHEL requires tilde as a separator to correctly order builds.
 # For example: 2.10.0-beta1 vs 2.10.0~beta1
 %global upstream_version @PACKAGE_VERSION@
-%global downstream_version %(echo "@PACKAGE_VERSION@" | sed 's/-/~/g')
+%global downstream_version %(echo "%{upstream_version}" | sed 's/-/~/g')
 
 %if 0%{?fedora} >= 43 || 0%{?rhel} >= 10
 %global build_idp 1

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -192,12 +192,6 @@ the existing back ends.
 %package common
 Summary: Common files for the SSSD
 License: GPL-3.0-or-later
-# libsss_simpleifp is removed starting 2.9.0
-Obsoletes: libsss_simpleifp < 2.9.0
-Obsoletes: libsss_simpleifp-debuginfo < 2.9.0
-%if %{use_sssd_user}
-Obsoletes: sssd-polkit-rules < 2.10.0
-%endif
 # Requires
 # due to ABI changes in 1.1.30/1.2.0
 Requires: libldb >= %{ldb_version}
@@ -216,7 +210,6 @@ Requires(pre): shadow-utils
 
 ### Provides ###
 Provides: libsss_sudo-devel = %{version}-%{release}
-Obsoletes: libsss_sudo-devel <= 1.10.0-7%{?dist}.beta1
 
 %description common
 Common files for the SSSD. The common package includes all the files needed

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -1038,5 +1038,4 @@ fi
 %systemd_postun_with_restart sssd.service
 
 %changelog
-* Thu Jan 21 2021 Pavel Březina <pbrezina@redhat.com> - @PACKAGE_NAME@-@PACKAGE_VERSION@-0@PRERELEASE_VERSION@
-- Built from upstream sources.
+%autochangelog

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -208,9 +208,6 @@ Requires(pre): shadow-utils
 %endif
 %{?systemd_requires}
 
-### Provides ###
-Provides: libsss_sudo-devel = %{version}-%{release}
-
 %description common
 Common files for the SSSD. The common package includes all the files needed
 to run a particular back end, however, the back ends are packaged in separate

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -125,9 +125,7 @@ BuildRequires: selinux-policy-targeted
 BuildRequires: bc
 BuildRequires: systemd-devel
 BuildRequires: systemtap-sdt-devel
-%if 0%{?fedora} >= 41 || 0%{?rhel} >= 10
 BuildRequires: systemtap-sdt-dtrace
-%endif
 BuildRequires: uid_wrapper
 BuildRequires: po4a
 %ifarch %{valgrind_arches}

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -1,12 +1,5 @@
 # SSSD SPEC file for Fedora 41+ and RHEL-10+
 
-# Upstream version is using pre-release version with dash as a separator
-# since git does not support tilde in tag name. On the other side, Fedora and
-# RHEL requires tilde as a separator to correctly order builds.
-# For example: 2.10.0-beta1 vs 2.10.0~beta1
-%global upstream_version @PACKAGE_VERSION@
-%global downstream_version %(echo "%{upstream_version}" | sed 's/-/~/g')
-
 %if 0%{?fedora} >= 43 || 0%{?rhel} >= 10
 %global build_idp 1
 %else
@@ -24,12 +17,12 @@
 %global samba_package_version %(rpm -q samba-devel --queryformat %{version})
 
 Name: @PACKAGE_NAME@
-Version: %{downstream_version}
+Version: %(echo "@PACKAGE_VERSION@" | sed 's/-/~/g')
 Release: 0@PRERELEASE_VERSION@%{?dist}
 Summary: System Security Services Daemon
 License: GPL-3.0-or-later
 URL: https://github.com/SSSD/sssd/
-Source0: %{url}/archive/%{upstream_version}/%{name}-%{upstream_version}.tar.gz
+Source0: %{url}/archive/%{version_no_tilde}/%{name}-%{version_no_tilde}.tar.gz
 Source1: sssd.sysusers
 
 ### Patches ###
@@ -476,7 +469,7 @@ This package provides helper processes and Kerberos plugins that are required to
 enable authentication with passkey token.
 
 %prep
-%autosetup -n %{name}-%{upstream_version} -p1
+%autosetup -n %{name}-%{version_no_tilde} -p1
 
 %build
 

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -79,8 +79,6 @@ BuildRequires: findutils
 BuildRequires: gcc
 BuildRequires: gdm-pam-extensions-devel
 BuildRequires: gettext-devel
-# required for p11_child smartcard tests
-BuildRequires: gnutls-utils
 BuildRequires: jansson-devel
 BuildRequires: libcap-devel
 BuildRequires: libcurl-devel
@@ -110,8 +108,6 @@ BuildRequires: m4
 BuildRequires: make
 BuildRequires: nss_wrapper
 BuildRequires: openldap-devel
-# required for p11_child smartcard tests
-BuildRequires: openssh
 BuildRequires: openssl >= 1.0.1
 BuildRequires: openssl-devel >= 1.0.1
 BuildRequires: p11-kit-devel
@@ -126,8 +122,6 @@ BuildRequires: samba-devel
 # required for idmap_sss.so
 BuildRequires: samba-winbind
 BuildRequires: selinux-policy-targeted
-# required for p11_child smartcard tests
-BuildRequires: softhsm >= 2.1.0
 BuildRequires: bc
 BuildRequires: systemd-devel
 BuildRequires: systemtap-sdt-devel
@@ -143,6 +137,10 @@ BuildRequires: shadow-utils-subid-devel
 BuildRequires: krb5-libs
 BuildRequires: systemd-rpm-macros
 %{?sysusers_requires_compat}
+# following packages are required for p11_child smartcard tests
+BuildRequires: gnutls-utils
+BuildRequires: openssh
+BuildRequires: softhsm >= 2.1.0
 
 %description
 Provides a set of daemons to manage access to remote directories and

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -7,15 +7,6 @@
 %global upstream_version @PACKAGE_VERSION@
 %global downstream_version %(echo "@PACKAGE_VERSION@" | sed 's/-/~/g')
 
-# define SSSD user
-%if 0%{?fedora} >= 41 || 0%{?rhel}
-%global use_sssd_user 1
-%global sssd_user sssd
-%else
-%global use_sssd_user 0
-%global sssd_user root
-%endif
-
 # sysusers depends on presence of sssd user
 %if 0%{?fedora} >= 41 || 0%{?rhel} >= 10
 %global use_sysusers 1
@@ -203,9 +194,7 @@ Requires: libsss_idmap = %{version}-%{release}
 Requires: libsss_certmap = %{version}-%{release}
 Requires(post): coreutils
 Requires(postun): coreutils
-%if %{use_sssd_user}
 Requires(pre): shadow-utils
-%endif
 %{?systemd_requires}
 
 %description common
@@ -515,9 +504,7 @@ Summary: SSSD helpers and plugins needed for authentication with passkey token
 License: GPL-3.0-or-later
 Requires: sssd-common = %{version}-%{release}
 Requires: libfido2
-%if "%{sssd_user}" != "root"
 Requires: acl
-%endif
 
 %description passkey
 This package provides helper processes and Kerberos plugins that are required to
@@ -549,14 +536,11 @@ autoreconf -ivf
     --with-mcache-path=%{mcpath} \
     --with-pipe-path=%{pipepath} \
     --with-pubconf-path=%{pubconfpath} \
-    --with-sssd-user=%{sssd_user} \
+    --with-sssd-user=sssd \
     --with-syslog=journald \
     --with-test-dir=/dev/shm \
 %if %{build_subid}
     --with-subid \
-%endif
-%if ! %{use_sssd_user}
-    --disable-polkit-rules-path \
 %endif
 %if %{build_passkey}
     --with-passkey \
@@ -604,9 +588,7 @@ cp $RPM_BUILD_ROOT/%{_datadir}/sssd/krb5-snippets/sssd_enable_idp \
 %if %{build_passkey}
 cp $RPM_BUILD_ROOT/%{_datadir}/sssd/krb5-snippets/sssd_enable_passkey \
    $RPM_BUILD_ROOT/%{_sysconfdir}/krb5.conf.d/sssd_enable_passkey
-%if "%{sssd_user}" != "root"
 install -D -p -m 0644 contrib/90-sssd-token-access.rules %{buildroot}%{_udevrulesdir}/90-sssd-token-access.rules
-%endif
 %endif
 
 # krb5 configuration snippet
@@ -744,7 +726,7 @@ install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/sssd.conf
 %dir %{_libexecdir}/%{servicename}
 %{_libexecdir}/%{servicename}/sssd_be
 %{_libexecdir}/%{servicename}/sssd_nss
-%attr(0750,root,%{sssd_user}) %caps(cap_dac_read_search=p) %{_libexecdir}/%{servicename}/sssd_pam
+%attr(0750,root,sssd) %caps(cap_dac_read_search=p) %{_libexecdir}/%{servicename}/sssd_pam
 %{_libexecdir}/%{servicename}/sssd_autofs
 %{_libexecdir}/%{servicename}/sssd_ssh
 %{_libexecdir}/%{servicename}/sssd_sudo
@@ -776,27 +758,27 @@ install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/sssd.conf
 %{_sbindir}/sss_cache
 %{_libexecdir}/%{servicename}/sss_signal
 
-%attr(775,%{sssd_user},%{sssd_user}) %dir %{sssdstatedir}
+%attr(775,sssd,sssd) %dir %{sssdstatedir}
 %dir %{_localstatedir}/cache/krb5rcache
-%attr(770,%{sssd_user},%{sssd_user}) %dir %{dbpath}
-%attr(775,%{sssd_user},%{sssd_user}) %dir %{mcpath}
-%attr(770,%{sssd_user},%{sssd_user}) %dir %{secdbpath}
-%attr(771,%{sssd_user},%{sssd_user}) %dir %{deskprofilepath}
-%attr(775,%{sssd_user},%{sssd_user}) %dir %{pipepath}
-%attr(770,%{sssd_user},%{sssd_user}) %dir %{pipepath}/private
-%attr(775,%{sssd_user},%{sssd_user}) %dir %{pubconfpath}
-%attr(770,%{sssd_user},%{sssd_user}) %dir %{gpocachepath}
-%attr(770,%{sssd_user},%{sssd_user}) %dir %{_var}/log/%{name}
-%attr(750,root,%{sssd_user}) %dir %{_sysconfdir}/sssd
-%attr(750,root,%{sssd_user}) %dir %{_sysconfdir}/sssd/conf.d
-%attr(750,root,%{sssd_user}) %dir %{_sysconfdir}/sssd/pki
-%ghost %attr(0640,root,%{sssd_user}) %config(noreplace) %{_sysconfdir}/sssd/sssd.conf
+%attr(770,sssd,sssd) %dir %{dbpath}
+%attr(775,sssd,sssd) %dir %{mcpath}
+%attr(770,sssd,sssd) %dir %{secdbpath}
+%attr(771,sssd,sssd) %dir %{deskprofilepath}
+%attr(775,sssd,sssd) %dir %{pipepath}
+%attr(770,sssd,sssd) %dir %{pipepath}/private
+%attr(775,sssd,sssd) %dir %{pubconfpath}
+%attr(770,sssd,sssd) %dir %{gpocachepath}
+%attr(770,sssd,sssd) %dir %{_var}/log/%{name}
+%attr(750,root,sssd) %dir %{_sysconfdir}/sssd
+%attr(750,root,sssd) %dir %{_sysconfdir}/sssd/conf.d
+%attr(750,root,sssd) %dir %{_sysconfdir}/sssd/pki
+%ghost %attr(0640,root,sssd) %config(noreplace) %{_sysconfdir}/sssd/sssd.conf
 %dir %{_sysconfdir}/logrotate.d
 %config(noreplace) %{_sysconfdir}/logrotate.d/sssd
 %dir %{_sysconfdir}/rwtab.d
 %config(noreplace) %{_sysconfdir}/rwtab.d/sssd
 %dir %{_datadir}/sssd
-%attr(775,%{sssd_user},%{sssd_user}) %dir %{_rundir}/sssd
+%attr(775,sssd,sssd) %dir %{_rundir}/sssd
 %config(noreplace) %{_sysconfdir}/pam.d/sssd-shadowutils
 %dir %{_libdir}/%{name}/conf
 %{_libdir}/%{name}/conf/sssd.conf
@@ -823,9 +805,7 @@ install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/sssd.conf
 %if %{use_sysusers}
 %{_sysusersdir}/sssd.conf
 %endif
-%if %{use_sssd_user}
 %{_datadir}/polkit-1/rules.d/*
-%endif
 
 
 %files ldap -f sssd_ldap.lang
@@ -836,9 +816,9 @@ install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/sssd.conf
 
 %files krb5-common
 %license COPYING
-%attr(775,%{sssd_user},%{sssd_user}) %dir %{pubconfpath}/krb5.include.d
-%attr(0750,root,%{sssd_user}) %caps(cap_dac_read_search=p) %{_libexecdir}/%{servicename}/ldap_child
-%attr(0750,root,%{sssd_user}) %caps(cap_dac_read_search,cap_setuid,cap_setgid=p) %{_libexecdir}/%{servicename}/krb5_child
+%attr(775,sssd,sssd) %dir %{pubconfpath}/krb5.include.d
+%attr(0750,root,sssd) %caps(cap_dac_read_search=p) %{_libexecdir}/%{servicename}/ldap_child
+%attr(0750,root,sssd) %caps(cap_dac_read_search,cap_setuid,cap_setgid=p) %{_libexecdir}/%{servicename}/krb5_child
 %config(noreplace) %{_sysconfdir}/krb5.conf.d/enable_sssd_conf_dir
 %dir %{_datadir}/sssd/krb5-snippets
 %{_datadir}/sssd/krb5-snippets/enable_sssd_conf_dir
@@ -854,9 +834,9 @@ install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/sssd.conf
 
 %files ipa -f sssd_ipa.lang
 %license COPYING
-%attr(770,%{sssd_user},%{sssd_user}) %dir %{keytabdir}
+%attr(770,sssd,sssd) %dir %{keytabdir}
 %{_libdir}/%{name}/libsss_ipa.so
-%attr(0750,root,%{sssd_user}) %caps(cap_setuid,cap_setgid=p) %{_libexecdir}/%{servicename}/selinux_child
+%attr(0750,root,sssd) %caps(cap_setuid,cap_setgid=p) %{_libexecdir}/%{servicename}/selinux_child
 %{_mandir}/man5/sssd-ipa.5*
 
 %files ad -f sssd_ad.lang
@@ -867,7 +847,7 @@ install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/sssd.conf
 
 %files proxy
 %license COPYING
-%attr(0750,root,%{sssd_user}) %{_libexecdir}/%{servicename}/proxy_child
+%attr(0750,root,sssd) %{_libexecdir}/%{servicename}/proxy_child
 %{_libdir}/%{name}/libsss_proxy.so
 
 %files dbus -f sssd_dbus.lang
@@ -1020,13 +1000,10 @@ install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/sssd.conf
 %{_libexecdir}/%{servicename}/passkey_child
 %{_libdir}/%{name}/modules/sssd_krb5_passkey_plugin.so
 %{_datadir}/sssd/krb5-snippets/sssd_enable_passkey
-%if "%{sssd_user}" != "root"
 %{_udevrulesdir}/90-sssd-token-access.rules
-%endif
 %config(noreplace) %{_sysconfdir}/krb5.conf.d/sssd_enable_passkey
 %endif
 
-%if %{use_sssd_user}
 %pre common
 ! getent passwd sssd >/dev/null || usermod sssd -d /run/sssd >/dev/null 2>&1 || true
 %if %{use_sysusers}
@@ -1034,7 +1011,6 @@ install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/sssd.conf
 %else
 getent group sssd >/dev/null || groupadd -r sssd
 getent passwd sssd >/dev/null || useradd -r -g sssd -d /run/sssd -s /sbin/nologin -c "User for sssd" sssd
-%endif
 %endif
 
 %post common
@@ -1050,12 +1026,12 @@ getent passwd sssd >/dev/null || useradd -r -g sssd -d /run/sssd -s /sbin/nologi
 %__rm -f %{mcpath}/initgroups
 %__rm -f %{mcpath}/sid
 %__rm -f %{pubconfpath}/known_hosts
-%__chown -f -R root:%{sssd_user} %{_sysconfdir}/sssd || true
+%__chown -f -R root:sssd %{_sysconfdir}/sssd || true
 %__chmod -f -R g+r %{_sysconfdir}/sssd || true
-%__chown -f %{sssd_user}:%{sssd_user} %{dbpath}/* || true
-%__chown -f %{sssd_user}:%{sssd_user} %{_var}/log/%{name}/*.log || true
-%__chown -f %{sssd_user}:%{sssd_user} %{secdbpath}/*.ldb || true
-%__chown -f -R %{sssd_user}:%{sssd_user} %{gpocachepath} || true
+%__chown -f sssd:sssd %{dbpath}/* || true
+%__chown -f sssd:sssd %{_var}/log/%{name}/*.log || true
+%__chown -f sssd:sssd %{secdbpath}/*.ldb || true
+%__chown -f -R sssd:sssd %{gpocachepath} || true
 
 %preun common
 %systemd_preun sssd.service

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -1,4 +1,4 @@
-# SSSD SPEC file for Fedora 34+ and RHEL-9+
+# SSSD SPEC file for Fedora 41+ and RHEL-10+
 
 # Upstream version is using pre-release version with dash as a separator
 # since git does not support tilde in tag name. On the other side, Fedora and

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -16,8 +16,6 @@
 # we don't want to provide private python extension libs
 %define __provides_exclude_from %{python3_sitearch}/.*\.so$
 
-%define _hardened_build 1
-
 # Determine the location of the LDB modules directory
 %global ldb_modulesdir %(pkg-config --variable=modulesdir ldb)
 %global ldb_version 1.2.0

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -7,8 +7,6 @@
 %global upstream_version @PACKAGE_VERSION@
 %global downstream_version %(echo "@PACKAGE_VERSION@" | sed 's/-/~/g')
 
-%global build_passkey 1
-
 %global build_idp 1
 
 # we don't want to provide private python extension libs
@@ -88,9 +86,7 @@ BuildRequires: keyutils-libs-devel
 BuildRequires: krb5-devel
 BuildRequires: libcmocka-devel >= 1.0.0
 BuildRequires: libdhash-devel >= 0.4.2
-%if %{build_passkey}
 BuildRequires: libfido2-devel
-%endif
 BuildRequires: libini_config-devel >= 1.3
 BuildRequires: libldb-devel >= %{ldb_version}
 BuildRequires: libnfsidmap-devel
@@ -471,7 +467,6 @@ This package provides Kerberos plugins that are required to enable
 authentication against external identity providers. Additionally a helper
 program to handle the OAuth 2.0 Device Authorization Grant is provided.
 
-%if %{build_passkey}
 %package passkey
 Summary: SSSD helpers and plugins needed for authentication with passkey token
 License: GPL-3.0-or-later
@@ -482,7 +477,6 @@ Requires: acl
 %description passkey
 This package provides helper processes and Kerberos plugins that are required to
 enable authentication with passkey token.
-%endif
 
 %prep
 %autosetup -n %{name}-%{upstream_version} -p1
@@ -513,9 +507,7 @@ autoreconf -ivf
     --with-syslog=journald \
     --with-test-dir=/dev/shm \
     --with-subid \
-%if %{build_passkey}
     --with-passkey \
-%endif
 %if ! %{build_idp}
     --with-id-provider-idp=no
 %endif
@@ -556,11 +548,9 @@ cp $RPM_BUILD_ROOT/%{_datadir}/sssd/krb5-snippets/sssd_enable_idp \
    $RPM_BUILD_ROOT/%{_sysconfdir}/krb5.conf.d/sssd_enable_idp
 
 # Enable krb5 passkey plugins by default (when sssd-passkey package is installed)
-%if %{build_passkey}
 cp $RPM_BUILD_ROOT/%{_datadir}/sssd/krb5-snippets/sssd_enable_passkey \
    $RPM_BUILD_ROOT/%{_sysconfdir}/krb5.conf.d/sssd_enable_passkey
 install -D -p -m 0644 contrib/90-sssd-token-access.rules %{buildroot}%{_udevrulesdir}/90-sssd-token-access.rules
-%endif
 
 # krb5 configuration snippet
 cp $RPM_BUILD_ROOT/%{_datadir}/sssd/krb5-snippets/enable_sssd_conf_dir \
@@ -960,14 +950,12 @@ install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/sssd.conf
 %{_datadir}/sssd/krb5-snippets/sssd_enable_idp
 %config(noreplace) %{_sysconfdir}/krb5.conf.d/sssd_enable_idp
 
-%if %{build_passkey}
 %files passkey
 %{_libexecdir}/%{servicename}/passkey_child
 %{_libdir}/%{name}/modules/sssd_krb5_passkey_plugin.so
 %{_datadir}/sssd/krb5-snippets/sssd_enable_passkey
 %{_udevrulesdir}/90-sssd-token-access.rules
 %config(noreplace) %{_sysconfdir}/krb5.conf.d/sssd_enable_passkey
-%endif
 
 %pre common
 ! getent passwd sssd >/dev/null || usermod sssd -d /run/sssd >/dev/null 2>&1 || true

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -19,6 +19,8 @@
 # Determine the location of the LDB modules directory
 %global ldb_modulesdir %(pkg-config --variable=modulesdir ldb)
 
+# Require users to upgrade samba-libs to version that was used to build SSSD
+# against, or newer
 %global samba_package_version %(rpm -q samba-devel --queryformat %{version})
 
 Name: @PACKAGE_NAME@

--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -7,7 +7,11 @@
 %global upstream_version @PACKAGE_VERSION@
 %global downstream_version %(echo "@PACKAGE_VERSION@" | sed 's/-/~/g')
 
+%if 0%{?fedora} >= 43 || 0%{?rhel} >= 10
 %global build_idp 1
+%else
+%global build_idp 0
+%endif
 
 # we don't want to provide private python extension libs
 %define __provides_exclude_from %{python3_sitearch}/.*\.so$


### PR DESCRIPTION
This patchset removes lots of old stuf from the spec file, making it more simple and straighforward again.