### PR TITLE
Test: missing KnownTopology import

### DIFF
--- a/src/tests/system/tests/test_access_control_simple.py
+++ b/src/tests/system/tests/test_access_control_simple.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import pytest
 from sssd_test_framework.roles.client import Client
 from sssd_test_framework.roles.generic import GenericProvider
-from sssd_test_framework.topology import KnownTopologyGroup
+from sssd_test_framework.topology import KnownTopology, KnownTopologyGroup
 
 
 @pytest.mark.topology(KnownTopologyGroup.AnyProvider)


### PR DESCRIPTION
test_access_control_simple.py is missing an import for KnownTopology for
the last test case that was added later.   Adding the import here to
resolve test failures.