### PR TITLE
tests: Stabilize analyze child logs

### DIFF
--- a/src/tests/system/tests/test_sssctl.py
+++ b/src/tests/system/tests/test_sssctl.py
@@ -7,7 +7,6 @@ SSSCTL tests.
 from __future__ import annotations
 
 import re
-import time
 
 import pytest
 from pytest_mh.conn import ProcessError
@@ -734,17 +733,15 @@ def test_sssctl__analyze_child_logs(client: Client, ipa: IPA):
     client.sssd.domain["debug_level"] = "9"
     client.sssd.start()
 
-    client.ssh("user1", "Secret123").connect()
-
-    result = client.sssctl.analyze_request("show --pam --child 1")
-    assert result.rc == 0
-    assert "user1@test" in result.stdout
-    assert "SSS_PAM_AUTHENTICATE" in result.stdout
+    with client.ssh("user1", "Secret123") as ssh:
+        result = ssh.run('sssctl analyze request show --pam --child 1')
+        assert result.rc == 0
+        assert "user1@test" in result.stdout
+        assert "SSS_PAM_AUTHENTICATE" in result.stdout
 
     client.sssd.stop()
     client.sssd.clear(db=True, memcache=True, logs=True)
     client.sssd.start()
-    time.sleep(5)
 
     with pytest.raises(SSHAuthenticationError):
         client.ssh("user1", "Wrong").connect()


### PR DESCRIPTION
Use `with` block to close ssh connection after initial successful login and remove `sleep` 