### PR TITLE
CI: drop Fedora-40 from testing since it is EOL

### DIFF
--- a/.github/workflows/copr_build.yml
+++ b/.github/workflows/copr_build.yml
@@ -69,7 +69,7 @@ jobs:
       uses: next-actions/copr/filter-chroots@master
       with:
         coprcfg: ${{ steps.copr.outputs.coprcfg }}
-        filter: "fedora-40-x86_64|centos-stream-9-x86_64"
+        filter: "centos-stream-9-x86_64"
 
     - name: Create copr project
       uses: next-actions/copr/create-project@master

--- a/contrib/ci/get-matrix.py
+++ b/contrib/ci/get-matrix.py
@@ -14,8 +14,8 @@ import os
 
 
 def get_fedora_matrix():
-    # Fedora 41 and up are using 2.10, Fedora 38 and older are EOL
-    return ['fedora-40']
+    # Fedora 41 and up are using 2.10, Fedora 40 and older are EOL
+    return []
 
 
 def get_centos_matrix():


### PR DESCRIPTION
Fedora 40 is EOL and can be removed from the matrix for testing sssd-2-9.

Resolves: https://github.com/SSSD/sssd/issues/8062