### PR TITLE
BUILD: Accept krb5 1.22 for building the PAC plugin

### DIFF
--- a/src/external/pac_responder.m4
+++ b/src/external/pac_responder.m4
@@ -23,7 +23,8 @@ then
         Kerberos\ 5\ release\ 1.18* | \
         Kerberos\ 5\ release\ 1.19* | \
         Kerberos\ 5\ release\ 1.20* | \
-        Kerberos\ 5\ release\ 1.21*)
+        Kerberos\ 5\ release\ 1.21* | \
+        Kerberos\ 5\ release\ 1.22*)
             krb5_version_ok=yes
             AC_MSG_RESULT([yes])
             ;;


### PR DESCRIPTION
At least on FreeBSD 14.2 this fixes the build with krb5 1.22.