### PR TITLE
ci: Workaround pylibssh Failed to open session

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
         sudo apt-get update
 
         # Install dependencies for python-ldap
-        sudo apt-get install -y libsasl2-dev python3-dev libldap2-dev libssl-dev
+        sudo apt-get install -y libsasl2-dev python3-dev libldap2-dev libssl-dev libssh-dev
 
         # Virtualenv
         pip3 install virtualenv

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -69,7 +69,7 @@ jobs:
         sudo apt-get update
 
         # Install dependencies for python-ldap
-        sudo apt-get install -y libsasl2-dev python3-dev libldap2-dev libssl-dev
+        sudo apt-get install -y libsasl2-dev python3-dev libldap2-dev libssl-dev libssh-dev
 
         pip3 install virtualenv
         python3 -m venv .venv

--- a/src/tests/system/constraints.txt
+++ b/src/tests/system/constraints.txt
@@ -1,0 +1,20 @@
+###############################################################################
+#                                                                             #
+# This file is only meant to exclude broken dependency versions, not feature  #
+# dependencies.                                                               #
+#                                                                             #
+# GUIDELINES:                                                                 #
+#   1. Only list PyPI project versions that need to be excluded using `!=`    #
+#      and `<`.                                                               #
+#   2. It is allowed to have transitive dependency limitations in this file.  #
+#   3. Apply bare minimum constraints under narrow conditions, use            #
+#      environment markers if possible. E.g.  `; python_version < "3.12"`.    #
+#   4. Whenever there are no constraints, let the file and this header        #
+#      remain in Git.                                                         #
+#                                                                             #
+###############################################################################
+
+# Retry with open session connect SSH_AGAIN by installing from https://github.com/ansible/pylibssh/pull/756
+ansible-pylibssh@git+https://github.com/justin-stephenson/pylibssh@975ac8786cd4984877563dce6573aef8143cc320
+# add open_session_retries=3 to libssh connect() in pytest-mh
+pytest-mh@git+https://github.com/justin-stephenson/pytest-mh@38dbbeb24b5a6b805709edf0f7a5188ea5a094b2

--- a/src/tests/system/requirements.txt
+++ b/src/tests/system/requirements.txt
@@ -1,8 +1,8 @@
 flaky
 pytest
 git+https://github.com/next-actions/pytest-importance
-git+https://github.com/next-actions/pytest-mh
 git+https://github.com/next-actions/pytest-ticket
 git+https://github.com/next-actions/pytest-tier
 git+https://github.com/next-actions/pytest-output
 git+https://github.com/SSSD/sssd-test-framework
+-c constraints.txt


### PR DESCRIPTION
Workaround ansible pylibssh issue which causes test failures

`   pylibsshext.errors.LibsshChannelException: Failed to open_session: [-2]`

PR https://github.com/ansible/pylibssh/pull/756 is under review but workaround it in the meantime.