### PR TITLE
ci: add automation for creating new release

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -1,8 +1,14 @@
 name: 'Install dependencies'
 description: 'Install dependencies to build sssd'
+inputs:
+  working-directory:
+    description: Working directory.
+    required: false
+    default: '.'
 runs:
   using: "composite"
   steps:
   - shell: bash
+    working-directory: ${{ inputs.working-directory }}
     run: |
       sudo ./contrib/ci/run --deps-only

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: "release"
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Target branch for release'
+        required: true
+        default: 'master'
+        type: string
+      version:
+        description: 'Release version'
+        required: true
+        type: string
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    container: quay.io/sssd/ci-client-devel:latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        path: sssd
+
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
+      with:
+        gpg_private_key: ${{ secrets.GPG_KEY }}
+        passphrase: ${{ secrets.GPG_PASSPHRASE }}
+        git_config_global: true
+        git_user_signingkey: true
+        git_tag_gpgsign: true
+        git_commit_gpgsign: true
+        git_committer_name: sssd-bot
+        git_committer_email: sssd-maintainers@lists.fedoraproject.org
+
+    - name: Install dependencies
+      uses: ./sssd/.github/actions/install-dependencies
+      with:
+        working-directory: sssd
+
+    - name: Execute release script
+      working-directory: sssd
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        ./scripts/release.sh "${{ inputs.branch }}" "${{ inputs.version }}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,29 +1,112 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-function config()
-{
-    autoreconf -i -f || return $?
-    ./configure
+set -e
+
+# Group output in Github Job view
+function GROUP_START() {
+  echo "::group::$1"
 }
 
-SAVED_PWD=$PWD
-version=`grep '\[VERSION_NUMBER], \[.*\]' version.m4 | grep '[0-9]\+\.[0-9]\+\.[0-9]\+\(-[^]]\+\)\?' -o`
-tag=${version}
+function GROUP_END() {
+  echo "::endgroup::"
+}
 
-trap "cd $SAVED_PWD; rm -rf sssd-${version} sssd-${version}.tar" EXIT
-
-git archive --format=tar --prefix=sssd-${version}/ ${tag} > sssd-${version}.tar
-if [ $? -ne 0 ]; then
-    echo "Cannot perform git-archive, check if tag $tag is present in git tree"
-    exit 1
+# Usage
+if [ "$#" -ne 2 ] && [ "$#" -ne 4 ]; then
+  echo "Usage: $0 <branch> <version> [<github-repo> <git-remote>]" >&2
+  exit 1
 fi
-tar xf sssd-${version}.tar
 
-pushd sssd-${version}
-config || exit 1
-make dist-gzip || exit 1  # also builds docs
-popd
+tmpdir=$(mktemp -d)
+scriptdir=`realpath \`dirname "$0"\``
+rootdir=`realpath "$scriptdir/.."`
+branch=$1
+version=$2
+github_repo="${3:-SSSD/sssd}"
+git_remote="${4:-origin}"
 
-mv sssd-${version}/sssd-${version}.tar.gz .
-gpg2 --default-key C13CD07FFB2DB1408E457A3CD3D21B2910CF6759 --detach-sign --armor sssd-${version}.tar.gz
-sha256sum sssd-${version}.tar.gz > sssd-${version}.tar.gz.sha256sum
+echo "SSSD sources location: $rootdir"
+echo "Repository: $github_repo"
+echo "Remote: $git_remote"
+echo "Temporary directory: $tmpdir"
+echo "Target branch: $branch"
+echo "Released version: $version"
+
+# Work in a temporary copy of the repository
+pushd $tmpdir
+trap 'rm -rf "$tmpdir"; popd' EXIT
+cp -a "$rootdir/." "$tmpdir"
+
+GROUP_START "Check prerequisites"
+# Check if required commands are installed
+for cmd in git gh autoreconf make sed gpg; do
+  if ! command -v "$cmd" &> /dev/null; then
+    echo "Error: Required command '$cmd' is not installed." >&2
+    exit 1
+  fi
+done
+
+# Check if there are any opened weblate pull requests
+if [ -n "$(gh pr list --author weblate --state open --base \"$branch\" --repo \"$github_repo\")" ]; then
+  echo "Error: There are open weblate pull-requests, please merge them first." >&2
+  exit 1
+fi
+
+# Check if repository is pristine
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Error: SSSD sources have uncommitted changes." >&2
+  exit 1
+fi
+GROUP_END
+
+set -x
+
+GROUP_START "Checkout branch"
+git checkout "$branch"
+git pull --rebase
+GROUP_END
+
+GROUP_START "Configure SSSD"
+autoreconf -if
+./configure
+GROUP_END
+
+GROUP_START "Update translations"
+make update-po
+git add po/ src/man/po/
+git commit -S -m "pot: update pot files"
+GROUP_END
+
+GROUP_START "Commit and tag release"
+# Set release version (allow empty commit in case it was already set)
+sed -i -E "s/(.+VERSION_NUMBER.+)\\[.+\\](.+)/\1[$version]\2/" version.m4
+git add version.m4
+git commit -S -m "Release sssd-$version" --allow-empty
+git tag -s "$version" -m "Release sssd-$version"
+GROUP_END
+
+GROUP_START "Create tarball"
+make dist-gzip
+GROUP_END
+
+GROUP_START "Sign tarball"
+gpg --default-key C13CD07FFB2DB1408E457A3CD3D21B2910CF6759 --detach-sign --armor "sssd-${version}.tar.gz"
+sha256sum "sssd-${version}.tar.gz" > "sssd-${version}.tar.gz.sha256sum"
+GROUP_END
+
+GROUP_START "Push commits and tag"
+git push "$git_remote" "$branch"
+git push "$git_remote" "$version"
+GROUP_END
+
+GROUP_START "Create GitHub release"
+gh release create "$version" \
+    --repo "$github_repo" \
+    --title "sssd-$version" \
+    --generate-notes \
+    --verify-tag \
+    --draft \
+    "sssd-${version}.tar.gz" \
+    "sssd-${version}.tar.gz.asc" \
+    "sssd-${version}.tar.gz.sha256sum"
+GROUP_END


### PR DESCRIPTION
This automation can be manually triggered in "Actions" tab.

- update translations
- bump version number
- create signed commits and tag
- push the content to upstream repository
- create new github release with autogenerated release notes

Since release notes generated from out commit messages are not yet
supported, the release is created as a draft. When created, we need
to updated release notes manually and then publish the release.

---

Note: this is the first step, release automation will come later.