### PR TITLE
ci: add autobackport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,24 @@
+name: Backport
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+jobs:
+  backport:
+    name: Backport
+    runs-on: ubuntu-latest
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && startsWith(github.event.label.name, 'backport-to-')
+        )
+      )
+    steps:
+      - uses: next-actions/backport@master
+        with:
+          user: sssd-bot
+          token: ${{ secrets.BOT_TOKEN }}


### PR DESCRIPTION
This adds an autobackport workflow that will automatically backport
pull request with backport-to-$branch label. Backport pull request
is created upon mergin the original pull request for each requested
branch. It is also possible to create additional backport by labeling
the already merged pull request.

If there are any conflicts during cherry-picks, they are commited and
pull request is still opened. The author of the original pull request
can then fix them and push to the backport pull request (guide is
presented in the PR description).

---

This uses https://github.com/next-actions/backport that I just wrote as I was not able to find existing action that would allow to create branches in forked repository (instead of upstream one) and also deal with conflicts gracefully.