### PR TITLE
Range retrieval

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -465,6 +465,9 @@ int sysdb_attrs_copy_values(struct sysdb_attrs *src,
                             struct sysdb_attrs *dst,
                             const char *name);
 errno_t sysdb_attrs_copy(struct sysdb_attrs *src, struct sysdb_attrs *dst);
+errno_t sysdb_attrs_join(struct sysdb_attrs *src,
+                         struct sysdb_attrs *dst,
+                         const char **exclude);
 int sysdb_attrs_get_el(struct sysdb_attrs *attrs, const char *name,
                        struct ldb_message_element **el);
 int sysdb_attrs_get_el_ext(struct sysdb_attrs *attrs, const char *name,

--- a/src/man/sssd-ldap.5.xml
+++ b/src/man/sssd-ldap.5.xml
@@ -744,9 +744,10 @@
                             this option prevents SSSD from parsing the range
                             extension. As a result large groups will appear as they
                             have no members.
-                            This option does not enable SSSD to read subsequent
-                            ranges. To retrieve all members of a group, you must
-                            increase the MaxValRange setting in Active Directory.
+                        </para>
+                        <para>
+                            By default, SSSD performs additional queries to obtain
+                            subsequent ranges and to complete information.
                         </para>
                         <para>
                             Default: False

--- a/src/providers/ldap/sdap.c
+++ b/src/providers/ldap/sdap.c
@@ -462,7 +462,7 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
     if (ret) goto done;
 
     if (map) {
-        vals = ldap_get_values_len(sh->ldap, sm->msg, "objectClass");
+        vals = ldap_get_values_len(sh->ldap, sm->msg, SYSDB_OBJECTCLASS);
         if (!vals) {
             DEBUG(SSSDBG_CRIT_FAILURE,
                   "Unknown entry type, no objectClasses found!\n");
@@ -520,7 +520,7 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
                 /* we need to ask objectClass to correctly
                  * identify the object later
                  */
-                next_attrs[next_attrs_count++] = "objectClass";
+                next_attrs[next_attrs_count++] = SYSDB_OBJECTCLASS;
             }
             next_attrs[next_attrs_count] = talloc_asprintf(next_attrs,
                                                            "%s;range=%d-*",
@@ -760,7 +760,7 @@ errno_t sdap_parse_deref(TALLOC_CTX *mem_ctx,
 
     ocs = NULL;
     for (dval = dref->attrVals; dval != NULL; dval = dval->next) {
-        if (strcasecmp("objectClass", dval->type) == 0) {
+        if (strcasecmp(SYSDB_OBJECTCLASS, dval->type) == 0) {
             if (dval->vals == NULL) {
                 DEBUG(SSSDBG_CONF_SETTINGS,
                       "No value for objectClass, skipping\n");
@@ -1710,7 +1710,7 @@ int build_attrs_from_map(TALLOC_CTX *memctx,
     }
 
     /* first attribute is "objectclass" not the specific one */
-    attrs[0] = talloc_strdup(memctx, "objectClass");
+    attrs[0] = talloc_strdup(memctx, SYSDB_OBJECTCLASS);
     if (!attrs[0]) return ENOMEM;
 
     /* add the others */
@@ -2119,11 +2119,12 @@ errno_t sdap_get_primary_fqdn_list(struct sss_domain_info *domain,
 char *sdap_make_oc_list(TALLOC_CTX *mem_ctx, struct sdap_attr_map *map)
 {
     if (map[SDAP_OC_GROUP_ALT].name == NULL) {
-        return talloc_asprintf(mem_ctx, "objectClass=%s",
+        return talloc_asprintf(mem_ctx, SYSDB_OBJECTCLASS"=%s",
                                map[SDAP_OC_GROUP].name);
     } else {
         return talloc_asprintf(mem_ctx,
-                               "|(objectClass=%s)(objectClass=%s)",
+                               "|("SYSDB_OBJECTCLASS"=%s)"
+                               "("SYSDB_OBJECTCLASS"=%s)",
                                map[SDAP_OC_GROUP].name,
                                map[SDAP_OC_GROUP_ALT].name);
     }

--- a/src/providers/ldap/sdap.c
+++ b/src/providers/ldap/sdap.c
@@ -405,7 +405,9 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
                      struct sdap_handle *sh, struct sdap_msg *sm,
                      struct sdap_attr_map *map, int attrs_num,
                      struct sysdb_attrs **_attrs,
-                     bool disable_range_retrieval)
+                     bool disable_range_retrieval,
+                     const char ***_next_attrs,
+                     const char **_next_attrs_dn)
 {
     struct sysdb_attrs *attrs;
     BerElement *ber = NULL;
@@ -420,9 +422,17 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
     bool base64;
     char *base_attr;
     uint32_t range_offset;
+    const char **next_attrs = NULL;
+    size_t next_attrs_count = 0;
     TALLOC_CTX *tmp_ctx = talloc_new(NULL);
     if (!tmp_ctx) return ENOMEM;
 
+    if (_next_attrs != NULL) {
+        *_next_attrs = NULL;
+    }
+    if (_next_attrs_dn != NULL) {
+        *_next_attrs_dn = NULL;
+    }
     lerrno = 0;
     ret = ldap_set_option(sh->ldap, LDAP_OPT_RESULT_CODE, &lerrno);
     if (ret != LDAP_OPT_SUCCESS) {
@@ -499,10 +509,32 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
             /* This attribute contained range values and needs more to
              * be retrieved
              */
-            /* TODO: return the set of attributes that need additional retrieval
-             * For now, we'll continue below and treat it as regular values.
-             */
-            /* FALLTHROUGH */
+            next_attrs = talloc_realloc(tmp_ctx, next_attrs, const char *,
+                                        next_attrs_count + 2
+                                        + (next_attrs_count > 0 ? 0 : 1));
+            if (next_attrs == NULL) {
+                ret = ENOMEM;
+                goto done;
+            }
+            if (next_attrs_count == 0) {
+                /* we need to ask objectClass to correctly
+                 * identify the object later
+                 */
+                next_attrs[next_attrs_count++] = "objectClass";
+            }
+            next_attrs[next_attrs_count] = talloc_asprintf(next_attrs,
+                                                           "%s;range=%d-*",
+                                                           base_attr,
+                                                           range_offset);
+            if (next_attrs[next_attrs_count] == NULL) {
+                ret = ENOMEM;
+                goto done;
+            }
+            DEBUG(SSSDBG_TRACE_INTERNAL,
+                  "Attribute [%s] for next range request found\n",
+                  next_attrs[next_attrs_count]);
+            next_attrs[++next_attrs_count] = NULL;
+            break;
         case ECANCELED:
             /* FALLTHROUGH */
         case EOK:
@@ -633,6 +665,12 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
 
     PROBE(SDAP_PARSE_ENTRY_DONE);
     *_attrs = talloc_steal(memctx, attrs);
+    if (_next_attrs != NULL && disable_range_retrieval == false) {
+        *_next_attrs = talloc_steal(memctx, next_attrs);
+        if (_next_attrs_dn != NULL) {
+            sysdb_attrs_get_string(attrs, SYSDB_ORIG_DN, _next_attrs_dn);
+        }
+    }
     ret = EOK;
 
 done:

--- a/src/providers/ldap/sdap.h
+++ b/src/providers/ldap/sdap.h
@@ -664,7 +664,9 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
                      struct sdap_handle *sh, struct sdap_msg *sm,
                      struct sdap_attr_map *map, int attrs_num,
                      struct sysdb_attrs **_attrs,
-                     bool disable_range_retrieval);
+                     bool disable_range_retrieval,
+                     const char *** _next_attrs,
+                     const char ** _next_attrs_dn);
 
 errno_t sdap_parse_deref(TALLOC_CTX *mem_ctx,
                          struct sdap_attr_map_info *minfo,

--- a/src/providers/ldap/sdap_async.c
+++ b/src/providers/ldap/sdap_async.c
@@ -1198,7 +1198,7 @@ struct tevent_req *sdap_get_rootdse_send(TALLOC_CTX *memctx,
 
     subreq = sdap_get_generic_send(state, ev, opts, sh,
                                    "", LDAP_SCOPE_BASE,
-                                   "(objectclass=*)", attrs, NULL, 0,
+                                   "("SYSDB_OBJECTCLASS"=*)", attrs, NULL, 0,
                                    dp_opt_get_int(state->opts->basic,
                                                   SDAP_SEARCH_TIMEOUT),
                                    false);
@@ -2939,7 +2939,8 @@ sdap_sd_search_send(TALLOC_CTX *memctx, struct tevent_context *ev,
 
     DEBUG(SSSDBG_TRACE_FUNC, "Searching entry [%s] using SD\n", base_dn);
     subreq = sdap_get_generic_ext_send(state, ev, opts, sh, base_dn,
-                                       LDAP_SCOPE_BASE, "(objectclass=*)",
+                                       LDAP_SCOPE_BASE,
+                                       "("SYSDB_OBJECTCLASS"=*)",
                                        attrs, false,
                                        state->ctrls, NULL, 0, timeout,
                                        sdap_sd_search_parse_entry,
@@ -3266,7 +3267,7 @@ static errno_t sdap_asq_search_parse_entry(struct sdap_handle *sh,
     }
 
     /* Find all suitable maps in the list */
-    vals = ldap_get_values_len(sh->ldap, msg->msg, "objectClass");
+    vals = ldap_get_values_len(sh->ldap, msg->msg, SYSDB_OBJECTCLASS);
     if (!vals) {
         DEBUG(SSSDBG_OP_FAILURE,
               "Unknown entry type, no objectClass found for DN [%s]!\n", dn);

--- a/src/providers/ldap/sdap_async.c
+++ b/src/providers/ldap/sdap_async.c
@@ -1289,10 +1289,56 @@ static inline size_t increase_reply_max(size_t current)
     return current == 0 ? REPLY_INITIAL_SIZE : (current * 2);
 }
 
+static int find_reply_by_dn(struct sdap_reply *replies, struct sysdb_attrs *msg)
+{
+    const char *msg_dn;
+    const char *reply_dn;
+    int i;
+    int ret;
+
+    ret = sysdb_attrs_get_string(msg, SYSDB_ORIG_DN, &msg_dn);
+    if (ret != EOK) {
+        return -1;
+    }
+
+    for (i = 0; i < replies->reply_count; i++) {
+        ret = sysdb_attrs_get_string(replies->reply[i], SYSDB_ORIG_DN, &reply_dn);
+        if (ret == EOK && strcasecmp(msg_dn, reply_dn) == 0) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
 static errno_t add_to_reply(TALLOC_CTX *mem_ctx,
                             struct sdap_reply *sreply,
-                            struct sysdb_attrs *msg)
+                            struct sysdb_attrs *msg,
+                            bool range_retrieval_update)
 {
+    int ret;
+    int idx;
+    static const char *exclude[] = {SYSDB_OBJECTCLASS,
+                                    SYSDB_ORIG_DN,
+                                    NULL};
+
+    if (range_retrieval_update) {
+        if (sreply->reply_count == 0) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "Can't update empty array\n");
+            return EINVAL;
+        }
+        idx = find_reply_by_dn(sreply, msg);
+        if (idx == -1) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Item for range retrieval update not found\n");
+            return EINVAL;
+        }
+        ret = sysdb_attrs_join(msg, sreply->reply[idx],
+                               exclude);
+        talloc_free(msg);
+        return ret;
+    }
+
     if (sreply->reply == NULL || sreply->reply_max == sreply->reply_count) {
         sreply->reply_max = increase_reply_max(sreply->reply_max);
         sreply->reply = talloc_realloc(mem_ctx, sreply->reply,
@@ -1497,7 +1543,10 @@ static void sdap_print_server(struct sdap_handle *sh)
 /* ==Generic Search exposing all options======================= */
 typedef errno_t (*sdap_parse_cb)(struct sdap_handle *sh,
                                  struct sdap_msg *msg,
-                                 void *pvt);
+                                 bool range_retrieval_step,
+                                 void *pvt,
+                                 const char ***_next_attrs,
+                                 const char **_next_attrs_dn);
 
 struct sdap_get_generic_ext_state {
     struct tevent_context *ev;
@@ -1507,6 +1556,9 @@ struct sdap_get_generic_ext_state {
     int scope;
     const char *filter;
     const char **attrs;
+    const char **next_attrs;
+    const char *next_attrs_dn;
+    bool range_retrieval_step;
     int timeout;
     int sizelimit;
 
@@ -1553,6 +1605,7 @@ sdap_get_generic_ext_send(TALLOC_CTX *memctx,
                           int scope,
                           const char *filter,
                           const char **attrs,
+                          bool range_retrieval_step,
                           LDAPControl **serverctrls,
                           LDAPControl **clientctrls,
                           int sizelimit,
@@ -1577,6 +1630,9 @@ sdap_get_generic_ext_send(TALLOC_CTX *memctx,
     state->scope = scope;
     state->filter = filter;
     state->attrs = attrs;
+    state->range_retrieval_step = range_retrieval_step;
+    state->next_attrs = NULL;
+    state->next_attrs_dn = NULL;
     state->op = NULL;
     state->sizelimit = sizelimit;
     state->timeout = timeout;
@@ -1799,6 +1855,7 @@ static void sdap_get_generic_op_finished(struct sdap_op *op,
                                             struct sdap_get_generic_ext_state);
     char *errmsg = NULL;
     char **refs = NULL;
+    const char **next_attrs = NULL;
     int result;
     int ret;
     int lret;
@@ -1841,13 +1898,15 @@ static void sdap_get_generic_op_finished(struct sdap_op *op,
         break;
 
     case LDAP_RES_SEARCH_ENTRY:
-        ret = state->parse_cb(state->sh, reply, state->cb_data);
+        ret = state->parse_cb(state->sh, reply, state->range_retrieval_step,
+                              state->cb_data, &next_attrs,
+                              &state->next_attrs_dn);
         if (ret != EOK) {
             DEBUG(SSSDBG_CRIT_FAILURE, "reply parsing callback failed.\n");
             tevent_req_error(req, ret);
             return;
         }
-
+        state->next_attrs = talloc_steal(state, next_attrs);
         sdap_unlock_next_reply(state->op);
         break;
 
@@ -1972,7 +2031,9 @@ static int
 sdap_get_generic_ext_recv(struct tevent_req *req,
                           TALLOC_CTX *mem_ctx,
                           size_t *ref_count,
-                          char ***refs)
+                          char ***refs,
+                          const char ***next_attrs,
+                          const char **next_attrs_dn)
 {
     struct sdap_get_generic_ext_state *state =
             tevent_req_data(req, struct sdap_get_generic_ext_state);
@@ -1990,21 +2051,80 @@ sdap_get_generic_ext_recv(struct tevent_req *req,
         *refs = talloc_steal(mem_ctx, state->refs);
     }
 
+    if (next_attrs) {
+        *next_attrs = talloc_steal(mem_ctx, state->next_attrs);
+        if (next_attrs_dn) {
+            *next_attrs_dn = state->next_attrs_dn;
+        }
+    }
+
     return EOK;
+}
+
+static struct tevent_req *
+sdap_get_generic_ext_send_next_range(TALLOC_CTX *ctx, struct tevent_req *subreq,
+                                     const char **attrs, const char *dn)
+{
+    static const char *filter_pattern = "(distinguishedName=%s)";
+    struct tevent_req *next_subreq = NULL;
+    struct sdap_get_generic_ext_state *state;
+    const char *filter = NULL;
+    char *sanitized_dn;
+
+    state = tevent_req_data(subreq, struct sdap_get_generic_ext_state);
+
+    if (strncasecmp(state->filter, filter_pattern, 19) != 0) {
+        /* not searching by DN, create filter to match the same object */
+        sss_filter_sanitize_dn(ctx, dn, &sanitized_dn);
+        if (sanitized_dn == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "Failed to create sanitized dn!\n");
+            return NULL;
+        }
+        filter = talloc_asprintf(state, filter_pattern, sanitized_dn);
+        talloc_free(sanitized_dn);
+        if (filter == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "Failed to create filter!\n");
+            return NULL;
+        }
+    }
+    next_subreq = sdap_get_generic_ext_send(ctx,
+                                            state->ev,
+                                            state->opts,
+                                            state->sh,
+                                            state->search_base,
+                                            state->scope,
+                                            filter ? filter : state->filter,
+                                            attrs,
+                                            true,
+                                            state->serverctrls,
+                                            state->clientctrls,
+                                            state->sizelimit,
+                                            state->timeout,
+                                            state->parse_cb,
+                                            state->cb_data,
+                                            state->flags);
+    if (next_subreq) {
+        talloc_steal(next_subreq, attrs);
+    }
+    return next_subreq;
 }
 
 /* This search handler can be used by most calls */
 static void generic_ext_search_handler(struct tevent_req *subreq,
-                                       struct sdap_options *opts)
+                                       struct sdap_options *opts,
+                                       tevent_req_fn done_callback)
 {
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                       struct tevent_req);
     int ret;
     size_t ref_count, i;
-    char **refs;
+    char **refs = NULL;
+    const char **next_attrs = NULL;
+    const char *next_attrs_dn = NULL;
+    struct tevent_req *next_subreq = NULL;
 
-    ret = sdap_get_generic_ext_recv(subreq, req, &ref_count, &refs);
-    talloc_zfree(subreq);
+    ret = sdap_get_generic_ext_recv(subreq, req, &ref_count, &refs,
+                                    &next_attrs, &next_attrs_dn);
 
     if (ret != EOK) {
         if (ret == ETIMEDOUT) {
@@ -2017,8 +2137,7 @@ static void generic_ext_search_handler(struct tevent_req *subreq,
                   "sdap_get_generic_ext_recv request failed: [%d]: %s\n",
                   ret, sss_strerror(ret));
         }
-        tevent_req_error(req, ret);
-        return;
+        goto done;
     }
 
     if (ref_count > 0) {
@@ -2033,8 +2152,33 @@ static void generic_ext_search_handler(struct tevent_req *subreq,
         }
     }
 
+    if (next_attrs != NULL) {
+        if (done_callback == NULL) {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "Range retrieval is not implemented "
+                  "for this type of request.\n");
+            goto done;
+        }
+        next_subreq = sdap_get_generic_ext_send_next_range(req, subreq,
+                                                           next_attrs,
+                                                           next_attrs_dn);
+        if (next_subreq == NULL) {
+            ret = ENOMEM;
+            goto done;
+        }
+        tevent_req_set_callback(next_subreq, done_callback, req);
+    }
+
+ done:
+    talloc_zfree(subreq);
     talloc_free(refs);
-    tevent_req_done(req);
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
+    if (next_subreq == NULL) {
+        tevent_req_done(req);
+    }
 }
 
 /* ==Generic Search exposing all options with multiple maps === */
@@ -2051,7 +2195,10 @@ static void sdap_get_and_multi_parse_generic_done(struct tevent_req *subreq);
 static errno_t
 sdap_get_and_multi_parse_generic_parse_entry(struct sdap_handle *sh,
                                              struct sdap_msg *msg,
-                                             void *pvt);
+                                             bool range_retrieval_step,
+                                             void *pvt,
+                                             const char ***_next_attrs,
+                                             const char **_next_attrs_dn);
 
 struct tevent_req *
 sdap_get_and_multi_parse_generic_send(TALLOC_CTX *memctx,
@@ -2095,7 +2242,7 @@ sdap_get_and_multi_parse_generic_send(TALLOC_CTX *memctx,
     }
 
     subreq = sdap_get_generic_ext_send(state, ev, opts, sh, search_base,
-                                       scope, filter, attrs, serverctrls,
+                                       scope, filter, attrs, false, serverctrls,
                                        clientctrls, sizelimit, timeout,
                                        sdap_get_and_multi_parse_generic_parse_entry,
                                        state, flags);
@@ -2128,7 +2275,10 @@ static bool has_required_attrs(struct sdap_handle *sh, struct sdap_msg *msg,
 static errno_t
 sdap_get_and_multi_parse_generic_parse_entry(struct sdap_handle *sh,
                                              struct sdap_msg *msg,
-                                             void *pvt)
+                                             bool range_retrieval_step,
+                                             void *pvt,
+                                             const char ***_next_attrs,
+                                             const char **_next_attrs_dn)
 {
     errno_t ret;
     struct sdap_get_and_multi_parse_generic_state *state =
@@ -2213,7 +2363,8 @@ sdap_get_and_multi_parse_generic_parse_entry(struct sdap_handle *sh,
 
         ret = sdap_parse_entry(state, sh, msg,
                                map, num_attrs,
-                               &attrs, disable_range_rtrvl);
+                               &attrs, disable_range_rtrvl,
+                               NULL, NULL);
         if (ret != EOK) {
             DEBUG(SSSDBG_MINOR_FAILURE,
                   "sdap_parse_entry failed [%d]: %s\n", ret, strerror(ret));
@@ -2249,7 +2400,7 @@ static void sdap_get_and_multi_parse_generic_done(struct tevent_req *subreq)
     struct sdap_get_and_multi_parse_generic_state *state = tevent_req_data(req,
                                  struct sdap_get_and_multi_parse_generic_state);
 
-    return generic_ext_search_handler(subreq, state->opts);
+    return generic_ext_search_handler(subreq, state->opts, NULL);
 }
 
 int sdap_get_and_multi_parse_generic_recv(struct tevent_req *req,
@@ -2280,9 +2431,14 @@ struct sdap_get_and_parse_generic_state {
 };
 
 static void sdap_get_and_parse_generic_done(struct tevent_req *subreq);
-static errno_t sdap_get_and_parse_generic_parse_entry(struct sdap_handle *sh,
-                                                      struct sdap_msg *msg,
-                                                      void *pvt);
+
+static errno_t
+sdap_get_and_parse_generic_parse_entry(struct sdap_handle *sh,
+                                       struct sdap_msg *msg,
+                                       bool range_retrieval_step,
+                                       void *pvt,
+                                       const char ***_next_attrs,
+                                       const char **_next_attrs_dn);
 
 struct tevent_req *sdap_get_and_parse_generic_send(TALLOC_CTX *memctx,
                                                    struct tevent_context *ev,
@@ -2323,7 +2479,7 @@ struct tevent_req *sdap_get_and_parse_generic_send(TALLOC_CTX *memctx,
     }
 
     subreq = sdap_get_generic_ext_send(state, ev, opts, sh, search_base,
-                                       scope, filter, attrs, serverctrls,
+                                       scope, filter, attrs, false, serverctrls,
                                        clientctrls, sizelimit, timeout,
                                        sdap_get_and_parse_generic_parse_entry,
                                        state, flags);
@@ -2338,7 +2494,10 @@ struct tevent_req *sdap_get_and_parse_generic_send(TALLOC_CTX *memctx,
 
 static errno_t sdap_get_and_parse_generic_parse_entry(struct sdap_handle *sh,
                                                       struct sdap_msg *msg,
-                                                      void *pvt)
+                                                      bool range_retrieval_step,
+                                                      void *pvt,
+                                                      const char ***_next_attrs,
+                                                      const char **_next_attrs_dn)
 {
     errno_t ret;
     struct sysdb_attrs *attrs;
@@ -2350,14 +2509,15 @@ static errno_t sdap_get_and_parse_generic_parse_entry(struct sdap_handle *sh,
 
     ret = sdap_parse_entry(state, sh, msg,
                            state->map, state->map_num_attrs,
-                           &attrs, disable_range_rtrvl);
+                           &attrs, disable_range_rtrvl,
+                           _next_attrs, _next_attrs_dn);
     if (ret != EOK) {
         DEBUG(SSSDBG_MINOR_FAILURE,
               "sdap_parse_entry failed [%d]: %s\n", ret, strerror(ret));
         return ret;
     }
 
-    ret = add_to_reply(state, &state->sreply, attrs);
+    ret = add_to_reply(state, &state->sreply, attrs, range_retrieval_step);
     if (ret != EOK) {
         talloc_free(attrs);
         DEBUG(SSSDBG_CRIT_FAILURE, "add_to_reply failed.\n");
@@ -2375,7 +2535,7 @@ static void sdap_get_and_parse_generic_done(struct tevent_req *subreq)
     struct sdap_get_and_parse_generic_state *state =
                 tevent_req_data(req, struct sdap_get_and_parse_generic_state);
 
-    return generic_ext_search_handler(subreq, state->opts);
+    return generic_ext_search_handler(subreq, state->opts, sdap_get_and_parse_generic_done);
 }
 
 int sdap_get_and_parse_generic_recv(struct tevent_req *req,
@@ -2481,7 +2641,10 @@ static int sdap_x_deref_search_ctrls_destructor(void *ptr);
 
 static errno_t sdap_x_deref_parse_entry(struct sdap_handle *sh,
                                         struct sdap_msg *msg,
-                                        void *pvt);
+                                        bool not_used,
+                                        void *pvt,
+                                        const char ***_not_used,
+                                        const char **_not_used2);
 struct sdap_x_deref_search_state {
     struct sdap_handle *sh;
     struct sdap_op *op;
@@ -2539,7 +2702,7 @@ sdap_x_deref_search_send(TALLOC_CTX *memctx, struct tevent_context *ev,
     subreq = sdap_get_generic_ext_send(state, ev, opts, sh, base_dn,
                                        filter == NULL ? LDAP_SCOPE_BASE
                                                       : LDAP_SCOPE_SUBTREE,
-                                       filter, attrs,
+                                       filter, attrs, false,
                                        state->ctrls, NULL, 0, timeout,
                                        sdap_x_deref_parse_entry,
                                        state, SDAP_SRCH_FLG_PAGING);
@@ -2586,7 +2749,10 @@ static int sdap_x_deref_create_control(struct sdap_handle *sh,
 
 static errno_t sdap_x_deref_parse_entry(struct sdap_handle *sh,
                                         struct sdap_msg *msg,
-                                        void *pvt)
+                                        bool not_used,
+                                        void *pvt,
+                                        const char ***_not_used,
+                                        const char **_not_used2)
 {
     errno_t ret;
     LDAPControl **ctrls = NULL;
@@ -2685,7 +2851,7 @@ static void sdap_x_deref_search_done(struct tevent_req *subreq)
     struct sdap_x_deref_search_state *state =
                 tevent_req_data(req, struct sdap_x_deref_search_state);
 
-    return generic_ext_search_handler(subreq, state->opts);
+    return generic_ext_search_handler(subreq, state->opts, NULL);
 }
 
 static int sdap_x_deref_search_ctrls_destructor(void *ptr)
@@ -2730,12 +2896,15 @@ struct sdap_sd_search_state {
 };
 
 static int sdap_sd_search_create_control(struct sdap_handle *sh,
-					 int val,
-					 LDAPControl **ctrl);
+                                         int val,
+                                         LDAPControl **ctrl);
 static int sdap_sd_search_ctrls_destructor(void *ptr);
 static errno_t sdap_sd_search_parse_entry(struct sdap_handle *sh,
                                           struct sdap_msg *msg,
-                                          void *pvt);
+                                          bool not_used,
+                                          void *pvt,
+                                          const char ***_not_used,
+                                          const char **_not_used2);
 static void sdap_sd_search_done(struct tevent_req *subreq);
 
 struct tevent_req *
@@ -2770,7 +2939,8 @@ sdap_sd_search_send(TALLOC_CTX *memctx, struct tevent_context *ev,
 
     DEBUG(SSSDBG_TRACE_FUNC, "Searching entry [%s] using SD\n", base_dn);
     subreq = sdap_get_generic_ext_send(state, ev, opts, sh, base_dn,
-                                       LDAP_SCOPE_BASE, "(objectclass=*)", attrs,
+                                       LDAP_SCOPE_BASE, "(objectclass=*)",
+                                       attrs, false,
                                        state->ctrls, NULL, 0, timeout,
                                        sdap_sd_search_parse_entry,
                                        state, SDAP_SRCH_FLG_PAGING);
@@ -2826,7 +2996,10 @@ static int sdap_sd_search_create_control(struct sdap_handle *sh,
 
 static errno_t sdap_sd_search_parse_entry(struct sdap_handle *sh,
                                           struct sdap_msg *msg,
-                                          void *pvt)
+                                          bool not_used,
+                                          void *pvt,
+                                          const char ***_not_used,
+                                          const char **_not_used2)
 {
     errno_t ret;
     struct sysdb_attrs *attrs;
@@ -2838,14 +3011,14 @@ static errno_t sdap_sd_search_parse_entry(struct sdap_handle *sh,
 
     ret = sdap_parse_entry(state, sh, msg,
                            NULL, 0,
-                           &attrs, disable_range_rtrvl);
+                           &attrs, disable_range_rtrvl, NULL, NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_MINOR_FAILURE,
               "sdap_parse_entry failed [%d]: %s\n", ret, strerror(ret));
         return ret;
     }
 
-    ret = add_to_reply(state, &state->sreply, attrs);
+    ret = add_to_reply(state, &state->sreply, attrs, false);
     if (ret != EOK) {
         talloc_free(attrs);
         DEBUG(SSSDBG_CRIT_FAILURE, "add_to_reply failed.\n");
@@ -2867,7 +3040,8 @@ static void sdap_sd_search_done(struct tevent_req *subreq)
 
     ret = sdap_get_generic_ext_recv(subreq, state,
                                     &state->ref_count,
-                                    &state->refs);
+                                    &state->refs,
+                                    NULL, NULL);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
@@ -2940,7 +3114,10 @@ static int sdap_asq_search_create_control(struct sdap_handle *sh,
 static int sdap_asq_search_ctrls_destructor(void *ptr);
 static errno_t sdap_asq_search_parse_entry(struct sdap_handle *sh,
                                            struct sdap_msg *msg,
-                                           void *pvt);
+                                           bool not_used,
+                                           void *pvt,
+                                           const char ***_not_used,
+                                           const char **_not_used2);
 static void sdap_asq_search_done(struct tevent_req *subreq);
 
 static struct tevent_req *
@@ -2981,7 +3158,8 @@ sdap_asq_search_send(TALLOC_CTX *memctx, struct tevent_context *ev,
 
     DEBUG(SSSDBG_TRACE_FUNC, "Dereferencing entry [%s] using ASQ\n", base_dn);
     subreq = sdap_get_generic_ext_send(state, ev, opts, sh, base_dn,
-                                       LDAP_SCOPE_BASE, NULL, attrs,
+                                       LDAP_SCOPE_BASE, NULL,
+                                       attrs, false,
                                        state->ctrls, NULL, 0, timeout,
                                        sdap_asq_search_parse_entry,
                                        state, SDAP_SRCH_FLG_PAGING);
@@ -3035,7 +3213,10 @@ static int sdap_asq_search_create_control(struct sdap_handle *sh,
 
 static errno_t sdap_asq_search_parse_entry(struct sdap_handle *sh,
                                            struct sdap_msg *msg,
-                                           void *pvt)
+                                           bool not_used,
+                                           void *pvt,
+                                           const char ***_not_used,
+                                           const char **_not_used2)
 {
     errno_t ret;
     struct sdap_asq_search_state *state =
@@ -3119,7 +3300,7 @@ static errno_t sdap_asq_search_parse_entry(struct sdap_handle *sh,
 
         ret = sdap_parse_entry(res[mi], sh, msg,
                                map, num_attrs,
-                               &res[mi]->attrs, disable_range_rtrvl);
+                               &res[mi]->attrs, disable_range_rtrvl, NULL, NULL);
         if (ret != EOK) {
             DEBUG(SSSDBG_MINOR_FAILURE,
                   "sdap_parse_entry failed [%d]: %s\n", ret, strerror(ret));
@@ -3155,7 +3336,7 @@ static void sdap_asq_search_done(struct tevent_req *subreq)
     struct sdap_asq_search_state *state =
                 tevent_req_data(req, struct sdap_asq_search_state);
 
-    return generic_ext_search_handler(subreq, state->opts);
+    return generic_ext_search_handler(subreq, state->opts, NULL);
 }
 
 static int sdap_asq_search_ctrls_destructor(void *ptr)

--- a/src/tests/cmocka/test_sdap.c
+++ b/src/tests/cmocka/test_sdap.c
@@ -307,7 +307,7 @@ void test_parse_with_map(void **state)
 
     ret = sdap_parse_entry(test_ctx, &test_ctx->sh, &test_ctx->sm,
                            map, SDAP_OPTS_USER,
-                           &attrs, false);
+                           &attrs, false, NULL, NULL);
     assert_int_equal(ret, ERR_OK);
 
     assert_int_equal(attrs->num, 4);
@@ -368,7 +368,7 @@ void test_parse_no_map(void **state)
     set_entry_parse(&test_nomap_entry);
 
     ret = sdap_parse_entry(test_ctx, &test_ctx->sh, &test_ctx->sm,
-                           NULL, 0, &attrs, false);
+                           NULL, 0, &attrs, false, NULL, NULL);
     assert_int_equal(ret, ERR_OK);
 
     assert_int_equal(attrs->num, 3);
@@ -413,7 +413,7 @@ void test_parse_no_attrs(void **state)
 
     ret = sdap_parse_entry(test_ctx, &test_ctx->sh, &test_ctx->sm,
                            map, SDAP_OPTS_USER,
-                           &attrs, false);
+                           &attrs, false, NULL, NULL);
     assert_int_equal(ret, ERR_OK);
 
     assert_int_equal(attrs->num, 1);
@@ -460,7 +460,7 @@ void test_parse_dups(void **state)
 
     ret = sdap_parse_entry(test_ctx, &test_ctx->sh, &test_ctx->sm,
                            map, SDAP_OPTS_USER,
-                           &attrs, false);
+                           &attrs, false, NULL, NULL);
     assert_int_equal(ret, ERR_OK);
 
     assert_int_equal(attrs->num, 3);
@@ -613,7 +613,7 @@ void test_parse_secondary_oc(void **state)
 
     ret = sdap_parse_entry(test_ctx, &test_ctx->sh, &test_ctx->sm,
                            map, SDAP_OPTS_GROUP,
-                           &attrs, false);
+                           &attrs, false, NULL, NULL);
     assert_int_equal(ret, ERR_OK);
 
     talloc_free(map);
@@ -647,7 +647,7 @@ void test_parse_bad_oc(void **state)
 
     ret = sdap_parse_entry(test_ctx, &test_ctx->sh, &test_ctx->sm,
                            map, SDAP_OPTS_USER,
-                           &attrs, false);
+                           &attrs, false, NULL, NULL);
     assert_int_not_equal(ret, ERR_OK);
 
     talloc_free(map);
@@ -680,7 +680,7 @@ void test_parse_no_oc(void **state)
 
     ret = sdap_parse_entry(test_ctx, &test_ctx->sh, &test_ctx->sm,
                            map, SDAP_OPTS_USER,
-                           &attrs, false);
+                           &attrs, false, NULL, NULL);
     assert_int_not_equal(ret, ERR_OK);
 
     talloc_free(map);
@@ -715,7 +715,7 @@ void test_parse_no_dn(void **state)
 
     ret = sdap_parse_entry(test_ctx, &test_ctx->sh, &test_ctx->sm,
                            map, SDAP_OPTS_USER,
-                           &attrs, false);
+                           &attrs, false, NULL, NULL);
     assert_int_not_equal(ret, ERR_OK);
 
     talloc_free(map);
@@ -1159,7 +1159,7 @@ static void test_sdap_get_primary_name(void **state)
     assert_int_equal(ret, ERR_OK);
 
     ret = sdap_parse_entry(test_ctx, &test_ctx->sh, &test_ctx->sm,
-                           map, SDAP_OPTS_IPHOST, &attrs, false);
+                           map, SDAP_OPTS_IPHOST, &attrs, false, NULL, NULL);
     assert_int_equal(ret, ERR_OK);
 
     assert_int_equal(attrs->num, 3);

--- a/src/tests/system/tests/test_ad.py
+++ b/src/tests/system/tests/test_ad.py
@@ -226,3 +226,78 @@ if (-not $c) { Write-Error "CA not found"; exit 1 }
 
     log = client.fs.read(client.sssd.logs.domain())
     assert f"ldaps://{ad.server}" in log, f"Logs should show LDAPS connection to {ad.server}"
+
+
+@pytest.mark.topology(KnownTopology.AD)
+@pytest.mark.ticket(jira="RHEL-75484")
+@pytest.mark.importance("high")
+def test_range_retrieval__group_membership_expired_group(client: Client, ad: AD):
+    """
+    :title: Groups with with more users than MaxValRange can be retrieved
+    :description:
+        Testing the feature to retrieve groups with more users than MaxValRange.
+    :setup:
+        1. Set MaxValRange in lDAPAdminLimits on AD.
+        2. Create an ad group with number of users > MaxValRange
+        3. Clear caches and restart sssd
+    :steps:
+        1. Retrieve all users one by one using gentent passwd
+        2. Retrieve the group running getent group and check cached content
+    :expectedresults:
+        1. Users are evaluated
+        2. No users are missing from the group
+    :customerscenario: True
+    """
+    size = 152
+    # The lDAPAdminLimits list contains mutiple items in key=value format.
+    # We retrieve the current lDAPAdminLimits, remove MaxValRange from it.
+    # Then we append new MaxValRange and write it back.
+    ad.host.conn.run(rf"""
+            $basedn = '{ad.naming_context}'
+            $policyDN = "CN=Default Query Policy,CN=Query-Policies,CN=Directory"+
+            " Service,CN=Windows NT,CN=Services,CN=Configuration,$basedn"
+            $currentLimits = (Get-ADObject -Identity $policyDN `
+            -Properties lDAPAdminLimits).lDAPAdminLimits
+            Write-Output "Current limits: $currentLimits"
+            $regexPattern = "MaxValRange=.*"
+            $newLimits = @()
+            $newLimits += $currentLimits -notmatch $regexPattern
+            $newLimits += "MaxValRange={size - 2}"
+            Write-Output "New limits: $newLimits"
+            Set-ADObject -Identity $policyDN -Replace @{{lDAPAdminLimits = $newLimits}}
+            """)
+    client.sssd.domain["ldap_id_mapping"] = "false"
+    client.sssd.domain["use_fully_qualified_names"] = "True"
+    client.sssd.start()
+    # Provisioning groups one by one using the framework functions
+    # each in its own ssh call takes too long.
+    ad.host.conn.run(rf"""
+            Import-Module ActiveDirectory
+            $basedn = '{ad.naming_context}'
+            $gidNumber = 30000
+            New-ADGroup -Name "big-group" -GroupScope 'Global' -GroupCategory `
+            'Security' -OtherAttributes @{{"gidNumber"="$gidNumber"}} -Path "cn=users,$basedn"
+            $count = 0
+            while ($count -lt {size}) {{
+                $uidNumber = 10001 + $count
+                $userName = "user-$count"
+                New-ADUser -Name $userName -AccountPassword (ConvertTo-SecureString `
+                "Secret123" -AsPlainText -force) -OtherAttributes @{{"uid"=$userName`
+                ;"uidNumber"=$uidNumber;"gidNumber"=20001;"gecos"=$userName;"loginShell"=`
+                "/bin/bash"}} -Enabled $True -Path "cn=users,$basedn" -EmailAddress `
+                "$userName@$basedn" -GivenName dummyfirstname -Surname dummylastname `
+                -UserPrincipalName "$userName@$basedn"
+                Add-ADGroupMember -Identity "cn=big-group,cn=users,$basedn" `
+                -Members "cn=$userName,cn=users,$basedn"
+                $count++
+            }}
+            """)
+    client.sssctl.cache_expire(everything=True)
+    # populate cache with users
+    for a in range(0, size):
+        user = client.tools.getent.passwd(f"user-{a}@{client.sssd.default_domain}")
+        assert user is not None, f"Failed to read user `user-{a}`, infrastructure issue?"
+    # get the group
+    result = client.tools.getent.group(f"big-group@{client.sssd.default_domain}")
+    assert result is not None, "Failed to resolve big-group!"
+    assert len(result.members) == size, "Some users are missing in the group!"


### PR DESCRIPTION
Implement support for range retrieval of attribute values.
When a multi-valued attribute has a large number of values Active
Directory response only with first batch of values. A common case
is the `memberOf` attribute when a user belongs to many groups.
This is controlled by AD `MaxValRange` values (default 1500) policy.

Range retrieval is indicated in the response and provides information
which part of the batch is provided (e. g., memberOf;range=0-1499).

SSSD must then perform additional requests to fetch the remaining
values (e. g., `memberOf;range=1500-*`)..

The implementation is written to allow extension to other search types
(e. g., root DSE search), although that is not currently required.

Resolves: https://github.com/SSSD/sssd/issues/8102