### PR TITLE
ipa: improve handling of external group memberships - 2.9.4

### DIFF
--- a/src/providers/ipa/ipa_subdomains_ext_groups.c
+++ b/src/providers/ipa/ipa_subdomains_ext_groups.c
@@ -208,6 +208,13 @@ static errno_t find_ipa_ext_memberships(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
+    user_dn = ldb_dn_copy(mem_ctx, result->msgs[0]->dn);
+    if (user_dn == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "ldb_dn_copy failed.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
     ret = sss_hash_create(tmp_ctx, 0, &group_hash);
     if (ret != HASH_SUCCESS) {
         DEBUG(SSSDBG_OP_FAILURE, "sss_hash_create failed.\n");
@@ -288,13 +295,6 @@ static errno_t find_ipa_ext_memberships(TALLOC_CTX *mem_ctx,
         c++;
     }
 
-    user_dn = ldb_dn_copy(mem_ctx, result->msgs[0]->dn);
-    if (user_dn == NULL) {
-        DEBUG(SSSDBG_OP_FAILURE, "ldb_dn_copy failed.\n");
-        ret = ENOMEM;
-        goto done;
-    }
-
     ret = EOK;
 done:
     *_user_dn = user_dn;
@@ -305,11 +305,12 @@ done:
     return ret;
 }
 
-static errno_t add_ad_user_to_cached_groups(struct ldb_dn *user_dn,
+static errno_t add_ad_user_to_cached_groups(TALLOC_CTX *mem_ctx,
+                                            struct ldb_dn *user_dn,
                                             struct sss_domain_info *user_dom,
                                             struct sss_domain_info *group_dom,
                                             char **groups,
-                                            bool *missing_groups)
+                                            char  ***_missing_groups)
 {
     size_t c;
     size_t d = 0;
@@ -322,11 +323,11 @@ static errno_t add_ad_user_to_cached_groups(struct ldb_dn *user_dn,
     char *user_name;
     char **sysdb_ipa_group_memberships;
     char **add_groups;
+    size_t add_groups_count;
     char **del_groups;
+    char **mis_groups = NULL;
     errno_t sret;
     bool in_transaction = false;
-
-    *missing_groups = false;
 
     tmp_ctx = talloc_new(NULL);
     if (tmp_ctx == NULL) {
@@ -382,25 +383,23 @@ static errno_t add_ad_user_to_cached_groups(struct ldb_dn *user_dn,
     /* Add all new IPA groups to SYSDB_ORIG_MEMBEROF because they are most
      * probably removed by the previous user update and mark all new groups as
      * processed. */
-    for (c = 0; groups[c] != NULL; c++) {
+    for (c = 0; groups != NULL && groups[c] != NULL; c++) {
         ret = sysdb_attrs_add_string(user_attrs, SYSDB_ORIG_MEMBEROF,
                                      groups[c]);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "sysdb_attrs_add_string failed.\n");
             goto done;
         }
-
-        groups[c][0] = '\0';
     }
 
+    for (add_groups_count = 0; add_groups[add_groups_count] != NULL; add_groups_count++);
     if (DEBUG_IS_SET(SSSDBG_TRACE_ALL)) {
         DEBUG(SSSDBG_TRACE_ALL, "New IPA groups [%zu].\n", c);
 
         for (c = 0; sysdb_ipa_group_memberships[c] != NULL; c++);
         DEBUG(SSSDBG_TRACE_ALL, "Cached IPA groups [%zu].\n", c);
 
-        for (c = 0; add_groups[c] != NULL; c++);
-        DEBUG(SSSDBG_TRACE_ALL, "Groups to add [%zu].\n", c);
+        DEBUG(SSSDBG_TRACE_ALL, "Groups to add [%zu].\n", add_groups_count);
 
         for (c = 0; del_groups[c] != NULL; c++);
         DEBUG(SSSDBG_TRACE_ALL, "Groups to delete [%zu].\n", c);
@@ -420,10 +419,18 @@ static errno_t add_ad_user_to_cached_groups(struct ldb_dn *user_dn,
             if (ret == ENOENT) {
                 DEBUG(SSSDBG_TRACE_ALL, "Group [%s] not in the cache.\n",
                                          add_groups[c]);
-                *missing_groups = true;
-                talloc_free(groups[d]);
-                /* add missing group back to the list */
-                groups[d++] = talloc_steal(groups, add_groups[c]);
+                if (mis_groups == NULL) {
+                    mis_groups = talloc_array(tmp_ctx, char *,
+                                              add_groups_count + 1);
+                    if (mis_groups == NULL) {
+                        DEBUG(SSSDBG_OP_FAILURE,
+                              "Failed to allocate memory for missing groups.\n");
+                        ret = ENOMEM;
+                        goto done;
+                    }
+                }
+                /* add missing group to the list */
+                mis_groups[d++] = talloc_steal(mis_groups, add_groups[c]);
                 continue;
             } else {
                 DEBUG(SSSDBG_OP_FAILURE, "sysdb_search_entry failed.\n");
@@ -439,8 +446,6 @@ static errno_t add_ad_user_to_cached_groups(struct ldb_dn *user_dn,
         }
 
     }
-    talloc_free(groups[d]);
-    groups[d] = NULL;
 
     for (c = 0; del_groups[c] != NULL; c++) {
         ret = sysdb_search_groups_by_orig_dn(tmp_ctx, group_dom, del_groups[c],
@@ -480,6 +485,13 @@ static errno_t add_ad_user_to_cached_groups(struct ldb_dn *user_dn,
     }
 
     in_transaction = false;
+
+    if (mis_groups == NULL) {
+        *_missing_groups = NULL;
+    } else {
+        mis_groups[d] = NULL;
+        *_missing_groups = talloc_steal(mem_ctx, mis_groups);
+    }
 
     ret = EOK;
 done:
@@ -740,8 +752,9 @@ static errno_t ipa_add_ext_groups_step(struct tevent_req *req)
         goto fail;
     }
 
-    if (groups == NULL) {
-        DEBUG(SSSDBG_TRACE_ALL, "No external groups memberships found.\n");
+    if (user_dn == NULL) {
+        DEBUG(SSSDBG_TRACE_ALL, "User [%s] not found in cache.\n",
+                                state->user_name);
         state->dp_error = DP_ERR_OK;
         return EOK;
     }
@@ -806,6 +819,7 @@ struct add_ad_membership_state {
     struct sss_domain_info *user_dom;
     struct sss_domain_info *group_dom;
     char **groups;
+    char **missing_groups;
     int dp_error;
     size_t iter;
     struct sdap_domain *group_sdom;
@@ -826,7 +840,6 @@ static struct tevent_req *ipa_add_ad_memberships_send(TALLOC_CTX *mem_ctx,
     struct tevent_req *req;
     struct tevent_req *subreq;
     struct add_ad_membership_state *state;
-    bool missing_groups = false;
 
     req = tevent_req_create(mem_ctx, &state, struct add_ad_membership_state);
     if (req == NULL) {
@@ -848,14 +861,14 @@ static struct tevent_req *ipa_add_ad_memberships_send(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    ret = add_ad_user_to_cached_groups(user_dn, user_dom, group_dom, groups,
-                                       &missing_groups);
+    ret = add_ad_user_to_cached_groups(state, user_dn, user_dom, group_dom,
+                                       groups, &state->missing_groups);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "add_ad_user_to_cached_groups failed.\n");
         goto done;
     }
 
-    if (!missing_groups) {
+    if (state->missing_groups == NULL) {
         DEBUG(SSSDBG_TRACE_ALL, "All groups found in cache.\n");
         ret = EOK;
         goto done;
@@ -929,25 +942,21 @@ static void ipa_add_ad_memberships_get_next(struct tevent_req *req)
     struct ldb_dn *group_dn;
     int ret;
     const struct ldb_val *val;
-    bool missing_groups;
     const char *fq_name;
     char *tmp_str;
 
-    while (state->groups[state->iter] != NULL
-            && state->groups[state->iter][0] == '\0') {
-        state->iter++;
-    }
-
-    if (state->groups[state->iter] == NULL) {
-        ret = add_ad_user_to_cached_groups(state->user_dn, state->user_dom,
+    if (state->missing_groups[state->iter] == NULL) {
+        talloc_zfree(state->missing_groups);
+        ret = add_ad_user_to_cached_groups(state, state->user_dn,
+                                           state->user_dom,
                                            state->group_dom, state->groups,
-                                           &missing_groups);
+                                           &state->missing_groups);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "add_ad_user_to_cached_groups failed.\n");
             goto fail;
         }
 
-        if (missing_groups) {
+        if (state->missing_groups != NULL) {
             /* this might be HBAC or sudo rule */
             DEBUG(SSSDBG_FUNC_DATA, "There are unresolved external group "
                                        "memberships even after all groups "
@@ -959,7 +968,7 @@ static void ipa_add_ad_memberships_get_next(struct tevent_req *req)
     }
 
     group_dn = ldb_dn_new(state, sysdb_ctx_get_ldb(state->group_dom->sysdb),
-                          state->groups[state->iter]);
+                          state->missing_groups[state->iter]);
     if (group_dn == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "ldb_dn_new failed.\n");
         ret = ENOMEM;
@@ -969,7 +978,7 @@ static void ipa_add_ad_memberships_get_next(struct tevent_req *req)
     val = ldb_dn_get_rdn_val(group_dn);
     if (val == NULL || val->data == NULL) {
         DEBUG(SSSDBG_OP_FAILURE,
-              "Invalid group DN [%s].\n", state->groups[state->iter]);
+              "Invalid group DN [%s].\n", state->missing_groups[state->iter]);
         ret = EINVAL;
         goto fail;
     }

--- a/src/tests/system/tests/test_ipa_trusts.py
+++ b/src/tests/system/tests/test_ipa_trusts.py
@@ -1,5 +1,5 @@
 """
-Identity of trusted users and groups.
+IPA Trusts.
 
 :requirement: IDM-SSSD-REQ: Testing SSSD in IPA Provider
 """
@@ -15,24 +15,27 @@ from sssd_test_framework.topology import KnownTopologyGroup
 @pytest.mark.importance("low")
 @pytest.mark.ticket(jira="RHEL-3925", gh=6942)
 @pytest.mark.topology(KnownTopologyGroup.IPATrust)
-def test_trust_identity__group_without_sid(ipa: IPA, trusted: GenericADProvider):
+def test_ipa_trusts__lookup_group_without_sid(ipa: IPA, trusted: GenericADProvider):
     """
-    :title: Subdomain goes offline if IPA group is missing SID
+    :title: Subdomain stays online if IPA group is missing SID
+    :description: This test is to check a bug that made SSSD go offline when an expected attribute was missing.
+        This happens during applying overrides on cached group during initgroups of trusted user. If the group
+        does not have SID (it's GID is outside the sidgen range), SSSD goes offline.
     :setup:
         1. Create IPA external group "external-group" and add AD user "Administrator" as a member
         2. Create IPA posix group "posix-group" and add "external-group" as a member
         3. Clear SSSD cache and logs on IPA server
         4. Restart SSSD on IPA server
     :steps:
-        1. Resolve user "Administrator@addomain"
-        2. Expire user "Administrator@addomain"
-        3. Resolve user "Administrator@addomain"
-        4. Run "sssctl domain-status addomain"
+        1. Lookup AD administrator user
+        2. Clear user cache
+        3. Lookup AD administrator user
+        4. Check logs using sssctl for domain status
     :expectedresults:
-        1. User is resolved and member of posix-group
-        2. User is expired in SSSD cache
-        3. User is resolved and member of posix-group
-        4. The Active Directory domain is still online
+        1. User is found and is a member of 'posix-group'
+        2. User cache expired
+        3. User is found and is a member of 'posix-group'
+        4. No messages indicating AD went offline
     :customerscenario: True
     """
     username = trusted.fqn("administrator")
@@ -44,18 +47,16 @@ def test_trust_identity__group_without_sid(ipa: IPA, trusted: GenericADProvider)
 
     # Cache trusted user
     result = ipa.tools.id(username)
-    assert result is not None
-    assert result.user.name == username
-    assert result.memberof("posix-group")
+    assert result is not None, "User not found!"
+    assert result.memberof("posix-group"), "User is not a member of 'posix-group'!"
 
     # Expire the user and resolve it again, this will trigger the affected code path
     ipa.sssctl.cache_expire(user=username)
     result = ipa.tools.id(username)
-    assert result is not None
-    assert result.user.name == username
-    assert result.memberof("posix-group")
+    assert result is not None, "User not found!"
+    assert result.memberof("posix-group"), "User is not a member of 'posix-group'!"
 
     # Check that SSSD did not go offline
     status = ipa.sssctl.domain_status(trusted.domain, online=True)
-    assert "online status: offline" not in status.stdout.lower()
-    assert "online status: online" in status.stdout.lower()
+    assert "online status: offline" not in status.stdout.lower(), "AD domain went offline!"
+    assert "online status: online" in status.stdout.lower(), "AD domain was not online!"

--- a/src/tests/system/tests/test_ipa_trusts.py
+++ b/src/tests/system/tests/test_ipa_trusts.py
@@ -7,6 +7,7 @@ IPA Trusts.
 from __future__ import annotations
 
 import time
+import uuid
 
 import pytest
 from sssd_test_framework.roles.generic import GenericADProvider
@@ -112,3 +113,68 @@ def test_ipa_trusts__add_and_remove_external_group_membership(
     result = ipa.tools.id(username)
     assert result is not None, "User not found!"
     assert not result.memberof("posix-group"), "User is still a member of 'posix-group'!"
+
+
+@pytest.mark.topology(KnownTopologyGroup.IPATrust)
+@pytest.mark.ticket(jira="RHEL-109087")
+@pytest.mark.importance("low")
+def test_ipa_trusts__aduser_membership_after_HBAC(ipa: IPA, trusted: GenericADProvider):
+    """
+    :title: Membership update of the AD-user after it's IPA-group is a member of a HBAC rule
+    :description: ADuser's ipa-group membership should not be lost after its ipa-group is added to an HBAC rule.
+    :setup:
+        1. Create a trusted AD-user.
+        2. Create an IPA external group and add the AD user as its member.
+        3. Create an IPA posix group and add the ipa external group as a member.
+    :steps:
+        1. Lookup AD user and verify initial group membership.
+        2. Create an HBAC rule for the all-host-category.
+        3. Add the IPA-posix-group to that HBAC rule.
+        4. Clear the cache for that user only.
+        5. Lookup the AD user again.
+    :expectedresults:
+        1. The user is found and is a member of the POSIX group.
+        2. The HBAC rule is created successfully.
+        3. The group is added to the HBAC rule successfully.
+        4. The user's cache is expired.
+        5. The user is still found and is still a member of the POSIX group.
+    :customerscenario: False
+    """
+    unique = str(uuid.uuid4())[:8]
+
+    # Define dynamic names for test objects
+    ad_user_name = f"aduser-{unique}"
+    external_group_name = f"ipa_external_group_{unique}"
+    posix_group_name = f"ipa_group_{unique}"
+    hbac_rule = f"hbac-rule-{unique}"
+
+    # --- Setup Phase ---
+    trusted.user(ad_user_name).add()
+    aduser_fqn = trusted.fqn(ad_user_name)
+
+    # ipa.host.conn.exec(["ipa", "trust-find"])
+    ipa.sssctl.cache_expire(everything=True)
+    user_found = ipa.tools.id(aduser_fqn)
+    assert user_found is not None, f"AD User '{aduser_fqn}' did not replicate to IPA server in time."
+
+    external = ipa.group(external_group_name).add(external=True).add_member(aduser_fqn)
+    posix_group = ipa.group(posix_group_name).add().add_member(external)
+
+    # --- Verification Phase 1: Initial State ---
+    # ipa.sssctl.cache_expire(everything=True)
+    ipa.sssd.restart(clean=True)
+    result = ipa.tools.id(aduser_fqn)
+    assert result is not None, "User not found"
+    assert result.memberof(posix_group.name), f"User lost membership in '{posix_group.name}' before HBAC update."
+
+    # --- Drop these hbac actions, Once HBAC module in in testframework
+    ipa.host.conn.exec(["ipa", "hbacrule-add", hbac_rule, "--hostcat=all"])
+    ipa.host.conn.exec(["ipa", "hbacrule-add-user", hbac_rule, f"--groups={posix_group.name}"])
+
+    ipa.sssctl.cache_expire(user=aduser_fqn)
+
+    # --- Verification Phase 2: State After HBAC Update ---
+    time.sleep(10)
+    result = ipa.tools.id(aduser_fqn)
+    assert result is not None, "User is not found"
+    assert result.memberof(posix_group.name), f"User lost membership in '{posix_group.name}' after HBAC update."

--- a/src/tests/system/tests/test_ipa_trusts.py
+++ b/src/tests/system/tests/test_ipa_trusts.py
@@ -6,6 +6,8 @@ IPA Trusts.
 
 from __future__ import annotations
 
+import time
+
 import pytest
 from sssd_test_framework.roles.generic import GenericADProvider
 from sssd_test_framework.roles.ipa import IPA
@@ -60,3 +62,53 @@ def test_ipa_trusts__lookup_group_without_sid(ipa: IPA, trusted: GenericADProvid
     status = ipa.sssctl.domain_status(trusted.domain, online=True)
     assert "online status: offline" not in status.stdout.lower(), "AD domain went offline!"
     assert "online status: online" in status.stdout.lower(), "AD domain was not online!"
+
+
+@pytest.mark.topology(KnownTopologyGroup.IPATrust)
+@pytest.mark.parametrize("use_token_groups", ["true", "false"])
+@pytest.mark.importance("low")
+@pytest.mark.ticket(jira="RHEL-77184")
+def test_ipa_trusts__add_and_remove_external_group_membership(
+    ipa: IPA, trusted: GenericADProvider, use_token_groups: str
+):
+    """
+    :title: Add and remove and AD user to an IPA group
+    :description: This test wil check if an AD user can be added and remove to an IPA group.
+    :setup:
+        1. Set 'ldap_use_tokengroups' option and inherit it to sub-domains
+        2. Create IPA external group "external-group" and add AD user "Administrator" as a member
+        3. Create IPA posix group "posix-group" and add "external-group" as a member
+    :steps:
+        1. Clear SSSD cache and lookup group memberships of  "Administrator"
+        2. Remove "Administrator" from "external-group"
+        3. Expire the cached user, wait 10s to expire the external group map
+           cache and lookup group memberships of "Administrator"
+    :expectedresults:
+        1. User "Administrator" is a member of "posix-group"
+        2. Command is successful
+        3. User "Administrator" is a not a member of "posix-group"
+    :customerscenario: True
+    """
+    ipa.sssd.dom(ipa.domain)["ldap_use_tokengroups"] = use_token_groups
+    ipa.sssd.dom(ipa.domain)["subdomain_inherit"] = "ldap_use_tokengroups"
+    ipa.sssd.config_apply()
+
+    username = trusted.fqn("administrator")
+    external = ipa.group("external-group").add(external=True).add_member(username)
+    ipa.group("posix-group").add().add_member(external)
+
+    ipa.sssd.clear(db=True, memcache=True, logs=False)
+    ipa.sssd.restart()
+
+    result = ipa.tools.id(username)
+    assert result is not None, "User not found!"
+    assert result.memberof("posix-group"), "User is not a member of 'posix-group'!"
+
+    external.remove_member(username)
+
+    ipa.sssctl.cache_expire(user=username)
+    # required sleep to expire SSSD's external group map cache
+    time.sleep(10)
+    result = ipa.tools.id(username)
+    assert result is not None, "User not found!"
+    assert not result.memberof("posix-group"), "User is still a member of 'posix-group'!"

--- a/src/tests/system/tests/test_sudo.py
+++ b/src/tests/system/tests/test_sudo.py
@@ -532,9 +532,9 @@ def test_sudo__local_users_negative_cache(client: Client, provider: LDAP):
     with client.ssh("user-1", "Secret123") as ssh:
         ssh.exec(["sudo", "/bin/ls", "/root"])
 
-        with client.tools.tcpdump("/tmp/sssd.pcap", ["-s0", "host", provider.host.hostname]):
+        with client.net.tcpdump("/tmp/sssd.pcap", ["-s0", "host", provider.host.hostname]):
             ssh.exec(["sudo", "/bin/ls", "/root"])
             ssh.exec(["sudo", "/bin/ls", "/root"])
 
-    result = client.tools.tshark(["-r", "/tmp/sssd.pcap", "-V", "-2", "-R", "ldap.filter"])
-    assert "uid=user-1" not in result.stdout
+    result = client.net.tshark(["-r", "/tmp/sssd.pcap", "-V", "-2", "-R", "ldap.filter"])
+    assert "uid=user-1" not in result.stdout, "Packets sent when resolving user!"


### PR DESCRIPTION
Backport for sssd-2-9-4

Recently add_ad_user_to_cached_groups() was modified to better handle
adding and removing group memberships of users from trusted domains in
groups of the local IPA domain. Before the change group members were only
added and with the change a removal was possible as well. This caused an
issues with an in-out parameter which contains the full list of IPA group
memberships at input and the list of group missing in the cache as output.
Since add_ad_user_to_cached_groups() is called twice, the second time after
the missing groups were read from the IPA server, this caused and
unexpected removal of group memberships since the second call to
add_ad_user_to_cached_groups() was done with the list of missing groups and
not with the full list.

With this patch a dedicated list is used for the missing groups to avoid
the described issues.

Additionally this PR contains a second patch which filters some objects SSSD
currently does not handle.

Resolves: https://github.com/SSSD/sssd/issues/7921