### PR TITLE
common.c: Be prepared for revents=POLLHUP when poll returns

### DIFF
--- a/src/sss_client/common.c
+++ b/src/sss_client/common.c
@@ -211,7 +211,7 @@ static enum sss_status sss_cli_send_req(enum sss_cli_command cmd,
             *errnop = ETIMEDOUT;
             break;
         case 1:
-            if (pfd.revents & (POLLERR | POLLHUP)) {
+            if ((pfd.revents & POLLERR) || (pfd.revents & POLLHUP)) {
                 *errnop = EPIPE;
             } else if (pfd.revents & POLLNVAL) {
                 /* Invalid request: fd is not opened */


### PR DESCRIPTION
Unlike Linux, FreeBSD returns POLLHUP without POLLERR only when the socket is closed.

Similar issue were found and fixed for Qt https://codereview.qt-project.org/c/qt/qtbase/+/651677 and DBus https://gitlab.freedesktop.org/dbus/dbus/-/merge_requests/526