### PR TITLE
util-tests.c: Properly bring back the value of TZ

### DIFF
--- a/src/tests/util-tests.c
+++ b/src/tests/util-tests.c
@@ -1071,9 +1071,6 @@ static void convert_time_tz(const char* tz)
     const char *orig_tz = NULL;
 
     orig_tz = getenv("TZ");
-    if (orig_tz == NULL) {
-        orig_tz = "";
-    }
 
     if (tz) {
         ret = setenv("TZ", tz, 1);
@@ -1088,6 +1085,10 @@ static void convert_time_tz(const char* tz)
         ret2 = setenv("TZ", orig_tz, 1);
         sss_ck_fail_if_msg(ret2 == -1,
                 "setenv failed with errno: %d", errno);
+    } else {
+        ret2 = unsetenv("TZ");
+        sss_ck_fail_if_msg(ret2 == -1,
+                "unsetenv failed with errno: %d", errno);
     }
     ck_assert_msg(ret == EOK && difftime(1735732662, unix_time) == 0,
                 "Expecting 1735732662 got: ret[%d] unix_time[%"SPRItime"]",


### PR DESCRIPTION
In its previous form the code was ending up with setting TZ even if it wasn't set before the test. The `if (orig_tz != NULL)` check was always true and redundant.