### PR TITLE
krb5: disable Kerberos localauth an2ln plugin for AD/IPA

### DIFF
--- a/src/util/domain_info_utils.c
+++ b/src/util/domain_info_utils.c
@@ -722,6 +722,7 @@ done:
 #define LOCALAUTH_PLUGIN_CONFIG \
 "[plugins]\n" \
 " localauth = {\n" \
+"  disable = an2ln\n" \
 "  module = sssd:"APP_MODULES_PATH"/sssd_krb5_localauth_plugin.so\n" \
 " }\n"
 


### PR DESCRIPTION
If a client is joined to AD or IPA SSSD's localauth plugin can handle
the mapping of Kerberos principals to local accounts. In case it cannot
map the Kerberos principals libkrb5 is currently configured to fall back
to the default localauth plugins 'default', 'rule', 'names',
'auth_to_local', 'k5login' and 'an2ln' (see man krb5.conf for details).
All plugins except 'an2ln' require some explicit configuration by either
the administrator or the local user. To avoid some unexpected mapping is
done by the 'an2ln' plugin this patch disables it in the configuration
snippets for SSSD's localauth plugin.