### PR TITLE
ci: Override shell builtin bash options for get-changed script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
         yq -i 'del(.domains[0].hosts.[] | select(.role == "ad"))' mhc.yaml
 
     - name: Get changed tests
-      shell: bash
+      shell: bash {0}
       env:
         PR_ID: ${{ github.event.pull_request.number }}
         GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
When only system test files are touched in a PR, the get-changed.sh script fails due to -o pipefail option being added by GH action shell built-in.

This overrides the default use of `bash --noprofile --norc -eo pipefail {0}` to `bash {0}` instead

https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defaultsrunshell