### PR TITLE
gpo_child: don't include 'util/signal.c'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4691,7 +4691,6 @@ gpo_child_SOURCES = \
     src/util/util.c \
     src/util/util_ext.c \
     src/util/util_errors.c \
-    src/util/signal.c \
     src/util/sss_chain_id.c \
     src/util/sss_prctl.c
 gpo_child_CFLAGS = \


### PR DESCRIPTION
It's not really needed.