### PR TITLE
gpo_child: don't include 'util/signal.c'  --  sssd-2-10- backport

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4755,7 +4755,6 @@ gpo_child_SOURCES = \
     src/util/util.c \
     src/util/util_ext.c \
     src/util/util_errors.c \
-    src/util/signal.c \
     src/util/sss_chain_id.c
 gpo_child_CFLAGS = \
     $(AM_CFLAGS) \


### PR DESCRIPTION
It's not really needed.

Reviewed-by: Sumit Bose <sbose@redhat.com>
Reviewed-by: Tomáš Halman <thalman@redhat.com>
(cherry picked from commit 488e540dd7a92ee0525236936b48a0f15b214533)