### PR TITLE
ci: fix dependabot.yml schema validation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,8 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    prefix: ci
     directory: /
     schedule:
       interval: monthly
+    commit-message:
+      prefix: ci


### PR DESCRIPTION
As specified in the documentation move prefix under commit-message section.

Example of failed execution: https://github.com/SSSD/sssd/runs/54018618899

Link: <https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference>