### PR TITLE
config/cfg_rules.ini: Make regexp's more POSIX compliant

### DIFF
--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -11,15 +11,15 @@ section = ifp
 section = kcm
 section = session_recording
 section_re = ^prompting/password$
-section_re = ^prompting/password/[^/\@]\+$
+section_re = ^prompting/password/[^/\@]\{1,\}$
 section_re = ^prompting/2fa$
-section_re = ^prompting/2fa/[^/\@]\+$
+section_re = ^prompting/2fa/[^/\@]\{1,\}$
 section_re = ^prompting/passkey$
-section_re = ^prompting/passkey/[^/\@]\+$
-section_re = ^domain/[^/\@]\+$
-section_re = ^domain/[^/\@]\+/[^/\@]\+$
-section_re = ^application/[^/\@]\+$
-section_re = ^certmap/[^/\@]\+/[^/\@]\+$
+section_re = ^prompting/passkey/[^/\@]\{1,\}$
+section_re = ^domain/[^/\@]\{1,\}$
+section_re = ^domain/[^/\@]\{1,\}/[^/\@]\{1,\}$
+section_re = ^application/[^/\@]\{1,\}$
+section_re = ^certmap/[^/\@]\{1,\}/[^/\@]\{1,\}$
 
 
 [rule/allowed_sssd_options]
@@ -316,13 +316,13 @@ option = touch_prompt
 
 [rule/allowed_prompting_password_subsec_options]
 validator = ini_allowed_options
-section_re = ^prompting/password/[^/\@]\+$
+section_re = ^prompting/password/[^/\@]\{1,\}$
 
 option = password_prompt
 
 [rule/allowed_prompting_2fa_subsec_options]
 validator = ini_allowed_options
-section_re = ^prompting/2fa/[^/\@]\+$
+section_re = ^prompting/2fa/[^/\@]\{1,\}$
 
 option = single_prompt
 option = first_prompt
@@ -330,7 +330,7 @@ option = second_prompt
 
 [rule/allowed_prompting_passkey_subsec_options]
 validator = ini_allowed_options
-section_re = ^prompting/passkey/[^/\@]\+$
+section_re = ^prompting/passkey/[^/\@]\{1,\}$
 
 option = interactive
 option = interactive_prompt
@@ -339,7 +339,7 @@ option = touch_prompt
 
 [rule/allowed_domain_options]
 validator = ini_allowed_options
-section_re = ^\(domain\|application\)/[^/]\+$
+section_re = ^\(domain\|application\)/[^/]\{1,\}$
 
 option = debug
 option = debug_level
@@ -796,7 +796,7 @@ option = inherit_from
 
 [rule/allowed_subdomain_options]
 validator = ini_allowed_options
-section_re = ^domain/[^/\@]\+/[^/\@]\+$
+section_re = ^domain/[^/\@]\{1,\}/[^/\@]\{1,\}$
 
 option = ldap_search_base
 option = ldap_user_search_base
@@ -818,7 +818,7 @@ validator = sssd_checks
 
 [rule/allowed_certmap_options]
 validator = ini_allowed_options
-section_re = ^certmap/[^/\@]\+/[^/\@]\+$
+section_re = ^certmap/[^/\@]\{1,\}/[^/\@]\{1,\}$
 
 option = matchrule
 option = maprule


### PR DESCRIPTION
According to section 9.3.2 BRE Ordinary Characters [1], the '\+' sequence may work as a plain character or like ERE special character. It is the latter for Linux, but it is the former for FreeBSD.

Instead, use '{1,}' as a portable way of expressing "one or many".

This fixes most of config validation tests on FreeBSD.

[1] https://pubs.opengroup.org/onlinepubs/9799919799.2024edition/basedefs/V1_chap09.html#tag_09_03_02