### PR TITLE
file_watch.c: Do not pass IN_IGNORED to inotify_add_watch

### DIFF
--- a/src/util/file_watch.c
+++ b/src/util/file_watch.c
@@ -178,7 +178,7 @@ static int try_inotify(struct file_watch_ctx *fw_ctx)
     snctx = snotify_create(fw_ctx, fw_ctx->ev, SNOTIFY_WATCH_DIR,
                            fw_ctx->filename, &delay,
                            IN_DELETE_SELF | IN_CLOSE_WRITE | IN_MOVE_SELF | \
-                           IN_CREATE | IN_MOVED_TO | IN_IGNORED,
+                           IN_CREATE | IN_MOVED_TO,
                            watched_file_inotify_cb, fw_ctx);
     if (snctx == NULL) {
         return EIO;

--- a/src/util/inotify.c
+++ b/src/util/inotify.c
@@ -210,7 +210,7 @@ static errno_t dispatch_event(struct snotify_ctx *snctx,
 {
     struct snotify_dispatcher *disp;
 
-    if ((snctx->cb.mask & ev_flags) == 0) {
+    if (((snctx->cb.mask | IN_IGNORED) & ev_flags) == 0) {
         return EOK;
     }
 


### PR DESCRIPTION
This is an output flag and it doesn't make sense to pass it as input. FreeBSD implementation is more finicky, so passing this flag makes the call fail.

Fixes the file-watch-tests test on FreeBSD.