### PR TITLE
github ci space cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         path: sssd
 
     - name: Setup containers
-      uses: SSSD/sssd-ci-containers/actions/setup@master
+      uses: spoore1/sssd-ci-containers/actions/setup@gdm_role
       with:
         path: sssd-ci-containers
         tag: ${{ matrix.tag }}
@@ -53,7 +53,7 @@ jobs:
               - ../sssd:/sssd:rw
 
     - name: Run integration tests
-      uses: SSSD/sssd-ci-containers/actions/exec@master
+      uses: spoore1/sssd-ci-containers/actions/exec@gdm_role
       with:
         working-directory: /sssd
         script: ./contrib/ci/run --moderate
@@ -104,6 +104,13 @@ jobs:
     permissions:
       contents: read
     steps:
+    #- name: Setup tmate session
+    #  id: tmate
+    #  uses: mxschmitt/action-tmate@v3
+    #  with:
+    #    detached: true
+    #    limit-access-to-actor: true
+
     - uses: actions/setup-python@v6
       with:
         python-version: '3.x'
@@ -114,7 +121,7 @@ jobs:
         path: sssd
 
     - name: Setup containers
-      uses: SSSD/sssd-ci-containers/actions/setup@master
+      uses: spoore1/sssd-ci-containers/actions/setup@gdm_role
       with:
         path: sssd-ci-containers
         tag: ${{ matrix.tag }}
@@ -136,7 +143,7 @@ jobs:
               - ../sssd:/sssd:rw
 
     - name: Build SSSD on the client and IPA
-      uses: SSSD/sssd-ci-containers/actions/exec@master
+      uses: spoore1/sssd-ci-containers/actions/exec@gdm_role
       with:
         log-file: build.log
         working-directory: /sssd
@@ -156,7 +163,7 @@ jobs:
           make rpms
 
     - name: Install SSSD on the client and IPA
-      uses: SSSD/sssd-ci-containers/actions/exec@master
+      uses: spoore1/sssd-ci-containers/actions/exec@gdm_role
       with:
         log-file: install.log
         user: root
@@ -174,7 +181,7 @@ jobs:
           systemctl enable --now sssd-kcm.socket
 
     - name: Restart SSSD on IPA server
-      uses: SSSD/sssd-ci-containers/actions/exec@master
+      uses: spoore1/sssd-ci-containers/actions/exec@gdm_role
       with:
         user: root
         where: ipa
@@ -185,7 +192,7 @@ jobs:
           systemctl restart sssd || systemctl status sssd
 
     - name: Patch the SSH configuration
-      uses: SSSD/sssd-ci-containers/actions/exec@master
+      uses: spoore1/sssd-ci-containers/actions/exec@gdm_role
       with:
         user: root
         script: |
@@ -297,6 +304,23 @@ jobs:
           --output-polarion-testcase=$GITHUB_WORKSPACE/artifacts/testcase.xml \
           ${{ steps.select-tests.outputs.SELECT_TESTS }} \
           --collect-only . |& tee $GITHUB_WORKSPACE/pytest-collect.log
+
+    - name: Cleanup disk space before running tests
+      shell: bash
+      working-directory: ./
+      run: |
+        # Run pytest in collect only mode to quickly catch issues in Polarion metadata.
+        set -x -o pipefail
+
+        sudo df -h
+        sudo mount
+        sudo du -sk /opt/hostedtoolcache/*
+        sudo rm -rf /opt/hostedtoolcache/go /opt/hostedtoolcache/CodeQL
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo apt-get clean
+        sudo du -sk /home/*
+        sudo df -h
 
     - name: Run tests
       shell: bash


### PR DESCRIPTION
In newer versions of Fedora, the github runners are filling disk space
during testing.   This is to try to alleviate some of the space
restraints so that the tests can complete.