### PR TITLE
SPEC: require reasonably up to date 'libldb' version

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -157,7 +157,7 @@ the existing back ends.
 %package common
 Summary: Common files for the SSSD
 License: GPL-3.0-or-later
-Requires: libldb
+Requires: libldb >= %{samba_package_version}
 Requires: sssd-client%{?_isa} = %{version}-%{release}
 Requires: (libsss_sudo = %{version}-%{release} if sudo)
 Requires: (libsss_autofs%{?_isa} = %{version}-%{release} if autofs)


### PR DESCRIPTION
Since 'libldb' is built from Samba sources, it uses the same version.