### PR TITLE
CONFIG: disable 'session_provider' by default

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -3316,8 +3316,7 @@ pam_gssapi_indicators_map = sudo:pkinit, sudo-i:pkinit
                             session related tasks.
                         </para>
                         <para>
-                            Default: <quote>id_provider</quote> is used if it
-                            is set and can perform session related tasks.
+                            Default: <quote>none</quote>.
                         </para>
                     </listitem>
                 </varlistentry>


### PR DESCRIPTION
:config: Default value of 'session_provider' option was changed to 'none' (i.e. disabled) doesn't matter what 'id_provider' used. Previously 'session_provider' was enabled by default for 'id_provider = ipa' case. But this didn't make sense because 'Fleet Commander', that is being integrated in this case, is long time obsolete.