### PR TITLE
ipa: check for empty trusts in ipa_get_trust_type()

### DIFF
--- a/src/providers/ipa/ipa_subdomains_id.c
+++ b/src/providers/ipa/ipa_subdomains_id.c
@@ -933,7 +933,7 @@ ipa_get_trust_type(struct ipa_id_ctx *ipa_ctx,
         if (iter->dom == dom) break;
     }
 
-    return iter->type;
+    return (iter != NULL) ? iter->type : IPA_TRUST_UNKNOWN;
 }
 
 static struct ipa_id_ctx *ipa_get_ipa_id_ctx(struct ipa_id_ctx *ipa_ctx,


### PR DESCRIPTION
Similar as ipa_get_ad_id_ctx() or ipa_get_ipa_id_ctx() ipa_get_trust_type() should be aware that the 'trusts' member of 'server_mode' might be NULL.