### PR TITLE
tests: Add incomplete triples and complex hierarchy netgroup tests

### DIFF
--- a/src/tests/system/tests/test_netgroups.py
+++ b/src/tests/system/tests/test_netgroups.py
@@ -317,3 +317,160 @@ def test_netgroup__uid_gt_2147483647(client: Client, provider: AD | LDAP | Samba
         group_result = client.tools.getent.group(grpname)
         assert group_result is not None, f"getent group for group '{grpname}' is empty!"
         assert group_result.name == grpname, f"Group name '{grpname}' did not match!"
+
+
+@pytest.mark.importance("high")
+@pytest.mark.topology(KnownTopology.LDAP)
+@pytest.mark.topology(KnownTopology.AD)
+@pytest.mark.topology(KnownTopology.Samba)
+@pytest.mark.preferred_topology(KnownTopology.LDAP)
+def test_netgroup__incomplete_triples(client: Client, provider: AD | LDAP | Samba):
+    """
+    :title: Netgroups with incomplete triples
+    :description: Netgroups with incomplete triples can be created and used.
+    :setup:
+        1. Create an empty netgroup
+        2. Create a netgroup with only host
+        3. Create a netgroup with only user
+        4. Create a netgroup with only domain
+        5. Create a netgroup with missing host
+        6. Create a netgroup with missing user
+        7. Create a netgroup with missing domain
+        8. Start SSSD
+    :steps:
+        1. Show the netgroups
+    :expectedresults:
+        1. Netgroups are shown and match the expectations
+    :customerscenario: False
+    """
+    domain = provider.domain
+
+    # (setup_params, expected_members)
+    cases = {
+        "ng-empty": ({}, set()),
+        "ng-only-host": ({"host": "testhost"}, {"(testhost,-,)"}),
+        "ng-only-user": ({"user": "testuser"}, {"(-,testuser,)"}),
+        "ng-only-domain": ({"domain": domain}, {f"(-,-,{domain})"}),
+        "ng-missing-host": (
+            {"user": "testuser", "domain": domain},
+            {f"(-,testuser,{domain})"},
+        ),
+        "ng-missing-user": (
+            {"host": "testhost", "domain": domain},
+            {f"(testhost,-,{domain})"},
+        ),
+        "ng-missing-domain": (
+            {"host": "testhost", "user": "testuser"},
+            {"(testhost,testuser,)"},
+        ),
+    }
+
+    for name, (params, _) in cases.items():
+        ng = provider.netgroup(name).add()
+        if params:
+            ng.add_member(**params)
+
+    client.sssd.start()
+
+    for name, (_, expected) in cases.items():
+        result = client.tools.getent.netgroup(name)
+        assert result is not None, f"Netgroup '{name}' not found!"
+        assert result.name == name
+        actual = {str(m) for m in result.members}
+        assert actual == expected, f"Netgroup '{name}': expected {expected}, got {actual}"
+
+
+@pytest.mark.importance("high")
+@pytest.mark.topology(KnownTopology.LDAP)
+@pytest.mark.topology(KnownTopology.AD)
+@pytest.mark.topology(KnownTopology.Samba)
+@pytest.mark.preferred_topology(KnownTopology.LDAP)
+def test_netgroups__complex_hierarchy(client: Client, provider: AD | LDAP | Samba):
+    """
+    :title: Complex netgroup hierarchy
+    :description: Netgroups with multiple levels of nesting work correctly
+    :setup:
+        1. Create multiple netgroups with various combinations of triples
+           and nested members
+        2. Create complex hierarchy with mixed triples and netgroup members
+        3. Start SSSD
+    :steps:
+        1. Query each netgroup in the hierarchy
+    :expectedresults:
+        1. Each netgroup returns correct combination of direct triples
+           and inherited members
+    :customerscenario: False
+    """
+    # Hierarchy:
+    # ng-top -> ng-mid1 -> ng-base1
+    #        -> ng-mid2 -> ng-base2
+    #                   -> ng-base3
+
+    domain = provider.domain
+
+    # Level 1: Base netgroups with only triples (no nested members)
+    provider.netgroup("ng-base1").add().add_member(host="host1", user="user1", domain=domain)
+    provider.netgroup("ng-base2").add().add_member(host="host2", user="user2", domain=domain)
+    provider.netgroup("ng-base3").add().add_member(user="user3")
+
+    # Level 2: Mid-level netgroups with both triples and nested members
+    ng_mid1 = provider.netgroup("ng-mid1").add()
+    ng_mid1.add_member(host="host4", user="user4", domain=domain)
+    ng_mid1.add_member(ng="ng-base1")
+
+    ng_mid2 = provider.netgroup("ng-mid2").add()
+    ng_mid2.add_member(user="user5")
+    ng_mid2.add_member(ng="ng-base2")
+    ng_mid2.add_member(ng="ng-base3")
+
+    # Level 3: Top-level netgroup containing mid-level netgroups
+    ng_top = provider.netgroup("ng-top").add()
+    ng_top.add_member(host="host6", user="user6", domain=domain)
+    ng_top.add_member(ng="ng-mid1")
+    ng_top.add_member(ng="ng-mid2")
+
+    client.sssd.start()
+
+    # Verify base netgroups (Level 1)
+    base_expectations = {
+        "ng-base1": {f"(host1,user1,{domain})"},
+        "ng-base2": {f"(host2,user2,{domain})"},
+        "ng-base3": {"(-,user3,)"},
+    }
+    for name, expected in base_expectations.items():
+        result = client.tools.getent.netgroup(name)
+        assert result is not None, f"Netgroup '{name}' not found!"
+        actual = {str(m) for m in result.members}
+        assert actual == expected, f"Netgroup '{name}': expected {expected}, got {actual}"
+
+    # Verify mid-level netgroups (Level 2)
+    mid_expectations = {
+        "ng-mid1": {
+            f"(host4,user4,{domain})",
+            f"(host1,user1,{domain})",
+        },
+        "ng-mid2": {
+            "(-,user5,)",
+            f"(host2,user2,{domain})",
+            "(-,user3,)",
+        },
+    }
+    for name, expected in mid_expectations.items():
+        result = client.tools.getent.netgroup(name)
+        assert result is not None, f"Netgroup '{name}' not found!"
+        actual = {str(m) for m in result.members}
+        assert actual == expected, f"Netgroup '{name}': expected {expected}, got {actual}"
+
+    # Verify top-level netgroup (Level 3)
+    result = client.tools.getent.netgroup("ng-top")
+    assert result is not None, "Netgroup 'ng-top' not found!"
+    expected = {
+        f"(host6,user6,{domain})",
+        f"(host4,user4,{domain})",
+        f"(host1,user1,{domain})",
+        "(-,user5,)",
+        f"(host2,user2,{domain})",
+        "(-,user3,)",
+    }
+    actual = {str(m) for m in result.members}
+    assert actual == expected, f"Netgroup 'ng-top': expected {expected}, got {actual}"


### PR DESCRIPTION
Adds two new netgroup tests.

1. test_netgroup__incomplete_triples - Verifies netgroups with missing host/user/domain fields work correctly

2. test_netgroups__complex_hierarchy - Verifies multi-level nested netgroups resolve inherited members correctly