### PR TITLE
KCM: root can't access arbitrary KCM cache

### DIFF
--- a/src/man/sssd-kcm.8.xml
+++ b/src/man/sssd-kcm.8.xml
@@ -41,7 +41,7 @@
         <para>
             The KCM server keeps track of each credential caches's owner and
             performs access check control based on the UID and GID of the
-            KCM client. The root user has access to all credential caches.
+            KCM client.
         </para>
         <para>
             The KCM credential cache has several interesting properties:

--- a/src/responder/kcm/kcmsrv_ccache.c
+++ b/src/responder/kcm/kcmsrv_ccache.c
@@ -159,11 +159,6 @@ bool kcm_cc_access(struct kcm_ccache *cc,
         return false;
     }
 
-    if (uid == 0 && gid == 0) {
-        /* root can access any ccache */
-        return true;
-    }
-
     ok = ((cc->owner.uid == uid) && (cc->owner.gid == gid));
     if (!ok) {
         DEBUG(SSSDBG_MINOR_FAILURE,

--- a/src/responder/kcm/kcmsrv_ccache.h
+++ b/src/responder/kcm/kcmsrv_ccache.h
@@ -80,10 +80,7 @@ errno_t kcm_cc_new(TALLOC_CTX *mem_ctx,
 struct kcm_ccache *kcm_cc_dup(TALLOC_CTX *mem_ctx,
                               const struct kcm_ccache *cc);
 
-/*
- * Returns true if a client can access a ccache.
- *
- * Note that root can access any ccache */
+/* Returns true if a client can access a ccache. */
 bool kcm_cc_access(struct kcm_ccache *cc,
                    struct cli_creds *client);
 
@@ -175,8 +172,7 @@ errno_t kcm_ccdb_nextid_recv(struct tevent_req *req,
  *
  * NOTE: Contrary to how Heimdal behaves, root CAN NOT list all ccaches
  * of all users. This is a deliberate decision to treat root as any other
- * user, except it can access a ccache of another user by name, just not
- * list them.
+ * user.
  *
  * If a client has no ccaches, the function returns OK, but an empty list
  * containing just the NULL sentinel.


### PR DESCRIPTION
so remove confusing traces suggesting otherwise

See: https://github.com/SSSD/sssd/issues/7274#issuecomment-2063499790

Resolves: https://github.com/SSSD/sssd/issues/7274