### PR TITLE
pac: fix issue with pac_check=no_check

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2262,6 +2262,13 @@ pam_json_services = gdm-switchable-auth
                             IPA and AD provider. If krb5_validate is set to
                             'False' the PAC checks will be skipped.
 			</para>
+			<para>
+                            Please note that the checks listed below only apply
+                            to PACs issued by Active Directory or recent
+                            versions of FreeIPA. PACs issued e.g. by a plain
+                            MIT Kerberos KDC will not contain the needed PAC
+                            data buffers to run the checks.
+			</para>
                         <para>
 			    The following options can be used alone or in a
 			    comma-separated list:

--- a/src/providers/ad/ad_pac_common.c
+++ b/src/providers/ad/ad_pac_common.c
@@ -394,13 +394,18 @@ errno_t ad_get_data_from_pac(TALLOC_CTX *mem_ctx, const uint32_t pac_check_opts,
         }
     }
 
-    /* The logon_info buffer is the main PAC buffer with the basic user
-     * information, if this is missing we consider the PAC as broken. */
-    if (_logon_info != NULL && *_logon_info == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "LOGON_INFO pac buffer missing.\n");
-        ret = ERR_CHECK_PAC_FAILED;
-        goto done;
+    /* The logon_info buffer is the main PAC buffer for AD and FreeIPA users
+     * with the basic user information, if this is missing we consider the PAC
+     * as broken if PAC checking is not switched off. This is important
+     * because new versions MIT Kerberos will add a PAC buffer as well, but
+     * without an AD logon_info buffer. */
+    if (pac_check_opts != 0) {
+        if (_logon_info != NULL && *_logon_info == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "LOGON_INFO pac buffer missing.\n");
+            ret = ERR_CHECK_PAC_FAILED;
+            goto done;
+        }
     }
 
     /* The upn_dns_info buffer was added with Windows 2008, so there might be


### PR DESCRIPTION
So far SSSD expected that the PAC contains the logon_info buffer even if PAC checks are disabled with the 'no_check' option. This causes issues with PACs issues by MIT Kerberos KDCs which do not contain this buffer. This patches makes sure that the logon_info is not expected if 'no_check' is set and adds some clarifications to the man page.

Resolves: https://github.com/SSSD/sssd/issues/8300