### PR TITLE
sysdb: do not treat missing id-override as an error

### DIFF
--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -743,6 +743,7 @@ int sysdb_search_user_by_upn_with_view_res(TALLOC_CTX *mem_ctx,
             DEBUG(SSSDBG_OP_FAILURE, "sysdb_add_overrides_to_object failed.\n");
             return ret;
         }
+        ret = EOK;
     }
 
     *out_res = orig_obj;


### PR DESCRIPTION
In sysdb_search_user_by_upn_with_view_res()
sysdb_add_overrides_to_object() can return ENOENT if there is no id-override for the given user. This is expected and should not be treated as an error.