### PR TITLE
RESPONDER: fix `responder_set_fd_limit()`

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -725,11 +725,9 @@
                         <para>
                             This option specifies the maximum number of file
                             descriptors that may be opened at one time by this
-                            SSSD process. On systems where SSSD is granted the
-                            CAP_SYS_RESOURCE capability, this will be an
-                            absolute setting. On systems without this
-                            capability, the resulting value will be the lower
-                            value of this or the limits.conf "hard" limit.
+                            SSSD process. Note this value will be capped by
+                            the init system at the startup of SSSD, see e.g.
+                            man systemd.exec for details.
                         </para>
                         <para>
                             Default: 8192 (or limits.conf "hard" limit)


### PR DESCRIPTION
to not even try setting hard limit as SSSD never has CAP_SYS_RESOURCE