### PR TITLE
scripts: fetch branch before checkout in release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -62,6 +62,7 @@ GROUP_END
 set -x
 
 GROUP_START "Checkout branch"
+git fetch origin "$branch"
 git checkout "$branch"
 git pull --rebase
 GROUP_END


### PR DESCRIPTION
actions/checkout does a sparse clone by default so the branch may not
be yet available.
