### PR TITLE
Backport 2-9-4: Enumerate objects with '#' in name

### DIFF
--- a/src/db/sysdb_search.c
+++ b/src/db/sysdb_search.c
@@ -784,6 +784,7 @@ static errno_t sysdb_enum_dn_filter(TALLOC_CTX *mem_ctx,
 {
     TALLOC_CTX *tmp_ctx = NULL;
     char *dn_filter;
+    char *sanitized_dn;
     const char *fqname;
     errno_t ret;
 
@@ -814,11 +815,18 @@ static errno_t sysdb_enum_dn_filter(TALLOC_CTX *mem_ctx,
     }
 
     for (size_t i = 0; i < ts_res->count; i++) {
+        ret = sss_filter_sanitize_dn(tmp_ctx,
+                                     ldb_dn_get_linearized(ts_res->msgs[i]->dn),
+                                     &sanitized_dn);
+        if (ret != EOK) {
+            goto done;
+        }
         dn_filter = talloc_asprintf_append(
                                   dn_filter,
                                   "(%s=%s)",
                                   SYSDB_DN,
-                                  ldb_dn_get_linearized(ts_res->msgs[i]->dn));
+                                  sanitized_dn);
+        talloc_free(sanitized_dn);
         if (dn_filter == NULL) {
             ret = ENOMEM;
             goto done;


### PR DESCRIPTION
This patch fixes enumeration when DN in LDAP server contains special characters.

The libldb expects that '\' is followed by two hex digits in filter. Strings like '\#' must be sanitized into '\5c#' before they are used for searching.

Resolves: https://github.com/SSSD/sssd/issues/7876

Reviewed-by: Alejandro López <allopez@redhat.com>
Reviewed-by: Dan Lavu <dlavu@redhat.com>
(cherry picked from commit 158b4cdb7ac62fde1280f50a5d678f80d0e99015)

Reviewed-by: Alejandro López <allopez@redhat.com>
(cherry picked from commit 116d6221c8dba014a12b7ca93eff62fd3f0f314f)