### PR TITLE
systemd: relaunch sssd after unclean exit

### DIFF
--- a/src/sysv/systemd/sssd.service.in
+++ b/src/sysv/systemd/sssd.service.in
@@ -23,7 +23,7 @@ ExecStartPre=+-/bin/sh -c "/bin/chown -f -h @SSSD_USER@:@SSSD_USER@ @logpath@/*.
 ExecStart=@sbindir@/sssd -i ${DEBUG_LOGGER}
 Type=notify
 NotifyAccess=main
-Restart=on-abnormal
+Restart=on-failure
 @capabilities@
 SecureBits=noroot noroot-locked
 User=@SSSD_USER@


### PR DESCRIPTION
This PR aims to fix #6219 by swapping the restart policy of the sssd systemd unit back to on-failure.

The change to `Restart=on-abnormal` was introduced in [Commit a049ac7](https://github.com/SSSD/sssd/commit/a049ac715a79ddfad0d67d48fc5c60408cf62127) to fix an infinite loop on system boot caused by misconfiguration (see #5753 / https://bugzilla.suse.com/show_bug.cgi?id=1188999).

While this fixed their issue, I'd argue that the StartLimit settings introduced alongside it should accomplish the goal of avoiding an infinite loop in most scenarios:

```
     StartLimitIntervalSec=50s
     StartLimitBurst=5
```

I believe that the issues fixed (#6219)  by setting the restart policy back to on-failure take precedence over the edge cases where sssd could inhibit system boot when sssd/subsystems are too slow to trigger the StartLimit.

