### PR TITLE
sdap: optimize initgroups for users with many groups

### DIFF
--- a/src/db/sysdb.h
+++ b/src/db/sysdb.h
@@ -1178,6 +1178,9 @@ int sysdb_add_group(struct sss_domain_info *domain,
                     int cache_timeout,
                     time_t now);
 
+/* If user_member is not NULL, the user will be added as a member of the
+ * group during creation, avoiding a separate sysdb_add_group_member() call.
+ */
 int sysdb_add_incomplete_group(struct sss_domain_info *domain,
                                const char *name,
                                gid_t gid,
@@ -1185,7 +1188,8 @@ int sysdb_add_incomplete_group(struct sss_domain_info *domain,
                                const char *sid_str,
                                const char *uuid,
                                bool posix,
-                               time_t now);
+                               time_t now,
+                               const char *user_member);
 
 /* Add netgroup (only basic attrs and w/o checks) */
 int sysdb_add_basic_netgroup(struct sss_domain_info *domain,

--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -2296,7 +2296,8 @@ int sysdb_add_incomplete_group(struct sss_domain_info *domain,
                                const char *sid_str,
                                const char *uuid,
                                bool posix,
-                               time_t now)
+                               time_t now,
+                               const char *user_member)
 {
     TALLOC_CTX *tmp_ctx;
     int ret;
@@ -2306,6 +2307,7 @@ int sysdb_add_incomplete_group(struct sss_domain_info *domain,
     const char *group_attrs[] = { SYSDB_SID_STR, SYSDB_UUID, SYSDB_ORIG_DN, NULL };
     const char *values[] = { sid_str, uuid, original_dn, NULL };
     bool same = false;
+    char *member_dn_str;
 
     tmp_ctx = talloc_new(NULL);
     if (!tmp_ctx) {
@@ -2381,6 +2383,17 @@ int sysdb_add_incomplete_group(struct sss_domain_info *domain,
     if (uuid) {
         ret = sysdb_attrs_add_string(attrs, SYSDB_UUID, uuid);
         if (ret) goto done;
+    }
+
+    if (user_member != NULL) {
+        member_dn_str = sysdb_user_strdn(tmp_ctx, domain->name, user_member);
+        if (member_dn_str == NULL) {
+            ret = ENOMEM;
+            goto done;
+        }
+
+        ret = sysdb_attrs_add_string(attrs, SYSDB_MEMBER, member_dn_str);
+        if (ret != EOK) goto done;
     }
 
     ret = sysdb_set_group_attr(domain, name, attrs, SYSDB_MOD_REP);

--- a/src/providers/idp/idp_id_eval.c
+++ b/src/providers/idp/idp_id_eval.c
@@ -208,7 +208,7 @@ static errno_t store_json_group(struct idp_id_ctx *idp_id_ctx, json_t *group,
     } else {
         ret = sysdb_add_incomplete_group(dom, fqdn, gid, NULL, NULL,
                                          json_string_value(uuid),
-                                         gid != 0, 0);
+                                         gid != 0, 0, NULL);
         if (ret != EOK && ret != ERR_GID_DUPLICATED) {
             DEBUG(SSSDBG_OP_FAILURE,
                   "Failed to create incomplete group [%s].\n", fqdn);

--- a/src/providers/ldap/sdap_async.h
+++ b/src/providers/ldap/sdap_async.h
@@ -498,7 +498,8 @@ sdap_handle_id_collision_for_incomplete_groups(struct data_provider *dp,
                                                const char *sid_str,
                                                const char *uuid,
                                                bool posix,
-                                               time_t now);
+                                               time_t now,
+                                               const char *user_member);
 
 struct sdap_id_conn_ctx *get_ldap_conn_from_sdom_pvt(struct sdap_options *opts,
                                                      struct sdap_domain *sdom);

--- a/src/providers/ldap/sdap_async_groups.c
+++ b/src/providers/ldap/sdap_async_groups.c
@@ -1963,7 +1963,8 @@ static void sdap_get_groups_process(struct tevent_req *subreq)
 
     if (state->no_members) {
         ret = sdap_add_incomplete_groups(state->sysdb, state->dom, state->opts,
-                                         state->groups, state->count);
+                                         state->groups, state->count,
+                                         NULL);
         if (ret == EOK) {
             DEBUG(SSSDBG_TRACE_LIBS,
                   "Writing only group data without members was successful.\n");

--- a/src/providers/ldap/sdap_async_initgroups.c
+++ b/src/providers/ldap/sdap_async_initgroups.c
@@ -34,7 +34,8 @@ errno_t sdap_add_incomplete_groups(struct sysdb_ctx *sysdb,
                                    struct sss_domain_info *domain,
                                    struct sdap_options *opts,
                                    struct sysdb_attrs **ldap_groups,
-                                   int ldap_groups_count)
+                                   int ldap_groups_count,
+                                   const char *user_member)
 {
     TALLOC_CTX *tmp_ctx;
     struct ldb_message *msg = NULL;
@@ -96,6 +97,17 @@ errno_t sdap_add_incomplete_groups(struct sysdb_ctx *sysdb,
         ret = sysdb_search_group_by_name(tmp_ctx, subdomain, groupname,
                                          NULL, &msg);
         if (ret == EOK) {
+            if (user_member != NULL) {
+                ret = sysdb_add_group_member(subdomain, groupname,
+                                             user_member, SYSDB_MEMBER_USER,
+                                             false);
+                if (ret != EOK && ret != EEXIST) {
+                    DEBUG(SSSDBG_CRIT_FAILURE,
+                          "Could not add member [%s] to group [%s]: [%d]: %s. "
+                          "Skipping.\n",
+                          user_member, groupname, ret, sss_strerror(ret));
+                }
+            }
             continue;
         } else if (ret != ENOENT) {
             DEBUG(SSSDBG_CRIT_FAILURE,
@@ -208,7 +220,8 @@ errno_t sdap_add_incomplete_groups(struct sysdb_ctx *sysdb,
               "Adding fake group %s to sysdb\n", groupname);
         ret = sysdb_add_incomplete_group(subdomain, groupname, gid,
                                          original_dn, sid_str,
-                                         uuid, posix, now);
+                                         uuid, posix, now,
+                                         user_member);
         if (ret == ERR_GID_DUPLICATED) {
             /* In case of group id-collision, do:
              * - Delete the group from sysdb
@@ -219,7 +232,7 @@ errno_t sdap_add_incomplete_groups(struct sysdb_ctx *sysdb,
             ret = sdap_handle_id_collision_for_incomplete_groups(
                                     opts->dp, subdomain, groupname, gid,
                                     original_dn, sid_str, uuid, posix,
-                                    now);
+                                    now, user_member);
         }
 
         if (ret != EOK) {
@@ -311,11 +324,14 @@ int sdap_initgr_common_store(struct sysdb_ctx *sysdb,
     in_transaction = true;
 
     /* Add fake entries for any groups the user should be added as
-     * member of but that are not cached in sysdb
+     * member of but that are not cached in sysdb.
+     * If type is SYSDB_MEMBER_USER, also add membership during this step
+     * to avoid a separate sysdb_update_members() call for add_groups.
      */
     if (add_groups && add_groups[0]) {
         ret = sdap_add_incomplete_groups(sysdb, domain, opts,
-                                         ldap_groups, ldap_groups_count);
+                                         ldap_groups, ldap_groups_count,
+                                         type == SYSDB_MEMBER_USER ? name : NULL);
         if (ret != EOK) {
             DEBUG(SSSDBG_CRIT_FAILURE, "Adding incomplete groups failed\n");
             goto done;
@@ -324,7 +340,8 @@ int sdap_initgr_common_store(struct sysdb_ctx *sysdb,
 
     DEBUG(SSSDBG_TRACE_INTERNAL, "Updating memberships for %s\n", name);
     ret = sysdb_update_members(domain, name, type,
-                               (const char *const *) add_groups,
+                               type == SYSDB_MEMBER_USER ? NULL
+                                   : (const char *const *) add_groups,
                                (const char *const *) del_groups);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Membership update failed [%d]: %s\n",
@@ -639,7 +656,8 @@ sdap_nested_groups_store(struct sysdb_ctx *sysdb,
     }
     in_transaction = true;
 
-    ret = sdap_add_incomplete_groups(sysdb, domain, opts, groups, count);
+    ret = sdap_add_incomplete_groups(sysdb, domain, opts, groups, count,
+                                     NULL);
     if (ret != EOK) {
         DEBUG(SSSDBG_TRACE_FUNC, "Could not add incomplete groups [%d]: %s\n",
                    ret, strerror(ret));
@@ -3582,7 +3600,8 @@ sdap_handle_id_collision_for_incomplete_groups(struct data_provider *dp,
                                                const char *sid_str,
                                                const char *uuid,
                                                bool posix,
-                                               time_t now)
+                                               time_t now,
+                                               const char *user_member)
 {
     errno_t ret;
 
@@ -3597,7 +3616,7 @@ sdap_handle_id_collision_for_incomplete_groups(struct data_provider *dp,
     }
 
     ret = sysdb_add_incomplete_group(domain, name, gid, original_dn, sid_str,
-                                     uuid, posix, now);
+                                     uuid, posix, now, user_member);
     if (ret != EOK) {
         return ret;
     }

--- a/src/providers/ldap/sdap_async_initgroups_ad.c
+++ b/src/providers/ldap/sdap_async_initgroups_ad.c
@@ -640,7 +640,8 @@ errno_t sdap_ad_save_group_membership_with_idmapping(const char *username,
             }
 
             ret = sysdb_add_incomplete_group(domain, name, gid,
-                                             NULL, sid, NULL, gid != 0, now);
+                                             NULL, sid, NULL, gid != 0, now,
+                                             NULL);
             if (ret == ERR_GID_DUPLICATED) {
                 /* In case o group id-collision, do:
                  * - Delete the group from sysdb
@@ -651,7 +652,7 @@ errno_t sdap_ad_save_group_membership_with_idmapping(const char *username,
                 ret = sdap_handle_id_collision_for_incomplete_groups(
                                             idmap_ctx->id_ctx->be->provider,
                                             domain, name, gid, NULL, sid, NULL,
-                                            false, now);
+                                            false, now, NULL);
             }
 
             if (ret != EOK) {

--- a/src/providers/ldap/sdap_async_private.h
+++ b/src/providers/ldap/sdap_async_private.h
@@ -164,11 +164,15 @@ sdap_nested_group_lookup_external_recv(TALLOC_CTX *mem_ctx,
                                        struct tevent_req *req);
 
 /* from sdap_async_initgroups.c */
+/* If user_member is not NULL, the user will be added as a member of all
+ * groups in sysdb_groupnames (both newly created and already existing).
+ */
 errno_t sdap_add_incomplete_groups(struct sysdb_ctx *sysdb,
                                    struct sss_domain_info *domain,
                                    struct sdap_options *opts,
                                    struct sysdb_attrs **ldap_groups,
-                                   int ldap_groups_count);
+                                   int ldap_groups_count,
+                                   const char *user_member);
 
 /* from sdap_ad_groups.c */
 errno_t sdap_check_ad_group_type(struct sss_domain_info *dom,

--- a/src/tests/sysdb-tests.c
+++ b/src/tests/sysdb-tests.c
@@ -394,7 +394,7 @@ static int test_add_incomplete_group(struct test_data *data)
 
     ret = sysdb_add_incomplete_group(data->ctx->domain, data->groupname,
                                      data->gid, data->orig_dn,
-                                     data->sid_str, NULL, true, 0);
+                                     data->sid_str, NULL, true, 0, NULL);
     return ret;
 }
 
@@ -1060,14 +1060,14 @@ START_TEST (test_sysdb_incomplete_group_rename)
     ret = sysdb_add_incomplete_group(test_ctx->domain, "incomplete_group",
                                      20000, NULL,
                                      "S-1-5-21-123-456-789-111",
-                                     NULL, true, 0);
+                                     NULL, true, 0, NULL);
     ck_assert_msg(ret == EOK,
                 "sysdb_add_incomplete_group error [%d][%s]",
                 ret, strerror(ret));
 
     /* Adding a group with the same GID and all the other characteristics unknown should succeed */
     ret = sysdb_add_incomplete_group(test_ctx->domain, "incomplete_group_new",
-                                     20000, NULL, NULL, NULL, true, 0);
+                                     20000, NULL, NULL, NULL, true, 0, NULL);
     ck_assert_msg(ret == ERR_GID_DUPLICATED,
                 "Did not catch a rename. ret: %d [%s]",
                 ret, sss_strerror(ret));
@@ -1076,7 +1076,7 @@ START_TEST (test_sysdb_incomplete_group_rename)
     ret = sysdb_add_incomplete_group(test_ctx->domain, "incomplete_group_new",
                                      20000, NULL,
                                      "S-1-5-21-123-456-789-222",
-                                     NULL, true, 0);
+                                     NULL, true, 0, NULL);
     ck_assert_msg(ret == ERR_GID_DUPLICATED,
                 "Did not catch a rename. ret: %d [%s]",
                 ret, sss_strerror(ret));
@@ -1087,7 +1087,7 @@ START_TEST (test_sysdb_incomplete_group_rename)
     ret = sysdb_add_incomplete_group(test_ctx->domain, "incomplete_group_new",
                                      20000, NULL,
                                      "S-1-5-21-123-456-789-111",
-                                     NULL, true, 0);
+                                     NULL, true, 0, NULL);
     ck_assert_msg(ret == ERR_GID_DUPLICATED,
                 "Did not catch a rename. ret: %d [%s]",
                 ret, sss_strerror(ret));
@@ -1672,7 +1672,7 @@ static void add_nonposix_incomplete_group(struct sysdb_test_ctx *test_ctx,
     sss_ck_fail_if_msg(fq_name == NULL, "Failed to create fq name.");
 
     ret = sysdb_add_incomplete_group(test_ctx->domain, fq_name, 0,
-                                     NULL, NULL, NULL, false, 0);
+                                     NULL, NULL, NULL, false, 0, NULL);
     sss_ck_fail_if_msg(ret != EOK, "sysdb_add_group failed.");
 
     /* Test */
@@ -4608,7 +4608,7 @@ START_TEST(test_odd_characters)
 
     /* Add */
     ret = sysdb_add_incomplete_group(test_ctx->domain, odd_groupname,
-                                     20000, NULL, NULL, NULL, true, 0);
+                                     20000, NULL, NULL, NULL, true, 0, NULL);
     ck_assert_msg(ret == EOK, "sysdb_add_incomplete_group error [%d][%s]",
                             ret, strerror(ret));
 
@@ -4777,7 +4777,7 @@ START_TEST(test_SSS_LDB_SEARCH)
 
     /* Add */
     ret = sysdb_add_incomplete_group(test_ctx->domain, groupname,
-                                     20000, NULL, NULL, NULL, true, 0);
+                                     20000, NULL, NULL, NULL, true, 0, NULL);
     ck_assert_msg(ret == EOK, "sysdb_add_incomplete_group error [%d][%s]",
                 ret, strerror(ret));
 


### PR DESCRIPTION
When an LDAP user is a member of many groups (~10k), handling of BE_REQ_INITGROUPS takes an extremely long time because:
1. sdap_add_incomplete_groups() iterates over all groups to create missing group entries
2. sysdb_update_members() iterates over all groups again to add the user as a member

This patch eliminates the second iteration by adding user membership during step 1. The functions sysdb_add_incomplete_group() and sdap_add_incomplete_groups() now accept an optional user_member parameter. When provided, the user is added as a member of each group during group processing (both for newly created incomplete groups and for already existing groups).

In sdap_initgr_common_store(), when the member type is SYSDB_MEMBER_USER, we pass the username to sdap_add_incomplete_groups() and then call sysdb_update_members() only for group deletions (add_groups=NULL).