### PR TITLE
CHILD HELPERS: use less severe debug level  --  sssd-2.9 backport

### DIFF
--- a/src/util/child_common.c
+++ b/src/util/child_common.c
@@ -654,8 +654,8 @@ static void child_sig_handler(struct tevent_context *ev,
         DEBUG(SSSDBG_CRIT_FAILURE,
               "waitpid failed [%d][%s].\n", err, strerror(err));
     } else if (ret == 0) {
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "waitpid did not find a child with changed status.\n");
+        DEBUG(SSSDBG_TRACE_LIBS,
+              "It wasn't child [%d].\n", child_ctx->pid);
     } else {
         if (WIFEXITED(child_ctx->child_status)) {
             if (WEXITSTATUS(child_ctx->child_status) != 0) {


### PR DESCRIPTION
if `child_sig_handler()` is called for unknown pid.

If there are N handlers registered and 1 child process exists, all N handlers will be invoked, and N-1 of them will get `waitpid() == 0`.

It would be possible to have a single handler registed that would manage a list (or hash table) of `sss_child_ctx`, but it still would have to perform N `waitpid()` calls (`waitpid(-1)` can't be used to avoid handling "foreign" process) so complexity overhead doesn't worth it.

Backport of 003c591a351792a2a7eaaa32ddcc7325e7672b94