### PR TITLE
sdap: do not require GID for non-POSIX group

### DIFF
--- a/src/providers/ldap/sdap_async_groups.c
+++ b/src/providers/ldap/sdap_async_groups.c
@@ -620,15 +620,17 @@ static int sdap_save_group(TALLOC_CTX *memctx,
                 goto done;
             }
 
-            ret = sysdb_attrs_get_uint32_t(attrs,
-                                           opts->group_map[SDAP_AT_GROUP_GID].sys_name,
-                                           &gid);
-            if (ret != EOK) {
-                DEBUG(SSSDBG_CRIT_FAILURE,
-                      "no gid provided for [%s] in domain [%s].\n",
-                          group_name, dom->name);
-                ret = EINVAL;
-                goto done;
+            if (posix_group) {
+                ret = sysdb_attrs_get_uint32_t(attrs,
+                                               opts->group_map[SDAP_AT_GROUP_GID].sys_name,
+                                               &gid);
+                if (ret != EOK) {
+                    DEBUG(SSSDBG_CRIT_FAILURE,
+                          "no gid provided for [%s] in domain [%s].\n",
+                              group_name, dom->name);
+                    ret = EINVAL;
+                    goto done;
+                }
             }
         }
     }


### PR DESCRIPTION
In 85b632d130d126861bda7472f7a7ae301e70c098 the attribute for the GID was removed from non-POSIX groups. Currently sdap_save_group() still requires the attribute and this patch removes this.

sdap_save_group() is currently only used in the code path handling nested groups. To verify the change a test was added were indirect group-members are coming from a nested non-POSIX group.

Resolves: https://github.com/SSSD/sssd/issues/8441