### PR TITLE
sdap: eliminate O(N^2) loop in `sdap_add_incomplete_groups()`

### DIFF
--- a/src/providers/ldap/sdap_async_groups.c
+++ b/src/providers/ldap/sdap_async_groups.c
@@ -1906,7 +1906,7 @@ static void sdap_get_groups_process(struct tevent_req *subreq)
     bool next_base = false;
     size_t count;
     struct sysdb_attrs **groups;
-    char **sysdb_groupnamelist;
+
 
     ret = sdap_get_and_parse_generic_recv(subreq, state,
                                           &count, &groups);
@@ -1962,22 +1962,8 @@ static void sdap_get_groups_process(struct tevent_req *subreq)
     }
 
     if (state->no_members) {
-        ret = sdap_get_primary_fqdn_list(state->dom, state,
-                                state->groups, state->count,
-                                state->opts->group_map[SDAP_AT_GROUP_NAME].name,
-                                state->opts->group_map[SDAP_AT_GROUP_OBJECTSID].name,
-                                state->opts->idmap_ctx,
-                                &sysdb_groupnamelist);
-        if (ret != EOK) {
-            DEBUG(SSSDBG_OP_FAILURE,
-                  "sysdb_attrs_primary_name_list failed.\n");
-            tevent_req_error(req, ret);
-            return;
-        }
-
         ret = sdap_add_incomplete_groups(state->sysdb, state->dom, state->opts,
-                                         sysdb_groupnamelist, state->groups,
-                                         state->count);
+                                         state->groups, state->count);
         if (ret == EOK) {
             DEBUG(SSSDBG_TRACE_LIBS,
                   "Writing only group data without members was successful.\n");

--- a/src/providers/ldap/sdap_async_private.h
+++ b/src/providers/ldap/sdap_async_private.h
@@ -157,7 +157,6 @@ sdap_nested_group_lookup_external_recv(TALLOC_CTX *mem_ctx,
 errno_t sdap_add_incomplete_groups(struct sysdb_ctx *sysdb,
                                    struct sss_domain_info *domain,
                                    struct sdap_options *opts,
-                                   char **sysdb_groupnames,
                                    struct sysdb_attrs **ldap_groups,
                                    int ldap_groups_count);
 


### PR DESCRIPTION
Those patch is based on a profiling of a following test case:
 - users `tu1` is a member of 5k LDAP groups (RFC2307 case, no nested groups)
 - SSSD stared with an empty cache
 - `time id tu1@ldap.test | tr ',' '\n' | wc -l` is executed

This patch provides a x2 performance gain for described test case on a laptop. See commit message for details.