### PR TITLE
memberOf plugin :: mbof_add_operation() optimizations

### DIFF
--- a/src/ldb_modules/memberof.c
+++ b/src/ldb_modules/memberof.c
@@ -757,20 +757,77 @@ static int mbof_next_add_callback(struct ldb_request *req,
     return LDB_SUCCESS;
 }
 
+/* based on `ldb_dn_from_ldb_val()` but avoids memcpy */
+static const char *sss_get_linearized_dn_from_ldb_val(const struct ldb_val *strdn)
+{
+    const char *data;
+
+    if (strdn == NULL || strdn->data == NULL || strdn->length == 0) {
+        return NULL;
+    }
+
+    data = (const char *)strdn->data;
+
+    if (data[0] == '<') {
+        const char *p_save = data;
+        const char *p = data;
+        do {
+            p_save = p;
+            p = strstr(p, ">;");
+            if (p) {
+                p = p + 2;
+            }
+        } while (p);
+
+        if (p_save == data) {
+            /* Only extended components, no linearized DN */
+            return NULL;
+        }
+        return p_save;
+    }
+
+    return data;
+}
+
+__attribute__((always_inline))
+static inline bool sss_linearized_dn_match(const char *dn1, const char *dn2)
+{
+    const char *comma = NULL;
+    size_t name_len;
+
+    if ((dn1 == NULL) || (dn2 == NULL)) {
+        return false;
+    }
+
+    if (strcasecmp(dn1, dn2) != 0) {
+        return false;
+    }
+
+    /* Since sysdb cache treats 'name' case-sensitive,
+     * perform additional check to be on a safe side.
+     */
+    if (strncasecmp(dn1, "name=", 5) != 0) {
+        return true;
+    }
+
+    comma = strchrnul(dn1+5, ',');
+    name_len = comma - (dn1 + 5);
+    return (strncmp(dn1+5, dn2+5, name_len) == 0);
+}
+
 /* if it is a group, add all members for cascade effect
  * add memberof attribute to this entry
  */
 static int mbof_add_operation(struct mbof_add_operation *addop)
 {
 
-    TALLOC_CTX *tmp_ctx;
     struct mbof_ctx *ctx;
     struct mbof_add_ctx *add_ctx;
     struct ldb_context *ldb;
     struct ldb_message_element *el;
     struct ldb_request *mod_req;
     struct ldb_message *msg;
-    struct ldb_dn *elval_dn;
+    const char *elval_dn;
     struct ldb_dn *valdn;
     struct mbof_dn_array *parents;
     int i, j, ret;
@@ -795,7 +852,8 @@ static int mbof_add_operation(struct mbof_add_operation *addop)
     /* create new parent set for this entry */
     for (i = 0; i < addop->parents->num; i++) {
         /* never add yourself as memberof */
-        if (ldb_dn_compare(addop->parents->dns[i], addop->entry_dn) == 0) {
+        if (sss_linearized_dn_match(ldb_dn_get_linearized(addop->parents->dns[i]),
+                                    ldb_dn_get_linearized(addop->entry_dn))) {
             continue;
         }
         parents->dns[parents->num] = addop->parents->dns[i];
@@ -806,19 +864,21 @@ static int mbof_add_operation(struct mbof_add_operation *addop)
     el = ldb_msg_find_element(addop->entry, DB_MEMBEROF);
     if (el) {
 
-        tmp_ctx = talloc_new(addop);
-        if (!tmp_ctx) return LDB_ERR_OPERATIONS_ERROR;
-
         for (i = 0; i < el->num_values; i++) {
-            elval_dn = ldb_dn_from_ldb_val(tmp_ctx, ldb, &el->values[i]);
-            if (!elval_dn) {
+            elval_dn = sss_get_linearized_dn_from_ldb_val(&el->values[i]);
+            if (elval_dn == NULL) {
                 ldb_debug(ldb, LDB_DEBUG_TRACE, "Invalid DN in memberof [%s]",
                                             (const char *)el->values[i].data);
-                talloc_free(tmp_ctx);
                 return LDB_ERR_OPERATIONS_ERROR;
             }
             for (j = 0; j < parents->num; j++) {
-                if (ldb_dn_compare(parents->dns[j], elval_dn) == 0) {
+                /* Don't use `ldb_dn_compare()` here -
+                 * it is heavy because when DNs are not equal (vast majority of cases)
+                 * it performs `ldb_dn_casefold_internal()` to return -1 or 1,
+                 * but it's not important in this context.
+                 */
+                if (sss_linearized_dn_match(ldb_dn_get_linearized(parents->dns[j]),
+                                            elval_dn)) {
                     /* duplicate found */
                     break;
                 }
@@ -832,7 +892,6 @@ static int mbof_add_operation(struct mbof_add_operation *addop)
 
         if (parents->num == 0) {
             /* already contains all parents as memberof, skip to next */
-            talloc_free(tmp_ctx);
             talloc_free(addop->entry);
             addop->entry = NULL;
 
@@ -850,7 +909,6 @@ static int mbof_add_operation(struct mbof_add_operation *addop)
                                        LDB_SUCCESS);
             }
         }
-        talloc_free(tmp_ctx);
     }
 
     /* if it is a group add all members */


### PR DESCRIPTION
Using the same test case as described in #8454 and testing on top of that PR:
 - users `tu1` and `tu2` are members of the same 5k LDAP groups (RFC2307 case, no nested groups)
 - SSSD stared with an empty cache
 - `time id tu1@ldap.test | tr ',' '\n' | wc -l` and then ``time id tu2@ldap.test | tr ',' '\n' | wc -l`` are executed

This patch set reduces time spent by `id tu1` from 27 to 8 seconds and by consequent `id tu2` from 23 to 5 seconds on my laptop.