### PR TITLE
ci: Skip GPG checks when installing sssd build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,12 @@ jobs:
           #!/bin/bash
           set -ex
 
-          dnf install -y /dev/shm/sssd/rpmbuild/RPMS/*/*.rpm
+          # Workaround Fedora rawhide (45) bug https://bugzilla.redhat.com/show_bug.cgi?id=2440722
+          if grep Rawhide /etc/redhat-release; then
+                  ARG="--no-gpgchecks"
+          fi
+
+          dnf $ARG install -y /dev/shm/sssd/rpmbuild/RPMS/*/*.rpm
           rm -fr /dev/shm/sssd
 
           # We need to reenable sssd-kcm since it was disabled by removing sssd not not enabled again


### PR DESCRIPTION
At this time, workaround rawhide dnf issue causing failed install

  Total size of inbound packages is 11 MiB. Need to download 0 B.
  After this operation, 30 MiB extra will be used (install 40 MiB, remove 10 MiB).
  Running transaction
  Transaction failed: Rpm transaction failed.
  Warning: skipped OpenPGP checks for 60 packages from repository: @commandline

    - package sssd-2.13.0-0.fc45.x86_64 does not verify: no signature
    - package sssd-common-2.13.0-0.fc45.x86_64 does not verify: no signature ...