### PR TITLE
sdap_select_principal_from_keytab_sync: waitpid() synchronously

### DIFF
--- a/src/providers/ldap/sdap_child_helpers.c
+++ b/src/providers/ldap/sdap_child_helpers.c
@@ -264,9 +264,9 @@ errno_t sdap_select_principal_from_keytab_sync(TALLOC_CTX *mem_ctx,
 
     FD_CLOSE(io->read_from_child_fd);
 
-    if (waitpid(io->pid, NULL, WNOHANG) != io->pid) {
-        DEBUG(SSSDBG_MINOR_FAILURE, "waitpid(ldap_child) failed, "
-              "process might be leaking\n");
+    if (waitpid(io->pid, NULL, 0) != io->pid) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "waitpid(ldap_child) failed: [%d][%s]\n",
+              errno, strerror(errno));
     }
 
     ret = parse_select_principal_response(mem_ctx, response, len,


### PR DESCRIPTION
Without this change the ldap_child process started by this function ends up in the `<defunct>` state. kernel trace hints that the process isn't fully finished by the time waitpid is called:

```
 13126 sssd_be  CALL  wait4(13127,0,0x1<WNOHANG>,0)
 13126 sssd_be  RET   wait4 0
waitpid(ldap_child) failed, process might be leaking
```

According to man waitpid(2), the function returns 0 when passed `WNOHANG` and there is no child process that can be reported as exited. Omitting `WNOHANG` fixes the issue.