### PR TITLE
ci: load kernel module for passkey testing with vfido

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,16 @@ jobs:
       with:
         path: sssd
 
+    - name: Install and load kernel module for passkey testing
+      shell: bash
+      run: |
+        set -ex -o pipefail
+
+        sudo apt-get update
+        sudo apt-get install -y linux-modules-extra-$(uname -r)
+
+        sudo modprobe vhci-hcd
+
     - name: Setup containers
       uses: SSSD/sssd-ci-containers/actions/setup@master
       with:


### PR DESCRIPTION
virtual-fido requires `vhci-hcd` kernel module to be loaded on the host to work