### PR TITLE
SDAP: save users we downloaded during nested group processing

### DIFF
--- a/src/providers/ldap/sdap_async_groups.c
+++ b/src/providers/ldap/sdap_async_groups.c
@@ -2139,6 +2139,111 @@ int sdap_get_groups_recv(struct tevent_req *req,
     return EOK;
 }
 
+struct sdap_save_users_state {
+    struct tevent_context *ev;
+    struct sdap_options *opts;
+    struct sss_domain_info *dom;
+    struct sysdb_ctx *sysdb;
+    struct sysdb_attrs **users;
+    struct sysdb_attrs **users_step;
+    time_t now;
+    int num_users;
+};
+
+/* saving 100 users to SysDB takes approx 90ms */
+#define STEP_SIZE 100
+
+struct tevent_req *
+sdap_save_users_send(TALLOC_CTX *memctx,
+		     struct tevent_context *ev,
+                     struct sdap_options *opts,
+                     struct sss_domain_info *dom,
+                     struct sysdb_ctx *sysdb,
+                     struct sysdb_attrs **users,
+		     struct sysdb_attrs **users_step,
+                     int num_users,
+		     time_t now)
+{
+    struct tevent_req *req;
+    struct sdap_save_users_state *state;
+/*    errno_t ret;
+    int    chunk = num_users > STEP_SIZE ? STEP_SIZE : num_users; */
+
+    req = tevent_req_create(memctx, &state,
+                            struct sdap_save_users_state);
+    if (req == NULL) {
+        return NULL;
+    }
+
+//    DEBUG(SSSDBG_TRACE_INTERNAL, "Saving %d users (%d left)\n", chunk, num_users);
+    state->ev = ev;
+    state->opts = opts;
+    state->dom = dom;
+    state->sysdb = sysdb;
+    state->users = users;
+    state->users_step = users_step;
+//    state->num_users = num_users - chunk;
+    state->num_users = num_users;
+    state->now = now;
+
+/*    ret = sdap_save_users(state,
+                          state->sysdb,
+                          state->dom,
+                          state->opts,
+                          state->users_step,
+                          chunk,
+                          NULL,NULL);
+
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Cannot save group members to sysdb [%d]: %s\n",
+              ret, sss_strerror(ret));
+        tevent_req_error(req, ret);
+    } */
+
+    return tevent_req_post(req, ev);
+}
+
+static void sdap_users_save_done(struct tevent_req *subreq)
+{
+    struct sdap_save_users_state *state;
+    struct tevent_req *subreq_step;
+    time_t now = time(NULL);
+
+    state = tevent_req_data(subreq, struct sdap_save_users_state);
+
+    if (state->num_users > 0 && now - state->now < 3) {
+       int    chunk = state->num_users > STEP_SIZE ? STEP_SIZE : state->num_users;
+
+       DEBUG(SSSDBG_TRACE_INTERNAL, "Saving %d users (%d left)\n", chunk, state->num_users);
+       sdap_save_users(state,
+                       state->sysdb,
+                       state->dom,
+                       state->opts,
+                       state->users_step,
+                       chunk,
+                       NULL,NULL);
+	    
+       subreq_step = sdap_save_users_send(state->ev, state->ev, state->opts,
+		       state->dom, state->sysdb, state->users,
+                     &state->users_step[STEP_SIZE], state->num_users - chunk, state->now);
+       talloc_zfree(subreq);
+       if (subreq_step == NULL){
+          tevent_req_error(subreq_step, ENOMEM);
+          return;
+       }
+       tevent_req_set_callback(subreq_step,
+                               sdap_users_save_done,
+                               subreq_step);
+       return;
+    }
+    if (now - state->now >= 3)
+        DEBUG(SSSDBG_TRACE_INTERNAL, "SysDB too slow, giving up saving group members!\n");
+    /* Everything stored */
+    talloc_zfree(state->users);
+    talloc_zfree(subreq);
+}
+
 static void sdap_nested_ext_done(struct tevent_req *subreq);
 
 static void sdap_nested_done(struct tevent_req *subreq)
@@ -2153,7 +2258,7 @@ static void sdap_nested_done(struct tevent_req *subreq)
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                       struct tevent_req);
     struct sdap_get_groups_state *state = tevent_req_data(req,
-                                            struct sdap_get_groups_state);
+                                          struct sdap_get_groups_state);
 
     ret = sdap_nested_group_recv(state, subreq, &user_count, &users,
                                  &group_count, &groups,
@@ -2199,6 +2304,25 @@ static void sdap_nested_done(struct tevent_req *subreq)
         goto fail;
     }
     in_transaction = false;
+
+    /* Store users in SysDB - Fire & Forget approach
+     * - is not necessary as the code works happily w/o this
+     *   (users would be stored as ghost members which is sufficient)
+     * - but since we received all attrs already, we just store them
+     * - advantage: Users stored can be used to speed up future nss
+     *         lookups (i.e. "getent passwd <user>") */
+    users = talloc_steal(state->ev, users);
+    subreq = sdap_save_users_send(state->ev, state->ev, state->opts, state->dom,
+		               state->sysdb,
+                               users, users,
+                               user_count, time(NULL));
+    if (subreq == NULL) {
+        ret = ENOMEM;
+        goto fail;
+    }
+    tevent_req_set_callback(subreq,
+                            sdap_users_save_done,
+                            subreq);
 
     if (hash_count(state->missing_external) == 0) {
         /* No external members. Processing complete */

--- a/src/providers/ldap/sdap_async_nested_groups.c
+++ b/src/providers/ldap/sdap_async_nested_groups.c
@@ -1731,7 +1731,7 @@ static errno_t set_nested_member_attrs(struct sdap_nested_group_ctx *gctx)
 
     /* pull down everything we need */
     gctx->nested_member_attrs = talloc_array(gctx, const char *,
-                                             SDAP_OPTS_USER + SDAP_OPTS_GROUP +
+                                             gctx->opts->user_map_cnt + SDAP_OPTS_GROUP +
                                              gctx->opts->fsp_map_cnt +
                                              1 + 1);
     if (gctx->nested_member_attrs == NULL) {
@@ -1744,7 +1744,7 @@ static errno_t set_nested_member_attrs(struct sdap_nested_group_ctx *gctx)
 
     /* Collect attributes from user_map, skip objectclass by starting with
      * SDAP_AT_USER_NAME */
-    for (int i = SDAP_AT_USER_NAME; i < SDAP_OPTS_USER; i++) {
+    for (int i = SDAP_AT_USER_NAME; i < gctx->opts->user_map_cnt; i++) {
         if (gctx->opts->user_map[i].name != NULL
             && !string_in_list_size(gctx->opts->user_map[i].name,
                                     gctx->nested_member_attrs, attr_idx, false)) {
@@ -1879,7 +1879,7 @@ sdap_nested_group_lookup_member_send(TALLOC_CTX *mem_ctx,
         goto immediately;
     }
     maps[0].map = group_ctx->opts->user_map;
-    maps[0].num_attrs = SDAP_OPTS_USER;
+    maps[0].num_attrs = group_ctx->opts->user_map_cnt;
     maps[0].map_type = SDAP_NESTED_GROUP_DN_USER;
     maps[0].required_attrs[0] = group_ctx->opts->user_map[SDAP_AT_USER_NAME].name;
     if (sdap_idmap_domain_has_algorithmic_mapping(group_ctx->opts->idmap_ctx,

--- a/src/providers/ldap/sdap_async_users.c
+++ b/src/providers/ldap/sdap_async_users.c
@@ -168,7 +168,6 @@ static int sdap_user_set_mpg(struct sysdb_attrs *user_attrs,
     return EOK;
 }
 
-/* FIXME: support storing additional attributes */
 int sdap_save_user(TALLOC_CTX *memctx,
                    struct sdap_options *opts,
                    struct sss_domain_info *dom,


### PR DESCRIPTION
Whilst enumerating groups, we also fetch users. These are not saved to SysDB atm (only exist as ghost entries for group members). This PR rectifies this, so group members are also saved to SysDB