### PR TITLE
KCM: fix use-after-free in `kcm_read_options()`

### DIFF
--- a/src/responder/kcm/kcm_renew.c
+++ b/src/responder/kcm/kcm_renew.c
@@ -228,7 +228,7 @@ static errno_t kcm_read_options(TALLOC_CTX *mem_ctx,
     *_validate = validate;
     *_canonicalize = canonicalize;
     *_timeout = timeout;
-    *_renew_intv = renew_intv;
+    *_renew_intv = talloc_steal(mem_ctx, renew_intv);
 
     ret = EOK;
 


### PR DESCRIPTION
The `renew_intv` string was allocated under tmp_ctx but not re-linked to mem_ctx before tmp_ctx was freed.

Assisted-By: Claude Code (Opus 4.6)

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2457467