### PR TITLE
CLIENT: fix thread unsafe access to autofs struct.

### DIFF
--- a/src/sss_client/autofs/sss_autofs.c
+++ b/src/sss_client/autofs/sss_autofs.c
@@ -65,7 +65,11 @@ struct automtent {
     size_t cursor;
 };
 
-static struct sss_getautomntent_data {
+static
+#ifdef HAVE_PTHREAD_EXT
+__thread
+#endif
+struct sss_getautomntent_data {
     char *mapname;
     size_t len;
     size_t ptr;

--- a/src/sss_client/autofs/sss_autofs.c
+++ b/src/sss_client/autofs/sss_autofs.c
@@ -18,6 +18,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "config.h"
+
 #include <errno.h>
 #include <stdlib.h>
 #include <stdatomic.h>


### PR DESCRIPTION
In case SSSD is built with lock-free client support, `sss_nss_lock()` is a no-op, thus resulting in thread unsafe access.

This is a fix similar to 69fd828c1d5e92bc3b2e327a45dfed116f49d50a

Reviewed-by: Pavel Březina <pbrezina@redhat.com>
Reviewed-by: Sumit Bose <sbose@redhat.com>
(cherry picked from commit f3af8c89af656767333410b0e94da9288dd8ade8) 