### PR TITLE
Add missing include

### DIFF
--- a/src/sss_client/autofs/sss_autofs.c
+++ b/src/sss_client/autofs/sss_autofs.c
@@ -18,6 +18,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "config.h"
+
 #include <errno.h>
 #include <stdlib.h>
 #include <stdatomic.h>


### PR DESCRIPTION
Original patch f3af8c89af656767333410b0e94da9288dd8ade8 didn't include "config.h" that provides `HAVE_PTHREAD_EXT`
It works in some branches accidentally because of transitive include via "sss_cli.h" but that's fragile (and in some branches "sss_cli.h" doesn't include "config.h")