### PR TITLE
[backport] Tests: Housekeeping and Clean Sweep of Sevice/Logging suite

### DIFF
--- a/src/tests/system/tests/test_logging.py
+++ b/src/tests/system/tests/test_logging.py
@@ -1,8 +1,13 @@
 """
 SSSD Logging Tests.
 
-client.sssd.start(debug_level=None), means no configuration. It is the same as if
-the parameter is omitted from 'sssd.conf'.
+client.sssd.start(debug_level=None), means no configuration. It is the same
+as if the parameter is omitted from 'sssd.conf'.
+
+The default debug level 2.
+It is handled and reported as a bitmask.
+See: https://github.com/SSSD/sssd/blob/77fc6ff1d83f1d8e20f519df7194a95d0abf7491/src/util/debug.h#L101
+
 
 :requirement: SSSD - Default debug level
 """
@@ -13,15 +18,17 @@ import time
 
 import pytest
 from sssd_test_framework.roles.client import Client
-from sssd_test_framework.topology import KnownTopology
+from sssd_test_framework.roles.generic import GenericProvider
+from sssd_test_framework.roles.ldap import LDAP
+from sssd_test_framework.topology import KnownTopology, KnownTopologyGroup
 
 
 @pytest.mark.integration
 @pytest.mark.importance("low")
 @pytest.mark.topology(KnownTopology.Client)
-def test_logging__default_settings_logs_debug_level(client: Client):
+def test_logging__default_debug_level(client: Client):
     """
-    :title: Default settings writes the debug level to logs
+    :title: Default log level 0x0070 is written to logs
     :setup:
         1. Configure SSSD for local system authentication
         2. Clear logs and start SSSD with default debug level
@@ -32,12 +39,16 @@ def test_logging__default_settings_logs_debug_level(client: Client):
     :customerscenario: False
     """
     client.sssd.common.local()
-    client.sssd.default_domain = "local"
-
     client.sssd.clear(logs=True)
     client.sssd.start(debug_level=None)
 
-    for file in [client.sssd.logs.monitor, client.sssd.logs.domain(), client.sssd.logs.nss, client.sssd.logs.pam]:
+    log_files = [
+        client.sssd.logs.monitor,
+        client.sssd.logs.domain(),
+        client.sssd.logs.nss,
+        client.sssd.logs.pam,
+    ]
+    for file in log_files:
         log_str = client.fs.read(file)
         assert "level = 0x0070" in log_str, "Logs should contain debug_level = 0x0070!"
 
@@ -45,16 +56,116 @@ def test_logging__default_settings_logs_debug_level(client: Client):
 @pytest.mark.integration
 @pytest.mark.importance("low")
 @pytest.mark.topology(KnownTopology.Client)
-def test_logging__default_settings_does_not_log_user_logins(client: Client):
+def test_logging__debug_level_is_written_to_logs(client: Client):
+    """
+    :title: Domain log level from configuration is honored
+    :setup:
+        1. Configure SSSD for local system authentication
+        2. Clear logs and start SSSD with debug level 9
+    :steps:
+        1. Check log files
+    :expectedresults:
+        1. Logs messages contain expected debug level 0x2f7f0
+    :customerscenario: False
+    """
+    client.sssd.common.local()
+    client.sssd.domain["debug_level"] = "9"
+    client.sssd.clear(logs=True)
+    client.sssd.start(debug_level=None)
+    log_str = client.fs.read(client.sssd.logs.domain())
+
+    assert "level = 0x2f7f0" in log_str, "Logs should contain debug level = 0x2f7f0!"
+
+
+@pytest.mark.integration
+@pytest.mark.importance("low")
+@pytest.mark.topology(KnownTopology.Client)
+def test_logging__change_debug_level_during_runtime(client: Client):
+    """
+    :title: Domain log level set in runtime is honored
+    :setup:
+        1. Configure SSSD for local system authentication
+        2. Clear logs and start SSSD with default level
+    :steps:
+        1. Check log file
+        2. Change domain debug level in runtime using sssctl debug-level
+        3. Check log file again
+    :expectedresults:
+        1. Logs messages contain default debug level 0x0070
+        2. Debug level change command succeeds
+        3. sssctl debug-level output contains default debug level 0x2f7f0
+    :customerscenario: False
+    """
+    client.sssd.common.local()
+    client.sssd.clear(logs=True)
+    client.sssd.start(debug_level=None)
+
+    log_str = client.fs.read(client.sssd.logs.domain())
+    sssctl_set = client.host.conn.run("sssctl debug-level --domain local 9")
+    sssctl_get = client.host.conn.run("sssctl debug-level --domain local")
+
+    assert "level = 0x0070" in log_str, "Logs should contain debug level = 0x0070!"
+    assert sssctl_set.rc == 0, "'sssctl debug-level' command failed!"
+    assert sssctl_get.rc == 0, "'sssctl debug-level' command failed!"
+    assert "0x2f7f0" in sssctl_get.stdout, "sssctl debug-level output should contain 0x2f7f0!"
+
+
+@pytest.mark.integration
+@pytest.mark.importance("low")
+@pytest.mark.topology(KnownTopologyGroup.AnyProvider)
+@pytest.mark.skip(reason="There are some error messages that need to have log level increased.")
+def test_logging__user_logins_are_not_written_to_logs(client: Client, provider: GenericProvider):
     """
     :title: Default debug level does not log user logins
     :setup:
         1. Create user
+        2. Configure SSSD for system authentication
+        3. Clear cache and logs and start SSSD with default debug level
+    :steps:
+        1. Store current logs and authenticate as a user
+        2. Compare stored logs with the current ones
+    :expectedresults:
+        1. Login was successful
+        2. The login event did not generate any new log lines
+    :customerscenario: False
+    """
+    # IPA
+    # [ssh] [cache_req_common_process_dp_reply] (0x3f7c0): [CID#1] CR #0:
+    #  Data Provider Error: 3, 22, Invalid argument
+    # ldap
+    # [ssh] [cache_req_common_process_dp_reply] (0x3f7c0): [CID#1] CR #0:
+    #  Data Provider Error: 3, 22, Invalid argument
+    # samba
+    # [ssh] [cache_req_common_process_dp_reply] (0x3f7c0): [CID#1] CR #0:
+    # Could not get account info [1432158215]: DP target is not configured
+    # AD
+    # [ssh] [cache_req_common_process_dp_reply] (0x3f7c0): [CID#1] CR #0:
+    #  Could not get account info [1432158215]: DP target is not configured
+    provider.user("user1").add(password="Secret123")
+    client.sssd.domain["fallback_homedir"] = "/home/%%u"
+    client.sssd.sssd["services"] = "nss, pam, ssh"
+    client.sssd.clear(logs=True, config=False)
+    client.sssd.start(debug_level=None)
+    time.sleep(30)
+
+    client.fs.copy("/var/log/sssd", "/tmp/copy")
+    assert client.auth.parametrize("ssh").password("user1", "Secret123"), "User failed login!"
+    assert not client.host.conn.run("diff /var/log/sssd /tmp/copy").stdout, "Debug messages were generated!"
+
+
+@pytest.mark.integration
+@pytest.mark.importance("low")
+@pytest.mark.topology(KnownTopology.Client)
+def test_logging__local_user_logins_are_not_written_to_log(client: Client):
+    """
+    :title: Default debug level does not log local user logins
+    :setup:
+        1. Create a local user
         2. Configure SSSD for local system authentication
         3. Clear cache and logs and start SSSD with default debug level
     :steps:
-        1. Store current logs and authenticate as a local user.
-        2. Compare stored logs with the current ones.
+        1. Store current logs and authenticate as a local user
+        2. Compare stored logs with the current ones
     :expectedresults:
         1. Login was successful
         2. Before event did not generate any new logs lines
@@ -108,9 +219,8 @@ def test_logging__default_settings_logs_sssd_conf_permissions_errors(client: Cli
 
 @pytest.mark.integration
 @pytest.mark.importance("low")
-@pytest.mark.ticket(bz=1893159)
 @pytest.mark.topology(KnownTopology.Client)
-def test_logging__default_settings_logs_domain_configuration_errors(client: Client):
+def test_logging__domain_configuration_errors(client: Client):
     """
     :title: Default debug_level logs domain configuration errors
     :setup:
@@ -120,10 +230,11 @@ def test_logging__default_settings_logs_domain_configuration_errors(client: Clie
         2. Check logs
     :expectedresults:
         1. SSSD failed to start
-        2. Logs contain error message
-    :customerscenario: True
+        2. Logs contain the error message
+    :customerscenario: False
     """
     client.sssd.sssd["domains"] = "non_existing_domain"
+
     assert client.sssd.start(debug_level=None, raise_on_error=False).rc != 0, "SSSD erroneously started!"
     assert "No properly configured domains, fatal error!" in client.fs.read(
         client.sssd.logs.monitor
@@ -132,31 +243,33 @@ def test_logging__default_settings_logs_domain_configuration_errors(client: Clie
 
 @pytest.mark.integration
 @pytest.mark.importance("low")
-@pytest.mark.ticket(bz=1893159)
 @pytest.mark.topology(KnownTopology.LDAP)
-def test_logging__default_settings_logs_offline_errors(client: Client):
+def test_logging__dns_resolution_issue_in_logs(client: Client):
     """
-    :title: Default debug_level logs offline errors
+    :title: Default debug_level logs backend dns resolution issue
     :setup:
-        1. Configure SSSD with an invalid uri and enable ifp responder
-        2. Start SSSD with default debug level
-        3. Enable infopipe responder
+        1. Configure SSSD with an invalid uri
+        2. Enable infopipe responder
+        3. Start SSSD with default debug level
+
     :steps:
         1. Check logs
         2. Check default domain status
     :expectedresults:
-        1. Logs contain connection errors
+        1. Logs contain the DNS name resolution error message
         2. SSSD is not connected
-    :customerscenario: True
+    :customerscenario: False
     """
     client.sssd.domain["ldap_uri"] = "ldap://typo.invalid"
     client.sssd.enable_responder("ifp")
     client.sssd.start(debug_level=None, raise_on_error=False)
+    if not client.sssd.default_domain:
+        client.sssd.default_domain = "ldap.test"
 
     logs = client.fs.read(client.sssd.logs.domain())
-    assert "Failed to connect, going offline" in logs, "Offline error messages are not in logs!"
-
-    assert client.sssd.default_domain is not None, "Failed to load default domain!"
+    assert (
+        "Failed to resolve server 'typo.invalid': Domain name not found" in logs
+    ), "'Domain name not found' error message is not in logs!"
     result = client.sssctl.domain_status(client.sssd.default_domain)
     assert result is not None
     assert "LDAP: not connected" in result.stdout, "LDAP is connected!"
@@ -164,32 +277,54 @@ def test_logging__default_settings_logs_offline_errors(client: Client):
 
 @pytest.mark.integration
 @pytest.mark.importance("low")
-@pytest.mark.ticket(bz=1416150)
 @pytest.mark.topology(KnownTopology.LDAP)
-def test_logging__default_settings_logs_to_syslog_when_ldap_is_offline(client: Client):
+def test_logging__offline_errors_are_written_to_logs_and_syslog(client: Client, ldap: LDAP):
     """
-    :title: Log to syslog when sssd cannot contact ldap servers and the servers go offline
+    :title: Default debug_level logs offline errors also to syslog
     :setup:
-        1. Configure SSSD with an invalid uri and start SSSD
+        1. Configure SSSD with ifp responder and LDAP backend
+        2. Reduce ldap_network_timeout to 1 second
+        3. Block LDAP access using firewall
+        4. Start SSSD with default debug level
     :steps:
-        1. Check domain status using sssctl
-        2. Clear syslog and restart SSSD and check syslog
+        1. Check default domain status
+        2. Check domain log
+        3. Check syslog/journal
     :expectedresults:
-        1. Domain is offline
-        2. Logs contain SSSD errors
-    :customerscenario: True
+        1. SSSD is not connected
+        2. Logs contain connection/timeout errors
+        3. Syslog contains the offline message
+    :customerscenario: False
     """
-    client.sssd.domain["ldap_uri"] = "ldaps://typo.invalid"
-    client.sssd.start()
+    client.sssd.stop()
+    client.firewall.outbound.reject_host(ldap)
+    client.sssd.domain["ldap_network_timeout"] = "1"
+    client.sssd.enable_responder("ifp")
+    client.sssd.start(debug_level=None, raise_on_error=False)
+    if not client.sssd.default_domain:
+        client.sssd.default_domain = "ldap.test"
 
-    assert client.sssd.default_domain is not None, "Failed to load default domain!"
-    status = client.sssctl.domain_status(client.sssd.default_domain)
-    assert status is not None
-    assert "Offline" in status.stdout or "Unable to get online status" in status.stderr, "Domain is not offline!"
+    for _ in range(1, 50):
+        result = client.sssctl.domain_status(client.sssd.default_domain)
+        if result is not None and "Online status: Offline" in result.stdout:
+            break
+        time.sleep(2)
+    else:
+        pytest.fail("Could not get domain status or sssd is not offline!")
 
-    client.journald.clear()
-    client.sssd.restart()
-    time.sleep(1)
+    logs = client.fs.read(client.sssd.logs.domain())
+    assert "Failed to connect, going offline" in logs, "Offline error message is not in domain log!"
+    assert (
+        "No available servers for service 'LDAP'" in logs
+    ), "'No available servers for service' error message is not in logs!"
+    assert "Connection timed out [ldap_network_timeout]" in logs, (
+        "'Connection timed out [ldap_network_timeout]' error message " "is not in logs!"
+    )
 
-    log = client.journald.journalctl(grep="Backend is offline", unit="sssd")
-    assert log.rc == 0, "Offline error messages are not in logs!"
+    for _ in range(1, 50):
+        log = client.journald.journalctl(grep="Backend is offline", unit="sssd")
+        if log.rc == 0:
+            break
+        time.sleep(2)
+    else:
+        pytest.fail("Offline error message is not in syslog!")


### PR DESCRIPTION
Manual cherry-pick of https://github.com/SSSD/sssd/pull/8512/commits .
Merged tests for sssd offline message in logs and syslog. Split backend offline(unreachable) and dns resolution error scenario. Check that user login does not generate logs on default debug level extended to all providers. Added link to debug level documentation. Dropped references to (now-irrelevant) bugzillas in rewritten tests.

Skipping test_logging__user_logins_are_not_written_to_logs as updating log level of the messages is low priority.