### PR TITLE
Fixes for OpenSSL-4 support

### DIFF
--- a/src/lib/certmap/sss_cert_content_crypto.c
+++ b/src/lib/certmap/sss_cert_content_crypto.c
@@ -37,6 +37,12 @@
 #define OID_NTDS_CA_SECURITY_EXT "1.3.6.1.4.1.311.25.2"
 #define OID_NTDS_OBJECTSID "1.3.6.1.4.1.311.25.2.1"
 
+#if OPENSSL_VERSION_NUMBER < 0x40000000L
+#define OSSL4_CONST
+#else
+#define OSSL4_CONST const
+#endif
+
 typedef struct PrincipalName_st {
     ASN1_INTEGER *name_type;
     STACK_OF(ASN1_GENERALSTRING) *name_string;
@@ -347,15 +353,15 @@ static int add_ip_to_san_list(TALLOC_CTX *mem_ctx, enum san_opt san_opt,
     return 0;
 }
 
-static int get_rdn_list(TALLOC_CTX *mem_ctx, X509_NAME *name,
+static int get_rdn_list(TALLOC_CTX *mem_ctx, OSSL4_CONST X509_NAME *name,
                         const char ***rdn_list)
 {
     int ret;
     size_t c;
     const char **list = NULL;
-    X509_NAME_ENTRY *e;
-    ASN1_STRING *rdn_str;
-    ASN1_OBJECT *rdn_name;
+    OSSL4_CONST X509_NAME_ENTRY *e;
+    OSSL4_CONST ASN1_STRING *rdn_str;
+    OSSL4_CONST ASN1_OBJECT *rdn_name;
     BIO *bio_mem = NULL;
     char *tmp_str;
     long tmp_str_size;
@@ -425,7 +431,7 @@ done:
 
 static int add_rdn_list_to_san_list(TALLOC_CTX *mem_ctx,
                                     enum san_opt san_opt,
-                                    X509_NAME *name,
+                                    OSSL4_CONST X509_NAME *name,
                                     struct san_list **item)
 {
     struct san_list *i = NULL;
@@ -667,8 +673,9 @@ static int get_san(TALLOC_CTX *mem_ctx, X509 *cert, struct san_list **san_list)
             break;
         case GEN_DIRNAME:
             ret = add_rdn_list_to_san_list(mem_ctx,
-                                    openssl_name_type_to_san_opt(current->type),
-                                    current->d.directoryName, &item);
+                             openssl_name_type_to_san_opt(current->type),
+                             (OSSL4_CONST X509_NAME *) current->d.directoryName,
+                             &item);
             if (ret != 0) {
                 goto done;
             }
@@ -748,7 +755,7 @@ static int get_sid_ext(TALLOC_CTX *mem_ctx, X509 *cert, const char **_sid)
     ASN1_OBJECT *sid_ext_oid = NULL;
     ASN1_OBJECT *sid_oid = NULL;
     int idx;
-    X509_EXTENSION *ext = NULL;
+    OSSL4_CONST X509_EXTENSION *ext = NULL;
     const unsigned char *p;
     NTDS_CA_SECURITY_EXTS *sec_exts = NULL;
     NTDS_CA_SECURITY_EXT *current;
@@ -996,7 +1003,7 @@ int sss_cert_get_content(TALLOC_CTX *mem_ctx,
     X509 *cert = NULL;
     const unsigned char *der;
     BIO *bio_mem = NULL;
-    X509_NAME *tmp_name;
+    OSSL4_CONST X509_NAME *tmp_name;
 
     if (der_blob == NULL || der_size == 0) {
         return EINVAL;

--- a/src/lib/certmap/sss_cert_content_crypto.c
+++ b/src/lib/certmap/sss_cert_content_crypto.c
@@ -248,8 +248,8 @@ static int add_pkinit_princ_to_san_list(TALLOC_CTX *mem_ctx,
     ASN1_GENERALSTRING *name_comp;
 
     oct = current->d.otherName->value->value.sequence;
-    p = oct->data;
-    princ = d2i_KRB5PrincipalName(NULL, &p, oct->length);
+    p = ASN1_STRING_get0_data(oct);
+    princ = d2i_KRB5PrincipalName(NULL, &p, ASN1_STRING_length(oct));
     if (princ == NULL) {
         return EINVAL;
     }
@@ -778,8 +778,8 @@ static int get_sid_ext(TALLOC_CTX *mem_ctx, X509 *cert, const char **_sid)
         return EINVAL;
     }
 
-    p = ext_data->data;
-    sec_exts = d2i_NTDS_CA_SECURITY_EXTS(NULL, &p, ext_data->length);
+    p = ASN1_STRING_get0_data(ext_data);
+    sec_exts = d2i_NTDS_CA_SECURITY_EXTS(NULL, &p, ASN1_STRING_length(ext_data));
     if (sec_exts == NULL) {
         return EIO;
     }
@@ -810,8 +810,9 @@ static int get_sid_ext(TALLOC_CTX *mem_ctx, X509 *cert, const char **_sid)
                 goto done;
             }
 
-            sid = talloc_strndup(mem_ctx, (char *) current->d.sid->value->data,
-                                          current->d.sid->value->length);
+            sid = talloc_strndup(mem_ctx,
+                                 (const char *) ASN1_STRING_get0_data(current->d.sid->value),
+                                 ASN1_STRING_length(current->d.sid->value));
             if (sid == NULL) {
                 ret = ENOMEM;
                 goto done;

--- a/src/p11_child/p11_child_openssl.c
+++ b/src/p11_child/p11_child_openssl.c
@@ -38,6 +38,12 @@
 #include "util/crypto/sss_crypto.h"
 #include "p11_child/p11_child.h"
 
+#if OPENSSL_VERSION_NUMBER < 0x40000000L
+#define OSSL4_CONST
+#else
+#define OSSL4_CONST const
+#endif
+
 struct p11_ctx {
     X509_STORE *x509_store;
     const char *ca_db;
@@ -199,8 +205,8 @@ static const EVP_MD *get_dgst(CK_MECHANISM_TYPE ocsp_dgst)
 
 static char *get_issuer_subject_str(TALLOC_CTX *mem_ctx, X509 *cert)
 {
-    X509_NAME *issuer_name;
-    X509_NAME *subject_name;
+    OSSL4_CONST X509_NAME *issuer_name;
+    OSSL4_CONST X509_NAME *subject_name;
     char *tmp_str = NULL;
     BIO *bio_mem = NULL;
     int ret;
@@ -291,7 +297,7 @@ static errno_t do_ocsp(struct p11_ctx *p11_ctx, X509 *cert)
     char *path = NULL;
     char *port = NULL;
     int use_ssl;
-    X509_NAME *issuer_name = NULL;
+    OSSL4_CONST X509_NAME *issuer_name = NULL;
     X509_OBJECT *x509_obj;
     STACK_OF(X509_OBJECT) *store_objects;
     const EVP_MD *ocsp_dgst = NULL;
@@ -966,7 +972,7 @@ static int read_certs(TALLOC_CTX *mem_ctx, CK_FUNCTION_LIST *module,
     CK_RV rv;
     struct cert_list *list = NULL;
     struct cert_list *item;
-    X509_NAME *tmp_name;
+    OSSL4_CONST X509_NAME *tmp_name;
     char *tmp_name_str;
 
     CK_OBJECT_CLASS cert_class = CKO_CERTIFICATE;


### PR DESCRIPTION
In OpenSSL-4 ASN1_STRING is completely opaque and suitable functions must be used to return the components. Additionally some functions are changed to return `const` values.

There is one open issue, `X509_STORE_get0_objects()` is deprecated in OpenSSL-4, but still present. This will be fixed in a separate PR.