### PR TITLE
Feat: Add authentik idp

### DIFF
--- a/src/man/sssd-idp.5.xml
+++ b/src/man/sssd-idp.5.xml
@@ -276,7 +276,7 @@
 id_provider = idp
 idp_type = entra_id
 idp_client_id = 12345678-abcd-0101-efef-ba9876543210
-idp_client_secret = YOUR-CLIENT-SCERET
+idp_client_secret = YOUR-CLIENT-SECRET
 idp_token_endpoint = https://login.microsoftonline.com/TENNANT-ID/oauth2/v2.0/token
 idp_userinfo_endpoint = https://graph.microsoft.com/v1.0/me
 idp_device_auth_endpoint = https://login.microsoftonline.com/TENNANT-ID/oauth2/v2.0/devicecode
@@ -288,13 +288,26 @@ idp_auth_scope = openid profile email
 idp_type = keycloak:https://master.keycloak.test:8443/auth/admin/realms/master/
 id_provider = idp
 idp_client_id = myclient
-idp_client_secret = YOUR-CLIENT-SCERET
+idp_client_secret = YOUR-CLIENT-SECRET
 idp_token_endpoint = https://master.keycloak.test:8443/auth/realms/master/protocol/openid-connect/token
 idp_userinfo_endpoint = https://master.keycloak.test:8443/auth/realms/master/protocol/openid-connect/userinfo
 idp_device_auth_endpoint = https://master.keycloak.test:8443/auth/realms/master/protocol/openid-connect/auth/device
 idp_id_scope = profile
 idp_auth_scope = openid profile email
 </programlisting>
+<programlisting>
+[domain/authentik]
+id_provider = idp
+idp_type = authentik:https://authentik.company/api/v3/core/
+idp_client_id = myclient
+idp_client_secret = YOUR-CLIENT-SECRET
+idp_token_endpoint = https://authentik.company/application/o/token/
+idp_userinfo_endpoint = https://authentik.company/application/o/userinfo/
+idp_device_auth_endpoint = https://authentik.company/application/o/device/
+idp_id_scope = goauthentik.io/api
+idp_auth_scope = openid profile email offline_access
+</programlisting>
+
         </para>
     </refsect1>
 

--- a/src/man/sssd-idp.5.xml
+++ b/src/man/sssd-idp.5.xml
@@ -63,8 +63,8 @@
                     <listitem>
                         <para>
                             Required option that specifies the IdP product.
-                            Currently Entra ID (entra_id) and Keycloak
-                            (keycloak) are supported.
+                            Currently Entra ID (entra_id), Keycloak
+                            (keycloak), and Authentik (authentik) are supported.
                         </para>
                         <para>
                              Depending on the IdP product additional platform

--- a/src/oidc_child/oidc_child.c
+++ b/src/oidc_child/oidc_child.c
@@ -864,18 +864,29 @@ int main(int argc, const char *argv[])
         /* Currently this reply is used by ipa-otpd as RADIUS Proxy-State and
          * Reply-Message.
          */
-        fprintf(stdout,
-                "{\"device_code\":\"%s\",\"expires_in\":%d,\"interval\":%d}\n",
-                dc_ctx->device_code, dc_ctx->expires_in, dc_ctx->interval);
-        fprintf(stdout,
-                "oauth2 {\"verification_uri\": \"%s\", "
-                "\"user_code\": \"%s%s%s\"}\n",
-                dc_ctx->verification_uri, dc_ctx->user_code,
-                dc_ctx->verification_uri_complete == NULL ? ""
-                                      : "\", \"verification_uri_complete\": \"",
-                dc_ctx->verification_uri_complete == NULL ? ""
-                                           : dc_ctx->verification_uri_complete);
+        json_t *tmp_json;
+        char *tmp_str;
+        
+        tmp_json = json_pack("{s:s, s:i, s:i}",
+                                "device_code", dc_ctx->device_code,
+                                "expires_in", dc_ctx->expires_in,
+                                "interval", dc_ctx->interval);
+        tmp_str = json_dumps(tmp_json, JSON_COMPACT);
+        fprintf(stdout, "%s\n", tmp_str);
+
+        tmp_json = json_pack("{s:s, s:s}",
+                        "verification_uri", dc_ctx->verification_uri,
+                        "user_code", dc_ctx->user_code);
+        if (dc_ctx->verification_uri_complete != NULL) {
+            json_object_set_new(tmp_json, "verification_uri_complete",
+                                json_string(dc_ctx->verification_uri_complete));
+        }
+        tmp_str = json_dumps(tmp_json, JSON_COMPACT);
+        json_decref(tmp_json);
+        fprintf(stdout, "oauth2 %s\n", tmp_str);
+
         fflush(stdout);
+        free(tmp_str);
     }
 
     if (opts.oidc_cmd == GET_ACCESS_TOKEN

--- a/src/oidc_child/oidc_child.c
+++ b/src/oidc_child/oidc_child.c
@@ -894,7 +894,7 @@ int main(int argc, const char *argv[])
         }
 
         if (dc_ctx->jwks_uri != NULL) {
-            ret = decode_token(dc_ctx, true, opts.idp_type);
+            ret = decode_token(dc_ctx, true);
             if (ret != EOK) {
                 DEBUG(SSSDBG_OP_FAILURE, "Failed to verify tokens.\n");
                 goto done;

--- a/src/oidc_child/oidc_child.c
+++ b/src/oidc_child/oidc_child.c
@@ -811,7 +811,7 @@ int main(int argc, const char *argv[])
     }
 
     if (opts.oidc_cmd == GET_DEVICE_CODE || opts.oidc_cmd == GET_ACCESS_TOKEN) {
-        ret = parse_result(dc_ctx, opts.idp_type);
+        ret = parse_result(dc_ctx);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "Failed to parse device code reply.\n");
             goto done;

--- a/src/oidc_child/oidc_child.c
+++ b/src/oidc_child/oidc_child.c
@@ -894,7 +894,7 @@ int main(int argc, const char *argv[])
         }
 
         if (dc_ctx->jwks_uri != NULL) {
-            ret = decode_token(dc_ctx, true);
+            ret = decode_token(dc_ctx, true, opts.idp_type);
             if (ret != EOK) {
                 DEBUG(SSSDBG_OP_FAILURE, "Failed to verify tokens.\n");
                 goto done;

--- a/src/oidc_child/oidc_child.c
+++ b/src/oidc_child/oidc_child.c
@@ -685,6 +685,8 @@ int main(int argc, const char *argv[])
     int exit_status = EXIT_FAILURE;
     char *out = NULL;
     char *client_secret_tmp = NULL;
+    json_t *tmp_json;
+    char *tmp_str;
 
     ret = parse_cli(argc, argv, &opts);
     if (ret != EOK) {
@@ -864,15 +866,14 @@ int main(int argc, const char *argv[])
         /* Currently this reply is used by ipa-otpd as RADIUS Proxy-State and
          * Reply-Message.
          */
-        json_t *tmp_json;
-        char *tmp_str;
-
         tmp_json = json_pack("{s:s, s:i, s:i}",
                                 "device_code", dc_ctx->device_code,
                                 "expires_in", dc_ctx->expires_in,
                                 "interval", dc_ctx->interval);
         tmp_str = json_dumps(tmp_json, JSON_COMPACT);
+        json_decref(tmp_json);
         fprintf(stdout, "%s\n", tmp_str);
+        free(tmp_str);
 
         tmp_json = json_pack("{s:s, s:s}",
                         "verification_uri", dc_ctx->verification_uri,
@@ -884,7 +885,6 @@ int main(int argc, const char *argv[])
         tmp_str = json_dumps(tmp_json, JSON_COMPACT);
         json_decref(tmp_json);
         fprintf(stdout, "oauth2 %s\n", tmp_str);
-
         fflush(stdout);
         free(tmp_str);
     }

--- a/src/oidc_child/oidc_child.c
+++ b/src/oidc_child/oidc_child.c
@@ -811,7 +811,7 @@ int main(int argc, const char *argv[])
     }
 
     if (opts.oidc_cmd == GET_DEVICE_CODE || opts.oidc_cmd == GET_ACCESS_TOKEN) {
-        ret = parse_result(dc_ctx);
+        ret = parse_result(dc_ctx, opts.idp_type);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "Failed to parse device code reply.\n");
             goto done;

--- a/src/oidc_child/oidc_child.c
+++ b/src/oidc_child/oidc_child.c
@@ -866,7 +866,7 @@ int main(int argc, const char *argv[])
          */
         json_t *tmp_json;
         char *tmp_str;
-        
+
         tmp_json = json_pack("{s:s, s:i, s:i}",
                                 "device_code", dc_ctx->device_code,
                                 "expires_in", dc_ctx->expires_in,

--- a/src/oidc_child/oidc_child_id.c
+++ b/src/oidc_child/oidc_child_id.c
@@ -512,7 +512,7 @@ errno_t authentik_lookup(TALLOC_CTX *mem_ctx, enum oidc_cmd oidc_cmd,
         if (sep == NULL || sep == input) {
             filter = talloc_asprintf(rest_ctx, "include_users=true&name=%s", input_enc);
         } else {
-            filter = talloc_asprintf(rest_ctx, "include_users=true&search=%s" , input_enc);
+            filter = talloc_asprintf(rest_ctx, "include_users=true&search=%s", input_enc);
         }
         break;
     default:
@@ -576,7 +576,8 @@ errno_t authentik_lookup(TALLOC_CTX *mem_ctx, enum oidc_cmd oidc_cmd,
         break;
     case GET_GROUP_MEMBERS:
         uri = talloc_asprintf(rest_ctx,
-            "%s/users/?groups_by_pk=%s&include_groups=false&include_roles=false&page=1&page_size=2000", base_url, obj_id);
+            "%s/users/?groups_by_pk=%s&include_groups=false&include_roles=false&page=1&page_size=2000",
+            base_url, obj_id);
         break;
     default:
         DEBUG(SSSDBG_OP_FAILURE, "Unknown command [%d].\n", oidc_cmd);
@@ -685,12 +686,12 @@ errno_t oidc_get_id(TALLOC_CTX *mem_ctx, enum oidc_cmd oidc_cmd,
         goto done;
     }
 
-    if (idp_type != NULL && strncasecmp(idp_type, "keycloak:",9) == 0) {
+    if (idp_type != NULL && strncasecmp(idp_type, "keycloak:", 9) == 0) {
         ret = keycloak_lookup(mem_ctx, oidc_cmd, base_url, input, input_type,
                               libcurl_debug, ca_db, client_id, client_secret,
                               token_endpoint, scope, bearer_token, rest_ctx,
                               out);
-    } else if (idp_type != NULL && strncasecmp(idp_type, "authentik:",10) == 0) {
+    } else if (idp_type != NULL && strncasecmp(idp_type, "authentik:", 10) == 0) {
         ret = authentik_lookup(mem_ctx, oidc_cmd, base_url, input, input_type,
                               libcurl_debug, ca_db, client_id, client_secret,
                               token_endpoint, scope, bearer_token, rest_ctx,

--- a/src/oidc_child/oidc_child_id.c
+++ b/src/oidc_child/oidc_child_id.c
@@ -572,6 +572,7 @@ errno_t authentik_lookup(TALLOC_CTX *mem_ctx, enum oidc_cmd oidc_cmd,
 
     switch (oidc_cmd) {
     case GET_USER_GROUPS:
+        free(uri);
         uri = talloc_asprintf(rest_ctx,
             "%s/groups/?include_users=false&members_by_pk=%s&page=1&page_size=100",
             base_url, obj_id);

--- a/src/oidc_child/oidc_child_id.c
+++ b/src/oidc_child/oidc_child_id.c
@@ -465,6 +465,170 @@ done:
     return ret;
 }
 
+/* The following function will lookup users and groups based on Authentik's
+ * REST API as described in
+ * https://api.goauthentik.io/ */
+errno_t authentik_lookup(TALLOC_CTX *mem_ctx, enum oidc_cmd oidc_cmd,
+                        char *base_url,
+                        char *input, enum search_str_type input_type,
+                        bool libcurl_debug, const char *ca_db,
+                        const char *client_id, const char *client_secret,
+                        const char *token_endpoint, const char *scope,
+                        const char *bearer_token, struct rest_ctx *rest_ctx,
+                        char **out)
+{
+    errno_t ret;
+    char *uri;
+    char *filter;
+    char *input_enc;
+    const char *obj_id;
+    char *sep;
+    char *tmp;
+    struct name_and_type_identifier authentik_name_and_type_identifier = {
+                            .user_identifier_attr = "username",
+                            .group_identifier_attr = "name",
+                            .user_name_attr = "username",
+                            .group_name_attr = "name" };
+
+    if (base_url == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Missing base URL in IdP type [authentik].\n");
+        return EINVAL;
+    }
+
+    input_enc = url_encode_string(rest_ctx, input);
+    if (input_enc == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to encode input [%s].\n", input);
+        return EINVAL;
+    }
+
+    switch (oidc_cmd) {
+    case GET_USER:
+    case GET_USER_GROUPS:
+        filter = talloc_asprintf(rest_ctx, "username=%s", input_enc);
+        break;
+    case GET_GROUP:
+    case GET_GROUP_MEMBERS:
+        sep = strrchr(input, '@');
+        if (sep == NULL || sep == input) {
+            filter = talloc_asprintf(rest_ctx, "include_users=true&name=%s", input_enc);
+        } else {
+            filter = talloc_asprintf(rest_ctx, "include_users=true&search=%s" , input_enc);
+        }
+        break;
+    default:
+        DEBUG(SSSDBG_OP_FAILURE, "Unknown command [%d].\n", oidc_cmd);
+        ret = EINVAL;
+        goto done;
+    }
+
+    if (filter == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to create user search filter.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    switch (oidc_cmd) {
+    case GET_USER:
+    case GET_USER_GROUPS:
+        uri = talloc_asprintf(rest_ctx, "%s/users/?%s" ,base_url, filter);
+        break;
+    case GET_GROUP:
+    case GET_GROUP_MEMBERS:
+        uri = talloc_asprintf(rest_ctx, "%s/groups/?%s" ,base_url, filter);
+        break;
+    default:
+        DEBUG(SSSDBG_OP_FAILURE, "Unknown command [%d].\n", oidc_cmd);
+        ret = EINVAL;
+        goto done;
+    }
+
+    if (uri == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to generate lookup URI.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    clean_http_data(rest_ctx);
+    ret = do_http_request(rest_ctx, uri, NULL, bearer_token);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "User search request failed.\n");
+        goto done;
+    }
+
+    if (oidc_cmd == GET_USER || oidc_cmd == GET_GROUP) {
+        ret = EOK;
+        goto done;
+    }
+
+    obj_id = get_str_attr_from_embed_json_string(
+        rest_ctx, get_http_data(rest_ctx), "results", "pk");
+
+    if (obj_id == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to read mandatory object id.\n");
+        ret = EINVAL;
+        goto done;
+    }
+
+    switch (oidc_cmd) {
+    case GET_USER_GROUPS:
+        uri = talloc_asprintf(rest_ctx,
+            "%s/groups/?include_users=false&members_by_pk=%s&page=1&page_size=2000", base_url, obj_id);
+        break;
+    case GET_GROUP_MEMBERS:
+        uri = talloc_asprintf(rest_ctx,
+            "%s/users/?groups_by_pk=%s&include_groups=false&include_roles=false&page=1&page_size=2000", base_url, obj_id);
+        break;
+    default:
+        DEBUG(SSSDBG_OP_FAILURE, "Unknown command [%d].\n", oidc_cmd);
+        ret = EINVAL;
+        goto done;
+    }
+
+    if (uri == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to generate lookup URI.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    clean_http_data(rest_ctx);
+    switch (oidc_cmd) {
+    case GET_USER_GROUPS:
+    case GET_GROUP_MEMBERS:
+        ret = do_http_request_json_data(rest_ctx, uri, NULL, bearer_token);
+        break;
+    default:
+        DEBUG(SSSDBG_OP_FAILURE, "Unknown command [%d].\n", oidc_cmd);
+        ret = EINVAL;
+        goto done;
+    }
+
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "Member(of) search request failed.\n");
+        goto done;
+    }
+
+    ret = EOK;
+
+done:
+    if (ret == EOK && out != NULL) {
+        tmp = get_json_string_array_from_json_string(
+            mem_ctx, get_http_data(rest_ctx), "results");
+
+        if (tmp == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE, "Failed to copy output data.\n");
+            return ENOMEM;
+        }
+        ret = add_posix_to_json_string_array(mem_ctx,
+                                                &authentik_name_and_type_identifier,
+                                                0, tmp, out);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_OP_FAILURE, "Failed to add POSIX data.\n");
+        }
+    }
+
+    return ret;
+}
+
 errno_t oidc_get_id(TALLOC_CTX *mem_ctx, enum oidc_cmd oidc_cmd,
                     char *idp_type,
                     char *input, enum search_str_type input_type,
@@ -523,6 +687,11 @@ errno_t oidc_get_id(TALLOC_CTX *mem_ctx, enum oidc_cmd oidc_cmd,
 
     if (idp_type != NULL && strncasecmp(idp_type, "keycloak:",9) == 0) {
         ret = keycloak_lookup(mem_ctx, oidc_cmd, base_url, input, input_type,
+                              libcurl_debug, ca_db, client_id, client_secret,
+                              token_endpoint, scope, bearer_token, rest_ctx,
+                              out);
+    } else if (idp_type != NULL && strncasecmp(idp_type, "authentik:",10) == 0) {
+        ret = authentik_lookup(mem_ctx, oidc_cmd, base_url, input, input_type,
                               libcurl_debug, ca_db, client_id, client_secret,
                               token_endpoint, scope, bearer_token, rest_ctx,
                               out);

--- a/src/oidc_child/oidc_child_id.c
+++ b/src/oidc_child/oidc_child_id.c
@@ -484,6 +484,7 @@ errno_t authentik_lookup(TALLOC_CTX *mem_ctx, enum oidc_cmd oidc_cmd,
     const char *obj_id;
     char *sep;
     char *tmp;
+    int page_count;
     struct name_and_type_identifier authentik_name_and_type_identifier = {
                             .user_identifier_attr = "username",
                             .group_identifier_attr = "name",
@@ -572,11 +573,12 @@ errno_t authentik_lookup(TALLOC_CTX *mem_ctx, enum oidc_cmd oidc_cmd,
     switch (oidc_cmd) {
     case GET_USER_GROUPS:
         uri = talloc_asprintf(rest_ctx,
-            "%s/groups/?include_users=false&members_by_pk=%s&page=1&page_size=2000", base_url, obj_id);
+            "%s/groups/?include_users=false&members_by_pk=%s&page=1&page_size=100",
+            base_url, obj_id);
         break;
     case GET_GROUP_MEMBERS:
         uri = talloc_asprintf(rest_ctx,
-            "%s/users/?groups_by_pk=%s&include_groups=false&include_roles=false&page=1&page_size=2000",
+            "%s/users/?groups_by_pk=%s&include_groups=false&include_roles=false&page=1&page_size=100",
             base_url, obj_id);
         break;
     default:
@@ -612,16 +614,21 @@ errno_t authentik_lookup(TALLOC_CTX *mem_ctx, enum oidc_cmd oidc_cmd,
 
 done:
     if (ret == EOK && out != NULL) {
+        page_count = get_authentik_pagination(get_http_data(rest_ctx));
+        if (page_count > 1) {
+            DEBUG(SSSDBG_MINOR_FAILURE, "WARNING: Authentik results have been "
+            "truncated. User or Group information might not be complete.\n");
+        }
+
         tmp = get_json_string_array_from_json_string(
             mem_ctx, get_http_data(rest_ctx), "results");
-
         if (tmp == NULL) {
             DEBUG(SSSDBG_OP_FAILURE, "Failed to copy output data.\n");
             return ENOMEM;
         }
         ret = add_posix_to_json_string_array(mem_ctx,
-                                                &authentik_name_and_type_identifier,
-                                                0, tmp, out);
+                                             &authentik_name_and_type_identifier,
+                                             0, tmp, out);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "Failed to add POSIX data.\n");
         }

--- a/src/oidc_child/oidc_child_json.c
+++ b/src/oidc_child/oidc_child_json.c
@@ -397,7 +397,6 @@ errno_t parse_result(struct devicecode_ctx *dc_ctx, char *idp_type)
     int ret;
     json_t *root = NULL;
     json_error_t json_error;
-    char *dc_enc;
 
     root = json_loads(get_http_data(dc_ctx->rest_ctx), 0, &json_error);
     if (root == NULL) {
@@ -413,23 +412,7 @@ errno_t parse_result(struct devicecode_ctx *dc_ctx, char *idp_type)
         talloc_set_destructor((void *) dc_ctx->user_code, sss_erase_talloc_mem_securely);
     }
 
-    /* as get_json_string() strips escape sequences, this is not guaranteed to be urlsafe anymore.
-     * This is relevant for Authentik, as its' device codes contain special chars. */
-    dc_enc = get_json_string(dc_ctx, root, "device_code");
-    if (dc_enc != NULL && dc_ctx->user_code != NULL &&
-       (idp_type != NULL && strncasecmp(idp_type, "authentik:",10) == 0)) {
-        /* when loading a stored request there is no user code,
-        * so we skip encoding to avoid double urlencodes. */
-        dc_enc = url_encode_string(dc_ctx->rest_ctx, dc_enc);
-    }
-
-    if (dc_enc == NULL) {
-        DEBUG(SSSDBG_OP_FAILURE, "Failed to encode device code.\n");
-        ret = EINVAL;
-        goto done;
-    }
-
-    dc_ctx->device_code = dc_enc;
+    dc_ctx->device_code = get_json_string(dc_ctx, root, "device_code");
     if (dc_ctx->device_code != NULL) {
         talloc_set_destructor((void *) dc_ctx->device_code, sss_erase_talloc_mem_securely);
     }

--- a/src/oidc_child/oidc_child_json.c
+++ b/src/oidc_child/oidc_child_json.c
@@ -411,7 +411,6 @@ errno_t parse_result(struct devicecode_ctx *dc_ctx)
     if (dc_ctx->user_code != NULL) {
         talloc_set_destructor((void *) dc_ctx->user_code, sss_erase_talloc_mem_securely);
     }
-
     dc_ctx->device_code = get_json_string(dc_ctx, root, "device_code");
     if (dc_ctx->device_code != NULL) {
         talloc_set_destructor((void *) dc_ctx->device_code, sss_erase_talloc_mem_securely);

--- a/src/oidc_child/oidc_child_json.c
+++ b/src/oidc_child/oidc_child_json.c
@@ -614,6 +614,25 @@ const char *get_str_attr_from_json_string(TALLOC_CTX *mem_ctx,
     return attr;
 }
 
+int get_authentik_pagination(const char *json_str)
+{
+    json_error_t json_error;
+    json_t *result = NULL;
+    json_t *pagination_data = NULL;
+    int page_count;
+
+    result = json_loads(json_str, 0, &json_error);
+    if (result == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE,
+            "Failed to parse json data on line [%d]: [%s].\n",
+            json_error.line, json_error.text);
+        return ENOMEM;
+    }
+    pagination_data = json_object_get(result, "pagination");
+    page_count = get_json_integer(pagination_data, "total_pages", true);
+    return page_count;
+}
+
 const char *get_str_attr_from_json_array_string(TALLOC_CTX *mem_ctx,
                                                 const char *json_str,
                                                 const char *attr_name)

--- a/src/oidc_child/oidc_child_json.c
+++ b/src/oidc_child/oidc_child_json.c
@@ -276,7 +276,7 @@ done:
  * understand if and how the keys based verification can be used so that we
  * might add new options to tune the verification for different IdPs.
  */
-errno_t decode_token(struct devicecode_ctx *dc_ctx, bool verify, char *idp_type)
+errno_t decode_token(struct devicecode_ctx *dc_ctx, bool verify)
 {
     int ret;
     json_t *keys = NULL;

--- a/src/oidc_child/oidc_child_json.c
+++ b/src/oidc_child/oidc_child_json.c
@@ -554,7 +554,6 @@ const char *get_user_identifier(TALLOC_CTX *mem_ctx, json_t *userinfo,
     id_attr_list[id_attr_index++] = "id";
     id_attr_list[id_attr_index] = NULL;
 
-
     for (c = 0; id_attr_list[c] != NULL; c++) {
         id_object = json_object_get(userinfo, id_attr_list[c]);
         if (id_object != NULL) {

--- a/src/oidc_child/oidc_child_json.c
+++ b/src/oidc_child/oidc_child_json.c
@@ -629,8 +629,8 @@ int get_authentik_pagination(const char *json_str)
         return ENOMEM;
     }
     pagination_data = json_object_get(result, "pagination");
-    json_decref(result);
     page_count = get_json_integer(pagination_data, "total_pages", true);
+    json_decref(result);
     return page_count;
 }
 

--- a/src/oidc_child/oidc_child_json.c
+++ b/src/oidc_child/oidc_child_json.c
@@ -392,7 +392,7 @@ done:
     return ret;
 }
 
-errno_t parse_result(struct devicecode_ctx *dc_ctx, char *idp_type)
+errno_t parse_result(struct devicecode_ctx *dc_ctx)
 {
     int ret;
     json_t *root = NULL;

--- a/src/oidc_child/oidc_child_json.c
+++ b/src/oidc_child/oidc_child_json.c
@@ -629,6 +629,7 @@ int get_authentik_pagination(const char *json_str)
         return ENOMEM;
     }
     pagination_data = json_object_get(result, "pagination");
+    json_decref(result);
     page_count = get_json_integer(pagination_data, "total_pages", true);
     return page_count;
 }

--- a/src/oidc_child/oidc_child_json.c
+++ b/src/oidc_child/oidc_child_json.c
@@ -41,8 +41,19 @@ static char *get_json_string(TALLOC_CTX *mem_ctx, const json_t *root,
 
     tmp = json_object_get(root, attr);
     if (!json_is_string(tmp)) {
+        if (json_is_integer(tmp)) {
+            char buffer[64];
+            json_int_t i_val = json_integer_value(tmp);
+            snprintf(buffer, sizeof(buffer), "%" JSON_INTEGER_FORMAT, i_val);
+            str = talloc_strdup(mem_ctx, buffer);
+            if (str == NULL) {
+                DEBUG(SSSDBG_OP_FAILURE, "Failed to copy '%s' string.\n", attr);
+                return NULL;
+            }
+            return str;
+        }
         DEBUG(SSSDBG_OP_FAILURE,
-              "Result does not contain the '%s' string.\n", attr);
+              "Result does not contain the field '%s'.\n", attr);
         return NULL;
     }
 
@@ -265,7 +276,7 @@ done:
  * understand if and how the keys based verification can be used so that we
  * might add new options to tune the verification for different IdPs.
  */
-errno_t decode_token(struct devicecode_ctx *dc_ctx, bool verify)
+errno_t decode_token(struct devicecode_ctx *dc_ctx, bool verify, char *idp_type)
 {
     int ret;
     json_t *keys = NULL;
@@ -381,11 +392,12 @@ done:
     return ret;
 }
 
-errno_t parse_result(struct devicecode_ctx *dc_ctx)
+errno_t parse_result(struct devicecode_ctx *dc_ctx, char *idp_type)
 {
     int ret;
     json_t *root = NULL;
     json_error_t json_error;
+    char *dc_enc;
 
     root = json_loads(get_http_data(dc_ctx->rest_ctx), 0, &json_error);
     if (root == NULL) {
@@ -400,7 +412,24 @@ errno_t parse_result(struct devicecode_ctx *dc_ctx)
     if (dc_ctx->user_code != NULL) {
         talloc_set_destructor((void *) dc_ctx->user_code, sss_erase_talloc_mem_securely);
     }
-    dc_ctx->device_code = get_json_string(dc_ctx, root, "device_code");
+
+    /* as get_json_string() strips escape sequences, this is not guaranteed to be urlsafe anymore.
+     * This is relevant for Authentik, as its' device codes contain special chars. */
+    dc_enc = get_json_string(dc_ctx, root, "device_code");
+    if (dc_enc != NULL && dc_ctx->user_code != NULL &&
+       (idp_type != NULL && strncasecmp(idp_type, "authentik:",10) == 0)) {
+        /* when loading a stored request there is no user code,
+        * so we skip encoding to avoid double urlencodes. */
+        dc_enc = url_encode_string(dc_ctx->rest_ctx, dc_enc);
+    }
+
+    if (dc_enc == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to encode device code.\n");
+        ret = EINVAL;
+        goto done;
+    }
+
+    dc_ctx->device_code = dc_enc;
     if (dc_ctx->device_code != NULL) {
         talloc_set_destructor((void *) dc_ctx->device_code, sss_erase_talloc_mem_securely);
     }
@@ -532,13 +561,17 @@ const char *get_user_identifier(TALLOC_CTX *mem_ctx, json_t *userinfo,
 {
     json_t *id_object = NULL;
     const char *user_identifier = NULL;
-    const char *id_attr_list[] = { "sub", "id", NULL };
+    const char *id_attr_list[4];
+    int id_attr_index = 0;
     size_t c;
 
     if (user_identifier_attr != NULL) {
-        id_attr_list[0] = user_identifier_attr;
-        id_attr_list[1] = NULL;
+        id_attr_list[id_attr_index++] = user_identifier_attr;
     }
+    id_attr_list[id_attr_index++] = "sub";
+    id_attr_list[id_attr_index++] = "id";
+    id_attr_list[id_attr_index] = NULL;
+
 
     for (c = 0; id_attr_list[c] != NULL; c++) {
         id_object = json_object_get(userinfo, id_attr_list[c]);

--- a/src/oidc_child/oidc_child_util.h
+++ b/src/oidc_child/oidc_child_util.h
@@ -200,6 +200,8 @@ json_t *token_data_to_json(struct devicecode_ctx *dc_ctx);
 char *get_jwt(struct rest_ctx *rest_ctx, const char *token_endpoint,
               const char *client_id);
 
+int get_authentik_pagination(const char *json_str);
+
 /* oidc_child_id.c */
 errno_t oidc_get_id(TALLOC_CTX *mem_ctx, enum oidc_cmd oidc_cmd,
                     char *idp_type,

--- a/src/oidc_child/oidc_child_util.h
+++ b/src/oidc_child/oidc_child_util.h
@@ -155,7 +155,7 @@ errno_t parse_result(struct devicecode_ctx *dc_ctx, char *idp_type);
 errno_t parse_token_result(struct devicecode_ctx *dc_ctx,
                            char **error_description);
 
-errno_t decode_token(struct devicecode_ctx *dc_ctx, bool verify, char *idp_type);
+errno_t decode_token(struct devicecode_ctx *dc_ctx, bool verify);
 
 const char *get_user_identifier(TALLOC_CTX *mem_ctx, json_t *userinfo,
                                 const char *user_identifier_attr,

--- a/src/oidc_child/oidc_child_util.h
+++ b/src/oidc_child/oidc_child_util.h
@@ -150,7 +150,7 @@ const char *rest_ctx_get_key_passwd(const struct rest_ctx *rest_ctx);
 /* oidc_child_json.c */
 errno_t parse_openid_configuration(struct devicecode_ctx *dc_ctx);
 
-errno_t parse_result(struct devicecode_ctx *dc_ctx, char *idp_type);
+errno_t parse_result(struct devicecode_ctx *dc_ctx);
 
 errno_t parse_token_result(struct devicecode_ctx *dc_ctx,
                            char **error_description);

--- a/src/oidc_child/oidc_child_util.h
+++ b/src/oidc_child/oidc_child_util.h
@@ -150,12 +150,12 @@ const char *rest_ctx_get_key_passwd(const struct rest_ctx *rest_ctx);
 /* oidc_child_json.c */
 errno_t parse_openid_configuration(struct devicecode_ctx *dc_ctx);
 
-errno_t parse_result(struct devicecode_ctx *dc_ctx);
+errno_t parse_result(struct devicecode_ctx *dc_ctx, char *idp_type);
 
 errno_t parse_token_result(struct devicecode_ctx *dc_ctx,
                            char **error_description);
 
-errno_t decode_token(struct devicecode_ctx *dc_ctx, bool verify);
+errno_t decode_token(struct devicecode_ctx *dc_ctx, bool verify, char *idp_type);
 
 const char *get_user_identifier(TALLOC_CTX *mem_ctx, json_t *userinfo,
                                 const char *user_identifier_attr,

--- a/src/providers/idp/idp_auth_eval.c
+++ b/src/providers/idp/idp_auth_eval.c
@@ -261,8 +261,6 @@ errno_t eval_access_token_buf(struct idp_auth_ctx *idp_auth_ctx,
 
     token_data = json_loadb((const char *) buf, token_buflen, 0, &json_error);
     if (token_data == NULL) {
-        // FIXME: Authentik fails at this point, 
-        // as the buffered device token contains special chars that let this operation fail
         DEBUG(SSSDBG_OP_FAILURE,
               "Failed to parse token data on line [%d]: [%s].\n",
               json_error.line, json_error.text);

--- a/src/providers/idp/idp_auth_eval.c
+++ b/src/providers/idp/idp_auth_eval.c
@@ -261,6 +261,8 @@ errno_t eval_access_token_buf(struct idp_auth_ctx *idp_auth_ctx,
 
     token_data = json_loadb((const char *) buf, token_buflen, 0, &json_error);
     if (token_data == NULL) {
+        // FIXME: Authentik fails at this point, 
+        // as the buffered device token contains special chars that let this operation fail
         DEBUG(SSSDBG_OP_FAILURE,
               "Failed to parse token data on line [%d]: [%s].\n",
               json_error.line, json_error.text);

--- a/src/providers/idp/idp_id_eval.c
+++ b/src/providers/idp/idp_id_eval.c
@@ -63,8 +63,11 @@ static errno_t store_json_user(struct idp_id_ctx *idp_id_ctx, json_t *user,
 
     uuid = json_object_get(user, "id");
     if (!json_is_string(uuid)) {
+        uuid = json_object_get(user, "uid");
+    }
+    if (!json_is_string(uuid)) {
         DEBUG(SSSDBG_OP_FAILURE,
-              "JSON user object does not contain 'id' string.\n");
+              "JSON user object does not contain 'id' or 'uid' string.\n");
         ret = EINVAL;
         goto done;
     }
@@ -164,8 +167,11 @@ static errno_t store_json_group(struct idp_id_ctx *idp_id_ctx, json_t *group,
 
     uuid = json_object_get(group, "id");
     if (!json_is_string(uuid)) {
+        uuid = json_object_get(group, "pk");
+    }
+    if (!json_is_string(uuid)) {
         DEBUG(SSSDBG_OP_FAILURE,
-              "JSON group object does not contain 'id' string.\n");
+              "JSON group object does not contain 'id' or 'pk' string.\n");
         ret = EINVAL;
         goto done;
     }


### PR DESCRIPTION
This PR add Authentik as an available IDP provider besides Entra and Keycloak.

From a quick look around the Authentik repo, it looks they do daily test runs against their Compose deployment (see [this workflow](https://github.com/goauthentik/authentik/blob/main/.github/workflows/ci-main-daily.yml)).

For testing, starting from a fresh Authentik instance ([Docker compose instructions](https://docs.goauthentik.io/install-config/install/docker-compose/)), the following additional configuration is needed:
- Create a default device flow: [Authentik Docs](https://docs.goauthentik.io/add-secure-apps/providers/oauth2/device_code/#create-and-apply-a-device-code-flow)
- Create a new OAuth Client:
  - Navigate to the Admin Interface
  - Applications -> Providers -> Create -> Oauth2/OpenID Provider
    - Set a provider name (e.g. `sssd-prod-prov`) and auth flow (e.g. `default-provider-authorization-implicit-consent (Authorize Application)`)
    - Open "Advanced protocol settings" and add the scope `authentik default OAuth Mapping: authentik API access` to "Selected Scopes"
    - Create Provider
  - Applications -> Applications -> Create 
    - Create a slug (e.g. `sssd-prod-app ` and select the previously created provider (e.g. `sssd-prod-prov`)
    - Create Application
  - Authentik creates a service account for this application if the device flow is used for the first time ([[docs](https://docs.goauthentik.io/add-secure-apps/providers/oauth2/machine_to_machine/#automatic-service-account-creation)](https://docs.goauthentik.io/add-secure-apps/providers/oauth2/machine_to_machine/#automatic-service-account-creation)), so let's get this created:
    - Start sssd with the new config and let it run - you likely get a 400. SSSD can be stopped.
    - It will have created a new service account (naming schema: `ak-<application>-client_credentials`)
  - Open the newly created Application, navigate to "Policy/Group/User bindings", select "Bind existing...", switch to "User" and select the autogenerated user for your application (e.g. "ak-sssd-prod-prov-client_credentials"), and select "Create"
  - Create a role to allow reading of users and groups: Directory -> Roles -> Create
	  - Give it a name (e.g. `authentik user goup read-only`)
	  - Open the created group -> Permissions -> Assign Permission
		  - Under `authentik Core` select `Can view Group` and `Can view User`
	  - Assign the Role to the `ak` service user of your application: Users -> $serviceaccout -> Roles -> Add to existing role -> select the created role

Combined with the following `sssd.conf` this will result in a running setup for ssh login and sudo management:
```
[domain/authentik]
id_provider = idp
idp_type = authentik:https://authentik.company/api/v3/core/
idp_client_id = myclient
idp_client_secret = YOUR-CLIENT-SCERET
idp_token_endpoint = https://authentik.company/application/o/token/
idp_userinfo_endpoint = https://authentik.company/application/o/userinfo/
idp_device_auth_endpoint = https://authentik.company/application/o/device/
idp_id_scope = goauthentik.io/api
idp_auth_scope = openid profile email offline_access
```
Note that authentik does not have application-specific endpoints for token, userinfo and device auth, but instead global endpoints. For example, the token endpoint for a given Authentik server would be `https://prod.idp.tld.com/application/o/token` (only `authentik.company` is a placeholder in this config).

Fixes #8613

