### PR TITLE
pam: fix out-of-bounds read in pam_passkey_child_read_data

### DIFF
--- a/src/responder/pam/pamsrv_passkey.c
+++ b/src/responder/pam/pamsrv_passkey.c
@@ -814,16 +814,26 @@ static void pam_passkey_child_read_data(struct tevent_req *subreq)
         return;
     }
 
-    str = malloc(sizeof(char) * buf_len);
-    if (str == NULL) {
+    if (buf_len == 0 || buf == NULL) {
+        tevent_req_error(req, EINVAL);
         return;
     }
 
-    snprintf(str, buf_len, "%s", buf);
+    str = malloc(buf_len + 1);
+    if (str == NULL) {
+        tevent_req_error(req, ENOMEM);
+        return;
+    }
 
-    sss_authtok_set_passkey_reply(state->pd->authtok, str, 0);
+    memcpy(str, buf, buf_len);
+    str[buf_len] = '\0';
 
+    ret = sss_authtok_set_passkey_reply(state->pd->authtok, str, 0);
     free(str);
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
 
     tevent_req_done(req);
     return;


### PR DESCRIPTION
The pam_passkey_child_read_data() function failed to properly handle raw bytes received from a pipe. The data was treated as a NUL-terminated C string without explicit termination, resulting in an out-of-bounds read when processed by snprintf() with %s format.

Fix by using memcpy instead of snprintf and explicitly NUL-terminating the buffer. Also fix the error handling to return ENOMEM on allocation failure.

Fixes: CVE-2026-6245