### PR TITLE
Backport: Fix libini_config related includes

### DIFF
--- a/src/tools/sssctl/sssctl_config.c
+++ b/src/tools/sssctl/sssctl_config.c
@@ -22,7 +22,6 @@
 
 #include <popt.h>
 #include <stdio.h>
-#include <ini_configobj.h>
 
 #include "util/util.h"
 #include "util/sss_ini.h"

--- a/src/util/sss_ini.c
+++ b/src/util/sss_ini.c
@@ -29,7 +29,6 @@
 #include <sys/stat.h>
 #include <talloc.h>
 #include <ini_configobj.h>
-#include <ini_config.h>
 
 #include "config.h"
 #include "util/util.h"
@@ -360,7 +359,7 @@ int sss_confdb_create_ldif(TALLOC_CTX *mem_ctx,
                              sec_dn, rdn);
         if (!dn) {
             ret = ENOMEM;
-            free_section_list(sections);
+            ini_free_section_list(sections);
             goto error;
         }
         dn_size = strlen(dn);
@@ -369,7 +368,7 @@ int sss_confdb_create_ldif(TALLOC_CTX *mem_ctx,
         attrs = ini_get_attribute_list(self->sssd_config, sections[i],
                                        &attr_count, &ret);
         if (ret != EOK) {
-            free_section_list(sections);
+            ini_free_section_list(sections);
             goto error;
         }
 
@@ -400,8 +399,8 @@ int sss_confdb_create_ldif(TALLOC_CTX *mem_ctx,
                                     dn_size+attr_len+1);
             if (!tmp_dn) {
                 ret = ENOMEM;
-                free_attribute_list(attrs);
-                free_section_list(sections);
+                ini_free_attribute_list(attrs);
+                ini_free_section_list(sections);
                 goto error;
             }
             dn = tmp_dn;
@@ -414,8 +413,8 @@ int sss_confdb_create_ldif(TALLOC_CTX *mem_ctx,
                                 dn_size+1);
         if (!tmp_dn) {
             ret = ENOMEM;
-            free_attribute_list(attrs);
-            free_section_list(sections);
+            ini_free_attribute_list(attrs);
+            ini_free_section_list(sections);
             goto error;
         }
         dn = tmp_dn;
@@ -428,15 +427,15 @@ int sss_confdb_create_ldif(TALLOC_CTX *mem_ctx,
                                   ldif_len+dn_size+1);
         if (!tmp_ldif) {
             ret = ENOMEM;
-            free_attribute_list(attrs);
-            free_section_list(sections);
+            ini_free_attribute_list(attrs);
+            ini_free_section_list(sections);
             goto error;
         }
         ldif = tmp_ldif;
         memcpy(ldif+ldif_len, dn, dn_size);
         ldif_len += dn_size;
 
-        free_attribute_list(attrs);
+        ini_free_attribute_list(attrs);
         talloc_free(dn);
     }
 
@@ -446,7 +445,7 @@ int sss_confdb_create_ldif(TALLOC_CTX *mem_ctx,
     }
     ldif[ldif_len] = '\0';
 
-    free_section_list(sections);
+    ini_free_section_list(sections);
 
     *config_ldif = (const char *)ldif;
     talloc_free(tmp_ctx);

--- a/src/util/sss_ini.c
+++ b/src/util/sss_ini.c
@@ -47,11 +47,6 @@ struct sss_ini {
     bool main_config_exists;
 };
 
-#define sss_ini_get_sec_list                   ini_get_section_list
-#define sss_ini_get_attr_list                  ini_get_attribute_list
-#define sss_ini_get_const_string_config_value  ini_get_const_string_config_value
-#define sss_ini_get_config_obj                 ini_get_config_valueobj
-
 
 static void sss_ini_free_error_messages(struct sss_ini *self)
 {
@@ -272,8 +267,8 @@ sss_ini_get_ra_error_list(struct sss_ini *self)
 int sss_ini_get_cfgobj(struct sss_ini *self,
                        const char *section, const char *name)
 {
-    return sss_ini_get_config_obj(section,name, self->sssd_config,
-                                  INI_GET_FIRST_VALUE, &self->obj);
+    return ini_get_config_valueobj(section,name, self->sssd_config,
+                                   INI_GET_FIRST_VALUE, &self->obj);
 }
 
 /* Check configuration object */
@@ -337,7 +332,7 @@ int sss_confdb_create_ldif(TALLOC_CTX *mem_ctx,
 
     /* Read in the collection and convert it to an LDIF */
     /* Get the list of sections */
-    sections = sss_ini_get_sec_list(self->sssd_config,
+    sections = ini_get_section_list(self->sssd_config,
                                     &section_count, &ret);
     if (ret != EOK) {
         goto error;
@@ -371,8 +366,8 @@ int sss_confdb_create_ldif(TALLOC_CTX *mem_ctx,
         dn_size = strlen(dn);
 
         /* Get all of the attributes and their values as LDIF */
-        attrs = sss_ini_get_attr_list(self->sssd_config, sections[i],
-                                   &attr_count, &ret);
+        attrs = ini_get_attribute_list(self->sssd_config, sections[i],
+                                       &attr_count, &ret);
         if (ret != EOK) {
             free_section_list(sections);
             goto error;
@@ -381,12 +376,12 @@ int sss_confdb_create_ldif(TALLOC_CTX *mem_ctx,
         for (j = 0; j < attr_count; j++) {
             DEBUG(SSSDBG_TRACE_LDB,
                     "Processing attribute [%s]\n", attrs[j]);
-            ret = sss_ini_get_config_obj(sections[i], attrs[j],
-                                         self->sssd_config,
-                                         INI_GET_FIRST_VALUE, &obj);
+            ret = ini_get_config_valueobj(sections[i], attrs[j],
+                                          self->sssd_config,
+                                          INI_GET_FIRST_VALUE, &obj);
             if (ret != EOK) goto error;
 
-            const char *value = sss_ini_get_const_string_config_value(obj, &ret);
+            const char *value = ini_get_const_string_config_value(obj, &ret);
             if (ret != EOK) goto error;
             if (value && value[0] == '\0') {
                 DEBUG(SSSDBG_CRIT_FAILURE,
@@ -520,7 +515,7 @@ static errno_t check_domain_id_provider(char *cfg_section,
                                  "missing in section '%s'.",
                                  cfg_section);
     } else {
-        value = sss_ini_get_const_string_config_value(vo, &ret);
+        value = ini_get_const_string_config_value(vo, &ret);
         if (ret != EOK) {
             goto done;
         }

--- a/src/util/sss_ini.c
+++ b/src/util/sss_ini.c
@@ -28,15 +28,14 @@
 #include <errno.h>
 #include <sys/stat.h>
 #include <talloc.h>
+#include <ini_configobj.h>
+#include <ini_config.h>
 
 #include "config.h"
 #include "util/util.h"
 #include "util/sss_ini.h"
 #include "confdb/confdb_setup.h"
 #include "confdb/confdb_private.h"
-
-#include "ini_configobj.h"
-#include "ini_config.h"
 
 struct sss_ini {
     char **error_list;

--- a/src/util/sss_ini.h
+++ b/src/util/sss_ini.h
@@ -28,6 +28,7 @@
 #define __SSS_INI_H__
 
 #include <stdbool.h>
+#include <ref_array.h>
 
 /**
  * @brief INI data structure


### PR DESCRIPTION
Cherry picking INI config patches from https://github.com/SSSD/sssd/pull/8409 to fix failing build in sssd-2-12 branch checks.