### PR TITLE
src/examples/sssd*conf: Enable the ifp service by default

### DIFF
--- a/src/examples/sssd-example.conf
+++ b/src/examples/sssd-example.conf
@@ -1,5 +1,5 @@
 [sssd]
-services = nss, pam
+services = nss, pam, ifp
 # SSSD will not start if you do not configure any domains.
 # Add new domain configurations as [domain/<NAME>] sections, and
 # then add the list of domains (in the order you want them to be

--- a/src/examples/sssd.conf
+++ b/src/examples/sssd.conf
@@ -1,5 +1,5 @@
 [sssd]
-services = nss, pam
+services = nss, pam, ifp
 domains = shadowutils
 
 [nss]


### PR DESCRIPTION
It is required for sssctl program to work and when ifp is not enabled, it fails with an obscure message