### PR TITLE
KRB5: read keytab copy in offline mode too

### DIFF
--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -4221,8 +4221,7 @@ static krb5_error_code privileged_krb5_setup(struct krb5_req *kr,
         k5c_ccache_check(kr, offline);
     }
 
-    if (!(offline ||
-            (kr->fast_val == K5C_FAST_NEVER && kr->validate == false))) {
+    if (!(kr->fast_val == K5C_FAST_NEVER && kr->validate == false)) {
         /* A Keytab is not used if fast with anonymous pkinit is used (and validate is false)*/
         if (!(kr->cli_opts->fast_use_anonymous_pkinit == true && kr->validate == false)) {
             sss_set_cap_effective(CAP_DAC_READ_SEARCH, true);
@@ -4238,7 +4237,7 @@ static krb5_error_code privileged_krb5_setup(struct krb5_req *kr,
             kr->keytab = mem_keytab;
         }
 
-        if (kr->fast_val != K5C_FAST_NEVER) {
+        if (!offline && kr->fast_val != K5C_FAST_NEVER) {
             kerr = k5c_setup_fast(kr, kr->fast_val == K5C_FAST_DEMAND);
             if (kerr != EOK) {
                 DEBUG(SSSDBG_OP_FAILURE, "Cannot set up FAST\n");


### PR DESCRIPTION
The process can transition from offline pre-auth to online auth within the same invocation.