### PR TITLE
sdap: let callers mark SSSD as offline if kinit fails

### DIFF
--- a/src/providers/ldap/sdap_async_connection.c
+++ b/src/providers/ldap/sdap_async_connection.c
@@ -2205,7 +2205,8 @@ static void sdap_cli_resolve_and_connect_kinit_done(struct tevent_req *subreq)
          * There's not much we can do except for going offline */
         DEBUG(SSSDBG_TRACE_FUNC,
               "Cannot get a TGT: ret [%d](%s)\n", ret, sss_strerror(ret));
-        tevent_req_error(req, EACCES);
+        state->can_retry = false;
+        tevent_req_error(req, EIO);
         return;
     }
 

--- a/src/tests/system/tests/test_failover.py
+++ b/src/tests/system/tests/test_failover.py
@@ -87,3 +87,72 @@ def test_failover__connect_using_ipv4_second_family(client: Client, provider: Ge
 
     result = client.tools.id(user.name)
     assert result is not None, f"{user.name} was not found, SSSD did not switch to IPv4 family!"
+
+
+# We do not authenticate the host on LDAP provider
+@pytest.mark.importance("high")
+@pytest.mark.ticket(bz=2466974)
+@pytest.mark.topology(KnownTopology.IPA)
+@pytest.mark.topology(KnownTopology.AD)
+@pytest.mark.topology(KnownTopology.Samba)
+@pytest.mark.preferred_topology(KnownTopology.IPA)
+def test_failover__go_offline_if_kinit_fails(client: Client, provider: GenericProvider):
+    """
+    :title: SSSD goes offline when Kerberos authentication fails
+    :setup:
+        1. Create user
+        2. Block outbound port 88 (Kerberos)
+        3. Start SSSD
+    :steps:
+        1. Try to resolve user
+        2. Check domain status
+    :expectedresults:
+        1. User is not found
+        2. SSSD is offline
+    :customerscenario: False
+    """
+    user = provider.user("testuser").add()
+    client.firewall.outbound.drop_port((88, "tcp"))
+    client.firewall.outbound.drop_port((88, "udp"))
+    client.sssd.start()
+
+    # Make sure SSSD tries to connect
+    result = client.tools.id(user.name)
+    assert result is None, f"{user.name} was found, SSSD is not offline!"
+
+    # SSSD was not able to connect. But check that it was actually set to offline internal state.
+    assert client.sssd.default_domain is not None, "No default domain?"
+    status = client.sssctl.domain_status(client.sssd.default_domain, online=True)
+    assert "Offline" in status.stdout, "SSSD is not offline!"
+
+
+@pytest.mark.importance("high")
+@pytest.mark.topology(KnownTopologyGroup.AnyProvider)
+@pytest.mark.preferred_topology(KnownTopology.LDAP)
+def test_failover__go_offline_if_ldap_fails(client: Client, provider: GenericProvider):
+    """
+    :title: SSSD goes offline when LDAP connection fails
+    :setup:
+        1. Create user
+        2. Block outbound port 389 (LDAP)
+        3. Start SSSD
+    :steps:
+        1. Try to resolve user
+        2. Check domain status
+    :expectedresults:
+        1. User is not found
+        2. SSSD is offline
+    :customerscenario: False
+    """
+    user = provider.user("testuser").add()
+    client.firewall.outbound.drop_port((389, "tcp"))
+    client.sssd.start()
+
+    # Make sure SSSD tries to connect
+    result = client.tools.id(user.name)
+    assert result is None, f"{user.name} was found, SSSD is not offline!"
+
+    # SSSD was not able to connect. But check that it was actually set to offline internal state.
+    assert client.sssd.default_domain is not None, "No default domain?"
+    status = client.sssctl.domain_status(client.sssd.default_domain, online=True)
+    assert "Offline" in status.stdout, "SSSD is not offline!"


### PR DESCRIPTION
The callers expected that ret == EIO and can_retry == false to bring
SSSD to an offline state.
