### PR TITLE
Files: fix build failure after sysdb_enumpwent removal

### DIFF
--- a/src/providers/files/files_ops.c
+++ b/src/providers/files/files_ops.c
@@ -492,7 +492,7 @@ static const char **get_cached_user_names(TALLOC_CTX *mem_ctx,
     const char **user_names = NULL;
     unsigned c = 0;
 
-    ret = sysdb_enumpwent(mem_ctx, dom, &res);
+    ret = sysdb_enumpwent_filter(mem_ctx, dom, NULL, NULL, NULL, &res);
     if (ret != EOK) {
         goto done;
     }


### PR DESCRIPTION
The files provider was still calling the removed sysdb_enumpwent() function, causing compilation failures. Replace the call with the equivalent sysdb_enumpwent_filter() function.

Fixes: 77e17ccf5411 ("SYSDB: Remove unused function")