### PR TITLE
sdap: Reduce log level when get_naming_context() fails

### DIFF
--- a/src/providers/ldap/sdap.c
+++ b/src/providers/ldap/sdap.c
@@ -1263,7 +1263,7 @@ errno_t sdap_set_config_options_with_rootdse(struct sysdb_attrs *rootdse,
     if (!sdom->naming_context) {
         sdom->naming_context = get_naming_context(sdom, rootdse);
         if (sdom->naming_context == NULL) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "get_naming_context failed.\n");
+            DEBUG(SSSDBG_MINOR_FAILURE, "get_naming_context failed.\n");
 
             /* This has to be non-fatal, since some servers offer
              * multiple namingContexts entries. We will just


### PR DESCRIPTION
When a plain LDAP server hosts multiple naming contexts but there is no `defaultNamingContext`  in the rootdse, the following message is logged periodically:

```[be[LDAP]] [sdap_set_config_options_with_rootdse] (0x0020): get_naming_context failed.```

The message is logged at `SSSDBG_CRIT_FAILURE` level, which seems too high for a non-fatal failure:
```       
        if (sdom->naming_context == NULL) {
            DEBUG(SSSDBG_CRIT_FAILURE, "get_naming_context failed.\n");

            /* This has to be non-fatal, since some servers offer
             * multiple namingContexts entries. We will just
             * add NULL checks for the search bases in the lookups.
             */
            ret = EOK;
            goto done;
        }
```