### PR TITLE
sdap: handle missing rootDSE gracefully

### DIFF
--- a/src/providers/ldap/sdap_async_connection.c
+++ b/src/providers/ldap/sdap_async_connection.c
@@ -2058,7 +2058,7 @@ int sdap_cli_connect_recv(struct tevent_req *req,
 {
     struct sdap_cli_connect_state *state = tevent_req_data(req,
                                              struct sdap_cli_connect_state);
-
+    errno_t ret;
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     if (gsh) {
@@ -2074,6 +2074,20 @@ int sdap_cli_connect_recv(struct tevent_req *req,
     }
 
     if (srv_opts) {
+        if (state->srv_opts == NULL) {
+            /* Always setup srv_opts to make sure it is never NULL (this can
+             * happen if rootdse_access == never or if rootDSE is not available
+             * on the server). */
+            ret = sdap_get_server_opts_from_rootdse(state, state->uri, NULL,
+                                                state->opts, &state->srv_opts);
+            if (ret) {
+                DEBUG(SSSDBG_OP_FAILURE,
+                      "Unable to setup server options [%d]: %s\n", ret,
+                      sss_strerror(ret));
+                return ret;
+            }
+        }
+
         *srv_opts = talloc_steal(memctx, state->srv_opts);
     }
 


### PR DESCRIPTION
If `ldap_read_rootdse = never` then srv_opts which is unexpected. It can
also happen on other path in the connection code, because
sdap_cli_use_rootdse() is called only when the rootDSE is successfully
fetch. This patch makes sure that srv_opts are always set.

:fixes: SSSD no longer crashes if `ldap_read_rootdse = never` and
  `enumarete = true`
