### PR TITLE
Plug memory leak: add missing dbus_message_unref

### DIFF
--- a/src/sbus/server/sbus_server.c
+++ b/src/sbus/server/sbus_server.c
@@ -506,6 +506,7 @@ sbus_server_name_owner_changed(struct sbus_server *server,
 
     /* Send the signal. */
     sbus_server_matchmaker(server, NULL, name, message);
+    dbus_message_unref(message);
 }
 
 void
@@ -525,6 +526,7 @@ sbus_server_name_acquired(struct sbus_server *server,
     dbus_message_set_sender(message, DBUS_SERVICE_DBUS);
     dbus_message_set_destination(message, conn->unique_name);
     dbus_connection_send(conn->connection, message, NULL);
+    dbus_message_unref(message);
 
     sbus_server_name_owner_changed(server, name, name, "");
 }
@@ -551,6 +553,7 @@ sbus_server_name_lost(struct sbus_server *server,
     dbus_message_set_sender(message, DBUS_SERVICE_DBUS);
     dbus_message_set_destination(message, conn->unique_name);
     dbus_connection_send(conn->connection, message, NULL);
+    dbus_message_unref(message);
 
     sbus_server_name_owner_changed(server, name, "", name);
 }

--- a/src/sbus/sync/sbus_sync_call.c
+++ b/src/sbus/sync/sbus_sync_call.c
@@ -98,4 +98,5 @@ sbus_sync_call_signal(struct sbus_sync_connection *conn,
     }
 
     sbus_sync_emit_signal(conn, msg);
+    dbus_message_unref(msg);
 }


### PR DESCRIPTION
  This patch fixes memory leaks where DBusMessage objects created with
  dbus_message_new_signal() were not unreferenced after dbus_connection_send().                                                                                                                                    
                                                                               
  According to libdbus documentation, dbus_connection_send() does not take
  ownership of the message, so the caller must still call dbus_message_unref().
                                                                               
  Fixed in:
  - sbus_server_name_owner_changed()
  - sbus_server_name_acquired()     
  - sbus_server_name_lost()
  - sbus_sync_message_send()
