### PR TITLE
oidc_child: add JWT and mTLS authentication

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3634,12 +3634,14 @@ test_cert_utils_SOURCES = \
     src/tests/cmocka/test_cert_utils.c \
     src/responder/ssh/ssh_cert_to_ssh_key.c \
     src/util/cert_derb64_to_ldap_filter.c \
+    src/oidc_child/libcrypto/oidc_child_get_jwk.c \
     $(NULL)
 test_cert_utils_CFLAGS = \
     $(AM_CFLAGS) \
     -U SSSD_LIBEXEC_PATH -DSSSD_LIBEXEC_PATH=\"$(abs_builddir)\" \
     -I$(abs_builddir)/src \
     $(CRYPTO_CFLAGS) \
+    $(JOSE_CFLAGS) \
     $(CMOCKA_CFLAGS) \
     $(NULL)
 test_cert_utils_LDADD = \
@@ -3647,6 +3649,7 @@ test_cert_utils_LDADD = \
     $(POPT_LIBS) \
     $(TALLOC_LIBS) \
     $(CRYPTO_LIBS) \
+    $(JOSE_LIBS) \
     libsss_debug.la \
     libsss_test_common.la \
     libsss_cert.la \
@@ -4914,6 +4917,7 @@ oidc_child_SOURCES = \
     src/oidc_child/oidc_child_curl.c \
     src/oidc_child/oidc_child_json.c \
     src/oidc_child/oidc_child_id.c \
+    src/oidc_child/libcrypto/oidc_child_get_jwk.c \
     src/util/child_bootstrap.c \
     src/util/atomic_io.c \
     src/util/memory.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -4925,6 +4925,7 @@ oidc_child_SOURCES = \
     src/util/strtonum.c \
     src/util/sss_chain_id.c \
     src/util/sss_prctl.c \
+    src/util/cert/libcrypto/cert.c \
     $(NULL)
 oidc_child_CFLAGS = \
     $(AM_CFLAGS) \
@@ -4932,6 +4933,8 @@ oidc_child_CFLAGS = \
     $(JANSSON_CFLAGS) \
     $(JOSE_CFLAGS) \
     $(CURL_CFLAGS) \
+    $(UUID_CFLAGS) \
+    $(CRYPTO_CFLAGS) \
     $(NULL)
 oidc_child_LDADD = \
     libsss_debug.la \
@@ -4940,6 +4943,8 @@ oidc_child_LDADD = \
     $(JANSSON_LIBS) \
     $(JOSE_LIBS) \
     $(CURL_LIBS) \
+    $(UUID_LIBS) \
+    $(CRYPTO_LIBS) \
     $(NULL)
 endif
 

--- a/src/oidc_child/libcrypto/oidc_child_get_jwk.c
+++ b/src/oidc_child/libcrypto/oidc_child_get_jwk.c
@@ -1,0 +1,640 @@
+/*
+    SSSD
+
+    Helper child for OIDC and OAuth 2.0 Device Authorization Grant
+    Utilities using OpenSSL's libcrypto
+
+    Authors:
+        Sumit Bose <sbose@redhat.com>
+
+    Copyright (C) 2026 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <openssl/x509.h>
+#include <openssl/pkcs12.h>
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#include <openssl/core_names.h>
+#endif
+
+#include "jose/b64.h"
+#include "util/util.h"
+#include "util/crypto/sss_crypto.h"
+
+static char *sss_jose_b64_enc_buf(TALLOC_CTX *mem_ctx,
+                                  unsigned char *in, size_t in_len)
+{
+    char *out = NULL;
+    size_t out_len;
+
+    out_len = jose_b64_enc_buf(in, in_len, NULL, 0);
+    if (out_len == 0 || out_len == SIZE_MAX) {
+        DEBUG(SSSDBG_OP_FAILURE, "jose_b64_enc_buf() failed.\n");
+        return NULL;
+    }
+
+    out = talloc_zero_size(mem_ctx, out_len + 1);
+    if (out == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "talloc_size() failed.\n");
+        return NULL;
+    }
+
+    out_len = jose_b64_enc_buf(in, in_len, out, out_len);
+    if (out_len == 0 || out_len == SIZE_MAX) {
+        talloc_free(out);
+        DEBUG(SSSDBG_OP_FAILURE, "jose_b64_enc_buf() failed.\n");
+        return NULL;
+    }
+
+    return out;
+}
+
+static int sss_bn_to_base64(TALLOC_CTX *mem_ctx, const BIGNUM *in, int exp_len,
+                            char **_out)
+{
+    int in_len;
+    int len;
+    int ret;
+    unsigned char *buf;
+
+    in_len = BN_num_bytes(in);
+    if (in_len == 0) {
+        DEBUG(SSSDBG_OP_FAILURE, "Given BIGNUM has len 0.\n");
+        return EINVAL;
+    }
+
+    if (exp_len == 0) {
+        len = in_len;
+    } else if (exp_len < 0 || (exp_len > 0 && exp_len < in_len)) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Expected length [%d] is smaller than needed [%d].\n",
+              exp_len, in_len);
+        return EINVAL;
+    } else {
+        len = exp_len;
+    }
+
+    buf = talloc_size(mem_ctx, len);
+    if (buf == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "talloc_size() failed.\n");
+        return ENOMEM;
+    }
+    talloc_set_destructor((void *) buf, sss_erase_talloc_mem_securely);
+
+    ret = BN_bn2binpad(in, buf, len);
+    if (ret != len) {
+        DEBUG(SSSDBG_OP_FAILURE, "Return of BN_bn2bin and BN_num_bytes differ.\n");
+        ret = EINVAL;
+        goto done;
+    }
+
+    *_out = sss_jose_b64_enc_buf(mem_ctx, buf, len);
+    if (*_out == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "sss_jose_b64_enc_buf() failed.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    talloc_set_destructor((void *) *_out, sss_erase_talloc_mem_securely);
+
+    ret = EOK;
+done:
+    talloc_free(buf);
+
+    return ret;
+}
+
+/* This function extracts the ecliptic curve private key parameters from a
+ * given EC private key so that the private key can be represented in a
+ * different format, e.g. JWK. */
+static int sss_ec_get_x_y_d(BN_CTX *bn_ctx, const EVP_PKEY *cert_priv_key,
+                            EC_GROUP **_ec_group,
+                            BIGNUM **_x, BIGNUM **_y, BIGNUM **_d)
+{
+    int ret;
+    BIGNUM *x = NULL;
+    BIGNUM *y = NULL;
+    BIGNUM *d = NULL;
+    char curve_name[4096];
+    EC_GROUP *ec_group = NULL;
+
+    ret = EVP_PKEY_get_bn_param(cert_priv_key, OSSL_PKEY_PARAM_EC_PUB_X, &x);
+    if (ret != 1) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to retrieve EC x coordinate.\n");
+        ret = EINVAL;
+        goto done;
+    }
+
+    ret = EVP_PKEY_get_bn_param(cert_priv_key, OSSL_PKEY_PARAM_EC_PUB_Y, &y);
+    if (ret != 1) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to retrieve EC y coordinate.\n");
+        ret = EINVAL;
+        goto done;
+    }
+
+    ret = EVP_PKEY_get_bn_param(cert_priv_key, OSSL_PKEY_PARAM_PRIV_KEY, &d);
+    if (ret != 1) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to retrieve EC private key.\n");
+        ret = EINVAL;
+        goto done;
+    }
+
+    ret = EVP_PKEY_get_utf8_string_param(cert_priv_key,
+                                         OSSL_PKEY_PARAM_GROUP_NAME,
+                                         curve_name, sizeof(curve_name), NULL);
+    if (ret != 1) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to retrieve EC group name.\n");
+        ret = EINVAL;
+        goto done;
+    }
+
+    ec_group = EC_GROUP_new_by_curve_name(OBJ_sn2nid(curve_name));
+    if (ec_group == NULL) {
+        ret = EINVAL;
+        goto done;
+    }
+
+    *_x = x;
+    *_y = y;
+    *_d = d;
+    *_ec_group = ec_group;
+
+    ret = EOK;
+
+done:
+    if (ret != EOK) {
+        BN_free(x);
+        BN_free(y);
+        BN_free(d);
+        EC_GROUP_free(ec_group);
+    }
+
+    return ret;
+}
+
+#define CRV_P256 "P-256"
+#define CRV_P384 "P-384"
+#define CRV_P521 "P-521"
+
+/* Extract to components of an EC private key and return a string with the
+ * corresponding items of a JWK private key. */
+static errno_t ec_priv_key_jwk(TALLOC_CTX *mem_ctx, EVP_PKEY *cert_priv_key,
+                               char **_jwk)
+{
+    int ret;
+    BIGNUM *x = NULL;
+    BIGNUM *y = NULL;
+    BIGNUM *d = NULL;
+    EC_GROUP *ec_group = NULL;
+    const char *jwk_crv;
+    char *out = NULL;
+    char *x_str = NULL;
+    char *y_str = NULL;
+    char *d_str = NULL;
+    BN_CTX *bn_ctx = NULL;
+    const char *alg;
+    int nid;
+    const char *curve_name;
+    int len;
+
+    bn_ctx =  BN_CTX_new();
+    if (bn_ctx == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "BN_CTX_new failed.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = sss_ec_get_x_y_d(bn_ctx, cert_priv_key, &ec_group, &x, &y, &d);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to retrieve EC parameters.\n");
+        goto done;
+    }
+
+    nid = EC_GROUP_get_curve_name(ec_group);
+    switch(nid) {
+    case NID_X9_62_prime256v1:
+        jwk_crv = CRV_P256;
+        alg  = "ES256";
+        break;
+    case NID_secp384r1:
+        jwk_crv = CRV_P384;
+        alg  = "ES384";
+        break;
+    case NID_secp521r1:
+        jwk_crv = CRV_P521;
+        alg = "ES512";
+        break;
+    default:
+        curve_name = OBJ_nid2sn(nid);
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unsupported curve [%d][%s]\n",
+              nid, curve_name != NULL ? curve_name : "- no name -");
+        ret = EINVAL;
+        goto done;
+    }
+
+    /* The encoded parameters must have a fixed byte length based on the curve, see
+     * e.g section 6.2.1.2 of RFC-7518. */
+    len = (EC_GROUP_get_degree(ec_group) + 7) / 8;
+
+    ret = sss_bn_to_base64(mem_ctx, x, len, &x_str);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sss_bn_to_base64() failed.\n");
+        goto done;
+    }
+    ret = sss_bn_to_base64(mem_ctx, y, len, &y_str);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sss_bn_to_base64() failed.\n");
+        goto done;
+    }
+    ret = sss_bn_to_base64(mem_ctx, d, len, &d_str);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sss_bn_to_base64() failed.\n");
+        goto done;
+    }
+    if (x_str == NULL || y_str == NULL || d_str == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to convert BIGNUM to base64.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    out = talloc_asprintf(mem_ctx,
+                          "\"kty\":\"EC\","
+                          "\"crv\":\"%s\","
+                          "\"alg\":\"%s\","
+                          "\"x\":\"%s\","
+                          "\"y\":\"%s\","
+                          "\"d\":\"%s\"", jwk_crv, alg, x_str, y_str, d_str);
+    if (out == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to generate JSON snippet.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+    talloc_set_destructor((void *) out, sss_erase_talloc_mem_securely);
+
+    *_jwk = out;
+
+    ret = EOK;
+done:
+    talloc_free(x_str);
+    talloc_free(y_str);
+    talloc_free(d_str);
+    BN_clear_free(x);
+    BN_clear_free(y);
+    BN_clear_free(d);
+    EC_GROUP_free(ec_group);
+    BN_CTX_free(bn_ctx);
+    return ret;
+}
+
+static int sss_rsa_get_priv_comps(const EVP_PKEY *cert_priv_key,
+                                  BIGNUM **_n, BIGNUM **_e,
+                                  BIGNUM **_d,
+                                  BIGNUM **_p, BIGNUM **_q,
+                                  BIGNUM **_dp, BIGNUM **_dq,
+                                  BIGNUM **_qi)
+{
+    int ret;
+    BIGNUM *n = NULL;
+    BIGNUM *e = NULL;
+    BIGNUM *d = NULL;
+    BIGNUM *p = NULL;
+    BIGNUM *q = NULL;
+    BIGNUM *dp = NULL;
+    BIGNUM *dq = NULL;
+    BIGNUM *qi = NULL;
+
+    ret = EVP_PKEY_get_bn_param(cert_priv_key, OSSL_PKEY_PARAM_RSA_N, &n);
+    if (ret != 1) {
+        ret = EINVAL;
+        goto done;
+    }
+
+    ret = EVP_PKEY_get_bn_param(cert_priv_key, OSSL_PKEY_PARAM_RSA_E, &e);
+    if (ret != 1) {
+        ret = EINVAL;
+        goto done;
+    }
+
+    ret = EVP_PKEY_get_bn_param(cert_priv_key, OSSL_PKEY_PARAM_RSA_D, &d);
+    if (ret != 1) {
+        ret = EINVAL;
+        goto done;
+    }
+
+    ret = EVP_PKEY_get_bn_param(cert_priv_key, OSSL_PKEY_PARAM_RSA_FACTOR1, &p);
+    if (ret != 1) {
+        ret = EINVAL;
+        goto done;
+    }
+
+    ret = EVP_PKEY_get_bn_param(cert_priv_key, OSSL_PKEY_PARAM_RSA_FACTOR2, &q);
+    if (ret != 1) {
+        ret = EINVAL;
+        goto done;
+    }
+
+    ret = EVP_PKEY_get_bn_param(cert_priv_key, OSSL_PKEY_PARAM_RSA_EXPONENT1, &dp);
+    if (ret != 1) {
+        ret = EINVAL;
+        goto done;
+    }
+
+    ret = EVP_PKEY_get_bn_param(cert_priv_key, OSSL_PKEY_PARAM_RSA_EXPONENT2, &dq);
+    if (ret != 1) {
+        ret = EINVAL;
+        goto done;
+    }
+
+    ret = EVP_PKEY_get_bn_param(cert_priv_key, OSSL_PKEY_PARAM_RSA_COEFFICIENT1, &qi);
+    if (ret != 1) {
+        ret = EINVAL;
+        goto done;
+    }
+
+    *_e = e;
+    *_n = n;
+    *_d = d;
+    *_p = p;
+    *_q = q;
+    *_dp = dp;
+    *_dq = dq;
+    *_qi = qi;
+
+    ret = EOK;
+
+done:
+    if (ret != EOK) {
+        BN_clear_free(n);
+        BN_clear_free(e);
+        BN_clear_free(d);
+        BN_clear_free(p);
+        BN_clear_free(q);
+        BN_clear_free(dp);
+        BN_clear_free(dq);
+        BN_clear_free(qi);
+    }
+
+    return ret;
+}
+
+static errno_t rsa_priv_key_jwk(TALLOC_CTX *mem_ctx, EVP_PKEY *cert_priv_key,
+                                char **_jwk)
+{
+    BIGNUM *n = NULL;
+    BIGNUM *e = NULL;
+    BIGNUM *d = NULL;
+    BIGNUM *p = NULL;
+    BIGNUM *q = NULL;
+    BIGNUM *dp = NULL;
+    BIGNUM *dq = NULL;
+    BIGNUM *qi = NULL;
+    int ret;
+    char *out = NULL;
+    char *n_str = NULL;
+    char *e_str = NULL;
+    char *d_str = NULL;
+    char *p_str = NULL;
+    char *q_str = NULL;
+    char *dp_str = NULL;
+    char *dq_str = NULL;
+    char *qi_str = NULL;
+    /* Currently it looks like it is sufficient to support RS256 for all RSA
+     * keys, this might change in future. */
+    const char *alg = "RS256";
+
+    ret = sss_rsa_get_priv_comps(cert_priv_key, &n, &e, &d, &p, &q,
+                                 &dp, &dq, &qi);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to retrieve RSA parameters.\n");
+        goto done;
+    }
+
+    ret = sss_bn_to_base64(mem_ctx, n, 0, &n_str);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sss_bn_to_base64() failed.\n");
+        goto done;
+    }
+    ret = sss_bn_to_base64(mem_ctx, e, 0, &e_str);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sss_bn_to_base64() failed.\n");
+        goto done;
+    }
+    ret = sss_bn_to_base64(mem_ctx, d, 0, &d_str);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sss_bn_to_base64() failed.\n");
+        goto done;
+    }
+    ret = sss_bn_to_base64(mem_ctx, p, 0, &p_str);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sss_bn_to_base64() failed.\n");
+        goto done;
+    }
+    ret = sss_bn_to_base64(mem_ctx, q, 0, &q_str);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sss_bn_to_base64() failed.\n");
+        goto done;
+    }
+    ret = sss_bn_to_base64(mem_ctx, dp, 0, &dp_str);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sss_bn_to_base64() failed.\n");
+        goto done;
+    }
+    ret = sss_bn_to_base64(mem_ctx, dq, 0, &dq_str);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sss_bn_to_base64() failed.\n");
+        goto done;
+    }
+    ret = sss_bn_to_base64(mem_ctx, qi, 0, &qi_str);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "sss_bn_to_base64() failed.\n");
+        goto done;
+    }
+    if (n_str == NULL || e_str == NULL || d_str == NULL || p_str == NULL
+                      || q_str == NULL || dp_str == NULL || dq_str == NULL
+                      || qi_str == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to convert BIGNUM to base64.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    out = talloc_asprintf(mem_ctx,
+                          "\"kty\":\"RSA\","
+                          "\"n\":\"%s\","
+                          "\"e\":\"%s\","
+                          "\"d\":\"%s\","
+                          "\"p\":\"%s\","
+                          "\"q\":\"%s\","
+                          "\"dp\":\"%s\","
+                          "\"dq\":\"%s\","
+                          "\"qi\":\"%s\","
+                          "\"alg\":\"%s\"", n_str, e_str, d_str, p_str,
+                                            q_str, dp_str, dq_str, qi_str,
+                                            alg);
+    if (out == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to generate JSON snippet.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+    talloc_set_destructor((void *) out, sss_erase_talloc_mem_securely);
+
+    *_jwk = out;
+
+    ret = EOK;
+done:
+
+    talloc_free(n_str);
+    talloc_free(e_str);
+    talloc_free(d_str);
+    talloc_free(p_str);
+    talloc_free(q_str);
+    talloc_free(dp_str);
+    talloc_free(dq_str);
+    talloc_free(qi_str);
+
+    BN_clear_free(n);
+    BN_clear_free(e);
+    BN_clear_free(d);
+    BN_clear_free(p);
+    BN_clear_free(q);
+    BN_clear_free(dp);
+    BN_clear_free(dq);
+    BN_clear_free(qi);
+
+    return ret;
+}
+
+static char *get_cert_sha256_hash(TALLOC_CTX *mem_ctx, const X509 *cert)
+{
+    EVP_MD *md = NULL;
+    unsigned char md_value[EVP_MAX_MD_SIZE];
+    unsigned int md_len;
+    char *out;
+    int ret;
+
+    md = EVP_MD_fetch(NULL, "sha256", NULL);
+    if (md == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to initialize hashing.\n");
+        return NULL;
+    }
+
+    ret = X509_digest(cert, md, md_value, &md_len);
+    EVP_MD_free(md);
+    if (ret != 1) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to calculate hash.\n");
+        return NULL;
+    }
+
+    out = sss_jose_b64_enc_buf(mem_ctx, md_value, md_len);
+    if (out == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to base64-encode hash value.\n");
+        return NULL;
+    }
+
+    return out;
+}
+
+errno_t get_jwk_from_pkcs12(TALLOC_CTX *mem_ctx,
+                            const uint8_t *der_blob, size_t der_size,
+                            const char *password,
+                            char **_jwk)
+{
+    int ret;
+    const unsigned char *d;
+    PKCS12 *pkcs12 = NULL;
+    EVP_PKEY *pkey = NULL;
+    X509 *cert = NULL;
+    char *jwk_base = NULL;
+    char *jwk = NULL;
+    char *cert_hash = NULL;
+
+    if (der_blob == NULL || der_size == 0) {
+        return EINVAL;
+    }
+
+    d = (const unsigned char *) der_blob;
+
+    pkcs12 = d2i_PKCS12(NULL, &d, (int) der_size);
+    if (pkcs12 == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "d2i_PKCS12 failed.\n");
+        return EINVAL;
+    }
+
+    ret = PKCS12_parse(pkcs12, password, &pkey, &cert, NULL);
+    if (ret != 1) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to extract private key.\n");
+        ret = EIO;
+        goto done;
+    }
+
+    cert_hash = get_cert_sha256_hash(mem_ctx, cert);
+    if (cert_hash == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Failed to get SHA-256 hash of certificate.\n");
+        ret = EIO;
+        goto done;
+    }
+
+    switch (EVP_PKEY_base_id(pkey)) {
+    case EVP_PKEY_RSA:
+        ret = rsa_priv_key_jwk(mem_ctx, pkey, &jwk_base);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_OP_FAILURE, "rsa_priv_key_jwk failed.\n");
+            goto done;
+        }
+        break;
+    case EVP_PKEY_EC:
+        ret = ec_priv_key_jwk(mem_ctx, pkey, &jwk_base);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_OP_FAILURE, "ec_priv_key_jwk failed.\n");
+            goto done;
+        }
+        break;
+    default:
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Expected RSA or EC public key, found unsupported [%d].\n",
+              EVP_PKEY_base_id(pkey));
+        ret = EINVAL;
+        goto done;
+    }
+
+    if (jwk_base == NULL || *jwk_base == '\0') {
+        DEBUG(SSSDBG_OP_FAILURE, "Missing JWK key data.\n");
+        ret = EINVAL;
+        goto done;
+    }
+
+    /* optional "use" or "kid" items can be added here */
+    jwk = talloc_asprintf(mem_ctx, "{\"keys\":[{%s,\"x5t#S256\":\"%s\"}]}",
+                                   jwk_base, cert_hash);
+    talloc_free(jwk_base);
+    if (jwk == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to generate JWK.\n");
+        ret = ENOMEM;
+        goto done;
+    }
+    talloc_set_destructor((void *) jwk, sss_erase_talloc_mem_securely);
+
+    *_jwk = jwk;
+
+    ret = EOK;
+
+done:
+    EVP_PKEY_free(pkey);
+    PKCS12_free(pkcs12);
+    X509_free(cert);
+    talloc_free(cert_hash);
+
+    return ret;
+}

--- a/src/oidc_child/oidc_child.c
+++ b/src/oidc_child/oidc_child.c
@@ -285,6 +285,7 @@ static struct devicecode_ctx *get_dc_ctx(TALLOC_CTX *mem_ctx,
                                          const char *userinfo_endpoint,
                                          const char *jwks_uri, const char *scope,
                                          const char *pkcs12_client_creds,
+                                         enum client_auth_method client_auth_method,
                                          const char *key_passwd)
 {
     struct devicecode_ctx *dc_ctx = NULL;
@@ -298,7 +299,8 @@ static struct devicecode_ctx *get_dc_ctx(TALLOC_CTX *mem_ctx,
     }
 
     dc_ctx->rest_ctx = get_rest_ctx(dc_ctx, libcurl_debug, ca_db,
-                                    pkcs12_client_creds, key_passwd);
+                                    pkcs12_client_creds, client_auth_method,
+                                    key_passwd);
     if (dc_ctx->rest_ctx == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to get curl context.\n");
         ret = ENOMEM;
@@ -357,6 +359,7 @@ struct cli_opts {
     char *idp_type;
     bool return_tokens;
     char *pkcs12_client_creds;
+    enum client_auth_method client_auth_method;
 };
 
 static void free_cli_opts_members(struct cli_opts *opts)
@@ -379,6 +382,71 @@ static void free_cli_opts_members(struct cli_opts *opts)
     free(opts->pkcs12_client_creds);
 }
 
+static bool has_creds_client_secret(struct cli_opts *opts)
+{
+    return (opts->client_secret != NULL || opts->client_secret_stdin);
+}
+
+static bool has_creds_pkcs12(struct cli_opts *opts)
+{
+    return (has_creds_client_secret(opts) && opts->pkcs12_client_creds != NULL);
+}
+
+static bool set_client_auth_method(const char *tmp_cam, struct cli_opts *opts)
+{
+    if (tmp_cam != NULL) {
+        if (strcasecmp(tmp_cam, "none") == 0) {
+            opts->client_auth_method = CAM_NONE;
+        } else if (strcasecmp(tmp_cam, "secret") == 0) {
+            opts->client_auth_method = CAM_SECRET;
+        } else if (strcasecmp(tmp_cam, "mtls") == 0) {
+            opts->client_auth_method = CAM_MTLS;
+        } else if (strcasecmp(tmp_cam, "jwt") == 0) {
+            opts->client_auth_method = CAM_JWT;
+        } else {
+            fprintf(stderr,
+                    "\nUnsupported client authentication method [%s].\n",
+                    tmp_cam);
+            return false;
+        }
+    } else {
+        opts->client_auth_method = CAM_SECRET;
+    }
+
+    switch (opts->client_auth_method) {
+    case CAM_SECRET:
+        if (!has_creds_client_secret(opts)) {
+            fprintf(stderr, "\nMissing client secret.\n");
+            return false;
+        }
+        if (has_creds_pkcs12(opts)) {
+            fprintf(stderr, "\nPath to PKCS12 file is not needed for "
+                            "authentication with client secret.\n");
+            return false;
+        }
+        break;
+    case CAM_MTLS:
+    case CAM_JWT:
+        if (!has_creds_pkcs12(opts)) {
+            fprintf(stderr, "\nPath to PKCS12 file and password/secret "
+                            "are needed for client authentication.\n");
+            return false;
+        }
+        break;
+    case CAM_NONE:
+        if (has_creds_client_secret(opts)) {
+            fprintf(stderr, "\nClient secrets are not expected.\n");
+            return false;
+        }
+        break;
+    default:
+        fprintf(stderr, "\nUnsupported client authentication method.\n");
+        return false;
+    }
+
+    return true;
+}
+
 static int parse_cli(int argc, const char *argv[], struct cli_opts *opts)
 {
     poptContext pc;
@@ -387,6 +455,7 @@ static int parse_cli(int argc, const char *argv[], struct cli_opts *opts)
     bool print_usage = true;
     char *tmp_name = NULL;
     char *tmp_obj_id = NULL;
+    char *tmp_cam = NULL;
 
     struct poptOption long_options[] = {
         SSSD_BASIC_CHILD_OPTS
@@ -421,9 +490,9 @@ static int parse_cli(int argc, const char *argv[], struct cli_opts *opts)
                 _("Supported scope of the IdP to get userinfo"), NULL},
         {"client-id", 0, POPT_ARG_STRING, &opts->client_id, 0, _("Client ID"), NULL},
         {"client-secret", 0, POPT_ARG_STRING, &opts->client_secret, 0,
-                _("Client secret (if needed)"), NULL},
+                _("Client secret/PKCS#12 password (if needed)"), NULL},
         {"client-secret-stdin", 0, POPT_ARG_NONE, NULL, 's',
-                _("Read client secret from standard input"), NULL},
+                _("Read client secret/PKCS#12 password from standard input"), NULL},
         {"idp-type", 0, POPT_ARG_STRING, &opts->idp_type, 0,
                 _("Type of the IdP (entra_id, keycloak etc)"), NULL},
         {"name", 0, POPT_ARG_STRING, &tmp_name, 0, _("Name of user or group"),
@@ -432,6 +501,9 @@ static int parse_cli(int argc, const char *argv[], struct cli_opts *opts)
                 _("Object ID of user or group"), NULL},
         {"pkcs12-client-creds", 0, POPT_ARG_STRING, &opts->pkcs12_client_creds, 0,
                 _("Client certificate and key in PKCS#12 format"), NULL},
+        {"client-auth-method", 0, POPT_ARG_STRING, &tmp_cam, 0,
+                _("Authentication method against IdP [secret (default), mtls, jwt, none]"),
+                NULL},
         {"ca-db", 0, POPT_ARG_STRING, &opts->ca_db, 0,
                 _("Path to PEM file with CA certificates"), NULL},
         {"return-tokens", 0, POPT_ARG_NONE, NULL, 'r',
@@ -498,6 +570,10 @@ static int parse_cli(int argc, const char *argv[], struct cli_opts *opts)
         goto done;
     }
 
+    if (!set_client_auth_method(tmp_cam, opts)) {
+        goto done;
+    }
+
     if (tmp_name != NULL) {
         opts->search_str = tmp_name;
         opts->search_str_type = TYPE_NAME;
@@ -521,6 +597,7 @@ static int parse_cli(int argc, const char *argv[], struct cli_opts *opts)
     ret = EOK;
 
 done:
+    free(tmp_cam);
     if (print_usage) {
         poptPrintUsage(pc, stderr, 0);
         poptFreeContext(pc);
@@ -663,6 +740,7 @@ int main(int argc, const char *argv[])
                           opts.libcurl_debug, opts.ca_db,
                           opts.client_id, opts.client_secret,
                           opts.pkcs12_client_creds,
+                          opts.client_auth_method,
                           opts.token_endpoint, opts.scope, &out);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "Id lookup failed.\n");
@@ -685,6 +763,7 @@ int main(int argc, const char *argv[])
                             opts.device_auth_endpoint, opts.token_endpoint,
                             opts.userinfo_endpoint, opts.jwks_uri, opts.scope,
                             opts.pkcs12_client_creds,
+                            opts.client_auth_method,
                             opts.pkcs12_client_creds == NULL ? NULL
                                                              : opts.client_secret);
         if (dc_ctx == NULL) {

--- a/src/oidc_child/oidc_child.c
+++ b/src/oidc_child/oidc_child.c
@@ -283,7 +283,9 @@ static struct devicecode_ctx *get_dc_ctx(TALLOC_CTX *mem_ctx,
                                          const char *device_auth_endpoint,
                                          const char *token_endpoint,
                                          const char *userinfo_endpoint,
-                                         const char *jwks_uri, const char *scope)
+                                         const char *jwks_uri, const char *scope,
+                                         const char *pkcs12_client_creds,
+                                         const char *key_passwd)
 {
     struct devicecode_ctx *dc_ctx = NULL;
     int ret;
@@ -295,7 +297,8 @@ static struct devicecode_ctx *get_dc_ctx(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    dc_ctx->rest_ctx = get_rest_ctx(dc_ctx, libcurl_debug, ca_db);
+    dc_ctx->rest_ctx = get_rest_ctx(dc_ctx, libcurl_debug, ca_db,
+                                    pkcs12_client_creds, key_passwd);
     if (dc_ctx->rest_ctx == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to get curl context.\n");
         ret = ENOMEM;
@@ -353,6 +356,7 @@ struct cli_opts {
     char *search_str;
     char *idp_type;
     bool return_tokens;
+    char *pkcs12_client_creds;
 };
 
 static void free_cli_opts_members(struct cli_opts *opts)
@@ -372,6 +376,7 @@ static void free_cli_opts_members(struct cli_opts *opts)
     free(opts->user_identifier_attr);
     free(opts->search_str);
     free(opts->idp_type);
+    free(opts->pkcs12_client_creds);
 }
 
 static int parse_cli(int argc, const char *argv[], struct cli_opts *opts)
@@ -425,6 +430,8 @@ static int parse_cli(int argc, const char *argv[], struct cli_opts *opts)
                 NULL},
         {"object-id", 0, POPT_ARG_STRING, &tmp_obj_id, 0,
                 _("Object ID of user or group"), NULL},
+        {"pkcs12-client-creds", 0, POPT_ARG_STRING, &opts->pkcs12_client_creds, 0,
+                _("Client certificate and key in PKCS#12 format"), NULL},
         {"ca-db", 0, POPT_ARG_STRING, &opts->ca_db, 0,
                 _("Path to PEM file with CA certificates"), NULL},
         {"return-tokens", 0, POPT_ARG_NONE, NULL, 'r',
@@ -655,6 +662,7 @@ int main(int argc, const char *argv[])
                           opts.search_str, opts.search_str_type,
                           opts.libcurl_debug, opts.ca_db,
                           opts.client_id, opts.client_secret,
+                          opts.pkcs12_client_creds,
                           opts.token_endpoint, opts.scope, &out);
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "Id lookup failed.\n");
@@ -675,7 +683,10 @@ int main(int argc, const char *argv[])
         dc_ctx = get_dc_ctx(main_ctx, opts.libcurl_debug, opts.ca_db,
                             opts.issuer_url,
                             opts.device_auth_endpoint, opts.token_endpoint,
-                            opts.userinfo_endpoint, opts.jwks_uri, opts.scope);
+                            opts.userinfo_endpoint, opts.jwks_uri, opts.scope,
+                            opts.pkcs12_client_creds,
+                            opts.pkcs12_client_creds == NULL ? NULL
+                                                             : opts.client_secret);
         if (dc_ctx == NULL) {
             DEBUG(SSSDBG_OP_FAILURE, "Failed to initialize main context.\n");
             goto done;

--- a/src/oidc_child/oidc_child_curl.c
+++ b/src/oidc_child/oidc_child_curl.c
@@ -31,6 +31,7 @@ struct rest_ctx {
     bool libcurl_debug;
     const char *ca_db;
     const char *pkcs12_client_creds;
+    enum client_auth_method client_auth_method;
     const char *key_passwd;
     char *http_data;
     CURL *curl_ctx;
@@ -61,6 +62,7 @@ static int rest_ctx_destructor(void *p);
 struct rest_ctx *get_rest_ctx(TALLOC_CTX *mem_ctx, bool libcurl_debug,
                               const char *ca_db,
                               const char *pkcs12_client_creds,
+                              enum client_auth_method client_auth_method,
                               const char *key_passwd)
 {
     struct rest_ctx *rest_ctx;
@@ -91,6 +93,7 @@ struct rest_ctx *get_rest_ctx(TALLOC_CTX *mem_ctx, bool libcurl_debug,
 
         rest_ctx->key_passwd = key_passwd;
     }
+    rest_ctx->client_auth_method = client_auth_method;
 
     rest_ctx->curl_ctx = init_curl();
     if (rest_ctx->curl_ctx == NULL) {
@@ -124,6 +127,16 @@ errno_t set_http_data(struct rest_ctx *rest_ctx, const char *str)
     rest_ctx->http_data = tmp;
 
     return EOK;
+}
+
+const char *rest_ctx_get_pkcs12_client_creds(const struct rest_ctx *rest_ctx)
+{
+    return (const char *) rest_ctx->pkcs12_client_creds;
+}
+
+const char *rest_ctx_get_key_passwd(const struct rest_ctx *rest_ctx)
+{
+    return (const char *) rest_ctx->key_passwd;
 }
 
 char *url_encode_string(struct rest_ctx *rest_ctx, const char *inp)
@@ -361,7 +374,7 @@ static errno_t set_http_opts(CURL *curl_ctx, struct rest_ctx *rest_ctx,
             ret = EIO;
             goto done;
         }
-    } else if (rest_ctx->pkcs12_client_creds != NULL) {
+    } else if (rest_ctx->client_auth_method == CAM_MTLS) {
         res = curl_easy_setopt(curl_ctx, CURLOPT_SSLCERT,
                                rest_ctx->pkcs12_client_creds);
         if (res != CURLE_OK) {
@@ -527,6 +540,65 @@ done:
     return ret;
 }
 
+static char *append_jwt_to_postdata(char *str, struct rest_ctx *rest_ctx,
+                                    const char *token_endpoint,
+                                    const char *client_id)
+{
+    char *out = NULL;
+    char *jwt = NULL;
+
+    out = append_to_post_data(str, "client_assertion_type",
+                                   "urn:ietf:params:oauth:client-assertion-type:jwt-bearer");
+    if (out == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Failed to add client_assertion_type to POST data.\n");
+        return out;
+    }
+
+    jwt = get_jwt(rest_ctx, token_endpoint, client_id);
+    if (jwt == NULL) {
+        talloc_free(out);
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to get JWT.\n");
+        return NULL;
+    }
+
+    out = append_to_post_data(out, "client_assertion", jwt);
+    talloc_free(jwt);
+    if (out == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Failed to add client_assertion to POST data.\n");
+        return NULL;
+    }
+
+    return out;
+}
+
+static char *append_to_creds_to_post_data(char *str,
+                                          struct rest_ctx *rest_ctx,
+                                          const char *token_endpoint,
+                                          const char *client_id,
+                                          const char *client_secret)
+{
+    char *out = str;
+
+    if (rest_ctx->client_auth_method == CAM_SECRET) {
+        out = append_to_post_data(out, "client_secret", client_secret);
+        if (out == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE, "Failed to add client_secret to POST data.\n");
+            return NULL;
+        }
+    } else if (rest_ctx->client_auth_method == CAM_JWT) {
+        out = append_jwt_to_postdata(out, rest_ctx, token_endpoint, client_id);
+        if (out == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE,
+                  "Failed to add JWT client assertion to POST data.\n");
+            return NULL;
+        }
+    }
+
+    return out;
+}
+
 #define AZURE_EXPECT_CODE "The request body must contain the following parameter: 'code'."
 
 errno_t get_token(TALLOC_CTX *mem_ctx,
@@ -564,13 +636,14 @@ errno_t get_token(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    if (client_secret != NULL) {
-        post_data = append_to_post_data(post_data, "client_secret", client_secret);
-        if (post_data == NULL) {
-            DEBUG(SSSDBG_OP_FAILURE, "Failed to add client_secret to POST data.\n");
-            ret = ENOMEM;
-            goto done;
-        }
+    post_data = append_to_creds_to_post_data(post_data, dc_ctx->rest_ctx,
+                                             dc_ctx->token_endpoint,
+                                             client_id, client_secret);
+    if (post_data == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Failed to add client credentials to POST data.\n");
+        ret = ENOMEM;
+        goto done;
     }
 
     /* Remember the offset of the device code for the azure fallback later. */
@@ -722,14 +795,16 @@ errno_t get_devicecode(struct devicecode_ctx *dc_ctx,
         goto done;
     }
 
-    if (client_secret != NULL && dc_ctx->rest_ctx->pkcs12_client_creds == NULL) {
-        post_data = append_to_post_data(post_data, "client_secret", client_secret);
-        if (post_data == NULL) {
-            DEBUG(SSSDBG_OP_FAILURE, "Failed to add client_secret to POST data.\n");
-            ret = ENOMEM;
-            goto done;
-        }
+    post_data = append_to_creds_to_post_data(post_data, dc_ctx->rest_ctx,
+                                             dc_ctx->token_endpoint,
+                                             client_id, client_secret);
+    if (post_data == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Failed to add client credentials to POST data.\n");
+        ret = ENOMEM;
+        goto done;
     }
+
 
     clean_http_data(dc_ctx->rest_ctx);
     ret = do_http_request(dc_ctx->rest_ctx,
@@ -806,7 +881,9 @@ errno_t client_credentials_grant(struct rest_ctx *rest_ctx,
         goto done;
     }
 
-    post_data = append_to_post_data(post_data, "client_secret", client_secret);
+    post_data = append_to_creds_to_post_data(post_data, rest_ctx,
+                                             token_endpoint, client_id,
+                                             client_secret);
     if (post_data == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to add client_secret to POST data.\n");
         ret = ENOMEM;
@@ -825,7 +902,8 @@ errno_t client_credentials_grant(struct rest_ctx *rest_ctx,
     clean_http_data(rest_ctx);
     ret = do_http_request(rest_ctx, token_endpoint, post_data, NULL);
     if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "Failed to send device code request.\n");
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Failed to send client credential grant request.\n");
     }
 
 done:
@@ -864,13 +942,14 @@ errno_t refresh_token(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    if (client_secret != NULL) {
-        post_data = append_to_post_data(post_data, "client_secret", client_secret);
-        if (post_data == NULL) {
-            DEBUG(SSSDBG_OP_FAILURE, "Failed to add client_secret to POST data.\n");
-            ret = ENOMEM;
-            goto done;
-        }
+    post_data = append_to_creds_to_post_data(post_data, dc_ctx->rest_ctx,
+                                             dc_ctx->token_endpoint,
+                                             client_id, client_secret);
+    if (post_data == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Failed to add client credentials to POST data.\n");
+        ret = ENOMEM;
+        goto done;
     }
 
     post_data = append_to_post_data(post_data, "scope", scope);

--- a/src/oidc_child/oidc_child_curl.c
+++ b/src/oidc_child/oidc_child_curl.c
@@ -30,6 +30,8 @@
 struct rest_ctx {
     bool libcurl_debug;
     const char *ca_db;
+    const char *pkcs12_client_creds;
+    const char *key_passwd;
     char *http_data;
     CURL *curl_ctx;
 };
@@ -57,7 +59,9 @@ static CURL *init_curl(void)
 
 static int rest_ctx_destructor(void *p);
 struct rest_ctx *get_rest_ctx(TALLOC_CTX *mem_ctx, bool libcurl_debug,
-                              const char *ca_db)
+                              const char *ca_db,
+                              const char *pkcs12_client_creds,
+                              const char *key_passwd)
 {
     struct rest_ctx *rest_ctx;
 
@@ -75,6 +79,17 @@ struct rest_ctx *get_rest_ctx(TALLOC_CTX *mem_ctx, bool libcurl_debug,
                   "Failed to allocate memory for CA DB string.\n");
             goto fail;
         }
+    }
+
+    if (pkcs12_client_creds != NULL) {
+        rest_ctx->pkcs12_client_creds = talloc_strdup(rest_ctx,
+                                                    pkcs12_client_creds);
+        if (rest_ctx->pkcs12_client_creds == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "Failed to copy PKCS#12 path.\n");
+            goto fail;
+        }
+
+        rest_ctx->key_passwd = key_passwd;
     }
 
     rest_ctx->curl_ctx = init_curl();
@@ -346,6 +361,27 @@ static errno_t set_http_opts(CURL *curl_ctx, struct rest_ctx *rest_ctx,
             ret = EIO;
             goto done;
         }
+    } else if (rest_ctx->pkcs12_client_creds != NULL) {
+        res = curl_easy_setopt(curl_ctx, CURLOPT_SSLCERT,
+                               rest_ctx->pkcs12_client_creds);
+        if (res != CURLE_OK) {
+            DEBUG(SSSDBG_OP_FAILURE, "Failed to set path the PKCS#12 file.\n");
+            ret = EIO;
+            goto done;
+        }
+        res = curl_easy_setopt(curl_ctx, CURLOPT_SSLCERTTYPE, "P12");
+        if (res != CURLE_OK) {
+            DEBUG(SSSDBG_OP_FAILURE, "Failed to set cert type.\n");
+            ret = EIO;
+            goto done;
+        }
+        res = curl_easy_setopt(curl_ctx, CURLOPT_KEYPASSWD,
+                               rest_ctx->key_passwd);
+        if (res != CURLE_OK) {
+            DEBUG(SSSDBG_OP_FAILURE, "Failed to set key password.\n");
+            ret = EIO;
+            goto done;
+        }
     }
 
     ret = EOK;
@@ -456,7 +492,8 @@ errno_t do_http_request(struct rest_ctx *rest_ctx, const char *uri,
         goto done;
     }
 
-    ret = set_http_opts(curl_ctx, rest_ctx, uri, post_data, token, headers);
+    ret = set_http_opts(curl_ctx, rest_ctx, uri, post_data,
+                        token, headers);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to set http options.\n");
         goto done;
@@ -685,7 +722,7 @@ errno_t get_devicecode(struct devicecode_ctx *dc_ctx,
         goto done;
     }
 
-    if (client_secret != NULL) {
+    if (client_secret != NULL && dc_ctx->rest_ctx->pkcs12_client_creds == NULL) {
         post_data = append_to_post_data(post_data, "client_secret", client_secret);
         if (post_data == NULL) {
             DEBUG(SSSDBG_OP_FAILURE, "Failed to add client_secret to POST data.\n");

--- a/src/oidc_child/oidc_child_id.c
+++ b/src/oidc_child/oidc_child_id.c
@@ -471,6 +471,7 @@ errno_t oidc_get_id(TALLOC_CTX *mem_ctx, enum oidc_cmd oidc_cmd,
                     bool libcurl_debug, const char *ca_db,
                     const char *client_id, const char *client_secret,
                     const char *pkcs12_client_creds,
+                    enum client_auth_method client_auth_method,
                     const char *token_endpoint, const char *scope, char **out)
 {
     errno_t ret;
@@ -490,7 +491,8 @@ errno_t oidc_get_id(TALLOC_CTX *mem_ctx, enum oidc_cmd oidc_cmd,
     }
 
     rest_ctx = get_rest_ctx(mem_ctx, libcurl_debug, ca_db,
-                            pkcs12_client_creds, client_secret);
+                            pkcs12_client_creds, client_auth_method,
+                            client_secret);
     if (rest_ctx == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to get REST context.\n");
         return ENOMEM;

--- a/src/oidc_child/oidc_child_id.c
+++ b/src/oidc_child/oidc_child_id.c
@@ -470,6 +470,7 @@ errno_t oidc_get_id(TALLOC_CTX *mem_ctx, enum oidc_cmd oidc_cmd,
                     char *input, enum search_str_type input_type,
                     bool libcurl_debug, const char *ca_db,
                     const char *client_id, const char *client_secret,
+                    const char *pkcs12_client_creds,
                     const char *token_endpoint, const char *scope, char **out)
 {
     errno_t ret;
@@ -488,7 +489,8 @@ errno_t oidc_get_id(TALLOC_CTX *mem_ctx, enum oidc_cmd oidc_cmd,
         return EINVAL;
     }
 
-    rest_ctx = get_rest_ctx(mem_ctx, libcurl_debug, ca_db);
+    rest_ctx = get_rest_ctx(mem_ctx, libcurl_debug, ca_db,
+                            pkcs12_client_creds, client_secret);
     if (rest_ctx == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to get REST context.\n");
         return ENOMEM;

--- a/src/oidc_child/oidc_child_json.c
+++ b/src/oidc_child/oidc_child_json.c
@@ -27,6 +27,8 @@
 #include <jose/jws.h>
 #include <jose/b64.h>
 #include <jansson.h>
+#include <uuid.h>
+#include <fcntl.h>
 
 #include "util/strtonum.h"
 #include "oidc_child/oidc_child_util.h"
@@ -51,6 +53,28 @@ static char *get_json_string(TALLOC_CTX *mem_ctx, const json_t *root,
     }
 
     return str;
+}
+
+static const char *get_json_const_string_from_first_key(const json_t *root,
+                                                        const char *attr)
+{
+    json_t *keys;
+    json_t *tmp;
+
+    keys = json_object_get(root, "keys");
+    if (!json_is_array(keys)) {
+        DEBUG(SSSDBG_OP_FAILURE, "Missing keys array.\n");
+        return NULL;
+    }
+
+    tmp = json_object_get(json_array_get(keys, 0), attr);
+    if (!json_is_string(tmp)) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Result does not contain the '%s' string.\n", attr);
+        return NULL;
+    }
+
+    return json_string_value(tmp);
 }
 
 static int get_json_integer(const json_t *root, const char *attr,
@@ -1093,4 +1117,197 @@ json_t *token_data_to_json(struct devicecode_ctx *dc_ctx)
 fail:
     json_decref(obj);
     return NULL;
+}
+
+static json_t *get_jwk(struct rest_ctx *rest_ctx)
+{
+    int ret;
+    int fd = -1;
+    struct stat st;
+    char *jwk_str = NULL;
+    json_t *jwk = NULL;
+    uint8_t *buf = NULL;
+    json_error_t json_error;
+
+    fd = open(rest_ctx_get_pkcs12_client_creds(rest_ctx), O_RDONLY);
+    if (fd == -1) {
+        ret = errno;
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "open() failed [%d][%s]\n", ret, strerror(ret));
+        goto done;
+    }
+    ret = fstat(fd, &st);
+    if (ret != 0) {
+        ret = errno;
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "stat() failed [%d][%s]\n", ret, strerror(ret));
+        goto done;
+    }
+    /* PKCS#12 must be a regular file and not larger than 10MiB */
+    if ((st.st_mode & S_IFMT) != S_IFREG) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "PKCS#12 file must be a regular file.\n");
+        ret = EINVAL;
+        goto done;
+    }
+    if (st.st_size > 10*1024*1024) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "PKCS#12 file is too large, current limit it 10MiB.\n");
+        ret = EINVAL;
+        goto done;
+    }
+
+    buf = talloc_size(rest_ctx, st.st_size);
+    if (buf == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to allocate buffer for PKCS#12.\n");
+        goto done;
+    }
+    if (sss_atomic_read_s(fd, buf, st.st_size) != st.st_size) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "sss_atomic_read_s() failed\n");
+        goto done;
+    }
+
+    ret = get_jwk_from_pkcs12(rest_ctx, buf, st.st_size,
+                              rest_ctx_get_key_passwd(rest_ctx), &jwk_str);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to get JWK from PKCS#12.\n");
+        goto done;
+    }
+
+    jwk = json_loads(jwk_str, 0, &json_error);
+    if (jwk == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Failed to parse JWK string on line [%d]: [%s].\n",
+              json_error.line, json_error.text);
+        ret = EINVAL;
+        goto done;
+    }
+
+    ret = EOK;
+
+done:
+    talloc_free(jwk_str);
+    talloc_free(buf);
+    if (fd != -1) {
+        close(fd);
+    }
+
+    return jwk;
+}
+
+static json_t *get_jwt_payload(const char *token_endpoint,
+                               const char *client_id)
+{
+    time_t iat = time(NULL);
+    time_t nbf = iat - 5;
+    time_t exp = iat + 60;
+    const char *aud = token_endpoint;
+    const char *iss = client_id;
+    const char *sub = client_id;
+    uuid_t uuid;
+    char jti[UUID_STR_LEN];
+    json_t *payload = NULL;
+    json_t *payload_b64 = NULL;
+    json_t *json = NULL;
+
+    uuid_generate(uuid);
+    uuid_unparse(uuid, jti);
+
+    payload = json_pack("{s:s, s:s, s:s, s:s, s:I, s:I, s:I}",
+                     "aud", aud,
+                     "iss", iss,
+                     "sub", sub,
+                     "jti", jti,
+                     "iat", (json_int_t) iat,
+                     "nbf", (json_int_t) nbf,
+                     "exp", (json_int_t) exp);
+    if (payload == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to generate JSON JWT payload.\n");
+        return NULL;
+    }
+
+    payload_b64 = jose_b64_enc_dump(payload);
+    json_decref(payload);
+    if (payload_b64 == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to encode payload.\n");
+        return NULL;
+    }
+
+    json = json_pack("{s:o}", "payload", payload_b64);
+    if (json == NULL) {
+        json_decref(payload_b64);
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to generate JSON payload.\n");
+        return NULL;
+    }
+
+    return json;
+}
+
+char *get_jwt(struct rest_ctx *rest_ctx, const char *token_endpoint,
+              const char *client_id)
+{
+    const char *payload_str = NULL;
+    const char *protected_str = NULL;
+    const char *signature_str = NULL;
+    json_t *payload = NULL;
+    json_t *signature_template = NULL;
+    json_t *jwk = NULL;
+    char *jwt = NULL;
+    const char *alg = NULL;
+    const char *cert_hash = NULL;
+
+    payload = get_jwt_payload(token_endpoint, client_id);
+    if (payload == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to get JWT payload.\n");
+        goto done;
+    }
+
+    jwk = get_jwk(rest_ctx);
+    if (jwk == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to get JWK.\n");
+        goto done;
+    }
+
+    alg = get_json_const_string_from_first_key(jwk, "alg");
+    cert_hash = get_json_const_string_from_first_key(jwk, "x5t#S256");
+    if (alg == NULL || cert_hash == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "JWK is missing required attributes.\n");
+        goto done;
+    }
+
+    signature_template = json_pack("{s:{s:s, s:s, s:s}}",
+                                   "protected",
+                                   "alg", alg,
+                                   "typ", "JWT",
+                                   "x5t#S256", cert_hash);
+    if (signature_template == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to generate signature template.\n");
+        goto done;
+    }
+
+    if (!jose_jws_sig(NULL, payload, signature_template, jwk)) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to sign JWT.\n");
+        goto done;
+    }
+
+    if (json_unpack(payload, "{s:s, s:s, s:s}",
+                            "payload", &payload_str,
+                            "protected", &protected_str,
+                            "signature", &signature_str) != 0) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to extract JWT components.\n");
+        goto done;
+    }
+
+    jwt = talloc_asprintf(rest_ctx, "%s.%s.%s",
+                          protected_str, payload_str, signature_str);
+    if (jwt == NULL) {
+        DEBUG(SSSDBG_OP_FAILURE, "Failed to generate JWT string.\n");
+        goto done;
+    }
+
+done:
+    json_decref(signature_template);
+    json_decref(jwk);
+    json_decref(payload);
+
+    return jwt;
 }

--- a/src/oidc_child/oidc_child_util.h
+++ b/src/oidc_child/oidc_child_util.h
@@ -190,4 +190,10 @@ errno_t oidc_get_id(TALLOC_CTX *mem_ctx, enum oidc_cmd oidc_cmd,
                     const char *client_id, const char *client_secret,
                     const char *token_endpoint, const char *scope, char **out);
 
+/* libcrypto/oidc_child_get_jwk.c */
+errno_t get_jwk_from_pkcs12(TALLOC_CTX *mem_ctx,
+                            const uint8_t *der_blob, size_t der_size,
+                            const char *password,
+                            char **_jwk);
+
 #endif /* __OIDC_CHILD_UTIL_H__ */

--- a/src/oidc_child/oidc_child_util.h
+++ b/src/oidc_child/oidc_child_util.h
@@ -89,7 +89,9 @@ struct name_and_type_identifier {
 
 /* oidc_child_curl.c */
 struct rest_ctx *get_rest_ctx(TALLOC_CTX *mem_ctx, bool libcurl_debug,
-                              const char *ca_db);
+                              const char *ca_db,
+                              const char *pkcs12_client_creds,
+                              const char *key_passwd);
 
 const char *get_http_data(struct rest_ctx *rest_ctx);
 
@@ -188,6 +190,7 @@ errno_t oidc_get_id(TALLOC_CTX *mem_ctx, enum oidc_cmd oidc_cmd,
                     char *input, enum search_str_type input_type,
                     bool libcurl_debug, const char *ca_db,
                     const char *client_id, const char *client_secret,
+                    const char *pkcs12_client_creds,
                     const char *token_endpoint, const char *scope, char **out);
 
 /* libcrypto/oidc_child_get_jwk.c */

--- a/src/oidc_child/oidc_child_util.h
+++ b/src/oidc_child/oidc_child_util.h
@@ -45,6 +45,14 @@ enum search_str_type {
     TYPE_OBJECT_ID = 2
 };
 
+enum client_auth_method {
+    CAM_NONE = 0,
+    CAM_SECRET,
+    CAM_MTLS, /* RFC-8705 */
+    CAM_JWT,  /* RFC-7523 */
+    CAM_SENTINEL
+};
+
 struct rest_ctx;
 
 struct token_data {
@@ -91,6 +99,7 @@ struct name_and_type_identifier {
 struct rest_ctx *get_rest_ctx(TALLOC_CTX *mem_ctx, bool libcurl_debug,
                               const char *ca_db,
                               const char *pkcs12_client_creds,
+                              enum client_auth_method client_auth_method,
                               const char *key_passwd);
 
 const char *get_http_data(struct rest_ctx *rest_ctx);
@@ -133,6 +142,10 @@ errno_t do_http_request(struct rest_ctx *rest_ctx, const char *uri,
 
 errno_t do_http_request_json_data(struct rest_ctx *rest_ctx, const char *uri,
                                   const char *post_data, const char *token);
+
+const char *rest_ctx_get_pkcs12_client_creds(const struct rest_ctx *rest_ctx);
+
+const char *rest_ctx_get_key_passwd(const struct rest_ctx *rest_ctx);
 
 /* oidc_child_json.c */
 errno_t parse_openid_configuration(struct devicecode_ctx *dc_ctx);
@@ -184,6 +197,9 @@ errno_t add_posix_to_json_string_array(TALLOC_CTX *mem_ctx,
 
 json_t *token_data_to_json(struct devicecode_ctx *dc_ctx);
 
+char *get_jwt(struct rest_ctx *rest_ctx, const char *token_endpoint,
+              const char *client_id);
+
 /* oidc_child_id.c */
 errno_t oidc_get_id(TALLOC_CTX *mem_ctx, enum oidc_cmd oidc_cmd,
                     char *idp_type,
@@ -191,6 +207,7 @@ errno_t oidc_get_id(TALLOC_CTX *mem_ctx, enum oidc_cmd oidc_cmd,
                     bool libcurl_debug, const char *ca_db,
                     const char *client_id, const char *client_secret,
                     const char *pkcs12_client_creds,
+                    enum client_auth_method client_auth_method,
                     const char *token_endpoint, const char *scope, char **out);
 
 /* libcrypto/oidc_child_get_jwk.c */

--- a/src/tests/cmocka/test_cert_utils.c
+++ b/src/tests/cmocka/test_cert_utils.c
@@ -32,6 +32,7 @@
 #include "tests/cmocka/common_mock.h"
 #include "util/crypto/sss_crypto.h"
 #include "responder/ssh/ssh_private.h"
+#include "oidc_child/oidc_child_util.h"
 
 #ifdef HAVE_TEST_CA
 #include "tests/test_CA/SSSD_test_cert_pubsshkey_0001.h"
@@ -42,6 +43,8 @@
 #include "tests/test_CA/SSSD_test_cert_x509_0007.h"
 #include "tests/test_ECC_CA/SSSD_test_ECC_cert_pubsshkey_0001.h"
 #include "tests/test_ECC_CA/SSSD_test_ECC_cert_x509_0001.h"
+#include "tests/test_CA/SSSD_test_cert_pkcs12_0001.h"
+#include "tests/test_ECC_CA/SSSD_test_ECC_cert_pkcs12_0001.h"
 #else
 #define SSSD_TEST_CERT_0001 ""
 #define SSSD_TEST_CERT_SSH_KEY_0001 ""
@@ -51,6 +54,8 @@
 #define SSSD_TEST_CERT_SSH_KEY_0007 ""
 #define SSSD_TEST_ECC_CERT_0001 ""
 #define SSSD_TEST_ECC_CERT_SSH_KEY_0001 ""
+#define SSSD_TEST_PKCS12_0001 ""
+#define SSSD_TEST_ECC_PKCS12_0001 ""
 #endif
 
 /* When run under valgrind with --trace-children=yes we have to increase the
@@ -825,6 +830,48 @@ void test_cert_to_ssh_2keys_with_certmap_2_send(void **state)
     talloc_free(ev);
 }
 
+void test_get_jwk_from_pkcs12(void **state)
+{
+    int ret;
+    char *jwk = NULL;
+    uint8_t *pkcs12;
+    size_t pkcs12_size;
+    const char rsa_prefix[] = "{\"keys\":[{\"kty\":\"RSA\",";
+    const char ecc_prefix[] = "{\"keys\":[{\"kty\":\"EC\",";
+
+    struct test_state *ts = talloc_get_type_abort(*state, struct test_state);
+    assert_non_null(ts);
+    ts->done = false;
+
+    ret = get_jwk_from_pkcs12(ts, NULL, 0, NULL, &jwk);
+    assert_int_equal(ret, EINVAL);
+
+    pkcs12 = sss_base64_decode(ts, SSSD_TEST_PKCS12_0001, &pkcs12_size);
+    assert_non_null(pkcs12);
+
+    ret = get_jwk_from_pkcs12(ts, pkcs12, pkcs12_size, "123456", &jwk);
+    assert_int_equal(ret, EOK);
+    assert_non_null(jwk);
+    assert_true(strlen(jwk) > strlen(rsa_prefix));
+    assert_true(strncmp(jwk, rsa_prefix, strlen(rsa_prefix)) == 0);
+
+    talloc_free(pkcs12);
+    talloc_free(jwk);
+    jwk = NULL;
+
+    pkcs12 = sss_base64_decode(ts, SSSD_TEST_ECC_PKCS12_0001, &pkcs12_size);
+    assert_non_null(pkcs12);
+
+    ret = get_jwk_from_pkcs12(ts, pkcs12, pkcs12_size, "123456", &jwk);
+    assert_int_equal(ret, EOK);
+    assert_non_null(jwk);
+    assert_true(strlen(jwk) > strlen(ecc_prefix));
+    assert_true(strncmp(jwk, ecc_prefix, strlen(ecc_prefix)) == 0);
+
+    talloc_free(pkcs12);
+    talloc_free(jwk);
+}
+
 int main(int argc, const char *argv[])
 {
     poptContext pc;
@@ -863,6 +910,8 @@ int main(int argc, const char *argv[])
         cmocka_unit_test_setup_teardown(test_cert_to_ssh_2keys_with_certmap_send,
                                         setup, teardown),
         cmocka_unit_test_setup_teardown(test_cert_to_ssh_2keys_with_certmap_2_send,
+                                        setup, teardown),
+        cmocka_unit_test_setup_teardown(test_get_jwk_from_pkcs12,
                                         setup, teardown),
 #endif
     };

--- a/src/tests/system/tests/test_oidc_child.py
+++ b/src/tests/system/tests/test_oidc_child.py
@@ -21,6 +21,11 @@ args = (
     "--client-id=myclient --client-secret=ClientSecret123 --scope='profile'"
 )
 
+args_get_device_code = (
+    "--libcurl-debug -d 9 --logger=stderr "
+    "--get-device-code --issuer-url=https://master.keycloak.test:8443/auth/realms/master"
+)
+
 
 @pytest.mark.importance("critical")
 @pytest.mark.topology(KnownTopology.Keycloak)
@@ -112,3 +117,155 @@ def test_oidc_child__get_group_members(client: Client, keycloak: Keycloak):
     data = json.loads(out.stdout)
     assert data[0]["posixUsername"] == "user1"
     assert data[0]["posixObjectType"] == "user"
+
+
+@pytest.mark.importance("high")
+@pytest.mark.topology(KnownTopology.Keycloak)
+def test_oidc_child__get_device_code(client: Client, keycloak: Keycloak):
+    """
+    :title: Authenticate with default settings
+    :setup:
+        1. no specific setup needed
+    :steps:
+        1. Request device code with oidc_child
+    :expectedresults:
+        1. oidc_child is successful and device code and other data is returned
+    :customerscenario: False
+    """
+
+    out = client.host.conn.run(
+        oidc_child_path + " " + args_get_device_code + " " + "--client-id=myclient --client-secret=ClientSecret123"
+    )
+    data = json.loads(out.stdout_lines[0])
+    assert "device_code" in data, "Missing device_code!"
+    assert "expires_in" in data, "Missing expires_in!"
+    assert "interval" in data, "Missing interval!"
+
+    assert out.stdout_lines[1][:8] == "oauth2 {", "Second line does not start with 'oauth2 {'!"
+    data = json.loads(out.stdout_lines[1][7:])
+    assert "verification_uri" in data, "Missing verification_uri!"
+    assert "user_code" in data, "Missing user_code"
+
+
+@pytest.mark.parametrize("key_type", ["RSA", "EC"])
+@pytest.mark.importance("high")
+@pytest.mark.topology(KnownTopology.Keycloak)
+def test_oidc_child__get_device_code_jwt(client: Client, keycloak: Keycloak, key_type: str):
+    """
+    :title: Authenticate with default settings
+    :setup:
+        1. Create certificate, key and PKCS#12 file
+        2. Create JWT client in Keycloak with certificate
+    :steps:
+        1. Request device code with oidc_child with JWT client authentication
+    :expectedresults:
+        1. oidc_child is successful and device code and other data is returned
+    :customerscenario: False
+    """
+
+    p12_pwd = "Secret123"
+    p12_path = "/tmp/my.p12"
+
+    key, cert = client.smartcard.generate_cert(key_type=key_type)
+
+    client.host.conn.run(f"openssl pkcs12 -export -password pass:{p12_pwd} -inkey {key} -in {cert}  -out {p12_path}")
+    out = client.host.conn.run(f"openssl x509 -in {cert} -outform der | openssl base64 -A")
+    cert_b64 = out.stdout
+
+    # Create an IdP JWT client
+    keycloak.host.kclogin()
+    keycloak.host.conn.run(
+        "/opt/keycloak/bin/kcadm.sh create clients -r master "
+        '-b \'{"clientId": "my_jwt_client", "clientAuthenticatorType": "client-jwt", '
+        '"serviceAccountsEnabled": true, '
+        '"attributes": {"oauth2.device.authorization.grant.enabled": "true", '
+        f'"jwt.credential.certificate": "{cert_b64}"}}}}\' '
+    )
+
+    out = client.host.conn.run(
+        oidc_child_path
+        + " "
+        + args_get_device_code
+        + " "
+        + f"--client-id=my_jwt_client --client-secret={p12_pwd} --pkcs12-client-creds={p12_path} "
+        + "--client-auth-method=jwt"
+    )
+    data = json.loads(out.stdout_lines[0])
+    assert "device_code" in data, "Missing device_code!"
+    assert "expires_in" in data, "Missing expires_in!"
+    assert "interval" in data, "Missing interval!"
+
+    assert out.stdout_lines[1][:8] == "oauth2 {", "Second line does not start with 'oauth2 {'!"
+    data = json.loads(out.stdout_lines[1][7:])
+    assert "verification_uri" in data, "Missing verification_uri!"
+    assert "user_code" in data, "Missing user_code"
+
+
+@pytest.mark.parametrize("key_type", ["RSA", "EC"])
+@pytest.mark.importance("high")
+@pytest.mark.topology(KnownTopology.Keycloak)
+def test_oidc_child__get_device_code_mtls(client: Client, keycloak: Keycloak, key_type: str):
+    """
+    :title: Authenticate with default settings
+    :setup:
+        1. Create certificate, key and PKCS#12 file
+        2. Let keycloak trust the client certificate
+        3. Enable HTTPS client authentication in Keycloak
+        4. Create MTLS client in Keycloak with the subject DN of the certificate
+    :steps:
+        1. Request device code with oidc_child with MTLS client authentication
+    :expectedresults:
+        1. oidc_child is successful and device code and other data is returned
+    :customerscenario: False
+    """
+
+    p12_pwd = "Secret123"
+    p12_path = "/tmp/my.p12"
+
+    key, cert = client.smartcard.generate_cert(key_type=key_type)
+
+    client.host.conn.run(f"openssl pkcs12 -export -password pass:{p12_pwd} -inkey {key} -in {cert}  -out {p12_path}")
+    out = client.host.conn.run(f"openssl x509 -in {cert} -noout -subject")
+    assert out.stdout[:8] == "subject=", "Unexpected output!"
+    subject_dn = out.stdout[8:]
+    cert_content = client.host.fs.read(cert)
+
+    # Add client certificate to Keycloak's kestore
+    keycloak.fs.write(cert, cert_content)
+    keycloak.host.conn.run(
+        "keytool -storepass Secret123 -keystore /var/data/certs/master.keycloak.test.keystore -noprompt "
+        + f"-importcert -file {cert} -alias mtls"
+    )
+    keycloak.svc.restart("keycloak.service")
+
+    # Create an IdP MTLS client
+    keycloak.host.kclogin()
+    keycloak.host.conn.run(
+        "/opt/keycloak/bin/kcadm.sh create clients -r master "
+        '-b \'{"clientId": "my_mtls_client", "clientAuthenticatorType": "client-x509", '
+        '"serviceAccountsEnabled": true, '
+        '"attributes": {"oauth2.device.authorization.grant.enabled": "true", '
+        f'"x509.subjectdn": "{subject_dn}"}}}}\' '
+    )
+
+    out = client.host.conn.run(
+        oidc_child_path
+        + " "
+        + args_get_device_code
+        + " "
+        + f"--client-id=my_mtls_client --client-secret={p12_pwd} --pkcs12-client-creds={p12_path} "
+        + "--client-auth-method=mtls"
+    )
+    # Currently the keystore is not restored by the framework
+    keycloak.host.conn.run(
+        "keytool -storepass Secret123 -keystore /var/data/certs/master.keycloak.test.keystore -delete -alias mtls"
+    )
+    data = json.loads(out.stdout_lines[0])
+    assert "device_code" in data, "Missing device_code!"
+    assert "expires_in" in data, "Missing expires_in!"
+    assert "interval" in data, "Missing interval!"
+
+    assert out.stdout_lines[1][:8] == "oauth2 {", "Second line does not start with 'oauth2 {'!"
+    data = json.loads(out.stdout_lines[1][7:])
+    assert "verification_uri" in data, "Missing verification_uri!"
+    assert "user_code" in data, "Missing user_code"

--- a/src/tests/test_CA/Makefile.am
+++ b/src/tests/test_CA/Makefile.am
@@ -36,6 +36,7 @@ certs_h = $(addprefix SSSD_test_cert_x509_,$(addsuffix .h,$(ids)))
 pubkeys = $(addprefix SSSD_test_cert_pubsshkey_,$(addsuffix .pub,$(ids)))
 pubkeys_h = $(addprefix SSSD_test_cert_pubsshkey_,$(addsuffix .h,$(ids)))
 pkcs12 = $(addprefix SSSD_test_cert_pkcs12_,$(addsuffix .pem,$(ids)))
+pkcs12_h = $(addprefix SSSD_test_cert_pkcs12_,$(addsuffix .h,$(ids)))
 
 
 extra = softhsm2_none softhsm2_one softhsm2_two softhsm2_2tokens softhsm2_ocsp softhsm2_2certs_same_id softhsm2_pss_one softhsm2_revoked SSSD_test_cert_x509_0001.der SSSD_test_cert_x509_0007.der
@@ -53,7 +54,7 @@ endif
 # If openssl is run in parallel there might be conflicts with the serial
 .NOTPARALLEL:
 
-ca_all: clean serial SSSD_test_CA.pem $(certs) $(certs_h) $(pubkeys) $(pubkeys_h) $(pkcs12) $(extra)
+ca_all: clean serial SSSD_test_CA.pem $(certs) $(certs_h) $(pubkeys) $(pubkeys_h) $(pkcs12) $(pkcs12_h) $(extra)
 
 $(pwdfile):
 	@echo "123456" > $@
@@ -120,6 +121,9 @@ SSSD_test_cert_x509_%.h: SSSD_test_cert_x509_%.pem
 
 SSSD_test_cert_pubsshkey_%.h: SSSD_test_cert_pubsshkey_%.pub
 	@echo "#define SSSD_TEST_CERT_SSH_KEY_$* \""$(shell cut -d' ' -f2 $<)"\"" > $@
+
+SSSD_test_cert_pkcs12_%.h: SSSD_test_cert_pkcs12_%.pem
+	@echo "#define SSSD_TEST_PKCS12_$* \""$(shell cat $< | base64 -w 0)"\"" > $@
 
 SSSD_test_CA_expired_crl.pem:
 	$(FAKETIME) -f '-7d' $(OPENSSL) ca -gencrl -out $@ -keyfile $(openssl_ca_key) -config ${openssl_ca_config} -crlhours 1
@@ -259,7 +263,7 @@ CLEANFILES = \
     serial  serial.old  \
     SSSD_test_CA.pem $(pwdfile) SSSD_test_CA_expired_crl.pem \
     SSSD_test_CA_crl.pem \
-    $(certs) $(certs_h) $(pubkeys) $(pubkeys_h) $(pkcs12) \
+    $(certs) $(certs_h) $(pubkeys) $(pubkeys_h) $(pkcs12) $(pkcs12_h) \
     softhsm2_*.conf \
     SSSD_test_*.der \
     $(NULL)

--- a/src/tests/test_ECC_CA/Makefile.am
+++ b/src/tests/test_ECC_CA/Makefile.am
@@ -15,13 +15,14 @@ certs_h = $(addprefix SSSD_test_ECC_cert_x509_,$(addsuffix .h,$(ids)))
 pubkeys = $(addprefix SSSD_test_ECC_cert_pubsshkey_,$(addsuffix .pub,$(ids)))
 pubkeys_h = $(addprefix SSSD_test_ECC_cert_pubsshkey_,$(addsuffix .h,$(ids)))
 pkcs12 = $(addprefix SSSD_test_ECC_cert_pkcs12_,$(addsuffix .pem,$(ids)))
+pkcs12_h = $(addprefix SSSD_test_ECC_cert_pkcs12_,$(addsuffix .h,$(ids)))
 
 extra = softhsm2_ecc_one SSSD_test_ECC_crl.pem
 
 # If openssl is run in parallel there might be conflicts with the serial
 .NOTPARALLEL:
 
-ca_all: clean serial SSSD_test_ECC_crl.pem $(certs) $(certs_h) $(pubkeys) $(pubkeys_h) $(pkcs12) $(extra)
+ca_all: clean serial SSSD_test_ECC_crl.pem $(certs) $(certs_h) $(pubkeys) $(pubkeys_h) $(pkcs12) $(pkcs12_h) $(extra)
 
 $(pwdfile):
 	@echo "123456" > $@
@@ -51,6 +52,9 @@ SSSD_test_ECC_cert_x509_%.h: SSSD_test_ECC_cert_x509_%.pem
 SSSD_test_ECC_cert_pubsshkey_%.h: SSSD_test_ECC_cert_pubsshkey_%.pub
 	@echo "#define SSSD_TEST_ECC_CERT_SSH_KEY_$* \""$(shell cut -d' ' -f2 $<)"\"" > $@
 
+SSSD_test_ECC_cert_pkcs12_%.h: SSSD_test_ECC_cert_pkcs12_%.pem
+	@echo "#define SSSD_TEST_ECC_PKCS12_$* \""$(shell cat $< | base64 -w 0)"\"" > $@
+
 SSSD_test_ECC_crl.pem: $(openssl_ecc_ca_key) SSSD_test_ECC_CA.pem
 	$(OPENSSL) ca -gencrl -out $@ -keyfile $(openssl_ecc_ca_key) -config $(openssl_ecc_ca_config) -crldays 99999
 
@@ -71,7 +75,7 @@ CLEANFILES = \
     index.txt.attr.old  index.txt.old \
     serial  serial.old  \
     SSSD_test_ECC_CA.pem SSSD_test_ECC_crl.pem $(pwdfile) \
-    $(certs) $(certs_h) $(pubkeys) $(pubkeys_h) $(pkcs12) \
+    $(certs) $(certs_h) $(pubkeys) $(pubkeys_h) $(pkcs12) $(pkcs12_h) \
     softhsm2_*.conf \
     $(NULL)
 


### PR DESCRIPTION
With the new option --client-auth-method oidc_child can select between
authentication with a client secret, mutual-TLS/mTLS (RFC-8705) and JWT
client assertion (RFC-7523). The latter require a PKCS#12 file with the
client credentials (certificate and private key) and the password to
unlock the private key must be provided with the --client-secret or
--client-secret-stdin option.