### PR TITLE
sdap: defer libldap global options setup to first connection

### DIFF
--- a/src/providers/ad/ad_init.c
+++ b/src/providers/ad/ad_init.c
@@ -372,15 +372,6 @@ static errno_t ad_init_misc(struct be_ctx *be_ctx,
         /* Continue without DNS updates */
     }
 
-    setup_ldap_debug(sdap_id_ctx->opts->basic);
-
-    ret = setup_tls_config(sdap_id_ctx->opts->basic);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to get TLS options [%d]: %s\n",
-              ret, sss_strerror(ret));
-        return ret;
-    }
-
     ret = sdap_idmap_init(sdap_id_ctx, sdap_id_ctx,
                           &sdap_id_ctx->opts->idmap_ctx);
     if (ret != EOK) {

--- a/src/providers/ipa/ipa_init.c
+++ b/src/providers/ipa/ipa_init.c
@@ -500,15 +500,6 @@ static errno_t ipa_init_auth_ctx(TALLOC_CTX *mem_ctx,
     }
     ipa_options->auth_ctx->sdap_auth_ctx = sdap_auth_ctx;
 
-    setup_ldap_debug(sdap_auth_ctx->opts->basic);
-
-    ret = setup_tls_config(sdap_auth_ctx->opts->basic);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "setup_tls_config failed [%d]: %s\n",
-              ret, sss_strerror(ret));
-        goto done;
-    }
-
     /* Initialize features needed by the krb5_child */
     ret = krb5_child_init(krb5_auth_ctx, be_ctx);
     if (ret != EOK) {
@@ -555,15 +546,6 @@ static errno_t ipa_init_misc(struct be_ctx *be_ctx,
     ret = ipa_init_dyndns(be_ctx, ipa_options);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to init dyndns [%d]: %s\n",
-              ret, sss_strerror(ret));
-        return ret;
-    }
-
-    setup_ldap_debug(sdap_id_ctx->opts->basic);
-
-    ret = setup_tls_config(sdap_id_ctx->opts->basic);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to get TLS options [%d]: %s\n",
               ret, sss_strerror(ret));
         return ret;
     }

--- a/src/providers/ldap/ldap_init.c
+++ b/src/providers/ldap/ldap_init.c
@@ -179,15 +179,6 @@ static errno_t ldap_init_misc(struct be_ctx *be_ctx,
         }
     }
 
-    setup_ldap_debug(options->basic);
-
-    ret = setup_tls_config(options->basic);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to get TLS options [%d]: %s\n",
-              ret, sss_strerror(ret));
-        return ret;
-    }
-
     /* Setup the ID mapping object */
     ret = sdap_idmap_init(id_ctx, id_ctx, &options->idmap_ctx);
     if (ret != EOK) {

--- a/src/providers/ldap/sdap.c
+++ b/src/providers/ldap/sdap.c
@@ -843,7 +843,7 @@ static void sss_ldap_debug(const char *buf)
                 "libldap: %s", buf);
 }
 
-void setup_ldap_debug(struct dp_option *basic_opts)
+static void setup_ldap_debug(struct dp_option *basic_opts)
 {
     int ret;
     int ldap_debug_level;
@@ -875,7 +875,7 @@ void setup_ldap_debug(struct dp_option *basic_opts)
     }
 }
 
-errno_t setup_tls_config(struct dp_option *basic_opts)
+static errno_t setup_tls_config(struct dp_option *basic_opts)
 {
     int ret;
     int ldap_opt_x_tls_require_cert;
@@ -969,6 +969,31 @@ errno_t setup_tls_config(struct dp_option *basic_opts)
         }
     }
 
+    return EOK;
+}
+
+errno_t sdap_setup_libldap_global_options(struct dp_option *basic_opts)
+{
+    static bool done = false;
+    errno_t ret;
+
+    if (done) {
+        return EOK;
+    }
+
+    if (basic_opts == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "'basic_opts' are NULL\n");
+        return EINVAL;
+    }
+
+    setup_ldap_debug(basic_opts);
+
+    ret = setup_tls_config(basic_opts);
+    if (ret != EOK) {
+        return ret;
+    }
+
+    done = true;
     return EOK;
 }
 

--- a/src/providers/ldap/sdap.h
+++ b/src/providers/ldap/sdap.h
@@ -672,9 +672,7 @@ errno_t sdap_parse_deref(TALLOC_CTX *mem_ctx,
                          LDAPDerefRes *dref,
                          struct sdap_deref_attrs ***_deref_res);
 
-void setup_ldap_debug(struct dp_option *basic_opts);
-
-errno_t setup_tls_config(struct dp_option *basic_opts);
+errno_t sdap_setup_libldap_global_options(struct dp_option *basic_opts);
 
 int sdap_set_rootdse_supported_lists(struct sysdb_attrs *rootdse,
                                      struct sdap_handle *sh);

--- a/src/providers/ldap/sdap_async_connection.c
+++ b/src/providers/ldap/sdap_async_connection.c
@@ -119,6 +119,14 @@ struct tevent_req *sdap_connect_send(TALLOC_CTX *memctx,
 
     timeout = dp_opt_get_int(state->opts->basic, SDAP_NETWORK_TIMEOUT);
 
+    ret = sdap_setup_libldap_global_options(state->opts->basic);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "sdap_setup_libldap_global_options failed [%d]: %s\n",
+              ret, sss_strerror(ret));
+        goto fail;
+    }
+
     subreq = sss_ldap_init_send(state, ev, state->uri, sockaddr,
                                 sockaddr_len, timeout);
     if (subreq == NULL) {


### PR DESCRIPTION
During initialization LDAP/AD/IPA backends unconditionally call `setup_tls_config()` and `setup_ldap_debug()` that call `ldap_set_option()`. This triggers `ldap_int_initialize()` -> `getaddrinfo(local_hostname)`. If DNS is unresponsive, this blocks and the backend doesn't complete initialization in time, so that 'monitor' terminates the entire SSSD.

Move these calls out of the module init path into a new `sdap_setup_libldap_global_options()` wrapper guarded by a static bool. Call it from `sdap_connect_send()` just before `sss_ldap_init_send()`, which is the single entry point for all LDAP connections.

:fixes:Fixed an issue where SSSD fails to start when DNS is unresponsive.

Assisted-By: Claude Code (Opus 4.6)