### PR TITLE
Fix: sss_analyze.py modified to print correct command in usage field

### DIFF
--- a/src/tools/analyzer/sss_analyze.py
+++ b/src/tools/analyzer/sss_analyze.py
@@ -72,7 +72,8 @@ class Analyzer:
         """
         # top level parser
         formatter = argparse.RawTextHelpFormatter
-        parser = argparse.ArgumentParser(description='Analyzer tool to assist '
+        parser = argparse.ArgumentParser(prog='sssctl analyze',
+                                         description='Analyzer tool to assist '
                                          'with SSSD log parsing',
                                          formatter_class=formatter)
         parser.add_argument('--source', default='files', choices=['files',


### PR DESCRIPTION
Explanation: This patch will make sure to print correct command i.e. `sssctl analyze` in **usage** field on running `sssctl analyze --help` command avoiding confusion.

Resolves: https://github.com/SSSD/sssd/issues/8718