### PR TITLE
ci: update passkey TMT plan for native CentOS Stream 10 execution

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -52,20 +52,7 @@ jobs:
       - upstream
     targets:
       - fedora-all
-
-  # Use fedora-latest as host for centos-10 tests due to memory constraints
-  # that cause swapping issues with centos-10 containers on centos hosts
-  - job: tests
-    trigger: pull_request
-    identifier: "centos-stream-10"
-    packages:
-      - upstream
-    targets:
-      - fedora-latest
-    tf_extra_params:
-      environments:
-        - variables:
-            CONTAINER_TARGET: "centos-10"
+      - centos-stream-10
 
   # Create Fedora pull request on release
   - job: propose_downstream

--- a/plans/passkey.fmf
+++ b/plans/passkey.fmf
@@ -6,10 +6,8 @@ tag: passkey
 
 provision:
     how: virtual
-    # Testing Farm provides a maximum of 4GB RAM,
-    # but 16GB allows smoother operation by avoiding memory swap
-    # when running locally or if memory limits increase
-    memory: 16384
+    hardware:
+      memory: ">= 16 GB"
 
 prepare:
     - name: Install general dependencies

--- a/plans/passkey.fmf
+++ b/plans/passkey.fmf
@@ -10,6 +10,13 @@ provision:
       memory: ">= 16 GB"
 
 prepare:
+    - name: Enable EPEL repository for CentOS Stream
+      how: shell
+      script: |
+        if grep -q "CentOS Stream" /etc/os-release 2>/dev/null; then
+          dnf install -y epel-release
+        fi
+
     - name: Install general dependencies
       how: install
       package:
@@ -31,11 +38,13 @@ prepare:
           ln -sf $(command -v podman-compose) /usr/local/bin/docker-compose
         fi
 
-    - name: Install and load kernel module for passkey testing
+    - name: Install and load kernel module for passkey testing on Fedora
       how: shell
       script: |
-        dnf install -y kernel-modules-extra-$(uname -r)
-        modprobe vhci_hcd
+        if grep -q "^ID=fedora" /etc/os-release 2>/dev/null; then
+          dnf install -y kernel-modules-extra-$(uname -r)
+          modprobe vhci_hcd
+        fi
 
     - name: Clone sssd
       how: shell
@@ -76,11 +85,11 @@ prepare:
         setsebool container_manage_cgroup true
         cp env.example .env
 
-        # Use CONTAINER_TARGET from packit if provided, otherwise use Fedora
-        if [ -n "$CONTAINER_TARGET" ]; then
-            CONTAINER_TAG="$CONTAINER_TARGET"
+        # Detect system distribution and set appropriate container tag
+        . /tmp/sssd/contrib/ci/distro.sh
+        if [ "$DISTRO_ID" = "centos" ]; then
+            CONTAINER_TAG="centos-$DISTRO_RELEASE"
         else
-            . /tmp/sssd/contrib/ci/distro.sh
             CONTAINER_TAG="fedora-$DISTRO_RELEASE"
         fi
         echo "Using container tag: $CONTAINER_TAG"
@@ -142,7 +151,9 @@ prepare:
 
         echo "Using COPR repo: $COPR_REPO"
 
-        if [[ "$CONTAINER_TARGET" == "centos-10" ]]; then
+        # Detect system distribution and set appropriate COPR command
+        . /tmp/sssd/contrib/ci/distro.sh
+        if [ "$DISTRO_ID" = "centos" ] && [ "$DISTRO_RELEASE" = "10" ]; then
           COPR_ENABLE_CMD="dnf copr enable -y $COPR_REPO centos-stream-10-x86_64"
         else
           COPR_ENABLE_CMD="dnf copr enable -y $COPR_REPO"

--- a/plans/passkey.fmf
+++ b/plans/passkey.fmf
@@ -154,7 +154,7 @@ prepare:
         ssh -i /tmp/sssd-ci-containers/data/ssh-keys/root.id_rsa \
             -o StrictHostKeyChecking=no \
             root@client.test "
-          $COPR_ENABLE_CMD
+          $COPR_ENABLE_CMD && \
           dnf upgrade -y --refresh sssd*
         "
 
@@ -162,7 +162,7 @@ prepare:
         ssh -i /tmp/sssd-ci-containers/data/ssh-keys/root.id_rsa \
             -o StrictHostKeyChecking=no \
             root@master.ipa.test "
-          $COPR_ENABLE_CMD
+          $COPR_ENABLE_CMD && \
           dnf upgrade -y --refresh sssd*
         "
 


### PR DESCRIPTION
* With 16GB RAM allocation, CentOS Stream 10 tests can now run directly on matching VM and containers. Thus, update distribution detection to use `distro.sh` script.
* If COPR_ENABLE_CMD fails, the script will now fail immediately instead of proceeding to dnf upgrade with packages from default repositories, ensuring tests run against the correct SSSD version. Reported in https://github.com/SSSD/sssd/pull/8728#discussion_r3298109673