### PR TITLE
sssd_be needs to elevate CAP_DAC_READ_SEARCH to read TLS certificates

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -687,7 +687,7 @@ install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/sssd.conf
 %{_tmpfilesdir}/%{name}.conf
 
 %dir %{_libexecdir}/%{servicename}
-%{_libexecdir}/%{servicename}/sssd_be
+%attr(0750,root,sssd) %caps(cap_dac_read_search=p) %{_libexecdir}/%{servicename}/sssd_be
 %{_libexecdir}/%{servicename}/sssd_nss
 %attr(0750,root,sssd) %caps(cap_dac_read_search=p) %{_libexecdir}/%{servicename}/sssd_pam
 %{_libexecdir}/%{servicename}/sssd_autofs

--- a/src/providers/ldap/sdap_async_connection.c
+++ b/src/providers/ldap/sdap_async_connection.c
@@ -405,8 +405,16 @@ static void sdap_connect_done(struct sdap_op *op,
         return;
     }
 
+    // Elevate to read the certificates
+    if (sss_set_cap_effective(CAP_DAC_READ_SEARCH, true) != 0) {
+        DEBUG(SSSDBG_IMPORTANT_INFO, "Failed to elevate CAP_DAC_READ_SEARCH to effective set\n");
+    }
+
 /* FIXME: take care that ldap_install_tls might block */
     ret = ldap_install_tls(state->sh->ldap);
+    if (sss_set_cap_effective(CAP_DAC_READ_SEARCH, false) != 0) {
+        DEBUG(SSSDBG_IMPORTANT_INFO, "Failed to drop CAP_DAC_READ_SEARCH from effective set\n");
+    }
     if (ret != LDAP_SUCCESS) {
         sss_ldap_error_debug(SSSDBG_MINOR_FAILURE, "ldap_install_tls failed",
                              state->sh->ldap, ret);
@@ -2412,7 +2420,14 @@ static int synchronous_tls_setup(LDAP *ldap)
         goto done;
     }
 
+    // Elevate to read the certificates
+    if (sss_set_cap_effective(CAP_DAC_READ_SEARCH, true) != 0) {
+        DEBUG(SSSDBG_IMPORTANT_INFO, "Failed to elevate CAP_DAC_READ_SEARCH to effective set\n");
+    }
     lret = ldap_install_tls(ldap);
+    if (sss_set_cap_effective(CAP_DAC_READ_SEARCH, false) != 0) {
+        DEBUG(SSSDBG_IMPORTANT_INFO, "Failed to drop CAP_DAC_READ_SEARCH from effective set\n");
+    }
     if (lret != LDAP_SUCCESS) {
         sss_ldap_error_debug(SSSDBG_MINOR_FAILURE, "ldap_install_tls failed",
                              ldap, lret);

--- a/src/util/sss_ldap.c
+++ b/src/util/sss_ldap.c
@@ -278,7 +278,16 @@ static void sss_ldap_init_sys_connect_done(struct tevent_req *subreq)
 
     if (ldap_is_ldaps_url(state->uri)) {
         ticks_before_install = get_watchdog_ticks();
+
+        // Elevate to read the certificates
+        if (sss_set_cap_effective(CAP_DAC_READ_SEARCH, true) != 0) {
+            DEBUG(SSSDBG_IMPORTANT_INFO, "Failed to elevate CAP_DAC_READ_SEARCH to effective set\n");
+        }
         lret = ldap_install_tls(state->ldap);
+        if (sss_set_cap_effective(CAP_DAC_READ_SEARCH, false) != 0) {
+            DEBUG(SSSDBG_IMPORTANT_INFO, "Failed to drop CAP_DAC_READ_SEARCH from effective set\n");
+        }
+
         ticks_after_install = get_watchdog_ticks();
         if (lret != LDAP_SUCCESS) {
             if (lret == LDAP_LOCAL_ERROR) {


### PR DESCRIPTION
Now that sssd drops all capabilities it is not possible to establish the TLS connection if the user running sssd can't access the certificates. For example, if sssd runs as `sssd` and certificates are owned by `root`:

```
id_provider = ldap
auth_provider = ldap

ldap_uri = ldaps://ldap.atest.net:636
ldap_tls_reqcert = demand
ldap_tls_cert = <client cert owned by other user>
ldap_tls_key = <client key owned by other user>
ldap_tls_cacert = <ca cert owned by other user>
```

Fails with:
```
[be[atest.net]] [sss_ldap_debug] (0x4000): libldap: ldap_create
[be[atest.net]] [sss_ldap_debug] (0x4000): libldap: ldap_url_parse_ext(ldaps://ldap.atest.net:636)
[be[atest.net]] [sss_ldap_debug] (0x4000): libldap: ldap_new_connection 1 0 0
[be[atest.net]] [sss_ldap_debug] (0x4000): libldap: TLS: could not use certificate file `<REDACTED, path to client cert>'.
[be[atest.net]] [sss_ldap_debug] (0x4000): libldap: TLS: error:0200100D:system library:fopen:Permission denied crypto/bio/bss_file.c:288
[be[atest.net]] [sss_ldap_debug] (0x4000): libldap: TLS: error:20074002:BIO routines:file_ctrl:system lib crypto/bio/bss_file.c:290
[be[atest.net]] [sss_ldap_debug] (0x4000): libldap: TLS: error:140DC002:SSL routines:use_certificate_chain_file:system lib ssl/ssl_rsa.c:596
[be[atest.net]] [sss_ldap_debug] (0x4000): libldap: ldap_err2string
[be[atest.net]] [sss_ldap_init_sys_connect_done] (0x0020): ldap_install_tls failed: [Connect error] [unknown error]
[be[atest.net]] [sss_ldap_init_state_destructor] (0x0400): calling ldap_unbind_ext for ldap:[0x55cc7f337d00] sd:[19]
```

The first patch elevates `CAP_DAC_READ_SEARCH` just to establish the TLS connection.

The second patch adjusts the spec file to set the file capability for `sssd_be` binary.