### PR TITLE
Tests: Update LdapOperations to fail on bind immediately

### DIFF
--- a/src/tests/multihost/sssd/testlib/common/utils.py
+++ b/src/tests/multihost/sssd/testlib/common/utils.py
@@ -1218,8 +1218,11 @@ class LdapOperations(object):
         self.uri = uri if not port else '%s:%s' % (uri, port)
         self.binddn = binddn
         self.bindpw = bindpw
-        self.conn = ldap.initialize(uri)
+        self.conn = ldap.initialize(self.uri)
         self.conn = self.bind()
+        if isinstance(self.conn, tuple):
+            raise LdapException("Failed to bind to ldap server, Error: %s"
+                                % self.conn[0])
 
     def bind(self):
         """ Bind to ldap server


### PR DESCRIPTION
## Summary
- fail fast in `LdapOperations.__init__` when LDAP bind fails, raising `LdapException` instead of keeping a tuple in `self.conn`
- initialize LDAP using `self.uri` so optional custom port values are honored
- avoid later misleading runtime errors such as `'tuple' object has no attribute 'modify_s'` and surface the real bind problem early