### PR TITLE
sssd man-page: Improve man-page for override_gid

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -3785,7 +3785,12 @@ pam_json_services = gdm-switchable-auth
                     <term>override_gid (integer)</term>
                     <listitem>
                         <para>
-                            Override the primary GID value with the one specified.
+                            Override the primary GID value for all users in the
+                            domain with specified value.
+                        </para>
+                        <para>
+                            Default: not set (Use the primary GID value retrieved
+                            from the identity provider)
                         </para>
                     </listitem>
                 </varlistentry>


### PR DESCRIPTION
This commit improves the man-page statement for override_gid option by adding clear description & "Default" value.

Resolves: https://github.com/SSSD/sssd/issues/7341