### PR TITLE
sssd man-page: Improve FILE FORMAT section

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -39,7 +39,10 @@
 
         <para>
             The data types used are string (no quotes needed), integer
-            and bool (with values of <quote>TRUE/FALSE</quote>).
+            and boolean (with values of <quote>TRUE/FALSE</quote>).
+            Boolean values are case-insensitive; for example, <quote>TRUE</quote>,
+            <quote>True</quote> and <quote>true</quote> are all equivalent and
+            valid; the same applies to <quote>FALSE</quote>.
         </para>
 
         <para>


### PR DESCRIPTION
This commit will improve FILE FORMAT section in sssd.conf(5)
man-page to clarify that boolean values are case-insensitive.
Values such as TRUE, True, and true are all equivalent and
valid which explains why available options under sssd.conf
man-page show different formats for "Default" values.

Resolves: https://github.com/SSSD/sssd/issues/7345