### PR TITLE
Avoid int overflow after year 2038

### DIFF
--- a/src/db/sysdb_sudo.c
+++ b/src/db/sysdb_sudo.c
@@ -674,7 +674,7 @@ static errno_t sysdb_sudo_get_refresh_time(struct sss_domain_info *domain,
         goto done;
     }
 
-    *value = ldb_msg_find_attr_as_int(res->msgs[0], attr_name, 0);
+    *value = (time_t)ldb_msg_find_attr_as_uint64(res->msgs[0], attr_name, 0);
 
     ret = EOK;
 

--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -306,19 +306,19 @@ static void sss_krb5_expire_callback_func(krb5_context context, void *data,
 {
     int ret;
     uint32_t *blob;
-    long exp_time;
+    long long exp_time;
     struct krb5_req *kr = talloc_get_type(data, struct krb5_req);
 
     if (password_expiration == 0) {
         return;
     }
 
-    exp_time = password_expiration - time(NULL);
+    exp_time = (long long)(uint32_t)password_expiration - (long long)time(NULL);
     if (exp_time < 0 || exp_time > UINT32_MAX) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Time to expire out of range.\n");
         return;
     }
-    DEBUG(SSSDBG_TRACE_INTERNAL, "exp_time: [%ld]\n", exp_time);
+    DEBUG(SSSDBG_TRACE_INTERNAL, "exp_time: [%lld]\n", exp_time);
 
     blob = talloc_array(kr->pd, uint32_t, 2);
     if (blob == NULL) {

--- a/src/providers/ldap/ldap_child.c
+++ b/src/providers/ldap/ldap_child.c
@@ -775,7 +775,7 @@ static krb5_error_code ldap_child_get_tgt_sync(TALLOC_CTX *memctx,
 
     krberr = 0;
     *ccname_out = talloc_steal(memctx, ccname);
-    *expire_time_out = my_creds.times.endtime - kdc_time_offset;
+    *expire_time_out = (time_t)(uint32_t)my_creds.times.endtime - kdc_time_offset;
 
 done:
     krb5_get_init_creds_opt_free(context, options);

--- a/src/responder/kcm/kcm_renew.c
+++ b/src/responder/kcm/kcm_renew.c
@@ -558,10 +558,10 @@ static errno_t kcm_creds_check_times(TALLOC_CTX *mem_ctx,
     int ret;
 
     memset(&tgtt, 0, sizeof(tgtt));
-    tgtt.authtime = creds->times.authtime;
-    tgtt.starttime = creds->times.starttime;
-    tgtt.endtime = creds->times.endtime;
-    tgtt.renew_till = creds->times.renew_till;
+    tgtt.authtime = (uint32_t)creds->times.authtime;
+    tgtt.starttime = (uint32_t)creds->times.starttime;
+    tgtt.endtime = (uint32_t)creds->times.endtime;
+    tgtt.renew_till = (uint32_t)creds->times.renew_till;
 
     now = time(NULL);
     /* Attempt renewal only after half of the ticket lifetime has exceeded */


### PR DESCRIPTION
We interpret krb5 timestamps as `uint32_t`
as recommended in
https://web.mit.edu/kerberos/krb5-devel/doc/appdev/refs/types/krb5_timestamp.html to make the code work until year 2106.

note: I only tested that it compiles and passes tests now. Without this patch, I observed failures in `test_sysdb_sudo` and `test_sudo_set_get_last_full_refresh` with negative epoch values in the output.

This patch was done while reviewing potential year-2038 issues in openSUSE.