### PR TITLE
sssd man-page: Add reference to FAILOVER section

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -3678,8 +3678,24 @@ pam_json_services = gdm-switchable-auth
                         </para>
                         <para>
                             Please see the section <quote>FAILOVER</quote>
-                            for more information about the service
-                            resolution.
+                            in
+                            <citerefentry>
+                                <refentrytitle>sssd-ldap</refentrytitle>
+                                <manvolnum>5</manvolnum>
+                            </citerefentry>,
+                            <citerefentry>
+                                <refentrytitle>sssd-krb5</refentrytitle>
+                                <manvolnum>5</manvolnum>
+                            </citerefentry>,
+                            <citerefentry>
+                                <refentrytitle>sssd-ipa</refentrytitle>
+                                <manvolnum>5</manvolnum>
+                           </citerefentry> or
+                            <citerefentry>
+                                <refentrytitle>sssd-ad</refentrytitle>
+                                <manvolnum>5</manvolnum>
+                            </citerefentry> for more information about the
+                            service resolution.
                         </para>
                         <para>
                             Default: 1000
@@ -3698,8 +3714,24 @@ pam_json_services = gdm-switchable-auth
                         </para>
                         <para>
                             Please see the section <quote>FAILOVER</quote>
-                            for more information about the service
-                            resolution.
+                            in
+                            <citerefentry>
+                                <refentrytitle>sssd-ldap</refentrytitle>
+                                <manvolnum>5</manvolnum>
+                            </citerefentry>,
+                            <citerefentry>
+                                <refentrytitle>sssd-krb5</refentrytitle>
+                                <manvolnum>5</manvolnum>
+                            </citerefentry>,
+                            <citerefentry>
+                                <refentrytitle>sssd-ipa</refentrytitle>
+                                <manvolnum>5</manvolnum>
+                            </citerefentry> or
+                            <citerefentry>
+                                <refentrytitle>sssd-ad</refentrytitle>
+                                <manvolnum>5</manvolnum>
+                            </citerefentry> for more information about the
+                            service resolution.
                         </para>
                         <para>
                             Default: 3
@@ -3719,8 +3751,24 @@ pam_json_services = gdm-switchable-auth
                         </para>
                         <para>
                             Please see the section <quote>FAILOVER</quote>
-                            for more information about the service
-                            resolution.
+                            in
+                            <citerefentry>
+                                <refentrytitle>sssd-ldap</refentrytitle>
+                                <manvolnum>5</manvolnum>
+                            </citerefentry>,
+                            <citerefentry>
+                                <refentrytitle>sssd-krb5</refentrytitle>
+                                <manvolnum>5</manvolnum>
+                            </citerefentry>,
+                            <citerefentry>
+                                <refentrytitle>sssd-ipa</refentrytitle>
+                                <manvolnum>5</manvolnum>
+                            </citerefentry> or
+                            <citerefentry>
+                                <refentrytitle>sssd-ad</refentrytitle>
+                                <manvolnum>5</manvolnum>
+                            </citerefentry> for more information about the
+                            service resolution.
                         </para>
                         <para>
                             Default: 6


### PR DESCRIPTION
Currently, FAILOVER section is not available in sssd.conf(5) man-page. This patch improves the statement about FAILOVER section mentioning its availability in other man-pages for example sssd-ldap(5).

Resolves: https://github.com/SSSD/sssd/issues/7339