### PR TITLE
ci: Add review-rules.md for gemini to ignore autobackports

### DIFF
--- a/.gemini/review-rules.md
+++ b/.gemini/review-rules.md
@@ -1,0 +1,10 @@
+# Gemini Code Review Guidelines
+
+## Scope and Exclusions
+
+### 1. Automated Backport Pull Requests
+- **Rule:** Do not perform code reviews, generate summaries, or post comments on pull requests or merge requests that contain the phrase `autobackport` in the name of the pull request or branch.
+- **Action:** If the name matches `*autobackport*`, immediately halt the automated review process and output a passive acknowledgment if required, without executing deep code analysis.
+
+### 2. Contextual Exception
+- Only provide a review on an `autobackport` if explicitly and manually commanded by a user prompt tagging you directly. Otherwise, default to skipping the review entirely.


### PR DESCRIPTION
Gemini has different findings for main PR and for autobackports creating a lot of noise. The autobackports are done after the main pr is merged so it it already late to implement changes directly without creating a new PR addressing the findings.