### PR TITLE
resolv: Fix incorrect variable used in ares_parse_txt_reply() error c…

### DIFF
--- a/src/resolv/async_resolv.c
+++ b/src/resolv/async_resolv.c
@@ -2118,7 +2118,7 @@ resolv_gettxt_done(void *arg, int status, int timeouts, unsigned char *abuf, int
     }
 
     ret = ares_parse_txt_reply(abuf, alen, &reply_list);
-    if (status != ARES_SUCCESS) {
+    if (ret != ARES_SUCCESS) {
         DEBUG(SSSDBG_OP_FAILURE,
               "TXT record parsing failed: %d: %s\n", ret, ares_strerror(ret));
         ret = return_code(ret);


### PR DESCRIPTION
  In src/resolv/async_resolv.c, the error handling for ares_parse_txt_reply() checks the wrong variable. After calling ares_parse_txt_reply(), the result is stored in ret, but the code incorrectly checks status
  (a previously used variable) instead.