### PR TITLE
Update/autoskip tests in image mode.

### DIFF
--- a/src/tests/system/tests/test_cache.py
+++ b/src/tests/system/tests/test_cache.py
@@ -43,6 +43,9 @@ def test_cache__entries_are_refreshed_as_configured(client: Client, provider: LD
         2. Objects 'lastUpdate' timestamp value has been refreshed
     :customerscenario: False
     """
+    if not client.fs.exists("/usr/bin/ldbsearch"):
+        pytest.skip("/usr/bin/ldbsearch is not available, skipping test")
+
     user = provider.user("test_user").add()
     provider.group("test_group").add().add_member(user)
     provider.netgroup("test_netgroup").add().add_member(user=user)
@@ -110,6 +113,9 @@ def test_cache__writes_to_both_database_files(client: Client, provider: LDAP):
         4. User found
     :customerscenario: False
     """
+    if not client.fs.exists("/usr/bin/ldbsearch"):
+        pytest.skip("/usr/bin/ldbsearch is not available, skipping test")
+
     provider.user("user1").add()
     client.sssd.start()
     client.tools.getent.passwd("user1")
@@ -143,6 +149,9 @@ def test_cache__writes_to_both_database_files_when_using_fully_qualified_names(c
         3. User found
     :customerscenario: False
     """
+    if not client.fs.exists("/usr/bin/ldbsearch"):
+        pytest.skip("/usr/bin/ldbsearch is not available, skipping test")
+
     provider.user("user1").add()
     client.sssd.domain["use_fully_qualified_names"] = "True"
     client.sssd.start()
@@ -269,6 +278,9 @@ def test_cache__invalidate_entries_in_domain_and_timestamps_caches(
         3. Attribute is found and the value is '[1]' meaning it is cleared
     :customerscenario: False
     """
+    if not client.fs.exists("/usr/bin/ldbsearch"):
+        pytest.skip("/usr/bin/ldbsearch is not available, skipping test")
+
     # Unable to parametrize provider method when adding objects, so all object types are created
     user = provider.user("user").add()
     provider.group("group").add().add_member(user)
@@ -320,6 +332,9 @@ def test_cache__extra_attributes_are_stored(client: Client, provider: LDAP):
         2. User is found and cache contains correct attributes and values
     :customerscenario: True
     """
+    if not client.fs.exists("/usr/bin/ldbsearch"):
+        pytest.skip("/usr/bin/ldbsearch is not available, skipping test")
+
     provider.user("user1").add(gid=111111, uid=100110, gecos="gecos user1", shell="/bin/sh", home="/home/user1")
     client.sssd.domain["ldap_user_extra_attrs"] = (
         "description:gecos, userID:uidNumber, shell:loginShell, groupID:gidNumber"
@@ -359,6 +374,9 @@ def test_cache__extra_attributes_with_empty_values_are_ignored(client: Client, p
         2. User is found and does not have the extra numbers attribute
     :customerscenario: False
     """
+    if not client.fs.exists("/usr/bin/ldbsearch"):
+        pytest.skip("/usr/bin/ldbsearch is not available, skipping test")
+
     provider.user("user1").add()
     client.sssd.domain["ldap_user_extra_attrs"] = "number:telephonenumber"
     client.sssd.start()
@@ -394,6 +412,9 @@ def test_cache__both_ldap_user_email_and_extra_attribute_email_are_stored(client
         2. User is found with description, mail and email attributes
     :customerscenario: False
     """
+    if not client.fs.exists("/usr/bin/ldbsearch"):
+        pytest.skip("/usr/bin/ldbsearch is not available, skipping test")
+
     ldap.user("user1").add(gecos="gecos1", mail="user1@example.test")
 
     client.sssd.domain["ldap_user_email"] = "mail"

--- a/src/tests/system/tests/test_nss.py
+++ b/src/tests/system/tests/test_nss.py
@@ -497,4 +497,8 @@ def test_nss__user_login_with_overriding_home_directory(client: Client, provider
     with client.ssh("user1", "Secret123") as ssh:
         result = ssh.run("pwd").stdout
         assert result is not None, "Getting path failed!"
-        assert result == home_exp, f"Current path {result} is not {home_exp}!"
+        # In image mode, the home prefix is /var/home
+        assert result in (
+            home_exp,
+            f"/var{home_exp}",
+        ), f"Current path {result} is neither {home_exp} nor /var{home_exp}!"

--- a/src/tests/system/tests/test_passkey.py
+++ b/src/tests/system/tests/test_passkey.py
@@ -391,6 +391,8 @@ def test_passkey__lookup_user_from_cache(
         2. Successfully get the user from ldbsearch command.
     :customerscenario: False
     """
+    if not client.fs.exists("/usr/bin/ldbsearch"):
+        pytest.skip("/usr/bin/ldbsearch is not available, skipping test")
 
     suffix = type(provider).__name__.lower()
 

--- a/src/tests/system/tests/test_sss_override.py
+++ b/src/tests/system/tests/test_sss_override.py
@@ -263,7 +263,7 @@ def test_sss_override__root_user_cannot_be_used(client: Client, provider: Generi
 @pytest.mark.preferred_topology(KnownTopology.LDAP)
 def test_sss_override__export_then_import_override_data(client: Client, provider: GenericProvider):
     """
-        :title: Export then  import override data
+    :title: Export then  import override data
     :setup:
         1. Create user, groups and start SSSD
         2. Create user and group overrides and restart SSSD
@@ -280,6 +280,9 @@ def test_sss_override__export_then_import_override_data(client: Client, provider
     :customerscenario: False
     :requirement: IDM-SSSD-TC: ldap_provider: local_overrides: import export user override
     """
+    if not client.fs.exists("/usr/bin/ldbsearch"):
+        pytest.skip("/usr/bin/ldbsearch is not available, skipping test")
+
     provider.user("user1").add(
         uid=999011, gid=999011, home="/home/user1", gecos="user", shell="/bin/bash", password="Secret123"
     )


### PR DESCRIPTION
Skip tests using lbsearch when it is not available.
For home override test allow prefix /var/home used in image mode.