### PR TITLE
enable file caching in OpenSC

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -1563,6 +1563,31 @@ pam_account_locked_message = Account locked, please contact help desk.
                         <para>
                             Default: False
                         </para>
+                        <para>
+                            Note: In case OpenSC is used for Smartcard access
+                            SSSD supports the filesystem caching in OpenSC when
+                            enabled in opensc.conf. The cached files are located
+                            in a common <quote>opensc</quote> directory in SSSD's state directory.
+                            The behaviour can be changed in opensc.conf
+                        </para>
+                        <para>
+                            Example opensc.conf (*):
+                            <programlisting>
+app /usr/libexec/sssd/p11_child {
+        framework pkcs15 {
+                use_file_caching = no;
+        }
+}
+app /usr/libexec/sssd/krb5_child {
+        framework pkcs15 {
+                use_file_caching = no;
+        }
+}
+                            </programlisting>
+                        </para>
+                        <para>
+                            (*) The actual <quote>libexec</quote> directory for p11_child and krb5_child depends on the distribution.
+                        </para>
                     </listitem>
                 </varlistentry>
                 <varlistentry>

--- a/src/p11_child/p11_child_common.c
+++ b/src/p11_child/p11_child_common.c
@@ -316,6 +316,15 @@ int main(int argc, const char *argv[])
           "Running with real IDs [%"SPRIuid"][%"SPRIgid"].\n",
           getuid(), getgid());
 
+    /* Caching for smartcard.
+     * OpenSC benefits from this by a factor of 10. */
+    ret = setenv("XDG_CACHE_HOME", SSS_STATEDIR, 1);
+    if (ret != 0) {
+        /* Log, but do not abort -- authentication can (slower) continue. */
+        DEBUG(SSSDBG_MINOR_FAILURE,
+              "Cannot set XDG_CACHE_HOME (%s).\n", strerror(errno));
+    }
+
     main_ctx = talloc_new(NULL);
     if (main_ctx == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "talloc_new failed.\n");

--- a/src/providers/krb5/krb5_child.c
+++ b/src/providers/krb5/krb5_child.c
@@ -4403,6 +4403,17 @@ int main(int argc, const char *argv[])
 
     sss_drop_all_caps();
 
+    /* In case of smartcard setup caching.
+     * OpenSC benefits from this by a factor of 10. */
+    if (IS_SC_AUTHTOK(kr->pd->authtok)) {
+        ret = setenv("XDG_CACHE_HOME", SSS_STATEDIR, 1);
+        if (ret != 0) {
+            /* Log, but do not abort -- authentication can (slower) continue. */
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "Cannot set XDG_CACHE_HOME (%s).\n", strerror(errno));
+        }
+    }
+
     /* For PKINIT we might need access to the pcscd socket which by default
      * is only allowed for authenticated users. Since PKINIT is part of
      * the authentication and the user is not authenticated yet, we have


### PR DESCRIPTION
OpenSC sets `use_file_caching`  to public. The speedup by file caching is around the factor of 10. Current sssd does not benefit from this speedup, leading to poor performance for smartcards.

This patch:

- enables file caching in OpenSC by exporting XDG_CACHE_HOME
- places the OpenSC cache to SSS_STATEDIR

Issue  #8743
