### PR TITLE
New `SSS_NSS_GETORIGBYUSERNAME_WITH_GROUPS` 'sss_client' command

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1386,7 +1386,7 @@ libsss_nss_idmap_la_LIBADD = \
     $(NULL)
 libsss_nss_idmap_la_LDFLAGS = \
     -Wl,--version-script,$(srcdir)/src/sss_client/idmap/sss_nss_idmap.exports \
-    -version-info 6:1:6
+    -version-info 7:0:7
 
 dist_noinst_DATA += src/sss_client/idmap/sss_nss_idmap.exports
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1390,7 +1390,7 @@ libsss_nss_idmap_la_LIBADD = \
     $(NULL)
 libsss_nss_idmap_la_LDFLAGS = \
     -Wl,--version-script,$(srcdir)/src/sss_client/idmap/sss_nss_idmap.exports \
-    -version-info 6:1:6
+    -version-info 7:0:7
 
 dist_noinst_DATA += src/sss_client/idmap/sss_nss_idmap.exports
 

--- a/src/responder/nss/nss_cmd.c
+++ b/src/responder/nss/nss_cmd.c
@@ -1246,6 +1246,179 @@ static errno_t sss_nss_cmd_getorigbygroupname(struct cli_ctx *cli_ctx)
     return sss_nss_cmd_getorigbyname_common(cli_ctx, CACHE_REQ_GROUP_BY_NAME);
 }
 
+struct sss_nss_getorigbyusername_wg_state {
+    struct sss_nss_cmd_ctx *cmd_ctx;
+    struct cache_req_result *user_result;
+};
+
+static void sss_nss_getorigbyusername_wg_user_done(struct tevent_req *subreq);
+static void sss_nss_getorigbyusername_wg_initgr_done(struct tevent_req *subreq);
+
+static errno_t
+sss_nss_cmd_getorigbyusername_with_groups(struct cli_ctx *cli_ctx)
+{
+    struct cache_req_data *data;
+    struct sss_nss_cmd_ctx *cmd_ctx;
+    struct sss_nss_ctx *nss_ctx;
+    struct tevent_req *subreq;
+    const char *rawname;
+    const char **attrs;
+    errno_t ret;
+    static const char *cache_attrs[] = { SYSDB_NAME,
+                                         SYSDB_OBJECTCATEGORY,
+                                         SYSDB_SID_STR,
+                                         SYSDB_DEFAULT_ATTRS,
+                                         NULL };
+
+    cmd_ctx = sss_nss_cmd_ctx_create(cli_ctx, cli_ctx, CACHE_REQ_USER_BY_NAME,
+                                     sss_nss_protocol_fill_orig);
+    if (cmd_ctx == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    cmd_ctx->include_initgroups = true;
+
+    ret = sss_nss_protocol_parse_name(cli_ctx, &rawname);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Invalid request message!\n");
+        goto done;
+    }
+
+    DEBUG(SSSDBG_TRACE_FUNC, "Input name: %s\n", rawname);
+
+    nss_ctx = talloc_get_type(cli_ctx->rctx->pvt_ctx, struct sss_nss_ctx);
+
+    ret = add_strings_lists_ex(cmd_ctx, cache_attrs,
+                               nss_ctx->full_attribute_list,
+                               false, true, &attrs);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Unable to concatenate attributes [%d]: %s\n",
+              ret, sss_strerror(ret));
+        ret = ENOMEM;
+        goto done;
+    }
+
+    data = cache_req_data_name_attrs(cmd_ctx, CACHE_REQ_USER_BY_NAME,
+                                     rawname, attrs);
+    if (data == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to set cache request data!\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    subreq = sss_nss_get_object_send(cmd_ctx, cli_ctx->ev, cli_ctx,
+                                     data, SSS_MC_NONE, rawname, 0);
+    if (subreq == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "sss_nss_get_object_send() failed\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    tevent_req_set_callback(subreq, sss_nss_getorigbyusername_wg_user_done,
+                            cmd_ctx);
+
+    ret = EOK;
+
+done:
+    if (ret != EOK) {
+        talloc_free(cmd_ctx);
+        return sss_nss_protocol_done(cli_ctx, ret);
+    }
+
+    return EOK;
+}
+
+static void
+sss_nss_getorigbyusername_wg_user_done(struct tevent_req *subreq)
+{
+    struct sss_nss_getorigbyusername_wg_state *state;
+    struct sss_nss_cmd_ctx *cmd_ctx;
+    struct cache_req_result *result;
+    struct tevent_req *initgr_req;
+    const char *name;
+    errno_t ret;
+
+    cmd_ctx = tevent_req_callback_data(subreq, struct sss_nss_cmd_ctx);
+
+    ret = sss_nss_get_object_recv(cmd_ctx, subreq, &result, &cmd_ctx->rawname);
+    talloc_zfree(subreq);
+    if (ret != EOK) {
+        sss_nss_protocol_done(cmd_ctx->cli_ctx, ret);
+        goto done;
+    }
+
+    if (result->count != 1) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Unexpected number of results [%u], expected [1].\n",
+              result->count);
+        sss_nss_protocol_done(cmd_ctx->cli_ctx, EINVAL);
+        goto done;
+    }
+
+    state = talloc_zero(cmd_ctx, struct sss_nss_getorigbyusername_wg_state);
+    if (state == NULL) {
+        sss_nss_protocol_done(cmd_ctx->cli_ctx, ENOMEM);
+        goto done;
+    }
+    state->cmd_ctx = cmd_ctx;
+    state->user_result = result;
+
+    name = ldb_msg_find_attr_as_string(result->msgs[0], SYSDB_NAME, NULL);
+    if (name == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Missing user name in result.\n");
+        sss_nss_protocol_done(cmd_ctx->cli_ctx, EINVAL);
+        goto done;
+    }
+
+    initgr_req = cache_req_initgr_by_name_send(state, cmd_ctx->cli_ctx->ev,
+                                cmd_ctx->cli_ctx->rctx,
+                                cmd_ctx->cli_ctx->rctx->ncache,
+                                cmd_ctx->nss_ctx->cache_refresh_percent,
+                                CACHE_REQ_POSIX_DOM,
+                                result->domain->name, name);
+    if (initgr_req == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "cache_req_send() failed\n");
+        sss_nss_protocol_done(cmd_ctx->cli_ctx, ENOMEM);
+        goto done;
+    }
+
+    tevent_req_set_callback(initgr_req,
+                            sss_nss_getorigbyusername_wg_initgr_done,
+                            state);
+    return;
+
+done:
+    talloc_free(cmd_ctx);
+}
+
+static void
+sss_nss_getorigbyusername_wg_initgr_done(struct tevent_req *subreq)
+{
+    struct sss_nss_getorigbyusername_wg_state *state;
+    struct sss_nss_cmd_ctx *cmd_ctx;
+    errno_t ret;
+
+    state = tevent_req_callback_data(subreq,
+                                     struct sss_nss_getorigbyusername_wg_state);
+    cmd_ctx = state->cmd_ctx;
+
+    ret = cache_req_initgr_by_name_recv(state, subreq, NULL);
+    talloc_zfree(subreq);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_MINOR_FAILURE,
+              "Initgroups cache refresh failed [%d]: %s, "
+              "skipping group memberships in response.\n",
+              ret, sss_strerror(ret));
+        cmd_ctx->include_initgroups = false;
+    }
+
+    sss_nss_protocol_reply(cmd_ctx->cli_ctx, cmd_ctx->nss_ctx, cmd_ctx,
+                           state->user_result, cmd_ctx->fill_fn);
+
+    talloc_free(cmd_ctx);
+}
 
 static errno_t sss_nss_cmd_getnamebycert(struct cli_ctx *cli_ctx)
 {
@@ -1389,6 +1562,7 @@ struct sss_cmd_table *get_sss_nss_cmds(void)
         { SSS_NSS_GETIDBYSID, sss_nss_cmd_getidbysid },
         { SSS_NSS_GETORIGBYNAME, sss_nss_cmd_getorigbyname },
         { SSS_NSS_GETORIGBYUSERNAME, sss_nss_cmd_getorigbyusername },
+        { SSS_NSS_GETORIGBYUSERNAME_WITH_GROUPS, sss_nss_cmd_getorigbyusername_with_groups },
         { SSS_NSS_GETORIGBYGROUPNAME, sss_nss_cmd_getorigbygroupname },
         { SSS_NSS_GETNAMEBYCERT, sss_nss_cmd_getnamebycert },
         { SSS_NSS_GETLISTBYCERT, sss_nss_cmd_getlistbycert },

--- a/src/responder/nss/nss_cmd.c
+++ b/src/responder/nss/nss_cmd.c
@@ -241,7 +241,8 @@ static errno_t sss_nss_getby_svc(struct cli_ctx *cli_ctx,
                                  data, SSS_MC_NONE, NULL, 0);
     if (subreq == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "sss_nss_get_object_send() failed\n");
-        return ENOMEM;
+        ret = ENOMEM;
+        goto done;
     }
 
     tevent_req_set_callback(subreq, sss_nss_getby_done, cmd_ctx);

--- a/src/responder/nss/nss_protocol.h
+++ b/src/responder/nss/nss_protocol.h
@@ -66,6 +66,9 @@ struct sss_nss_cmd_ctx {
 
     /* For SID lookups. */
     enum sss_id_type sid_id_type;
+
+    /* Include group memberships in getorigbyname response. */
+    bool include_initgroups;
 };
 
 /**

--- a/src/responder/nss/nss_protocol.h
+++ b/src/responder/nss/nss_protocol.h
@@ -127,6 +127,16 @@ sss_nss_protocol_parse_addr(struct cli_ctx *cli_ctx,
 			uint32_t *_addrlen,
 			uint8_t **_addr);
 
+/* Shared helper. */
+
+bool
+sss_nss_protocol_resolve_initgr_group(struct sss_nss_ctx *nss_ctx,
+                                      struct sss_domain_info *domain,
+                                      struct ldb_message *msg,
+                                      struct sss_domain_info **_grp_dom,
+                                      gid_t *_gid,
+                                      const char **_grp_name);
+
 /* Create response packet. */
 
 errno_t

--- a/src/responder/nss/nss_protocol_grent.c
+++ b/src/responder/nss/nss_protocol_grent.c
@@ -406,7 +406,6 @@ sss_nss_protocol_fill_initgr(struct sss_nss_ctx *nss_ctx,
     size_t body_len;
     size_t rp;
     gid_t gid;
-    const char *grp_name;
     gid_t orig_gid;
     errno_t ret;
     int i;
@@ -461,7 +460,7 @@ sss_nss_protocol_fill_initgr(struct sss_nss_ctx *nss_ctx,
     for (i = 1; i < result->count; i++) {
         if (!sss_nss_protocol_resolve_initgr_group(nss_ctx, domain,
                                                    result->msgs[i],
-                                                   &grp_dom, &gid, &grp_name)) {
+                                                   &grp_dom, &gid, NULL)) {
             continue;
         }
 

--- a/src/responder/nss/nss_protocol_grent.c
+++ b/src/responder/nss/nss_protocol_grent.c
@@ -337,6 +337,52 @@ static bool is_group_filtered(struct sss_nc_ctx *ncache,
     return false;
 }
 
+bool
+sss_nss_protocol_resolve_initgr_group(struct sss_nss_ctx *nss_ctx,
+                                      struct sss_domain_info *domain,
+                                      struct ldb_message *msg,
+                                      struct sss_domain_info **_grp_dom,
+                                      gid_t *_gid,
+                                      const char **_grp_name)
+{
+    struct sss_domain_info *grp_dom;
+    const char *posix;
+    gid_t gid;
+    const char *grp_name;
+
+    grp_dom = find_domain_by_msg(domain, msg);
+    gid = sss_view_ldb_msg_find_attr_as_uint64(grp_dom, msg, SYSDB_GIDNUM, 0);
+    posix = ldb_msg_find_attr_as_string(msg, SYSDB_POSIX, NULL);
+    grp_name = sss_view_ldb_msg_find_attr_as_string(grp_dom, msg, SYSDB_NAME,
+                                                    NULL);
+
+    if (gid == 0) {
+        if (posix != NULL && strcmp(posix, "FALSE") == 0) {
+            return false;
+        }
+        DEBUG(SSSDBG_MINOR_FAILURE,
+              "Incomplete group object [%s] for initgroups! "
+              "Skipping.\n", ldb_dn_get_linearized(msg->dn));
+        return false;
+    }
+
+    if (is_group_filtered(nss_ctx->rctx->ncache, grp_dom, grp_name, gid)) {
+        return false;
+    }
+
+    if (_grp_dom != NULL) {
+        *_grp_dom = grp_dom;
+    }
+    if (_gid != NULL) {
+        *_gid = gid;
+    }
+    if (_grp_name != NULL) {
+        *_grp_name = grp_name;
+    }
+
+    return true;
+}
+
 errno_t
 sss_nss_protocol_fill_initgr(struct sss_nss_ctx *nss_ctx,
                              struct sss_nss_cmd_ctx *cmd_ctx,
@@ -346,9 +392,7 @@ sss_nss_protocol_fill_initgr(struct sss_nss_ctx *nss_ctx,
     struct sss_domain_info *domain;
     struct sss_domain_info *grp_dom;
     struct ldb_message *user;
-    struct ldb_message *msg;
     struct ldb_message *primary_group_msg;
-    const char *posix;
     struct sized_string rawname;
     struct sized_string canonical_name;
     uint32_t num_results;
@@ -409,26 +453,9 @@ sss_nss_protocol_fill_initgr(struct sss_nss_ctx *nss_ctx,
     /* First message is user, skip it. */
     num_results = 0;
     for (i = 1; i < result->count; i++) {
-        msg = result->msgs[i];
-        grp_dom = find_domain_by_msg(domain, msg);
-        gid = sss_view_ldb_msg_find_attr_as_uint64(grp_dom, msg, SYSDB_GIDNUM,
-                                                   0);
-        posix = ldb_msg_find_attr_as_string(msg, SYSDB_POSIX, NULL);
-        grp_name = sss_view_ldb_msg_find_attr_as_string(grp_dom, msg, SYSDB_NAME,
-                                                        NULL);
-
-        if (gid == 0) {
-            if (posix != NULL && strcmp(posix, "FALSE") == 0) {
-                continue;
-            } else {
-                DEBUG(SSSDBG_MINOR_FAILURE,
-                      "Incomplete group object [%s] for initgroups! "
-                      "Skipping.\n", ldb_dn_get_linearized(msg->dn));
-                continue;
-            }
-        }
-
-        if (is_group_filtered(nss_ctx->rctx->ncache, grp_dom, grp_name, gid)) {
+        if (!sss_nss_protocol_resolve_initgr_group(nss_ctx, domain,
+                                                   result->msgs[i],
+                                                   &grp_dom, &gid, &grp_name)) {
             continue;
         }
 

--- a/src/responder/nss/nss_protocol_grent.c
+++ b/src/responder/nss/nss_protocol_grent.c
@@ -351,6 +351,12 @@ sss_nss_protocol_resolve_initgr_group(struct sss_nss_ctx *nss_ctx,
     const char *grp_name;
 
     grp_dom = find_domain_by_msg(domain, msg);
+    if (grp_dom == NULL) {
+        DEBUG(SSSDBG_MINOR_FAILURE,
+              "Could not determine domain for group [%s], skipping.\n",
+              ldb_dn_get_linearized(msg->dn));
+        return false;
+    }
     gid = sss_view_ldb_msg_find_attr_as_uint64(grp_dom, msg, SYSDB_GIDNUM, 0);
     posix = ldb_msg_find_attr_as_string(msg, SYSDB_POSIX, NULL);
     grp_name = sss_view_ldb_msg_find_attr_as_string(grp_dom, msg, SYSDB_NAME,

--- a/src/responder/nss/nss_protocol_sid.c
+++ b/src/responder/nss/nss_protocol_sid.c
@@ -359,7 +359,7 @@ sss_nss_protocol_fill_orig(struct sss_nss_ctx *nss_ctx,
 
     ret = sss_nss_get_id_type(cmd_ctx, result, &id_type);
     if (ret != EOK) {
-        return ret;
+        goto done;
     }
 
     if (nss_ctx->full_attribute_list != NULL) {

--- a/src/responder/nss/nss_protocol_sid.c
+++ b/src/responder/nss/nss_protocol_sid.c
@@ -19,6 +19,7 @@
 */
 
 #include "util/crypto/sss_crypto.h"
+#include "db/sysdb.h"
 #include "responder/nss/nss_protocol.h"
 
 static errno_t
@@ -323,6 +324,97 @@ static errno_t process_attr_list(TALLOC_CTX *mem_ctx, struct ldb_message *msg,
     return EOK;
 }
 
+static errno_t
+fill_orig_initgr_names(TALLOC_CTX *mem_ctx,
+                       struct sss_nss_ctx *nss_ctx,
+                       struct cache_req_result *result,
+                       struct sized_string **_keys,
+                       struct sized_string **_vals,
+                       size_t *array_size,
+                       size_t *sum,
+                       size_t *found)
+{
+    struct ldb_result *initgr_res = NULL;
+    struct sss_domain_info *domain;
+    struct sss_domain_info *grp_dom;
+    struct sized_string *keys;
+    struct sized_string *vals;
+    const char *grp_name;
+    const char *username;
+    char *fq_name;
+    size_t i;
+    errno_t ret;
+
+    domain = result->domain;
+    username = ldb_msg_find_attr_as_string(result->msgs[0], SYSDB_NAME, NULL);
+    if (username == NULL) {
+        DEBUG(SSSDBG_MINOR_FAILURE, "Missing user name, skipping initgroups.\n");
+        return EOK;
+    }
+
+    ret = sysdb_initgroups_with_views(mem_ctx, domain, username, &initgr_res);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_MINOR_FAILURE,
+              "sysdb_initgroups_with_views() failed [%d]: %s, "
+              "skipping group memberships.\n", ret, sss_strerror(ret));
+        return EOK;
+    }
+
+    if (initgr_res->count <= 1) {
+        talloc_free(initgr_res);
+        return EOK;
+    }
+
+    *array_size += initgr_res->count - 1;
+    keys = talloc_realloc(mem_ctx, *_keys, struct sized_string, *array_size);
+    if (keys == NULL) {
+        talloc_free(initgr_res);
+        return ENOMEM;
+    }
+    *_keys = keys;
+
+    vals = talloc_realloc(mem_ctx, *_vals, struct sized_string, *array_size);
+    if (vals == NULL) {
+        talloc_free(initgr_res);
+        return ENOMEM;
+    }
+    *_vals = vals;
+
+    /* First message is the user, skip it. */
+    for (i = 1; i < initgr_res->count; i++) {
+        if (!sss_nss_protocol_resolve_initgr_group(nss_ctx, domain,
+                                                   initgr_res->msgs[i],
+                                                   &grp_dom, NULL, &grp_name)) {
+            continue;
+        }
+
+        if (grp_name == NULL) {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "Group object [%s] has no name, skipping.\n",
+                  ldb_dn_get_linearized(initgr_res->msgs[i]->dn));
+            continue;
+        }
+
+        ret = sss_output_fqname(mem_ctx, grp_dom, grp_name,
+                                nss_ctx->rctx->override_space, &fq_name);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "sss_output_fqname() failed for group [%s], skipping.\n",
+                  grp_name);
+            continue;
+        }
+
+        to_sized_string(&keys[*found], SSS_NSS_ATTR_NAME_GROUP_MEMBERSHIP);
+        *sum += keys[*found].len;
+        to_sized_string(&vals[*found], fq_name);
+        *sum += vals[*found].len;
+        (*found)++;
+    }
+
+    talloc_free(initgr_res);
+    return EOK;
+}
+
 errno_t
 sss_nss_protocol_fill_orig(struct sss_nss_ctx *nss_ctx,
                            struct sss_nss_cmd_ctx *cmd_ctx,
@@ -387,6 +479,17 @@ sss_nss_protocol_fill_orig(struct sss_nss_ctx *nss_ctx,
         if (ret != EOK) {
             DEBUG(SSSDBG_OP_FAILURE, "process_attr_list failed.\n");
             goto done;
+        }
+    }
+
+    if (cmd_ctx->include_initgroups
+            && (id_type == SSS_ID_TYPE_UID || id_type == SSS_ID_TYPE_BOTH)) {
+        ret = fill_orig_initgr_names(tmp_ctx, nss_ctx, result,
+                                     &keys, &vals, &array_size,
+                                     &sum, &found);
+        if (ret != EOK) {
+            DEBUG(SSSDBG_MINOR_FAILURE,
+                  "Failed to add initgroups names, continuing without.\n");
         }
     }
 

--- a/src/sss_client/idmap/sss_nss_idmap.c
+++ b/src/sss_client/idmap/sss_nss_idmap.c
@@ -255,6 +255,7 @@ static int sss_nss_getyyybyxxx(union input inp, enum sss_cli_command cmd,
     case SSS_NSS_GETIDBYSID:
     case SSS_NSS_GETORIGBYNAME:
     case SSS_NSS_GETORIGBYUSERNAME:
+    case SSS_NSS_GETORIGBYUSERNAME_WITH_GROUPS:
     case SSS_NSS_GETORIGBYGROUPNAME:
         ret = sss_strnlen(inp.str, 2048, &inp_len);
         if (ret != EOK) {
@@ -385,6 +386,7 @@ static int sss_nss_getyyybyxxx(union input inp, enum sss_cli_command cmd,
         break;
     case SSS_NSS_GETORIGBYNAME:
     case SSS_NSS_GETORIGBYUSERNAME:
+    case SSS_NSS_GETORIGBYUSERNAME_WITH_GROUPS:
     case SSS_NSS_GETORIGBYGROUPNAME:
         ret = buf_to_kv_list(repbuf + DATA_START, data_len, &kv_list);
         if (ret != EOK) {
@@ -673,6 +675,24 @@ int sss_nss_getorigbyusername(const char *fq_name, struct sss_nss_kv **kv_list,
                              enum sss_id_type *type)
 {
     return sss_nss_getorigbyusername_timeout(fq_name, NO_TIMEOUT, kv_list, type);
+}
+
+int sss_nss_getorigbyusername_with_groups_timeout(const char *fq_name,
+                                                  unsigned int timeout,
+                                                  struct sss_nss_kv **kv_list,
+                                                  enum sss_id_type *type)
+{
+    return sss_nss_getorigbyname_timeout_common(fq_name, timeout,
+                                        SSS_NSS_GETORIGBYUSERNAME_WITH_GROUPS,
+                                        kv_list, type);
+}
+
+int sss_nss_getorigbyusername_with_groups(const char *fq_name,
+                                          struct sss_nss_kv **kv_list,
+                                          enum sss_id_type *type)
+{
+    return sss_nss_getorigbyusername_with_groups_timeout(fq_name, NO_TIMEOUT,
+                                                        kv_list, type);
 }
 
 int sss_nss_getorigbygroupname_timeout(const char *fq_name, unsigned int timeout,

--- a/src/sss_client/idmap/sss_nss_idmap.exports
+++ b/src/sss_client/idmap/sss_nss_idmap.exports
@@ -75,3 +75,10 @@ SSS_NSS_IDMAP_0.7.0 {
         sss_nss_getsidbygroupname;
         sss_nss_getsidbygroupname_timeout;
 } SSS_NSS_IDMAP_0.6.0;
+
+SSS_NSS_IDMAP_0.8.0 {
+    # public functions
+    global:
+        sss_nss_getorigbyusername_with_groups;
+        sss_nss_getorigbyusername_with_groups_timeout;
+} SSS_NSS_IDMAP_0.7.0;

--- a/src/sss_client/idmap/sss_nss_idmap.h
+++ b/src/sss_client/idmap/sss_nss_idmap.h
@@ -204,6 +204,27 @@ int sss_nss_getorigbyusername(const char *fq_name, struct sss_nss_kv **kv_list,
                               enum sss_id_type *type);
 
 /**
+ * @brief Find original data and group memberships by fully qualified user name
+ *
+ * Like sss_nss_getorigbyusername() but the returned kv_list also contains
+ * entries with key "groupMembership" (SSS_NSS_ATTR_NAME_GROUP_MEMBERSHIP)
+ * whose values are fully qualified names of the groups the user belongs to.
+ * The key may appear multiple times (once per group).
+ *
+ * @param[in] fq_name  Fully qualified name of a user
+ * @param[out] kv_list A NULL terminated list of key-value pairs where the key
+ *                     is the attribute name in the cache of SSSD,
+ *                     must be freed by the caller with sss_nss_free_kv()
+ * @param[out] type    Type of the object related to the given name
+ *
+ * @return
+ *  - see #sss_nss_getorigbyname
+ */
+int sss_nss_getorigbyusername_with_groups(const char *fq_name,
+                                          struct sss_nss_kv **kv_list,
+                                          enum sss_id_type *type);
+
+/**
  * @brief Find original data by fully qualified group name
  *
  * @param[in] fq_name  Fully qualified name of a group
@@ -278,8 +299,9 @@ void sss_nss_free_kv(struct sss_nss_kv *kv_list);
  *  This flag cannot be used together with SSS_NSS_EX_FLAG_NO_CACHE */
 #define SSS_NSS_EX_FLAG_INVALIDATE_CACHE (1 << 1)
 
-#ifdef IPA_389DS_PLUGIN_HELPER_CALLS
+#define SSS_NSS_ATTR_NAME_GROUP_MEMBERSHIP "groupMembership"
 
+#ifdef IPA_389DS_PLUGIN_HELPER_CALLS
 /**
  * @brief Return user information based on the user name
  *
@@ -574,6 +596,30 @@ int sss_nss_getorigbyname_timeout(const char *fq_name, unsigned int timeout,
 int sss_nss_getorigbyusername_timeout(const char *fq_name, unsigned int timeout,
                                       struct sss_nss_kv **kv_list,
                                       enum sss_id_type *type);
+
+/**
+ * @brief Find original data and group memberships by fully qualified user name
+ *        with timeout
+ *
+ * Like sss_nss_getorigbyusername_timeout() but the returned kv_list also
+ * contains entries with key "groupMembership" (SSS_NSS_ATTR_NAME_GROUP_MEMBERSHIP)
+ * whose values are fully qualified names of the groups the user belongs to.
+ * The key may appear multiple times (once per group).
+ *
+ * @param[in] fq_name  Fully qualified name of a user
+ * @param[in] timeout  timeout in milliseconds
+ * @param[out] kv_list A NULL terminated list of key-value pairs where the key
+ *                     is the attribute name in the cache of SSSD,
+ *                     must be freed by the caller with sss_nss_free_kv()
+ * @param[out] type    Type of the object related to the given name
+ *
+ * @return
+ *  - see #sss_nss_getorigbyname_timeout
+ */
+int sss_nss_getorigbyusername_with_groups_timeout(const char *fq_name,
+                                                  unsigned int timeout,
+                                                  struct sss_nss_kv **kv_list,
+                                                  enum sss_id_type *type);
 
 /**
  * @brief Find original data by fully qualified group name with timeout

--- a/src/sss_client/sss_cli.h
+++ b/src/sss_client/sss_cli.h
@@ -313,6 +313,10 @@ SSS_NSS_GETSIDBYGROUPNAME = 0x011D, /**< Takes a zero terminated fully qualified
                                      name and returns the zero terminated
                                      string representation of the SID of the
                                      group with the given name. */
+SSS_NSS_GETORIGBYUSERNAME_WITH_GROUPS = 0x011E, /**< Like GETORIGBYUSERNAME but
+                                     also includes groupMembership key-value
+                                     pairs with fully qualified group names
+                                     in the response. */
 
 
 /* subid */


### PR DESCRIPTION
New NSS responder command similar to `getorigbyusername()` but additionally
returns group membership names as key-value pairs in the response.

The IPA extdom plugin currently resolves user group memberships via N+2
NSS round-trips: getorigbyusername (1), getgrouplist (1), then getgrgid
per GID (N). New command returns "groupMembership" kv pairs with
fully qualified group names directly in the 'getorigbyusername_with_groups'
response, allowing to reduce the interaction to a single call.

New command handler uses a two-phase flow:
1. CACHE_REQ_USER_BY_NAME to fetch user attributes
2. CACHE_REQ_INITGROUPS to ensure group cache freshness

The fill function then reads groups from sysdb and appends them using
the shared `nss_protocol_resolve_initgr_group()` helper.