### PR TITLE
ci: Clear cache before installing built rpms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,10 @@ jobs:
                   ARG="--no-gpgchecks"
           fi
 
+          # Avoid error 'Lower version of database is expected!' for locally built installed rpms
+          systemctl stop sssd
+          rm -f /var/lib/sss/db/*
+
           dnf $ARG install -y /dev/shm/sssd/rpmbuild/RPMS/*/*.rpm
           rm -fr /dev/shm/sssd
 


### PR DESCRIPTION
`sssd-2-10` branch c10s system tests fail during setup/rpm install of SSSD on ipa and client containers. Container installation of sssd rpms built from checkout has this error:
```
Running scriptlet: sssd-common-2.10.2-0.el10.x86_64 88/88 
  Running scriptlet: python3-sss-murmur-2.13.0-1.el10.x86_64 88/88 
 Job for sssd.service failed because the control process exited with error code. 
 See "systemctl status sssd.service" and "journalctl -xeu sssd.service" for details.

```
```
Then subsequent Restarting SSSD on the IPA server step fails with
 Jun 10 17:59:56 master.ipa.test systemd[1]: Starting sssd.service - System Security Services Daemon... 
 Jun 10 17:59:56 master.ipa.test sssd[93420]: Starting up 
 Jun 10 17:59:56 master.ipa.test sssd[93420]: Lower version of database is expected! 
 Jun 10 17:59:56 master.ipa.test sssd[93420]: Removing cache files in /var/lib/sss/db should fix the issue, but note that removing cache files will also remove all of your cached credentials. 
 Jun 10 17:59:56 master.ipa.test systemd[1]: sssd.service: Main process exited, code=exited, status=10/n/a 
 Jun 10 17:59:56 master.ipa.test systemd[1]: sssd.service: Failed with result 'exit-code'. 
 Jun 10 17:59:56 master.ipa.test systemd[1]: Failed to start sssd.service - System Security Services Daemon.
```