### PR TITLE
sssd man-page: Add headings [ ] for all services 

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -827,7 +827,8 @@
             <title>NSS configuration options</title>
             <para>
                 These options can be used to configure the
-                Name Service Switch (NSS) service.
+                Name Service Switch (NSS) service and should be
+                specified under the <quote>[nss]</quote> section.
             </para>
             <variablelist>
                 <varlistentry>
@@ -1236,7 +1237,8 @@ fallback_homedir = /home/%u
             <title>PAM configuration options</title>
             <para>
                 These options can be used to configure the
-                Pluggable Authentication Module (PAM) service.
+                Pluggable Authentication Module (PAM) service and should be
+                specified under the <quote>[pam]</quote> section.
             </para>
             <variablelist>
                 <varlistentry>
@@ -1993,7 +1995,10 @@ pam_json_services = gdm-switchable-auth
         <refsect2 id='SUDO' condition="with_sudo">
             <title>SUDO configuration options</title>
             <para>
-                These options can be used to configure the sudo service.
+                These options can be used to configure the sudo service
+                and should be specified under the <quote>[sudo]</quote> section.
+            </para>
+            <para>
                 The detailed instructions for configuration of
                 <citerefentry>
                     <refentrytitle>sudo</refentrytitle>
@@ -2049,7 +2054,9 @@ pam_json_services = gdm-switchable-auth
         <refsect2 id='AUTOFS' condition="with_autofs">
             <title>AUTOFS configuration options</title>
             <para>
-                These options can be used to configure the autofs service.
+                These options can be used to configure the autofs service
+                and should be specified under the <quote>[autofs]</quote>
+                section.
             </para>
             <variablelist>
                 <varlistentry>
@@ -2074,7 +2081,9 @@ pam_json_services = gdm-switchable-auth
         <refsect2 id='SSH' condition="with_ssh">
             <title>SSH configuration options</title>
             <para>
-                These options can be used to configure the SSH service.
+                These options can be used to configure the SSH service
+                and should be specified under the <quote>[ssh]</quote>
+                section.
             </para>
             <variablelist>
                 <varlistentry>
@@ -2181,7 +2190,8 @@ pam_json_services = gdm-switchable-auth
                 </itemizedlist>
             </para>
             <para>
-                These options can be used to configure the PAC responder.
+                These options can be used to configure the PAC responder
+                and should be specified under the <quote>[pac]</quote> section.
             </para>
             <variablelist>
                 <varlistentry>
@@ -2361,7 +2371,9 @@ pam_json_services = gdm-switchable-auth
                 </citerefentry>.
             </para>
             <para>
-                These options can be used to configure session recording.
+                These options can be used to configure session recording
+                and should be specified under the
+                <quote>[session_recording]</quote> section.
             </para>
             <variablelist>
                 <varlistentry>


### PR DESCRIPTION
This patch adds headings enclosed in [ ] for all service
sections including session_recording, nss, pam, autofs,
ssh, pac, sudo in sssd.conf.

Resolves: https://github.com/SSSD/sssd/issues/7380