### PR TITLE
sssd-ipa man: Improvement in sssd-ipa(5) man-page

### DIFF
--- a/src/man/sssd-ipa.5.xml
+++ b/src/man/sssd-ipa.5.xml
@@ -253,7 +253,7 @@
                 </varlistentry>
 
                 <varlistentry>
-                    <term>dyndns_update_ptr (bool)</term>
+                    <term>dyndns_update_ptr (boolean)</term>
                     <listitem>
                         <para>
                             Whether the PTR record should also be explicitly
@@ -278,7 +278,7 @@
                 </varlistentry>
 
                 <varlistentry>
-                    <term>dyndns_force_tcp (bool)</term>
+                    <term>dyndns_force_tcp (boolean)</term>
                     <listitem>
                         <para>
                             Whether the nsupdate utility should default to using

--- a/src/man/sssd-ipa.5.xml
+++ b/src/man/sssd-ipa.5.xml
@@ -646,7 +646,7 @@
                 </varlistentry>
 
                 <varlistentry>
-                    <term>ipa_hbac_selinux (integer)</term>
+                    <term>ipa_selinux_refresh (integer)</term>
                     <listitem>
                         <para>
                             The amount of time between lookups of the SELinux

--- a/src/man/sssd-ipa.5.xml
+++ b/src/man/sssd-ipa.5.xml
@@ -138,11 +138,6 @@
                             <quote>dyndns_iface</quote> option.
                         </para>
                         <para>
-                            NOTE: On older systems (such as RHEL 5), for this
-                            behavior to work reliably, the default Kerberos
-                            realm must be set properly in /etc/krb5.conf
-                        </para>
-                        <para>
                             Default: false
                         </para>
                     </listitem>


### PR DESCRIPTION
Group CONFIGURATION OPTIONS by prefix (ipa, krb5, dyndns) to make the man page easier to read. Remove the obsolete RHEL 5 krb5.conf note and use (boolean) consistently for dyndns boolean options.
This patch also replaces `ipa_hbac_selinux` option (incorrect) in sssd-ipa(5) man-page with `ipa_selinux_refresh` (correct).

Resolves: https://github.com/SSSD/sssd/issues/8823