### PR TITLE
sssd.conf man: Improve explanation for cached_auth_timeout

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -4035,12 +4035,11 @@ subdomain_inherit = ldap_purge_cache_timeout
                     <term>cached_auth_timeout (int)</term>
                     <listitem>
                         <para>
-                            Specifies time in seconds since last successful
-                            online authentication for which user will be
-                            authenticated using cached credentials while
-                            SSSD is in the online mode. If the credentials
-                            are incorrect, SSSD falls back to online
-                            authentication.
+                            Specifies the number of seconds since the last successful
+                            online authentication during which SSSD will authenticate
+                            users via cached credentials, even while online.
+                            If the cached authentication fails, SSSD immediately
+                            falls back to online authentication.
                         </para>
                         <para>
                             This option's value is inherited by all trusted


### PR DESCRIPTION
This patch improves explanation for `cached_auth_timeout` option in sssd.conf(5) man-page providing clear context.

Resolves: https://github.com/SSSD/sssd/issues/7351