### PR TITLE
sssd man-page: Add Default for id_provider

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -3045,6 +3045,11 @@ pam_json_services = gdm-switchable-auth
                                 <manvolnum>5</manvolnum>
                             </citerefentry> for more information.
                         </para>
+                        <para>
+                            Default: Not set (This is a mandatory setting that
+                            must be explicitly defined for each configured
+                            domain).
+                        </para>
                     </listitem>
                 </varlistentry>
 


### PR DESCRIPTION
This patch adds 'Default' for id_provider in sssd.conf(5) along with a statement mentioning its mandatory nature.

Resolves: https://github.com/SSSD/sssd/issues/7335