### PR TITLE
man: Remove obsolete RHEL 5 krb5.conf note from sssd-ad

### DIFF
--- a/src/man/sssd-ad.5.xml
+++ b/src/man/sssd-ad.5.xml
@@ -1177,11 +1177,6 @@ ad_gpo_map_deny = +my_pam_service
                             by using the <quote>dyndns_iface</quote> option.
                         </para>
                         <para>
-                            NOTE: On older systems (such as RHEL 5), for this
-                            behavior to work reliably, the default Kerberos
-                            realm must be set properly in /etc/krb5.conf
-                        </para>
-                        <para>
                             Default: true
                         </para>
                     </listitem>


### PR DESCRIPTION
This patch removes the RHEL 5 reference from sssd-ad(5) man-page 
as it is no longer relevant in supported deployments.