### PR TITLE
Refactor backend to use only one return code instead of 3

### DIFF
--- a/src/providers/ad/ad_dyndns.c
+++ b/src/providers/ad/ad_dyndns.c
@@ -203,7 +203,7 @@ static void ad_dyndns_update_connect_done(struct tevent_req *subreq)
             DEBUG(SSSDBG_OP_FAILURE,
                   "Failed to connect to LDAP server: [%d](%s)\n",
                   ret, sss_strerror(ret));
-            tevent_req_error(req, ERR_NETWORK_IO);
+            tevent_req_error(req, ERR_SERVER_FAILURE);
         }
         return;
     }

--- a/src/providers/ad/ad_dyndns.c
+++ b/src/providers/ad/ad_dyndns.c
@@ -180,7 +180,6 @@ done:
 
 static void ad_dyndns_update_connect_done(struct tevent_req *subreq)
 {
-    int dp_error;
     int ret;
     struct tevent_req *req;
     struct ad_dyndns_update_state *state;
@@ -191,11 +190,14 @@ static void ad_dyndns_update_connect_done(struct tevent_req *subreq)
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct ad_dyndns_update_state);
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
+    ctx = state->ad_ctx;
+    sdap_ctx = ctx->id_ctx->sdap_id_ctx;
+
     if (ret != EOK) {
-        if (dp_error == DP_ERR_OFFLINE) {
+        if (ret == ERR_OFFLINE) {
             DEBUG(SSSDBG_MINOR_FAILURE, "No server is available, "
                   "dynamic DNS update is skipped in offline mode.\n");
             tevent_req_error(req, ERR_DYNDNS_OFFLINE);
@@ -207,9 +209,6 @@ static void ad_dyndns_update_connect_done(struct tevent_req *subreq)
         }
         return;
     }
-
-    ctx = state->ad_ctx;
-    sdap_ctx = ctx->id_ctx->sdap_id_ctx;
 
     ret = ldap_url_parse(ctx->service->sdap->uri, &lud);
     if (ret != LDAP_SUCCESS) {

--- a/src/providers/ad/ad_gpo.c
+++ b/src/providers/ad/ad_gpo.c
@@ -2283,7 +2283,6 @@ ad_gpo_target_dn_retrieval_done(struct tevent_req *subreq)
     struct ad_gpo_access_state *state;
     int ret;
     int dp_error;
-    int sdap_ret;
     const char *target_dn = NULL;
     uint32_t uac;
     static const char *host_attrs[] = { SYSDB_ORIG_DN, SYSDB_AD_USER_ACCOUNT_CONTROL, SYSDB_SID_STR, NULL };
@@ -2293,10 +2292,10 @@ ad_gpo_target_dn_retrieval_done(struct tevent_req *subreq)
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct ad_gpo_access_state);
-    ret = groups_by_user_recv(subreq, &dp_error, &sdap_ret);
+    ret = groups_by_user_recv(subreq, &dp_error);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        if (sdap_ret == EAGAIN && dp_error == DP_ERR_OFFLINE) {
+        if (ret == EAGAIN && dp_error == DP_ERR_OFFLINE) {
             DEBUG(SSSDBG_TRACE_FUNC, "Preparing for offline operation.\n");
             ret = process_offline_gpos(state,
                                        state->user,

--- a/src/providers/ad/ad_gpo.c
+++ b/src/providers/ad/ad_gpo.c
@@ -2135,7 +2135,6 @@ ad_gpo_connect_done(struct tevent_req *subreq)
 {
     struct tevent_req *req;
     struct ad_gpo_access_state *state;
-    int dp_error;
     errno_t ret;
     char *server_uri;
     LDAPURLDesc *lud;
@@ -2145,11 +2144,11 @@ ad_gpo_connect_done(struct tevent_req *subreq)
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct ad_gpo_access_state);
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
-        if (dp_error != DP_ERR_OFFLINE) {
+        if (ret != ERR_OFFLINE) {
             DEBUG(SSSDBG_OP_FAILURE,
                   "Failed to connect to AD server: [%d](%s)\n",
                   ret, sss_strerror(ret));
@@ -2282,7 +2281,6 @@ ad_gpo_target_dn_retrieval_done(struct tevent_req *subreq)
     struct tevent_req *req;
     struct ad_gpo_access_state *state;
     int ret;
-    int dp_error;
     const char *target_dn = NULL;
     uint32_t uac;
     static const char *host_attrs[] = { SYSDB_ORIG_DN, SYSDB_AD_USER_ACCOUNT_CONTROL, SYSDB_SID_STR, NULL };
@@ -2292,10 +2290,10 @@ ad_gpo_target_dn_retrieval_done(struct tevent_req *subreq)
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct ad_gpo_access_state);
-    ret = groups_by_user_recv(subreq, &dp_error);
+    ret = groups_by_user_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        if (ret == EAGAIN && dp_error == DP_ERR_OFFLINE) {
+        if (ret == ERR_OFFLINE) {
             DEBUG(SSSDBG_TRACE_FUNC, "Preparing for offline operation.\n");
             ret = process_offline_gpos(state,
                                        state->user,
@@ -2481,7 +2479,6 @@ ad_gpo_process_gpo_done(struct tevent_req *subreq)
     struct tevent_req *req;
     struct ad_gpo_access_state *state;
     int ret;
-    int dp_error;
     struct gp_gpo **candidate_gpos = NULL;
     int num_candidate_gpos = 0;
     int i = 0;
@@ -2493,7 +2490,7 @@ ad_gpo_process_gpo_done(struct tevent_req *subreq)
 
     talloc_zfree(subreq);
 
-    ret = sdap_id_op_done(state->sdap_op, ret, &dp_error);
+    ret = sdap_id_op_done(state->sdap_op, ret);
 
     if (ret != EOK && ret != ENOENT) {
         DEBUG(SSSDBG_OP_FAILURE,
@@ -3367,7 +3364,6 @@ ad_gpo_site_dn_retrieval_done(struct tevent_req *subreq)
     struct tevent_req *req;
     struct ad_gpo_process_som_state *state;
     int ret;
-    int dp_error;
     int i = 0;
     size_t reply_count;
     struct sysdb_attrs **reply;
@@ -3380,7 +3376,7 @@ ad_gpo_site_dn_retrieval_done(struct tevent_req *subreq)
                                 &reply_count, &reply);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        ret = sdap_id_op_done(state->sdap_op, ret, &dp_error);
+        ret = sdap_id_op_done(state->sdap_op, ret);
 
         DEBUG(SSSDBG_OP_FAILURE,
               "Unable to get configNC: [%d](%s)\n", ret, sss_strerror(ret));
@@ -3493,7 +3489,6 @@ ad_gpo_get_som_attrs_done(struct tevent_req *subreq)
     struct tevent_req *req;
     struct ad_gpo_process_som_state *state;
     int ret;
-    int dp_error;
     size_t num_results;
     struct sysdb_attrs **results;
     struct ldb_message_element *el = NULL;
@@ -3509,7 +3504,7 @@ ad_gpo_get_som_attrs_done(struct tevent_req *subreq)
     talloc_zfree(subreq);
 
     if (ret != EOK) {
-        ret = sdap_id_op_done(state->sdap_op, ret, &dp_error);
+        ret = sdap_id_op_done(state->sdap_op, ret);
 
         DEBUG(SSSDBG_OP_FAILURE,
               "Unable to get SOM attributes: [%d](%s)\n",
@@ -4216,7 +4211,6 @@ ad_gpo_get_gpo_attrs_done(struct tevent_req *subreq)
     struct tevent_req *req;
     struct ad_gpo_process_gpo_state *state;
     int ret;
-    int dp_error;
     size_t num_results, refcount;
     struct sysdb_attrs **results;
     char **refs;
@@ -4230,7 +4224,7 @@ ad_gpo_get_gpo_attrs_done(struct tevent_req *subreq)
     talloc_zfree(subreq);
 
     if (ret != EOK) {
-        ret = sdap_id_op_done(state->sdap_op, ret, &dp_error);
+        ret = sdap_id_op_done(state->sdap_op, ret);
 
         DEBUG(SSSDBG_OP_FAILURE,
               "Unable to get GPO attributes: [%d](%s)\n",
@@ -4290,7 +4284,6 @@ void
 ad_gpo_get_sd_referral_done(struct tevent_req *subreq)
 {
     errno_t ret;
-    int dp_error;
     struct sysdb_attrs *reply;
     char *smb_host;
 
@@ -4303,7 +4296,7 @@ ad_gpo_get_sd_referral_done(struct tevent_req *subreq)
     talloc_zfree(subreq);
     if (ret != EOK) {
         /* Terminate the sdap_id_op */
-        ret = sdap_id_op_done(state->sdap_op, ret, &dp_error);
+        ret = sdap_id_op_done(state->sdap_op, ret);
 
         DEBUG(SSSDBG_OP_FAILURE,
               "Unable to get referred GPO attributes: [%d](%s)\n",
@@ -5025,7 +5018,6 @@ static void
 ad_gpo_get_sd_referral_conn_done(struct tevent_req *subreq)
 {
     errno_t ret;
-    int dp_error;
     const char *attrs[] = AD_GPO_ATTRS;
     LDAPURLDesc *lud = NULL;
 
@@ -5034,10 +5026,10 @@ ad_gpo_get_sd_referral_conn_done(struct tevent_req *subreq)
     struct ad_gpo_get_sd_referral_state *state =
             tevent_req_data(req, struct ad_gpo_get_sd_referral_state);
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        if (dp_error == DP_ERR_OFFLINE) {
+        if (ret == ERR_OFFLINE) {
             DEBUG(SSSDBG_TRACE_FUNC,
                   "Backend is marked offline, retry later!\n");
             tevent_req_done(req);
@@ -5091,7 +5083,6 @@ static void
 ad_gpo_get_sd_referral_search_done(struct tevent_req *subreq)
 {
     errno_t ret;
-    int dp_error;
     size_t num_results, num_refs;
     struct sysdb_attrs **results = NULL;
     char **refs;
@@ -5105,7 +5096,7 @@ ad_gpo_get_sd_referral_search_done(struct tevent_req *subreq)
                               &num_refs, &refs);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        ret = sdap_id_op_done(state->ref_op, ret, &dp_error);
+        ret = sdap_id_op_done(state->ref_op, ret);
 
         DEBUG(SSSDBG_OP_FAILURE,
               "Unable to get GPO attributes: [%d](%s)\n",

--- a/src/providers/ad/ad_id.c
+++ b/src/providers/ad/ad_id.c
@@ -111,7 +111,6 @@ struct ad_handle_acct_info_state {
     struct ad_options *ad_options;
     bool using_pac;
 
-    int dp_error;
     const char *err;
 };
 
@@ -240,7 +239,6 @@ static void
 ad_handle_acct_info_done(struct tevent_req *subreq)
 {
     errno_t ret;
-    int dp_error;
     const char *err;
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                       struct tevent_req);
@@ -248,11 +246,11 @@ ad_handle_acct_info_done(struct tevent_req *subreq)
                                             struct ad_handle_acct_info_state);
 
     if (state->using_pac) {
-        ret = ad_handle_pac_initgr_recv(subreq, &dp_error, &err);
+        ret = ad_handle_pac_initgr_recv(subreq, &err);
     } else {
-        ret = sdap_handle_acct_req_recv(subreq, &dp_error, &err);
+        ret = sdap_handle_acct_req_recv(subreq, &err);
     }
-    if (dp_error == DP_ERR_OFFLINE
+    if (ret == ERR_OFFLINE
         && state->conn[state->cindex+1] != NULL
         && state->conn[state->cindex]->ignore_mark_offline) {
          /* This is a special case: GC does not work.
@@ -262,8 +260,7 @@ ad_handle_acct_info_done(struct tevent_req *subreq)
     }
     talloc_zfree(subreq);
     if (ret != EOK) {
-        /* if GC was not used dp error should be set */
-        state->dp_error = dp_error;
+        /* if GC was not used error should be set */
         state->err = err;
 
         goto fail;
@@ -284,7 +281,6 @@ ad_handle_acct_info_done(struct tevent_req *subreq)
         /* No additional search in progress. Save the last
          * error status, we'll be returning it.
          */
-        state->dp_error = dp_error;
         state->err = err;
 
         if (ret == EOK) {
@@ -316,14 +312,10 @@ fail:
 
 errno_t
 ad_handle_acct_info_recv(struct tevent_req *req,
-                         int *_dp_error, const char **_err)
+                         const char **_err)
 {
     struct ad_handle_acct_info_state *state = tevent_req_data(req,
                                             struct ad_handle_acct_info_state);
-
-    if (_dp_error) {
-        *_dp_error = state->dp_error;
-    }
 
     if (_err) {
         *_err = state->err;
@@ -360,7 +352,6 @@ get_conn_list(TALLOC_CTX *mem_ctx, struct ad_id_ctx *ad_ctx,
 
 struct ad_account_info_state {
     const char *err_msg;
-    int dp_error;
 };
 
 static void ad_account_info_done(struct tevent_req *subreq);
@@ -439,7 +430,7 @@ static void ad_account_info_done(struct tevent_req *subreq)
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct ad_account_info_state);
 
-    ret = ad_handle_acct_info_recv(subreq, &state->dp_error, &state->err_msg);
+    ret = ad_handle_acct_info_recv(subreq, &state->err_msg);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
               "ad_handle_acct_info_recv failed [%d]: %s\n",
@@ -451,7 +442,6 @@ static void ad_account_info_done(struct tevent_req *subreq)
 }
 
 errno_t ad_account_info_recv(struct tevent_req *req,
-                             int *_dp_error,
                              const char **_err_msg)
 {
     struct ad_account_info_state *state = NULL;
@@ -461,11 +451,6 @@ errno_t ad_account_info_recv(struct tevent_req *req,
     if (_err_msg != NULL) {
         *_err_msg = state->err_msg;
     }
-
-    if (_dp_error) {
-        *_dp_error = state->dp_error;
-    }
-
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
@@ -515,7 +500,7 @@ ad_account_info_handler_send(TALLOC_CTX *mem_ctx,
     return req;
 
 immediately:
-    dp_reply_std_set(&state->reply, DP_ERR_DECIDE, ret, NULL);
+    dp_reply_std_set(&state->reply, ret, NULL);
 
     /* TODO For backward compatibility we always return EOK to DP now. */
     tevent_req_done(req);
@@ -529,17 +514,16 @@ static void ad_account_info_handler_done(struct tevent_req *subreq)
     struct ad_account_info_handler_state *state;
     struct tevent_req *req;
     const char *err_msg;
-    int dp_error = DP_ERR_FATAL;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct ad_account_info_handler_state);
 
-    ret = ad_account_info_recv(subreq, &dp_error, &err_msg);
+    ret = ad_account_info_recv(subreq, &err_msg);
     talloc_zfree(subreq);
 
     /* TODO For backward compatibility we always return EOK to DP now. */
-    dp_reply_std_set(&state->reply, dp_error, ret, err_msg);
+    dp_reply_std_set(&state->reply, ret, err_msg);
     tevent_req_done(req);
 }
 
@@ -581,7 +565,6 @@ struct ad_get_account_domain_state {
     const char *base_filter;
     char *filter;
     const char **attrs;
-    int dp_error;
     struct dp_reply_std reply;
     struct sdap_id_op *op;
     struct sysdb_attrs **objects;
@@ -635,11 +618,11 @@ ad_get_account_domain_send(TALLOC_CTX *mem_ctx,
         if (domain == NULL) {
             DEBUG(SSSDBG_TRACE_INTERNAL,
                   "SID %s does not fit into any domain\n", data->filter_value);
-            dp_reply_std_set(&state->reply, DP_ERR_DECIDE, ERR_NOT_FOUND, NULL);
+            dp_reply_std_set(&state->reply, ERR_NOT_FOUND, NULL);
         } else {
             DEBUG(SSSDBG_TRACE_INTERNAL,
                   "SID %s fits into domain %s\n", data->filter_value, domain->name);
-            dp_reply_std_set(&state->reply, DP_ERR_DECIDE, EOK, domain->name);
+            dp_reply_std_set(&state->reply, EOK, domain->name);
         }
         tevent_req_done(req);
         tevent_req_post(req, params->ev);
@@ -711,7 +694,7 @@ ad_get_account_domain_send(TALLOC_CTX *mem_ctx,
     return req;
 
 immediately:
-    dp_reply_std_set(&state->reply, DP_ERR_DECIDE, ret, NULL);
+    dp_reply_std_set(&state->reply, ret, NULL);
 
     /* TODO For backward compatibility we always return EOK to DP now. */
     tevent_req_done(req);
@@ -793,16 +776,12 @@ static void ad_get_account_domain_connect_done(struct tevent_req *subreq)
 {
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                       struct tevent_req);
-    struct ad_get_account_domain_state *state = tevent_req_data(req,
-                                          struct ad_get_account_domain_state);
-    int dp_error = DP_ERR_FATAL;
     errno_t ret;
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -929,7 +908,7 @@ static void ad_get_account_domain_evaluate(struct tevent_req *req)
         }
 
         DEBUG(SSSDBG_TRACE_FUNC, "Not found\n");
-        dp_reply_std_set(&state->reply, DP_ERR_DECIDE, ERR_NOT_FOUND, NULL);
+        dp_reply_std_set(&state->reply, ERR_NOT_FOUND, NULL);
         tevent_req_done(req);
         return;
     } else if (state->count > 1) {
@@ -939,7 +918,7 @@ static void ad_get_account_domain_evaluate(struct tevent_req *req)
          * from the responder side
          */
         DEBUG(SSSDBG_OP_FAILURE, "Multiple entries found, error!\n");
-        dp_reply_std_set(&state->reply, DP_ERR_DECIDE, ERANGE, NULL);
+        dp_reply_std_set(&state->reply, ERANGE, NULL);
         tevent_req_done(req);
         return;
     }
@@ -951,14 +930,14 @@ static void ad_get_account_domain_evaluate(struct tevent_req *req)
     if (obj_dom == NULL) {
         DEBUG(SSSDBG_OP_FAILURE,
               "Could not match entry with domain!\n");
-        dp_reply_std_set(&state->reply, DP_ERR_DECIDE, ERR_NOT_FOUND, NULL);
+        dp_reply_std_set(&state->reply, ERR_NOT_FOUND, NULL);
         tevent_req_done(req);
         return;
     }
 
     DEBUG(SSSDBG_TRACE_INTERNAL,
           "Found object in domain %s\n", obj_dom->name);
-    dp_reply_std_set(&state->reply, DP_ERR_DECIDE, EOK, obj_dom->name);
+    dp_reply_std_set(&state->reply, EOK, obj_dom->name);
     tevent_req_done(req);
 }
 

--- a/src/providers/ad/ad_id.c
+++ b/src/providers/ad/ad_id.c
@@ -241,7 +241,6 @@ ad_handle_acct_info_done(struct tevent_req *subreq)
 {
     errno_t ret;
     int dp_error;
-    int sdap_err;
     const char *err;
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                       struct tevent_req);
@@ -249,9 +248,9 @@ ad_handle_acct_info_done(struct tevent_req *subreq)
                                             struct ad_handle_acct_info_state);
 
     if (state->using_pac) {
-        ret = ad_handle_pac_initgr_recv(subreq, &dp_error, &err, &sdap_err);
+        ret = ad_handle_pac_initgr_recv(subreq, &dp_error, &err);
     } else {
-        ret = sdap_handle_acct_req_recv(subreq, &dp_error, &err, &sdap_err);
+        ret = sdap_handle_acct_req_recv(subreq, &dp_error, &err);
     }
     if (dp_error == DP_ERR_OFFLINE
         && state->conn[state->cindex+1] != NULL
@@ -259,8 +258,7 @@ ad_handle_acct_info_done(struct tevent_req *subreq)
          /* This is a special case: GC does not work.
           *  We need to Fall back to ldap
           */
-        ret = EOK;
-        sdap_err = ENOENT;
+        ret = ENOENT;
     }
     talloc_zfree(subreq);
     if (ret != EOK) {
@@ -271,10 +269,10 @@ ad_handle_acct_info_done(struct tevent_req *subreq)
         goto fail;
     }
 
-    if (sdap_err == EOK) {
+    if (ret == EOK) {
         tevent_req_done(req);
         return;
-    } else if (sdap_err != ENOENT) {
+    } else if (ret != ENOENT) {
         ret = EIO;
         goto fail;
     }

--- a/src/providers/ad/ad_id.c
+++ b/src/providers/ad/ad_id.c
@@ -250,37 +250,33 @@ ad_handle_acct_info_done(struct tevent_req *subreq)
     } else {
         ret = sdap_handle_acct_req_recv(subreq, &err);
     }
+    talloc_zfree(subreq);
+
     if (ret == ERR_OFFLINE
         && state->conn[state->cindex+1] != NULL
         && state->conn[state->cindex]->ignore_mark_offline) {
-         /* This is a special case: GC does not work.
-          *  We need to Fall back to ldap
-          */
+        /* This is a special case: GC does not work.
+         * We need to fall back to LDAP
+         */
         ret = ENOENT;
-    }
-    talloc_zfree(subreq);
-    if (ret != EOK) {
-        /* if GC was not used error should be set */
-        state->err = err;
-
-        goto fail;
     }
 
     if (ret == EOK) {
         tevent_req_done(req);
         return;
-    } else if (ret != ENOENT) {
-        ret = EIO;
+    }
+
+    if (ret != ENOENT) {
+        /* Non-ENOENT errors should be propagated */
+        state->err = err;
         goto fail;
     }
 
-    /* Ret is only ENOENT now. Try the next connection */
+    /* ret is ENOENT - try the next connection */
     state->cindex++;
     ret = ad_handle_acct_info_step(req);
     if (ret != EAGAIN) {
-        /* No additional search in progress. Save the last
-         * error status, we'll be returning it.
-         */
+        /* No additional search in progress. Save the last error */
         state->err = err;
 
         if (ret == EOK) {

--- a/src/providers/ad/ad_id.h
+++ b/src/providers/ad/ad_id.h
@@ -40,7 +40,6 @@ ad_account_info_send(TALLOC_CTX *mem_ctx,
                      struct dp_id_data *data);
 
 errno_t ad_account_info_recv(struct tevent_req *req,
-                             int *_dp_error,
                              const char **_err_msg);
 
 struct tevent_req *
@@ -52,7 +51,7 @@ ad_handle_acct_info_send(TALLOC_CTX *mem_ctx,
                          struct sdap_id_conn_ctx **conn);
 errno_t
 ad_handle_acct_info_recv(struct tevent_req *req,
-                         int *_dp_error, const char **_err);
+                          const char **_err);
 
 struct tevent_req *
 ad_get_account_domain_send(TALLOC_CTX *mem_ctx,

--- a/src/providers/ad/ad_pac.c
+++ b/src/providers/ad/ad_pac.c
@@ -275,7 +275,7 @@ struct tevent_req *ad_handle_pac_initgr_send(TALLOC_CTX *mem_ctx,
      * sdap_handle_acct_req_recv() from the alternative group-membership
      * lookup path. */
     state->err = NULL;
-    state->dp_error = DP_ERR_OK;
+    state->dp_error = EOK;
 
     ret = ad_get_pac_data_from_user_entry(state, msg,
                                           id_ctx->opts->idmap_ctx->map,
@@ -431,15 +431,11 @@ done:
 }
 
 errno_t ad_handle_pac_initgr_recv(struct tevent_req *req,
-                                  int *_dp_error, const char **_err)
+                                  const char **_err)
 {
     struct ad_handle_pac_initgr_state *state;
 
     state = tevent_req_data(req, struct ad_handle_pac_initgr_state);
-
-    if (_dp_error) {
-        *_dp_error = state->dp_error;
-    }
 
     if (_err) {
         *_err = state->err;

--- a/src/providers/ad/ad_pac.c
+++ b/src/providers/ad/ad_pac.c
@@ -230,7 +230,6 @@ struct ad_handle_pac_initgr_state {
     struct dp_id_data *ar;
     const char *err;
     int dp_error;
-    int sdap_ret;
     struct sdap_options *opts;
 
     size_t num_missing_sids;
@@ -277,7 +276,6 @@ struct tevent_req *ad_handle_pac_initgr_send(TALLOC_CTX *mem_ctx,
      * lookup path. */
     state->err = NULL;
     state->dp_error = DP_ERR_OK;
-    state->sdap_ret = EOK;
 
     ret = ad_get_pac_data_from_user_entry(state, msg,
                                           id_ctx->opts->idmap_ctx->map,
@@ -433,8 +431,7 @@ done:
 }
 
 errno_t ad_handle_pac_initgr_recv(struct tevent_req *req,
-                                  int *_dp_error, const char **_err,
-                                  int *sdap_ret)
+                                  int *_dp_error, const char **_err)
 {
     struct ad_handle_pac_initgr_state *state;
 
@@ -448,9 +445,6 @@ errno_t ad_handle_pac_initgr_recv(struct tevent_req *req,
         *_err = state->err;
     }
 
-    if (sdap_ret) {
-        *sdap_ret = state->sdap_ret;
-    }
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     return EOK;

--- a/src/providers/ad/ad_pac.h
+++ b/src/providers/ad/ad_pac.h
@@ -77,7 +77,7 @@ struct tevent_req *ad_handle_pac_initgr_send(TALLOC_CTX *mem_ctx,
                                              struct ldb_message *msg);
 
 errno_t ad_handle_pac_initgr_recv(struct tevent_req *req,
-                                  int *_dp_error, const char **_err);
+                                   const char **_err);
 
 errno_t check_upn_and_sid_from_user_and_pac(struct ldb_message *msg,
                                           struct sss_idmap_ctx *ctx,

--- a/src/providers/ad/ad_pac.h
+++ b/src/providers/ad/ad_pac.h
@@ -77,8 +77,7 @@ struct tevent_req *ad_handle_pac_initgr_send(TALLOC_CTX *mem_ctx,
                                              struct ldb_message *msg);
 
 errno_t ad_handle_pac_initgr_recv(struct tevent_req *req,
-                                  int *_dp_error, const char **_err,
-                                  int *sdap_ret);
+                                  int *_dp_error, const char **_err);
 
 errno_t check_upn_and_sid_from_user_and_pac(struct ldb_message *msg,
                                           struct sss_idmap_ctx *ctx,

--- a/src/providers/ad/ad_refresh.c
+++ b/src/providers/ad/ad_refresh.c
@@ -154,18 +154,17 @@ static void ad_refresh_done(struct tevent_req *subreq)
     struct ad_refresh_state *state = NULL;
     struct tevent_req *req = NULL;
     const char *err_msg = NULL;
-    errno_t dp_error;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct ad_refresh_state);
 
-    ret = ad_account_info_recv(subreq, &dp_error, &err_msg);
+    ret = ad_account_info_recv(subreq, &err_msg);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to refresh %s [dp_error: %d, "
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to refresh %s, "
               "errno: %d]: %s\n", be_req2str(state->account_req->entry_type),
-              dp_error, ret, err_msg);
+              ret, err_msg);
         goto done;
     }
 

--- a/src/providers/ad/ad_resolver.c
+++ b/src/providers/ad/ad_resolver.c
@@ -303,12 +303,12 @@ ad_resolver_enumeration_conn_done(struct tevent_req *subreq)
     struct ad_resolver_enum_state *state = tevent_req_data(req,
                                                  struct ad_resolver_enum_state);
     struct sdap_id_ctx *id_ctx = state->resolver_ctx->ad_id_ctx->sdap_id_ctx;
-    int ret, dp_error;
+    int ret;
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        if (dp_error == DP_ERR_OFFLINE) {
+        if (ret == ERR_OFFLINE) {
             DEBUG(SSSDBG_TRACE_FUNC,
                   "Backend is marked offline, retry later!\n");
             tevent_req_done(req);

--- a/src/providers/ad/ad_subdomains.c
+++ b/src/providers/ad/ad_subdomains.c
@@ -1191,7 +1191,6 @@ static void ad_get_slave_domain_connect_done(struct tevent_req *subreq)
 {
     struct ad_get_slave_domain_state *state;
     struct tevent_req *req = NULL;
-    int dp_error;
     errno_t ret;
     const char *attrs[] = { AD_AT_FLATNAME, AD_AT_TRUST_PARTNER,
                             AD_AT_SID, AD_AT_DOMAIN_NAME,
@@ -1200,16 +1199,15 @@ static void ad_get_slave_domain_connect_done(struct tevent_req *subreq)
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct ad_get_slave_domain_state);
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to connect to LDAP "
               "[%d]: %s\n", ret, sss_strerror(ret));
-        if (dp_error == DP_ERR_OFFLINE) {
+        if (ret == ERR_OFFLINE) {
             DEBUG(SSSDBG_MINOR_FAILURE, "No AD server is available, "
                   "cannot get the subdomain list while offline\n");
-            ret = ERR_OFFLINE;
         }
         tevent_req_error(req, ret);
         return;
@@ -1238,7 +1236,6 @@ static void ad_get_slave_domain_done(struct tevent_req *subreq)
     struct sysdb_attrs **subdoms;
     size_t nsubdoms;
     bool has_changes;
-    int dp_error;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
@@ -1252,17 +1249,14 @@ static void ad_get_slave_domain_done(struct tevent_req *subreq)
         /* We continue to finish sdap_id_op. */
     }
 
-    ret = sdap_id_op_done(state->sdap_op, ret, &dp_error);
-    if (dp_error == DP_ERR_OK && ret != EOK) {
+    ret = sdap_id_op_done(state->sdap_op, ret);
+    if (ret == EAGAIN) {
         /* retry */
         ret = ad_get_slave_domain_retry(req);
         if (ret != EOK) {
             goto done;
         }
         return;
-    } else if (dp_error == DP_ERR_OFFLINE) {
-        ret = ERR_OFFLINE;
-        goto done;
     } else if (ret != EOK) {
         goto done;
     }
@@ -2034,22 +2028,20 @@ static void ad_subdomains_refresh_connect_done(struct tevent_req *subreq)
 {
     struct ad_subdomains_refresh_state *state;
     struct tevent_req *req;
-    int dp_error;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct ad_subdomains_refresh_state);
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to connect to LDAP "
               "[%d]: %s\n", ret, sss_strerror(ret));
-        if (dp_error == DP_ERR_OFFLINE) {
+        if (ret == ERR_OFFLINE) {
             DEBUG(SSSDBG_MINOR_FAILURE, "No AD server is available, "
                   "cannot get the subdomain list while offline\n");
-            ret = ERR_OFFLINE;
         }
         tevent_req_error(req, ret);
         return;
@@ -2262,7 +2254,6 @@ static void ad_subdomains_refresh_root_done(struct tevent_req *subreq)
     struct tevent_req *req;
     struct ad_id_ctx *root_id_ctx;
     struct sysdb_attrs *root_attrs;
-    int dp_error;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
@@ -2283,16 +2274,13 @@ static void ad_subdomains_refresh_root_done(struct tevent_req *subreq)
 
     /* We finish sdap_id_op here since we connect
      * to forest root for slave domains. */
-    ret = sdap_id_op_done(state->sdap_op, ret, &dp_error);
-    if (dp_error == DP_ERR_OK && ret != EOK) {
+    ret = sdap_id_op_done(state->sdap_op, ret);
+    if (ret == EAGAIN) {
         /* retry */
         ret = ad_subdomains_refresh_retry(req);
         if (ret != EOK) {
             tevent_req_error(req, ret);
         }
-        return;
-    } else if (dp_error == DP_ERR_OFFLINE) {
-        tevent_req_error(req, ERR_OFFLINE);
         return;
     } else if (ret != EOK) {
         tevent_req_error(req, ret);
@@ -2385,7 +2373,7 @@ ad_subdomains_handler_send(TALLOC_CTX *mem_ctx,
     return req;
 
 immediately:
-    dp_reply_std_set(&state->reply, DP_ERR_DECIDE, ret, NULL);
+    dp_reply_std_set(&state->reply, ret, NULL);
 
     /* TODO For backward compatibility we always return EOK to DP now. */
     tevent_req_done(req);
@@ -2407,7 +2395,7 @@ static void ad_subdomains_handler_done(struct tevent_req *subreq)
     talloc_zfree(subreq);
 
     /* TODO For backward compatibility we always return EOK to DP now. */
-    dp_reply_std_set(&state->reply, DP_ERR_DECIDE, ret, NULL);
+    dp_reply_std_set(&state->reply, ret, NULL);
     tevent_req_done(req);
 }
 
@@ -2671,21 +2659,19 @@ static void ad_check_domain_connect_done(struct tevent_req *subreq)
     struct tevent_req *req;
     struct ad_check_domain_state *state;
     int ret;
-    int dp_error;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct ad_check_domain_state);
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to connect to LDAP "
               "[%d]: %s\n", ret, sss_strerror(ret));
-        if (dp_error == DP_ERR_OFFLINE) {
+        if (ret == ERR_OFFLINE) {
             DEBUG(SSSDBG_MINOR_FAILURE, "No AD server is available, "
                   "cannot get the subdomain list while offline\n");
-            ret = ERR_OFFLINE;
         }
         tevent_req_error(req, ret);
         return;

--- a/src/providers/backend.h
+++ b/src/providers/backend.h
@@ -114,7 +114,7 @@ struct be_ctx {
     struct sbus_connection *conn;
 
     /* Indicates whether the last state of the DP that has been logged is
-     * DP_ERR_OK or DP_ERR_OFFLINE. The only usage of this var, so far, is
+     * EOK or ERR_OFFLINE. The only usage of this var, so far, is
      * to log the DP status without spamming the syslog/journal. */
     int last_dp_state;
 

--- a/src/providers/data_provider.h
+++ b/src/providers/data_provider.h
@@ -110,12 +110,6 @@
  * @}
  */ /* end of group pamHandler */
 
-#define DP_ERR_DECIDE -1
-#define DP_ERR_OK 0
-#define DP_ERR_OFFLINE 1
-#define DP_ERR_TIMEOUT 2
-#define DP_ERR_FATAL 3
-
 #define BE_FILTER_NAME 1
 #define BE_FILTER_IDNUM 2
 #define BE_FILTER_ENUM 3

--- a/src/providers/data_provider/dp_custom_data.h
+++ b/src/providers/data_provider/dp_custom_data.h
@@ -66,23 +66,21 @@ struct dp_resolver_data {
 /* Reply private data. */
 
 struct dp_reply_std {
-    int dp_error;
     int error;
     const char *message;
 };
 
 void dp_reply_std_set(struct dp_reply_std *reply,
-                      int dp_error,
                       int error,
                       const char *msg);
 
+void dp_req_reply_std_with_msg(const char *request_name,
+                               struct dp_reply_std *reply,
+                               uint32_t *_error,
+                               const char **_message);
+
 void dp_req_reply_std(const char *request_name,
                       struct dp_reply_std *reply,
-                      uint16_t *_dp_error,
-                      uint32_t *_error,
-                      const char **_message);
-
-/* Convert pair of ret and dp_error to single ret value. */
-errno_t dp_error_to_ret(errno_t ret, int dp_error);
+                      uint32_t *_error);
 
 #endif /* _DP_CUSTOM_DATA_H_ */

--- a/src/providers/data_provider/dp_iface.h
+++ b/src/providers/data_provider/dp_iface.h
@@ -40,9 +40,7 @@ dp_get_account_info_send(TALLOC_CTX *mem_ctx,
 errno_t
 dp_get_account_info_recv(TALLOC_CTX *mem_ctx,
                          struct tevent_req *req,
-                         uint16_t *_dp_error,
-                         uint32_t *_error,
-                         const char **_err_msg);
+                         uint32_t *_error);
 
 struct tevent_req *
 dp_pam_handler_send(TALLOC_CTX *mem_ctx,
@@ -66,9 +64,7 @@ dp_sudo_handler_send(TALLOC_CTX *mem_ctx,
 errno_t
 dp_sudo_handler_recv(TALLOC_CTX *mem_ctx,
                      struct tevent_req *req,
-                     uint16_t *_dp_error,
-                     uint32_t *_error,
-                     const char **_err_msg);
+                     uint32_t *_error);
 
 struct tevent_req *
 dp_host_handler_send(TALLOC_CTX *mem_ctx,
@@ -83,9 +79,7 @@ dp_host_handler_send(TALLOC_CTX *mem_ctx,
 errno_t
 dp_host_handler_recv(TALLOC_CTX *mem_ctx,
                      struct tevent_req *req,
-                     uint16_t *_dp_error,
-                     uint32_t *_error,
-                     const char **_err_msg);
+                     uint32_t *_error);
 
 struct tevent_req *
 dp_autofs_handler_send(TALLOC_CTX *mem_ctx,
@@ -98,9 +92,7 @@ dp_autofs_handler_send(TALLOC_CTX *mem_ctx,
 errno_t
 dp_autofs_handler_recv(TALLOC_CTX *mem_ctx,
                        struct tevent_req *req,
-                       uint16_t *_dp_error,
-                       uint32_t *_error,
-                       const char **_err_msg);
+                       uint32_t *_error);
 
 struct tevent_req *
 dp_autofs_get_map_send(TALLOC_CTX *mem_ctx,
@@ -146,9 +138,7 @@ dp_subdomains_handler_send(TALLOC_CTX *mem_ctx,
 errno_t
 dp_subdomains_handler_recv(TALLOC_CTX *mem_ctx,
                            struct tevent_req *req,
-                           uint16_t *_dp_error,
-                           uint32_t *_error,
-                           const char **_err_msg);
+                           uint32_t *_error);
 
 struct tevent_req *
 dp_resolver_handler_send(TALLOC_CTX *mem_ctx,
@@ -164,20 +154,18 @@ dp_resolver_handler_send(TALLOC_CTX *mem_ctx,
 errno_t
 dp_resolver_handler_recv(TALLOC_CTX *mem_ctx,
                          struct tevent_req *req,
-                         uint16_t *_dp_error,
-                         uint32_t *_error,
-                         const char **_err_msg);
+                         uint32_t *_error);
 
 /*
  * Return a domain the account belongs to.
  *
  * The request uses the dp_reply_std structure for reply, with the following
  * semantics:
- *  - DP_ERR_OK - it is expected that the string message contains the domain name
+ *  - ERR_OK - it is expected that the string message contains the domain name
  *                the entry was found in. A 'negative' reply where the
- *                request returns DP_ERR_OK, but no domain should be treated
+ *                request returns ERR_OK, but no domain should be treated
  *                as authoritative, as if the entry does not exist.
- *  - DP_ERR_*  - the string message contains error string that corresponds
+ *  - ERR_*  - the string message contains error string that corresponds
  *                to the errno field in dp_reply_std().
  */
 struct tevent_req *
@@ -193,7 +181,6 @@ dp_get_account_domain_send(TALLOC_CTX *mem_ctx,
 errno_t
 dp_get_account_domain_recv(TALLOC_CTX *mem_ctx,
                            struct tevent_req *req,
-                           uint16_t *_dp_error,
                            uint32_t *_error,
                            const char **_err_msg);
 

--- a/src/providers/data_provider/dp_reply_std.c
+++ b/src/providers/data_provider/dp_reply_std.c
@@ -25,32 +25,17 @@
 #include "util/sss_utf8.h"
 #include "util/util.h"
 
-static const char *dp_err_to_string(int dp_err_type)
-{
-    switch (dp_err_type) {
-    case DP_ERR_OK:
-        return "Success";
-    case DP_ERR_OFFLINE:
-        return "Provider is Offline";
-    case DP_ERR_TIMEOUT:
-        return "Request timed out";
-    case DP_ERR_FATAL:
-        return "Internal Error";
-    default:
-        break;
-    }
-
-    return "Unknown Error";
-}
-
 static const char *safe_be_req_err_msg(const char *msg_in,
-                                       int dp_err_type)
+                                       int error)
 {
     bool ok;
+    const char *def_msg;
+
+    def_msg = sss_strerror(error);
 
     if (msg_in == NULL) {
         /* No custom error, just use default */
-        return dp_err_to_string(dp_err_type);
+        return def_msg;
     }
 
     ok = sss_utf8_check((const uint8_t *) msg_in,
@@ -59,7 +44,7 @@ static const char *safe_be_req_err_msg(const char *msg_in,
         DEBUG(SSSDBG_MINOR_FAILURE,
               "Back end message [%s] contains invalid non-UTF8 character, " \
               "using default\n", msg_in);
-        return dp_err_to_string(dp_err_type);
+        return def_msg;
     }
 
     return msg_in;
@@ -67,84 +52,43 @@ static const char *safe_be_req_err_msg(const char *msg_in,
 
 void dp_req_reply_std(const char *request_name,
                       struct dp_reply_std *reply,
-                      uint16_t *_dp_error,
-                      uint32_t *_error,
-                      const char **_message)
+                      uint32_t *_error)
+{
+    const char *msg;
+
+    msg = sss_strerror(*_error);
+
+    DP_REQ_DEBUG(SSSDBG_TRACE_LIBS, request_name, "Returning [%d]: %s",
+                 *_error, msg);
+
+    *_error = reply->error;
+    msg = reply->message;
+}
+
+void dp_req_reply_std_with_msg(const char *request_name,
+                               struct dp_reply_std *reply,
+                               uint32_t *_error,
+                               const char **_message)
 {
     const char *safe_err_msg;
 
-    safe_err_msg = safe_be_req_err_msg(reply->message, reply->dp_error);
+    safe_err_msg = safe_be_req_err_msg(reply->message, reply->error);
 
-    DP_REQ_DEBUG(SSSDBG_TRACE_LIBS, request_name, "Returning [%s]: %d,%d,%s",
-                 dp_err_to_string(reply->dp_error), reply->dp_error,
+    DP_REQ_DEBUG(SSSDBG_TRACE_LIBS, request_name, "Returning [%d]: %s",
                  reply->error, reply->message);
 
-    *_dp_error = reply->dp_error;
     *_error = reply->error;
     *_message = safe_err_msg;
 }
 
 void dp_reply_std_set(struct dp_reply_std *reply,
-                      int dp_error,
                       int error,
                       const char *msg)
 {
     const char *def_msg;
 
-    if (dp_error == DP_ERR_DECIDE) {
-        switch (error) {
-        case EOK:
-            dp_error = DP_ERR_OK;
-            break;
-        case ERR_OFFLINE:
-            dp_error = DP_ERR_OFFLINE;
-            break;
-        case ETIMEDOUT:
-            dp_error = DP_ERR_TIMEOUT;
-            break;
-        default:
-            dp_error = DP_ERR_FATAL;
-            break;
-        }
-    }
+    def_msg = sss_strerror(error);
 
-    switch (dp_error) {
-    case DP_ERR_OK:
-        def_msg = "Success";
-        break;
-    case DP_ERR_OFFLINE:
-        def_msg = "Offline";
-        break;
-    default:
-        def_msg = sss_strerror(error);
-        break;
-    }
-
-    if (dp_error == DP_ERR_OK && error != EOK) {
-        DEBUG(SSSDBG_MINOR_FAILURE, "DP Error is OK on failed request?\n");
-    }
-
-    reply->dp_error = dp_error;
     reply->error = error;
     reply->message = msg == NULL ? def_msg : msg;
-}
-
-errno_t dp_error_to_ret(errno_t ret, int dp_error)
-{
-    if (ret != EOK) {
-        return ret;
-    }
-
-    switch (dp_error) {
-    case DP_ERR_OK:
-        return EOK;
-    case DP_ERR_OFFLINE:
-        return ERR_OFFLINE;
-    case DP_ERR_TIMEOUT:
-        return ETIMEDOUT;
-    case DP_ERR_FATAL:
-        return EFAULT;
-    }
-
-    return ERR_INTERNAL;
 }

--- a/src/providers/data_provider/dp_target_hostid.c
+++ b/src/providers/data_provider/dp_target_hostid.c
@@ -110,9 +110,7 @@ static void dp_host_handler_done(struct tevent_req *subreq)
 errno_t
 dp_host_handler_recv(TALLOC_CTX *mem_ctx,
                      struct tevent_req *req,
-                     uint16_t *_dp_error,
-                     uint32_t *_error,
-                     const char **_err_msg)
+                     uint32_t *_error)
 {
     struct dp_host_handler_state *state;
     state = tevent_req_data(req, struct dp_host_handler_state);
@@ -120,7 +118,7 @@ dp_host_handler_recv(TALLOC_CTX *mem_ctx,
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     dp_req_reply_std(state->request_name, &state->reply,
-                     _dp_error, _error, _err_msg);
+                     _error);
 
     return EOK;
 }

--- a/src/providers/data_provider/dp_target_id.c
+++ b/src/providers/data_provider/dp_target_id.c
@@ -434,7 +434,7 @@ static void dp_req_initgr_pp_set_initgr_timestamp(struct dp_initgr_ctx *ctx,
 {
     errno_t ret;
 
-    if (reply->dp_error != DP_ERR_OK || reply->error != EOK) {
+    if (reply->error != EOK) {
         /* Only bump the timestamp on successful lookups */
         return;
     }
@@ -887,17 +887,14 @@ static void dp_get_account_info_done(struct tevent_req *subreq)
 errno_t
 dp_get_account_info_recv(TALLOC_CTX *mem_ctx,
                          struct tevent_req *req,
-                         uint16_t *_dp_error,
-                         uint32_t *_error,
-                         const char **_err_msg)
+                         uint32_t *_error)
 {
     struct dp_get_account_info_state *state;
     state = tevent_req_data(req, struct dp_get_account_info_state);
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
-    dp_req_reply_std(state->request_name, &state->reply,
-                     _dp_error, _error, _err_msg);
+    dp_req_reply_std(state->request_name, &state->reply, _error);
 
     return EOK;
 }
@@ -1025,7 +1022,6 @@ static void dp_get_account_domain_done(struct tevent_req *subreq)
 errno_t
 dp_get_account_domain_recv(TALLOC_CTX *mem_ctx,
                            struct tevent_req *req,
-                           uint16_t *_dp_error,
                            uint32_t *_error,
                            const char **_err_msg)
 {
@@ -1034,8 +1030,8 @@ dp_get_account_domain_recv(TALLOC_CTX *mem_ctx,
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
-    dp_req_reply_std(state->request_name, &state->reply,
-                     _dp_error, _error, _err_msg);
+    dp_req_reply_std_with_msg(state->request_name, &state->reply, _error,
+                              _err_msg);
 
     return EOK;
 }
@@ -1061,7 +1057,7 @@ default_account_domain_send(TALLOC_CTX *mem_ctx,
     }
 
     dp_reply_std_set(&state->reply,
-                     DP_ERR_DECIDE, ERR_GET_ACCT_DOM_NOT_SUPPORTED,
+                     ERR_GET_ACCT_DOM_NOT_SUPPORTED,
                      NULL);
     tevent_req_done(req);
     tevent_req_post(req, params->ev);

--- a/src/providers/data_provider/dp_target_resolver.c
+++ b/src/providers/data_provider/dp_target_resolver.c
@@ -132,17 +132,14 @@ static void dp_resolver_handler_done(struct tevent_req *subreq)
 errno_t
 dp_resolver_handler_recv(TALLOC_CTX *mem_ctx,
                          struct tevent_req *req,
-                         uint16_t *_dp_error,
-                         uint32_t *_error,
-                         const char **_err_msg)
+                         uint32_t *_error)
 {
     struct dp_resolver_handler_state *state;
     state = tevent_req_data(req, struct dp_resolver_handler_state);
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
-    dp_req_reply_std(state->request_name, &state->reply,
-                     _dp_error, _error, _err_msg);
+    dp_req_reply_std(state->request_name, &state->reply, _error);
 
     return EOK;
 }

--- a/src/providers/data_provider/dp_target_subdomains.c
+++ b/src/providers/data_provider/dp_target_subdomains.c
@@ -106,17 +106,14 @@ static void dp_subdomains_handler_done(struct tevent_req *subreq)
 errno_t
 dp_subdomains_handler_recv(TALLOC_CTX *mem_ctx,
                            struct tevent_req *req,
-                           uint16_t *_dp_error,
-                           uint32_t *_error,
-                           const char **_err_msg)
+                           uint32_t *_error)
 {
     struct dp_subdomains_handler_state *state;
     state = tevent_req_data(req, struct dp_subdomains_handler_state);
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
-    dp_req_reply_std(state->request_name, &state->reply,
-                     _dp_error, _error, _err_msg);
+    dp_req_reply_std(state->request_name, &state->reply, _error);
 
     return EOK;
 }

--- a/src/providers/data_provider/dp_target_sudo.c
+++ b/src/providers/data_provider/dp_target_sudo.c
@@ -189,17 +189,14 @@ static void dp_sudo_handler_done(struct tevent_req *subreq)
 errno_t
 dp_sudo_handler_recv(TALLOC_CTX *mem_ctx,
                      struct tevent_req *req,
-                     uint16_t *_dp_error,
-                     uint32_t *_error,
-                     const char **_err_msg)
+                     uint32_t *_error)
 {
     struct dp_sudo_handler_state *state;
     state = tevent_req_data(req, struct dp_sudo_handler_state);
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
-    dp_req_reply_std(state->request_name, &state->reply,
-                     _dp_error, _error, _err_msg);
+    dp_req_reply_std(state->request_name, &state->reply, _error);
 
     return EOK;
 }

--- a/src/providers/data_provider_be.c
+++ b/src/providers/data_provider_be.c
@@ -343,30 +343,30 @@ static void be_check_online_done(struct tevent_req *req)
         goto done;
     }
 
-    switch (reply->dp_error) {
-    case DP_ERR_OK:
-        if (be_ctx->last_dp_state != DP_ERR_OK) {
-            be_ctx->last_dp_state = DP_ERR_OK;
+    switch (reply->error) {
+    case EOK:
+        if (be_ctx->last_dp_state != EOK) {
+            be_ctx->last_dp_state = EOK;
             sss_log(SSS_LOG_INFO, "Backend is online\n");
         }
         DEBUG(SSSDBG_TRACE_FUNC, "Backend is online\n");
         break;
-    case DP_ERR_OFFLINE:
-        if (be_ctx->last_dp_state != DP_ERR_OFFLINE) {
-            be_ctx->last_dp_state = DP_ERR_OFFLINE;
+    case ERR_OFFLINE:
+        if (be_ctx->last_dp_state != ERR_OFFLINE) {
+            be_ctx->last_dp_state = ERR_OFFLINE;
             sss_log(SSS_LOG_INFO, "Backend is offline\n");
         }
         DEBUG(SSSDBG_TRACE_FUNC, "Backend is offline\n");
         break;
     default:
         DEBUG(SSSDBG_TRACE_FUNC, "Error during online check [%d]: %s\n",
-              ret, sss_strerror(ret));
+              reply->error, sss_strerror(reply->error));
         break;
     }
 
     be_ctx->check_online_ref_count--;
 
-    if (reply->dp_error != DP_ERR_OK && be_ctx->check_online_ref_count > 0) {
+    if (reply->error != EOK && be_ctx->check_online_ref_count > 0) {
         be_ctx->check_online_retry_delay *= 2;
         if (be_ctx->check_online_retry_delay > ONLINE_CB_RETRY_MAX_DELAY) {
             be_ctx->check_online_retry_delay = ONLINE_CB_RETRY_MAX_DELAY;
@@ -390,8 +390,8 @@ static void be_check_online_done(struct tevent_req *req)
 
 done:
     be_ctx->check_online_ref_count = 0;
-    if (reply && reply->dp_error != DP_ERR_OFFLINE) {
-        if (reply->dp_error != DP_ERR_OK) {
+    if (reply && reply->error != ERR_OFFLINE) {
+        if (reply->error != EOK) {
             reset_fo(be_ctx);
         }
         be_reset_offline(be_ctx);

--- a/src/providers/idp/idp_id.c
+++ b/src/providers/idp/idp_id.c
@@ -162,7 +162,6 @@ struct idp_type_get_state {
     struct tevent_context *ev;
     struct idp_id_ctx *idp_id_ctx;
     struct idp_req *idp_req;
-    int dp_error;
     int idp_ret;
     enum idp_lookup_type lookup_type;
     const char *filter_value;
@@ -202,7 +201,6 @@ static struct tevent_req *idp_type_get_send(TALLOC_CTX *memctx,
 
     state->ev = ev;
     state->idp_id_ctx = idp_id_ctx;
-    state->dp_error = DP_ERR_FATAL;
     state->idp_ret = ENODATA;
     state->lookup_type = lookup_type;
     state->filter_value = talloc_strdup(state, filter_value);
@@ -295,7 +293,6 @@ static void idp_type_get_done(struct tevent_req *subreq)
     ret = handle_oidc_child_recv(subreq, state, &buf, &buflen);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        state->dp_error = DP_ERR_FATAL;
         tevent_req_error(req, ret);
         return;
     }
@@ -336,26 +333,20 @@ static void idp_type_get_done(struct tevent_req *subreq)
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
               "Failed to evaluate user data returned by oidc_child.\n");
-        state->dp_error = DP_ERR_FATAL;
         tevent_req_error(req, ret);
         return;
     }
 
-    state->dp_error = DP_ERR_OK;
     tevent_req_done(req);
 }
 
 
-static int idp_type_get_recv(struct tevent_req *req, int *dp_error_out,
+static int idp_type_get_recv(struct tevent_req *req,
                              int *idp_ret)
 {
     struct idp_type_get_state *state;
 
     state = tevent_req_data(req, struct idp_type_get_state);
-
-    if (dp_error_out != NULL) {
-        *dp_error_out = state->dp_error;
-    }
 
     if (idp_ret != NULL) {
         *idp_ret = state->idp_ret;
@@ -380,10 +371,10 @@ static struct tevent_req *idp_users_get_send(TALLOC_CTX *memctx,
                              noexist_delete, false, set_non_posix);
 }
 
-static int idp_users_get_recv(struct tevent_req *req, int *dp_error_out,
+static int idp_users_get_recv(struct tevent_req *req,
                               int *idp_ret)
 {
-    return idp_type_get_recv(req, dp_error_out, idp_ret);
+    return idp_type_get_recv(req, idp_ret);
 }
 
 static struct tevent_req *idp_groups_get_send(TALLOC_CTX *memctx,
@@ -400,10 +391,10 @@ static struct tevent_req *idp_groups_get_send(TALLOC_CTX *memctx,
                              no_members, set_non_posix);
 }
 
-static int idp_groups_get_recv(struct tevent_req *req, int *dp_error_out,
+static int idp_groups_get_recv(struct tevent_req *req,
                                int *idp_ret)
 {
-    return idp_type_get_recv(req, dp_error_out, idp_ret);
+    return idp_type_get_recv(req, idp_ret);
 }
 
 static struct tevent_req *idp_groups_by_user_send(TALLOC_CTX *memctx,
@@ -420,16 +411,15 @@ static struct tevent_req *idp_groups_by_user_send(TALLOC_CTX *memctx,
                              false, set_non_posix);
 }
 
-static int idp_groups_by_user_recv(struct tevent_req *req, int *dp_error_out,
+static int idp_groups_by_user_recv(struct tevent_req *req,
                                    int *idp_ret)
 {
-    return idp_type_get_recv(req, dp_error_out, idp_ret);
+    return idp_type_get_recv(req, idp_ret);
 }
 
 struct idp_handle_acct_req_state {
     struct dp_id_data *ar;
     const char *err;
-    int dp_error;
     int idp_ret;
 };
 
@@ -536,15 +526,15 @@ static void idp_handle_acct_req_done(struct tevent_req *subreq)
     switch (state->ar->entry_type & BE_REQ_TYPE_MASK) {
     case BE_REQ_USER: /* user */
         err = "User lookup failed";
-        ret = idp_users_get_recv(subreq, &state->dp_error, &state->idp_ret);
+        ret = idp_users_get_recv(subreq, &state->idp_ret);
         break;
     case BE_REQ_GROUP: /* group */
         err = "Group lookup failed";
-        ret = idp_groups_get_recv(subreq, &state->dp_error, &state->idp_ret);
+        ret = idp_groups_get_recv(subreq, &state->idp_ret);
         break;
     case BE_REQ_INITGROUPS: /* init groups for user */
         err = "Init group lookup failed";
-        ret = idp_groups_by_user_recv(subreq, &state->dp_error, &state->idp_ret);
+        ret = idp_groups_by_user_recv(subreq, &state->idp_ret);
         break;
     default: /* fail */
         ret = EINVAL;
@@ -564,16 +554,12 @@ static void idp_handle_acct_req_done(struct tevent_req *subreq)
 
 static errno_t
 idp_handle_acct_req_recv(struct tevent_req *req,
-                          int *_dp_error, const char **_err,
+                           const char **_err,
                           int *idp_ret)
 {
     struct idp_handle_acct_req_state *state;
 
     state = tevent_req_data(req, struct idp_handle_acct_req_state);
-
-    if (_dp_error) {
-        *_dp_error = state->dp_error;
-    }
 
     if (_err) {
         *_err = state->err;
@@ -624,7 +610,7 @@ idp_account_info_handler_send(TALLOC_CTX *mem_ctx,
     return req;
 
 immediately:
-    dp_reply_std_set(&state->reply, DP_ERR_DECIDE, ret, NULL);
+    dp_reply_std_set(&state->reply, ret, NULL);
 
     /* TODO For backward compatibility we always return EOK to DP now. */
     tevent_req_done(req);
@@ -638,17 +624,16 @@ static void idp_account_info_handler_done(struct tevent_req *subreq)
     struct idp_account_info_handler_state *state;
     struct tevent_req *req;
     const char *error_msg = NULL;
-    int dp_error = DP_ERR_FATAL;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct idp_account_info_handler_state);
 
-    ret = idp_handle_acct_req_recv(subreq, &dp_error, &error_msg, NULL);
+    ret = idp_handle_acct_req_recv(subreq, &error_msg, NULL);
     talloc_zfree(subreq);
 
     /* TODO For backward compatibility we always return EOK to DP now. */
-    dp_reply_std_set(&state->reply, dp_error, ret, error_msg);
+    dp_reply_std_set(&state->reply, ret, error_msg);
     tevent_req_done(req);
 }
 

--- a/src/providers/idp/idp_online_check.c
+++ b/src/providers/idp/idp_online_check.c
@@ -49,7 +49,7 @@ idp_online_check_handler_send(TALLOC_CTX *mem_ctx,
     /* TODO: evaluate if proper online check is needed */
     ret = ENOTSUP;
 
-    dp_reply_std_set(&state->reply, DP_ERR_DECIDE, ret, NULL);
+    dp_reply_std_set(&state->reply, ret, NULL);
 
     /* TODO For backward compatibility we always return EOK to DP now. */
     tevent_req_done(req);

--- a/src/providers/ipa/ipa_access.c
+++ b/src/providers/ipa/ipa_access.c
@@ -217,19 +217,16 @@ static errno_t ipa_fetch_hbac_retry(struct tevent_req *req)
 static void ipa_fetch_hbac_connect_done(struct tevent_req *subreq)
 {
     struct tevent_req *req = NULL;
-    int dp_error;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        goto done;
-    }
-
-    if (dp_error == DP_ERR_OFFLINE) {
-        ret = EOK;
+        if (ret == ERR_OFFLINE) {
+            ret = EOK;
+        }
         goto done;
     }
 
@@ -293,7 +290,6 @@ static void ipa_fetch_hbac_hostinfo_done(struct tevent_req *subreq)
     struct ipa_fetch_hbac_state *state = NULL;
     struct tevent_req *req = NULL;
     errno_t ret;
-    int dp_error;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct ipa_fetch_hbac_state);
@@ -313,8 +309,8 @@ static void ipa_fetch_hbac_hostinfo_done(struct tevent_req *subreq)
          * so that all searches are in another sub-request so that we can
          * error out at any step and the parent request can call
          * sdap_id_op_done just once. */
-        ret = sdap_id_op_done(state->sdap_op, ret, &dp_error);
-        if (dp_error == DP_ERR_OK && ret != EOK) {
+        ret = sdap_id_op_done(state->sdap_op, ret);
+        if (ret == EAGAIN) {
             /* retry */
             ret = ipa_fetch_hbac_retry(req);
             if (ret != EAGAIN) {
@@ -405,7 +401,6 @@ static void ipa_fetch_hbac_rules_done(struct tevent_req *subreq)
 {
     struct ipa_fetch_hbac_state *state = NULL;
     struct tevent_req *req = NULL;
-    int dp_error;
     errno_t ret;
     bool found;
 
@@ -427,8 +422,8 @@ static void ipa_fetch_hbac_rules_done(struct tevent_req *subreq)
         goto done;
     }
 
-    ret = sdap_id_op_done(state->sdap_op, ret, &dp_error);
-    if (dp_error == DP_ERR_OK && ret != EOK) {
+    ret = sdap_id_op_done(state->sdap_op, ret);
+    if (ret == EAGAIN) {
         /* retry */
         ret = ipa_fetch_hbac_retry(req);
         if (ret != EAGAIN) {

--- a/src/providers/ipa/ipa_auth.c
+++ b/src/providers/ipa/ipa_auth.c
@@ -101,12 +101,12 @@ static void get_password_migration_flag_auth_done(struct tevent_req *subreq)
     struct get_password_migration_flag_state *state = tevent_req_data(req,
                                       struct get_password_migration_flag_state);
     static const char *attrs[] = {IPA_CONFIG_MIGRATION_ENABLED, NULL};
-    int ret, dp_error;
+    int ret;
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
     if (ret) {
-        if (dp_error == DP_ERR_OFFLINE) {
+        if (ret == ERR_OFFLINE) {
             DEBUG(SSSDBG_MINOR_FAILURE,
                   "No IPA server is available, cannot get the "
                    "migration flag while offline\n");
@@ -246,7 +246,6 @@ static void ipa_pam_auth_handler_krb5_done(struct tevent_req *subreq)
 {
     struct ipa_pam_auth_handler_state *state;
     struct tevent_req *req;
-    int dp_err;
     char *realm;
     errno_t ret;
 
@@ -254,7 +253,7 @@ static void ipa_pam_auth_handler_krb5_done(struct tevent_req *subreq)
     state = tevent_req_data(req, struct ipa_pam_auth_handler_state);
 
     state->pd->pam_status = PAM_SYSTEM_ERR;
-    ret = krb5_auth_queue_recv(subreq, &state->pd->pam_status, &dp_err);
+    ret = krb5_auth_queue_recv(subreq, &state->pd->pam_status);
     talloc_free(subreq);
     if (ret != EOK && state->pd->pam_status != PAM_CRED_ERR) {
         DEBUG(SSSDBG_OP_FAILURE, "KRB5 auth failed [%d]: %s\n",
@@ -262,9 +261,11 @@ static void ipa_pam_auth_handler_krb5_done(struct tevent_req *subreq)
         goto done;
     }
 
-    if (dp_err != DP_ERR_OK) {
+    /* We are offline */
+    if (state->pd->pam_status == PAM_AUTHINFO_UNAVAIL) {
         goto done;
     }
+
     if (state->pd->cmd == SSS_PAM_CHAUTHTOK_PRELIM
         && state->pd->pam_status == PAM_TRY_AGAIN) {
         /* Reset this to fork a new krb5_child in handle_child_send() */
@@ -468,13 +469,12 @@ static void ipa_pam_auth_handler_retry_done(struct tevent_req *subreq)
 {
     struct ipa_pam_auth_handler_state *state;
     struct tevent_req *req;
-    int dp_err;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct ipa_pam_auth_handler_state);
 
-    ret = krb5_auth_queue_recv(subreq, &state->pd->pam_status, &dp_err);
+    ret = krb5_auth_queue_recv(subreq, &state->pd->pam_status);
     talloc_free(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "krb5_auth_recv request failed.\n");

--- a/src/providers/ipa/ipa_dyndns.c
+++ b/src/providers/ipa/ipa_dyndns.c
@@ -155,7 +155,6 @@ done:
 static void
 ipa_dyndns_update_connect_done(struct tevent_req *subreq)
 {
-    int dp_error;
     int ret;
     struct ipa_options *ctx;
     struct tevent_req *req;
@@ -165,11 +164,14 @@ ipa_dyndns_update_connect_done(struct tevent_req *subreq)
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct ipa_dyndns_update_state);
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
+    ctx = state->ipa_ctx;
+    sdap_ctx = ctx->id_ctx->sdap_id_ctx;
+
     if (ret != EOK) {
-        if (dp_error == DP_ERR_OFFLINE) {
+        if (ret == ERR_OFFLINE) {
             DEBUG(SSSDBG_MINOR_FAILURE, "No server is available, "
                   "dynamic DNS update is skipped in offline mode.\n");
             tevent_req_error(req, ERR_DYNDNS_OFFLINE);
@@ -181,9 +183,6 @@ ipa_dyndns_update_connect_done(struct tevent_req *subreq)
         }
         return;
     }
-
-    ctx = state->ipa_ctx;
-    sdap_ctx = ctx->id_ctx->sdap_id_ctx;
 
     /* The following three checks are here to prevent SEGFAULT
      * from ticket #3076. */

--- a/src/providers/ipa/ipa_dyndns.c
+++ b/src/providers/ipa/ipa_dyndns.c
@@ -177,7 +177,7 @@ ipa_dyndns_update_connect_done(struct tevent_req *subreq)
             DEBUG(SSSDBG_OP_FAILURE,
                   "Failed to connect to LDAP server: [%d](%s)\n",
                   ret, sss_strerror(ret));
-            tevent_req_error(req, ERR_NETWORK_IO);
+            tevent_req_error(req, ERR_SERVER_FAILURE);
         }
         return;
     }

--- a/src/providers/ipa/ipa_id.c
+++ b/src/providers/ipa/ipa_id.c
@@ -781,7 +781,7 @@ static void ipa_id_get_account_info_orig_done(struct tevent_req *subreq)
                             SYSDB_HOMEDIR,
                             NULL };
 
-    ret = sdap_handle_acct_req_recv(subreq, &dp_error, NULL, NULL);
+    ret = sdap_handle_acct_req_recv(subreq, &dp_error, NULL);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "sdap_handle_acct request failed: %d\n", ret);

--- a/src/providers/ipa/ipa_id.c
+++ b/src/providers/ipa/ipa_id.c
@@ -59,8 +59,6 @@ struct ipa_resolve_user_list_state {
     struct sss_domain_info *domain;
     struct sss_domain_info *user_domain;
     size_t user_idx;
-
-    int dp_error;
 };
 
 static errno_t ipa_resolve_user_list_get_user_step(struct tevent_req *req);
@@ -90,13 +88,11 @@ ipa_resolve_user_list_send(TALLOC_CTX *memctx, struct tevent_context *ev,
                                         state->domain_name, true);
     state->users = users;
     state->user_idx = 0;
-    state->dp_error = DP_ERR_FATAL;
 
     ret = ipa_resolve_user_list_get_user_step(req);
     if (ret == EAGAIN) {
         return req;
     } else if (ret == EOK) {
-        state->dp_error = DP_ERR_OK;
         tevent_req_done(req);
     } else {
         DEBUG(SSSDBG_OP_FAILURE,
@@ -166,9 +162,9 @@ static void ipa_resolve_user_list_get_user_done(struct tevent_req *subreq)
     int ret;
 
     if (state->user_domain != state->ipa_ctx->sdap_id_ctx->be->domain) {
-        ret = ipa_subdomain_account_recv(subreq, &state->dp_error);
+        ret = ipa_subdomain_account_recv(subreq);
     } else {
-        ret = ipa_id_get_account_info_recv(subreq, &state->dp_error);
+        ret = ipa_id_get_account_info_recv(subreq);
     }
     talloc_zfree(subreq);
     if (ret != EOK) {
@@ -189,26 +185,15 @@ static void ipa_resolve_user_list_get_user_done(struct tevent_req *subreq)
 
 done:
     if (ret == EOK) {
-        state->dp_error = DP_ERR_OK;
         tevent_req_done(req);
     } else {
-        if (state->dp_error == DP_ERR_OK) {
-            state->dp_error = DP_ERR_FATAL;
-        }
         tevent_req_error(req, ret);
     }
     return;
 }
 
-int ipa_resolve_user_list_recv(struct tevent_req *req, int *dp_error)
+int ipa_resolve_user_list_recv(struct tevent_req *req)
 {
-    struct ipa_resolve_user_list_state *state = tevent_req_data(req,
-                                            struct ipa_resolve_user_list_state);
-
-    if (dp_error) {
-        *dp_error = state->dp_error;
-    }
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     return EOK;
@@ -225,8 +210,6 @@ struct ipa_initgr_get_overrides_state {
     const char *groups_id_attr;
     size_t group_idx;
     struct dp_id_data *ar;
-
-    int dp_error;
 };
 
 static int ipa_initgr_get_overrides_step(struct tevent_req *req);
@@ -361,7 +344,7 @@ static void ipa_initgr_get_overrides_override_done(struct tevent_req *subreq)
     int ret;
     struct sysdb_attrs *override_attrs = NULL;
 
-    ret = ipa_get_trusted_override_recv(subreq, &state->dp_error, state,
+    ret = ipa_get_trusted_override_recv(subreq, state,
                                    &override_attrs);
     talloc_zfree(subreq);
     if (ret != EOK) {
@@ -421,15 +404,8 @@ static void ipa_initgr_get_overrides_override_done(struct tevent_req *subreq)
     tevent_req_done(req);
 }
 
-int ipa_initgr_get_overrides_recv(struct tevent_req *req, int *dp_error)
+int ipa_initgr_get_overrides_recv(struct tevent_req *req)
 {
-    struct ipa_initgr_get_overrides_state *state = tevent_req_data(req,
-                                        struct ipa_initgr_get_overrides_state);
-
-    if (dp_error) {
-        *dp_error = state->dp_error;
-    }
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
     return EOK;
 }
@@ -518,7 +494,6 @@ struct ipa_id_get_account_info_state {
 
     struct ldb_result *res;
     size_t res_index;
-    int dp_error;
 };
 
 static void ipa_id_get_account_info_connected(struct tevent_req *subreq);
@@ -549,7 +524,6 @@ ipa_id_get_account_info_send(TALLOC_CTX *memctx, struct tevent_context *ev,
     state->ev = ev;
     state->ipa_ctx = ipa_ctx;
     state->ctx = ipa_ctx->sdap_id_ctx;
-    state->dp_error = DP_ERR_FATAL;
 
     state->op = sdap_id_op_create(state, state->ctx->conn->conn_cache);
     if (state->op == NULL) {
@@ -616,10 +590,9 @@ static void ipa_id_get_account_info_connected(struct tevent_req *subreq)
                                                 struct tevent_req);
     struct ipa_id_get_account_info_state *state = tevent_req_data(req,
                                           struct ipa_id_get_account_info_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "sdap_id_op_connect request failed.\n");
@@ -640,7 +613,6 @@ static void ipa_id_get_account_info_connected(struct tevent_req *subreq)
     return;
 
 fail:
-    state->dp_error = dp_error;
     tevent_req_error(req, ret);
     return;
 }
@@ -651,20 +623,19 @@ static void ipa_id_get_account_info_got_override(struct tevent_req *subreq)
                                                 struct tevent_req);
     struct ipa_id_get_account_info_state *state = tevent_req_data(req,
                                           struct ipa_id_get_account_info_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
     const char *anchor = NULL;
     char *anchor_domain;
     char *ipa_uuid;
 
-    ret = ipa_get_trusted_override_recv(subreq, &dp_error, state,
+    ret = ipa_get_trusted_override_recv(subreq, state,
                                         &state->override_attrs);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
-        ret = sdap_id_op_done(state->op, ret, &dp_error);
+        ret = sdap_id_op_done(state->op, ret);
 
-        if (dp_error == DP_ERR_OK && ret != EOK) {
+        if (ret == EAGAIN) {
             /* retry */
             subreq = sdap_id_op_connect_send(state->op, state, &ret);
             if (subreq == NULL) {
@@ -736,7 +707,6 @@ static void ipa_id_get_account_info_got_override(struct tevent_req *subreq)
     return;
 
 fail:
-    state->dp_error = dp_error;
     tevent_req_error(req, ret);
     return;
 }
@@ -770,7 +740,6 @@ static void ipa_id_get_account_info_orig_done(struct tevent_req *subreq)
                                                 struct tevent_req);
     struct ipa_id_get_account_info_state *state = tevent_req_data(req,
                                           struct ipa_id_get_account_info_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
     const char *attrs[] = { SYSDB_NAME,
                             SYSDB_UIDNUM,
@@ -781,7 +750,7 @@ static void ipa_id_get_account_info_orig_done(struct tevent_req *subreq)
                             SYSDB_HOMEDIR,
                             NULL };
 
-    ret = sdap_handle_acct_req_recv(subreq, &dp_error, NULL);
+    ret = sdap_handle_acct_req_recv(subreq, NULL);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "sdap_handle_acct request failed: %d\n", ret);
@@ -790,7 +759,6 @@ static void ipa_id_get_account_info_orig_done(struct tevent_req *subreq)
 
     if (! is_object_overridable(state->ar)) {
         DEBUG(SSSDBG_FUNC_DATA, "Object not overridable, ending request\n");
-        state->dp_error = DP_ERR_OK;
         tevent_req_done(req);
         return;
     }
@@ -825,7 +793,6 @@ static void ipa_id_get_account_info_orig_done(struct tevent_req *subreq)
                                     &state->obj_msg);
         if (ret == ENOENT) {
             DEBUG(SSSDBG_MINOR_FAILURE, "Object not found, ending request\n");
-            state->dp_error = DP_ERR_OK;
             tevent_req_done(req);
             return;
         } else if (ret != EOK) {
@@ -842,12 +809,10 @@ static void ipa_id_get_account_info_orig_done(struct tevent_req *subreq)
         goto fail;
     }
 
-    state->dp_error = DP_ERR_OK;
     tevent_req_done(req);
     return;
 
 fail:
-    state->dp_error = dp_error;
     tevent_req_error(req, ret);
     return;
 }
@@ -999,12 +964,11 @@ static void ipa_id_get_account_info_done(struct tevent_req *subreq)
                                                 struct tevent_req);
     struct ipa_id_get_account_info_state *state = tevent_req_data(req,
                                           struct ipa_id_get_account_info_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
     const char *class;
     enum sysdb_member_type type;
 
-    ret = ipa_get_trusted_override_recv(subreq, &dp_error, state,
+    ret = ipa_get_trusted_override_recv(subreq, state,
                                         &state->override_attrs);
     talloc_zfree(subreq);
     if (ret != EOK) {
@@ -1089,12 +1053,10 @@ static void ipa_id_get_account_info_done(struct tevent_req *subreq)
         }
     }
 
-    state->dp_error = DP_ERR_OK;
     tevent_req_done(req);
     return;
 
 fail:
-    state->dp_error = dp_error;
     tevent_req_error(req, ret);
     return;
 }
@@ -1105,10 +1067,9 @@ static void ipa_id_get_user_list_done(struct tevent_req *subreq)
                                                 struct tevent_req);
     struct ipa_id_get_account_info_state *state = tevent_req_data(req,
                                           struct ipa_id_get_account_info_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
 
-    ret = ipa_resolve_user_list_recv(subreq, &dp_error);
+    ret = ipa_resolve_user_list_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "IPA resolve user list %d\n", ret);
@@ -1127,12 +1088,10 @@ static void ipa_id_get_user_list_done(struct tevent_req *subreq)
         }
     }
 
-    state->dp_error = DP_ERR_OK;
     tevent_req_done(req);
     return;
 
 fail:
-    state->dp_error = dp_error;
     tevent_req_error(req, ret);
     return;
 }
@@ -1143,10 +1102,9 @@ static void ipa_id_get_user_groups_done(struct tevent_req *subreq)
                                                 struct tevent_req);
     struct ipa_id_get_account_info_state *state = tevent_req_data(req,
                                           struct ipa_id_get_account_info_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
 
-    ret = ipa_initgr_get_overrides_recv(subreq, &dp_error);
+    ret = ipa_initgr_get_overrides_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "IPA resolve user groups %d\n", ret);
@@ -1165,25 +1123,16 @@ static void ipa_id_get_user_groups_done(struct tevent_req *subreq)
         }
     }
 
-    state->dp_error = DP_ERR_OK;
     tevent_req_done(req);
     return;
 
 fail:
-    state->dp_error = dp_error;
     tevent_req_error(req, ret);
     return;
 }
 
-int ipa_id_get_account_info_recv(struct tevent_req *req, int *dp_error)
+int ipa_id_get_account_info_recv(struct tevent_req *req)
 {
-    struct ipa_id_get_account_info_state *state = tevent_req_data(req,
-                                          struct ipa_id_get_account_info_state);
-
-    if (dp_error) {
-        *dp_error = state->dp_error;
-    }
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     return EOK;
@@ -1207,8 +1156,6 @@ struct ipa_id_get_netgroup_state {
 
     size_t count;
     struct sysdb_attrs **netgroups;
-
-    int dp_error;
 };
 
 static void ipa_id_get_netgroup_connected(struct tevent_req *subreq);
@@ -1233,7 +1180,6 @@ static struct tevent_req *ipa_id_get_netgroup_send(TALLOC_CTX *memctx,
 
     state->ev = ev;
     state->ctx = ipa_ctx;
-    state->dp_error = DP_ERR_FATAL;
 
     state->op = sdap_id_op_create(state, ctx->conn->conn_cache);
     if (!state->op) {
@@ -1288,15 +1234,13 @@ static void ipa_id_get_netgroup_connected(struct tevent_req *subreq)
                     tevent_req_callback_data(subreq, struct tevent_req);
     struct ipa_id_get_netgroup_state *state =
                     tevent_req_data(req, struct ipa_id_get_netgroup_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
     struct sdap_id_ctx *sdap_ctx = state->ctx->sdap_id_ctx;
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -1322,15 +1266,14 @@ static void ipa_id_get_netgroup_done(struct tevent_req *subreq)
                     tevent_req_callback_data(subreq, struct tevent_req);
     struct ipa_id_get_netgroup_state *state =
                     tevent_req_data(req, struct ipa_id_get_netgroup_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
 
     ret = ipa_get_netgroups_recv(subreq, state,
                                  &state->count, &state->netgroups);
     talloc_zfree(subreq);
-    ret = sdap_id_op_done(state->op, ret, &dp_error);
+    ret = sdap_id_op_done(state->op, ret);
 
-    if (dp_error == DP_ERR_OK && ret != EOK) {
+    if (ret == EAGAIN) {
         /* retry */
         subreq = sdap_id_op_connect_send(state->op, state, &ret);
         if (!subreq) {
@@ -1342,7 +1285,6 @@ static void ipa_id_get_netgroup_done(struct tevent_req *subreq)
     }
 
     if (ret && ret != ENOENT) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -1363,20 +1305,12 @@ static void ipa_id_get_netgroup_done(struct tevent_req *subreq)
         }
     }
 
-    state->dp_error = DP_ERR_OK;
     tevent_req_done(req);
     return;
 }
 
-static int ipa_id_get_netgroup_recv(struct tevent_req *req, int *dp_error)
+static int ipa_id_get_netgroup_recv(struct tevent_req *req)
 {
-    struct ipa_id_get_netgroup_state *state =
-                    tevent_req_data(req, struct ipa_id_get_netgroup_state);
-
-    if (dp_error) {
-        *dp_error = state->dp_error;
-    }
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     return EOK;
@@ -1404,7 +1338,6 @@ struct ipa_account_info_state {
     enum ipa_account_info_type type;
 
     const char *err_msg;
-    int dp_error;
 };
 
 static void ipa_account_info_done(struct tevent_req *subreq);
@@ -1472,13 +1405,13 @@ static void ipa_account_info_done(struct tevent_req *subreq)
 
     switch (state->type) {
     case IPA_ACCOUNT_INFO_SUBDOMAIN:
-        ret = ipa_subdomain_account_recv(subreq, &state->dp_error);
+        ret = ipa_subdomain_account_recv(subreq);
         break;
     case IPA_ACCOUNT_INFO_NETGROUP:
-        ret = ipa_id_get_netgroup_recv(subreq, &state->dp_error);
+        ret = ipa_id_get_netgroup_recv(subreq);
         break;
     case IPA_ACCOUNT_INFO_OTHER:
-        ret = ipa_id_get_account_info_recv(subreq, &state->dp_error);
+        ret = ipa_id_get_account_info_recv(subreq);
         break;
     default:
         ret = EINVAL;
@@ -1494,18 +1427,8 @@ static void ipa_account_info_done(struct tevent_req *subreq)
     tevent_req_done(req);
 }
 
-errno_t ipa_account_info_recv(struct tevent_req *req,
-                              int *_dp_error)
+errno_t ipa_account_info_recv(struct tevent_req *req)
 {
-    struct ipa_account_info_state *state = NULL;
-
-    state = tevent_req_data(req, struct ipa_account_info_state);
-
-    /* Fail the request after collecting the dp_error */
-    if (_dp_error) {
-        *_dp_error = state->dp_error;
-    }
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
     return EOK;
 }
@@ -1550,7 +1473,7 @@ ipa_account_info_handler_send(TALLOC_CTX *mem_ctx,
     return req;
 
 immediately:
-    dp_reply_std_set(&state->reply, DP_ERR_DECIDE, ret, NULL);
+    dp_reply_std_set(&state->reply, ret, NULL);
 
     /* TODO For backward compatibility we always return EOK to DP now. */
     tevent_req_done(req);
@@ -1563,17 +1486,16 @@ static void ipa_account_info_handler_done(struct tevent_req *subreq)
 {
     struct ipa_account_info_handler_state *state;
     struct tevent_req *req;
-    int dp_error;
     errno_t ret = ERR_INTERNAL;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct ipa_account_info_handler_state);
 
-    ret = ipa_account_info_recv(subreq, &dp_error);
+    ret = ipa_account_info_recv(subreq);
     talloc_zfree(subreq);
 
     /* TODO For backward compatibility we always return EOK to DP now. */
-    dp_reply_std_set(&state->reply, dp_error, ret, NULL);
+    dp_reply_std_set(&state->reply, ret, NULL);
     tevent_req_done(req);
 }
 

--- a/src/providers/ipa/ipa_id.h
+++ b/src/providers/ipa/ipa_id.h
@@ -38,8 +38,7 @@ ipa_account_info_send(TALLOC_CTX *mem_ctx,
                       struct be_ctx *be_ctx,
                       struct ipa_id_ctx *id_ctx,
                       struct dp_id_data *data);
-errno_t ipa_account_info_recv(struct tevent_req *req,
-                              int *_dp_error);
+errno_t ipa_account_info_recv(struct tevent_req *req);
 
 struct tevent_req *
 ipa_account_info_handler_send(TALLOC_CTX *mem_ctx,
@@ -83,7 +82,7 @@ struct tevent_req *ipa_get_subdom_acct_send(TALLOC_CTX *memctx,
                                             struct ipa_id_ctx *ipa_ctx,
                                             struct sysdb_attrs *override_attrs,
                                             struct dp_id_data *ar);
-int ipa_get_subdom_acct_recv(struct tevent_req *req, int *dp_error_out);
+int ipa_get_subdom_acct_recv(struct tevent_req *req);
 
 errno_t get_dp_id_data_for_sid(TALLOC_CTX *mem_ctx, const char *sid,
                                 const char *domain_name,
@@ -106,7 +105,7 @@ struct tevent_req *ipa_get_trusted_override_send(TALLOC_CTX *mem_ctx,
                                                  const char *view_name,
                                                  struct dp_id_data *ar);
 
-errno_t ipa_get_trusted_override_recv(struct tevent_req *req, int *dp_error_out,
+errno_t ipa_get_trusted_override_recv(struct tevent_req *req,
                                       TALLOC_CTX *mem_ctx,
                                       struct sysdb_attrs **override_attrs);
 
@@ -115,7 +114,7 @@ struct tevent_req *ipa_subdomain_account_send(TALLOC_CTX *memctx,
                                               struct ipa_id_ctx *ipa_ctx,
                                               struct dp_id_data *ar);
 
-errno_t ipa_subdomain_account_recv(struct tevent_req *req, int *dp_error_out);
+errno_t ipa_subdomain_account_recv(struct tevent_req *req);
 
 errno_t split_ipa_anchor(TALLOC_CTX *mem_ctx, const char *anchor,
                          char **_anchor_domain, char **_ipa_uuid);
@@ -133,7 +132,7 @@ ipa_initgr_get_overrides_send(TALLOC_CTX *memctx,
                              size_t groups_count,
                              struct ldb_message **groups,
                              const char *groups_id_attr);
-int ipa_initgr_get_overrides_recv(struct tevent_req *req, int *dp_error);
+int ipa_initgr_get_overrides_recv(struct tevent_req *req);
 
 struct tevent_req *ipa_get_subdom_acct_process_pac_send(TALLOC_CTX *mem_ctx,
                                                    struct tevent_context *ev,
@@ -149,11 +148,11 @@ ipa_resolve_user_list_send(TALLOC_CTX *memctx, struct tevent_context *ev,
                            struct ipa_id_ctx *ipa_ctx,
                            const char *domain_name,
                            struct ldb_message_element *users);
-int ipa_resolve_user_list_recv(struct tevent_req *req, int *dp_error);
+int ipa_resolve_user_list_recv(struct tevent_req *req);
 
 struct tevent_req *
 ipa_id_get_account_info_send(TALLOC_CTX *memctx, struct tevent_context *ev,
                              struct ipa_id_ctx *ipa_ctx,
                              struct dp_id_data *ar);
-int ipa_id_get_account_info_recv(struct tevent_req *req, int *dp_error);
+int ipa_id_get_account_info_recv(struct tevent_req *req);
 #endif

--- a/src/providers/ipa/ipa_refresh.c
+++ b/src/providers/ipa/ipa_refresh.c
@@ -134,18 +134,17 @@ static void ipa_refresh_done(struct tevent_req *subreq)
 {
     struct ipa_refresh_state *state = NULL;
     struct tevent_req *req = NULL;
-    errno_t dp_error;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct ipa_refresh_state);
 
-    ret = ipa_account_info_recv(subreq, &dp_error);
+    ret = ipa_account_info_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to refresh %s [dp_error: %d, "
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to refresh %s, "
               "errno: %d]\n", be_req2str(state->account_req->entry_type),
-              dp_error, ret);
+              ret);
         goto done;
     }
 

--- a/src/providers/ipa/ipa_s2n_exop.c
+++ b/src/providers/ipa/ipa_s2n_exop.c
@@ -1560,17 +1560,15 @@ fail:
 static void ipa_s2n_get_list_ipa_next(struct tevent_req *subreq)
 {
     int ret;
-    int dp_error;
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                       struct tevent_req);
     struct ipa_s2n_get_list_state *state = tevent_req_data(req,
                                                struct ipa_s2n_get_list_state);
 
-    ret = ipa_id_get_account_info_recv(subreq, &dp_error);
+    ret = ipa_id_get_account_info_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "ipa_id_get_account_info failed: %d %d\n", ret,
-                                 dp_error);
+        DEBUG(SSSDBG_OP_FAILURE, "ipa_id_get_account_info failed: %d\n", ret);
         goto done;
     }
 
@@ -1601,7 +1599,7 @@ static void ipa_s2n_get_list_get_override_done(struct tevent_req *subreq)
     struct ipa_s2n_get_list_state *state = tevent_req_data(req,
                                                struct ipa_s2n_get_list_state);
 
-    ret = ipa_get_trusted_override_recv(subreq, NULL, state, &state->override_attrs);
+    ret = ipa_get_trusted_override_recv(subreq, state, &state->override_attrs);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "IPA override lookup failed: %d\n", ret);
@@ -3086,7 +3084,7 @@ static void ipa_s2n_get_user_get_override_done(struct tevent_req *subreq)
                                                 struct ipa_s2n_get_user_state);
     struct sysdb_attrs *override_attrs = NULL;
 
-    ret = ipa_get_trusted_override_recv(subreq, NULL, state, &override_attrs);
+    ret = ipa_get_trusted_override_recv(subreq, state, &override_attrs);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "IPA override lookup failed: %d\n", ret);

--- a/src/providers/ipa/ipa_s2n_exop.c
+++ b/src/providers/ipa/ipa_s2n_exop.c
@@ -174,7 +174,7 @@ static struct tevent_req *ipa_s2n_exop_send(TALLOC_CTX *mem_ctx,
                                   bv, NULL, NULL, &msgid);
     if (ret == -1 || msgid == -1) {
         DEBUG(SSSDBG_CRIT_FAILURE, "ldap_extended_operation failed\n");
-        ret = ERR_NETWORK_IO;
+        ret = ERR_SERVER_FAILURE;
         goto fail;
     }
     DEBUG(SSSDBG_TRACE_INTERNAL, "ldap_extended_operation sent, msgid = %d\n",
@@ -228,7 +228,7 @@ static void ipa_s2n_exop_done(struct sdap_op *op,
     if (ret != LDAP_SUCCESS) {
         DEBUG(SSSDBG_OP_FAILURE, "ldap_parse_result failed (%d)\n",
                                  sdap_op_get_msgid(state->op));
-        ret = ERR_NETWORK_IO;
+        ret = ERR_SERVER_FAILURE;
         goto done;
     }
 
@@ -243,7 +243,7 @@ static void ipa_s2n_exop_done(struct sdap_op *op,
         } else {
             DEBUG(SSSDBG_OP_FAILURE, "ldap_extended_operation failed, server " \
                                      "logs might contain more details.\n");
-            ret = ERR_NETWORK_IO;
+            ret = ERR_SERVER_FAILURE;
         }
         goto done;
     }
@@ -253,7 +253,7 @@ static void ipa_s2n_exop_done(struct sdap_op *op,
     if (ret != LDAP_SUCCESS) {
         DEBUG(SSSDBG_OP_FAILURE, "ldap_parse_extendend_result failed (%d)\n",
                                  ret);
-        ret = ERR_NETWORK_IO;
+        ret = ERR_SERVER_FAILURE;
         goto done;
     }
     if (retdata == NULL) {
@@ -1721,7 +1721,7 @@ struct tevent_req *ipa_s2n_get_acct_info_send(TALLOC_CTX *mem_ctx,
     } else {
         DEBUG(SSSDBG_CRIT_FAILURE, "Extdom not supported on the server, "
                               "cannot resolve objects from trusted domains.\n");
-        ret = EIO;
+        ret = ERR_SERVER_FAILURE;
         goto fail;
     }
 

--- a/src/providers/ipa/ipa_selinux.c
+++ b/src/providers/ipa/ipa_selinux.c
@@ -809,17 +809,16 @@ static void ipa_get_selinux_connect_done(struct tevent_req *subreq)
                                                   struct tevent_req);
     struct ipa_get_selinux_state *state = tevent_req_data(req,
                                                   struct ipa_get_selinux_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
     struct ipa_id_ctx *id_ctx = state->selinux_ctx->id_ctx;
     struct dp_module *access_mod;
     struct dp_module *selinux_mod;
     const char *hostname;
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
-    if (dp_error == DP_ERR_OFFLINE) {
+    if (ret == ERR_OFFLINE) {
         talloc_zfree(state->op);
         ret = ipa_get_selinux_maps_offline(req);
         if (ret == EOK) {

--- a/src/providers/ipa/ipa_session.c
+++ b/src/providers/ipa/ipa_session.c
@@ -208,12 +208,11 @@ static void
 ipa_fetch_deskprofile_connect_done(struct tevent_req *subreq)
 {
     struct tevent_req *req = NULL;
-    int dp_error;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
         goto done;
@@ -355,7 +354,6 @@ ipa_fetch_deskprofile_rules_done(struct tevent_req *subreq)
 {
     struct tevent_req *req;
     struct ipa_fetch_deskprofile_state *state;
-    int dp_error;
     errno_t ret;
     bool found;
 
@@ -378,8 +376,8 @@ ipa_fetch_deskprofile_rules_done(struct tevent_req *subreq)
         goto done;
     }
 
-    ret = sdap_id_op_done(state->sdap_op, ret, &dp_error);
-    if (dp_error == DP_ERR_OK && ret != EOK) {
+    ret = sdap_id_op_done(state->sdap_op, ret);
+    if (ret == EAGAIN) {
         /* retry */
         ret = ipa_fetch_deskprofile_retry(req);
         if (ret != EAGAIN) {

--- a/src/providers/ipa/ipa_subdomains.c
+++ b/src/providers/ipa/ipa_subdomains.c
@@ -2957,22 +2957,20 @@ static void ipa_subdomains_refresh_connect_done(struct tevent_req *subreq)
 {
     struct ipa_subdomains_refresh_state *state;
     struct tevent_req *req;
-    int dp_error;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct ipa_subdomains_refresh_state);
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to connect to LDAP "
               "[%d]: %s\n", ret, sss_strerror(ret));
-        if (dp_error == DP_ERR_OFFLINE) {
+        if (ret == ERR_OFFLINE) {
             DEBUG(SSSDBG_MINOR_FAILURE, "No IPA server is available, "
                   "cannot get the subdomain list while offline\n");
-            ret = ERR_OFFLINE;
         }
         tevent_req_error(req, ret);
         return;
@@ -3201,7 +3199,6 @@ ipa_domain_refresh_resolution_order_done(struct tevent_req *subreq)
 {
     struct ipa_subdomains_refresh_state *state;
     struct tevent_req *req;
-    int dp_error;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
@@ -3216,12 +3213,10 @@ ipa_domain_refresh_resolution_order_done(struct tevent_req *subreq)
         /* Not good, but let's try to continue with other server side options */
     }
 
-    ret = sdap_id_op_done(state->sdap_op, ret, &dp_error);
-    if (dp_error == DP_ERR_OK && ret != EOK) {
+    ret = sdap_id_op_done(state->sdap_op, ret);
+    if (ret == EAGAIN) {
         /* retry */
         ret = ipa_subdomains_refresh_retry(req);
-    } else if (dp_error == DP_ERR_OFFLINE) {
-        ret = ERR_OFFLINE;
     }
 
     if (ret != EOK) {
@@ -3313,7 +3308,7 @@ ipa_subdomains_handler_send(TALLOC_CTX *mem_ctx,
     return req;
 
 immediately:
-    dp_reply_std_set(&state->reply, DP_ERR_DECIDE, ret, NULL);
+    dp_reply_std_set(&state->reply, ret, NULL);
 
     /* TODO For backward compatibility we always return EOK to DP now. */
     tevent_req_done(req);
@@ -3339,7 +3334,7 @@ static void ipa_subdomains_handler_done(struct tevent_req *subreq)
     }
 
     /* TODO For backward compatibility we always return EOK to DP now. */
-    dp_reply_std_set(&state->reply, DP_ERR_DECIDE, ret, NULL);
+    dp_reply_std_set(&state->reply, ret, NULL);
     tevent_req_done(req);
 }
 

--- a/src/providers/ipa/ipa_subdomains.h
+++ b/src/providers/ipa/ipa_subdomains.h
@@ -172,7 +172,7 @@ struct tevent_req *ipa_get_trusted_memberships_send(TALLOC_CTX *mem_ctx,
                                                     struct sdap_id_ctx *sdap_id_ctx,
                                                     const char *domain);
 
-errno_t ipa_get_trusted_memberships_recv(struct tevent_req *req, int *dp_error_out);
+errno_t ipa_get_trusted_memberships_recv(struct tevent_req *req);
 
 struct tevent_req *ipa_ext_group_member_send(TALLOC_CTX *mem_ctx,
                                              struct tevent_context *ev,

--- a/src/providers/ipa/ipa_subdomains_ext_groups.c
+++ b/src/providers/ipa/ipa_subdomains_ext_groups.c
@@ -1098,7 +1098,7 @@ static void ipa_add_trusted_memberships_get_group_done(struct tevent_req *subreq
                                                 struct add_trusted_membership_state);
     int ret;
 
-    ret = groups_get_recv(subreq, &state->dp_error, NULL);
+    ret = groups_get_recv(subreq, &state->dp_error);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to read group [%s] from LDAP [%d](%s)\n",

--- a/src/providers/ipa/ipa_subdomains_ext_groups.c
+++ b/src/providers/ipa/ipa_subdomains_ext_groups.c
@@ -525,7 +525,6 @@ struct get_trusted_membership_state {
     char *user_name;
     struct sss_domain_info *user_dom;
 
-    int dp_error;
     const char *domain;
     size_t reply_count;
     struct sysdb_attrs **reply;
@@ -534,8 +533,7 @@ struct get_trusted_membership_state {
 static void ipa_get_trusted_memberships_connect_done(struct tevent_req *subreq);
 static void ipa_get_ext_groups_done(struct tevent_req *subreq);
 static errno_t ipa_add_ext_groups_step(struct tevent_req *req);
-static errno_t ipa_add_trusted_memberships_recv(struct tevent_req *req,
-                                                int *dp_error_out);
+static errno_t ipa_add_trusted_memberships_recv(struct tevent_req *req);
 
 struct tevent_req *ipa_get_trusted_memberships_send(TALLOC_CTX *mem_ctx,
                                                     struct tevent_context *ev,
@@ -561,7 +559,6 @@ struct tevent_req *ipa_get_trusted_memberships_send(TALLOC_CTX *mem_ctx,
     state->sdap_id_ctx = sdap_id_ctx;
     state->srv = NULL;
     state->domain = domain;
-    state->dp_error = -1;
 
     if (((ar->entry_type & BE_REQ_TYPE_MASK) != BE_REQ_INITGROUPS
             && (ar->entry_type & BE_REQ_TYPE_MASK) != BE_REQ_USER)
@@ -624,10 +621,8 @@ struct tevent_req *ipa_get_trusted_memberships_send(TALLOC_CTX *mem_ctx,
 
 done:
     if (ret != EOK) {
-        state->dp_error = DP_ERR_FATAL;
         tevent_req_error(req, ret);
     } else {
-        state->dp_error = DP_ERR_OK;
         tevent_req_done(req);
     }
     tevent_req_post(req, state->ev);
@@ -643,10 +638,10 @@ static void ipa_get_trusted_memberships_connect_done(struct tevent_req *subreq)
                                                 struct get_trusted_membership_state);
     int ret;
 
-    ret = sdap_id_op_connect_recv(subreq, &state->dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        if (state->dp_error == DP_ERR_OFFLINE) {
+        if (ret == ERR_OFFLINE) {
             DEBUG(SSSDBG_MINOR_FAILURE,
                   "No IPA server is available, going offline\n");
         } else {
@@ -755,7 +750,6 @@ static errno_t ipa_add_ext_groups_step(struct tevent_req *req)
     if (user_dn == NULL) {
         DEBUG(SSSDBG_TRACE_ALL, "User [%s] not found in cache.\n",
                                 state->user_name);
-        state->dp_error = DP_ERR_OK;
         return EOK;
     }
 
@@ -780,11 +774,9 @@ static void ipa_add_trusted_memberships_done(struct tevent_req *subreq)
 {
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                       struct tevent_req);
-    struct get_trusted_membership_state *state = tevent_req_data(req,
-                                                struct get_trusted_membership_state);
     int ret;
 
-    ret = ipa_add_trusted_memberships_recv(subreq, &state->dp_error);
+    ret = ipa_add_trusted_memberships_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "ipa_add_ad_memberships request failed.\n");
@@ -792,21 +784,13 @@ static void ipa_add_trusted_memberships_done(struct tevent_req *subreq)
         return;
     }
 
-    state->dp_error = DP_ERR_OK;
     tevent_req_done(req);
     return;
 }
 
-errno_t ipa_get_trusted_memberships_recv(struct tevent_req *req, int *dp_error_out)
+errno_t ipa_get_trusted_memberships_recv(struct tevent_req *req)
 {
-    struct get_trusted_membership_state *state = tevent_req_data(req,
-                                                struct get_trusted_membership_state);
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
-
-    if (dp_error_out) {
-        *dp_error_out = state->dp_error;
-    }
 
     return EOK;
 }
@@ -873,7 +857,6 @@ struct add_trusted_membership_state {
     char **orig_groups; /* a superset of `groups`, memory is shared */
     char **groups;
     char **missing_groups;
-    int dp_error;
     size_t iter;
     struct sdap_domain *group_sdom;
 };
@@ -929,7 +912,6 @@ static struct tevent_req *ipa_add_trusted_memberships_send(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    state->dp_error = -1;
     state->iter = 0;
     state->group_sdom = sdap_domain_get(sdap_id_ctx->opts, group_dom);
     if (state->group_sdom == NULL) {
@@ -971,10 +953,8 @@ static struct tevent_req *ipa_add_trusted_memberships_send(TALLOC_CTX *mem_ctx,
 
 done:
     if (ret != EOK) {
-        state->dp_error = DP_ERR_FATAL;
         tevent_req_error(req, ret);
     } else {
-        state->dp_error = DP_ERR_OK;
         tevent_req_done(req);
     }
     tevent_req_post(req, state->ev);
@@ -990,10 +970,10 @@ static void ipa_add_trusted_memberships_connect_done(struct tevent_req *subreq)
                                                 struct add_trusted_membership_state);
     int ret;
 
-    ret = sdap_id_op_connect_recv(subreq, &state->dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        if (state->dp_error == DP_ERR_OFFLINE) {
+        if (ret == ERR_OFFLINE) {
             DEBUG(SSSDBG_MINOR_FAILURE,
                   "No IPA server is available, going offline\n");
         } else {
@@ -1098,7 +1078,7 @@ static void ipa_add_trusted_memberships_get_group_done(struct tevent_req *subreq
                                                 struct add_trusted_membership_state);
     int ret;
 
-    ret = groups_get_recv(subreq, &state->dp_error);
+    ret = groups_get_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to read group [%s] from LDAP [%d](%s)\n",
@@ -1112,17 +1092,9 @@ static void ipa_add_trusted_memberships_get_group_done(struct tevent_req *subreq
     ipa_add_trusted_memberships_get_next(req);
 }
 
-static errno_t ipa_add_trusted_memberships_recv(struct tevent_req *req,
-                                           int *dp_error_out)
+static errno_t ipa_add_trusted_memberships_recv(struct tevent_req *req)
 {
-    struct add_trusted_membership_state *state = tevent_req_data(req,
-                                                struct add_trusted_membership_state);
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
-
-    if (dp_error_out) {
-        *dp_error_out = state->dp_error;
-    }
 
     return EOK;
 }
@@ -1346,10 +1318,10 @@ static void ipa_ext_group_member_done(struct tevent_req *subreq)
         DEBUG(SSSDBG_OP_FAILURE, "dp_req_recv failed\n");
         tevent_req_error(req, ret);
         return;
-    } else if (reply->dp_error != DP_ERR_OK) {
+    } else if (reply->error != EOK) {
         DEBUG(SSSDBG_MINOR_FAILURE,
-              "Cannot refresh data from DP: %u,%u: %s\n",
-              reply->dp_error, reply->error, reply->message);
+              "Cannot refresh data from DP: %u: %s\n",
+              reply->error, reply->message);
         tevent_req_error(req, EIO);
         return;
     }

--- a/src/providers/ipa/ipa_subdomains_ext_groups.c
+++ b/src/providers/ipa/ipa_subdomains_ext_groups.c
@@ -1078,7 +1078,7 @@ static void ipa_add_trusted_memberships_get_group_done(struct tevent_req *subreq
                                                 struct add_trusted_membership_state);
     int ret;
 
-    ret = groups_get_recv(subreq);
+    ret = groups_get_recv(subreq, NULL);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to read group [%s] from LDAP [%d](%s)\n",

--- a/src/providers/ipa/ipa_subdomains_id.c
+++ b/src/providers/ipa/ipa_subdomains_id.c
@@ -45,7 +45,7 @@ ipa_srv_acct_send(TALLOC_CTX *mem_ctx,
                   struct sysdb_attrs *override_attrs,
                   struct dp_id_data *ar);
 static errno_t
-ipa_srv_acct_recv(struct tevent_req *req, int *dp_error_out);
+ipa_srv_acct_recv(struct tevent_req *req);
 
 struct ipa_subdomain_account_state {
     struct tevent_context *ev;
@@ -64,8 +64,6 @@ struct ipa_subdomain_account_state {
     struct sysdb_attrs *override_attrs;
     struct sysdb_attrs *mapped_attrs;
     char *object_sid;
-
-    int dp_error;
 };
 
 static void ipa_subdomain_account_connected(struct tevent_req *subreq);
@@ -93,7 +91,6 @@ struct tevent_req *ipa_subdomain_account_send(TALLOC_CTX *memctx,
     state->ev = ev;
     state->ipa_ctx = ipa_ctx;
     state->ctx = ipa_ctx->sdap_id_ctx;
-    state->dp_error = DP_ERR_FATAL;
 
     state->op = sdap_id_op_create(state, state->ctx->conn->conn_cache);
     if (!state->op) {
@@ -161,10 +158,9 @@ static void ipa_subdomain_account_connected(struct tevent_req *subreq)
                                                 struct tevent_req);
     struct ipa_subdomain_account_state *state = tevent_req_data(req,
                                             struct ipa_subdomain_account_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "sdap_id_op_connect request failed.\n");
@@ -187,7 +183,6 @@ static void ipa_subdomain_account_connected(struct tevent_req *subreq)
     return;
 
 fail:
-    state->dp_error = dp_error;
     tevent_req_error(req, ret);
     return;
 }
@@ -201,18 +196,17 @@ static void ipa_subdomain_account_got_override(struct tevent_req *subreq)
                                                 struct tevent_req);
     struct ipa_subdomain_account_state *state = tevent_req_data(req,
                                             struct ipa_subdomain_account_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
     const char *anchor = NULL;
     struct dp_id_data *ar;
 
-    ret = ipa_get_trusted_override_recv(subreq, &dp_error, state,
+    ret = ipa_get_trusted_override_recv(subreq, state,
                                         &state->override_attrs);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        ret = sdap_id_op_done(state->op, ret, &dp_error);
+        ret = sdap_id_op_done(state->op, ret);
 
-        if (dp_error == DP_ERR_OK && ret != EOK) {
+        if (ret == EAGAIN) {
             /* retry */
             subreq = sdap_id_op_connect_send(state->op, state, &ret);
             if (subreq == NULL) {
@@ -326,7 +320,6 @@ static void ipa_subdomain_account_got_override(struct tevent_req *subreq)
     return;
 
 fail:
-    state->dp_error = dp_error;
     tevent_req_error(req, ret);
     return;
 }
@@ -363,21 +356,19 @@ static void ipa_subdomain_account_done(struct tevent_req *subreq)
                                                 struct tevent_req);
     struct ipa_subdomain_account_state *state = tevent_req_data(req,
                                             struct ipa_subdomain_account_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
     struct ldb_result *res;
     struct sss_domain_info *object_dom;
 
     if (state->ipa_server_mode) {
-        ret = ipa_srv_acct_recv(subreq, &dp_error);
+        ret = ipa_srv_acct_recv(subreq);
     } else {
-        ret = ipa_get_subdom_acct_recv(subreq, &dp_error);
+        ret = ipa_get_subdom_acct_recv(subreq);
     }
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "ipa_get_*_acct request failed: [%d]: %s.\n",
               ret, sss_strerror(ret));
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -406,20 +397,12 @@ static void ipa_subdomain_account_done(struct tevent_req *subreq)
         }
     }
 
-    state->dp_error = DP_ERR_OK;
     tevent_req_done(req);
     return;
 }
 
-errno_t ipa_subdomain_account_recv(struct tevent_req *req, int *dp_error_out)
+errno_t ipa_subdomain_account_recv(struct tevent_req *req)
 {
-    struct ipa_subdomain_account_state *state = tevent_req_data(req,
-                                            struct ipa_subdomain_account_state);
-
-    if (dp_error_out) {
-        *dp_error_out = state->dp_error;
-    }
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     return EOK;
@@ -440,8 +423,6 @@ struct ipa_get_subdom_acct {
     const char *extra_value;
     bool use_pac;
     struct ldb_message *user_msg;
-
-    int dp_error;
 };
 
 static void ipa_get_subdom_acct_connected(struct tevent_req *subreq);
@@ -464,7 +445,6 @@ struct tevent_req *ipa_get_subdom_acct_send(TALLOC_CTX *memctx,
     state->ev = ev;
     state->ipa_ctx = ipa_ctx;
     state->ctx = ipa_ctx->sdap_id_ctx;
-    state->dp_error = DP_ERR_FATAL;
     state->override_attrs = override_attrs;
     state->use_pac = false;
 
@@ -538,16 +518,14 @@ static void ipa_get_subdom_acct_connected(struct tevent_req *subreq)
                                                 struct tevent_req);
     struct ipa_get_subdom_acct *state = tevent_req_data(req,
                                                 struct ipa_get_subdom_acct);
-    int dp_error = DP_ERR_FATAL;
     int ret;
     char *endptr;
     struct req_input *req_input;
     char *shortname;
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -659,14 +637,12 @@ static void ipa_get_subdom_acct_connected(struct tevent_req *subreq)
             } else {
                 DEBUG(SSSDBG_OP_FAILURE,
                       "Lookup by certificate not supported by the server.\n");
-                state->dp_error = DP_ERR_OK;
                 tevent_req_error(req, EINVAL);
                 return;
             }
             break;
         default:
             DEBUG(SSSDBG_OP_FAILURE, "Invalid sub-domain filter type.\n");
-            state->dp_error = dp_error;
             tevent_req_error(req, EINVAL);
             return;
     }
@@ -695,14 +671,13 @@ static void ipa_get_subdom_acct_done(struct tevent_req *subreq)
                                                 struct tevent_req);
     struct ipa_get_subdom_acct *state = tevent_req_data(req,
                                                 struct ipa_get_subdom_acct);
-    int dp_error = DP_ERR_FATAL;
     int ret;
 
     ret = ipa_s2n_get_acct_info_recv(subreq);
     talloc_zfree(subreq);
 
-    ret = sdap_id_op_done(state->op, ret, &dp_error);
-    if (dp_error == DP_ERR_OK && ret != EOK) {
+    ret = sdap_id_op_done(state->op, ret);
+    if (ret == EAGAIN) {
         /* retry */
         subreq = sdap_id_op_connect_send(state->op, state, &ret);
         if (!subreq) {
@@ -714,26 +689,17 @@ static void ipa_get_subdom_acct_done(struct tevent_req *subreq)
     }
 
     if (ret && ret != ENOENT) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
 
     /* FIXME: do we need some special handling of ENOENT */
 
-    state->dp_error = DP_ERR_OK;
     tevent_req_done(req);
 }
 
-int ipa_get_subdom_acct_recv(struct tevent_req *req, int *dp_error_out)
+int ipa_get_subdom_acct_recv(struct tevent_req *req)
 {
-    struct ipa_get_subdom_acct *state = tevent_req_data(req,
-                                                struct ipa_get_subdom_acct);
-
-    if (dp_error_out) {
-        *dp_error_out = state->dp_error;
-    }
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     return EOK;
@@ -787,7 +753,6 @@ ipa_ad_gc_conn_list(TALLOC_CTX *mem_ctx, struct ipa_id_ctx *ipa_ctx,
 
 /* IPA lookup for server mode. AD or IPA subdomain */
 struct ipa_get_acct_state {
-    int dp_error;
     struct tevent_context *ev;
     struct ipa_id_ctx *ipa_ctx;
     struct dp_id_data *ar;
@@ -828,7 +793,6 @@ ipa_get_ad_acct_send(TALLOC_CTX *mem_ctx,
     req = tevent_req_create(mem_ctx, &state, struct ipa_get_acct_state);
     if (req == NULL) return NULL;
 
-    state->dp_error = -1;
     state->ev = ev;
     state->ipa_ctx = ipa_ctx;
     state->ar = ar;
@@ -891,7 +855,6 @@ ipa_get_ad_acct_send(TALLOC_CTX *mem_ctx,
     return req;
 
 fail:
-    state->dp_error = DP_ERR_FATAL;
     tevent_req_error(req, ret);
     tevent_req_post(req, ev);
     return req;
@@ -958,7 +921,6 @@ ipa_get_ipa_acct_send(TALLOC_CTX *mem_ctx,
     req = tevent_req_create(mem_ctx, &state, struct ipa_get_acct_state);
     if (req == NULL) return NULL;
 
-    state->dp_error = -1;
     state->ev = ev;
     state->ipa_ctx = ipa_ctx;
     state->ar = ar;
@@ -999,7 +961,6 @@ ipa_get_ipa_acct_send(TALLOC_CTX *mem_ctx,
     return req;
 
 fail:
-    state->dp_error = DP_ERR_FATAL;
     tevent_req_error(req, ret);
     tevent_req_post(req, ev);
     return req;
@@ -1365,7 +1326,6 @@ done:
 static void ipa_get_sid_ipa_next(struct tevent_req *subreq)
 {
     int ret;
-    int dp_error = DP_ERR_FATAL;
     const char *sid;
     const char *user;
     struct ldb_message *user_msg;
@@ -1376,11 +1336,10 @@ static void ipa_get_sid_ipa_next(struct tevent_req *subreq)
     struct ipa_get_acct_state *state = tevent_req_data(req,
                                                 struct ipa_get_acct_state);
 
-    ret = ipa_subdomain_account_recv(subreq, &state->dp_error);
+    ret = ipa_subdomain_account_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        DEBUG(SSSDBG_OP_FAILURE, "ipa_id_get_account_info failed: %d %d\n", ret,
-                                 dp_error);
+        DEBUG(SSSDBG_OP_FAILURE, "ipa_id_get_account_info failed: %d \n", ret);
         goto done;
     }
 
@@ -1472,9 +1431,9 @@ ipa_get_trusted_acct_part_done(struct tevent_req *subreq)
     struct dp_id_data *user_ar;
 
     if (state->type == IPA_TRUST_AD) {
-        ret = ad_handle_acct_info_recv(subreq, &state->dp_error, NULL);
+        ret = ad_handle_acct_info_recv(subreq, NULL);
     } else if (state->type == IPA_TRUST_IPA) {
-        ret = ipa_id_get_account_info_recv(subreq, &state->dp_error);
+        ret = ipa_id_get_account_info_recv(subreq);
     } else {
         ret = EINVAL;
     }
@@ -1591,7 +1550,6 @@ ipa_get_trusted_acct_part_done(struct tevent_req *subreq)
     return;
 
 fail:
-    state->dp_error = DP_ERR_FATAL;
     tevent_req_error(req, ret);
     return;
 }
@@ -1606,7 +1564,7 @@ ipa_get_trusted_override_done(struct tevent_req *subreq)
                                                 struct ipa_get_acct_state);
     errno_t ret;
 
-    ret = ipa_get_trusted_override_recv(subreq, &state->dp_error, state,
+    ret = ipa_get_trusted_override_recv(subreq, state,
                                    &state->override_attrs);
     talloc_zfree(subreq);
     if (ret != EOK) {
@@ -1625,7 +1583,6 @@ ipa_get_trusted_override_done(struct tevent_req *subreq)
     return;
 
 fail:
-    state->dp_error = DP_ERR_FATAL;
     tevent_req_error(req, ret);
     return;
 }
@@ -1678,7 +1635,7 @@ static void ipa_check_ghost_members_done(struct tevent_req *subreq)
                                                 struct tevent_req);
     int ret;
 
-    ret = ipa_resolve_user_list_recv(subreq, NULL);
+    ret = ipa_resolve_user_list_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "ipa_resolve_user_list request failed [%d]\n",
@@ -1825,7 +1782,7 @@ static void ipa_id_get_groups_overrides_done(struct tevent_req *subreq)
                                                 struct tevent_req);
     errno_t ret;
 
-    ret = ipa_initgr_get_overrides_recv(subreq, NULL);
+    ret = ipa_initgr_get_overrides_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
@@ -1872,11 +1829,9 @@ ipa_get_trusted_acct_done(struct tevent_req *subreq)
 {
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                 struct tevent_req);
-    struct ipa_get_acct_state *state = tevent_req_data(req,
-                                                struct ipa_get_acct_state);
     errno_t ret;
 
-    ret = ipa_get_trusted_memberships_recv(subreq, &state->dp_error);
+    ret = ipa_get_trusted_memberships_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "IPA external groups lookup failed: %d\n",
@@ -1890,15 +1845,8 @@ ipa_get_trusted_acct_done(struct tevent_req *subreq)
 }
 
 static errno_t
-ipa_get_acct_recv(struct tevent_req *req, int *dp_error_out)
+ipa_get_acct_recv(struct tevent_req *req)
 {
-    struct ipa_get_acct_state *state = tevent_req_data(req,
-                                                struct ipa_get_acct_state);
-
-    if (dp_error_out) {
-        *dp_error_out = state->dp_error;
-    }
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     return EOK;
@@ -1914,8 +1862,6 @@ struct ipa_srv_acct_state {
     struct be_ctx *be_ctx;
     enum ipa_trust_type type;
     bool retry;
-
-    int dp_error;
 };
 
 static int ipa_srv_acct_lookup_step(struct tevent_req *req);
@@ -1943,7 +1889,6 @@ ipa_srv_acct_send(TALLOC_CTX *mem_ctx,
     state->override_attrs = override_attrs;
     state->ar = ar;
     state->retry = true;
-    state->dp_error = DP_ERR_FATAL;
     state->be_ctx = ipa_ctx->sdap_id_ctx->be;
 
     state->obj_dom = find_domain_by_name(
@@ -2002,13 +1947,12 @@ static int ipa_srv_acct_lookup_step(struct tevent_req *req)
 static void ipa_srv_acct_lookup_done(struct tevent_req *subreq)
 {
     errno_t ret;
-    int dp_error = DP_ERR_FATAL;
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                 struct tevent_req);
     struct ipa_srv_acct_state *state = tevent_req_data(req,
                                             struct ipa_srv_acct_state);
 
-    ret = ipa_get_acct_recv(subreq, &dp_error);
+    ret = ipa_get_acct_recv(subreq);
     talloc_free(subreq);
     if (ret == ERR_SUBDOM_INACTIVE && state->retry == true) {
 
@@ -2033,12 +1977,10 @@ static void ipa_srv_acct_lookup_done(struct tevent_req *subreq)
         goto fail;
     }
 
-    state->dp_error = DP_ERR_OK;
     tevent_req_done(req);
     return;
 
 fail:
-    state->dp_error = dp_error;
     tevent_req_error(req, ret);
 }
 
@@ -2056,7 +1998,6 @@ static void ipa_srv_acct_retried(struct tevent_req *subreq)
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
               "Failed to re-set subdomain [%d]: %s\n", ret, sss_strerror(ret));
-        state->dp_error = DP_ERR_FATAL;
         tevent_req_error(req, ret);
         return;
     }
@@ -2065,7 +2006,6 @@ static void ipa_srv_acct_retried(struct tevent_req *subreq)
     ad_id_ctx = ipa_get_ad_id_ctx(state->ipa_ctx, state->obj_dom);
     if (ad_id_ctx == NULL || ad_id_ctx->ad_options == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "No AD ID ctx or no ID CTX options?\n");
-        state->dp_error = DP_ERR_FATAL;
         tevent_req_error(req, EINVAL);
         return;
     }
@@ -2076,22 +2016,14 @@ static void ipa_srv_acct_retried(struct tevent_req *subreq)
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
               "Failed to look up AD acct [%d]: %s\n", ret, sss_strerror(ret));
-        state->dp_error = DP_ERR_FATAL;
         tevent_req_error(req, ret);
         return;
     }
 }
 
 static errno_t
-ipa_srv_acct_recv(struct tevent_req *req, int *dp_error_out)
+ipa_srv_acct_recv(struct tevent_req *req)
 {
-    struct ipa_srv_acct_state *state = tevent_req_data(req,
-                                                struct ipa_srv_acct_state);
-
-    if (dp_error_out) {
-        *dp_error_out = state->dp_error;
-    }
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
     return EOK;
 }

--- a/src/providers/ipa/ipa_sudo.c
+++ b/src/providers/ipa/ipa_sudo.c
@@ -80,7 +80,7 @@ ipa_sudo_handler_send(TALLOC_CTX *mem_ctx,
     return req;
 
 immediately:
-    dp_reply_std_set(&state->reply, DP_ERR_DECIDE, ret, NULL);
+    dp_reply_std_set(&state->reply, ret, NULL);
 
     /* TODO For backward compatibility we always return EOK to DP now. */
     tevent_req_done(req);
@@ -93,7 +93,6 @@ static void ipa_sudo_handler_done(struct tevent_req *subreq)
 {
     struct ipa_sudo_handler_state *state;
     struct tevent_req *req;
-    int dp_error;
     bool deleted;
     errno_t ret;
 
@@ -102,17 +101,17 @@ static void ipa_sudo_handler_done(struct tevent_req *subreq)
 
     switch (state->type) {
     case BE_REQ_SUDO_FULL:
-        ret = ipa_sudo_full_refresh_recv(subreq, &dp_error);
+        ret = ipa_sudo_full_refresh_recv(subreq);
         talloc_zfree(subreq);
 
         /* Postpone the periodic task since the refresh was just finished
          * per user request. */
-        if (ret == EOK && dp_error == DP_ERR_OK) {
+        if (ret == EOK) {
             be_ptask_postpone(state->sudo_ctx->full_refresh);
         }
         break;
     case BE_REQ_SUDO_RULES:
-        ret = ipa_sudo_rules_refresh_recv(subreq, &dp_error, &deleted);
+        ret = ipa_sudo_rules_refresh_recv(subreq, &deleted);
         talloc_zfree(subreq);
         if (ret == EOK && deleted == true) {
             ret = ENOENT;
@@ -120,13 +119,12 @@ static void ipa_sudo_handler_done(struct tevent_req *subreq)
         break;
     default:
         DEBUG(SSSDBG_CRIT_FAILURE, "Invalid request type: %d\n", state->type);
-        dp_error = DP_ERR_FATAL;
         ret = ERR_INTERNAL;
         break;
     }
 
     /* TODO For backward compatibility we always return EOK to DP now. */
-    dp_reply_std_set(&state->reply, dp_error, ret, NULL);
+    dp_reply_std_set(&state->reply, ret, NULL);
     tevent_req_done(req);
 }
 

--- a/src/providers/ipa/ipa_sudo.h
+++ b/src/providers/ipa/ipa_sudo.h
@@ -47,12 +47,10 @@ ipa_sudo_full_refresh_send(TALLOC_CTX *mem_ctx,
                            struct ipa_sudo_ctx *sudo_ctx);
 
 int
-ipa_sudo_full_refresh_recv(struct tevent_req *req,
-                           int *dp_error);
+ipa_sudo_full_refresh_recv(struct tevent_req *req);
 
 int
 ipa_sudo_rules_refresh_recv(struct tevent_req *req,
-                            int *dp_error,
                             bool *deleted);
 
 struct tevent_req *
@@ -72,7 +70,6 @@ ipa_sudo_rules_refresh_send(TALLOC_CTX *mem_ctx,
 
 errno_t
 ipa_sudo_refresh_recv(struct tevent_req *req,
-                      int *dp_error,
                       size_t *_num_rules);
 
 struct ipa_sudo_conv;

--- a/src/providers/ipa/ipa_sudo_async.c
+++ b/src/providers/ipa/ipa_sudo_async.c
@@ -851,7 +851,6 @@ struct ipa_sudo_refresh_state {
 
     struct sdap_id_op *sdap_op;
     struct sdap_handle *sh;
-    int dp_error;
 
     struct sysdb_attrs **rules;
     size_t num_rules;
@@ -887,7 +886,6 @@ ipa_sudo_refresh_send(TALLOC_CTX *mem_ctx,
     state->sudo_ctx = sudo_ctx;
     state->ipa_opts = sudo_ctx->ipa_opts;
     state->sdap_opts = sudo_ctx->sdap_opts;
-    state->dp_error = DP_ERR_FATAL;
     state->update_usn = update_usn;
 
     state->sdap_op = sdap_id_op_create(state,
@@ -960,19 +958,17 @@ ipa_sudo_refresh_connect_done(struct tevent_req *subreq)
     struct ipa_sudo_refresh_state *state;
     const char *hostname;
     struct tevent_req *req;
-    int dp_error;
     int ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct ipa_sudo_refresh_state);
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "SUDO LDAP connection failed "
                                    "[%d]: %s\n", ret, strerror(ret));
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -991,7 +987,6 @@ ipa_sudo_refresh_connect_done(struct tevent_req *subreq)
                                 state->ipa_opts->hostgroup_map,
                                 state->ipa_opts->id->sdom->host_search_bases);
     if (subreq == NULL) {
-        state->dp_error = DP_ERR_FATAL;
         tevent_req_error(req, ENOMEM);
         return;
     }
@@ -1012,7 +1007,6 @@ ipa_sudo_refresh_host_done(struct tevent_req *subreq)
 
     host = talloc_zero(state, struct ipa_hostinfo);
     if (host == NULL) {
-        state->dp_error = DP_ERR_FATAL;
         tevent_req_error(req, ENOMEM);
         return;
     }
@@ -1023,7 +1017,6 @@ ipa_sudo_refresh_host_done(struct tevent_req *subreq)
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "Unable to retrieve host information "
                                  "[%d]: %s\n", ret, sss_strerror(ret));
-        state->dp_error = DP_ERR_FATAL;
         tevent_req_error(req, ret);
         return;
     }
@@ -1036,7 +1029,6 @@ ipa_sudo_refresh_host_done(struct tevent_req *subreq)
                                  state->ipa_opts->hostgroup_map, state->sh,
                                  state->cmdgroups_filter, state->search_filter);
     if (subreq == NULL) {
-        state->dp_error = DP_ERR_FATAL;
         tevent_req_error(req, ENOMEM);
         return;
     }
@@ -1061,8 +1053,8 @@ ipa_sudo_refresh_done(struct tevent_req *subreq)
                               &state->num_rules, &usn);
     talloc_zfree(subreq);
 
-    ret = sdap_id_op_done(state->sdap_op, ret, &state->dp_error);
-    if (state->dp_error == DP_ERR_OK && ret != EOK) {
+    ret = sdap_id_op_done(state->sdap_op, ret);
+    if (ret == EAGAIN) {
         /* retry */
         ret = ipa_sudo_refresh_retry(req);
         if (ret != EOK) {
@@ -1123,15 +1115,12 @@ done:
 
 errno_t
 ipa_sudo_refresh_recv(struct tevent_req *req,
-                      int *dp_error,
                       size_t *_num_rules)
 {
     struct ipa_sudo_refresh_state *state = NULL;
     state = tevent_req_data(req, struct ipa_sudo_refresh_state);
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
-
-    *dp_error = state->dp_error;
 
     if (_num_rules != NULL) {
         *_num_rules = state->num_rules;

--- a/src/providers/ipa/ipa_sudo_refresh.c
+++ b/src/providers/ipa/ipa_sudo_refresh.c
@@ -31,7 +31,6 @@
 struct ipa_sudo_full_refresh_state {
     struct ipa_sudo_ctx *sudo_ctx;
     struct sss_domain_info *domain;
-    int dp_error;
 };
 
 static void ipa_sudo_full_refresh_done(struct tevent_req *subreq);
@@ -95,9 +94,9 @@ ipa_sudo_full_refresh_done(struct tevent_req *subreq)
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct ipa_sudo_full_refresh_state);
 
-    ret = ipa_sudo_refresh_recv(subreq, &state->dp_error, NULL);
+    ret = ipa_sudo_refresh_recv(subreq, NULL);
     talloc_zfree(subreq);
-    if (ret != EOK || state->dp_error != DP_ERR_OK) {
+    if (ret != EOK) {
         goto done;
     }
 
@@ -122,21 +121,14 @@ done:
 }
 
 int
-ipa_sudo_full_refresh_recv(struct tevent_req *req,
-                           int *dp_error)
+ipa_sudo_full_refresh_recv(struct tevent_req *req)
 {
-    struct ipa_sudo_full_refresh_state *state;
-    state = tevent_req_data(req, struct ipa_sudo_full_refresh_state);
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
-
-    *dp_error = state->dp_error;
 
     return EOK;
 }
 
 struct ipa_sudo_smart_refresh_state {
-    int dp_error;
 };
 
 static void ipa_sudo_smart_refresh_done(struct tevent_req *subreq);
@@ -165,7 +157,6 @@ ipa_sudo_smart_refresh_send(TALLOC_CTX *mem_ctx,
     if (be_ptask_running(sudo_ctx->full_refresh)) {
         DEBUG(SSSDBG_TRACE_FUNC, "Skipping smart refresh because "
               "there is ongoing full refresh.\n");
-        state->dp_error = DP_ERR_OK;
         ret = EOK;
         goto immediately;
     }
@@ -223,15 +214,13 @@ immediately:
 static void ipa_sudo_smart_refresh_done(struct tevent_req *subreq)
 {
     struct tevent_req *req = NULL;
-    struct ipa_sudo_smart_refresh_state *state = NULL;
     int ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
-    state = tevent_req_data(req, struct ipa_sudo_smart_refresh_state);
 
-    ret = ipa_sudo_refresh_recv(subreq, &state->dp_error, NULL);
+    ret = ipa_sudo_refresh_recv(subreq, NULL);
     talloc_zfree(subreq);
-    if (ret != EOK || state->dp_error != DP_ERR_OK) {
+    if (ret != EOK) {
         goto done;
     }
 
@@ -246,22 +235,15 @@ done:
     tevent_req_done(req);
 }
 
-int ipa_sudo_smart_refresh_recv(struct tevent_req *req,
-                                int *dp_error)
+int ipa_sudo_smart_refresh_recv(struct tevent_req *req)
 {
-    struct ipa_sudo_smart_refresh_state *state = NULL;
-    state = tevent_req_data(req, struct ipa_sudo_smart_refresh_state);
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
-
-    *dp_error = state->dp_error;
 
     return EOK;
 }
 
 struct ipa_sudo_rules_refresh_state {
     size_t num_rules;
-    int dp_error;
     bool deleted;
 };
 
@@ -297,7 +279,6 @@ ipa_sudo_rules_refresh_send(TALLOC_CTX *mem_ctx,
     }
 
     if (rules == NULL || rules[0] == NULL) {
-        state->dp_error = DP_ERR_OK;
         state->num_rules = 0;
         state->deleted = false;
         ret = EOK;
@@ -381,9 +362,9 @@ ipa_sudo_rules_refresh_done(struct tevent_req *subreq)
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct ipa_sudo_rules_refresh_state);
 
-    ret = ipa_sudo_refresh_recv(subreq, &state->dp_error, &downloaded_rules_num);
+    ret = ipa_sudo_refresh_recv(subreq, &downloaded_rules_num);
     talloc_zfree(subreq);
-    if (ret != EOK || state->dp_error != DP_ERR_OK) {
+    if (ret != EOK) {
         goto done;
     }
 
@@ -400,7 +381,6 @@ done:
 
 int
 ipa_sudo_rules_refresh_recv(struct tevent_req *req,
-                            int *dp_error,
                             bool *deleted)
 {
     struct ipa_sudo_rules_refresh_state *state;
@@ -408,7 +388,6 @@ ipa_sudo_rules_refresh_recv(struct tevent_req *req,
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
-    *dp_error = state->dp_error;
     *deleted = state->deleted;
 
     return EOK;
@@ -430,9 +409,7 @@ ipa_sudo_ptask_full_refresh_send(TALLOC_CTX *mem_ctx,
 static errno_t
 ipa_sudo_ptask_full_refresh_recv(struct tevent_req *req)
 {
-    int dp_error;
-
-    return ipa_sudo_full_refresh_recv(req, &dp_error);
+    return ipa_sudo_full_refresh_recv(req);
 }
 
 static struct tevent_req *
@@ -451,9 +428,7 @@ ipa_sudo_ptask_smart_refresh_send(TALLOC_CTX *mem_ctx,
 static errno_t
 ipa_sudo_ptask_smart_refresh_recv(struct tevent_req *req)
 {
-    int dp_error;
-
-    return ipa_sudo_smart_refresh_recv(req, &dp_error);
+    return ipa_sudo_smart_refresh_recv(req);
 }
 
 errno_t

--- a/src/providers/ipa/ipa_views.c
+++ b/src/providers/ipa/ipa_views.c
@@ -389,7 +389,6 @@ struct ipa_get_trusted_override_state {
     struct sss_domain_info *dom;
 
     struct sdap_id_op *sdap_op;
-    int dp_error;
     struct sysdb_attrs *override_attrs;
     char *filter;
     bool login_override_checked;
@@ -424,7 +423,6 @@ struct tevent_req *ipa_get_trusted_override_send(TALLOC_CTX *mem_ctx,
     state->ipa_options = ipa_options;
     state->ipa_realm = ipa_realm;
     state->ar = ar;
-    state->dp_error = -1;
     state->override_attrs = NULL;
     state->filter = NULL;
 
@@ -469,10 +467,8 @@ struct tevent_req *ipa_get_trusted_override_send(TALLOC_CTX *mem_ctx,
 
 done:
     if (ret != EOK) {
-        state->dp_error = DP_ERR_FATAL;
         tevent_req_error(req, ret);
     } else {
-        state->dp_error = DP_ERR_OK;
         tevent_req_done(req);
     }
     tevent_req_post(req, state->ev);
@@ -491,10 +487,10 @@ static void ipa_get_trusted_override_connect_done(struct tevent_req *subreq)
     char *search_base;
     struct ipa_options *ipa_opts = state->ipa_options;
 
-    ret = sdap_id_op_connect_recv(subreq, &state->dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        if (state->dp_error == DP_ERR_OFFLINE) {
+        if (ret == ERR_OFFLINE) {
             DEBUG(SSSDBG_MINOR_FAILURE,
                   "No IPA server is available, going offline\n");
         } else {
@@ -550,7 +546,6 @@ static void ipa_get_trusted_override_connect_done(struct tevent_req *subreq)
     return;
 
 fail:
-    state->dp_error = DP_ERR_FATAL;
     tevent_req_error(req, ret);
     return;
 }
@@ -603,7 +598,6 @@ static void ipa_get_trusted_override_done(struct tevent_req *subreq)
             state->ar->entry_type = BE_REQ_GROUP;
         }
 
-        state->dp_error = DP_ERR_OK;
         tevent_req_done(req);
         return;
     } else if (reply_count == MAX_USER_AND_GROUP_REPLIES &&
@@ -634,12 +628,10 @@ static void ipa_get_trusted_override_done(struct tevent_req *subreq)
         goto fail;
     }
 
-    state->dp_error = DP_ERR_OK;
     tevent_req_done(req);
     return;
 
 fail:
-    state->dp_error = DP_ERR_FATAL;
     tevent_req_error(req, ret);
     return;
 }
@@ -671,16 +663,12 @@ static errno_t ipa_get_trusted_override_qualify_name(
     return EOK;
 }
 
-errno_t ipa_get_trusted_override_recv(struct tevent_req *req, int *dp_error_out,
+errno_t ipa_get_trusted_override_recv(struct tevent_req *req,
                                  TALLOC_CTX *mem_ctx,
                                  struct sysdb_attrs **override_attrs)
 {
     struct ipa_get_trusted_override_state *state = tevent_req_data(req,
                                               struct ipa_get_trusted_override_state);
-
-    if (dp_error_out != NULL) {
-        *dp_error_out = state->dp_error;
-    }
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
 

--- a/src/providers/krb5/krb5_auth.c
+++ b/src/providers/krb5/krb5_auth.c
@@ -250,7 +250,7 @@ static void krb5_auth_cache_creds(struct krb5_ctx *krb5_ctx,
                                   struct sss_domain_info *domain,
                                   struct confdb_ctx *cdb,
                                   struct pam_data *pd, uid_t uid,
-                                  int *pam_status, int *dp_err)
+                                  int *pam_status)
 {
     const char *password = NULL;
     errno_t ret;
@@ -262,7 +262,6 @@ static void krb5_auth_cache_creds(struct krb5_ctx *krb5_ctx,
               "available for password authentication (single factor).\n",
               ret, strerror(ret));
         *pam_status = PAM_SYSTEM_ERR;
-        *dp_err = DP_ERR_OK;
         return;
     }
 
@@ -271,7 +270,6 @@ static void krb5_auth_cache_creds(struct krb5_ctx *krb5_ctx,
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Offline authentication failed\n");
         *pam_status = cached_login_pam_status(ret);
-        *dp_err = DP_ERR_OK;
         return;
     }
 
@@ -285,7 +283,6 @@ static void krb5_auth_cache_creds(struct krb5_ctx *krb5_ctx,
               "add_user_to_delayed_online_authentication failed.\n");
     }
     *pam_status = PAM_AUTHINFO_UNAVAIL;
-    *dp_err = DP_ERR_OFFLINE;
 }
 
 static errno_t krb5_auth_prepare_ccache_name(struct krb5child_req *kr,
@@ -499,7 +496,6 @@ struct krb5_auth_state {
     bool search_kpasswd;
 
     int pam_status;
-    int dp_err;
 };
 
 static void krb5_auth_resolve_done(struct tevent_req *subreq);
@@ -534,7 +530,6 @@ struct tevent_req *krb5_auth_send(TALLOC_CTX *mem_ctx,
     state->krb5_ctx = krb5_ctx;
     state->kr = NULL;
     state->pam_status = PAM_SYSTEM_ERR;
-    state->dp_err = DP_ERR_FATAL;
 
     ret = get_domain_or_subdomain(be_ctx, pd->domain, &state->domain);
     if (ret != EOK) {
@@ -565,7 +560,6 @@ struct tevent_req *krb5_auth_send(TALLOC_CTX *mem_ctx,
                           "Illegal empty authtok for user [%s]\n",
                            pd->user);
                     state->pam_status = PAM_AUTH_ERR;
-                    state->dp_err = DP_ERR_OK;
                     ret = EOK;
                     goto done;
                 }
@@ -576,7 +570,6 @@ struct tevent_req *krb5_auth_send(TALLOC_CTX *mem_ctx,
                           SSS_AUTHTOK_TYPE_PASSWORD,
                           authtok_type);
                 state->pam_status = PAM_SYSTEM_ERR;
-                state->dp_err = DP_ERR_FATAL;
                 ret = EINVAL;
                 goto done;
             }
@@ -587,7 +580,6 @@ struct tevent_req *krb5_auth_send(TALLOC_CTX *mem_ctx,
                 DEBUG(SSSDBG_MINOR_FAILURE,
                       "Password reset by root is not supported.\n");
                 state->pam_status = PAM_PERM_DENIED;
-                state->dp_err = DP_ERR_OK;
                 ret = EOK;
                 goto done;
             }
@@ -598,7 +590,6 @@ struct tevent_req *krb5_auth_send(TALLOC_CTX *mem_ctx,
             if (pd->child_pid != 0) {
                 soft_terminate_krb5_child(state, pd, krb5_ctx);
                 state->pam_status = PAM_TRY_AGAIN;
-                state->dp_err = DP_ERR_OK;
                 ret = EOK;
                 goto done;
              }
@@ -612,7 +603,6 @@ struct tevent_req *krb5_auth_send(TALLOC_CTX *mem_ctx,
                           SSS_AUTHTOK_TYPE_CCFILE,
                           authtok_type);
                 state->pam_status = PAM_SYSTEM_ERR;
-                state->dp_err = DP_ERR_FATAL;
                 ret = EINVAL;
                 goto done;
             }
@@ -622,7 +612,6 @@ struct tevent_req *krb5_auth_send(TALLOC_CTX *mem_ctx,
         default:
             DEBUG(SSSDBG_CONF_SETTINGS, "Unexpected pam task %d.\n", pd->cmd);
             state->pam_status = PAM_SYSTEM_ERR;
-            state->dp_err = DP_ERR_FATAL;
             ret = EINVAL;
             goto done;
     }
@@ -634,7 +623,6 @@ struct tevent_req *krb5_auth_send(TALLOC_CTX *mem_ctx,
               "Password changes and ticket renewal are not possible "
                   "while offline.\n");
         state->pam_status = PAM_AUTHINFO_UNAVAIL;
-        state->dp_err = DP_ERR_OFFLINE;
         ret = EOK;
         goto done;
     }
@@ -668,7 +656,6 @@ struct tevent_req *krb5_auth_send(TALLOC_CTX *mem_ctx,
         DEBUG(SSSDBG_FUNC_DATA,
               "sysdb search for upn of user [%s] failed.\n", pd->user);
         state->pam_status = PAM_SYSTEM_ERR;
-        state->dp_err = DP_ERR_OK;
         goto done;
     }
 
@@ -752,7 +739,6 @@ struct tevent_req *krb5_auth_send(TALLOC_CTX *mem_ctx,
         DEBUG(SSSDBG_TRACE_FUNC,
               "Skipping password checks for OTP-enabled user\n");
         state->pam_status = PAM_SUCCESS;
-        state->dp_err = DP_ERR_OK;
         ret = EOK;
         goto done;
     }
@@ -806,7 +792,6 @@ static void krb5_auth_resolve_done(struct tevent_req *subreq)
              * authentication is. We return an PAM error here, but do not
              * mark the backend offline. */
             state->pam_status = PAM_AUTHTOK_LOCK_BUSY;
-            state->dp_err = DP_ERR_OK;
             ret = EOK;
             goto done;
         }
@@ -824,7 +809,6 @@ static void krb5_auth_resolve_done(struct tevent_req *subreq)
                 DEBUG(SSSDBG_TRACE_FUNC,
                       "No KDC suitable for password change is available\n");
                 state->pam_status = PAM_AUTHTOK_LOCK_BUSY;
-                state->dp_err = DP_ERR_OK;
                 ret = EOK;
                 goto done;
             }
@@ -933,7 +917,6 @@ static void krb5_auth_done(struct tevent_req *subreq)
             }
         case SSS_PAM_PREAUTH:
             state->pam_status = PAM_CRED_UNAVAIL;
-            state->dp_err = DP_ERR_OK;
             ret = EOK;
             goto done;
         default:
@@ -1029,7 +1012,6 @@ static void krb5_auth_done(struct tevent_req *subreq)
          * change password request just return success. */
         if (pd->cmd == SSS_PAM_CHAUTHTOK_PRELIM) {
             state->pam_status = PAM_SUCCESS;
-            state->dp_err = DP_ERR_OK;
             ret = EOK;
             goto done;
         }
@@ -1101,49 +1083,41 @@ static void krb5_auth_done(struct tevent_req *subreq)
         }
 
         state->pam_status = PAM_NEW_AUTHTOK_REQD;
-        state->dp_err = DP_ERR_OK;
         ret = EOK;
         goto done;
 
     case ERR_CREDS_INVALID:
         state->pam_status = PAM_CRED_ERR;
-        state->dp_err = DP_ERR_OK;
         ret = EOK;
         goto done;
 
     case ERR_ACCOUNT_EXPIRED:
         state->pam_status = PAM_ACCT_EXPIRED;
-        state->dp_err = DP_ERR_OK;
         ret = EOK;
         goto done;
 
     case ERR_ACCOUNT_LOCKED:
         state->pam_status = PAM_PERM_DENIED;
-        state->dp_err = DP_ERR_OK;
         ret = EOK;
         goto done;
 
     case ERR_NO_CREDS:
         state->pam_status = PAM_CRED_UNAVAIL;
-        state->dp_err = DP_ERR_OK;
         ret = EOK;
         goto done;
 
     case ERR_AUTH_FAILED:
         state->pam_status = PAM_AUTH_ERR;
-        state->dp_err = DP_ERR_OK;
         ret = EOK;
         goto done;
 
     case ERR_CHPASS_FAILED:
         state->pam_status = PAM_AUTHTOK_ERR;
-        state->dp_err = DP_ERR_OK;
         ret = EOK;
         goto done;
 
     case ERR_NO_AUTH_METHOD_AVAILABLE:
         state->pam_status = PAM_NO_MODULE_DATA;
-        state->dp_err = DP_ERR_OK;
         ret = EOK;
         goto done;
 
@@ -1152,7 +1126,6 @@ static void krb5_auth_done(struct tevent_req *subreq)
               "The krb5_child process returned an error. Please inspect the "
               "krb5_child.log file or the journal for more information\n");
         state->pam_status = PAM_SYSTEM_ERR;
-        state->dp_err = DP_ERR_OK;
         ret = EOK;
         goto done;
     }
@@ -1172,7 +1145,6 @@ static void krb5_auth_done(struct tevent_req *subreq)
 
     if (pd->cmd == SSS_PAM_PREAUTH) {
         state->pam_status = PAM_SUCCESS;
-        state->dp_err = DP_ERR_OK;
         ret = EOK;
         goto done;
     }
@@ -1228,12 +1200,11 @@ static void krb5_auth_done(struct tevent_req *subreq)
                                   state->domain,
                                   state->be_ctx->cdb,
                                   state->pd, state->kr->uid,
-                                  &state->pam_status, &state->dp_err);
+                                  &state->pam_status);
         } else {
             DEBUG(SSSDBG_CONF_SETTINGS,
                   "Backend is marked offline, retry later!\n");
             state->pam_status = PAM_AUTHINFO_UNAVAIL;
-            state->dp_err = DP_ERR_OFFLINE;
         }
         ret = EOK;
         goto done;
@@ -1260,13 +1231,11 @@ static void krb5_auth_done(struct tevent_req *subreq)
                   "pam_add_response failed: %d (%s).\n",
                   ret, sss_strerror(ret));
             state->pam_status = PAM_SYSTEM_ERR;
-            state->dp_err = DP_ERR_OK;
             goto done;
         }
     }
 
     state->pam_status = PAM_SUCCESS;
-    state->dp_err = DP_ERR_OK;
     ret = EOK;
 
 done:
@@ -1278,11 +1247,10 @@ done:
 
 }
 
-int krb5_auth_recv(struct tevent_req *req, int *pam_status, int *dp_err)
+int krb5_auth_recv(struct tevent_req *req, int *pam_status)
 {
     struct krb5_auth_state *state = tevent_req_data(req, struct krb5_auth_state);
     *pam_status = state->pam_status;
-    *dp_err = state->dp_err;
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
@@ -1381,7 +1349,7 @@ static void krb5_pam_handler_auth_done(struct tevent_req *subreq)
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct krb5_pam_handler_state);
 
-    ret = krb5_auth_queue_recv(subreq, &state->pd->pam_status, NULL);
+    ret = krb5_auth_queue_recv(subreq, &state->pd->pam_status);
     talloc_zfree(subreq);
     if (ret != EOK) {
         state->pd->pam_status = PAM_SYSTEM_ERR;
@@ -1423,7 +1391,7 @@ static void krb5_pam_handler_auth_retry_done(struct tevent_req *subreq)
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct krb5_pam_handler_state);
 
-    ret = krb5_auth_queue_recv(subreq, &state->pd->pam_status, NULL);
+    ret = krb5_auth_queue_recv(subreq, &state->pd->pam_status);
     talloc_free(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "krb5_auth_recv request failed.\n");

--- a/src/providers/krb5/krb5_auth.h
+++ b/src/providers/krb5/krb5_auth.h
@@ -97,7 +97,7 @@ struct tevent_req *krb5_auth_send(TALLOC_CTX *mem_ctx,
                                   struct be_ctx *be_ctx,
                                   struct pam_data *pd,
                                   struct krb5_ctx *krb5_ctx);
-int krb5_auth_recv(struct tevent_req *req, int *pam_status, int *dp_err);
+int krb5_auth_recv(struct tevent_req *req, int *pam_status);
 
 struct tevent_req *handle_child_send(TALLOC_CTX *mem_ctx,
                                      struct tevent_context *ev,
@@ -148,7 +148,6 @@ struct tevent_req *krb5_auth_queue_send(TALLOC_CTX *mem_ctx,
                                         struct krb5_ctx *krb5_ctx);
 
 int krb5_auth_queue_recv(struct tevent_req *req,
-                         int *_pam_status,
-                         int *_dp_err);
+                         int *_pam_status);
 
 #endif /* __KRB5_AUTH_H__ */

--- a/src/providers/krb5/krb5_delayed_online_authentication.c
+++ b/src/providers/krb5/krb5_delayed_online_authentication.c
@@ -118,9 +118,8 @@ static void authenticate_user_done(struct tevent_req *req)
                                                            struct auth_data);
     int ret;
     int pam_status = PAM_SYSTEM_ERR;
-    int dp_err = DP_ERR_OK;
 
-    ret = krb5_auth_queue_recv(req, &pam_status, &dp_err);
+    ret = krb5_auth_queue_recv(req, &pam_status);
     talloc_free(req);
     if (ret) {
         DEBUG(SSSDBG_CRIT_FAILURE, "krb5_auth request failed.\n");

--- a/src/providers/krb5/krb5_renew_tgt.c
+++ b/src/providers/krb5/krb5_renew_tgt.c
@@ -85,10 +85,9 @@ static void renew_tgt_done(struct tevent_req *req)
                                                            struct auth_data);
     int ret;
     int pam_status = PAM_SYSTEM_ERR;
-    int dp_err;
     hash_value_t value;
 
-    ret = krb5_auth_queue_recv(req, &pam_status, &dp_err);
+    ret = krb5_auth_queue_recv(req, &pam_status);
     talloc_free(req);
     if (ret) {
         DEBUG(SSSDBG_CRIT_FAILURE, "krb5_auth request failed.\n");

--- a/src/providers/krb5/krb5_wait_queue.c
+++ b/src/providers/krb5/krb5_wait_queue.c
@@ -43,7 +43,7 @@ struct queue_entry {
 static void wait_queue_auth_done(struct tevent_req *req);
 
 static void krb5_auth_queue_finish(struct tevent_req *req, errno_t ret,
-                                   int pam_status, int dp_err);
+                                   int pam_status);
 
 static void wait_queue_auth(struct tevent_context *ev, struct tevent_timer *te,
                             struct timeval current_time, void *private_data)
@@ -68,16 +68,15 @@ static void wait_queue_auth_done(struct tevent_req *req)
     struct tevent_req *parent_req = \
                 tevent_req_callback_data(req, struct tevent_req);
     int pam_status;
-    int dp_err;
     errno_t ret;
 
-    ret = krb5_auth_recv(req, &pam_status, &dp_err);
+    ret = krb5_auth_recv(req, &pam_status);
     talloc_zfree(req);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "krb5_auth_recv failed: %d\n", ret);
     }
 
-    krb5_auth_queue_finish(parent_req, ret, pam_status, dp_err);
+    krb5_auth_queue_finish(parent_req, ret, pam_status);
 }
 
 static void wait_queue_del_cb(hash_entry_t *entry, hash_destroy_enum type,
@@ -242,7 +241,6 @@ struct krb5_auth_queue_state {
     struct pam_data *pd;
 
     int pam_status;
-    int dp_err;
 };
 
 static void krb5_auth_queue_done(struct tevent_req *subreq);
@@ -309,7 +307,7 @@ static void krb5_auth_queue_done(struct tevent_req *subreq)
                 tevent_req_data(req, struct krb5_auth_queue_state);
     errno_t ret;
 
-    ret = krb5_auth_recv(subreq, &state->pam_status, &state->dp_err);
+    ret = krb5_auth_recv(subreq, &state->pam_status);
     talloc_zfree(subreq);
 
     check_wait_queue(state->krb5_ctx, state->pd->user);
@@ -331,8 +329,7 @@ static void krb5_auth_queue_done(struct tevent_req *subreq)
  */
 static void krb5_auth_queue_finish(struct tevent_req *req,
                                    errno_t ret,
-                                   int pam_status,
-                                   int dp_err)
+                                   int pam_status)
 {
     struct krb5_auth_queue_state *state = \
                 tevent_req_data(req, struct krb5_auth_queue_state);
@@ -340,7 +337,6 @@ static void krb5_auth_queue_finish(struct tevent_req *req,
     check_wait_queue(state->krb5_ctx, state->pd->user);
 
     state->pam_status = pam_status;
-    state->dp_err = dp_err;
     if (ret != EOK) {
         tevent_req_error(req, ret);
     } else {
@@ -350,8 +346,7 @@ static void krb5_auth_queue_finish(struct tevent_req *req,
 }
 
 int krb5_auth_queue_recv(struct tevent_req *req,
-                         int *_pam_status,
-                         int *_dp_err)
+                         int *_pam_status)
 {
     struct krb5_auth_queue_state *state = \
                 tevent_req_data(req, struct krb5_auth_queue_state);
@@ -361,10 +356,6 @@ int krb5_auth_queue_recv(struct tevent_req *req,
      */
     if (_pam_status) {
         *_pam_status = state->pam_status;
-    }
-
-    if (_dp_err) {
-        *_dp_err = state->dp_err;
     }
 
     TEVENT_REQ_RETURN_ON_ERROR(req);

--- a/src/providers/ldap/ldap_auth.c
+++ b/src/providers/ldap/ldap_auth.c
@@ -855,17 +855,14 @@ static void auth_connect_done(struct tevent_req *subreq)
                                             NULL);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        /* As sdap_cli_resolve_and_connect_recv() returns EIO in case all the
-         * servers are down and we have to go offline, let's treat it
+        /* As sdap_cli_resolve_and_connect_recv() returns ERR_SERVER_FAILURE
+         * in case all the servers are down and we have to go offline, let's treat it
          * accordingly here and allow the PAM responder to switch to offline
          * authentication.
          *
-         * Unfortunately, there's not much pattern within our code and the way
-         * to indicate we're going down in this part of the code is returning an
-         * ETIMEDOUT.
          */
-        if (ret == EIO) {
-            tevent_req_error(req, ETIMEDOUT);
+        if (ret == ERR_SERVER_FAILURE) {
+            tevent_req_error(req, ERR_SERVER_FAILURE);
         } else {
             if (auth_connect_send(req) == NULL) {
                 tevent_req_error(req, ENOMEM);
@@ -962,8 +959,7 @@ static void auth_bind_user_done(struct tevent_req *subreq)
     switch (ret) {
     case EOK:
         break;
-    case ETIMEDOUT:
-    case ERR_NETWORK_IO:
+    case ERR_SERVER_FAILURE:
         if (auth_connect_send(req) == NULL) {
             tevent_req_error(req, ENOMEM);
         }
@@ -1116,8 +1112,7 @@ static void sdap_pam_auth_handler_done(struct tevent_req *subreq)
     case ERR_AUTH_FAILED:
         state->pd->pam_status = PAM_AUTH_ERR;
         break;
-    case ETIMEDOUT:
-    case ERR_NETWORK_IO:
+    case ERR_SERVER_FAILURE:
         state->pd->pam_status = PAM_AUTHINFO_UNAVAIL;
         be_mark_offline(state->be_ctx);
         break;
@@ -1497,8 +1492,7 @@ static void sdap_pam_chpass_handler_auth_done(struct tevent_req *subreq)
                 }
             }
             break;
-        case ETIMEDOUT:
-        case ERR_NETWORK_IO:
+        case ERR_SERVER_FAILURE:
             state->pd->pam_status = PAM_AUTHINFO_UNAVAIL;
             be_mark_offline(state->be_ctx);
             break;
@@ -1601,7 +1595,7 @@ static void sdap_pam_chpass_handler_chpass_done(struct tevent_req *subreq)
     case ERR_CHPASS_DENIED:
         state->pd->pam_status = PAM_NEW_AUTHTOK_REQD;
         break;
-    case ERR_NETWORK_IO:
+    case ERR_SERVER_FAILURE:
         state->pd->pam_status = PAM_AUTHTOK_ERR;
         break;
     default:

--- a/src/providers/ldap/ldap_common.h
+++ b/src/providers/ldap/ldap_common.h
@@ -157,7 +157,7 @@ sdap_handle_acct_req_send(TALLOC_CTX *mem_ctx,
                           bool noexist_delete);
 errno_t
 sdap_handle_acct_req_recv(struct tevent_req *req,
-                          int *_dp_error, const char **_err);
+                           const char **_err);
 
 struct tevent_req *
 sdap_pam_auth_handler_send(TALLOC_CTX *mem_ctx,
@@ -301,7 +301,7 @@ struct tevent_req *groups_get_send(TALLOC_CTX *memctx,
                                    bool noexist_delete,
                                    bool no_members,
                                    bool set_non_posix);
-int groups_get_recv(struct tevent_req *req, int *dp_error_out);
+int groups_get_recv(struct tevent_req *req);
 
 struct tevent_req *groups_by_user_send(TALLOC_CTX *memctx,
                                        struct tevent_context *ev,
@@ -317,7 +317,7 @@ struct tevent_req *groups_by_user_send(TALLOC_CTX *memctx,
                                        bool noexist_delete,
                                        bool set_non_posix);
 
-int groups_by_user_recv(struct tevent_req *req, int *dp_error_out);
+int groups_by_user_recv(struct tevent_req *req);
 
 struct tevent_req *ldap_netgroup_get_send(TALLOC_CTX *memctx,
                                           struct tevent_context *ev,
@@ -326,7 +326,7 @@ struct tevent_req *ldap_netgroup_get_send(TALLOC_CTX *memctx,
                                           struct sdap_id_conn_ctx *conn,
                                           const char *name,
                                           bool noexist_delete);
-int ldap_netgroup_get_recv(struct tevent_req *req, int *dp_error_out);
+int ldap_netgroup_get_recv(struct tevent_req *req);
 
 struct tevent_req *
 services_get_send(TALLOC_CTX *mem_ctx,
@@ -340,7 +340,7 @@ services_get_send(TALLOC_CTX *mem_ctx,
                   bool noexist_delete);
 
 errno_t
-services_get_recv(struct tevent_req *req, int *dp_error_out);
+services_get_recv(struct tevent_req *req);
 
 struct tevent_req *
 sdap_iphost_handler_send(TALLOC_CTX *mem_ctx,
@@ -490,7 +490,7 @@ struct tevent_req *subid_ranges_get_send(TALLOC_CTX *memctx,
                                          struct sdap_id_conn_ctx *conn,
                                          const char* filter_value);
 
-int subid_ranges_get_recv(struct tevent_req *req, int *dp_error_out);
+int subid_ranges_get_recv(struct tevent_req *req);
 #endif
 
 #endif /* _LDAP_COMMON_H_ */

--- a/src/providers/ldap/ldap_common.h
+++ b/src/providers/ldap/ldap_common.h
@@ -157,8 +157,7 @@ sdap_handle_acct_req_send(TALLOC_CTX *mem_ctx,
                           bool noexist_delete);
 errno_t
 sdap_handle_acct_req_recv(struct tevent_req *req,
-                          int *_dp_error, const char **_err,
-                          int *sdap_ret);
+                          int *_dp_error, const char **_err);
 
 struct tevent_req *
 sdap_pam_auth_handler_send(TALLOC_CTX *mem_ctx,
@@ -302,7 +301,7 @@ struct tevent_req *groups_get_send(TALLOC_CTX *memctx,
                                    bool noexist_delete,
                                    bool no_members,
                                    bool set_non_posix);
-int groups_get_recv(struct tevent_req *req, int *dp_error_out, int *sdap_ret);
+int groups_get_recv(struct tevent_req *req, int *dp_error_out);
 
 struct tevent_req *groups_by_user_send(TALLOC_CTX *memctx,
                                        struct tevent_context *ev,
@@ -318,7 +317,7 @@ struct tevent_req *groups_by_user_send(TALLOC_CTX *memctx,
                                        bool noexist_delete,
                                        bool set_non_posix);
 
-int groups_by_user_recv(struct tevent_req *req, int *dp_error_out, int *sdap_ret);
+int groups_by_user_recv(struct tevent_req *req, int *dp_error_out);
 
 struct tevent_req *ldap_netgroup_get_send(TALLOC_CTX *memctx,
                                           struct tevent_context *ev,
@@ -327,7 +326,7 @@ struct tevent_req *ldap_netgroup_get_send(TALLOC_CTX *memctx,
                                           struct sdap_id_conn_ctx *conn,
                                           const char *name,
                                           bool noexist_delete);
-int ldap_netgroup_get_recv(struct tevent_req *req, int *dp_error_out, int *sdap_ret);
+int ldap_netgroup_get_recv(struct tevent_req *req, int *dp_error_out);
 
 struct tevent_req *
 services_get_send(TALLOC_CTX *mem_ctx,
@@ -341,7 +340,7 @@ services_get_send(TALLOC_CTX *mem_ctx,
                   bool noexist_delete);
 
 errno_t
-services_get_recv(struct tevent_req *req, int *dp_error_out, int *sdap_ret);
+services_get_recv(struct tevent_req *req, int *dp_error_out);
 
 struct tevent_req *
 sdap_iphost_handler_send(TALLOC_CTX *mem_ctx,
@@ -491,8 +490,7 @@ struct tevent_req *subid_ranges_get_send(TALLOC_CTX *memctx,
                                          struct sdap_id_conn_ctx *conn,
                                          const char* filter_value);
 
-int subid_ranges_get_recv(struct tevent_req *req, int *dp_error_out,
-                          int *sdap_ret);
+int subid_ranges_get_recv(struct tevent_req *req, int *dp_error_out);
 #endif
 
 #endif /* _LDAP_COMMON_H_ */

--- a/src/providers/ldap/ldap_common.h
+++ b/src/providers/ldap/ldap_common.h
@@ -301,7 +301,8 @@ struct tevent_req *groups_get_send(TALLOC_CTX *memctx,
                                    bool noexist_delete,
                                    bool no_members,
                                    bool set_non_posix);
-int groups_get_recv(struct tevent_req *req);
+int groups_get_recv(struct tevent_req *req,
+                    int *sdap_ret);
 
 struct tevent_req *groups_by_user_send(TALLOC_CTX *memctx,
                                        struct tevent_context *ev,

--- a/src/providers/ldap/ldap_id.c
+++ b/src/providers/ldap/ldap_id.c
@@ -146,6 +146,7 @@ struct users_get_state {
     bool use_id_mapping;
     bool non_posix;
 
+    int sdap_ret;
     bool noexist_delete;
     struct sysdb_attrs *extra_attrs;
 };
@@ -374,6 +375,7 @@ struct tevent_req *users_get_send(TALLOC_CTX *memctx,
             }
 
             ret = EOK;
+            state->sdap_ret = ENOENT;
             goto done;
         }
 
@@ -592,6 +594,8 @@ static void users_get_done(struct tevent_req *subreq)
         }
     }
 
+    state->sdap_ret = ret;
+
     if (ret && ret != ENOENT) {
         tevent_req_error(req, ret);
         return;
@@ -610,8 +614,15 @@ static void users_get_done(struct tevent_req *subreq)
     tevent_req_done(req);
 }
 
-int users_get_recv(struct tevent_req *req)
+int users_get_recv(struct tevent_req *req, int *sdap_ret)
 {
+    struct users_get_state *state = tevent_req_data(req,
+                                                    struct users_get_state);
+
+    if (sdap_ret) {
+        *sdap_ret = state->sdap_ret;
+    }
+
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     return EOK;
@@ -636,6 +647,7 @@ struct groups_get_state {
     bool use_id_mapping;
     bool non_posix;
 
+    int sdap_ret;
     bool noexist_delete;
     bool no_members;
 };
@@ -1004,7 +1016,7 @@ static void groups_get_mpg_done(struct tevent_req *subreq)
     struct groups_get_state *state = tevent_req_data(req,
                                                      struct groups_get_state);
 
-    ret = users_get_recv(subreq);
+    ret = users_get_recv(subreq, &state->sdap_ret);
     talloc_zfree(subreq);
 
     if (ret != EOK && ret != ENOENT) {
@@ -1012,7 +1024,7 @@ static void groups_get_mpg_done(struct tevent_req *subreq)
         return;
     }
 
-    if (ret == ENOENT && state->noexist_delete == true) {
+    if (state->sdap_ret == ENOENT && state->noexist_delete == true) {
         ret = groups_get_handle_no_group(state, state->domain,
                                          state->filter_type,
                                          state->filter_value);
@@ -1088,8 +1100,15 @@ errno_t groups_get_handle_no_group(TALLOC_CTX *mem_ctx,
     return ret;
 }
 
-int groups_get_recv(struct tevent_req *req)
+int groups_get_recv(struct tevent_req *req, int *sdap_ret)
 {
+
+    struct groups_get_state *state = tevent_req_data(req,
+                                                     struct groups_get_state);
+    if (sdap_ret) {
+        *sdap_ret = state->sdap_ret;
+    }
+
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     return EOK;
@@ -1558,11 +1577,11 @@ sdap_handle_acct_req_done(struct tevent_req *subreq)
     switch (state->ar->entry_type & BE_REQ_TYPE_MASK) {
     case BE_REQ_USER: /* user */
         err = "User lookup failed";
-        ret = users_get_recv(subreq);
+        ret = users_get_recv(subreq, NULL);
         break;
     case BE_REQ_GROUP: /* group */
         err = "Group lookup failed";
-        ret = groups_get_recv(subreq);
+        ret = groups_get_recv(subreq, NULL);
         break;
     case BE_REQ_INITGROUPS: /* init groups for user */
         err = "Init group lookup failed";
@@ -1594,7 +1613,7 @@ sdap_handle_acct_req_done(struct tevent_req *subreq)
         break;
     case BE_REQ_BY_CERT:
         err = "User lookup by certificate failed";
-        ret = users_get_recv(subreq);
+        ret = users_get_recv(subreq, NULL);
         break;
     default: /* fail */
         ret = EINVAL;
@@ -1648,6 +1667,7 @@ struct get_user_and_group_state {
     char *filter;
     const char **attrs;
 
+    int sdap_ret;
     bool noexist_delete;
 };
 
@@ -1721,14 +1741,18 @@ static void get_user_and_group_groups_done(struct tevent_req *subreq)
     int ret;
     struct sdap_id_conn_ctx *user_conn;
 
-    ret = groups_get_recv(subreq);
+    ret = groups_get_recv(subreq, &state->sdap_ret);
     talloc_zfree(subreq);
 
-    if (ret == EOK) {   /* Matching group found */
+    if (ret != EOK) {           /* Fatal error while looking up group */
+        tevent_req_error(req, ret);
+    }
+
+    if (state->sdap_ret == EOK) {   /* Matching group found */
         tevent_req_done(req);
         return;
-    } else if (ret != EOK && ret != ENOENT) {  /* Fatal error while looking up group */
-        tevent_req_error(req, ret);
+    } else if (state->sdap_ret != ENOENT) {
+        tevent_req_error(req, EIO);
         return;
     }
 
@@ -1761,11 +1785,12 @@ static void get_user_and_group_users_done(struct tevent_req *subreq)
     struct get_user_and_group_state *state = tevent_req_data(req,
                                                struct get_user_and_group_state);
     int ret;
+    int sdap_ret;
 
-    ret = users_get_recv(subreq);
+    ret = users_get_recv(subreq, &sdap_ret);
     talloc_zfree(subreq);
 
-    if (ret == ENOENT) {
+    if (sdap_ret == ENOENT) {
         if (state->noexist_delete == true) {
             /* The search ran to completion, but nothing was found.
              * Delete the existing entry, if any. */

--- a/src/providers/ldap/ldap_id.c
+++ b/src/providers/ldap/ldap_id.c
@@ -1833,7 +1833,7 @@ static void get_user_and_group_users_done(struct tevent_req *subreq)
             }
         }
     } else if (ret != EOK) {
-        tevent_req_error(req, EIO);
+        tevent_req_error(req, ERR_SERVER_FAILURE);
         return;
     }
 

--- a/src/providers/ldap/ldap_id.c
+++ b/src/providers/ldap/ldap_id.c
@@ -146,7 +146,6 @@ struct users_get_state {
     bool use_id_mapping;
     bool non_posix;
 
-    int dp_error;
     bool noexist_delete;
     struct sysdb_attrs *extra_attrs;
 };
@@ -187,7 +186,6 @@ struct tevent_req *users_get_send(TALLOC_CTX *memctx,
     state->ctx = ctx;
     state->sdom = sdom;
     state->conn = conn;
-    state->dp_error = DP_ERR_FATAL;
     state->noexist_delete = noexist_delete;
     state->extra_attrs = NULL;
 
@@ -376,7 +374,6 @@ struct tevent_req *users_get_send(TALLOC_CTX *memctx,
             }
 
             ret = EOK;
-            state->dp_error = DP_ERR_OK;
             goto done;
         }
 
@@ -493,16 +490,12 @@ static void users_get_connect_done(struct tevent_req *subreq)
 {
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                       struct tevent_req);
-    struct users_get_state *state = tevent_req_data(req,
-                                                     struct users_get_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -547,14 +540,13 @@ static void users_get_done(struct tevent_req *subreq)
                                                      struct users_get_state);
     char *endptr;
     uid_t uid = 0;
-    int dp_error = DP_ERR_FATAL;
     int ret;
 
     ret = sdap_get_users_recv(subreq, NULL, NULL);
     talloc_zfree(subreq);
 
-    ret = sdap_id_op_done(state->op, ret, &dp_error);
-    if (dp_error == DP_ERR_OK && ret != EOK) {
+    ret = sdap_id_op_done(state->op, ret);
+    if (ret == EAGAIN) {
         /* retry */
         ret = users_get_retry(req);
         if (ret != EOK) {
@@ -601,7 +593,6 @@ static void users_get_done(struct tevent_req *subreq)
     }
 
     if (ret && ret != ENOENT) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -615,20 +606,12 @@ static void users_get_done(struct tevent_req *subreq)
         }
     }
 
-    state->dp_error = DP_ERR_OK;
     /* FIXME - return sdap error so that we know the user was not found */
     tevent_req_done(req);
 }
 
-int users_get_recv(struct tevent_req *req, int *dp_error_out)
+int users_get_recv(struct tevent_req *req)
 {
-    struct users_get_state *state = tevent_req_data(req,
-                                                    struct users_get_state);
-
-    if (dp_error_out) {
-        *dp_error_out = state->dp_error;
-    }
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     return EOK;
@@ -653,7 +636,6 @@ struct groups_get_state {
     bool use_id_mapping;
     bool non_posix;
 
-    int dp_error;
     bool noexist_delete;
     bool no_members;
 };
@@ -695,7 +677,6 @@ struct tevent_req *groups_get_send(TALLOC_CTX *memctx,
     state->ctx = ctx;
     state->sdom = sdom;
     state->conn = conn;
-    state->dp_error = DP_ERR_FATAL;
     state->noexist_delete = noexist_delete;
     state->no_members = no_members;
 
@@ -907,16 +888,12 @@ static void groups_get_connect_done(struct tevent_req *subreq)
 {
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                       struct tevent_req);
-    struct groups_get_state *state = tevent_req_data(req,
-                                                     struct groups_get_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -959,14 +936,13 @@ static void groups_get_done(struct tevent_req *subreq)
                                                       struct tevent_req);
     struct groups_get_state *state = tevent_req_data(req,
                                                      struct groups_get_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
 
     ret = sdap_get_groups_recv(subreq, NULL, NULL);
     talloc_zfree(subreq);
-    ret = sdap_id_op_done(state->op, ret, &dp_error);
+    ret = sdap_id_op_done(state->op, ret);
 
-    if (dp_error == DP_ERR_OK && ret != EOK) {
+    if (ret == EAGAIN) {
         /* retry */
         ret = groups_get_retry(req);
         if (ret != EOK) {
@@ -978,7 +954,6 @@ static void groups_get_done(struct tevent_req *subreq)
     }
 
     if (ret && ret != ENOENT) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -1018,7 +993,6 @@ static void groups_get_done(struct tevent_req *subreq)
         }
     }
 
-    state->dp_error = DP_ERR_OK;
     tevent_req_done(req);
 }
 
@@ -1030,10 +1004,10 @@ static void groups_get_mpg_done(struct tevent_req *subreq)
     struct groups_get_state *state = tevent_req_data(req,
                                                      struct groups_get_state);
 
-    ret = users_get_recv(subreq, &state->dp_error);
+    ret = users_get_recv(subreq);
     talloc_zfree(subreq);
 
-    if (ret != EOK) {
+    if (ret != EOK && ret != ENOENT) {
         tevent_req_error(req, ret);
         return;
     }
@@ -1114,15 +1088,8 @@ errno_t groups_get_handle_no_group(TALLOC_CTX *mem_ctx,
     return ret;
 }
 
-int groups_get_recv(struct tevent_req *req, int *dp_error_out)
+int groups_get_recv(struct tevent_req *req)
 {
-    struct groups_get_state *state = tevent_req_data(req,
-                                                     struct groups_get_state);
-
-    if (dp_error_out) {
-        *dp_error_out = state->dp_error;
-    }
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     return EOK;
@@ -1149,7 +1116,6 @@ struct groups_by_user_state {
     const char **attrs;
     bool non_posix;
 
-    int dp_error;
     bool noexist_delete;
 };
 
@@ -1180,7 +1146,6 @@ struct tevent_req *groups_by_user_send(TALLOC_CTX *memctx,
 
     state->ev = ev;
     state->ctx = ctx;
-    state->dp_error = DP_ERR_FATAL;
     state->conn = conn;
     state->sdom = sdom;
     state->noexist_delete = noexist_delete;
@@ -1244,14 +1209,12 @@ static void groups_by_user_connect_done(struct tevent_req *subreq)
                                                       struct tevent_req);
     struct groups_by_user_state *state = tevent_req_data(req,
                                                      struct groups_by_user_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -1283,14 +1246,13 @@ static void groups_by_user_done(struct tevent_req *subreq)
                                                       struct tevent_req);
     struct groups_by_user_state *state = tevent_req_data(req,
                                                      struct groups_by_user_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
 
     ret = sdap_get_initgr_recv(subreq);
     talloc_zfree(subreq);
-    ret = sdap_id_op_done(state->op, ret, &dp_error);
+    ret = sdap_id_op_done(state->op, ret);
 
-    if (dp_error == DP_ERR_OK && ret != EOK) {
+    if (ret == EAGAIN) {
         /* retry */
         ret = groups_by_user_retry(req);
         if (ret != EOK) {
@@ -1330,24 +1292,15 @@ static void groups_by_user_done(struct tevent_req *subreq)
     case EOK:
         break;
     default:
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
 
-    state->dp_error = DP_ERR_OK;
     tevent_req_done(req);
 }
 
-int groups_by_user_recv(struct tevent_req *req, int *dp_error_out)
+int groups_by_user_recv(struct tevent_req *req)
 {
-    struct groups_by_user_state *state = tevent_req_data(req,
-                                                             struct groups_by_user_state);
-
-    if (dp_error_out) {
-        *dp_error_out = state->dp_error;
-    }
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     return EOK;
@@ -1367,8 +1320,7 @@ static struct tevent_req *get_user_and_group_send(TALLOC_CTX *memctx,
                                                   int filter_type,
                                                   bool noexist_delete);
 
-errno_t sdap_get_user_and_group_recv(struct tevent_req *req,
-                                     int *dp_error_out);
+errno_t sdap_get_user_and_group_recv(struct tevent_req *req);
 
 bool sdap_is_enum_request(struct dp_id_data *ar)
 {
@@ -1388,7 +1340,6 @@ bool sdap_is_enum_request(struct dp_id_data *ar)
 struct sdap_handle_acct_req_state {
     struct dp_id_data *ar;
     const char *err;
-    int dp_error;
 };
 
 static void sdap_handle_acct_req_done(struct tevent_req *subreq);
@@ -1607,31 +1558,31 @@ sdap_handle_acct_req_done(struct tevent_req *subreq)
     switch (state->ar->entry_type & BE_REQ_TYPE_MASK) {
     case BE_REQ_USER: /* user */
         err = "User lookup failed";
-        ret = users_get_recv(subreq, &state->dp_error);
+        ret = users_get_recv(subreq);
         break;
     case BE_REQ_GROUP: /* group */
         err = "Group lookup failed";
-        ret = groups_get_recv(subreq, &state->dp_error);
+        ret = groups_get_recv(subreq);
         break;
     case BE_REQ_INITGROUPS: /* init groups for user */
         err = "Init group lookup failed";
-        ret = groups_by_user_recv(subreq, &state->dp_error);
+        ret = groups_by_user_recv(subreq);
         break;
     case BE_REQ_SUBID_RANGES:
         err = "Subid ranges lookup failed";
 #ifdef BUILD_SUBID
-        ret = subid_ranges_get_recv(subreq, &state->dp_error);
+        ret = subid_ranges_get_recv(subreq);
 #else
         ret = EINVAL;
 #endif
         break;
     case BE_REQ_NETGROUP:
         err = "Netgroup lookup failed";
-        ret = ldap_netgroup_get_recv(subreq, &state->dp_error);
+        ret = ldap_netgroup_get_recv(subreq);
         break;
     case BE_REQ_SERVICES:
         err = "Service lookup failed";
-        ret = services_get_recv(subreq, &state->dp_error);
+        ret = services_get_recv(subreq);
         break;
     case BE_REQ_BY_SECID:
         /* Fall through */
@@ -1639,11 +1590,11 @@ sdap_handle_acct_req_done(struct tevent_req *subreq)
         /* Fall through */
     case BE_REQ_USER_AND_GROUP:
         err = "Lookup by SID failed";
-        ret = sdap_get_user_and_group_recv(subreq, &state->dp_error);
+        ret = sdap_get_user_and_group_recv(subreq);
         break;
     case BE_REQ_BY_CERT:
         err = "User lookup by certificate failed";
-        ret = users_get_recv(subreq, &state->dp_error);
+        ret = users_get_recv(subreq);
         break;
     default: /* fail */
         ret = EINVAL;
@@ -1663,7 +1614,7 @@ sdap_handle_acct_req_done(struct tevent_req *subreq)
 
 errno_t
 sdap_handle_acct_req_recv(struct tevent_req *req,
-                          int *_dp_error, const char **_err)
+                           const char **_err)
 {
     struct sdap_handle_acct_req_state *state;
 
@@ -1673,10 +1624,6 @@ sdap_handle_acct_req_recv(struct tevent_req *req,
           state->ar->entry_type & BE_REQ_TYPE_MASK,
           state->ar->filter_type, state->ar->filter_value,
           PROBE_SAFE_STR(state->ar->extra_value));
-
-    if (_dp_error) {
-        *_dp_error = state->dp_error;
-    }
 
     if (_err) {
         *_err = state->err;
@@ -1701,7 +1648,6 @@ struct get_user_and_group_state {
     char *filter;
     const char **attrs;
 
-    int dp_error;
     bool noexist_delete;
 };
 
@@ -1732,7 +1678,6 @@ static struct tevent_req *get_user_and_group_send(TALLOC_CTX *memctx,
     state->id_ctx = id_ctx;
     state->sdom = sdom;
     state->conn = conn;
-    state->dp_error = DP_ERR_FATAL;
     state->noexist_delete = noexist_delete;
 
     state->op = sdap_id_op_create(state, state->conn->conn_cache);
@@ -1776,7 +1721,7 @@ static void get_user_and_group_groups_done(struct tevent_req *subreq)
     int ret;
     struct sdap_id_conn_ctx *user_conn;
 
-    ret = groups_get_recv(subreq, &state->dp_error);
+    ret = groups_get_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret == EOK) {   /* Matching group found */
@@ -1817,7 +1762,7 @@ static void get_user_and_group_users_done(struct tevent_req *subreq)
                                                struct get_user_and_group_state);
     int ret;
 
-    ret = users_get_recv(subreq, &state->dp_error);
+    ret = users_get_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret == ENOENT) {
@@ -1842,16 +1787,8 @@ static void get_user_and_group_users_done(struct tevent_req *subreq)
     return;
 }
 
-errno_t sdap_get_user_and_group_recv(struct tevent_req *req,
-                                     int *dp_error_out)
+errno_t sdap_get_user_and_group_recv(struct tevent_req *req)
 {
-    struct get_user_and_group_state *state = tevent_req_data(req,
-                                               struct get_user_and_group_state);
-
-    if (dp_error_out) {
-        *dp_error_out = state->dp_error;
-    }
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     return EOK;
@@ -1899,7 +1836,7 @@ sdap_account_info_handler_send(TALLOC_CTX *mem_ctx,
     return req;
 
 immediately:
-    dp_reply_std_set(&state->reply, DP_ERR_DECIDE, ret, NULL);
+    dp_reply_std_set(&state->reply, ret, NULL);
 
     /* TODO For backward compatibility we always return EOK to DP now. */
     tevent_req_done(req);
@@ -1913,17 +1850,16 @@ static void sdap_account_info_handler_done(struct tevent_req *subreq)
     struct sdap_account_info_handler_state *state;
     struct tevent_req *req;
     const char *error_msg;
-    int dp_error;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_account_info_handler_state);
 
-    ret = sdap_handle_acct_req_recv(subreq, &dp_error, &error_msg);
+    ret = sdap_handle_acct_req_recv(subreq, &error_msg);
     talloc_zfree(subreq);
 
     /* TODO For backward compatibility we always return EOK to DP now. */
-    dp_reply_std_set(&state->reply, dp_error, ret, error_msg);
+    dp_reply_std_set(&state->reply, ret, error_msg);
     tevent_req_done(req);
 }
 

--- a/src/providers/ldap/ldap_id.c
+++ b/src/providers/ldap/ldap_id.c
@@ -147,7 +147,6 @@ struct users_get_state {
     bool non_posix;
 
     int dp_error;
-    int sdap_ret;
     bool noexist_delete;
     struct sysdb_attrs *extra_attrs;
 };
@@ -377,7 +376,6 @@ struct tevent_req *users_get_send(TALLOC_CTX *memctx,
             }
 
             ret = EOK;
-            state->sdap_ret = ENOENT;
             state->dp_error = DP_ERR_OK;
             goto done;
         }
@@ -601,7 +599,6 @@ static void users_get_done(struct tevent_req *subreq)
             }
         }
     }
-    state->sdap_ret = ret;
 
     if (ret && ret != ENOENT) {
         state->dp_error = dp_error;
@@ -623,17 +620,13 @@ static void users_get_done(struct tevent_req *subreq)
     tevent_req_done(req);
 }
 
-int users_get_recv(struct tevent_req *req, int *dp_error_out, int *sdap_ret)
+int users_get_recv(struct tevent_req *req, int *dp_error_out)
 {
     struct users_get_state *state = tevent_req_data(req,
                                                     struct users_get_state);
 
     if (dp_error_out) {
         *dp_error_out = state->dp_error;
-    }
-
-    if (sdap_ret) {
-        *sdap_ret = state->sdap_ret;
     }
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
@@ -661,7 +654,6 @@ struct groups_get_state {
     bool non_posix;
 
     int dp_error;
-    int sdap_ret;
     bool noexist_delete;
     bool no_members;
 };
@@ -984,7 +976,6 @@ static void groups_get_done(struct tevent_req *subreq)
 
         return;
     }
-    state->sdap_ret = ret;
 
     if (ret && ret != ENOENT) {
         state->dp_error = dp_error;
@@ -1039,7 +1030,7 @@ static void groups_get_mpg_done(struct tevent_req *subreq)
     struct groups_get_state *state = tevent_req_data(req,
                                                      struct groups_get_state);
 
-    ret = users_get_recv(subreq, &state->dp_error, &state->sdap_ret);
+    ret = users_get_recv(subreq, &state->dp_error);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
@@ -1047,7 +1038,7 @@ static void groups_get_mpg_done(struct tevent_req *subreq)
         return;
     }
 
-    if (state->sdap_ret == ENOENT && state->noexist_delete == true) {
+    if (ret == ENOENT && state->noexist_delete == true) {
         ret = groups_get_handle_no_group(state, state->domain,
                                          state->filter_type,
                                          state->filter_value);
@@ -1123,17 +1114,13 @@ errno_t groups_get_handle_no_group(TALLOC_CTX *mem_ctx,
     return ret;
 }
 
-int groups_get_recv(struct tevent_req *req, int *dp_error_out, int *sdap_ret)
+int groups_get_recv(struct tevent_req *req, int *dp_error_out)
 {
     struct groups_get_state *state = tevent_req_data(req,
                                                      struct groups_get_state);
 
     if (dp_error_out) {
         *dp_error_out = state->dp_error;
-    }
-
-    if (sdap_ret) {
-        *sdap_ret = state->sdap_ret;
     }
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
@@ -1163,7 +1150,6 @@ struct groups_by_user_state {
     bool non_posix;
 
     int dp_error;
-    int sdap_ret;
     bool noexist_delete;
 };
 
@@ -1314,9 +1300,8 @@ static void groups_by_user_done(struct tevent_req *subreq)
 
         return;
     }
-    state->sdap_ret = ret;
 
-    switch (state->sdap_ret) {
+    switch (ret) {
     case ENOENT:
         if (state->noexist_delete == true) {
             const char *cname;
@@ -1354,17 +1339,13 @@ static void groups_by_user_done(struct tevent_req *subreq)
     tevent_req_done(req);
 }
 
-int groups_by_user_recv(struct tevent_req *req, int *dp_error_out, int *sdap_ret)
+int groups_by_user_recv(struct tevent_req *req, int *dp_error_out)
 {
     struct groups_by_user_state *state = tevent_req_data(req,
                                                              struct groups_by_user_state);
 
     if (dp_error_out) {
         *dp_error_out = state->dp_error;
-    }
-
-    if (sdap_ret) {
-        *sdap_ret = state->sdap_ret;
     }
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
@@ -1387,7 +1368,7 @@ static struct tevent_req *get_user_and_group_send(TALLOC_CTX *memctx,
                                                   bool noexist_delete);
 
 errno_t sdap_get_user_and_group_recv(struct tevent_req *req,
-                                     int *dp_error_out, int *sdap_ret);
+                                     int *dp_error_out);
 
 bool sdap_is_enum_request(struct dp_id_data *ar)
 {
@@ -1408,7 +1389,6 @@ struct sdap_handle_acct_req_state {
     struct dp_id_data *ar;
     const char *err;
     int dp_error;
-    int sdap_ret;
 };
 
 static void sdap_handle_acct_req_done(struct tevent_req *subreq);
@@ -1627,31 +1607,31 @@ sdap_handle_acct_req_done(struct tevent_req *subreq)
     switch (state->ar->entry_type & BE_REQ_TYPE_MASK) {
     case BE_REQ_USER: /* user */
         err = "User lookup failed";
-        ret = users_get_recv(subreq, &state->dp_error, &state->sdap_ret);
+        ret = users_get_recv(subreq, &state->dp_error);
         break;
     case BE_REQ_GROUP: /* group */
         err = "Group lookup failed";
-        ret = groups_get_recv(subreq, &state->dp_error, &state->sdap_ret);
+        ret = groups_get_recv(subreq, &state->dp_error);
         break;
     case BE_REQ_INITGROUPS: /* init groups for user */
         err = "Init group lookup failed";
-        ret = groups_by_user_recv(subreq, &state->dp_error, &state->sdap_ret);
+        ret = groups_by_user_recv(subreq, &state->dp_error);
         break;
     case BE_REQ_SUBID_RANGES:
         err = "Subid ranges lookup failed";
 #ifdef BUILD_SUBID
-        ret = subid_ranges_get_recv(subreq, &state->dp_error, &state->sdap_ret);
+        ret = subid_ranges_get_recv(subreq, &state->dp_error);
 #else
         ret = EINVAL;
 #endif
         break;
     case BE_REQ_NETGROUP:
         err = "Netgroup lookup failed";
-        ret = ldap_netgroup_get_recv(subreq, &state->dp_error, &state->sdap_ret);
+        ret = ldap_netgroup_get_recv(subreq, &state->dp_error);
         break;
     case BE_REQ_SERVICES:
         err = "Service lookup failed";
-        ret = services_get_recv(subreq, &state->dp_error, &state->sdap_ret);
+        ret = services_get_recv(subreq, &state->dp_error);
         break;
     case BE_REQ_BY_SECID:
         /* Fall through */
@@ -1659,12 +1639,11 @@ sdap_handle_acct_req_done(struct tevent_req *subreq)
         /* Fall through */
     case BE_REQ_USER_AND_GROUP:
         err = "Lookup by SID failed";
-        ret = sdap_get_user_and_group_recv(subreq, &state->dp_error,
-                                           &state->sdap_ret);
+        ret = sdap_get_user_and_group_recv(subreq, &state->dp_error);
         break;
     case BE_REQ_BY_CERT:
         err = "User lookup by certificate failed";
-        ret = users_get_recv(subreq, &state->dp_error, &state->sdap_ret);
+        ret = users_get_recv(subreq, &state->dp_error);
         break;
     default: /* fail */
         ret = EINVAL;
@@ -1684,8 +1663,7 @@ sdap_handle_acct_req_done(struct tevent_req *subreq)
 
 errno_t
 sdap_handle_acct_req_recv(struct tevent_req *req,
-                          int *_dp_error, const char **_err,
-                          int *sdap_ret)
+                          int *_dp_error, const char **_err)
 {
     struct sdap_handle_acct_req_state *state;
 
@@ -1702,10 +1680,6 @@ sdap_handle_acct_req_recv(struct tevent_req *req,
 
     if (_err) {
         *_err = state->err;
-    }
-
-    if (sdap_ret) {
-        *sdap_ret = state->sdap_ret;
     }
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
@@ -1728,7 +1702,6 @@ struct get_user_and_group_state {
     const char **attrs;
 
     int dp_error;
-    int sdap_ret;
     bool noexist_delete;
 };
 
@@ -1803,19 +1776,14 @@ static void get_user_and_group_groups_done(struct tevent_req *subreq)
     int ret;
     struct sdap_id_conn_ctx *user_conn;
 
-    ret = groups_get_recv(subreq, &state->dp_error, &state->sdap_ret);
+    ret = groups_get_recv(subreq, &state->dp_error);
     talloc_zfree(subreq);
 
-    if (ret != EOK) {           /* Fatal error while looking up group */
-        tevent_req_error(req, ret);
-        return;
-    }
-
-    if (state->sdap_ret == EOK) {   /* Matching group found */
+    if (ret == EOK) {   /* Matching group found */
         tevent_req_done(req);
         return;
-    } else if (state->sdap_ret != ENOENT) {
-        tevent_req_error(req, EIO);
+    } else if (ret != EOK && ret != ENOENT) {  /* Fatal error while looking up group */
+        tevent_req_error(req, ret);
         return;
     }
 
@@ -1849,14 +1817,10 @@ static void get_user_and_group_users_done(struct tevent_req *subreq)
                                                struct get_user_and_group_state);
     int ret;
 
-    ret = users_get_recv(subreq, &state->dp_error, &state->sdap_ret);
+    ret = users_get_recv(subreq, &state->dp_error);
     talloc_zfree(subreq);
 
-    if (ret != EOK) {
-        tevent_req_error(req, ret);
-        return;
-    }
-    if (state->sdap_ret == ENOENT) {
+    if (ret == ENOENT) {
         if (state->noexist_delete == true) {
             /* The search ran to completion, but nothing was found.
              * Delete the existing entry, if any. */
@@ -1868,28 +1832,24 @@ static void get_user_and_group_users_done(struct tevent_req *subreq)
                 return;
             }
         }
-    } else if (state->sdap_ret != EOK) {
+    } else if (ret != EOK) {
         tevent_req_error(req, EIO);
         return;
     }
 
-    /* Both ret and sdap->ret are EOK. Matching user found */
+    /* Matching user found */
     tevent_req_done(req);
     return;
 }
 
 errno_t sdap_get_user_and_group_recv(struct tevent_req *req,
-                                     int *dp_error_out, int *sdap_ret)
+                                     int *dp_error_out)
 {
     struct get_user_and_group_state *state = tevent_req_data(req,
                                                struct get_user_and_group_state);
 
     if (dp_error_out) {
         *dp_error_out = state->dp_error;
-    }
-
-    if (sdap_ret) {
-        *sdap_ret = state->sdap_ret;
     }
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
@@ -1959,7 +1919,7 @@ static void sdap_account_info_handler_done(struct tevent_req *subreq)
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_account_info_handler_state);
 
-    ret = sdap_handle_acct_req_recv(subreq, &dp_error, &error_msg, NULL);
+    ret = sdap_handle_acct_req_recv(subreq, &dp_error, &error_msg);
     talloc_zfree(subreq);
 
     /* TODO For backward compatibility we always return EOK to DP now. */

--- a/src/providers/ldap/ldap_id_netgroup.c
+++ b/src/providers/ldap/ldap_id_netgroup.c
@@ -49,7 +49,6 @@ struct ldap_netgroup_get_state {
     struct sysdb_attrs **netgroups;
 
     int dp_error;
-    int sdap_ret;
     bool noexist_delete;
 };
 
@@ -199,7 +198,6 @@ static void ldap_netgroup_get_done(struct tevent_req *subreq)
 
         return;
     }
-    state->sdap_ret = ret;
 
     if (ret && ret != ENOENT) {
         state->dp_error = dp_error;
@@ -228,17 +226,13 @@ static void ldap_netgroup_get_done(struct tevent_req *subreq)
     return;
 }
 
-int ldap_netgroup_get_recv(struct tevent_req *req, int *dp_error_out, int *sdap_ret)
+int ldap_netgroup_get_recv(struct tevent_req *req, int *dp_error_out)
 {
     struct ldap_netgroup_get_state *state = tevent_req_data(req,
                                                     struct ldap_netgroup_get_state);
 
     if (dp_error_out) {
         *dp_error_out = state->dp_error;
-    }
-
-    if (sdap_ret) {
-        *sdap_ret = state->sdap_ret;
     }
 
     TEVENT_REQ_RETURN_ON_ERROR(req);

--- a/src/providers/ldap/ldap_id_netgroup.c
+++ b/src/providers/ldap/ldap_id_netgroup.c
@@ -48,7 +48,6 @@ struct ldap_netgroup_get_state {
     size_t count;
     struct sysdb_attrs **netgroups;
 
-    int dp_error;
     bool noexist_delete;
 };
 
@@ -76,7 +75,6 @@ struct tevent_req *ldap_netgroup_get_send(TALLOC_CTX *memctx,
     state->ctx = ctx;
     state->sdom = sdom;
     state->conn = conn;
-    state->dp_error = DP_ERR_FATAL;
     state->noexist_delete = noexist_delete;
 
     state->op = sdap_id_op_create(state, state->conn->conn_cache);
@@ -146,14 +144,12 @@ static void ldap_netgroup_get_connect_done(struct tevent_req *subreq)
                                                       struct tevent_req);
     struct ldap_netgroup_get_state *state = tevent_req_data(req,
                                                     struct ldap_netgroup_get_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -180,15 +176,14 @@ static void ldap_netgroup_get_done(struct tevent_req *subreq)
                                                       struct tevent_req);
     struct ldap_netgroup_get_state *state = tevent_req_data(req,
                                                     struct ldap_netgroup_get_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
 
     ret = sdap_get_netgroups_recv(subreq, state, NULL, &state->count,
                                   &state->netgroups);
     talloc_zfree(subreq);
-    ret = sdap_id_op_done(state->op, ret, &dp_error);
+    ret = sdap_id_op_done(state->op, ret);
 
-    if (dp_error == DP_ERR_OK && ret != EOK) {
+    if (ret == EAGAIN) {
         /* retry */
         ret = ldap_netgroup_get_retry(req);
         if (ret != EOK) {
@@ -200,7 +195,6 @@ static void ldap_netgroup_get_done(struct tevent_req *subreq)
     }
 
     if (ret && ret != ENOENT) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -221,20 +215,12 @@ static void ldap_netgroup_get_done(struct tevent_req *subreq)
         }
     }
 
-    state->dp_error = DP_ERR_OK;
     tevent_req_done(req);
     return;
 }
 
-int ldap_netgroup_get_recv(struct tevent_req *req, int *dp_error_out)
+int ldap_netgroup_get_recv(struct tevent_req *req)
 {
-    struct ldap_netgroup_get_state *state = tevent_req_data(req,
-                                                    struct ldap_netgroup_get_state);
-
-    if (dp_error_out) {
-        *dp_error_out = state->dp_error;
-    }
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     return EOK;

--- a/src/providers/ldap/ldap_id_services.c
+++ b/src/providers/ldap/ldap_id_services.c
@@ -48,7 +48,6 @@ struct sdap_services_get_state {
     int filter_type;
 
     int dp_error;
-    int sdap_ret;
     bool noexist_delete;
 };
 
@@ -242,7 +241,6 @@ services_get_done(struct tevent_req *subreq)
         /* Return to the mainloop to retry */
         return;
     }
-    state->sdap_ret = ret;
 
     /* An error occurred. */
     if (ret && ret != ENOENT) {
@@ -289,17 +287,13 @@ services_get_done(struct tevent_req *subreq)
 }
 
 errno_t
-services_get_recv(struct tevent_req *req, int *dp_error_out, int *sdap_ret)
+services_get_recv(struct tevent_req *req, int *dp_error_out)
 {
     struct sdap_services_get_state *state =
             tevent_req_data(req, struct sdap_services_get_state);
 
     if (dp_error_out) {
         *dp_error_out = state->dp_error;
-    }
-
-    if (sdap_ret) {
-        *sdap_ret = state->sdap_ret;
     }
 
     TEVENT_REQ_RETURN_ON_ERROR(req);

--- a/src/providers/ldap/ldap_id_services.c
+++ b/src/providers/ldap/ldap_id_services.c
@@ -47,7 +47,6 @@ struct sdap_services_get_state {
 
     int filter_type;
 
-    int dp_error;
     bool noexist_delete;
 };
 
@@ -83,7 +82,6 @@ services_get_send(TALLOC_CTX *mem_ctx,
     state->id_ctx = id_ctx;
     state->sdom = sdom;
     state->conn = conn;
-    state->dp_error = DP_ERR_FATAL;
     state->domain = sdom->dom;
     state->sysdb = sdom->dom->sysdb;
     state->name = name;
@@ -184,13 +182,11 @@ services_get_connect_done(struct tevent_req *subreq)
             tevent_req_callback_data(subreq, struct tevent_req);
     struct sdap_services_get_state *state =
             tevent_req_data(req, struct sdap_services_get_state);
-    int dp_error = DP_ERR_FATAL;
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -221,7 +217,6 @@ services_get_done(struct tevent_req *subreq)
             tevent_req_callback_data(subreq, struct tevent_req);
     struct sdap_services_get_state *state =
             tevent_req_data(req, struct sdap_services_get_state);
-    int dp_error = DP_ERR_FATAL;
 
     ret = sdap_get_services_recv(NULL, subreq, NULL);
     talloc_zfree(subreq);
@@ -229,8 +224,8 @@ services_get_done(struct tevent_req *subreq)
     /* Check whether we need to try again with another
      * failover server.
      */
-    ret = sdap_id_op_done(state->op, ret, &dp_error);
-    if (dp_error == DP_ERR_OK && ret != EOK) {
+    ret = sdap_id_op_done(state->op, ret);
+    if (ret == EAGAIN) {
         /* retry */
         ret = services_get_retry(req);
         if (ret != EOK) {
@@ -244,7 +239,6 @@ services_get_done(struct tevent_req *subreq)
 
     /* An error occurred. */
     if (ret && ret != ENOENT) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -282,20 +276,12 @@ services_get_done(struct tevent_req *subreq)
         }
     }
 
-    state->dp_error = DP_ERR_OK;
     tevent_req_done(req);
 }
 
 errno_t
-services_get_recv(struct tevent_req *req, int *dp_error_out)
+services_get_recv(struct tevent_req *req)
 {
-    struct sdap_services_get_state *state =
-            tevent_req_data(req, struct sdap_services_get_state);
-
-    if (dp_error_out) {
-        *dp_error_out = state->dp_error;
-    }
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     return EOK;

--- a/src/providers/ldap/ldap_id_subid.c
+++ b/src/providers/ldap/ldap_id_subid.c
@@ -36,7 +36,7 @@ struct tevent_req *users_get_send(TALLOC_CTX *memctx,
                                   const char *extra_value,
                                   bool noexist_delete,
                                   bool set_non_posix);
-int users_get_recv(struct tevent_req *req, int *dp_error_out, int *sdap_ret);
+int users_get_recv(struct tevent_req *req, int *dp_error_out);
 
 static int subid_ranges_get_retry(struct tevent_req *req);
 static void subid_ranges_get_connect_done(struct tevent_req *subreq);
@@ -60,7 +60,6 @@ struct subid_ranges_get_state {
     const char **attrs;
 
     int dp_error;
-    int sdap_ret;
 };
 
 struct tevent_req *subid_ranges_get_send(TALLOC_CTX *memctx,
@@ -221,7 +220,7 @@ static void subid_ranges_resolve_owner_done(struct tevent_req *subreq)
     int dp_error = DP_ERR_FATAL;
     int ret;
 
-    ret = users_get_recv(subreq, &dp_error, NULL);
+    ret = users_get_recv(subreq, &dp_error);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
@@ -314,7 +313,6 @@ static void subid_ranges_get_done(struct tevent_req *subreq)
         }
         return;
     }
-    state->sdap_ret = ret;
 
     if (ret && ret != ENOENT) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to retrieve subid ranges.\n");
@@ -343,18 +341,13 @@ static void subid_ranges_get_done(struct tevent_req *subreq)
     tevent_req_done(req);
 }
 
-int subid_ranges_get_recv(struct tevent_req *req, int *dp_error_out,
-                          int *sdap_ret)
+int subid_ranges_get_recv(struct tevent_req *req, int *dp_error_out)
 {
     struct subid_ranges_get_state *state = tevent_req_data(req,
                                                     struct subid_ranges_get_state);
 
     if (dp_error_out) {
         *dp_error_out = state->dp_error;
-    }
-
-    if (sdap_ret) {
-        *sdap_ret = state->sdap_ret;
     }
 
     TEVENT_REQ_RETURN_ON_ERROR(req);

--- a/src/providers/ldap/ldap_id_subid.c
+++ b/src/providers/ldap/ldap_id_subid.c
@@ -36,7 +36,7 @@ struct tevent_req *users_get_send(TALLOC_CTX *memctx,
                                   const char *extra_value,
                                   bool noexist_delete,
                                   bool set_non_posix);
-int users_get_recv(struct tevent_req *req, int *dp_error_out);
+int users_get_recv(struct tevent_req *req);
 
 static int subid_ranges_get_retry(struct tevent_req *req);
 static void subid_ranges_get_connect_done(struct tevent_req *subreq);
@@ -58,8 +58,6 @@ struct subid_ranges_get_state {
     char *owner_name;
     char *owner_dn;
     const char **attrs;
-
-    int dp_error;
 };
 
 struct tevent_req *subid_ranges_get_send(TALLOC_CTX *memctx,
@@ -82,7 +80,6 @@ struct tevent_req *subid_ranges_get_send(TALLOC_CTX *memctx,
     state->ctx = ctx;
     state->sdom = sdom;
     state->conn = conn;
-    state->dp_error = DP_ERR_FATAL;
     state->owner_name = talloc_strdup(state, filter_value);
     if (!state->owner_name) {
         DEBUG(SSSDBG_OP_FAILURE, "talloc_strdup failed\n");
@@ -135,16 +132,12 @@ static void subid_ranges_get_connect_done(struct tevent_req *subreq)
 {
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                       struct tevent_req);
-    struct subid_ranges_get_state *state = tevent_req_data(req,
-                                                     struct subid_ranges_get_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -217,14 +210,12 @@ static void subid_ranges_resolve_owner_done(struct tevent_req *subreq)
                                                       struct tevent_req);
     struct subid_ranges_get_state *state = tevent_req_data(req,
                                                      struct subid_ranges_get_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
 
-    ret = users_get_recv(subreq, &dp_error);
+    ret = users_get_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -233,7 +224,6 @@ static void subid_ranges_resolve_owner_done(struct tevent_req *subreq)
     if (state->owner_dn == NULL) {
         DEBUG(SSSDBG_TRACE_FUNC,
               "Online lookup didn't find range owner '%s'\n", state->owner_name);
-        state->dp_error = DP_ERR_OK;
         tevent_req_done(req);
         return;
     }
@@ -291,7 +281,6 @@ static void subid_ranges_get_done(struct tevent_req *subreq)
                                                       struct tevent_req);
     struct subid_ranges_get_state *state = tevent_req_data(req,
                                                      struct subid_ranges_get_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
     struct sysdb_attrs **results;
     size_t num_results;
@@ -303,8 +292,8 @@ static void subid_ranges_get_done(struct tevent_req *subreq)
         return;
     }
 
-    ret = sdap_id_op_done(state->op, ret, &dp_error);
-    if (dp_error == DP_ERR_OK && ret != EOK) {
+    ret = sdap_id_op_done(state->op, ret);
+    if (ret == EAGAIN) {
         /* retry */
         ret = subid_ranges_get_retry(req);
         if (ret != EOK) {
@@ -316,7 +305,6 @@ static void subid_ranges_get_done(struct tevent_req *subreq)
 
     if (ret && ret != ENOENT) {
         DEBUG(SSSDBG_OP_FAILURE, "Failed to retrieve subid ranges.\n");
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -337,19 +325,11 @@ static void subid_ranges_get_done(struct tevent_req *subreq)
                                 results[0]);
     }
 
-    state->dp_error = DP_ERR_OK;
     tevent_req_done(req);
 }
 
-int subid_ranges_get_recv(struct tevent_req *req, int *dp_error_out)
+int subid_ranges_get_recv(struct tevent_req *req)
 {
-    struct subid_ranges_get_state *state = tevent_req_data(req,
-                                                    struct subid_ranges_get_state);
-
-    if (dp_error_out) {
-        *dp_error_out = state->dp_error;
-    }
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     return EOK;

--- a/src/providers/ldap/sdap_access.c
+++ b/src/providers/ldap/sdap_access.c
@@ -1688,7 +1688,7 @@ static void sdap_access_ppolicy_get_lockout_done(struct tevent_req *subreq)
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE, "Cannot retrieve ppolicy\n");
-        ret = ERR_NETWORK_IO;
+        ret = ERR_SERVER_FAILURE;
         goto done;
     }
 

--- a/src/providers/ldap/sdap_access.c
+++ b/src/providers/ldap/sdap_access.c
@@ -989,20 +989,19 @@ static void sdap_access_filter_connect_done(struct tevent_req *subreq)
                                                       struct tevent_req);
     struct sdap_access_filter_req_ctx *state =
             tevent_req_data(req, struct sdap_access_filter_req_ctx);
-    int ret, dp_error;
+    int ret;
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
-        if (dp_error == DP_ERR_OFFLINE) {
+        if (ret == ERR_OFFLINE) {
             ret = sdap_access_decide_offline(state->cached_access);
             if (ret == EOK) {
                 tevent_req_done(req);
                 return;
             }
         }
-
         tevent_req_error(req, ret);
         return;
     }
@@ -1032,7 +1031,7 @@ static void sdap_access_filter_connect_done(struct tevent_req *subreq)
 
 static void sdap_access_filter_done(struct tevent_req *subreq)
 {
-    int ret, tret, dp_error;
+    int ret, tret;
     size_t num_results;
     bool found = false;
     struct sysdb_attrs **results;
@@ -1045,15 +1044,15 @@ static void sdap_access_filter_done(struct tevent_req *subreq)
                                 &num_results, &results);
     talloc_zfree(subreq);
 
-    ret = sdap_id_op_done(state->sdap_op, ret, &dp_error);
-    if (ret != EOK) {
-        if (dp_error == DP_ERR_OK) {
-            /* retry */
-            tret = sdap_access_filter_retry(req);
-            if (tret == EOK) {
-                return;
-            }
-        } else if (dp_error == DP_ERR_OFFLINE) {
+    ret = sdap_id_op_done(state->sdap_op, ret);
+    if (ret == EAGAIN) {
+        /* retry */
+        tret = sdap_access_filter_retry(req);
+        if (tret == EOK) {
+            return;
+        }
+    } else if (ret != EOK) {
+        if (ret == ERR_OFFLINE) {
             ret = sdap_access_decide_offline(state->cached_access);
         } else if (ret == ERR_INVALID_FILTER) {
             sss_log(SSS_LOG_ERR, MALFORMED_FILTER, state->filter);
@@ -1558,24 +1557,23 @@ static void sdap_access_ppolicy_connect_done(struct tevent_req *subreq)
 {
     struct tevent_req *req;
     struct sdap_access_ppolicy_req_ctx *state;
-    int ret, dp_error;
+    int ret;
     const char *ppolicy_dn;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_access_ppolicy_req_ctx);
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
-        if (dp_error == DP_ERR_OFFLINE) {
+        if (ret == ERR_OFFLINE) {
             ret = sdap_access_decide_offline(state->cached_access);
             if (ret == EOK) {
                 tevent_req_done(req);
                 return;
             }
         }
-
         tevent_req_error(req, ret);
         return;
     }
@@ -1674,7 +1672,7 @@ done:
 
 static void sdap_access_ppolicy_get_lockout_done(struct tevent_req *subreq)
 {
-    int ret, tret, dp_error;
+    int ret, tret;
     size_t num_results;
     bool pwdLockout = false;
     struct sysdb_attrs **results;
@@ -1773,7 +1771,7 @@ static void sdap_access_ppolicy_get_lockout_done(struct tevent_req *subreq)
 done:
     if (ret != EAGAIN) {
         /* release connection */
-        tret = sdap_id_op_done(state->sdap_op, ret, &dp_error);
+        tret = sdap_id_op_done(state->sdap_op, ret);
         if (tret != EOK) {
             DEBUG(SSSDBG_CRIT_FAILURE,
                   "sdap_get_generic_send() returned error [%d][%s]\n",
@@ -1911,7 +1909,7 @@ done:
 
 static void sdap_access_ppolicy_step_done(struct tevent_req *subreq)
 {
-    int ret, tret, dp_error;
+    int ret, tret;
     size_t num_results;
     bool locked = false;
     const char *pwdAccountLockedTime;
@@ -1926,15 +1924,15 @@ static void sdap_access_ppolicy_step_done(struct tevent_req *subreq)
     ret = sdap_get_generic_recv(subreq, state, &num_results, &results);
     talloc_zfree(subreq);
 
-    ret = sdap_id_op_done(state->sdap_op, ret, &dp_error);
+    ret = sdap_id_op_done(state->sdap_op, ret);
     if (ret != EOK) {
-        if (dp_error == DP_ERR_OK) {
+        if (ret == EAGAIN) {
             /* retry */
             tret = sdap_access_ppolicy_retry(req);
             if (tret == EOK) {
                 return;
             }
-        } else if (dp_error == DP_ERR_OFFLINE) {
+        } else if (ret == ERR_OFFLINE) {
             ret = sdap_access_decide_offline(state->cached_access);
         } else {
             DEBUG(SSSDBG_CRIT_FAILURE,

--- a/src/providers/ldap/sdap_async.c
+++ b/src/providers/ldap/sdap_async.c
@@ -576,7 +576,7 @@ sdap_chpass_result(TALLOC_CTX *mem_ctx,
         ret = ERR_CHPASS_DENIED;
         break;
     default:
-        ret = ERR_NETWORK_IO;
+        ret = ERR_SERVER_FAILURE;
     }
 
     if (ldap_msg != NULL) {
@@ -674,7 +674,7 @@ struct tevent_req *sdap_exop_modify_passwd_send(TALLOC_CTX *memctx,
     if (ctrls[0]) ldap_control_free(ctrls[0]);
     if (ret == -1 || msgid == -1) {
         DEBUG(SSSDBG_CRIT_FAILURE, "ldap_extended_operation failed\n");
-        ret = ERR_NETWORK_IO;
+        ret = ERR_SERVER_FAILURE;
         goto fail;
     }
     DEBUG(SSSDBG_TRACE_INTERNAL,
@@ -749,7 +749,7 @@ static void sdap_exop_modify_passwd_done(struct sdap_op *op,
                 if (ret != LDAP_SUCCESS) {
                     DEBUG(SSSDBG_CRIT_FAILURE,
                           "ldap_parse_passwordpolicy_control failed.\n");
-                    ret = ERR_NETWORK_IO;
+                    ret = ERR_SERVER_FAILURE;
                     goto done;
                 }
 
@@ -1590,7 +1590,7 @@ sdap_get_generic_ext_send(TALLOC_CTX *memctx,
     if (state->sh == NULL || state->sh->ldap == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Trying LDAP search while not connected.\n");
-        tevent_req_error(req, EIO);
+        tevent_req_error(req, ERR_SERVER_FAILURE);
         tevent_req_post(req, ev);
         return req;
     }
@@ -1684,12 +1684,12 @@ static errno_t sdap_get_generic_ext_step(struct tevent_req *req)
         lret = ldap_create_page_control(state->sh->ldap,
                                         state->sh->page_size,
                                         state->cookie.bv_val ?
-                                            &state->cookie :
-                                            NULL,
+                                        &state->cookie :
+                                        NULL,
                                         false,
                                         &page_control);
         if (lret != LDAP_SUCCESS) {
-            ret = EIO;
+            ret = ERR_SERVER_FAILURE;
             goto done;
         }
         state->serverctrls[state->nserverctrls] = page_control;
@@ -1708,14 +1708,14 @@ static errno_t sdap_get_generic_ext_step(struct tevent_req *req)
         DEBUG(SSSDBG_MINOR_FAILURE,
               "ldap_search_ext failed: %s\n", sss_ldap_err2string(lret));
         if (lret == LDAP_SERVER_DOWN) {
-            ret = ETIMEDOUT;
+            ret = ERR_SERVER_FAILURE;
             sss_ldap_error_debug(SSSDBG_MINOR_FAILURE, "Connection error",
                                  state->sh->ldap, lret);
             sss_log(SSS_LOG_ERR, "LDAP connection error");
         } else if (lret == LDAP_FILTER_ERROR) {
             ret = ERR_INVALID_FILTER;
         } else {
-            ret = EIO;
+            ret = ERR_SERVER_FAILURE;
         }
         goto done;
     }
@@ -2007,16 +2007,9 @@ static void generic_ext_search_handler(struct tevent_req *subreq,
     talloc_zfree(subreq);
 
     if (ret != EOK) {
-        if (ret == ETIMEDOUT) {
-            DEBUG(SSSDBG_CRIT_FAILURE,
-                  "sdap_get_generic_ext_recv failed: [%d]: %s "
-                  "[ldap_search_timeout]\n",
-                  ret, sss_strerror(ret));
-        } else {
-            DEBUG(SSSDBG_CRIT_FAILURE,
-                  "sdap_get_generic_ext_recv request failed: [%d]: %s\n",
-                  ret, sss_strerror(ret));
-        }
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "sdap_get_generic_ext_recv request failed: [%d]: %s\n",
+              ret, sss_strerror(ret));
         tevent_req_error(req, ret);
         return;
     }
@@ -2871,16 +2864,9 @@ static void sdap_sd_search_done(struct tevent_req *subreq)
     talloc_zfree(subreq);
 
     if (ret != EOK) {
-        if (ret == ETIMEDOUT) {
-            DEBUG(SSSDBG_CRIT_FAILURE,
-                  "sdap_get_generic_ext_recv request failed: [%d]: %s "
-                  "[ldap_network_timeout]\n",
-                  ret, sss_strerror(ret));
-        } else {
-            DEBUG(SSSDBG_CRIT_FAILURE,
-                  "sdap_get_generic_ext_recv request failed: [%d]: %s\n",
-                  ret, sss_strerror(ret));
-        }
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "sdap_get_generic_ext_recv request failed: [%d]: %s\n",
+              ret, sss_strerror(ret));
         tevent_req_error(req, ret);
         return;
     }

--- a/src/providers/ldap/sdap_async_autofs.c
+++ b/src/providers/ldap/sdap_async_autofs.c
@@ -647,8 +647,6 @@ struct sdap_autofs_setautomntent_state {
     struct sysdb_attrs *map;
     struct sysdb_attrs **entries;
     size_t entries_count;
-
-    int dp_error;
 };
 
 static void
@@ -767,7 +765,6 @@ sdap_autofs_setautomntent_done(struct tevent_req *subreq)
         return;
     }
 
-    state->dp_error = DP_ERR_OK;
     tevent_req_done(req);
     return;
 }
@@ -971,7 +968,6 @@ struct sdap_autofs_get_map_state {
     struct sdap_options *opts;
     struct sdap_id_op *sdap_op;
     const char *mapname;
-    int dp_error;
 };
 
 static errno_t sdap_autofs_get_map_retry(struct tevent_req *req);
@@ -994,7 +990,6 @@ struct tevent_req *sdap_autofs_get_map_send(TALLOC_CTX *mem_ctx,
     state->id_ctx = id_ctx;
     state->opts = id_ctx->opts;
     state->mapname = mapname;
-    state->dp_error = DP_ERR_FATAL;
 
     state->sdap_op = sdap_id_op_create(state, id_ctx->conn->conn_cache);
     if (!state->sdap_op) {
@@ -1047,19 +1042,17 @@ static void sdap_autofs_get_map_connect_done(struct tevent_req *subreq)
     char *filter;
     char *safe_mapname;
     const char **attrs;
-    int dp_error;
     int ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_autofs_get_map_state);
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "LDAP connection failed "
                                    "[%d]: %s\n", ret, strerror(ret));
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -1097,7 +1090,6 @@ static void sdap_autofs_get_map_connect_done(struct tevent_req *subreq)
                     dp_opt_get_int(state->opts->basic, SDAP_SEARCH_TIMEOUT),
                     filter, attrs, NULL);
     if (subreq == NULL) {
-        state->dp_error = DP_ERR_FATAL;
         tevent_req_error(req, ENOMEM);
         return;
     }
@@ -1120,8 +1112,8 @@ static void sdap_autofs_get_map_done(struct tevent_req *subreq)
                                               &reply);
     talloc_zfree(subreq);
 
-    ret = sdap_id_op_done(state->sdap_op, ret, &state->dp_error);
-    if (state->dp_error == DP_ERR_OK && ret != EOK) {
+    ret = sdap_id_op_done(state->sdap_op, ret);
+    if (ret == EAGAIN) {
         /* retry */
         ret = sdap_autofs_get_map_retry(req);
         if (ret != EOK) {
@@ -1159,16 +1151,9 @@ static void sdap_autofs_get_map_done(struct tevent_req *subreq)
     tevent_req_done(req);
 }
 
-errno_t sdap_autofs_get_map_recv(struct tevent_req *req,
-                                 int *dp_error)
+errno_t sdap_autofs_get_map_recv(struct tevent_req *req)
 {
-    struct sdap_autofs_get_map_state *state;
-
-    state = tevent_req_data(req, struct sdap_autofs_get_map_state);
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
-
-    *dp_error = state->dp_error;
 
     return EOK;
 }
@@ -1179,7 +1164,6 @@ struct sdap_autofs_get_entry_state {
     struct sdap_id_op *sdap_op;
     const char *mapname;
     const char *entryname;
-    int dp_error;
 };
 
 static errno_t sdap_autofs_get_entry_retry(struct tevent_req *req);
@@ -1204,7 +1188,6 @@ struct tevent_req *sdap_autofs_get_entry_send(TALLOC_CTX *mem_ctx,
     state->opts = id_ctx->opts;
     state->mapname = mapname;
     state->entryname = entryname;
-    state->dp_error = DP_ERR_FATAL;
 
     state->sdap_op = sdap_id_op_create(state, id_ctx->conn->conn_cache);
     if (!state->sdap_op) {
@@ -1259,19 +1242,17 @@ static void sdap_autofs_get_entry_connect_done(struct tevent_req *subreq)
     char *safe_entryname;
     const char **attrs;
     const char *base_dn;
-    int dp_error;
     int ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_autofs_get_entry_state);
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "LDAP connection failed "
                                    "[%d]: %s\n", ret, strerror(ret));
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -1329,7 +1310,6 @@ static void sdap_autofs_get_entry_connect_done(struct tevent_req *subreq)
                     dp_opt_get_int(state->opts->basic, SDAP_SEARCH_TIMEOUT),
                     filter, attrs, base_dn);
     if (subreq == NULL) {
-        state->dp_error = DP_ERR_FATAL;
         tevent_req_error(req, ENOMEM);
         return;
     }
@@ -1359,8 +1339,8 @@ static void sdap_autofs_get_entry_done(struct tevent_req *subreq)
                                               &reply);
     talloc_zfree(subreq);
 
-    ret = sdap_id_op_done(state->sdap_op, ret, &state->dp_error);
-    if (state->dp_error == DP_ERR_OK && ret != EOK) {
+    ret = sdap_id_op_done(state->sdap_op, ret);
+    if (ret == EAGAIN) {
         /* retry */
         ret = sdap_autofs_get_entry_retry(req);
         if (ret != EOK) {
@@ -1402,16 +1382,9 @@ done:
     return;
 }
 
-errno_t sdap_autofs_get_entry_recv(struct tevent_req *req,
-                                   int *dp_error)
+errno_t sdap_autofs_get_entry_recv(struct tevent_req *req)
 {
-    struct sdap_autofs_get_entry_state *state;
-
-    state = tevent_req_data(req, struct sdap_autofs_get_entry_state);
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
-
-    *dp_error = state->dp_error;
 
     return EOK;
 }

--- a/src/providers/ldap/sdap_async_connection.c
+++ b/src/providers/ldap/sdap_async_connection.c
@@ -368,11 +368,7 @@ fail:
     if (ret) {
         tevent_req_error(req, ret);
     } else {
-        if (lret == LDAP_SERVER_DOWN) {
-            tevent_req_error(req, ETIMEDOUT);
-        } else {
-            tevent_req_error(req, EIO);
-        }
+        tevent_req_error(req, ERR_SERVER_FAILURE);
     }
     return;
 }
@@ -420,7 +416,7 @@ static void sdap_connect_done(struct sdap_op *op,
                              state->sh->ldap, ret);
         sss_log(SSS_LOG_ERR, "Could not start TLS encryption.");
         state->result = ret;
-        tevent_req_error(req, EIO);
+        tevent_req_error(req, ERR_SERVER_FAILURE);
         return;
     }
 
@@ -733,11 +729,7 @@ static struct tevent_req *simple_bind_send(TALLOC_CTX *memctx,
     return req;
 
 fail:
-    if (ret == LDAP_SERVER_DOWN) {
-        tevent_req_error(req, ETIMEDOUT);
-    } else {
-        tevent_req_error(req, ERR_NETWORK_IO);
-    }
+    tevent_req_error(req, ERR_SERVER_FAILURE);
     tevent_req_post(req, ev);
     return req;
 }
@@ -1015,7 +1007,7 @@ static struct tevent_req *sasl_bind_send(TALLOC_CTX *memctx,
     if (state->sh == NULL || state->sh->ldap == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Trying LDAP search while not connected.\n");
-        ret = ERR_NETWORK_IO;
+        ret = ERR_SERVER_FAILURE;
         goto fail;
     }
 
@@ -1045,7 +1037,7 @@ static struct tevent_req *sasl_bind_send(TALLOC_CTX *memctx,
 
 fail:
     if (ret == LDAP_SERVER_DOWN || ret == LDAP_TIMEOUT) {
-        tevent_req_error(req, ETIMEDOUT);
+        tevent_req_error(req, ERR_SERVER_FAILURE);
     } else {
         tevent_req_error(req, ERR_AUTH_FAILED);
     }
@@ -1223,7 +1215,7 @@ static void sdap_kinit_kdc_resolved(struct tevent_req *subreq)
     if (ret != EOK) {
         /* all servers have been tried and none
          * was found good, go offline */
-        tevent_req_error(req, ERR_NETWORK_IO);
+        tevent_req_error(req, ERR_NO_MORE_SERVERS);
         return;
     }
 
@@ -1724,7 +1716,7 @@ static void sdap_cli_rootdse_done(struct tevent_req *subreq)
     ret = sdap_get_rootdse_recv(subreq, state, &state->rootdse);
     talloc_zfree(subreq);
     if (ret) {
-        if (ret == ETIMEDOUT) { /* retry another server */
+        if (ret == ERR_SERVER_FAILURE) { /* retry another server */
             tevent_req_error(req, ERR_SERVER_FAILURE);
             return;
         }
@@ -1970,7 +1962,7 @@ static void sdap_cli_auth_reconnect_done(struct tevent_req *subreq)
     /* End request if reconnecting failed to avoid endless loop */
     if (state->sh == NULL || !state->sh->connected) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Failed to reconnect.\n");
-        ret = EIO;
+        ret = ERR_SERVER_FAILURE;
         goto done;
     }
 
@@ -2029,7 +2021,7 @@ static void sdap_cli_rootdse_auth_done(struct tevent_req *subreq)
     ret = sdap_get_rootdse_recv(subreq, state, &state->rootdse);
     talloc_zfree(subreq);
     if (ret) {
-        if (ret == ETIMEDOUT) {
+        if (ret == ERR_SERVER_FAILURE) {
             /* The server we authenticated against went down. Retry another
              * one */
             tevent_req_error(req, ERR_SERVER_FAILURE);
@@ -2228,7 +2220,7 @@ static void sdap_cli_resolve_and_connect_kinit_done(struct tevent_req *subreq)
         DEBUG(SSSDBG_TRACE_FUNC,
               "Cannot get a TGT: ret [%d](%s)\n", ret, sss_strerror(ret));
         state->can_retry = false;
-        tevent_req_error(req, EIO);
+        tevent_req_error(req, ERR_SERVER_FAILURE);
         return;
     }
 
@@ -2279,7 +2271,7 @@ static void sdap_cli_resolve_and_connect_next_server_done(struct tevent_req *sub
         state->can_retry = false;
         /* all servers have been tried and none
          * was found good, go offline */
-        tevent_req_error(req, EIO);
+        tevent_req_error(req, ERR_SERVER_FAILURE);
         return;
     }
 
@@ -2453,7 +2445,7 @@ static int sdap_rebind_proc(LDAP *ldap, LDAP_CONST char *url, ber_tag_t request,
     if (ldap == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Trying LDAP rebind while not connected.\n");
-        return ERR_NETWORK_IO;
+        return ERR_SERVER_FAILURE;
     }
 
     if (p->use_start_tls) {

--- a/src/providers/ldap/sdap_async_enum.c
+++ b/src/providers/ldap/sdap_async_enum.c
@@ -150,14 +150,13 @@ static errno_t sdap_dom_enum_ex_retry(struct tevent_req *req,
 static bool sdap_dom_enum_ex_connected(struct tevent_req *subreq)
 {
     errno_t ret;
-    int dp_error;
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                       struct tevent_req);
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        if (dp_error == DP_ERR_OFFLINE) {
+        if (ret == ERR_OFFLINE) {
             DEBUG(SSSDBG_TRACE_FUNC,
                   "Backend is marked offline, retry later!\n");
             tevent_req_done(req);
@@ -201,12 +200,11 @@ static void sdap_dom_enum_ex_users_done(struct tevent_req *subreq)
     struct sdap_dom_enum_ex_state *state = tevent_req_data(req,
                                                 struct sdap_dom_enum_ex_state);
     errno_t ret;
-    int dp_error;
 
     ret = enum_users_recv(subreq);
     talloc_zfree(subreq);
-    ret = sdap_id_op_done(state->user_op, ret, &dp_error);
-    if (dp_error == DP_ERR_OK && ret != EOK) {
+    ret = sdap_id_op_done(state->user_op, ret);
+    if (ret == EAGAIN) {
         /* retry */
         ret = sdap_dom_enum_ex_retry(req, state->user_op,
                                      sdap_dom_enum_ex_get_users);
@@ -215,7 +213,7 @@ static void sdap_dom_enum_ex_users_done(struct tevent_req *subreq)
             return;
         }
         return;
-    } else if (dp_error == DP_ERR_OFFLINE) {
+    } else if (ret == ERR_OFFLINE) {
         DEBUG(SSSDBG_TRACE_FUNC, "Backend is offline, retrying later\n");
         tevent_req_done(req);
         return;
@@ -272,12 +270,11 @@ static void sdap_dom_enum_ex_groups_done(struct tevent_req *subreq)
     struct sdap_dom_enum_ex_state *state = tevent_req_data(req,
                                                 struct sdap_dom_enum_ex_state);
     int ret;
-    int dp_error;
 
     ret = enum_groups_recv(subreq);
     talloc_zfree(subreq);
-    ret = sdap_id_op_done(state->group_op, ret, &dp_error);
-    if (dp_error == DP_ERR_OK && ret != EOK) {
+    ret = sdap_id_op_done(state->group_op, ret);
+    if (ret == EAGAIN) {
         /* retry */
         ret = sdap_dom_enum_ex_retry(req, state->group_op,
                                      sdap_dom_enum_ex_get_groups);
@@ -286,7 +283,7 @@ static void sdap_dom_enum_ex_groups_done(struct tevent_req *subreq)
             return;
         }
         return;
-    } else if (dp_error == DP_ERR_OFFLINE) {
+    } else if (ret == ERR_OFFLINE) {
         DEBUG(SSSDBG_TRACE_FUNC, "Backend is offline, retrying later\n");
         tevent_req_done(req);
         return;
@@ -297,7 +294,6 @@ static void sdap_dom_enum_ex_groups_done(struct tevent_req *subreq)
         tevent_req_error(req, ret);
         return;
     }
-
 
     state->svc_op = sdap_id_op_create(state, state->svc_conn->conn_cache);
     if (state->svc_op == NULL) {
@@ -341,12 +337,11 @@ static void sdap_dom_enum_ex_svcs_done(struct tevent_req *subreq)
     struct sdap_dom_enum_ex_state *state = tevent_req_data(req,
                                                 struct sdap_dom_enum_ex_state);
     int ret;
-    int dp_error;
 
     ret = enum_services_recv(subreq);
     talloc_zfree(subreq);
-    ret = sdap_id_op_done(state->svc_op, ret, &dp_error);
-    if (dp_error == DP_ERR_OK && ret != EOK) {
+    ret = sdap_id_op_done(state->svc_op, ret);
+    if (ret == EAGAIN) {
         /* retry */
         ret = sdap_dom_enum_ex_retry(req, state->user_op,
                                      sdap_dom_enum_ex_get_svcs);
@@ -355,7 +350,7 @@ static void sdap_dom_enum_ex_svcs_done(struct tevent_req *subreq)
             return;
         }
         return;
-    } else if (dp_error == DP_ERR_OFFLINE) {
+    } else if (ret == ERR_OFFLINE) {
         DEBUG(SSSDBG_TRACE_FUNC, "Backend is offline, retrying later\n");
         tevent_req_done(req);
         return;

--- a/src/providers/ldap/sdap_async_groups.c
+++ b/src/providers/ldap/sdap_async_groups.c
@@ -1815,12 +1815,11 @@ static void sdap_get_groups_ldap_connect_done(struct tevent_req *subreq)
     struct tevent_req *req;
     struct sdap_get_groups_state *state;
     int ret;
-    int dp_error;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_get_groups_state);
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {

--- a/src/providers/ldap/sdap_async_initgroups.c
+++ b/src/providers/ldap/sdap_async_initgroups.c
@@ -2907,10 +2907,9 @@ static void sdap_get_initgr_user_connect_done(struct tevent_req *subreq)
 {
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                       struct tevent_req);
-    int dp_error = DP_ERR_FATAL;
     int ret;
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
@@ -3442,7 +3441,7 @@ static void sdap_get_initgr_pgid(struct tevent_req *subreq)
             tevent_req_callback_data(subreq, struct tevent_req);
     errno_t ret;
 
-    ret = groups_get_recv(subreq, NULL);
+    ret = groups_get_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
         tevent_req_error(req, ret);

--- a/src/providers/ldap/sdap_async_initgroups.c
+++ b/src/providers/ldap/sdap_async_initgroups.c
@@ -3442,7 +3442,7 @@ static void sdap_get_initgr_pgid(struct tevent_req *subreq)
             tevent_req_callback_data(subreq, struct tevent_req);
     errno_t ret;
 
-    ret = groups_get_recv(subreq, NULL, NULL);
+    ret = groups_get_recv(subreq, NULL);
     talloc_zfree(subreq);
     if (ret != EOK) {
         tevent_req_error(req, ret);

--- a/src/providers/ldap/sdap_async_initgroups.c
+++ b/src/providers/ldap/sdap_async_initgroups.c
@@ -3441,7 +3441,7 @@ static void sdap_get_initgr_pgid(struct tevent_req *subreq)
             tevent_req_callback_data(subreq, struct tevent_req);
     errno_t ret;
 
-    ret = groups_get_recv(subreq);
+    ret = groups_get_recv(subreq, NULL);
     talloc_zfree(subreq);
     if (ret != EOK) {
         tevent_req_error(req, ret);

--- a/src/providers/ldap/sdap_async_initgroups_ad.c
+++ b/src/providers/ldap/sdap_async_initgroups_ad.c
@@ -361,26 +361,25 @@ static void sdap_ad_resolve_sids_done(struct tevent_req *subreq)
     struct sdap_ad_resolve_sids_state *state = NULL;
     struct tevent_req *req = NULL;
     int dp_error;
-    int sdap_error;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_ad_resolve_sids_state);
 
-    ret = groups_get_recv(subreq, &dp_error, &sdap_error);
+    ret = groups_get_recv(subreq, &dp_error);
     talloc_zfree(subreq);
 
-    if (ret == EOK && sdap_error == ENOENT && dp_error == DP_ERR_OK) {
+    if (ret == ENOENT && dp_error == DP_ERR_OK) {
         /* Group was not found, we will ignore the error and continue with
          * next group. This may happen for example if the group is built-in,
          * but a custom search base is provided. */
         DEBUG(SSSDBG_MINOR_FAILURE,
               "Unable to resolve SID %s - will try next sid.\n",
               state->current_sid);
-    } else if (ret != EOK || sdap_error != EOK || dp_error != DP_ERR_OK) {
+    } else if (ret != EOK || dp_error != DP_ERR_OK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to resolve SID %s [dp_error: %d, "
-              "sdap_error: %d, ret: %d]: %s\n", state->current_sid, dp_error,
-              sdap_error, ret, strerror(ret));
+              "ret: %d]: %s\n", state->current_sid, dp_error,
+              ret, strerror(ret));
         goto done;
     }
 

--- a/src/providers/ldap/sdap_async_initgroups_ad.c
+++ b/src/providers/ldap/sdap_async_initgroups_ad.c
@@ -360,26 +360,25 @@ static void sdap_ad_resolve_sids_done(struct tevent_req *subreq)
 {
     struct sdap_ad_resolve_sids_state *state = NULL;
     struct tevent_req *req = NULL;
-    int dp_error;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_ad_resolve_sids_state);
 
-    ret = groups_get_recv(subreq, &dp_error);
+    ret = groups_get_recv(subreq);
     talloc_zfree(subreq);
 
-    if (ret == ENOENT && dp_error == DP_ERR_OK) {
+    if (ret == ENOENT) {
         /* Group was not found, we will ignore the error and continue with
          * next group. This may happen for example if the group is built-in,
          * but a custom search base is provided. */
         DEBUG(SSSDBG_MINOR_FAILURE,
               "Unable to resolve SID %s - will try next sid.\n",
               state->current_sid);
-    } else if (ret != EOK || dp_error != DP_ERR_OK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to resolve SID %s [dp_error: %d, "
-              "ret: %d]: %s\n", state->current_sid, dp_error,
-              ret, strerror(ret));
+    } else if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to resolve SID %s, "
+              "ret: %d]: %s\n", state->current_sid, ret,
+              strerror(ret));
         goto done;
     }
 
@@ -523,14 +522,13 @@ sdap_ad_tokengroups_initgr_mapping_connect_done(struct tevent_req *subreq)
     struct sdap_ad_tokengroups_initgr_mapping_state *state = NULL;
     struct tevent_req *req = NULL;
     int ret;
-    int dp_error = DP_ERR_FATAL;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req,
                             struct sdap_ad_tokengroups_initgr_mapping_state);
 
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
@@ -870,14 +868,13 @@ sdap_ad_tokengroups_initgr_posix_sids_connect_done(struct tevent_req *subreq)
     struct sdap_ad_tokengroups_initgr_posix_state *state = NULL;
     struct tevent_req *req = NULL;
     int ret;
-    int dp_error = DP_ERR_FATAL;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req,
                             struct sdap_ad_tokengroups_initgr_posix_state);
 
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
@@ -1160,7 +1157,6 @@ struct sdap_ad_get_domain_local_groups_state {
     struct sdap_id_op *op;
     struct sysdb_ctx *sysdb;
     struct sss_domain_info *dom;
-    int dp_error;
 
     struct sdap_search_base **search_bases;
     struct sysdb_attrs **groups;
@@ -1243,14 +1239,12 @@ sdap_ad_get_domain_local_groups_connect_done(struct tevent_req *subreq)
                                                       struct tevent_req);
     struct sdap_ad_get_domain_local_groups_state *state = tevent_req_data(req,
                                   struct sdap_ad_get_domain_local_groups_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -1262,7 +1256,6 @@ sdap_ad_get_domain_local_groups_connect_done(struct tevent_req *subreq)
                                            state->group_hash, 0);
     if (subreq == NULL) {
         DEBUG(SSSDBG_OP_FAILURE, "rfc2307bis_nested_groups_send failed.\n");
-        state->dp_error = DP_ERR_FATAL;
         tevent_req_error(req, ENOMEM);
         return;
     }

--- a/src/providers/ldap/sdap_async_initgroups_ad.c
+++ b/src/providers/ldap/sdap_async_initgroups_ad.c
@@ -360,22 +360,23 @@ static void sdap_ad_resolve_sids_done(struct tevent_req *subreq)
 {
     struct sdap_ad_resolve_sids_state *state = NULL;
     struct tevent_req *req = NULL;
+    int sdap_error;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_ad_resolve_sids_state);
 
-    ret = groups_get_recv(subreq);
+    ret = groups_get_recv(subreq, &sdap_error);
     talloc_zfree(subreq);
 
-    if (ret == ENOENT) {
+    if (ret == EOK && sdap_error == ENOENT) {
         /* Group was not found, we will ignore the error and continue with
          * next group. This may happen for example if the group is built-in,
          * but a custom search base is provided. */
         DEBUG(SSSDBG_MINOR_FAILURE,
               "Unable to resolve SID %s - will try next sid.\n",
               state->current_sid);
-    } else if (ret != EOK) {
+    } else if (ret != EOK || sdap_error != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to resolve SID %s, "
               "ret: %d]: %s\n", state->current_sid, ret,
               strerror(ret));

--- a/src/providers/ldap/sdap_async_resolver_enum.c
+++ b/src/providers/ldap/sdap_async_resolver_enum.c
@@ -121,15 +121,14 @@ sdap_dom_resolver_enum_retry(struct tevent_req *req,
 static bool sdap_dom_resolver_enum_connected(struct tevent_req *subreq)
 {
     errno_t ret;
-    int dp_error;
     struct tevent_req *req = tevent_req_callback_data(subreq,
                                                       struct tevent_req);
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
-        if (dp_error == DP_ERR_OFFLINE) {
+        if (ret == ERR_OFFLINE) {
             DEBUG(SSSDBG_TRACE_FUNC,
                   "Backend is marked offline, retry later!\n");
             tevent_req_done(req);
@@ -175,15 +174,14 @@ static void sdap_dom_resolver_enum_iphost_done(struct tevent_req *subreq)
                                                       struct tevent_req);
     struct sdap_dom_resolver_enum_state *state;
     errno_t ret;
-    int dp_error;
 
     state = tevent_req_data(req, struct sdap_dom_resolver_enum_state);
 
     ret = enum_iphosts_recv(subreq);
     talloc_zfree(subreq);
 
-    ret = sdap_id_op_done(state->iphost_op, ret, &dp_error);
-    if (dp_error == DP_ERR_OK && ret != EOK) {
+    ret = sdap_id_op_done(state->iphost_op, ret);
+    if (ret == EAGAIN) {
         /* retry */
         ret = sdap_dom_resolver_enum_retry(req, state->iphost_op,
                                            sdap_dom_resolver_enum_get_iphost);
@@ -192,7 +190,7 @@ static void sdap_dom_resolver_enum_iphost_done(struct tevent_req *subreq)
             return;
         }
         return;
-    } else if (dp_error == DP_ERR_OFFLINE) {
+    } else if (ret == ERR_OFFLINE) {
         DEBUG(SSSDBG_TRACE_FUNC, "Backend is offline, retrying later\n");
         tevent_req_done(req);
         return;
@@ -252,15 +250,14 @@ static void sdap_dom_resolver_enum_ipnetwork_done(struct tevent_req *subreq)
                                                       struct tevent_req);
     struct sdap_dom_resolver_enum_state *state;
     errno_t ret;
-    int dp_error;
 
     state = tevent_req_data(req, struct sdap_dom_resolver_enum_state);
 
     ret = enum_ipnetworks_recv(subreq);
     talloc_zfree(subreq);
 
-    ret = sdap_id_op_done(state->ipnetwork_op, ret, &dp_error);
-    if (dp_error == DP_ERR_OK && ret != EOK) {
+    ret = sdap_id_op_done(state->ipnetwork_op, ret);
+    if (ret == EAGAIN) {
         /* retry */
         ret = sdap_dom_resolver_enum_retry(req, state->ipnetwork_op,
                                         sdap_dom_resolver_enum_get_ipnetwork);
@@ -269,7 +266,7 @@ static void sdap_dom_resolver_enum_ipnetwork_done(struct tevent_req *subreq)
             return;
         }
         return;
-    } else if (dp_error == DP_ERR_OFFLINE) {
+    } else if (ret == ERR_OFFLINE) {
         DEBUG(SSSDBG_TRACE_FUNC, "Backend is offline, retrying later\n");
         tevent_req_done(req);
         return;

--- a/src/providers/ldap/sdap_async_sudo.c
+++ b/src/providers/ldap/sdap_async_sudo.c
@@ -289,7 +289,6 @@ struct sdap_sudo_refresh_state {
     const char *delete_filter;
     bool update_usn;
 
-    int dp_error;
     size_t num_rules;
 };
 
@@ -326,7 +325,6 @@ struct tevent_req *sdap_sudo_refresh_send(TALLOC_CTX *mem_ctx,
     state->opts = id_ctx->opts;
     state->domain = id_ctx->be->domain;
     state->sysdb = id_ctx->be->domain->sysdb;
-    state->dp_error = DP_ERR_FATAL;
     state->update_usn = update_usn;
 
     state->sdap_op = sdap_id_op_create(state, id_ctx->conn->conn_cache);
@@ -389,19 +387,17 @@ static void sdap_sudo_refresh_connect_done(struct tevent_req *subreq)
 {
     struct tevent_req *req;
     struct sdap_sudo_refresh_state *state;
-    int dp_error;
     int ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_sudo_refresh_state);
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "SUDO LDAP connection failed "
                                    "[%d]: %s\n", ret, strerror(ret));
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -413,7 +409,6 @@ static void sdap_sudo_refresh_connect_done(struct tevent_req *subreq)
         subreq = sdap_sudo_get_hostinfo_send(state, state->opts,
                                              state->sudo_ctx->id_ctx->be);
         if (subreq == NULL) {
-            state->dp_error = DP_ERR_FATAL;
             tevent_req_error(req, ENOMEM);
             return;
         }
@@ -425,7 +420,6 @@ static void sdap_sudo_refresh_connect_done(struct tevent_req *subreq)
 
     ret = sdap_sudo_refresh_sudoers(req);
     if (ret != EAGAIN) {
-        state->dp_error = DP_ERR_FATAL;
         tevent_req_error(req, ret);
     }
 }
@@ -456,7 +450,6 @@ static void sdap_sudo_refresh_hostinfo_done(struct tevent_req *subreq)
 
     ret = sdap_sudo_refresh_sudoers(req);
     if (ret != EAGAIN) {
-        state->dp_error = DP_ERR_FATAL;
         tevent_req_error(req, ret);
     }
 }
@@ -584,7 +577,6 @@ static void sdap_sudo_refresh_done(struct tevent_req *subreq)
     struct sysdb_attrs **rules = NULL;
     size_t rules_count = 0;
     char *usn = NULL;
-    int dp_error;
     int ret;
     errno_t sret;
     bool in_transaction = false;
@@ -595,8 +587,8 @@ static void sdap_sudo_refresh_done(struct tevent_req *subreq)
     ret = sdap_sudo_load_sudoers_recv(subreq, state, &rules_count, &rules);
     talloc_zfree(subreq);
 
-    ret = sdap_id_op_done(state->sdap_op, ret, &dp_error);
-    if (dp_error == DP_ERR_OK && ret != EOK) {
+    ret = sdap_id_op_done(state->sdap_op, ret);
+    if (ret == EAGAIN) {
         /* retry */
         ret = sdap_sudo_refresh_retry(req);
         if (ret != EOK) {
@@ -669,7 +661,6 @@ done:
         }
     }
 
-    state->dp_error = dp_error;
     if (ret == EOK) {
         tevent_req_done(req);
     } else {
@@ -679,7 +670,6 @@ done:
 
 int sdap_sudo_refresh_recv(TALLOC_CTX *mem_ctx,
                            struct tevent_req *req,
-                           int *dp_error,
                            size_t *num_rules)
 {
     struct sdap_sudo_refresh_state *state;
@@ -687,8 +677,6 @@ int sdap_sudo_refresh_recv(TALLOC_CTX *mem_ctx,
     state = tevent_req_data(req, struct sdap_sudo_refresh_state);
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
-
-    *dp_error = state->dp_error;
 
     if (num_rules != NULL) {
         *num_rules = state->num_rules;

--- a/src/providers/ldap/sdap_autofs.c
+++ b/src/providers/ldap/sdap_autofs.c
@@ -60,8 +60,6 @@ struct sdap_autofs_enumerate_state {
     struct sdap_id_ctx *ctx;
     struct sdap_id_op *op;
     const char *map_name;
-
-    int dp_error;
 };
 
 static errno_t
@@ -86,7 +84,6 @@ sdap_autofs_enumerate_send(TALLOC_CTX *mem_ctx,
 
     state->ev = ev;
     state->ctx = ctx;
-    state->dp_error = DP_ERR_FATAL;
     state->map_name = map_name;
 
     state->op = sdap_id_op_create(state, state->ctx->conn->conn_cache);
@@ -133,14 +130,12 @@ sdap_autofs_enumerate_connect_done(struct tevent_req *subreq)
                                                       struct tevent_req);
     struct sdap_autofs_enumerate_state *state =
                 tevent_req_data(req, struct sdap_autofs_enumerate_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -169,14 +164,13 @@ sdap_autofs_enumerate_done(struct tevent_req *subreq)
                                                       struct tevent_req);
     struct sdap_autofs_enumerate_state *state =
         tevent_req_data(req, struct sdap_autofs_enumerate_state);
-    int dp_error = DP_ERR_FATAL;
     int ret;
 
     ret = sdap_autofs_setautomntent_recv(subreq);
     talloc_zfree(subreq);
 
-    ret = sdap_id_op_done(state->op, ret, &dp_error);
-    if (dp_error == DP_ERR_OK && ret != EOK) {
+    ret = sdap_id_op_done(state->op, ret);
+    if (ret == EAGAIN) {
         /* retry */
         ret = sdap_autofs_enumerate_retry(req);
         if (ret != EOK) {
@@ -187,7 +181,6 @@ sdap_autofs_enumerate_done(struct tevent_req *subreq)
     }
 
     if (ret && ret != ENOENT) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -203,20 +196,12 @@ sdap_autofs_enumerate_done(struct tevent_req *subreq)
         }
     }
 
-    state->dp_error = DP_ERR_OK;
     tevent_req_done(req);
 }
 
 static errno_t
-sdap_autofs_enumerate_recv(struct tevent_req *req, int *dp_error_out)
+sdap_autofs_enumerate_recv(struct tevent_req *req)
 {
-    struct sdap_autofs_enumerate_state *state =
-        tevent_req_data(req, struct sdap_autofs_enumerate_state);
-
-    if (dp_error_out) {
-        *dp_error_out = state->dp_error;
-    }
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     return EOK;
@@ -275,14 +260,12 @@ immediately:
 static void sdap_autofs_enumerate_handler_done(struct tevent_req *subreq)
 {
     struct tevent_req *req;
-    int dp_error;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
 
-    ret = sdap_autofs_enumerate_recv(subreq, &dp_error);
+    ret = sdap_autofs_enumerate_recv(subreq);
     talloc_zfree(subreq);
-    ret = dp_error_to_ret(ret, dp_error);
 
     if (ret != EOK) {
         tevent_req_error(req, ret);
@@ -354,14 +337,12 @@ immediately:
 static void sdap_autofs_get_map_handler_done(struct tevent_req *subreq)
 {
     struct tevent_req *req;
-    int dp_error;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
 
-    ret = sdap_autofs_get_map_recv(subreq, &dp_error);
+    ret = sdap_autofs_get_map_recv(subreq);
     talloc_zfree(subreq);
-    ret = dp_error_to_ret(ret, dp_error);
 
     if (ret != EOK) {
         tevent_req_error(req, ret);
@@ -433,14 +414,12 @@ immediately:
 static void sdap_autofs_get_entry_handler_done(struct tevent_req *subreq)
 {
     struct tevent_req *req;
-    int dp_error;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
 
-    ret = sdap_autofs_get_entry_recv(subreq, &dp_error);
+    ret = sdap_autofs_get_entry_recv(subreq);
     talloc_zfree(subreq);
-    ret = dp_error_to_ret(ret, dp_error);
 
     if (ret != EOK) {
         tevent_req_error(req, ret);

--- a/src/providers/ldap/sdap_autofs.h
+++ b/src/providers/ldap/sdap_autofs.h
@@ -47,15 +47,13 @@ struct tevent_req *sdap_autofs_get_map_send(TALLOC_CTX *mem_ctx,
                                             struct sdap_id_ctx *id_ctx,
                                             const char *mapname);
 
-errno_t sdap_autofs_get_map_recv(struct tevent_req *req,
-                                 int *dp_error);
+errno_t sdap_autofs_get_map_recv(struct tevent_req *req);
 
 struct tevent_req *sdap_autofs_get_entry_send(TALLOC_CTX *mem_ctx,
                                               struct sdap_id_ctx *id_ctx,
                                               const char *mapname,
                                               const char *entryname);
 
-errno_t sdap_autofs_get_entry_recv(struct tevent_req *req,
-                                   int *dp_error);
+errno_t sdap_autofs_get_entry_recv(struct tevent_req *req);
 
 #endif /* _SDAP_AUTOFS_H_ */

--- a/src/providers/ldap/sdap_dyndns.c
+++ b/src/providers/ldap/sdap_dyndns.c
@@ -635,17 +635,16 @@ static void
 sdap_dyndns_get_addrs_done(struct tevent_req *subreq)
 {
     errno_t ret;
-    int dp_error;
     struct tevent_req *req;
     struct sdap_dyndns_get_addrs_state *state;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_dyndns_get_addrs_state);
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        if (dp_error == DP_ERR_OFFLINE) {
+        if (ret == ERR_OFFLINE) {
             DEBUG(SSSDBG_MINOR_FAILURE, "No LDAP server is available, "
                   "dynamic DNS update is skipped in offline mode.\n");
             ret = ERR_DYNDNS_OFFLINE;

--- a/src/providers/ldap/sdap_hostid.c
+++ b/src/providers/ldap/sdap_hostid.c
@@ -35,7 +35,6 @@ struct hosts_get_state {
 
     size_t count;
     struct sysdb_attrs **hosts;
-    int dp_error;
 };
 
 static errno_t
@@ -61,7 +60,6 @@ hosts_get_send(TALLOC_CTX *memctx,
 
     state->ev = ev;
     state->id_ctx = id_ctx;
-    state->dp_error = DP_ERR_FATAL;
 
     state->op = sdap_id_op_create(state, id_ctx->conn->conn_cache);
     if (!state->op) {
@@ -111,14 +109,12 @@ hosts_get_connect_done(struct tevent_req *subreq)
                                                       struct tevent_req);
     struct hosts_get_state *state = tevent_req_data(req,
                                                     struct hosts_get_state);
-    int dp_error = DP_ERR_FATAL;
     errno_t ret;
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -142,7 +138,6 @@ hosts_get_done(struct tevent_req *subreq)
                                                       struct tevent_req);
     struct hosts_get_state *state = tevent_req_data(req,
                                                     struct hosts_get_state);
-    int dp_error = DP_ERR_FATAL;
     errno_t ret;
     struct sysdb_attrs *attrs;
     time_t now = time(NULL);
@@ -151,8 +146,8 @@ hosts_get_done(struct tevent_req *subreq)
                               &state->count, &state->hosts);
     talloc_zfree(subreq);
 
-    ret = sdap_id_op_done(state->op, ret, &dp_error);
-    if (dp_error == DP_ERR_OK && ret != EOK) {
+    ret = sdap_id_op_done(state->op, ret);
+    if (ret == EAGAIN) {
         /* retry */
         ret = hosts_get_retry(req);
         if (ret != EOK) {
@@ -203,10 +198,7 @@ hosts_get_done(struct tevent_req *subreq)
         goto done;
     }
 
-    dp_error = DP_ERR_OK;
-
 done:
-    state->dp_error = dp_error;
     if (ret == EOK) {
         tevent_req_done(req);
     } else {
@@ -215,16 +207,8 @@ done:
 }
 
 static errno_t
-hosts_get_recv(struct tevent_req *req,
-               int *dp_error_out)
+hosts_get_recv(struct tevent_req *req)
 {
-    struct hosts_get_state *state = tevent_req_data(req,
-                                                    struct hosts_get_state);
-
-    if (dp_error_out) {
-        *dp_error_out = state->dp_error;
-    }
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     return EOK;
@@ -266,7 +250,7 @@ sdap_hostid_handler_send(TALLOC_CTX *mem_ctx,
     return req;
 
 immediately:
-    dp_reply_std_set(&state->reply, DP_ERR_DECIDE, ret, NULL);
+    dp_reply_std_set(&state->reply, ret, NULL);
 
     /* TODO For backward compatibility we always return EOK to DP now. */
     tevent_req_done(req);
@@ -279,17 +263,16 @@ static void sdap_hostid_handler_done(struct tevent_req *subreq)
 {
     struct sdap_hostid_handler_state *state;
     struct tevent_req *req;
-    int dp_error;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_hostid_handler_state);
 
-    ret = hosts_get_recv(subreq, &dp_error);
+    ret = hosts_get_recv(subreq);
     talloc_zfree(subreq);
 
     /* TODO For backward compatibility we always return EOK to DP now. */
-    dp_reply_std_set(&state->reply, dp_error, ret, NULL);
+    dp_reply_std_set(&state->reply, ret, NULL);
     tevent_req_done(req);
 }
 

--- a/src/providers/ldap/sdap_id_op.c
+++ b/src/providers/ldap/sdap_id_op.c
@@ -860,7 +860,7 @@ static void sdap_id_op_connect_done(struct tevent_req *subreq)
             sdap_id_op_connect_req_complete(op, ret);
         } else if (is_offline) {
             DEBUG(SSSDBG_TRACE_ALL, "notify offline to op #%d\n", notify_count);
-            sdap_id_op_connect_req_complete(op, EAGAIN);
+            sdap_id_op_connect_req_complete(op, ERR_OFFLINE);
         } else {
             DEBUG(SSSDBG_TRACE_ALL,
                   "notify error to op #%d: %d [%s]\n", notify_count, ret, strerror(ret));
@@ -1006,7 +1006,7 @@ int sdap_id_op_done(struct sdap_id_op *op, int retval)
         op->reconnect_retry_count = 0;
     } else if (be_is_offline(op->conn_cache->id_conn->id_ctx->be)) {
         /* if backend is already offline, just report offline, do not duplicate errors */
-        retval = EAGAIN;
+        retval = ERR_OFFLINE;
         op->reconnect_retry_count = 0;
         DEBUG(SSSDBG_TRACE_ALL, "falling back to offline data...\n");
     } else if (communication_error) {

--- a/src/providers/ldap/sdap_id_op.c
+++ b/src/providers/ldap/sdap_id_op.c
@@ -108,7 +108,7 @@ static void sdap_id_op_hook_conn_data(struct sdap_id_op *op, struct sdap_id_conn
 static int sdap_id_op_destroy(void *pvt);
 static bool sdap_id_op_can_reconnect(struct sdap_id_op *op);
 
-static void sdap_id_op_connect_req_complete(struct sdap_id_op *op, int dp_error, int ret);
+static void sdap_id_op_connect_req_complete(struct sdap_id_op *op, int ret);
 static int sdap_id_op_connect_state_destroy(void *pvt);
 static int sdap_id_op_connect_step(struct tevent_req *req);
 static void sdap_id_op_connect_done(struct tevent_req *subreq);
@@ -518,7 +518,6 @@ struct sdap_id_op_connect_state {
     struct sdap_id_conn_ctx *id_conn;
     struct tevent_context *ev;
     struct sdap_id_op *op;
-    int dp_error;
     int result;
 };
 
@@ -848,7 +847,7 @@ static void sdap_id_op_connect_done(struct tevent_req *subreq)
                 int retry_ret = sdap_id_op_connect_step(op->connect_req);
                 if (retry_ret != EOK) {
                     can_retry = false;
-                    sdap_id_op_connect_req_complete(op, DP_ERR_FATAL, retry_ret);
+                    sdap_id_op_connect_req_complete(op, retry_ret);
                 }
 
                 continue;
@@ -858,14 +857,14 @@ static void sdap_id_op_connect_done(struct tevent_req *subreq)
         if (ret == EOK) {
             DEBUG(SSSDBG_TRACE_ALL,
                   "notify connected to op #%d\n", notify_count);
-            sdap_id_op_connect_req_complete(op, DP_ERR_OK, ret);
+            sdap_id_op_connect_req_complete(op, ret);
         } else if (is_offline) {
             DEBUG(SSSDBG_TRACE_ALL, "notify offline to op #%d\n", notify_count);
-            sdap_id_op_connect_req_complete(op, DP_ERR_OFFLINE, EAGAIN);
+            sdap_id_op_connect_req_complete(op, EAGAIN);
         } else {
             DEBUG(SSSDBG_TRACE_ALL,
                   "notify error to op #%d: %d [%s]\n", notify_count, ret, strerror(ret));
-            sdap_id_op_connect_req_complete(op, DP_ERR_FATAL, ret);
+            sdap_id_op_connect_req_complete(op, ret);
         }
     }
 
@@ -927,7 +926,7 @@ static void sdap_id_op_connect_reinit_done(struct tevent_req *req)
 }
 
 /* Mark operation connection request as complete */
-static void sdap_id_op_connect_req_complete(struct sdap_id_op *op, int dp_error, int ret)
+static void sdap_id_op_connect_req_complete(struct sdap_id_op *op, int ret)
 {
     struct tevent_req *req = op->connect_req;
     struct sdap_id_op_connect_state *state;
@@ -940,7 +939,6 @@ static void sdap_id_op_connect_req_complete(struct sdap_id_op *op, int dp_error,
     op->connect_req = NULL;
 
     state = tevent_req_data(req, struct sdap_id_op_connect_state);
-    state->dp_error = dp_error;
     state->result = ret;
 
     /* Set the chain id to the one associated with this request. */
@@ -956,29 +954,27 @@ static void sdap_id_op_connect_req_complete(struct sdap_id_op *op, int dp_error,
 
 /* Get the result of an asynchronous connect operation on sdap_id_op
  *
- * In dp_error data provider error code is returned:
- *   DP_ERR_OK - connection established
- *   DP_ERR_OFFLINE - backend is offline, operation result is set EAGAIN
- *   DP_ERR_FATAL - operation failed
+ * In data provider error code is returned:
+ *   ERR_OK - connection established
+ *   ERR_OFFLINE - backend is offline, operation result is set EAGAIN
+ *   ERR_FATAL - operation failed
  */
-int sdap_id_op_connect_recv(struct tevent_req *req, int *dp_error)
+int sdap_id_op_connect_recv(struct tevent_req *req)
 {
     struct sdap_id_op_connect_state *state = tevent_req_data(req,
                                                              struct sdap_id_op_connect_state);
 
-    *dp_error = state->dp_error;
     return state->result;
 }
 
 /* Report completion of LDAP operation and release associated connection.
  * Returns operation result (possible updated) passed in ret parameter.
  *
- * In dp_error data provider error code is returned:
- *   DP_ERR_OK (operation result = EOK) - operation completed
- *   DP_ERR_OK (operation result != EOK) - operation can be retried
- *   DP_ERR_OFFLINE - backend is offline, operation result is set EAGAIN
- *   DP_ERR_FATAL - operation failed */
-int sdap_id_op_done(struct sdap_id_op *op, int retval, int *dp_err_out)
+ *   ERR_OK - operation completed
+ *   EAGAIN- operation can be retried
+ *   ERR_OFFLINE - backend is offline
+ *   ERR_SERVER_FAILURE - operation failed */
+int sdap_id_op_done(struct sdap_id_op *op, int retval)
 {
     bool communication_error;
     struct sdap_id_conn_data *current_conn = op->conn_data;
@@ -1005,36 +1001,30 @@ int sdap_id_op_done(struct sdap_id_op *op, int retval, int *dp_err_out)
                               op->conn_cache->id_conn->service->name);
     }
 
-    int dp_err;
     if (retval == EOK) {
-        dp_err = DP_ERR_OK;
+        /* operation completed successfully */
+        op->reconnect_retry_count = 0;
     } else if (be_is_offline(op->conn_cache->id_conn->id_ctx->be)) {
         /* if backend is already offline, just report offline, do not duplicate errors */
-        dp_err = DP_ERR_OFFLINE;
         retval = EAGAIN;
+        op->reconnect_retry_count = 0;
         DEBUG(SSSDBG_TRACE_ALL, "falling back to offline data...\n");
     } else if (communication_error) {
         /* communication error, can try to reconnect */
 
         if (!sdap_id_op_can_reconnect(op)) {
-            dp_err = DP_ERR_FATAL;
             DEBUG(SSSDBG_TRACE_ALL,
                   "too many communication failures, giving up...\n");
+            op->reconnect_retry_count = 0;
+            retval = ERR_SERVER_FAILURE;
         } else {
-            dp_err = DP_ERR_OK;
             retval = EAGAIN;
+            op->reconnect_retry_count++;
+            DEBUG(SSSDBG_TRACE_ALL,
+                  "advising for connection retry #%i\n", op->reconnect_retry_count);
         }
     } else {
-        dp_err = DP_ERR_FATAL;
-    }
-
-    if (dp_err == DP_ERR_OK && retval != EOK) {
-        /* reconnect retry */
-        op->reconnect_retry_count++;
-        DEBUG(SSSDBG_TRACE_ALL,
-              "advising for connection retry #%i\n", op->reconnect_retry_count);
-    } else {
-        /* end of request */
+        /* fatal error, cannot retry */
         op->reconnect_retry_count = 0;
     }
 
@@ -1043,7 +1033,6 @@ int sdap_id_op_done(struct sdap_id_op *op, int retval, int *dp_err_out)
         sdap_id_op_hook_conn_data(op, NULL);
     }
 
-    *dp_err_out = dp_err;
     return retval;
 }
 

--- a/src/providers/ldap/sdap_id_op.h
+++ b/src/providers/ldap/sdap_id_op.h
@@ -51,22 +51,21 @@ struct tevent_req *sdap_id_op_connect_send(struct sdap_id_op *op,
 
 /* Get the result of an asynchronous connect operation on sdap_id_op
  *
- * In dp_error data provider error code is returned:
- *   DP_ERR_OK - connection established
- *   DP_ERR_OFFLINE - backend is offline, operation result is set EAGAIN
- *   DP_ERR_FATAL - operation failed
+ * Data provider error code is returned:
+ *   ERR_OK - connection established
+ *   ERR_OFFLINE - backend is offline, operation result is set EAGAIN
+ *   ERR_FATAL - operation failed
  */
-int sdap_id_op_connect_recv(struct tevent_req *req, int *dp_error);
+int sdap_id_op_connect_recv(struct tevent_req *req);
 
 /* Report completion of LDAP operation and release associated connection.
  * Returns operation result (possible updated) passed in ret parameter.
  *
- * In dp_error data provider error code is returned:
- *   DP_ERR_OK (operation result = EOK) - operation completed
- *   DP_ERR_OK (operation result != EOK) - operation can be retried
- *   DP_ERR_OFFLINE - backend is offline, operation result is set EAGAIN
- *   DP_ERR_FATAL - operation failed */
-int sdap_id_op_done(struct sdap_id_op*, int ret, int *dp_error);
+ *   ERR_OK - operation completed
+ *   EAGAIN - operation can be retried
+ *   ERR_OFFLINE - backend is offline
+ *   ERR_SERVER_FAILURE - operation failed */
+int sdap_id_op_done(struct sdap_id_op*, int ret);
 
 /* Get SDAP handle associated with operation by sdap_id_op_connect */
 struct sdap_handle *sdap_id_op_handle(struct sdap_id_op *op);

--- a/src/providers/ldap/sdap_iphost.c
+++ b/src/providers/ldap/sdap_iphost.c
@@ -40,7 +40,6 @@ struct sdap_ip_host_get_state {
     const char **attrs;
 
     int dp_error;
-    int sdap_ret;
     bool noexist_delete;
 };
 
@@ -222,7 +221,6 @@ sdap_ip_host_get_done(struct tevent_req *subreq)
         /* Return to the mainloop to retry */
         return;
     }
-    state->sdap_ret = ret;
 
     /* An error occurred. */
     if (ret && ret != ENOENT) {
@@ -264,8 +262,7 @@ sdap_ip_host_get_done(struct tevent_req *subreq)
 
 static errno_t
 sdap_ip_host_get_recv(struct tevent_req *req,
-                      int *dp_error_out,
-                      int *sdap_ret)
+                      int *dp_error_out)
 {
     struct sdap_ip_host_get_state *state;
 
@@ -273,10 +270,6 @@ sdap_ip_host_get_recv(struct tevent_req *req,
 
     if (dp_error_out != NULL) {
         *dp_error_out = state->dp_error;
-    }
-
-    if (sdap_ret != NULL) {
-        *sdap_ret = state->sdap_ret;
     }
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
@@ -350,7 +343,7 @@ static void sdap_ip_host_handler_done(struct tevent_req *subreq)
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_ip_host_handler_state);
 
-    ret = sdap_ip_host_get_recv(subreq, &dp_error, NULL);
+    ret = sdap_ip_host_get_recv(subreq, &dp_error);
     talloc_zfree(subreq);
 
     /* TODO For backward compatibility we always return EOK to DP now. */

--- a/src/providers/ldap/sdap_iphost.c
+++ b/src/providers/ldap/sdap_iphost.c
@@ -39,7 +39,6 @@ struct sdap_ip_host_get_state {
     char *filter;
     const char **attrs;
 
-    int dp_error;
     bool noexist_delete;
 };
 
@@ -71,7 +70,6 @@ sdap_iphost_get_send(TALLOC_CTX *mem_ctx,
     state->id_ctx = id_ctx;
     state->sdom = sdom;
     state->conn = conn;
-    state->dp_error = DP_ERR_FATAL;
     state->domain = sdom->dom;
     state->sysdb = sdom->dom->sysdb;
     state->filter_value = filter_value;
@@ -161,17 +159,15 @@ sdap_ip_host_get_connect_done(struct tevent_req *subreq)
 {
     struct tevent_req *req;
     struct sdap_ip_host_get_state *state;
-    int dp_error = DP_ERR_FATAL;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_ip_host_get_state);
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -199,7 +195,6 @@ sdap_ip_host_get_done(struct tevent_req *subreq)
     errno_t ret;
     struct tevent_req *req;
     struct sdap_ip_host_get_state *state;
-    int dp_error = DP_ERR_FATAL;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_ip_host_get_state);
@@ -209,8 +204,8 @@ sdap_ip_host_get_done(struct tevent_req *subreq)
 
     /* Check whether we need to try again with another
      * failover server. */
-    ret = sdap_id_op_done(state->op, ret, &dp_error);
-    if (dp_error == DP_ERR_OK && ret != EOK) {
+    ret = sdap_id_op_done(state->op, ret);
+    if (ret == EAGAIN) {
         /* retry */
         ret = sdap_ip_host_get_retry(req);
         if (ret != EOK) {
@@ -224,7 +219,6 @@ sdap_ip_host_get_done(struct tevent_req *subreq)
 
     /* An error occurred. */
     if (ret && ret != ENOENT) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -256,22 +250,12 @@ sdap_ip_host_get_done(struct tevent_req *subreq)
         }
     }
 
-    state->dp_error = DP_ERR_OK;
     tevent_req_done(req);
 }
 
 static errno_t
-sdap_ip_host_get_recv(struct tevent_req *req,
-                      int *dp_error_out)
+sdap_ip_host_get_recv(struct tevent_req *req)
 {
-    struct sdap_ip_host_get_state *state;
-
-    state = tevent_req_data(req, struct sdap_ip_host_get_state);
-
-    if (dp_error_out != NULL) {
-        *dp_error_out = state->dp_error;
-    }
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     return EOK;
@@ -324,7 +308,7 @@ sdap_iphost_handler_send(TALLOC_CTX *mem_ctx,
     return req;
 
 immediately:
-    dp_reply_std_set(&state->reply, DP_ERR_DECIDE, ret, NULL);
+    dp_reply_std_set(&state->reply, ret, NULL);
 
     /* TODO For backward compatibility we always return EOK to DP now. */
     tevent_req_done(req);
@@ -337,17 +321,16 @@ static void sdap_ip_host_handler_done(struct tevent_req *subreq)
 {
     struct sdap_ip_host_handler_state *state;
     struct tevent_req *req;
-    int dp_error;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_ip_host_handler_state);
 
-    ret = sdap_ip_host_get_recv(subreq, &dp_error);
+    ret = sdap_ip_host_get_recv(subreq);
     talloc_zfree(subreq);
 
     /* TODO For backward compatibility we always return EOK to DP now. */
-    dp_reply_std_set(&state->reply, dp_error, ret, NULL);
+    dp_reply_std_set(&state->reply, ret, NULL);
     tevent_req_done(req);
 }
 

--- a/src/providers/ldap/sdap_ipnetwork.c
+++ b/src/providers/ldap/sdap_ipnetwork.c
@@ -40,7 +40,6 @@ struct sdap_ipnetwork_get_state {
     const char **attrs;
 
     int dp_error;
-    int sdap_ret;
     bool noexist_delete;
 };
 
@@ -222,7 +221,6 @@ sdap_ipnetwork_get_done(struct tevent_req *subreq)
         /* Return to the mainloop to retry */
         return;
     }
-    state->sdap_ret = ret;
 
     /* An error occurred. */
     if (ret && ret != ENOENT) {
@@ -265,8 +263,7 @@ sdap_ipnetwork_get_done(struct tevent_req *subreq)
 
 static errno_t
 sdap_ipnetwork_get_recv(struct tevent_req *req,
-                        int *dp_error_out,
-                        int *sdap_ret)
+                        int *dp_error_out)
 {
     struct sdap_ipnetwork_get_state *state;
 
@@ -274,10 +271,6 @@ sdap_ipnetwork_get_recv(struct tevent_req *req,
 
     if (dp_error_out != NULL) {
         *dp_error_out = state->dp_error;
-    }
-
-    if (sdap_ret != NULL) {
-        *sdap_ret = state->sdap_ret;
     }
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
@@ -353,7 +346,7 @@ sdap_ipnetwork_handler_done(struct tevent_req *subreq)
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_ipnetwork_handler_state);
 
-    ret = sdap_ipnetwork_get_recv(subreq, &dp_error, NULL);
+    ret = sdap_ipnetwork_get_recv(subreq, &dp_error);
     talloc_zfree(subreq);
 
     /* TODO For backward compatibility we always return EOK to DP now. */

--- a/src/providers/ldap/sdap_ipnetwork.c
+++ b/src/providers/ldap/sdap_ipnetwork.c
@@ -39,7 +39,6 @@ struct sdap_ipnetwork_get_state {
     char *filter;
     const char **attrs;
 
-    int dp_error;
     bool noexist_delete;
 };
 
@@ -71,7 +70,6 @@ sdap_ipnetwork_get_send(TALLOC_CTX *mem_ctx,
     state->id_ctx = id_ctx;
     state->sdom = sdom;
     state->conn = conn;
-    state->dp_error = DP_ERR_FATAL;
     state->domain = sdom->dom;
     state->sysdb = sdom->dom->sysdb;
     state->filter_value = filter_value;
@@ -161,17 +159,15 @@ sdap_ipnetwork_get_connect_done(struct tevent_req *subreq)
 {
     struct tevent_req *req;
     struct sdap_ipnetwork_get_state *state;
-    int dp_error = DP_ERR_FATAL;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_ipnetwork_get_state);
 
-    ret = sdap_id_op_connect_recv(subreq, &dp_error);
+    ret = sdap_id_op_connect_recv(subreq);
     talloc_zfree(subreq);
 
     if (ret != EOK) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -199,7 +195,6 @@ sdap_ipnetwork_get_done(struct tevent_req *subreq)
     errno_t ret;
     struct tevent_req *req;
     struct sdap_ipnetwork_get_state *state;
-    int dp_error = DP_ERR_FATAL;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_ipnetwork_get_state);
@@ -209,8 +204,8 @@ sdap_ipnetwork_get_done(struct tevent_req *subreq)
 
     /* Check whether we need to try again with another
      * failover server. */
-    ret = sdap_id_op_done(state->op, ret, &dp_error);
-    if (dp_error == DP_ERR_OK && ret != EOK) {
+    ret = sdap_id_op_done(state->op, ret);
+    if (ret == EAGAIN) {
         /* retry */
         ret = sdap_ipnetwork_get_retry(req);
         if (ret != EOK) {
@@ -224,7 +219,6 @@ sdap_ipnetwork_get_done(struct tevent_req *subreq)
 
     /* An error occurred. */
     if (ret && ret != ENOENT) {
-        state->dp_error = dp_error;
         tevent_req_error(req, ret);
         return;
     }
@@ -257,22 +251,12 @@ sdap_ipnetwork_get_done(struct tevent_req *subreq)
         }
     }
 
-    state->dp_error = DP_ERR_OK;
     tevent_req_done(req);
 }
 
 static errno_t
-sdap_ipnetwork_get_recv(struct tevent_req *req,
-                        int *dp_error_out)
+sdap_ipnetwork_get_recv(struct tevent_req *req)
 {
-    struct sdap_ipnetwork_get_state *state;
-
-    state = tevent_req_data(req, struct sdap_ipnetwork_get_state);
-
-    if (dp_error_out != NULL) {
-        *dp_error_out = state->dp_error;
-    }
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     return EOK;
@@ -326,7 +310,7 @@ sdap_ipnetwork_handler_send(TALLOC_CTX *mem_ctx,
     return req;
 
 immediately:
-    dp_reply_std_set(&state->reply, DP_ERR_DECIDE, ret, NULL);
+    dp_reply_std_set(&state->reply, ret, NULL);
 
     /* TODO For backward compatibility we always return EOK to DP now. */
     tevent_req_done(req);
@@ -340,17 +324,16 @@ sdap_ipnetwork_handler_done(struct tevent_req *subreq)
 {
     struct sdap_ipnetwork_handler_state *state;
     struct tevent_req *req;
-    int dp_error;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_ipnetwork_handler_state);
 
-    ret = sdap_ipnetwork_get_recv(subreq, &dp_error);
+    ret = sdap_ipnetwork_get_recv(subreq);
     talloc_zfree(subreq);
 
     /* TODO For backward compatibility we always return EOK to DP now. */
-    dp_reply_std_set(&state->reply, dp_error, ret, NULL);
+    dp_reply_std_set(&state->reply, ret, NULL);
     tevent_req_done(req);
 }
 

--- a/src/providers/ldap/sdap_online_check.c
+++ b/src/providers/ldap/sdap_online_check.c
@@ -207,7 +207,7 @@ sdap_online_check_handler_send(TALLOC_CTX *mem_ctx,
     return req;
 
 immediately:
-    dp_reply_std_set(&state->reply, DP_ERR_DECIDE, ret, NULL);
+    dp_reply_std_set(&state->reply, ret, NULL);
 
     /* TODO For backward compatibility we always return EOK to DP now. */
     tevent_req_done(req);
@@ -242,7 +242,7 @@ static void sdap_online_check_handler_done(struct tevent_req *subreq)
     }
 
     /* TODO For backward compatibility we always return EOK to DP now. */
-    dp_reply_std_set(&state->reply, DP_ERR_DECIDE, ret, NULL);
+    dp_reply_std_set(&state->reply, ret, NULL);
     tevent_req_done(req);
 }
 
@@ -271,7 +271,7 @@ static void sdap_online_check_subdomains_done(struct tevent_req *subreq)
 
     /* We return the EOK of the initial online check here, the result of the
      * subdomains request is not important for the online-check request. */
-    dp_reply_std_set(&state->reply, DP_ERR_DECIDE, EOK, NULL);
+    dp_reply_std_set(&state->reply, EOK, NULL);
     tevent_req_done(req);
 }
 

--- a/src/providers/ldap/sdap_refresh.c
+++ b/src/providers/ldap/sdap_refresh.c
@@ -151,19 +151,18 @@ static void sdap_refresh_done(struct tevent_req *subreq)
     struct tevent_req *req = NULL;
     const char *err_msg = NULL;
     errno_t dp_error;
-    int sdap_ret;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_refresh_state);
 
-    ret = sdap_handle_acct_req_recv(subreq, &dp_error, &err_msg, &sdap_ret);
+    ret = sdap_handle_acct_req_recv(subreq, &dp_error, &err_msg);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to refresh %s [dp_error: %d, "
-              "sdap_ret: %d, errno: %d]: %s\n",
+              "errno: %d]: %s\n",
                be_req2str(state->account_req->entry_type),
-              dp_error, sdap_ret, ret, err_msg);
+              dp_error, ret, err_msg);
         goto done;
     }
 

--- a/src/providers/ldap/sdap_refresh.c
+++ b/src/providers/ldap/sdap_refresh.c
@@ -150,19 +150,17 @@ static void sdap_refresh_done(struct tevent_req *subreq)
     struct sdap_refresh_state *state = NULL;
     struct tevent_req *req = NULL;
     const char *err_msg = NULL;
-    errno_t dp_error;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_refresh_state);
 
-    ret = sdap_handle_acct_req_recv(subreq, &dp_error, &err_msg);
+    ret = sdap_handle_acct_req_recv(subreq, &err_msg);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to refresh %s [dp_error: %d, "
-              "errno: %d]: %s\n",
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to refresh %s [errno: %d]: %s\n",
                be_req2str(state->account_req->entry_type),
-              dp_error, ret, err_msg);
+              ret, err_msg);
         goto done;
     }
 

--- a/src/providers/ldap/sdap_sudo.c
+++ b/src/providers/ldap/sdap_sudo.c
@@ -83,7 +83,7 @@ sdap_sudo_handler_send(TALLOC_CTX *mem_ctx,
     return req;
 
 immediately:
-    dp_reply_std_set(&state->reply, DP_ERR_DECIDE, ret, NULL);
+    dp_reply_std_set(&state->reply, ret, NULL);
 
     /* TODO For backward compatibility we always return EOK to DP now. */
     tevent_req_done(req);
@@ -96,7 +96,6 @@ static void sdap_sudo_handler_done(struct tevent_req *subreq)
 {
     struct sdap_sudo_handler_state *state;
     struct tevent_req *req;
-    int dp_error;
     bool deleted;
     errno_t ret;
 
@@ -105,17 +104,17 @@ static void sdap_sudo_handler_done(struct tevent_req *subreq)
 
     switch (state->type) {
     case BE_REQ_SUDO_FULL:
-        ret = sdap_sudo_full_refresh_recv(subreq, &dp_error);
+        ret = sdap_sudo_full_refresh_recv(subreq);
         talloc_zfree(subreq);
 
         /* Reschedule the periodic task since the refresh was just finished
          * per user request. */
-        if (ret == EOK && dp_error == DP_ERR_OK) {
+        if (ret == EOK) {
             be_ptask_postpone(state->sudo_ctx->full_refresh);
         }
         break;
     case BE_REQ_SUDO_RULES:
-        ret = sdap_sudo_rules_refresh_recv(subreq, &dp_error, &deleted);
+        ret = sdap_sudo_rules_refresh_recv(subreq, &deleted);
         talloc_zfree(subreq);
         if (ret == EOK && deleted == true) {
             ret = ENOENT;
@@ -123,13 +122,12 @@ static void sdap_sudo_handler_done(struct tevent_req *subreq)
         break;
     default:
         DEBUG(SSSDBG_CRIT_FAILURE, "Invalid request type: %d\n", state->type);
-        dp_error = DP_ERR_FATAL;
         ret = ERR_INTERNAL;
         break;
     }
 
     /* TODO For backward compatibility we always return EOK to DP now. */
-    dp_reply_std_set(&state->reply, dp_error, ret, NULL);
+    dp_reply_std_set(&state->reply, ret, NULL);
     tevent_req_done(req);
 }
 

--- a/src/providers/ldap/sdap_sudo.h
+++ b/src/providers/ldap/sdap_sudo.h
@@ -57,27 +57,23 @@ struct tevent_req *sdap_sudo_refresh_send(TALLOC_CTX *mem_ctx,
 
 int sdap_sudo_refresh_recv(TALLOC_CTX *mem_ctx,
                            struct tevent_req *req,
-                           int *dp_error,
                            size_t *num_rules);
 
 struct tevent_req *sdap_sudo_full_refresh_send(TALLOC_CTX *mem_ctx,
                                                struct sdap_sudo_ctx *sudo_ctx);
 
-int sdap_sudo_full_refresh_recv(struct tevent_req *req,
-                                int *dp_error);
+int sdap_sudo_full_refresh_recv(struct tevent_req *req);
 
 struct tevent_req *sdap_sudo_smart_refresh_send(TALLOC_CTX *mem_ctx,
                                                 struct sdap_sudo_ctx *sudo_ctx);
 
-int sdap_sudo_smart_refresh_recv(struct tevent_req *req,
-                                 int *dp_error);
+int sdap_sudo_smart_refresh_recv(struct tevent_req *req);
 
 struct tevent_req *sdap_sudo_rules_refresh_send(TALLOC_CTX *mem_ctx,
                                                 struct sdap_sudo_ctx *sudo_ctx,
                                                 const char **rules);
 
 int sdap_sudo_rules_refresh_recv(struct tevent_req *req,
-                                 int *dp_error,
                                  bool *deleted);
 
 errno_t

--- a/src/providers/ldap/sdap_sudo_refresh.c
+++ b/src/providers/ldap/sdap_sudo_refresh.c
@@ -33,7 +33,6 @@ struct sdap_sudo_full_refresh_state {
     struct sdap_id_ctx *id_ctx;
     struct sysdb_ctx *sysdb;
     struct sss_domain_info *domain;
-    int dp_error;
 };
 
 static void sdap_sudo_full_refresh_done(struct tevent_req *subreq);
@@ -106,9 +105,9 @@ static void sdap_sudo_full_refresh_done(struct tevent_req *subreq)
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_sudo_full_refresh_state);
 
-    ret = sdap_sudo_refresh_recv(state, subreq, &state->dp_error, NULL);
+    ret = sdap_sudo_refresh_recv(state, subreq, NULL);
     talloc_zfree(subreq);
-    if (ret != EOK || state->dp_error != DP_ERR_OK) {
+    if (ret != EOK) {
         goto done;
     }
 
@@ -136,15 +135,9 @@ done:
     tevent_req_done(req);
 }
 
-int sdap_sudo_full_refresh_recv(struct tevent_req *req,
-                                int *dp_error)
+int sdap_sudo_full_refresh_recv(struct tevent_req *req)
 {
-    struct sdap_sudo_full_refresh_state *state = NULL;
-    state = tevent_req_data(req, struct sdap_sudo_full_refresh_state);
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
-
-    *dp_error = state->dp_error;
 
     return EOK;
 }
@@ -152,7 +145,6 @@ int sdap_sudo_full_refresh_recv(struct tevent_req *req,
 struct sdap_sudo_smart_refresh_state {
     struct sdap_id_ctx *id_ctx;
     struct sysdb_ctx *sysdb;
-    int dp_error;
 };
 
 static void sdap_sudo_smart_refresh_done(struct tevent_req *subreq);
@@ -179,7 +171,6 @@ struct tevent_req *sdap_sudo_smart_refresh_send(TALLOC_CTX *mem_ctx,
     if (be_ptask_running(sudo_ctx->full_refresh)) {
         DEBUG(SSSDBG_TRACE_FUNC, "Skipping smart refresh because "
               "there is ongoing full refresh.\n");
-        state->dp_error = DP_ERR_OK;
         ret = EOK;
         goto immediately;
     }
@@ -245,9 +236,9 @@ static void sdap_sudo_smart_refresh_done(struct tevent_req *subreq)
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_sudo_smart_refresh_state);
 
-    ret = sdap_sudo_refresh_recv(state, subreq, &state->dp_error, NULL);
+    ret = sdap_sudo_refresh_recv(state, subreq, NULL);
     talloc_zfree(subreq);
-    if (ret != EOK || state->dp_error != DP_ERR_OK) {
+    if (ret != EOK) {
         goto done;
     }
 
@@ -262,15 +253,9 @@ done:
     tevent_req_done(req);
 }
 
-int sdap_sudo_smart_refresh_recv(struct tevent_req *req,
-                                 int *dp_error)
+int sdap_sudo_smart_refresh_recv(struct tevent_req *req)
 {
-    struct sdap_sudo_smart_refresh_state *state = NULL;
-    state = tevent_req_data(req, struct sdap_sudo_smart_refresh_state);
-
     TEVENT_REQ_RETURN_ON_ERROR(req);
-
-    *dp_error = state->dp_error;
 
     return EOK;
 }
@@ -278,7 +263,6 @@ int sdap_sudo_smart_refresh_recv(struct tevent_req *req,
 struct sdap_sudo_rules_refresh_state {
     struct sdap_id_ctx *id_ctx;
     size_t num_rules;
-    int dp_error;
     bool deleted;
 };
 
@@ -396,10 +380,9 @@ static void sdap_sudo_rules_refresh_done(struct tevent_req *subreq)
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sdap_sudo_rules_refresh_state);
 
-    ret = sdap_sudo_refresh_recv(state, subreq, &state->dp_error,
-                                 &downloaded_rules_num);
+    ret = sdap_sudo_refresh_recv(state, subreq, &downloaded_rules_num);
     talloc_zfree(subreq);
-    if (ret != EOK || state->dp_error != DP_ERR_OK) {
+    if (ret != EOK) {
         goto done;
     }
 
@@ -415,7 +398,6 @@ done:
 }
 
 int sdap_sudo_rules_refresh_recv(struct tevent_req *req,
-                                 int *dp_error,
                                  bool *deleted)
 {
     struct sdap_sudo_rules_refresh_state *state = NULL;
@@ -423,7 +405,6 @@ int sdap_sudo_rules_refresh_recv(struct tevent_req *req,
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
-    *dp_error = state->dp_error;
     *deleted = state->deleted;
 
     return EOK;
@@ -445,9 +426,7 @@ sdap_sudo_ptask_full_refresh_send(TALLOC_CTX *mem_ctx,
 static errno_t
 sdap_sudo_ptask_full_refresh_recv(struct tevent_req *req)
 {
-    int dp_error;
-
-    return sdap_sudo_full_refresh_recv(req, &dp_error);
+    return sdap_sudo_full_refresh_recv(req);
 }
 
 static struct tevent_req *
@@ -466,9 +445,7 @@ sdap_sudo_ptask_smart_refresh_send(TALLOC_CTX *mem_ctx,
 static errno_t
 sdap_sudo_ptask_smart_refresh_recv(struct tevent_req *req)
 {
-    int dp_error;
-
-    return sdap_sudo_smart_refresh_recv(req, &dp_error);
+    return sdap_sudo_smart_refresh_recv(req);
 }
 
 errno_t

--- a/src/providers/proxy/proxy_hosts.c
+++ b/src/providers/proxy/proxy_hosts.c
@@ -704,7 +704,7 @@ proxy_hosts_info(TALLOC_CTX *mem_ctx,
         break;
 
     default:
-        dp_reply_std_set(&reply, DP_ERR_FATAL, EINVAL,
+        dp_reply_std_set(&reply, EINVAL,
                          "Invalid filter type");
         return reply;
     }
@@ -716,11 +716,11 @@ proxy_hosts_info(TALLOC_CTX *mem_ctx,
             be_mark_offline(be_ctx);
         }
 
-        dp_reply_std_set(&reply, DP_ERR_FATAL, ret, NULL);
+        dp_reply_std_set(&reply, ret, NULL);
         return reply;
     }
 
-    dp_reply_std_set(&reply, DP_ERR_OK, EOK, NULL);
+    dp_reply_std_set(&reply, EOK, NULL);
     return reply;
 }
 

--- a/src/providers/proxy/proxy_id.c
+++ b/src/providers/proxy/proxy_id.c
@@ -1748,7 +1748,7 @@ proxy_account_info(TALLOC_CTX *mem_ctx,
 
     /* Proxy provider does not support security ID lookups. */
     if (data->filter_type == BE_FILTER_SECID) {
-        dp_reply_std_set(&reply, DP_ERR_FATAL, ENOSYS,
+        dp_reply_std_set(&reply, ERR_INVALID_FILTER,
                          "Security lookups are not supported");
         return reply;
     }
@@ -1767,14 +1767,14 @@ proxy_account_info(TALLOC_CTX *mem_ctx,
         case BE_FILTER_IDNUM:
             uid = (uid_t) strtouint32(data->filter_value, &endptr, 10);
             if (errno || *endptr || (data->filter_value == endptr)) {
-                dp_reply_std_set(&reply, DP_ERR_FATAL, EINVAL,
+                dp_reply_std_set(&reply, ERR_INVALID_FILTER,
                                  "Invalid attr type");
                 return reply;
             }
             ret = get_pw_uid(ctx, domain, uid);
             break;
         default:
-            dp_reply_std_set(&reply, DP_ERR_FATAL, EINVAL,
+            dp_reply_std_set(&reply, ERR_INVALID_FILTER,
                              "Invalid filter type");
             return reply;
         }
@@ -1791,14 +1791,14 @@ proxy_account_info(TALLOC_CTX *mem_ctx,
         case BE_FILTER_IDNUM:
             gid = (gid_t) strtouint32(data->filter_value, &endptr, 10);
             if (errno || *endptr || (data->filter_value == endptr)) {
-                dp_reply_std_set(&reply, DP_ERR_FATAL, EINVAL,
+                dp_reply_std_set(&reply, ERR_INVALID_FILTER,
                                  "Invalid attr type");
                 return reply;
             }
             ret = get_gr_gid(mem_ctx, ctx, sysdb, domain, gid, 0);
             break;
         default:
-            dp_reply_std_set(&reply, DP_ERR_FATAL, EINVAL,
+            dp_reply_std_set(&reply, ERR_INVALID_FILTER,
                              "Invalid filter type");
             return reply;
         }
@@ -1806,12 +1806,12 @@ proxy_account_info(TALLOC_CTX *mem_ctx,
 
     case BE_REQ_INITGROUPS: /* init groups for user */
         if (data->filter_type != BE_FILTER_NAME) {
-            dp_reply_std_set(&reply, DP_ERR_FATAL, EINVAL,
+            dp_reply_std_set(&reply, ERR_INVALID_FILTER,
                              "Invalid filter type");
             return reply;
         }
         if (ctx->ops.initgroups_dyn == NULL) {
-            dp_reply_std_set(&reply, DP_ERR_FATAL, ENODEV,
+            dp_reply_std_set(&reply, ERR_INTERNAL,
                              "Initgroups call not supported");
             return reply;
         }
@@ -1820,13 +1820,13 @@ proxy_account_info(TALLOC_CTX *mem_ctx,
 
     case BE_REQ_NETGROUP:
         if (data->filter_type != BE_FILTER_NAME) {
-            dp_reply_std_set(&reply, DP_ERR_FATAL, EINVAL,
+            dp_reply_std_set(&reply, ERR_INVALID_FILTER,
                              "Invalid filter type");
             return reply;
         }
         if (ctx->ops.setnetgrent == NULL || ctx->ops.getnetgrent_r == NULL ||
             ctx->ops.endnetgrent == NULL) {
-            dp_reply_std_set(&reply, DP_ERR_FATAL, ENODEV,
+            dp_reply_std_set(&reply, ERR_INTERNAL,
                              "Netgroups are not supported");
             return reply;
         }
@@ -1838,7 +1838,7 @@ proxy_account_info(TALLOC_CTX *mem_ctx,
         switch (data->filter_type) {
         case BE_FILTER_NAME:
             if (ctx->ops.getservbyname_r == NULL) {
-                dp_reply_std_set(&reply, DP_ERR_FATAL, ENODEV,
+                dp_reply_std_set(&reply, ERR_INTERNAL,
                                  "Services are not supported");
                 return reply;
             }
@@ -1848,7 +1848,7 @@ proxy_account_info(TALLOC_CTX *mem_ctx,
             break;
         case BE_FILTER_IDNUM:
             if (ctx->ops.getservbyport_r == NULL) {
-                dp_reply_std_set(&reply, DP_ERR_FATAL, ENODEV,
+                dp_reply_std_set(&reply, ERR_INTERNAL,
                                  "Services are not supported");
                 return reply;
             }
@@ -1860,14 +1860,14 @@ proxy_account_info(TALLOC_CTX *mem_ctx,
             if (!ctx->ops.setservent
                     || !ctx->ops.getservent_r
                     || !ctx->ops.endservent) {
-                dp_reply_std_set(&reply, DP_ERR_FATAL, ENODEV,
+                dp_reply_std_set(&reply, ERR_INTERNAL,
                                  "Services are not supported");
                 return reply;
             }
             ret = enum_services(ctx, sysdb, domain);
             break;
         default:
-            dp_reply_std_set(&reply, DP_ERR_FATAL, EINVAL,
+            dp_reply_std_set(&reply, ERR_INVALID_FILTER,
                              "Invalid filter type");
             return reply;
         }
@@ -1878,7 +1878,7 @@ proxy_account_info(TALLOC_CTX *mem_ctx,
             DEBUG(SSSDBG_CRIT_FAILURE,
                   "Unexpected filter type for lookup by cert: %d\n",
                   data->filter_type);
-            dp_reply_std_set(&reply, DP_ERR_FATAL, EINVAL,
+            dp_reply_std_set(&reply, ERR_INVALID_FILTER,
                              "Unexpected filter type for lookup by cert");
             return reply;
         }
@@ -1896,7 +1896,7 @@ proxy_account_info(TALLOC_CTX *mem_ctx,
         break;
 
     default: /*fail*/
-        dp_reply_std_set(&reply, DP_ERR_FATAL, EINVAL,
+        dp_reply_std_set(&reply, ERR_INVALID_FILTER,
                          "Invalid filter type");
         return reply;
     }
@@ -1908,11 +1908,11 @@ proxy_account_info(TALLOC_CTX *mem_ctx,
             be_mark_offline(be_ctx);
         }
 
-        dp_reply_std_set(&reply, DP_ERR_FATAL, ret, NULL);
+        dp_reply_std_set(&reply, ret, NULL);
         return reply;
     }
 
-    dp_reply_std_set(&reply, DP_ERR_OK, EOK, NULL);
+    dp_reply_std_set(&reply, EOK, NULL);
     return reply;
 }
 

--- a/src/providers/proxy/proxy_ipnetworks.c
+++ b/src/providers/proxy/proxy_ipnetworks.c
@@ -565,7 +565,7 @@ proxy_nets_info(TALLOC_CTX *mem_ctx,
         break;
 
     default:
-        dp_reply_std_set(&reply, DP_ERR_FATAL, EINVAL,
+        dp_reply_std_set(&reply, EINVAL,
                          "Invalid filter type");
         return reply;
     }
@@ -577,11 +577,11 @@ proxy_nets_info(TALLOC_CTX *mem_ctx,
             be_mark_offline(be_ctx);
         }
 
-        dp_reply_std_set(&reply, DP_ERR_FATAL, ret, NULL);
+        dp_reply_std_set(&reply, ret, NULL);
         return reply;
     }
 
-    dp_reply_std_set(&reply, DP_ERR_OK, EOK, NULL);
+    dp_reply_std_set(&reply, EOK, NULL);
     return reply;
 }
 

--- a/src/providers/simple/simple_access_check.c
+++ b/src/providers/simple/simple_access_check.c
@@ -369,10 +369,10 @@ static void simple_resolve_group_done(struct tevent_req *subreq)
         return;
     }
 
-    if (reply->dp_error != DP_ERR_OK) {
+    if (reply->error != EOK) {
         DEBUG(SSSDBG_MINOR_FAILURE,
-              "Cannot refresh data from DP: %u,%u: %s\n",
-              reply->dp_error, reply->error, reply->message);
+              "Cannot refresh data from DP: %u: %s\n",
+              reply->error, reply->message);
         tevent_req_error(req, EIO);
         return;
     }

--- a/src/responder/common/cache_req/cache_req_private.h
+++ b/src/responder/common/cache_req/cache_req_private.h
@@ -208,9 +208,7 @@ cache_req_well_known_sid_result(TALLOC_CTX *mem_ctx,
 bool
 cache_req_common_process_dp_reply(struct cache_req *cr,
                                   errno_t ret,
-                                  uint16_t err_maj,
-                                  uint32_t err_min,
-                                  const char *err_msg);
+                                  uint32_t err);
 
 bool
 cache_req_common_dp_recv(struct tevent_req *subreq,

--- a/src/responder/common/cache_req/plugins/cache_req_common.c
+++ b/src/responder/common/cache_req/plugins/cache_req_common.c
@@ -122,9 +122,7 @@ cache_req_well_known_sid_result(TALLOC_CTX *mem_ctx,
 bool
 cache_req_common_process_dp_reply(struct cache_req *cr,
                                   errno_t ret,
-                                  uint16_t err_maj,
-                                  uint32_t err_min,
-                                  const char *err_msg)
+                                  uint32_t err)
 {
     bool bret;
 
@@ -142,10 +140,10 @@ cache_req_common_process_dp_reply(struct cache_req *cr,
         goto done;
     }
 
-    if (err_maj) {
+    if (err) {
         CACHE_REQ_DEBUG(SSSDBG_IMPORTANT_INFO, cr,
-                        "Data Provider Error: %u, %u, %s\n",
-                        (unsigned int)err_maj, (unsigned int)err_min, err_msg);
+                        "Data Provider Error: %u, %s\n",
+                        (unsigned int)err, sss_strerror(err));
         CACHE_REQ_DEBUG(SSSDBG_TRACE_FUNC, cr,
                         "Due to an error we will return cached data\n");
 
@@ -163,16 +161,12 @@ bool
 cache_req_common_dp_recv(struct tevent_req *subreq,
                          struct cache_req *cr)
 {
-    const char *err_msg;
-    uint16_t err_maj;
-    uint32_t err_min;
+    uint32_t err;
     errno_t ret;
     bool bret;
 
-    /* Use subreq as memory context so err_msg is freed with it. */
-    ret = sss_dp_get_account_recv(subreq, subreq, &err_maj, &err_min, &err_msg);
-    bret = cache_req_common_process_dp_reply(cr, ret, err_maj,
-                                             err_min, err_msg);
+    ret = sss_dp_get_account_recv(subreq, subreq, &err);
+    bret = cache_req_common_process_dp_reply(cr, ret, err);
 
     return bret;
 }

--- a/src/responder/common/cache_req/plugins/cache_req_enum_ip_hosts.c
+++ b/src/responder/common/cache_req/plugins/cache_req_enum_ip_hosts.c
@@ -63,15 +63,11 @@ cache_req_enum_host_dp_recv(struct tevent_req *subreq,
                             struct cache_req *cr)
 {
     bool bret;
-    uint16_t err_maj;
-    uint32_t err_min;
+    uint32_t err;
     errno_t ret;
-    const char *err_msg;
 
-    ret = sss_dp_resolver_get_recv(subreq, subreq, &err_maj, &err_min,
-                                   &err_msg);
-    bret = cache_req_common_process_dp_reply(cr, ret, err_maj,
-                                             err_min, err_msg);
+    ret = sss_dp_resolver_get_recv(subreq, subreq, &err);
+    bret = cache_req_common_process_dp_reply(cr, ret, err);
 
     return bret;
 }

--- a/src/responder/common/cache_req/plugins/cache_req_enum_ip_networks.c
+++ b/src/responder/common/cache_req/plugins/cache_req_enum_ip_networks.c
@@ -63,15 +63,11 @@ cache_req_enum_ip_networks_dp_recv(struct tevent_req *subreq,
                                    struct cache_req *cr)
 {
     bool bret;
-    uint16_t err_maj;
-    uint32_t err_min;
+    uint32_t err;
     errno_t ret;
-    const char *err_msg;
 
-    ret = sss_dp_resolver_get_recv(subreq, subreq, &err_maj, &err_min,
-                                   &err_msg);
-    bret = cache_req_common_process_dp_reply(cr, ret, err_maj,
-                                             err_min, err_msg);
+    ret = sss_dp_resolver_get_recv(subreq, subreq, &err);
+    bret = cache_req_common_process_dp_reply(cr, ret, err);
 
     return bret;
 }

--- a/src/responder/common/cache_req/plugins/cache_req_ip_host_by_addr.c
+++ b/src/responder/common/cache_req/plugins/cache_req_ip_host_by_addr.c
@@ -108,15 +108,11 @@ cache_req_ip_host_by_addr_dp_recv(struct tevent_req *subreq,
                                   struct cache_req *cr)
 {
     bool bret;
-    uint16_t err_maj;
-    uint32_t err_min;
+    uint32_t err;
     errno_t ret;
-    const char *err_msg;
 
-    ret = sss_dp_resolver_get_recv(subreq, subreq, &err_maj, &err_min,
-                                   &err_msg);
-    bret = cache_req_common_process_dp_reply(cr, ret, err_maj,
-                                             err_min, err_msg);
+    ret = sss_dp_resolver_get_recv(subreq, subreq, &err);
+    bret = cache_req_common_process_dp_reply(cr, ret, err);
 
     return bret;
 }

--- a/src/responder/common/cache_req/plugins/cache_req_ip_host_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_ip_host_by_name.c
@@ -103,15 +103,11 @@ cache_req_ip_host_by_name_dp_recv(struct tevent_req *subreq,
                                   struct cache_req *cr)
 {
     bool bret;
-    uint16_t err_maj;
-    uint32_t err_min;
+    uint32_t err;
     errno_t ret;
-    const char *err_msg;
 
-    ret = sss_dp_resolver_get_recv(subreq, subreq, &err_maj, &err_min,
-                                   &err_msg);
-    bret = cache_req_common_process_dp_reply(cr, ret, err_maj,
-                                             err_min, err_msg);
+    ret = sss_dp_resolver_get_recv(subreq, subreq, &err);
+    bret = cache_req_common_process_dp_reply(cr, ret, err);
 
     return bret;
 }

--- a/src/responder/common/cache_req/plugins/cache_req_ip_network_by_addr.c
+++ b/src/responder/common/cache_req/plugins/cache_req_ip_network_by_addr.c
@@ -108,15 +108,11 @@ cache_req_ip_network_by_addr_dp_recv(struct tevent_req *subreq,
                                      struct cache_req *cr)
 {
     bool bret;
-    uint16_t err_maj;
-    uint32_t err_min;
+    uint32_t err;
     errno_t ret;
-    const char *err_msg;
 
-    ret = sss_dp_resolver_get_recv(subreq, subreq, &err_maj, &err_min,
-                                   &err_msg);
-    bret = cache_req_common_process_dp_reply(cr, ret, err_maj,
-                                             err_min, err_msg);
+    ret = sss_dp_resolver_get_recv(subreq, subreq, &err);
+    bret = cache_req_common_process_dp_reply(cr, ret, err);
 
     return bret;
 }

--- a/src/responder/common/cache_req/plugins/cache_req_ip_network_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_ip_network_by_name.c
@@ -103,15 +103,11 @@ cache_req_ip_network_by_name_dp_recv(struct tevent_req *subreq,
                                      struct cache_req *cr)
 {
     bool bret;
-    uint16_t err_maj;
-    uint32_t err_min;
+    uint32_t err;
     errno_t ret;
-    const char *err_msg;
 
-    ret = sss_dp_resolver_get_recv(subreq, subreq, &err_maj, &err_min,
-                                   &err_msg);
-    bret = cache_req_common_process_dp_reply(cr, ret, err_maj,
-                                             err_min, err_msg);
+    ret = sss_dp_resolver_get_recv(subreq, subreq, &err);
+    bret = cache_req_common_process_dp_reply(cr, ret, err);
 
     return bret;
 }

--- a/src/responder/common/cache_req/plugins/cache_req_ssh_host_id_by_name.c
+++ b/src/responder/common/cache_req/plugins/cache_req_ssh_host_id_by_name.c
@@ -89,17 +89,12 @@ static bool
 cache_req_host_by_name_dp_recv(struct tevent_req *subreq,
                                struct cache_req *cr)
 {
-    const char *err_msg;
-    dbus_uint16_t err_maj;
-    dbus_uint32_t err_min;
+    dbus_uint32_t err;
     errno_t ret;
     bool bret;
 
-    /* Use subreq as memory context so err_msg is freed with it. */
-    ret = sbus_call_dp_dp_hostHandler_recv(subreq, subreq, &err_maj,
-                                           &err_min, &err_msg);
-    bret = cache_req_common_process_dp_reply(cr, ret, err_maj,
-                                             err_min, err_msg);
+    ret = sbus_call_dp_dp_hostHandler_recv(subreq, &err);
+    bret = cache_req_common_process_dp_reply(cr, ret, err);
 
     return bret;
 }

--- a/src/responder/common/responder.h
+++ b/src/responder/common/responder.h
@@ -259,9 +259,7 @@ sss_dp_get_account_send(TALLOC_CTX *mem_ctx,
 errno_t
 sss_dp_get_account_recv(TALLOC_CTX *mem_ctx,
                         struct tevent_req *req,
-                        uint16_t *_dp_error,
-                        uint32_t *_error,
-                        const char **_error_message);
+                        uint32_t *_error);
 
 struct tevent_req *
 sss_dp_resolver_get_send(TALLOC_CTX *mem_ctx,
@@ -275,9 +273,7 @@ sss_dp_resolver_get_send(TALLOC_CTX *mem_ctx,
 errno_t
 sss_dp_resolver_get_recv(TALLOC_CTX *mem_ctx,
                          struct tevent_req *req,
-                         uint16_t *_dp_error,
-                         uint32_t *_error,
-                         const char **_error_message);
+                         uint32_t *_error);
 
 bool sss_utf8_check(const uint8_t *s, size_t n);
 

--- a/src/responder/common/responder_dp.c
+++ b/src/responder/common/responder_dp.c
@@ -114,9 +114,7 @@ sss_dp_get_account_filter(TALLOC_CTX *mem_ctx,
 }
 
 struct sss_dp_get_account_state {
-    uint16_t dp_error;
     uint32_t error;
-    const char *error_message;
 };
 
 static void sss_dp_get_account_done(struct tevent_req *subreq);
@@ -210,9 +208,7 @@ static void sss_dp_get_account_done(struct tevent_req *subreq)
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sss_dp_get_account_state);
 
-    ret = sbus_call_dp_dp_getAccountInfo_recv(state, subreq, &state->dp_error,
-                                              &state->error,
-                                              &state->error_message);
+    ret = sbus_call_dp_dp_getAccountInfo_recv(subreq, &state->error);
     talloc_zfree(subreq);
     if (ret != EOK) {
         tevent_req_error(req, ret);
@@ -226,26 +222,20 @@ static void sss_dp_get_account_done(struct tevent_req *subreq)
 errno_t
 sss_dp_get_account_recv(TALLOC_CTX *mem_ctx,
                         struct tevent_req *req,
-                        uint16_t *_dp_error,
-                        uint32_t *_error,
-                        const char **_error_message)
+                        uint32_t *_error)
 {
     struct sss_dp_get_account_state *state;
     state = tevent_req_data(req, struct sss_dp_get_account_state);
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
-    *_dp_error = state->dp_error;
     *_error = state->error;
-    *_error_message = talloc_steal(mem_ctx, state->error_message);
 
     return EOK;
 }
 
 struct sss_dp_resolver_get_state {
-    uint16_t dp_error;
     uint32_t error;
-    const char *error_message;
 };
 
 static void sss_dp_resolver_get_done(struct tevent_req *subreq);
@@ -334,10 +324,7 @@ static void sss_dp_resolver_get_done(struct tevent_req *subreq)
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sss_dp_resolver_get_state);
 
-    ret = sbus_call_dp_dp_resolverHandler_recv(state, subreq,
-                                               &state->dp_error,
-                                               &state->error,
-                                               &state->error_message);
+    ret = sbus_call_dp_dp_resolverHandler_recv(subreq, &state->error);
     talloc_zfree(subreq);
     if (ret != EOK) {
         tevent_req_error(req, ret);
@@ -351,18 +338,14 @@ static void sss_dp_resolver_get_done(struct tevent_req *subreq)
 errno_t
 sss_dp_resolver_get_recv(TALLOC_CTX *mem_ctx,
                          struct tevent_req *req,
-                         uint16_t *_dp_error,
-                         uint32_t *_error,
-                         const char **_error_message)
+                         uint32_t *_error)
 {
     struct sss_dp_resolver_get_state *state;
     state = tevent_req_data(req, struct sss_dp_resolver_get_state);
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
-    *_dp_error = state->dp_error;
     *_error = state->error;
-    *_error_message = talloc_steal(mem_ctx, state->error_message);
 
     return EOK;
 }

--- a/src/responder/common/responder_get_domains.c
+++ b/src/responder/common/responder_get_domains.c
@@ -27,9 +27,7 @@
 
 /* ========== Get subdomains for a domain ================= */
 struct get_subdomains_state {
-    uint16_t dp_error;
     uint32_t error;
-    const char *error_message;
 };
 
 static void get_subdomains_done(struct tevent_req *subreq);
@@ -89,11 +87,9 @@ static void get_subdomains_done(struct tevent_req *subreq)
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct get_subdomains_state);
 
-    ret = sbus_call_dp_dp_getDomains_recv(state, subreq, &state->dp_error,
-                                          &state->error, &state->error_message);
+    ret = sbus_call_dp_dp_getDomains_recv(subreq, &state->error);
     talloc_zfree(subreq);
     if (ret != EOK) {
-        state->dp_error = DP_ERR_FATAL;
         state->error = ret;
     }
 
@@ -104,18 +100,14 @@ static void get_subdomains_done(struct tevent_req *subreq)
 static errno_t
 get_subdomains_recv(TALLOC_CTX *mem_ctx,
                     struct tevent_req *req,
-                    uint16_t *_dp_error,
-                    uint32_t *_error,
-                    const char **_error_message)
+                    uint32_t *_error)
 {
     struct get_subdomains_state *state;
     state = tevent_req_data(req, struct get_subdomains_state);
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
-    *_dp_error = state->dp_error;
     *_error = state->error;
-    *_error_message = talloc_steal(mem_ctx, state->error_message);
 
     return EOK;
 }
@@ -230,11 +222,9 @@ sss_dp_get_domains_process(struct tevent_req *subreq)
                                                       struct tevent_req);
     struct sss_dp_get_domains_state *state = tevent_req_data(req,
                                                 struct sss_dp_get_domains_state);
-    uint16_t dp_err;
-    uint32_t dp_ret;
-    const char *err_msg;
+    uint32_t err;
 
-    ret = get_subdomains_recv(subreq, subreq, &dp_err, &dp_ret, &err_msg);
+    ret = get_subdomains_recv(subreq, subreq, &err);
     talloc_zfree(subreq);
     if (ret != EOK) {
         goto fail;
@@ -630,7 +620,6 @@ errno_t sss_parse_inp_recv(struct tevent_req *req, TALLOC_CTX *mem_ctx,
 
 
 struct sss_dp_get_account_domain_state {
-    uint16_t dp_error;
     uint32_t error;
     const char *domain_name;
 };
@@ -738,7 +727,7 @@ static void sss_dp_get_account_domain_done(struct tevent_req *subreq)
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sss_dp_get_account_domain_state);
 
-    ret = sbus_call_dp_dp_getAccountDomain_recv(state, subreq, &state->dp_error,
+    ret = sbus_call_dp_dp_getAccountDomain_recv(state, subreq,
                                                 &state->error,
                                                 &state->domain_name);
     talloc_zfree(subreq);
@@ -749,12 +738,11 @@ static void sss_dp_get_account_domain_done(struct tevent_req *subreq)
         return;
     }
 
-    if (state->dp_error != DP_ERR_OK) {
+    if (state->error != ERR_OK) {
         DEBUG(state->error == ERR_GET_ACCT_DOM_NOT_SUPPORTED ? SSSDBG_TRACE_INTERNAL
                                                              : SSSDBG_IMPORTANT_INFO,
-              "Data Provider Error: %u, %u [%s]\n",
-              (unsigned int)state->dp_error, (unsigned int)state->error,
-              sss_strerror(state->error));
+              "Data Provider Error: %u [%s]\n",
+              (unsigned int)state->error, sss_strerror(state->error));
         tevent_req_error(req, state->error ? state->error : EIO);
         return;
     }

--- a/src/responder/sudo/sudosrv_dp.c
+++ b/src/responder/sudo/sudosrv_dp.c
@@ -137,9 +137,7 @@ fail:
 }
 
 struct sss_dp_get_sudoers_state {
-    uint16_t dp_error;
     uint32_t error;
-    const char *error_message;
 };
 
 static void sss_dp_get_sudoers_done(struct tevent_req *subreq);
@@ -209,9 +207,7 @@ static void sss_dp_get_sudoers_done(struct tevent_req *subreq)
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sss_dp_get_sudoers_state);
 
-    ret = sbus_call_dp_dp_sudoHandler_recv(state, subreq, &state->dp_error,
-                                           &state->error,
-                                           &state->error_message);
+    ret = sbus_call_dp_dp_sudoHandler_recv(subreq, &state->error);
     talloc_zfree(subreq);
     if (ret != EOK) {
         tevent_req_error(req, ret);
@@ -225,18 +221,14 @@ static void sss_dp_get_sudoers_done(struct tevent_req *subreq)
 errno_t
 sss_dp_get_sudoers_recv(TALLOC_CTX *mem_ctx,
                         struct tevent_req *req,
-                        uint16_t *_dp_error,
-                        uint32_t *_error,
-                        const char ** _error_message)
+                        uint32_t *_error)
 {
     struct sss_dp_get_sudoers_state *state;
     state = tevent_req_data(req, struct sss_dp_get_sudoers_state);
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
-    *_dp_error = state->dp_error;
     *_error = state->error;
-    *_error_message = talloc_steal(mem_ctx, state->error_message);
 
     return EOK;
 }

--- a/src/responder/sudo/sudosrv_get_sudorules.c
+++ b/src/responder/sudo/sudosrv_get_sudorules.c
@@ -663,30 +663,19 @@ static void sudosrv_refresh_rules_done(struct tevent_req *subreq)
 {
     struct sudosrv_refresh_rules_state *state;
     struct tevent_req *req;
-    dbus_uint16_t err_maj;
-    dbus_uint32_t err_min;
-    const char *err_msg;
+    uint32_t err;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sudosrv_refresh_rules_state);
 
-    ret = sss_dp_get_sudoers_recv(state, subreq, &err_maj, &err_min, &err_msg);
+    ret = sss_dp_get_sudoers_recv(state, subreq, &err);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to refresh rules [%d]: %s\n",
               ret, sss_strerror(ret));
         goto done;
-    } else if (err_maj != 0 || err_min != 0) {
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Unable to get information from Data Provider, "
-              "Error: %u, %u, %s\n",
-              (unsigned int)err_maj, (unsigned int)err_min,
-              (err_msg == NULL ? "(null)" : err_msg));
-        goto done;
-    }
-
-    if (err_min == ENOENT) {
+    } else if (err == ENOENT) {
         DEBUG(SSSDBG_TRACE_INTERNAL,
               "Some expired rules were removed from the server, scheduling "
               "full refresh out of band\n");
@@ -701,6 +690,13 @@ static void sudosrv_refresh_rules_done(struct tevent_req *subreq)
         }
 
         tevent_req_set_callback(subreq, sudosrv_dp_oob_req_done, NULL);
+    } else if (err != 0) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Unable to get information from Data Provider, "
+              "Error: %u, %s\n",
+              (unsigned int)err,
+              sss_strerror(err));
+        goto done;
     }
 
     ret = EOK;

--- a/src/responder/sudo/sudosrv_private.h
+++ b/src/responder/sudo/sudosrv_private.h
@@ -105,8 +105,6 @@ sss_dp_get_sudoers_send(TALLOC_CTX *mem_ctx,
 errno_t
 sss_dp_get_sudoers_recv(TALLOC_CTX *mem_ctx,
                         struct tevent_req *req,
-                        uint16_t *_dp_error,
-                        uint32_t *_error,
-                        const char ** _error_message);
+                        uint32_t *_error);
 
 #endif /* _SUDOSRV_PRIVATE_H_ */

--- a/src/sss_iface/sbus_sss_arguments.c
+++ b/src/sss_iface/sbus_sss_arguments.c
@@ -201,55 +201,6 @@ errno_t _sbus_sss_invoker_write_q
     return EOK;
 }
 
-errno_t _sbus_sss_invoker_read_qus
-   (TALLOC_CTX *mem_ctx,
-    DBusMessageIter *iter,
-    struct _sbus_sss_invoker_args_qus *args)
-{
-    errno_t ret;
-
-    ret = sbus_iterator_read_q(iter, &args->arg0);
-    if (ret != EOK) {
-        return ret;
-    }
-
-    ret = sbus_iterator_read_u(iter, &args->arg1);
-    if (ret != EOK) {
-        return ret;
-    }
-
-    ret = sbus_iterator_read_s(mem_ctx, iter, &args->arg2);
-    if (ret != EOK) {
-        return ret;
-    }
-
-    return EOK;
-}
-
-errno_t _sbus_sss_invoker_write_qus
-   (DBusMessageIter *iter,
-    struct _sbus_sss_invoker_args_qus *args)
-{
-    errno_t ret;
-
-    ret = sbus_iterator_write_q(iter, args->arg0);
-    if (ret != EOK) {
-        return ret;
-    }
-
-    ret = sbus_iterator_write_u(iter, args->arg1);
-    if (ret != EOK) {
-        return ret;
-    }
-
-    ret = sbus_iterator_write_s(iter, args->arg2);
-    if (ret != EOK) {
-        return ret;
-    }
-
-    return EOK;
-}
-
 errno_t _sbus_sss_invoker_read_s
    (TALLOC_CTX *mem_ctx,
     DBusMessageIter *iter,
@@ -438,6 +389,45 @@ errno_t _sbus_sss_invoker_write_u
     errno_t ret;
 
     ret = sbus_iterator_write_u(iter, args->arg0);
+    if (ret != EOK) {
+        return ret;
+    }
+
+    return EOK;
+}
+
+errno_t _sbus_sss_invoker_read_us
+   (TALLOC_CTX *mem_ctx,
+    DBusMessageIter *iter,
+    struct _sbus_sss_invoker_args_us *args)
+{
+    errno_t ret;
+
+    ret = sbus_iterator_read_u(iter, &args->arg0);
+    if (ret != EOK) {
+        return ret;
+    }
+
+    ret = sbus_iterator_read_s(mem_ctx, iter, &args->arg1);
+    if (ret != EOK) {
+        return ret;
+    }
+
+    return EOK;
+}
+
+errno_t _sbus_sss_invoker_write_us
+   (DBusMessageIter *iter,
+    struct _sbus_sss_invoker_args_us *args)
+{
+    errno_t ret;
+
+    ret = sbus_iterator_write_u(iter, args->arg0);
+    if (ret != EOK) {
+        return ret;
+    }
+
+    ret = sbus_iterator_write_s(iter, args->arg1);
     if (ret != EOK) {
         return ret;
     }

--- a/src/sss_iface/sbus_sss_arguments.h
+++ b/src/sss_iface/sbus_sss_arguments.h
@@ -118,23 +118,6 @@ _sbus_sss_invoker_write_q
    (DBusMessageIter *iter,
     struct _sbus_sss_invoker_args_q *args);
 
-struct _sbus_sss_invoker_args_qus {
-    uint16_t arg0;
-    uint32_t arg1;
-    const char * arg2;
-};
-
-errno_t
-_sbus_sss_invoker_read_qus
-   (TALLOC_CTX *mem_ctx,
-    DBusMessageIter *iter,
-    struct _sbus_sss_invoker_args_qus *args);
-
-errno_t
-_sbus_sss_invoker_write_qus
-   (DBusMessageIter *iter,
-    struct _sbus_sss_invoker_args_qus *args);
-
 struct _sbus_sss_invoker_args_s {
     const char * arg0;
 };
@@ -214,6 +197,22 @@ errno_t
 _sbus_sss_invoker_write_u
    (DBusMessageIter *iter,
     struct _sbus_sss_invoker_args_u *args);
+
+struct _sbus_sss_invoker_args_us {
+    uint32_t arg0;
+    const char * arg1;
+};
+
+errno_t
+_sbus_sss_invoker_read_us
+   (TALLOC_CTX *mem_ctx,
+    DBusMessageIter *iter,
+    struct _sbus_sss_invoker_args_us *args);
+
+errno_t
+_sbus_sss_invoker_write_us
+   (DBusMessageIter *iter,
+    struct _sbus_sss_invoker_args_us *args);
 
 struct _sbus_sss_invoker_args_usq {
     uint32_t arg0;

--- a/src/sss_iface/sbus_sss_client_async.c
+++ b/src/sss_iface/sbus_sss_client_async.c
@@ -212,30 +212,30 @@ sbus_method_in_pam_data_out_pam_response_recv
     return EOK;
 }
 
-struct sbus_method_in_raw_out_qus_state {
-    struct _sbus_sss_invoker_args_qus *out;
+struct sbus_method_in_raw_out_u_state {
+    struct _sbus_sss_invoker_args_u *out;
 };
 
-static void sbus_method_in_raw_out_qus_done(struct tevent_req *subreq);
+static void sbus_method_in_raw_out_u_done(struct tevent_req *subreq);
 
 static struct tevent_req *
-sbus_method_in_raw_out_qus_send
+sbus_method_in_raw_out_u_send
     (TALLOC_CTX *mem_ctx,
      struct sbus_connection *conn,
      DBusMessage *raw_message)
 {
-    struct sbus_method_in_raw_out_qus_state *state;
+    struct sbus_method_in_raw_out_u_state *state;
     struct tevent_req *subreq;
     struct tevent_req *req;
     errno_t ret;
 
-    req = tevent_req_create(mem_ctx, &state, struct sbus_method_in_raw_out_qus_state);
+    req = tevent_req_create(mem_ctx, &state, struct sbus_method_in_raw_out_u_state);
     if (req == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
         return NULL;
     }
 
-    state->out = talloc_zero(state, struct _sbus_sss_invoker_args_qus);
+    state->out = talloc_zero(state, struct _sbus_sss_invoker_args_u);
     if (state->out == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Unable to allocate space for output parameters!\n");
@@ -254,7 +254,7 @@ sbus_method_in_raw_out_qus_send
         goto done;
     }
 
-    tevent_req_set_callback(subreq, sbus_method_in_raw_out_qus_done, req);
+    tevent_req_set_callback(subreq, sbus_method_in_raw_out_u_done, req);
 
     ret = EAGAIN;
 
@@ -267,15 +267,15 @@ done:
     return req;
 }
 
-static void sbus_method_in_raw_out_qus_done(struct tevent_req *subreq)
+static void sbus_method_in_raw_out_u_done(struct tevent_req *subreq)
 {
-    struct sbus_method_in_raw_out_qus_state *state;
+    struct sbus_method_in_raw_out_u_state *state;
     struct tevent_req *req;
     DBusMessage *reply;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
-    state = tevent_req_data(req, struct sbus_method_in_raw_out_qus_state);
+    state = tevent_req_data(req, struct sbus_method_in_raw_out_u_state);
 
     ret = sbus_call_method_recv(state, subreq, &reply);
     talloc_zfree(subreq);
@@ -284,7 +284,7 @@ static void sbus_method_in_raw_out_qus_done(struct tevent_req *subreq)
         return;
     }
 
-    ret = sbus_read_output(state->out, reply, (sbus_invoker_reader_fn)_sbus_sss_invoker_read_qus, state->out);
+    ret = sbus_read_output(state->out, reply, (sbus_invoker_reader_fn)_sbus_sss_invoker_read_u, state->out);
     if (ret != EOK) {
         tevent_req_error(req, ret);
         return;
@@ -295,21 +295,16 @@ static void sbus_method_in_raw_out_qus_done(struct tevent_req *subreq)
 }
 
 static errno_t
-sbus_method_in_raw_out_qus_recv
-    (TALLOC_CTX *mem_ctx,
-     struct tevent_req *req,
-     uint16_t* _arg0,
-     uint32_t* _arg1,
-     const char ** _arg2)
+sbus_method_in_raw_out_u_recv
+    (struct tevent_req *req,
+     uint32_t* _arg0)
 {
-    struct sbus_method_in_raw_out_qus_state *state;
-    state = tevent_req_data(req, struct sbus_method_in_raw_out_qus_state);
+    struct sbus_method_in_raw_out_u_state *state;
+    state = tevent_req_data(req, struct sbus_method_in_raw_out_u_state);
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     *_arg0 = state->out->arg0;
-    *_arg1 = state->out->arg1;
-    *_arg2 = talloc_steal(mem_ctx, state->out->arg2);
 
     return EOK;
 }
@@ -521,114 +516,6 @@ sbus_method_in_s_out_b_recv
     return EOK;
 }
 
-struct sbus_method_in_s_out_qus_state {
-    struct _sbus_sss_invoker_args_s in;
-    struct _sbus_sss_invoker_args_qus *out;
-};
-
-static void sbus_method_in_s_out_qus_done(struct tevent_req *subreq);
-
-static struct tevent_req *
-sbus_method_in_s_out_qus_send
-    (TALLOC_CTX *mem_ctx,
-     struct sbus_connection *conn,
-     sbus_invoker_keygen keygen,
-     const char *bus,
-     const char *path,
-     const char *iface,
-     const char *method,
-     const char * arg0)
-{
-    struct sbus_method_in_s_out_qus_state *state;
-    struct tevent_req *subreq;
-    struct tevent_req *req;
-    errno_t ret;
-
-    req = tevent_req_create(mem_ctx, &state, struct sbus_method_in_s_out_qus_state);
-    if (req == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
-        return NULL;
-    }
-
-    state->out = talloc_zero(state, struct _sbus_sss_invoker_args_qus);
-    if (state->out == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Unable to allocate space for output parameters!\n");
-        ret = ENOMEM;
-        goto done;
-    }
-
-    state->in.arg0 = arg0;
-
-    subreq = sbus_call_method_send(state, conn, NULL, keygen,
-                                   (sbus_invoker_writer_fn)_sbus_sss_invoker_write_s,
-                                   bus, path, iface, method, &state->in);
-    if (subreq == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
-        ret = ENOMEM;
-        goto done;
-    }
-
-    tevent_req_set_callback(subreq, sbus_method_in_s_out_qus_done, req);
-
-    ret = EAGAIN;
-
-done:
-    if (ret != EAGAIN) {
-        tevent_req_error(req, ret);
-        tevent_req_post(req, conn->ev);
-    }
-
-    return req;
-}
-
-static void sbus_method_in_s_out_qus_done(struct tevent_req *subreq)
-{
-    struct sbus_method_in_s_out_qus_state *state;
-    struct tevent_req *req;
-    DBusMessage *reply;
-    errno_t ret;
-
-    req = tevent_req_callback_data(subreq, struct tevent_req);
-    state = tevent_req_data(req, struct sbus_method_in_s_out_qus_state);
-
-    ret = sbus_call_method_recv(state, subreq, &reply);
-    talloc_zfree(subreq);
-    if (ret != EOK) {
-        tevent_req_error(req, ret);
-        return;
-    }
-
-    ret = sbus_read_output(state->out, reply, (sbus_invoker_reader_fn)_sbus_sss_invoker_read_qus, state->out);
-    if (ret != EOK) {
-        tevent_req_error(req, ret);
-        return;
-    }
-
-    tevent_req_done(req);
-    return;
-}
-
-static errno_t
-sbus_method_in_s_out_qus_recv
-    (TALLOC_CTX *mem_ctx,
-     struct tevent_req *req,
-     uint16_t* _arg0,
-     uint32_t* _arg1,
-     const char ** _arg2)
-{
-    struct sbus_method_in_s_out_qus_state *state;
-    state = tevent_req_data(req, struct sbus_method_in_s_out_qus_state);
-
-    TEVENT_REQ_RETURN_ON_ERROR(req);
-
-    *_arg0 = state->out->arg0;
-    *_arg1 = state->out->arg1;
-    *_arg2 = talloc_steal(mem_ctx, state->out->arg2);
-
-    return EOK;
-}
-
 struct sbus_method_in_s_out_s_state {
     struct _sbus_sss_invoker_args_s in;
     struct _sbus_sss_invoker_args_s *out;
@@ -729,6 +616,109 @@ sbus_method_in_s_out_s_recv
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     *_arg0 = talloc_steal(mem_ctx, state->out->arg0);
+
+    return EOK;
+}
+
+struct sbus_method_in_s_out_u_state {
+    struct _sbus_sss_invoker_args_s in;
+    struct _sbus_sss_invoker_args_u *out;
+};
+
+static void sbus_method_in_s_out_u_done(struct tevent_req *subreq);
+
+static struct tevent_req *
+sbus_method_in_s_out_u_send
+    (TALLOC_CTX *mem_ctx,
+     struct sbus_connection *conn,
+     sbus_invoker_keygen keygen,
+     const char *bus,
+     const char *path,
+     const char *iface,
+     const char *method,
+     const char * arg0)
+{
+    struct sbus_method_in_s_out_u_state *state;
+    struct tevent_req *subreq;
+    struct tevent_req *req;
+    errno_t ret;
+
+    req = tevent_req_create(mem_ctx, &state, struct sbus_method_in_s_out_u_state);
+    if (req == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
+        return NULL;
+    }
+
+    state->out = talloc_zero(state, struct _sbus_sss_invoker_args_u);
+    if (state->out == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Unable to allocate space for output parameters!\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    state->in.arg0 = arg0;
+
+    subreq = sbus_call_method_send(state, conn, NULL, keygen,
+                                   (sbus_invoker_writer_fn)_sbus_sss_invoker_write_s,
+                                   bus, path, iface, method, &state->in);
+    if (subreq == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    tevent_req_set_callback(subreq, sbus_method_in_s_out_u_done, req);
+
+    ret = EAGAIN;
+
+done:
+    if (ret != EAGAIN) {
+        tevent_req_error(req, ret);
+        tevent_req_post(req, conn->ev);
+    }
+
+    return req;
+}
+
+static void sbus_method_in_s_out_u_done(struct tevent_req *subreq)
+{
+    struct sbus_method_in_s_out_u_state *state;
+    struct tevent_req *req;
+    DBusMessage *reply;
+    errno_t ret;
+
+    req = tevent_req_callback_data(subreq, struct tevent_req);
+    state = tevent_req_data(req, struct sbus_method_in_s_out_u_state);
+
+    ret = sbus_call_method_recv(state, subreq, &reply);
+    talloc_zfree(subreq);
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    ret = sbus_read_output(state->out, reply, (sbus_invoker_reader_fn)_sbus_sss_invoker_read_u, state->out);
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    tevent_req_done(req);
+    return;
+}
+
+static errno_t
+sbus_method_in_s_out_u_recv
+    (struct tevent_req *req,
+     uint32_t* _arg0)
+{
+    struct sbus_method_in_s_out_u_state *state;
+    state = tevent_req_data(req, struct sbus_method_in_s_out_u_state);
+
+    TEVENT_REQ_RETURN_ON_ERROR(req);
+
+    *_arg0 = state->out->arg0;
 
     return EOK;
 }
@@ -1182,15 +1172,15 @@ sbus_method_in_ussu_out__recv
     return EOK;
 }
 
-struct sbus_method_in_ussu_out_qus_state {
+struct sbus_method_in_ussu_out_u_state {
     struct _sbus_sss_invoker_args_ussu in;
-    struct _sbus_sss_invoker_args_qus *out;
+    struct _sbus_sss_invoker_args_u *out;
 };
 
-static void sbus_method_in_ussu_out_qus_done(struct tevent_req *subreq);
+static void sbus_method_in_ussu_out_u_done(struct tevent_req *subreq);
 
 static struct tevent_req *
-sbus_method_in_ussu_out_qus_send
+sbus_method_in_ussu_out_u_send
     (TALLOC_CTX *mem_ctx,
      struct sbus_connection *conn,
      sbus_invoker_keygen keygen,
@@ -1203,18 +1193,18 @@ sbus_method_in_ussu_out_qus_send
      const char * arg2,
      uint32_t arg3)
 {
-    struct sbus_method_in_ussu_out_qus_state *state;
+    struct sbus_method_in_ussu_out_u_state *state;
     struct tevent_req *subreq;
     struct tevent_req *req;
     errno_t ret;
 
-    req = tevent_req_create(mem_ctx, &state, struct sbus_method_in_ussu_out_qus_state);
+    req = tevent_req_create(mem_ctx, &state, struct sbus_method_in_ussu_out_u_state);
     if (req == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
         return NULL;
     }
 
-    state->out = talloc_zero(state, struct _sbus_sss_invoker_args_qus);
+    state->out = talloc_zero(state, struct _sbus_sss_invoker_args_u);
     if (state->out == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Unable to allocate space for output parameters!\n");
@@ -1236,7 +1226,7 @@ sbus_method_in_ussu_out_qus_send
         goto done;
     }
 
-    tevent_req_set_callback(subreq, sbus_method_in_ussu_out_qus_done, req);
+    tevent_req_set_callback(subreq, sbus_method_in_ussu_out_u_done, req);
 
     ret = EAGAIN;
 
@@ -1249,15 +1239,15 @@ done:
     return req;
 }
 
-static void sbus_method_in_ussu_out_qus_done(struct tevent_req *subreq)
+static void sbus_method_in_ussu_out_u_done(struct tevent_req *subreq)
 {
-    struct sbus_method_in_ussu_out_qus_state *state;
+    struct sbus_method_in_ussu_out_u_state *state;
     struct tevent_req *req;
     DBusMessage *reply;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
-    state = tevent_req_data(req, struct sbus_method_in_ussu_out_qus_state);
+    state = tevent_req_data(req, struct sbus_method_in_ussu_out_u_state);
 
     ret = sbus_call_method_recv(state, subreq, &reply);
     talloc_zfree(subreq);
@@ -1266,7 +1256,7 @@ static void sbus_method_in_ussu_out_qus_done(struct tevent_req *subreq)
         return;
     }
 
-    ret = sbus_read_output(state->out, reply, (sbus_invoker_reader_fn)_sbus_sss_invoker_read_qus, state->out);
+    ret = sbus_read_output(state->out, reply, (sbus_invoker_reader_fn)_sbus_sss_invoker_read_u, state->out);
     if (ret != EOK) {
         tevent_req_error(req, ret);
         return;
@@ -1277,21 +1267,16 @@ static void sbus_method_in_ussu_out_qus_done(struct tevent_req *subreq)
 }
 
 static errno_t
-sbus_method_in_ussu_out_qus_recv
-    (TALLOC_CTX *mem_ctx,
-     struct tevent_req *req,
-     uint16_t* _arg0,
-     uint32_t* _arg1,
-     const char ** _arg2)
+sbus_method_in_ussu_out_u_recv
+    (struct tevent_req *req,
+     uint32_t* _arg0)
 {
-    struct sbus_method_in_ussu_out_qus_state *state;
-    state = tevent_req_data(req, struct sbus_method_in_ussu_out_qus_state);
+    struct sbus_method_in_ussu_out_u_state *state;
+    state = tevent_req_data(req, struct sbus_method_in_ussu_out_u_state);
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     *_arg0 = state->out->arg0;
-    *_arg1 = state->out->arg1;
-    *_arg2 = talloc_steal(mem_ctx, state->out->arg2);
 
     return EOK;
 }
@@ -1382,15 +1367,15 @@ sbus_method_in_usu_out__recv
     return EOK;
 }
 
-struct sbus_method_in_uusssu_out_qus_state {
+struct sbus_method_in_uusssu_out_u_state {
     struct _sbus_sss_invoker_args_uusssu in;
-    struct _sbus_sss_invoker_args_qus *out;
+    struct _sbus_sss_invoker_args_u *out;
 };
 
-static void sbus_method_in_uusssu_out_qus_done(struct tevent_req *subreq);
+static void sbus_method_in_uusssu_out_u_done(struct tevent_req *subreq);
 
 static struct tevent_req *
-sbus_method_in_uusssu_out_qus_send
+sbus_method_in_uusssu_out_u_send
     (TALLOC_CTX *mem_ctx,
      struct sbus_connection *conn,
      sbus_invoker_keygen keygen,
@@ -1405,18 +1390,18 @@ sbus_method_in_uusssu_out_qus_send
      const char * arg4,
      uint32_t arg5)
 {
-    struct sbus_method_in_uusssu_out_qus_state *state;
+    struct sbus_method_in_uusssu_out_u_state *state;
     struct tevent_req *subreq;
     struct tevent_req *req;
     errno_t ret;
 
-    req = tevent_req_create(mem_ctx, &state, struct sbus_method_in_uusssu_out_qus_state);
+    req = tevent_req_create(mem_ctx, &state, struct sbus_method_in_uusssu_out_u_state);
     if (req == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
         return NULL;
     }
 
-    state->out = talloc_zero(state, struct _sbus_sss_invoker_args_qus);
+    state->out = talloc_zero(state, struct _sbus_sss_invoker_args_u);
     if (state->out == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Unable to allocate space for output parameters!\n");
@@ -1440,7 +1425,7 @@ sbus_method_in_uusssu_out_qus_send
         goto done;
     }
 
-    tevent_req_set_callback(subreq, sbus_method_in_uusssu_out_qus_done, req);
+    tevent_req_set_callback(subreq, sbus_method_in_uusssu_out_u_done, req);
 
     ret = EAGAIN;
 
@@ -1453,15 +1438,15 @@ done:
     return req;
 }
 
-static void sbus_method_in_uusssu_out_qus_done(struct tevent_req *subreq)
+static void sbus_method_in_uusssu_out_u_done(struct tevent_req *subreq)
 {
-    struct sbus_method_in_uusssu_out_qus_state *state;
+    struct sbus_method_in_uusssu_out_u_state *state;
     struct tevent_req *req;
     DBusMessage *reply;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
-    state = tevent_req_data(req, struct sbus_method_in_uusssu_out_qus_state);
+    state = tevent_req_data(req, struct sbus_method_in_uusssu_out_u_state);
 
     ret = sbus_call_method_recv(state, subreq, &reply);
     talloc_zfree(subreq);
@@ -1470,7 +1455,7 @@ static void sbus_method_in_uusssu_out_qus_done(struct tevent_req *subreq)
         return;
     }
 
-    ret = sbus_read_output(state->out, reply, (sbus_invoker_reader_fn)_sbus_sss_invoker_read_qus, state->out);
+    ret = sbus_read_output(state->out, reply, (sbus_invoker_reader_fn)_sbus_sss_invoker_read_u, state->out);
     if (ret != EOK) {
         tevent_req_error(req, ret);
         return;
@@ -1481,34 +1466,29 @@ static void sbus_method_in_uusssu_out_qus_done(struct tevent_req *subreq)
 }
 
 static errno_t
-sbus_method_in_uusssu_out_qus_recv
-    (TALLOC_CTX *mem_ctx,
-     struct tevent_req *req,
-     uint16_t* _arg0,
-     uint32_t* _arg1,
-     const char ** _arg2)
+sbus_method_in_uusssu_out_u_recv
+    (struct tevent_req *req,
+     uint32_t* _arg0)
 {
-    struct sbus_method_in_uusssu_out_qus_state *state;
-    state = tevent_req_data(req, struct sbus_method_in_uusssu_out_qus_state);
+    struct sbus_method_in_uusssu_out_u_state *state;
+    state = tevent_req_data(req, struct sbus_method_in_uusssu_out_u_state);
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     *_arg0 = state->out->arg0;
-    *_arg1 = state->out->arg1;
-    *_arg2 = talloc_steal(mem_ctx, state->out->arg2);
 
     return EOK;
 }
 
-struct sbus_method_in_uusu_out_qus_state {
+struct sbus_method_in_uusu_out_us_state {
     struct _sbus_sss_invoker_args_uusu in;
-    struct _sbus_sss_invoker_args_qus *out;
+    struct _sbus_sss_invoker_args_us *out;
 };
 
-static void sbus_method_in_uusu_out_qus_done(struct tevent_req *subreq);
+static void sbus_method_in_uusu_out_us_done(struct tevent_req *subreq);
 
 static struct tevent_req *
-sbus_method_in_uusu_out_qus_send
+sbus_method_in_uusu_out_us_send
     (TALLOC_CTX *mem_ctx,
      struct sbus_connection *conn,
      sbus_invoker_keygen keygen,
@@ -1521,18 +1501,18 @@ sbus_method_in_uusu_out_qus_send
      const char * arg2,
      uint32_t arg3)
 {
-    struct sbus_method_in_uusu_out_qus_state *state;
+    struct sbus_method_in_uusu_out_us_state *state;
     struct tevent_req *subreq;
     struct tevent_req *req;
     errno_t ret;
 
-    req = tevent_req_create(mem_ctx, &state, struct sbus_method_in_uusu_out_qus_state);
+    req = tevent_req_create(mem_ctx, &state, struct sbus_method_in_uusu_out_us_state);
     if (req == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
         return NULL;
     }
 
-    state->out = talloc_zero(state, struct _sbus_sss_invoker_args_qus);
+    state->out = talloc_zero(state, struct _sbus_sss_invoker_args_us);
     if (state->out == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Unable to allocate space for output parameters!\n");
@@ -1554,7 +1534,7 @@ sbus_method_in_uusu_out_qus_send
         goto done;
     }
 
-    tevent_req_set_callback(subreq, sbus_method_in_uusu_out_qus_done, req);
+    tevent_req_set_callback(subreq, sbus_method_in_uusu_out_us_done, req);
 
     ret = EAGAIN;
 
@@ -1567,15 +1547,15 @@ done:
     return req;
 }
 
-static void sbus_method_in_uusu_out_qus_done(struct tevent_req *subreq)
+static void sbus_method_in_uusu_out_us_done(struct tevent_req *subreq)
 {
-    struct sbus_method_in_uusu_out_qus_state *state;
+    struct sbus_method_in_uusu_out_us_state *state;
     struct tevent_req *req;
     DBusMessage *reply;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
-    state = tevent_req_data(req, struct sbus_method_in_uusu_out_qus_state);
+    state = tevent_req_data(req, struct sbus_method_in_uusu_out_us_state);
 
     ret = sbus_call_method_recv(state, subreq, &reply);
     talloc_zfree(subreq);
@@ -1584,7 +1564,7 @@ static void sbus_method_in_uusu_out_qus_done(struct tevent_req *subreq)
         return;
     }
 
-    ret = sbus_read_output(state->out, reply, (sbus_invoker_reader_fn)_sbus_sss_invoker_read_qus, state->out);
+    ret = sbus_read_output(state->out, reply, (sbus_invoker_reader_fn)_sbus_sss_invoker_read_us, state->out);
     if (ret != EOK) {
         tevent_req_error(req, ret);
         return;
@@ -1595,34 +1575,32 @@ static void sbus_method_in_uusu_out_qus_done(struct tevent_req *subreq)
 }
 
 static errno_t
-sbus_method_in_uusu_out_qus_recv
+sbus_method_in_uusu_out_us_recv
     (TALLOC_CTX *mem_ctx,
      struct tevent_req *req,
-     uint16_t* _arg0,
-     uint32_t* _arg1,
-     const char ** _arg2)
+     uint32_t* _arg0,
+     const char ** _arg1)
 {
-    struct sbus_method_in_uusu_out_qus_state *state;
-    state = tevent_req_data(req, struct sbus_method_in_uusu_out_qus_state);
+    struct sbus_method_in_uusu_out_us_state *state;
+    state = tevent_req_data(req, struct sbus_method_in_uusu_out_us_state);
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     *_arg0 = state->out->arg0;
-    *_arg1 = state->out->arg1;
-    *_arg2 = talloc_steal(mem_ctx, state->out->arg2);
+    *_arg1 = talloc_steal(mem_ctx, state->out->arg1);
 
     return EOK;
 }
 
-struct sbus_method_in_uuusu_out_qus_state {
+struct sbus_method_in_uuusu_out_u_state {
     struct _sbus_sss_invoker_args_uuusu in;
-    struct _sbus_sss_invoker_args_qus *out;
+    struct _sbus_sss_invoker_args_u *out;
 };
 
-static void sbus_method_in_uuusu_out_qus_done(struct tevent_req *subreq);
+static void sbus_method_in_uuusu_out_u_done(struct tevent_req *subreq);
 
 static struct tevent_req *
-sbus_method_in_uuusu_out_qus_send
+sbus_method_in_uuusu_out_u_send
     (TALLOC_CTX *mem_ctx,
      struct sbus_connection *conn,
      sbus_invoker_keygen keygen,
@@ -1636,18 +1614,18 @@ sbus_method_in_uuusu_out_qus_send
      const char * arg3,
      uint32_t arg4)
 {
-    struct sbus_method_in_uuusu_out_qus_state *state;
+    struct sbus_method_in_uuusu_out_u_state *state;
     struct tevent_req *subreq;
     struct tevent_req *req;
     errno_t ret;
 
-    req = tevent_req_create(mem_ctx, &state, struct sbus_method_in_uuusu_out_qus_state);
+    req = tevent_req_create(mem_ctx, &state, struct sbus_method_in_uuusu_out_u_state);
     if (req == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
         return NULL;
     }
 
-    state->out = talloc_zero(state, struct _sbus_sss_invoker_args_qus);
+    state->out = talloc_zero(state, struct _sbus_sss_invoker_args_u);
     if (state->out == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE,
               "Unable to allocate space for output parameters!\n");
@@ -1670,7 +1648,7 @@ sbus_method_in_uuusu_out_qus_send
         goto done;
     }
 
-    tevent_req_set_callback(subreq, sbus_method_in_uuusu_out_qus_done, req);
+    tevent_req_set_callback(subreq, sbus_method_in_uuusu_out_u_done, req);
 
     ret = EAGAIN;
 
@@ -1683,15 +1661,15 @@ done:
     return req;
 }
 
-static void sbus_method_in_uuusu_out_qus_done(struct tevent_req *subreq)
+static void sbus_method_in_uuusu_out_u_done(struct tevent_req *subreq)
 {
-    struct sbus_method_in_uuusu_out_qus_state *state;
+    struct sbus_method_in_uuusu_out_u_state *state;
     struct tevent_req *req;
     DBusMessage *reply;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
-    state = tevent_req_data(req, struct sbus_method_in_uuusu_out_qus_state);
+    state = tevent_req_data(req, struct sbus_method_in_uuusu_out_u_state);
 
     ret = sbus_call_method_recv(state, subreq, &reply);
     talloc_zfree(subreq);
@@ -1700,7 +1678,7 @@ static void sbus_method_in_uuusu_out_qus_done(struct tevent_req *subreq)
         return;
     }
 
-    ret = sbus_read_output(state->out, reply, (sbus_invoker_reader_fn)_sbus_sss_invoker_read_qus, state->out);
+    ret = sbus_read_output(state->out, reply, (sbus_invoker_reader_fn)_sbus_sss_invoker_read_u, state->out);
     if (ret != EOK) {
         tevent_req_error(req, ret);
         return;
@@ -1711,21 +1689,16 @@ static void sbus_method_in_uuusu_out_qus_done(struct tevent_req *subreq)
 }
 
 static errno_t
-sbus_method_in_uuusu_out_qus_recv
-    (TALLOC_CTX *mem_ctx,
-     struct tevent_req *req,
-     uint16_t* _arg0,
-     uint32_t* _arg1,
-     const char ** _arg2)
+sbus_method_in_uuusu_out_u_recv
+    (struct tevent_req *req,
+     uint32_t* _arg0)
 {
-    struct sbus_method_in_uuusu_out_qus_state *state;
-    state = tevent_req_data(req, struct sbus_method_in_uuusu_out_qus_state);
+    struct sbus_method_in_uuusu_out_u_state *state;
+    state = tevent_req_data(req, struct sbus_method_in_uuusu_out_u_state);
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     *_arg0 = state->out->arg0;
-    *_arg1 = state->out->arg1;
-    *_arg2 = talloc_steal(mem_ctx, state->out->arg2);
 
     return EOK;
 }
@@ -1967,7 +1940,7 @@ sbus_call_dp_dp_getAccountDomain_send
      const char * arg_filter,
      uint32_t arg_cli_id)
 {
-    return sbus_method_in_uusu_out_qus_send(mem_ctx, conn, _sbus_sss_key_uusu_0_1_2,
+    return sbus_method_in_uusu_out_us_send(mem_ctx, conn, _sbus_sss_key_uusu_0_1_2,
         busname, object_path, "sssd.dataprovider", "getAccountDomain", arg_dp_flags, arg_entry_type, arg_filter, arg_cli_id);
 }
 
@@ -1975,11 +1948,10 @@ errno_t
 sbus_call_dp_dp_getAccountDomain_recv
     (TALLOC_CTX *mem_ctx,
      struct tevent_req *req,
-     uint16_t* _dp_error,
      uint32_t* _error,
      const char ** _domain_name)
 {
-    return sbus_method_in_uusu_out_qus_recv(mem_ctx, req, _dp_error, _error, _domain_name);
+    return sbus_method_in_uusu_out_us_recv(mem_ctx, req, _error, _domain_name);
 }
 
 struct tevent_req *
@@ -1995,19 +1967,16 @@ sbus_call_dp_dp_getAccountInfo_send
      const char * arg_extra,
      uint32_t arg_cli_id)
 {
-    return sbus_method_in_uusssu_out_qus_send(mem_ctx, conn, _sbus_sss_key_uusssu_0_1_2_3_4,
+    return sbus_method_in_uusssu_out_u_send(mem_ctx, conn, _sbus_sss_key_uusssu_0_1_2_3_4,
         busname, object_path, "sssd.dataprovider", "getAccountInfo", arg_dp_flags, arg_entry_type, arg_filter, arg_domain, arg_extra, arg_cli_id);
 }
 
 errno_t
 sbus_call_dp_dp_getAccountInfo_recv
-    (TALLOC_CTX *mem_ctx,
-     struct tevent_req *req,
-     uint16_t* _dp_error,
-     uint32_t* _error,
-     const char ** _error_message)
+    (struct tevent_req *req,
+     uint32_t* _error)
 {
-    return sbus_method_in_uusssu_out_qus_recv(mem_ctx, req, _dp_error, _error, _error_message);
+    return sbus_method_in_uusssu_out_u_recv(req, _error);
 }
 
 struct tevent_req *
@@ -2018,19 +1987,16 @@ sbus_call_dp_dp_getDomains_send
      const char *object_path,
      const char * arg_domain_hint)
 {
-    return sbus_method_in_s_out_qus_send(mem_ctx, conn, _sbus_sss_key_s_0,
+    return sbus_method_in_s_out_u_send(mem_ctx, conn, _sbus_sss_key_s_0,
         busname, object_path, "sssd.dataprovider", "getDomains", arg_domain_hint);
 }
 
 errno_t
 sbus_call_dp_dp_getDomains_recv
-    (TALLOC_CTX *mem_ctx,
-     struct tevent_req *req,
-     uint16_t* _dp_error,
-     uint32_t* _error,
-     const char ** _error_message)
+    (struct tevent_req *req,
+     uint32_t* _error)
 {
-    return sbus_method_in_s_out_qus_recv(mem_ctx, req, _dp_error, _error, _error_message);
+    return sbus_method_in_s_out_u_recv(req, _error);
 }
 
 struct tevent_req *
@@ -2044,19 +2010,16 @@ sbus_call_dp_dp_hostHandler_send
      const char * arg_alias,
      uint32_t arg_cli_id)
 {
-    return sbus_method_in_ussu_out_qus_send(mem_ctx, conn, _sbus_sss_key_ussu_0_1,
+    return sbus_method_in_ussu_out_u_send(mem_ctx, conn, _sbus_sss_key_ussu_0_1,
         busname, object_path, "sssd.dataprovider", "hostHandler", arg_dp_flags, arg_name, arg_alias, arg_cli_id);
 }
 
 errno_t
 sbus_call_dp_dp_hostHandler_recv
-    (TALLOC_CTX *mem_ctx,
-     struct tevent_req *req,
-     uint16_t* _dp_error,
-     uint32_t* _error,
-     const char ** _error_message)
+    (struct tevent_req *req,
+     uint32_t* _error)
 {
-    return sbus_method_in_ussu_out_qus_recv(mem_ctx, req, _dp_error, _error, _error_message);
+    return sbus_method_in_ussu_out_u_recv(req, _error);
 }
 
 struct tevent_req *
@@ -2092,19 +2055,16 @@ sbus_call_dp_dp_resolverHandler_send
      const char * arg_filter_value,
      uint32_t arg_cli_id)
 {
-    return sbus_method_in_uuusu_out_qus_send(mem_ctx, conn, _sbus_sss_key_uuusu_0_1_2_3,
+    return sbus_method_in_uuusu_out_u_send(mem_ctx, conn, _sbus_sss_key_uuusu_0_1_2_3,
         busname, object_path, "sssd.dataprovider", "resolverHandler", arg_dp_flags, arg_entry_type, arg_filter_type, arg_filter_value, arg_cli_id);
 }
 
 errno_t
 sbus_call_dp_dp_resolverHandler_recv
-    (TALLOC_CTX *mem_ctx,
-     struct tevent_req *req,
-     uint16_t* _dp_error,
-     uint32_t* _error,
-     const char ** _error_message)
+    (struct tevent_req *req,
+     uint32_t* _error)
 {
-    return sbus_method_in_uuusu_out_qus_recv(mem_ctx, req, _dp_error, _error, _error_message);
+    return sbus_method_in_uuusu_out_u_recv(req, _error);
 }
 
 struct tevent_req *
@@ -2113,18 +2073,15 @@ sbus_call_dp_dp_sudoHandler_send
      struct sbus_connection *conn,
      DBusMessage *raw_message)
 {
-    return sbus_method_in_raw_out_qus_send(mem_ctx, conn, raw_message);
+    return sbus_method_in_raw_out_u_send(mem_ctx, conn, raw_message);
 }
 
 errno_t
 sbus_call_dp_dp_sudoHandler_recv
-    (TALLOC_CTX *mem_ctx,
-     struct tevent_req *req,
-     uint16_t* _dp_error,
-     uint32_t* _error,
-     const char ** _error_message)
+    (struct tevent_req *req,
+     uint32_t* _error)
 {
-    return sbus_method_in_raw_out_qus_recv(mem_ctx, req, _dp_error, _error, _error_message);
+    return sbus_method_in_raw_out_u_recv(req, _error);
 }
 
 struct tevent_req *

--- a/src/sss_iface/sbus_sss_client_async.h
+++ b/src/sss_iface/sbus_sss_client_async.h
@@ -192,7 +192,6 @@ errno_t
 sbus_call_dp_dp_getAccountDomain_recv
     (TALLOC_CTX *mem_ctx,
      struct tevent_req *req,
-     uint16_t* _dp_error,
      uint32_t* _error,
      const char ** _domain_name);
 
@@ -211,11 +210,8 @@ sbus_call_dp_dp_getAccountInfo_send
 
 errno_t
 sbus_call_dp_dp_getAccountInfo_recv
-    (TALLOC_CTX *mem_ctx,
-     struct tevent_req *req,
-     uint16_t* _dp_error,
-     uint32_t* _error,
-     const char ** _error_message);
+    (struct tevent_req *req,
+     uint32_t* _error);
 
 struct tevent_req *
 sbus_call_dp_dp_getDomains_send
@@ -227,11 +223,8 @@ sbus_call_dp_dp_getDomains_send
 
 errno_t
 sbus_call_dp_dp_getDomains_recv
-    (TALLOC_CTX *mem_ctx,
-     struct tevent_req *req,
-     uint16_t* _dp_error,
-     uint32_t* _error,
-     const char ** _error_message);
+    (struct tevent_req *req,
+     uint32_t* _error);
 
 struct tevent_req *
 sbus_call_dp_dp_hostHandler_send
@@ -246,11 +239,8 @@ sbus_call_dp_dp_hostHandler_send
 
 errno_t
 sbus_call_dp_dp_hostHandler_recv
-    (TALLOC_CTX *mem_ctx,
-     struct tevent_req *req,
-     uint16_t* _dp_error,
-     uint32_t* _error,
-     const char ** _error_message);
+    (struct tevent_req *req,
+     uint32_t* _error);
 
 struct tevent_req *
 sbus_call_dp_dp_pamHandler_send
@@ -280,11 +270,8 @@ sbus_call_dp_dp_resolverHandler_send
 
 errno_t
 sbus_call_dp_dp_resolverHandler_recv
-    (TALLOC_CTX *mem_ctx,
-     struct tevent_req *req,
-     uint16_t* _dp_error,
-     uint32_t* _error,
-     const char ** _error_message);
+    (struct tevent_req *req,
+     uint32_t* _error);
 
 struct tevent_req *
 sbus_call_dp_dp_sudoHandler_send
@@ -294,11 +281,8 @@ sbus_call_dp_dp_sudoHandler_send
 
 errno_t
 sbus_call_dp_dp_sudoHandler_recv
-    (TALLOC_CTX *mem_ctx,
-     struct tevent_req *req,
-     uint16_t* _dp_error,
-     uint32_t* _error,
-     const char ** _error_message);
+    (struct tevent_req *req,
+     uint32_t* _error);
 
 struct tevent_req *
 sbus_call_monitor_RegisterService_send

--- a/src/sss_iface/sbus_sss_interface.h
+++ b/src/sss_iface/sbus_sss_interface.h
@@ -497,88 +497,88 @@
 
 /* Method: sssd.dataprovider.getAccountDomain */
 #define SBUS_METHOD_SYNC_sssd_dataprovider_getAccountDomain(handler, data) ({ \
-    SBUS_CHECK_SYNC((handler), (data), uint32_t, uint32_t, const char *, uint32_t, uint16_t*, uint32_t*, const char **); \
+    SBUS_CHECK_SYNC((handler), (data), uint32_t, uint32_t, const char *, uint32_t, uint32_t*, const char **); \
     sbus_method_sync("getAccountDomain", \
         &_sbus_sss_args_sssd_dataprovider_getAccountDomain, \
         NULL, \
-        _sbus_sss_invoke_in_uusu_out_qus_send, \
+        _sbus_sss_invoke_in_uusu_out_us_send, \
         _sbus_sss_key_uusu_0_1_2, \
         (handler), (data)); \
 })
 
 #define SBUS_METHOD_ASYNC_sssd_dataprovider_getAccountDomain(handler_send, handler_recv, data) ({ \
     SBUS_CHECK_SEND((handler_send), (data), uint32_t, uint32_t, const char *, uint32_t); \
-    SBUS_CHECK_RECV((handler_recv), uint16_t*, uint32_t*, const char **); \
+    SBUS_CHECK_RECV((handler_recv), uint32_t*, const char **); \
     sbus_method_async("getAccountDomain", \
         &_sbus_sss_args_sssd_dataprovider_getAccountDomain, \
         NULL, \
-        _sbus_sss_invoke_in_uusu_out_qus_send, \
+        _sbus_sss_invoke_in_uusu_out_us_send, \
         _sbus_sss_key_uusu_0_1_2, \
         (handler_send), (handler_recv), (data)); \
 })
 
 /* Method: sssd.dataprovider.getAccountInfo */
 #define SBUS_METHOD_SYNC_sssd_dataprovider_getAccountInfo(handler, data) ({ \
-    SBUS_CHECK_SYNC((handler), (data), uint32_t, uint32_t, const char *, const char *, const char *, uint32_t, uint16_t*, uint32_t*, const char **); \
+    SBUS_CHECK_SYNC((handler), (data), uint32_t, uint32_t, const char *, const char *, const char *, uint32_t, uint32_t*); \
     sbus_method_sync("getAccountInfo", \
         &_sbus_sss_args_sssd_dataprovider_getAccountInfo, \
         NULL, \
-        _sbus_sss_invoke_in_uusssu_out_qus_send, \
+        _sbus_sss_invoke_in_uusssu_out_u_send, \
         _sbus_sss_key_uusssu_0_1_2_3_4, \
         (handler), (data)); \
 })
 
 #define SBUS_METHOD_ASYNC_sssd_dataprovider_getAccountInfo(handler_send, handler_recv, data) ({ \
     SBUS_CHECK_SEND((handler_send), (data), uint32_t, uint32_t, const char *, const char *, const char *, uint32_t); \
-    SBUS_CHECK_RECV((handler_recv), uint16_t*, uint32_t*, const char **); \
+    SBUS_CHECK_RECV((handler_recv), uint32_t*); \
     sbus_method_async("getAccountInfo", \
         &_sbus_sss_args_sssd_dataprovider_getAccountInfo, \
         NULL, \
-        _sbus_sss_invoke_in_uusssu_out_qus_send, \
+        _sbus_sss_invoke_in_uusssu_out_u_send, \
         _sbus_sss_key_uusssu_0_1_2_3_4, \
         (handler_send), (handler_recv), (data)); \
 })
 
 /* Method: sssd.dataprovider.getDomains */
 #define SBUS_METHOD_SYNC_sssd_dataprovider_getDomains(handler, data) ({ \
-    SBUS_CHECK_SYNC((handler), (data), const char *, uint16_t*, uint32_t*, const char **); \
+    SBUS_CHECK_SYNC((handler), (data), const char *, uint32_t*); \
     sbus_method_sync("getDomains", \
         &_sbus_sss_args_sssd_dataprovider_getDomains, \
         NULL, \
-        _sbus_sss_invoke_in_s_out_qus_send, \
+        _sbus_sss_invoke_in_s_out_u_send, \
         _sbus_sss_key_s_0, \
         (handler), (data)); \
 })
 
 #define SBUS_METHOD_ASYNC_sssd_dataprovider_getDomains(handler_send, handler_recv, data) ({ \
     SBUS_CHECK_SEND((handler_send), (data), const char *); \
-    SBUS_CHECK_RECV((handler_recv), uint16_t*, uint32_t*, const char **); \
+    SBUS_CHECK_RECV((handler_recv), uint32_t*); \
     sbus_method_async("getDomains", \
         &_sbus_sss_args_sssd_dataprovider_getDomains, \
         NULL, \
-        _sbus_sss_invoke_in_s_out_qus_send, \
+        _sbus_sss_invoke_in_s_out_u_send, \
         _sbus_sss_key_s_0, \
         (handler_send), (handler_recv), (data)); \
 })
 
 /* Method: sssd.dataprovider.hostHandler */
 #define SBUS_METHOD_SYNC_sssd_dataprovider_hostHandler(handler, data) ({ \
-    SBUS_CHECK_SYNC((handler), (data), uint32_t, const char *, const char *, uint32_t, uint16_t*, uint32_t*, const char **); \
+    SBUS_CHECK_SYNC((handler), (data), uint32_t, const char *, const char *, uint32_t, uint32_t*); \
     sbus_method_sync("hostHandler", \
         &_sbus_sss_args_sssd_dataprovider_hostHandler, \
         NULL, \
-        _sbus_sss_invoke_in_ussu_out_qus_send, \
+        _sbus_sss_invoke_in_ussu_out_u_send, \
         _sbus_sss_key_ussu_0_1, \
         (handler), (data)); \
 })
 
 #define SBUS_METHOD_ASYNC_sssd_dataprovider_hostHandler(handler_send, handler_recv, data) ({ \
     SBUS_CHECK_SEND((handler_send), (data), uint32_t, const char *, const char *, uint32_t); \
-    SBUS_CHECK_RECV((handler_recv), uint16_t*, uint32_t*, const char **); \
+    SBUS_CHECK_RECV((handler_recv), uint32_t*); \
     sbus_method_async("hostHandler", \
         &_sbus_sss_args_sssd_dataprovider_hostHandler, \
         NULL, \
-        _sbus_sss_invoke_in_ussu_out_qus_send, \
+        _sbus_sss_invoke_in_ussu_out_u_send, \
         _sbus_sss_key_ussu_0_1, \
         (handler_send), (handler_recv), (data)); \
 })
@@ -607,44 +607,44 @@
 
 /* Method: sssd.dataprovider.resolverHandler */
 #define SBUS_METHOD_SYNC_sssd_dataprovider_resolverHandler(handler, data) ({ \
-    SBUS_CHECK_SYNC((handler), (data), uint32_t, uint32_t, uint32_t, const char *, uint32_t, uint16_t*, uint32_t*, const char **); \
+    SBUS_CHECK_SYNC((handler), (data), uint32_t, uint32_t, uint32_t, const char *, uint32_t, uint32_t*); \
     sbus_method_sync("resolverHandler", \
         &_sbus_sss_args_sssd_dataprovider_resolverHandler, \
         NULL, \
-        _sbus_sss_invoke_in_uuusu_out_qus_send, \
+        _sbus_sss_invoke_in_uuusu_out_u_send, \
         _sbus_sss_key_uuusu_0_1_2_3, \
         (handler), (data)); \
 })
 
 #define SBUS_METHOD_ASYNC_sssd_dataprovider_resolverHandler(handler_send, handler_recv, data) ({ \
     SBUS_CHECK_SEND((handler_send), (data), uint32_t, uint32_t, uint32_t, const char *, uint32_t); \
-    SBUS_CHECK_RECV((handler_recv), uint16_t*, uint32_t*, const char **); \
+    SBUS_CHECK_RECV((handler_recv), uint32_t*); \
     sbus_method_async("resolverHandler", \
         &_sbus_sss_args_sssd_dataprovider_resolverHandler, \
         NULL, \
-        _sbus_sss_invoke_in_uuusu_out_qus_send, \
+        _sbus_sss_invoke_in_uuusu_out_u_send, \
         _sbus_sss_key_uuusu_0_1_2_3, \
         (handler_send), (handler_recv), (data)); \
 })
 
 /* Method: sssd.dataprovider.sudoHandler */
 #define SBUS_METHOD_SYNC_sssd_dataprovider_sudoHandler(handler, data) ({ \
-    SBUS_CHECK_SYNC((handler), (data), DBusMessageIter *, uint16_t*, uint32_t*, const char **); \
+    SBUS_CHECK_SYNC((handler), (data), DBusMessageIter *, uint32_t*); \
     sbus_method_sync("sudoHandler", \
         &_sbus_sss_args_sssd_dataprovider_sudoHandler, \
         NULL, \
-        _sbus_sss_invoke_in_raw_out_qus_send, \
+        _sbus_sss_invoke_in_raw_out_u_send, \
         NULL, \
         (handler), (data)); \
 })
 
 #define SBUS_METHOD_ASYNC_sssd_dataprovider_sudoHandler(handler_send, handler_recv, data) ({ \
     SBUS_CHECK_SEND((handler_send), (data), DBusMessageIter *); \
-    SBUS_CHECK_RECV((handler_recv), uint16_t*, uint32_t*, const char **); \
+    SBUS_CHECK_RECV((handler_recv), uint32_t*); \
     sbus_method_async("sudoHandler", \
         &_sbus_sss_args_sssd_dataprovider_sudoHandler, \
         NULL, \
-        _sbus_sss_invoke_in_raw_out_qus_send, \
+        _sbus_sss_invoke_in_raw_out_u_send, \
         NULL, \
         (handler_send), (handler_recv), (data)); \
 })

--- a/src/sss_iface/sbus_sss_invokers.c
+++ b/src/sss_iface/sbus_sss_invokers.c
@@ -561,14 +561,14 @@ static void _sbus_sss_invoke_in_pam_data_out_pam_response_done(struct tevent_req
     return;
 }
 
-struct _sbus_sss_invoke_in_raw_out_qus_state {
-    struct _sbus_sss_invoker_args_qus out;
+struct _sbus_sss_invoke_in_raw_out_u_state {
+    struct _sbus_sss_invoker_args_u out;
     struct {
         enum sbus_handler_type type;
         void *data;
-        errno_t (*sync)(TALLOC_CTX *, struct sbus_request *, void *, DBusMessageIter *, uint16_t*, uint32_t*, const char **);
+        errno_t (*sync)(TALLOC_CTX *, struct sbus_request *, void *, DBusMessageIter *, uint32_t*);
         struct tevent_req * (*send)(TALLOC_CTX *, struct tevent_context *, struct sbus_request *, void *, DBusMessageIter *);
-        errno_t (*recv)(TALLOC_CTX *, struct tevent_req *, uint16_t*, uint32_t*, const char **);
+        errno_t (*recv)(TALLOC_CTX *, struct tevent_req *, uint32_t*);
     } handler;
 
     struct sbus_request *sbus_req;
@@ -577,18 +577,18 @@ struct _sbus_sss_invoke_in_raw_out_qus_state {
 };
 
 static void
-_sbus_sss_invoke_in_raw_out_qus_step
+_sbus_sss_invoke_in_raw_out_u_step
     (struct tevent_context *ev,
      struct tevent_timer *te,
      struct timeval tv,
      void *private_data);
 
 static void
-_sbus_sss_invoke_in_raw_out_qus_done
+_sbus_sss_invoke_in_raw_out_u_done
    (struct tevent_req *subreq);
 
 struct tevent_req *
-_sbus_sss_invoke_in_raw_out_qus_send
+_sbus_sss_invoke_in_raw_out_u_send
    (TALLOC_CTX *mem_ctx,
     struct tevent_context *ev,
     struct sbus_request *sbus_req,
@@ -598,12 +598,12 @@ _sbus_sss_invoke_in_raw_out_qus_send
     DBusMessageIter *write_iterator,
     const char **_key)
 {
-    struct _sbus_sss_invoke_in_raw_out_qus_state *state;
+    struct _sbus_sss_invoke_in_raw_out_u_state *state;
     struct tevent_req *req;
     const char *key;
     errno_t ret;
 
-    req = tevent_req_create(mem_ctx, &state, struct _sbus_sss_invoke_in_raw_out_qus_state);
+    req = tevent_req_create(mem_ctx, &state, struct _sbus_sss_invoke_in_raw_out_u_state);
     if (req == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
         return NULL;
@@ -619,7 +619,7 @@ _sbus_sss_invoke_in_raw_out_qus_send
     state->read_iterator = read_iterator;
     state->write_iterator = write_iterator;
 
-    ret = sbus_invoker_schedule(state, ev, _sbus_sss_invoke_in_raw_out_qus_step, req);
+    ret = sbus_invoker_schedule(state, ev, _sbus_sss_invoke_in_raw_out_u_step, req);
     if (ret != EOK) {
         goto done;
     }
@@ -644,19 +644,19 @@ done:
     return req;
 }
 
-static void _sbus_sss_invoke_in_raw_out_qus_step
+static void _sbus_sss_invoke_in_raw_out_u_step
    (struct tevent_context *ev,
     struct tevent_timer *te,
     struct timeval tv,
     void *private_data)
 {
-    struct _sbus_sss_invoke_in_raw_out_qus_state *state;
+    struct _sbus_sss_invoke_in_raw_out_u_state *state;
     struct tevent_req *subreq;
     struct tevent_req *req;
     errno_t ret;
 
     req = talloc_get_type(private_data, struct tevent_req);
-    state = tevent_req_data(req, struct _sbus_sss_invoke_in_raw_out_qus_state);
+    state = tevent_req_data(req, struct _sbus_sss_invoke_in_raw_out_u_state);
 
     switch (state->handler.type) {
     case SBUS_HANDLER_SYNC:
@@ -666,12 +666,12 @@ static void _sbus_sss_invoke_in_raw_out_qus_step
             goto done;
         }
 
-        ret = state->handler.sync(state, state->sbus_req, state->handler.data, state->read_iterator, &state->out.arg0, &state->out.arg1, &state->out.arg2);
+        ret = state->handler.sync(state, state->sbus_req, state->handler.data, state->read_iterator, &state->out.arg0);
         if (ret != EOK) {
             goto done;
         }
 
-        ret = _sbus_sss_invoker_write_qus(state->write_iterator, &state->out);
+        ret = _sbus_sss_invoker_write_u(state->write_iterator, &state->out);
         goto done;
     case SBUS_HANDLER_ASYNC:
         if (state->handler.send == NULL || state->handler.recv == NULL) {
@@ -687,7 +687,7 @@ static void _sbus_sss_invoke_in_raw_out_qus_step
             goto done;
         }
 
-        tevent_req_set_callback(subreq, _sbus_sss_invoke_in_raw_out_qus_done, req);
+        tevent_req_set_callback(subreq, _sbus_sss_invoke_in_raw_out_u_done, req);
         ret = EAGAIN;
         goto done;
     }
@@ -702,23 +702,23 @@ done:
     }
 }
 
-static void _sbus_sss_invoke_in_raw_out_qus_done(struct tevent_req *subreq)
+static void _sbus_sss_invoke_in_raw_out_u_done(struct tevent_req *subreq)
 {
-    struct _sbus_sss_invoke_in_raw_out_qus_state *state;
+    struct _sbus_sss_invoke_in_raw_out_u_state *state;
     struct tevent_req *req;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
-    state = tevent_req_data(req, struct _sbus_sss_invoke_in_raw_out_qus_state);
+    state = tevent_req_data(req, struct _sbus_sss_invoke_in_raw_out_u_state);
 
-    ret = state->handler.recv(state, subreq, &state->out.arg0, &state->out.arg1, &state->out.arg2);
+    ret = state->handler.recv(state, subreq, &state->out.arg0);
     talloc_zfree(subreq);
     if (ret != EOK) {
         tevent_req_error(req, ret);
         return;
     }
 
-    ret = _sbus_sss_invoker_write_qus(state->write_iterator, &state->out);
+    ret = _sbus_sss_invoker_write_u(state->write_iterator, &state->out);
     if (ret != EOK) {
         tevent_req_error(req, ret);
         return;
@@ -1263,187 +1263,6 @@ static void _sbus_sss_invoke_in_s_out_b_done(struct tevent_req *subreq)
     return;
 }
 
-struct _sbus_sss_invoke_in_s_out_qus_state {
-    struct _sbus_sss_invoker_args_s *in;
-    struct _sbus_sss_invoker_args_qus out;
-    struct {
-        enum sbus_handler_type type;
-        void *data;
-        errno_t (*sync)(TALLOC_CTX *, struct sbus_request *, void *, const char *, uint16_t*, uint32_t*, const char **);
-        struct tevent_req * (*send)(TALLOC_CTX *, struct tevent_context *, struct sbus_request *, void *, const char *);
-        errno_t (*recv)(TALLOC_CTX *, struct tevent_req *, uint16_t*, uint32_t*, const char **);
-    } handler;
-
-    struct sbus_request *sbus_req;
-    DBusMessageIter *read_iterator;
-    DBusMessageIter *write_iterator;
-};
-
-static void
-_sbus_sss_invoke_in_s_out_qus_step
-    (struct tevent_context *ev,
-     struct tevent_timer *te,
-     struct timeval tv,
-     void *private_data);
-
-static void
-_sbus_sss_invoke_in_s_out_qus_done
-   (struct tevent_req *subreq);
-
-struct tevent_req *
-_sbus_sss_invoke_in_s_out_qus_send
-   (TALLOC_CTX *mem_ctx,
-    struct tevent_context *ev,
-    struct sbus_request *sbus_req,
-    sbus_invoker_keygen keygen,
-    const struct sbus_handler *handler,
-    DBusMessageIter *read_iterator,
-    DBusMessageIter *write_iterator,
-    const char **_key)
-{
-    struct _sbus_sss_invoke_in_s_out_qus_state *state;
-    struct tevent_req *req;
-    const char *key;
-    errno_t ret;
-
-    req = tevent_req_create(mem_ctx, &state, struct _sbus_sss_invoke_in_s_out_qus_state);
-    if (req == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
-        return NULL;
-    }
-
-    state->handler.type = handler->type;
-    state->handler.data = handler->data;
-    state->handler.sync = handler->sync;
-    state->handler.send = handler->async_send;
-    state->handler.recv = handler->async_recv;
-
-    state->sbus_req = sbus_req;
-    state->read_iterator = read_iterator;
-    state->write_iterator = write_iterator;
-
-    state->in = talloc_zero(state, struct _sbus_sss_invoker_args_s);
-    if (state->in == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE,
-              "Unable to allocate space for input parameters!\n");
-        ret = ENOMEM;
-        goto done;
-    }
-
-    ret = _sbus_sss_invoker_read_s(state, read_iterator, state->in);
-    if (ret != EOK) {
-        goto done;
-    }
-
-    ret = sbus_invoker_schedule(state, ev, _sbus_sss_invoke_in_s_out_qus_step, req);
-    if (ret != EOK) {
-        goto done;
-    }
-
-    ret = sbus_request_key(state, keygen, sbus_req, state->in, &key);
-    if (ret != EOK) {
-        goto done;
-    }
-
-    if (_key != NULL) {
-        *_key = talloc_steal(mem_ctx, key);
-    }
-
-    ret = EAGAIN;
-
-done:
-    if (ret != EAGAIN) {
-        tevent_req_error(req, ret);
-        tevent_req_post(req, ev);
-    }
-
-    return req;
-}
-
-static void _sbus_sss_invoke_in_s_out_qus_step
-   (struct tevent_context *ev,
-    struct tevent_timer *te,
-    struct timeval tv,
-    void *private_data)
-{
-    struct _sbus_sss_invoke_in_s_out_qus_state *state;
-    struct tevent_req *subreq;
-    struct tevent_req *req;
-    errno_t ret;
-
-    req = talloc_get_type(private_data, struct tevent_req);
-    state = tevent_req_data(req, struct _sbus_sss_invoke_in_s_out_qus_state);
-
-    switch (state->handler.type) {
-    case SBUS_HANDLER_SYNC:
-        if (state->handler.sync == NULL) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "Bug: sync handler is not specified!\n");
-            ret = ERR_INTERNAL;
-            goto done;
-        }
-
-        ret = state->handler.sync(state, state->sbus_req, state->handler.data, state->in->arg0, &state->out.arg0, &state->out.arg1, &state->out.arg2);
-        if (ret != EOK) {
-            goto done;
-        }
-
-        ret = _sbus_sss_invoker_write_qus(state->write_iterator, &state->out);
-        goto done;
-    case SBUS_HANDLER_ASYNC:
-        if (state->handler.send == NULL || state->handler.recv == NULL) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "Bug: async handler is not specified!\n");
-            ret = ERR_INTERNAL;
-            goto done;
-        }
-
-        subreq = state->handler.send(state, ev, state->sbus_req, state->handler.data, state->in->arg0);
-        if (subreq == NULL) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
-            ret = ENOMEM;
-            goto done;
-        }
-
-        tevent_req_set_callback(subreq, _sbus_sss_invoke_in_s_out_qus_done, req);
-        ret = EAGAIN;
-        goto done;
-    }
-
-    ret = ERR_INTERNAL;
-
-done:
-    if (ret == EOK) {
-        tevent_req_done(req);
-    } else if (ret != EAGAIN) {
-        tevent_req_error(req, ret);
-    }
-}
-
-static void _sbus_sss_invoke_in_s_out_qus_done(struct tevent_req *subreq)
-{
-    struct _sbus_sss_invoke_in_s_out_qus_state *state;
-    struct tevent_req *req;
-    errno_t ret;
-
-    req = tevent_req_callback_data(subreq, struct tevent_req);
-    state = tevent_req_data(req, struct _sbus_sss_invoke_in_s_out_qus_state);
-
-    ret = state->handler.recv(state, subreq, &state->out.arg0, &state->out.arg1, &state->out.arg2);
-    talloc_zfree(subreq);
-    if (ret != EOK) {
-        tevent_req_error(req, ret);
-        return;
-    }
-
-    ret = _sbus_sss_invoker_write_qus(state->write_iterator, &state->out);
-    if (ret != EOK) {
-        tevent_req_error(req, ret);
-        return;
-    }
-
-    tevent_req_done(req);
-    return;
-}
-
 struct _sbus_sss_invoke_in_s_out_s_state {
     struct _sbus_sss_invoker_args_s *in;
     struct _sbus_sss_invoker_args_s out;
@@ -1616,6 +1435,187 @@ static void _sbus_sss_invoke_in_s_out_s_done(struct tevent_req *subreq)
     }
 
     ret = _sbus_sss_invoker_write_s(state->write_iterator, &state->out);
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    tevent_req_done(req);
+    return;
+}
+
+struct _sbus_sss_invoke_in_s_out_u_state {
+    struct _sbus_sss_invoker_args_s *in;
+    struct _sbus_sss_invoker_args_u out;
+    struct {
+        enum sbus_handler_type type;
+        void *data;
+        errno_t (*sync)(TALLOC_CTX *, struct sbus_request *, void *, const char *, uint32_t*);
+        struct tevent_req * (*send)(TALLOC_CTX *, struct tevent_context *, struct sbus_request *, void *, const char *);
+        errno_t (*recv)(TALLOC_CTX *, struct tevent_req *, uint32_t*);
+    } handler;
+
+    struct sbus_request *sbus_req;
+    DBusMessageIter *read_iterator;
+    DBusMessageIter *write_iterator;
+};
+
+static void
+_sbus_sss_invoke_in_s_out_u_step
+    (struct tevent_context *ev,
+     struct tevent_timer *te,
+     struct timeval tv,
+     void *private_data);
+
+static void
+_sbus_sss_invoke_in_s_out_u_done
+   (struct tevent_req *subreq);
+
+struct tevent_req *
+_sbus_sss_invoke_in_s_out_u_send
+   (TALLOC_CTX *mem_ctx,
+    struct tevent_context *ev,
+    struct sbus_request *sbus_req,
+    sbus_invoker_keygen keygen,
+    const struct sbus_handler *handler,
+    DBusMessageIter *read_iterator,
+    DBusMessageIter *write_iterator,
+    const char **_key)
+{
+    struct _sbus_sss_invoke_in_s_out_u_state *state;
+    struct tevent_req *req;
+    const char *key;
+    errno_t ret;
+
+    req = tevent_req_create(mem_ctx, &state, struct _sbus_sss_invoke_in_s_out_u_state);
+    if (req == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
+        return NULL;
+    }
+
+    state->handler.type = handler->type;
+    state->handler.data = handler->data;
+    state->handler.sync = handler->sync;
+    state->handler.send = handler->async_send;
+    state->handler.recv = handler->async_recv;
+
+    state->sbus_req = sbus_req;
+    state->read_iterator = read_iterator;
+    state->write_iterator = write_iterator;
+
+    state->in = talloc_zero(state, struct _sbus_sss_invoker_args_s);
+    if (state->in == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Unable to allocate space for input parameters!\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = _sbus_sss_invoker_read_s(state, read_iterator, state->in);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    ret = sbus_invoker_schedule(state, ev, _sbus_sss_invoke_in_s_out_u_step, req);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    ret = sbus_request_key(state, keygen, sbus_req, state->in, &key);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    if (_key != NULL) {
+        *_key = talloc_steal(mem_ctx, key);
+    }
+
+    ret = EAGAIN;
+
+done:
+    if (ret != EAGAIN) {
+        tevent_req_error(req, ret);
+        tevent_req_post(req, ev);
+    }
+
+    return req;
+}
+
+static void _sbus_sss_invoke_in_s_out_u_step
+   (struct tevent_context *ev,
+    struct tevent_timer *te,
+    struct timeval tv,
+    void *private_data)
+{
+    struct _sbus_sss_invoke_in_s_out_u_state *state;
+    struct tevent_req *subreq;
+    struct tevent_req *req;
+    errno_t ret;
+
+    req = talloc_get_type(private_data, struct tevent_req);
+    state = tevent_req_data(req, struct _sbus_sss_invoke_in_s_out_u_state);
+
+    switch (state->handler.type) {
+    case SBUS_HANDLER_SYNC:
+        if (state->handler.sync == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "Bug: sync handler is not specified!\n");
+            ret = ERR_INTERNAL;
+            goto done;
+        }
+
+        ret = state->handler.sync(state, state->sbus_req, state->handler.data, state->in->arg0, &state->out.arg0);
+        if (ret != EOK) {
+            goto done;
+        }
+
+        ret = _sbus_sss_invoker_write_u(state->write_iterator, &state->out);
+        goto done;
+    case SBUS_HANDLER_ASYNC:
+        if (state->handler.send == NULL || state->handler.recv == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "Bug: async handler is not specified!\n");
+            ret = ERR_INTERNAL;
+            goto done;
+        }
+
+        subreq = state->handler.send(state, ev, state->sbus_req, state->handler.data, state->in->arg0);
+        if (subreq == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create subrequest!\n");
+            ret = ENOMEM;
+            goto done;
+        }
+
+        tevent_req_set_callback(subreq, _sbus_sss_invoke_in_s_out_u_done, req);
+        ret = EAGAIN;
+        goto done;
+    }
+
+    ret = ERR_INTERNAL;
+
+done:
+    if (ret == EOK) {
+        tevent_req_done(req);
+    } else if (ret != EAGAIN) {
+        tevent_req_error(req, ret);
+    }
+}
+
+static void _sbus_sss_invoke_in_s_out_u_done(struct tevent_req *subreq)
+{
+    struct _sbus_sss_invoke_in_s_out_u_state *state;
+    struct tevent_req *req;
+    errno_t ret;
+
+    req = tevent_req_callback_data(subreq, struct tevent_req);
+    state = tevent_req_data(req, struct _sbus_sss_invoke_in_s_out_u_state);
+
+    ret = state->handler.recv(state, subreq, &state->out.arg0);
+    talloc_zfree(subreq);
+    if (ret != EOK) {
+        tevent_req_error(req, ret);
+        return;
+    }
+
+    ret = _sbus_sss_invoker_write_u(state->write_iterator, &state->out);
     if (ret != EOK) {
         tevent_req_error(req, ret);
         return;
@@ -2679,15 +2679,15 @@ static void _sbus_sss_invoke_in_ussu_out__done(struct tevent_req *subreq)
     return;
 }
 
-struct _sbus_sss_invoke_in_ussu_out_qus_state {
+struct _sbus_sss_invoke_in_ussu_out_u_state {
     struct _sbus_sss_invoker_args_ussu *in;
-    struct _sbus_sss_invoker_args_qus out;
+    struct _sbus_sss_invoker_args_u out;
     struct {
         enum sbus_handler_type type;
         void *data;
-        errno_t (*sync)(TALLOC_CTX *, struct sbus_request *, void *, uint32_t, const char *, const char *, uint32_t, uint16_t*, uint32_t*, const char **);
+        errno_t (*sync)(TALLOC_CTX *, struct sbus_request *, void *, uint32_t, const char *, const char *, uint32_t, uint32_t*);
         struct tevent_req * (*send)(TALLOC_CTX *, struct tevent_context *, struct sbus_request *, void *, uint32_t, const char *, const char *, uint32_t);
-        errno_t (*recv)(TALLOC_CTX *, struct tevent_req *, uint16_t*, uint32_t*, const char **);
+        errno_t (*recv)(TALLOC_CTX *, struct tevent_req *, uint32_t*);
     } handler;
 
     struct sbus_request *sbus_req;
@@ -2696,18 +2696,18 @@ struct _sbus_sss_invoke_in_ussu_out_qus_state {
 };
 
 static void
-_sbus_sss_invoke_in_ussu_out_qus_step
+_sbus_sss_invoke_in_ussu_out_u_step
     (struct tevent_context *ev,
      struct tevent_timer *te,
      struct timeval tv,
      void *private_data);
 
 static void
-_sbus_sss_invoke_in_ussu_out_qus_done
+_sbus_sss_invoke_in_ussu_out_u_done
    (struct tevent_req *subreq);
 
 struct tevent_req *
-_sbus_sss_invoke_in_ussu_out_qus_send
+_sbus_sss_invoke_in_ussu_out_u_send
    (TALLOC_CTX *mem_ctx,
     struct tevent_context *ev,
     struct sbus_request *sbus_req,
@@ -2717,12 +2717,12 @@ _sbus_sss_invoke_in_ussu_out_qus_send
     DBusMessageIter *write_iterator,
     const char **_key)
 {
-    struct _sbus_sss_invoke_in_ussu_out_qus_state *state;
+    struct _sbus_sss_invoke_in_ussu_out_u_state *state;
     struct tevent_req *req;
     const char *key;
     errno_t ret;
 
-    req = tevent_req_create(mem_ctx, &state, struct _sbus_sss_invoke_in_ussu_out_qus_state);
+    req = tevent_req_create(mem_ctx, &state, struct _sbus_sss_invoke_in_ussu_out_u_state);
     if (req == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
         return NULL;
@@ -2751,7 +2751,7 @@ _sbus_sss_invoke_in_ussu_out_qus_send
         goto done;
     }
 
-    ret = sbus_invoker_schedule(state, ev, _sbus_sss_invoke_in_ussu_out_qus_step, req);
+    ret = sbus_invoker_schedule(state, ev, _sbus_sss_invoke_in_ussu_out_u_step, req);
     if (ret != EOK) {
         goto done;
     }
@@ -2776,19 +2776,19 @@ done:
     return req;
 }
 
-static void _sbus_sss_invoke_in_ussu_out_qus_step
+static void _sbus_sss_invoke_in_ussu_out_u_step
    (struct tevent_context *ev,
     struct tevent_timer *te,
     struct timeval tv,
     void *private_data)
 {
-    struct _sbus_sss_invoke_in_ussu_out_qus_state *state;
+    struct _sbus_sss_invoke_in_ussu_out_u_state *state;
     struct tevent_req *subreq;
     struct tevent_req *req;
     errno_t ret;
 
     req = talloc_get_type(private_data, struct tevent_req);
-    state = tevent_req_data(req, struct _sbus_sss_invoke_in_ussu_out_qus_state);
+    state = tevent_req_data(req, struct _sbus_sss_invoke_in_ussu_out_u_state);
 
     switch (state->handler.type) {
     case SBUS_HANDLER_SYNC:
@@ -2798,12 +2798,12 @@ static void _sbus_sss_invoke_in_ussu_out_qus_step
             goto done;
         }
 
-        ret = state->handler.sync(state, state->sbus_req, state->handler.data, state->in->arg0, state->in->arg1, state->in->arg2, state->in->arg3, &state->out.arg0, &state->out.arg1, &state->out.arg2);
+        ret = state->handler.sync(state, state->sbus_req, state->handler.data, state->in->arg0, state->in->arg1, state->in->arg2, state->in->arg3, &state->out.arg0);
         if (ret != EOK) {
             goto done;
         }
 
-        ret = _sbus_sss_invoker_write_qus(state->write_iterator, &state->out);
+        ret = _sbus_sss_invoker_write_u(state->write_iterator, &state->out);
         goto done;
     case SBUS_HANDLER_ASYNC:
         if (state->handler.send == NULL || state->handler.recv == NULL) {
@@ -2819,7 +2819,7 @@ static void _sbus_sss_invoke_in_ussu_out_qus_step
             goto done;
         }
 
-        tevent_req_set_callback(subreq, _sbus_sss_invoke_in_ussu_out_qus_done, req);
+        tevent_req_set_callback(subreq, _sbus_sss_invoke_in_ussu_out_u_done, req);
         ret = EAGAIN;
         goto done;
     }
@@ -2834,23 +2834,23 @@ done:
     }
 }
 
-static void _sbus_sss_invoke_in_ussu_out_qus_done(struct tevent_req *subreq)
+static void _sbus_sss_invoke_in_ussu_out_u_done(struct tevent_req *subreq)
 {
-    struct _sbus_sss_invoke_in_ussu_out_qus_state *state;
+    struct _sbus_sss_invoke_in_ussu_out_u_state *state;
     struct tevent_req *req;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
-    state = tevent_req_data(req, struct _sbus_sss_invoke_in_ussu_out_qus_state);
+    state = tevent_req_data(req, struct _sbus_sss_invoke_in_ussu_out_u_state);
 
-    ret = state->handler.recv(state, subreq, &state->out.arg0, &state->out.arg1, &state->out.arg2);
+    ret = state->handler.recv(state, subreq, &state->out.arg0);
     talloc_zfree(subreq);
     if (ret != EOK) {
         tevent_req_error(req, ret);
         return;
     }
 
-    ret = _sbus_sss_invoker_write_qus(state->write_iterator, &state->out);
+    ret = _sbus_sss_invoker_write_u(state->write_iterator, &state->out);
     if (ret != EOK) {
         tevent_req_error(req, ret);
         return;
@@ -3033,15 +3033,15 @@ static void _sbus_sss_invoke_in_usu_out__done(struct tevent_req *subreq)
     return;
 }
 
-struct _sbus_sss_invoke_in_uusssu_out_qus_state {
+struct _sbus_sss_invoke_in_uusssu_out_u_state {
     struct _sbus_sss_invoker_args_uusssu *in;
-    struct _sbus_sss_invoker_args_qus out;
+    struct _sbus_sss_invoker_args_u out;
     struct {
         enum sbus_handler_type type;
         void *data;
-        errno_t (*sync)(TALLOC_CTX *, struct sbus_request *, void *, uint32_t, uint32_t, const char *, const char *, const char *, uint32_t, uint16_t*, uint32_t*, const char **);
+        errno_t (*sync)(TALLOC_CTX *, struct sbus_request *, void *, uint32_t, uint32_t, const char *, const char *, const char *, uint32_t, uint32_t*);
         struct tevent_req * (*send)(TALLOC_CTX *, struct tevent_context *, struct sbus_request *, void *, uint32_t, uint32_t, const char *, const char *, const char *, uint32_t);
-        errno_t (*recv)(TALLOC_CTX *, struct tevent_req *, uint16_t*, uint32_t*, const char **);
+        errno_t (*recv)(TALLOC_CTX *, struct tevent_req *, uint32_t*);
     } handler;
 
     struct sbus_request *sbus_req;
@@ -3050,18 +3050,18 @@ struct _sbus_sss_invoke_in_uusssu_out_qus_state {
 };
 
 static void
-_sbus_sss_invoke_in_uusssu_out_qus_step
+_sbus_sss_invoke_in_uusssu_out_u_step
     (struct tevent_context *ev,
      struct tevent_timer *te,
      struct timeval tv,
      void *private_data);
 
 static void
-_sbus_sss_invoke_in_uusssu_out_qus_done
+_sbus_sss_invoke_in_uusssu_out_u_done
    (struct tevent_req *subreq);
 
 struct tevent_req *
-_sbus_sss_invoke_in_uusssu_out_qus_send
+_sbus_sss_invoke_in_uusssu_out_u_send
    (TALLOC_CTX *mem_ctx,
     struct tevent_context *ev,
     struct sbus_request *sbus_req,
@@ -3071,12 +3071,12 @@ _sbus_sss_invoke_in_uusssu_out_qus_send
     DBusMessageIter *write_iterator,
     const char **_key)
 {
-    struct _sbus_sss_invoke_in_uusssu_out_qus_state *state;
+    struct _sbus_sss_invoke_in_uusssu_out_u_state *state;
     struct tevent_req *req;
     const char *key;
     errno_t ret;
 
-    req = tevent_req_create(mem_ctx, &state, struct _sbus_sss_invoke_in_uusssu_out_qus_state);
+    req = tevent_req_create(mem_ctx, &state, struct _sbus_sss_invoke_in_uusssu_out_u_state);
     if (req == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
         return NULL;
@@ -3105,7 +3105,7 @@ _sbus_sss_invoke_in_uusssu_out_qus_send
         goto done;
     }
 
-    ret = sbus_invoker_schedule(state, ev, _sbus_sss_invoke_in_uusssu_out_qus_step, req);
+    ret = sbus_invoker_schedule(state, ev, _sbus_sss_invoke_in_uusssu_out_u_step, req);
     if (ret != EOK) {
         goto done;
     }
@@ -3130,19 +3130,19 @@ done:
     return req;
 }
 
-static void _sbus_sss_invoke_in_uusssu_out_qus_step
+static void _sbus_sss_invoke_in_uusssu_out_u_step
    (struct tevent_context *ev,
     struct tevent_timer *te,
     struct timeval tv,
     void *private_data)
 {
-    struct _sbus_sss_invoke_in_uusssu_out_qus_state *state;
+    struct _sbus_sss_invoke_in_uusssu_out_u_state *state;
     struct tevent_req *subreq;
     struct tevent_req *req;
     errno_t ret;
 
     req = talloc_get_type(private_data, struct tevent_req);
-    state = tevent_req_data(req, struct _sbus_sss_invoke_in_uusssu_out_qus_state);
+    state = tevent_req_data(req, struct _sbus_sss_invoke_in_uusssu_out_u_state);
 
     switch (state->handler.type) {
     case SBUS_HANDLER_SYNC:
@@ -3152,12 +3152,12 @@ static void _sbus_sss_invoke_in_uusssu_out_qus_step
             goto done;
         }
 
-        ret = state->handler.sync(state, state->sbus_req, state->handler.data, state->in->arg0, state->in->arg1, state->in->arg2, state->in->arg3, state->in->arg4, state->in->arg5, &state->out.arg0, &state->out.arg1, &state->out.arg2);
+        ret = state->handler.sync(state, state->sbus_req, state->handler.data, state->in->arg0, state->in->arg1, state->in->arg2, state->in->arg3, state->in->arg4, state->in->arg5, &state->out.arg0);
         if (ret != EOK) {
             goto done;
         }
 
-        ret = _sbus_sss_invoker_write_qus(state->write_iterator, &state->out);
+        ret = _sbus_sss_invoker_write_u(state->write_iterator, &state->out);
         goto done;
     case SBUS_HANDLER_ASYNC:
         if (state->handler.send == NULL || state->handler.recv == NULL) {
@@ -3173,7 +3173,7 @@ static void _sbus_sss_invoke_in_uusssu_out_qus_step
             goto done;
         }
 
-        tevent_req_set_callback(subreq, _sbus_sss_invoke_in_uusssu_out_qus_done, req);
+        tevent_req_set_callback(subreq, _sbus_sss_invoke_in_uusssu_out_u_done, req);
         ret = EAGAIN;
         goto done;
     }
@@ -3188,23 +3188,23 @@ done:
     }
 }
 
-static void _sbus_sss_invoke_in_uusssu_out_qus_done(struct tevent_req *subreq)
+static void _sbus_sss_invoke_in_uusssu_out_u_done(struct tevent_req *subreq)
 {
-    struct _sbus_sss_invoke_in_uusssu_out_qus_state *state;
+    struct _sbus_sss_invoke_in_uusssu_out_u_state *state;
     struct tevent_req *req;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
-    state = tevent_req_data(req, struct _sbus_sss_invoke_in_uusssu_out_qus_state);
+    state = tevent_req_data(req, struct _sbus_sss_invoke_in_uusssu_out_u_state);
 
-    ret = state->handler.recv(state, subreq, &state->out.arg0, &state->out.arg1, &state->out.arg2);
+    ret = state->handler.recv(state, subreq, &state->out.arg0);
     talloc_zfree(subreq);
     if (ret != EOK) {
         tevent_req_error(req, ret);
         return;
     }
 
-    ret = _sbus_sss_invoker_write_qus(state->write_iterator, &state->out);
+    ret = _sbus_sss_invoker_write_u(state->write_iterator, &state->out);
     if (ret != EOK) {
         tevent_req_error(req, ret);
         return;
@@ -3214,15 +3214,15 @@ static void _sbus_sss_invoke_in_uusssu_out_qus_done(struct tevent_req *subreq)
     return;
 }
 
-struct _sbus_sss_invoke_in_uusu_out_qus_state {
+struct _sbus_sss_invoke_in_uusu_out_us_state {
     struct _sbus_sss_invoker_args_uusu *in;
-    struct _sbus_sss_invoker_args_qus out;
+    struct _sbus_sss_invoker_args_us out;
     struct {
         enum sbus_handler_type type;
         void *data;
-        errno_t (*sync)(TALLOC_CTX *, struct sbus_request *, void *, uint32_t, uint32_t, const char *, uint32_t, uint16_t*, uint32_t*, const char **);
+        errno_t (*sync)(TALLOC_CTX *, struct sbus_request *, void *, uint32_t, uint32_t, const char *, uint32_t, uint32_t*, const char **);
         struct tevent_req * (*send)(TALLOC_CTX *, struct tevent_context *, struct sbus_request *, void *, uint32_t, uint32_t, const char *, uint32_t);
-        errno_t (*recv)(TALLOC_CTX *, struct tevent_req *, uint16_t*, uint32_t*, const char **);
+        errno_t (*recv)(TALLOC_CTX *, struct tevent_req *, uint32_t*, const char **);
     } handler;
 
     struct sbus_request *sbus_req;
@@ -3231,18 +3231,18 @@ struct _sbus_sss_invoke_in_uusu_out_qus_state {
 };
 
 static void
-_sbus_sss_invoke_in_uusu_out_qus_step
+_sbus_sss_invoke_in_uusu_out_us_step
     (struct tevent_context *ev,
      struct tevent_timer *te,
      struct timeval tv,
      void *private_data);
 
 static void
-_sbus_sss_invoke_in_uusu_out_qus_done
+_sbus_sss_invoke_in_uusu_out_us_done
    (struct tevent_req *subreq);
 
 struct tevent_req *
-_sbus_sss_invoke_in_uusu_out_qus_send
+_sbus_sss_invoke_in_uusu_out_us_send
    (TALLOC_CTX *mem_ctx,
     struct tevent_context *ev,
     struct sbus_request *sbus_req,
@@ -3252,12 +3252,12 @@ _sbus_sss_invoke_in_uusu_out_qus_send
     DBusMessageIter *write_iterator,
     const char **_key)
 {
-    struct _sbus_sss_invoke_in_uusu_out_qus_state *state;
+    struct _sbus_sss_invoke_in_uusu_out_us_state *state;
     struct tevent_req *req;
     const char *key;
     errno_t ret;
 
-    req = tevent_req_create(mem_ctx, &state, struct _sbus_sss_invoke_in_uusu_out_qus_state);
+    req = tevent_req_create(mem_ctx, &state, struct _sbus_sss_invoke_in_uusu_out_us_state);
     if (req == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
         return NULL;
@@ -3286,7 +3286,7 @@ _sbus_sss_invoke_in_uusu_out_qus_send
         goto done;
     }
 
-    ret = sbus_invoker_schedule(state, ev, _sbus_sss_invoke_in_uusu_out_qus_step, req);
+    ret = sbus_invoker_schedule(state, ev, _sbus_sss_invoke_in_uusu_out_us_step, req);
     if (ret != EOK) {
         goto done;
     }
@@ -3311,19 +3311,19 @@ done:
     return req;
 }
 
-static void _sbus_sss_invoke_in_uusu_out_qus_step
+static void _sbus_sss_invoke_in_uusu_out_us_step
    (struct tevent_context *ev,
     struct tevent_timer *te,
     struct timeval tv,
     void *private_data)
 {
-    struct _sbus_sss_invoke_in_uusu_out_qus_state *state;
+    struct _sbus_sss_invoke_in_uusu_out_us_state *state;
     struct tevent_req *subreq;
     struct tevent_req *req;
     errno_t ret;
 
     req = talloc_get_type(private_data, struct tevent_req);
-    state = tevent_req_data(req, struct _sbus_sss_invoke_in_uusu_out_qus_state);
+    state = tevent_req_data(req, struct _sbus_sss_invoke_in_uusu_out_us_state);
 
     switch (state->handler.type) {
     case SBUS_HANDLER_SYNC:
@@ -3333,12 +3333,12 @@ static void _sbus_sss_invoke_in_uusu_out_qus_step
             goto done;
         }
 
-        ret = state->handler.sync(state, state->sbus_req, state->handler.data, state->in->arg0, state->in->arg1, state->in->arg2, state->in->arg3, &state->out.arg0, &state->out.arg1, &state->out.arg2);
+        ret = state->handler.sync(state, state->sbus_req, state->handler.data, state->in->arg0, state->in->arg1, state->in->arg2, state->in->arg3, &state->out.arg0, &state->out.arg1);
         if (ret != EOK) {
             goto done;
         }
 
-        ret = _sbus_sss_invoker_write_qus(state->write_iterator, &state->out);
+        ret = _sbus_sss_invoker_write_us(state->write_iterator, &state->out);
         goto done;
     case SBUS_HANDLER_ASYNC:
         if (state->handler.send == NULL || state->handler.recv == NULL) {
@@ -3354,7 +3354,7 @@ static void _sbus_sss_invoke_in_uusu_out_qus_step
             goto done;
         }
 
-        tevent_req_set_callback(subreq, _sbus_sss_invoke_in_uusu_out_qus_done, req);
+        tevent_req_set_callback(subreq, _sbus_sss_invoke_in_uusu_out_us_done, req);
         ret = EAGAIN;
         goto done;
     }
@@ -3369,23 +3369,23 @@ done:
     }
 }
 
-static void _sbus_sss_invoke_in_uusu_out_qus_done(struct tevent_req *subreq)
+static void _sbus_sss_invoke_in_uusu_out_us_done(struct tevent_req *subreq)
 {
-    struct _sbus_sss_invoke_in_uusu_out_qus_state *state;
+    struct _sbus_sss_invoke_in_uusu_out_us_state *state;
     struct tevent_req *req;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
-    state = tevent_req_data(req, struct _sbus_sss_invoke_in_uusu_out_qus_state);
+    state = tevent_req_data(req, struct _sbus_sss_invoke_in_uusu_out_us_state);
 
-    ret = state->handler.recv(state, subreq, &state->out.arg0, &state->out.arg1, &state->out.arg2);
+    ret = state->handler.recv(state, subreq, &state->out.arg0, &state->out.arg1);
     talloc_zfree(subreq);
     if (ret != EOK) {
         tevent_req_error(req, ret);
         return;
     }
 
-    ret = _sbus_sss_invoker_write_qus(state->write_iterator, &state->out);
+    ret = _sbus_sss_invoker_write_us(state->write_iterator, &state->out);
     if (ret != EOK) {
         tevent_req_error(req, ret);
         return;
@@ -3395,15 +3395,15 @@ static void _sbus_sss_invoke_in_uusu_out_qus_done(struct tevent_req *subreq)
     return;
 }
 
-struct _sbus_sss_invoke_in_uuusu_out_qus_state {
+struct _sbus_sss_invoke_in_uuusu_out_u_state {
     struct _sbus_sss_invoker_args_uuusu *in;
-    struct _sbus_sss_invoker_args_qus out;
+    struct _sbus_sss_invoker_args_u out;
     struct {
         enum sbus_handler_type type;
         void *data;
-        errno_t (*sync)(TALLOC_CTX *, struct sbus_request *, void *, uint32_t, uint32_t, uint32_t, const char *, uint32_t, uint16_t*, uint32_t*, const char **);
+        errno_t (*sync)(TALLOC_CTX *, struct sbus_request *, void *, uint32_t, uint32_t, uint32_t, const char *, uint32_t, uint32_t*);
         struct tevent_req * (*send)(TALLOC_CTX *, struct tevent_context *, struct sbus_request *, void *, uint32_t, uint32_t, uint32_t, const char *, uint32_t);
-        errno_t (*recv)(TALLOC_CTX *, struct tevent_req *, uint16_t*, uint32_t*, const char **);
+        errno_t (*recv)(TALLOC_CTX *, struct tevent_req *, uint32_t*);
     } handler;
 
     struct sbus_request *sbus_req;
@@ -3412,18 +3412,18 @@ struct _sbus_sss_invoke_in_uuusu_out_qus_state {
 };
 
 static void
-_sbus_sss_invoke_in_uuusu_out_qus_step
+_sbus_sss_invoke_in_uuusu_out_u_step
     (struct tevent_context *ev,
      struct tevent_timer *te,
      struct timeval tv,
      void *private_data);
 
 static void
-_sbus_sss_invoke_in_uuusu_out_qus_done
+_sbus_sss_invoke_in_uuusu_out_u_done
    (struct tevent_req *subreq);
 
 struct tevent_req *
-_sbus_sss_invoke_in_uuusu_out_qus_send
+_sbus_sss_invoke_in_uuusu_out_u_send
    (TALLOC_CTX *mem_ctx,
     struct tevent_context *ev,
     struct sbus_request *sbus_req,
@@ -3433,12 +3433,12 @@ _sbus_sss_invoke_in_uuusu_out_qus_send
     DBusMessageIter *write_iterator,
     const char **_key)
 {
-    struct _sbus_sss_invoke_in_uuusu_out_qus_state *state;
+    struct _sbus_sss_invoke_in_uuusu_out_u_state *state;
     struct tevent_req *req;
     const char *key;
     errno_t ret;
 
-    req = tevent_req_create(mem_ctx, &state, struct _sbus_sss_invoke_in_uuusu_out_qus_state);
+    req = tevent_req_create(mem_ctx, &state, struct _sbus_sss_invoke_in_uuusu_out_u_state);
     if (req == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Unable to create tevent request!\n");
         return NULL;
@@ -3467,7 +3467,7 @@ _sbus_sss_invoke_in_uuusu_out_qus_send
         goto done;
     }
 
-    ret = sbus_invoker_schedule(state, ev, _sbus_sss_invoke_in_uuusu_out_qus_step, req);
+    ret = sbus_invoker_schedule(state, ev, _sbus_sss_invoke_in_uuusu_out_u_step, req);
     if (ret != EOK) {
         goto done;
     }
@@ -3492,19 +3492,19 @@ done:
     return req;
 }
 
-static void _sbus_sss_invoke_in_uuusu_out_qus_step
+static void _sbus_sss_invoke_in_uuusu_out_u_step
    (struct tevent_context *ev,
     struct tevent_timer *te,
     struct timeval tv,
     void *private_data)
 {
-    struct _sbus_sss_invoke_in_uuusu_out_qus_state *state;
+    struct _sbus_sss_invoke_in_uuusu_out_u_state *state;
     struct tevent_req *subreq;
     struct tevent_req *req;
     errno_t ret;
 
     req = talloc_get_type(private_data, struct tevent_req);
-    state = tevent_req_data(req, struct _sbus_sss_invoke_in_uuusu_out_qus_state);
+    state = tevent_req_data(req, struct _sbus_sss_invoke_in_uuusu_out_u_state);
 
     switch (state->handler.type) {
     case SBUS_HANDLER_SYNC:
@@ -3514,12 +3514,12 @@ static void _sbus_sss_invoke_in_uuusu_out_qus_step
             goto done;
         }
 
-        ret = state->handler.sync(state, state->sbus_req, state->handler.data, state->in->arg0, state->in->arg1, state->in->arg2, state->in->arg3, state->in->arg4, &state->out.arg0, &state->out.arg1, &state->out.arg2);
+        ret = state->handler.sync(state, state->sbus_req, state->handler.data, state->in->arg0, state->in->arg1, state->in->arg2, state->in->arg3, state->in->arg4, &state->out.arg0);
         if (ret != EOK) {
             goto done;
         }
 
-        ret = _sbus_sss_invoker_write_qus(state->write_iterator, &state->out);
+        ret = _sbus_sss_invoker_write_u(state->write_iterator, &state->out);
         goto done;
     case SBUS_HANDLER_ASYNC:
         if (state->handler.send == NULL || state->handler.recv == NULL) {
@@ -3535,7 +3535,7 @@ static void _sbus_sss_invoke_in_uuusu_out_qus_step
             goto done;
         }
 
-        tevent_req_set_callback(subreq, _sbus_sss_invoke_in_uuusu_out_qus_done, req);
+        tevent_req_set_callback(subreq, _sbus_sss_invoke_in_uuusu_out_u_done, req);
         ret = EAGAIN;
         goto done;
     }
@@ -3550,23 +3550,23 @@ done:
     }
 }
 
-static void _sbus_sss_invoke_in_uuusu_out_qus_done(struct tevent_req *subreq)
+static void _sbus_sss_invoke_in_uuusu_out_u_done(struct tevent_req *subreq)
 {
-    struct _sbus_sss_invoke_in_uuusu_out_qus_state *state;
+    struct _sbus_sss_invoke_in_uuusu_out_u_state *state;
     struct tevent_req *req;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
-    state = tevent_req_data(req, struct _sbus_sss_invoke_in_uuusu_out_qus_state);
+    state = tevent_req_data(req, struct _sbus_sss_invoke_in_uuusu_out_u_state);
 
-    ret = state->handler.recv(state, subreq, &state->out.arg0, &state->out.arg1, &state->out.arg2);
+    ret = state->handler.recv(state, subreq, &state->out.arg0);
     talloc_zfree(subreq);
     if (ret != EOK) {
         tevent_req_error(req, ret);
         return;
     }
 
-    ret = _sbus_sss_invoker_write_qus(state->write_iterator, &state->out);
+    ret = _sbus_sss_invoker_write_u(state->write_iterator, &state->out);
     if (ret != EOK) {
         tevent_req_error(req, ret);
         return;

--- a/src/sss_iface/sbus_sss_invokers.h
+++ b/src/sss_iface/sbus_sss_invokers.h
@@ -42,22 +42,22 @@
 _sbus_sss_declare_invoker(, );
 _sbus_sss_declare_invoker(, u);
 _sbus_sss_declare_invoker(pam_data, pam_response);
-_sbus_sss_declare_invoker(raw, qus);
+_sbus_sss_declare_invoker(raw, u);
 _sbus_sss_declare_invoker(s, );
 _sbus_sss_declare_invoker(s, as);
 _sbus_sss_declare_invoker(s, b);
-_sbus_sss_declare_invoker(s, qus);
 _sbus_sss_declare_invoker(s, s);
+_sbus_sss_declare_invoker(s, u);
 _sbus_sss_declare_invoker(sqq, q);
 _sbus_sss_declare_invoker(ss, o);
 _sbus_sss_declare_invoker(ssau, );
 _sbus_sss_declare_invoker(u, );
 _sbus_sss_declare_invoker(usq, );
 _sbus_sss_declare_invoker(ussu, );
-_sbus_sss_declare_invoker(ussu, qus);
+_sbus_sss_declare_invoker(ussu, u);
 _sbus_sss_declare_invoker(usu, );
-_sbus_sss_declare_invoker(uusssu, qus);
-_sbus_sss_declare_invoker(uusu, qus);
-_sbus_sss_declare_invoker(uuusu, qus);
+_sbus_sss_declare_invoker(uusssu, u);
+_sbus_sss_declare_invoker(uusu, us);
+_sbus_sss_declare_invoker(uuusu, u);
 
 #endif /* _SBUS_SSS_INVOKERS_H_ */

--- a/src/sss_iface/sbus_sss_symbols.c
+++ b/src/sss_iface/sbus_sss_symbols.c
@@ -225,7 +225,6 @@ _sbus_sss_args_sssd_dataprovider_getAccountDomain = {
         {NULL}
     },
     .output = (const struct sbus_argument[]){
-        {.type = "q", .name = "dp_error"},
         {.type = "u", .name = "error"},
         {.type = "s", .name = "domain_name"},
         {NULL}
@@ -244,9 +243,7 @@ _sbus_sss_args_sssd_dataprovider_getAccountInfo = {
         {NULL}
     },
     .output = (const struct sbus_argument[]){
-        {.type = "q", .name = "dp_error"},
         {.type = "u", .name = "error"},
-        {.type = "s", .name = "error_message"},
         {NULL}
     }
 };
@@ -258,9 +255,7 @@ _sbus_sss_args_sssd_dataprovider_getDomains = {
         {NULL}
     },
     .output = (const struct sbus_argument[]){
-        {.type = "q", .name = "dp_error"},
         {.type = "u", .name = "error"},
-        {.type = "s", .name = "error_message"},
         {NULL}
     }
 };
@@ -275,9 +270,7 @@ _sbus_sss_args_sssd_dataprovider_hostHandler = {
         {NULL}
     },
     .output = (const struct sbus_argument[]){
-        {.type = "q", .name = "dp_error"},
         {.type = "u", .name = "error"},
-        {.type = "s", .name = "error_message"},
         {NULL}
     }
 };
@@ -305,9 +298,7 @@ _sbus_sss_args_sssd_dataprovider_resolverHandler = {
         {NULL}
     },
     .output = (const struct sbus_argument[]){
-        {.type = "q", .name = "dp_error"},
         {.type = "u", .name = "error"},
-        {.type = "s", .name = "error_message"},
         {NULL}
     }
 };
@@ -318,9 +309,7 @@ _sbus_sss_args_sssd_dataprovider_sudoHandler = {
         {NULL}
     },
     .output = (const struct sbus_argument[]){
-        {.type = "q", .name = "dp_error"},
         {.type = "u", .name = "error"},
-        {.type = "s", .name = "error_message"},
         {NULL}
     }
 };

--- a/src/sss_iface/sss_iface.xml
+++ b/src/sss_iface/sss_iface.xml
@@ -107,18 +107,14 @@
         </method>
         <method name="sudoHandler">
             <annotation name="codegen.CustomInputHandler" value="true" />
-            <arg name="dp_error" type="q" direction="out" />
             <arg name="error" type="u" direction="out" />
-            <arg name="error_message" type="s" direction="out" />
         </method>
         <method name="hostHandler">
             <arg name="dp_flags" type="u" direction="in" key="1" />
             <arg name="name" type="s" direction="in" key="2" />
             <arg name="alias" type="s" direction="in" />
             <arg name="cli_id" type="u" direction="in" />
-            <arg name="dp_error" type="q" direction="out" />
             <arg name="error" type="u" direction="out" />
-            <arg name="error_message" type="s" direction="out" />
         </method>
         <method name="resolverHandler">
             <arg name="dp_flags" type="u" direction="in" key="1" />
@@ -126,15 +122,11 @@
             <arg name="filter_type" type="u" direction="in" key="3" />
             <arg name="filter_value" type="s" direction="in" key="4" />
             <arg name="cli_id" type="u" direction="in" />
-            <arg name="dp_error" type="q" direction="out" />
             <arg name="error" type="u" direction="out" />
-            <arg name="error_message" type="s" direction="out" />
         </method>
         <method name="getDomains">
             <arg name="domain_hint" type="s" direction="in" key="1" />
-            <arg name="dp_error" type="q" direction="out" />
             <arg name="error" type="u" direction="out" />
-            <arg name="error_message" type="s" direction="out" />
         </method>
         <method name="getAccountInfo">
             <arg name="dp_flags" type="u" direction="in" key="1" />
@@ -143,16 +135,13 @@
             <arg name="domain" type="s" direction="in" key="4" />
             <arg name="extra" type="s" direction="in" key="5" />
             <arg name="cli_id" type="u" direction="in" />
-            <arg name="dp_error" type="q" direction="out" />
             <arg name="error" type="u" direction="out" />
-            <arg name="error_message" type="s" direction="out" />
         </method>
         <method name="getAccountDomain">
             <arg name="dp_flags" type="u" direction="in" key="1" />
             <arg name="entry_type" type="u" direction="in" key="2" />
             <arg name="filter" type="s" direction="in" key="3" />
             <arg name="cli_id" type="u" direction="in" />
-            <arg name="dp_error" type="q" direction="out" />
             <arg name="error" type="u" direction="out" />
             <arg name="domain_name" type="s" direction="out" />
         </method>

--- a/src/tests/cmocka/common_mock_resp.h
+++ b/src/tests/cmocka/common_mock_resp.h
@@ -47,7 +47,7 @@ mock_prctx(TALLOC_CTX *mem_ctx);
  * sss_dp_get_account_recv call by calling mock_account_recv.
  *
  * The mocked sss_sp_get_account_recv shall return the return values
- * given with parameters dp_err, dp_ret and msg and optionally also call
+ * given with parameters dp_ret and optionally also call
  * the acct_cb_t callback, if given with the pvt pointer as user data.
  * The callback can for instance populate the cache, thus simulating
  * Data Provider lookup.
@@ -58,8 +58,7 @@ mock_prctx(TALLOC_CTX *mem_ctx);
 typedef int (*acct_cb_t)(void *);
 typedef int (*resolver_cb_t)(void *);
 
-void mock_account_recv(uint16_t dp_err, uint32_t dp_ret, char *msg,
-                       acct_cb_t acct_cb, void *pvt);
+void mock_account_recv(uint32_t dp_ret, acct_cb_t acct_cb, void *pvt);
 
 void mock_account_recv_simple(void);
 

--- a/src/tests/cmocka/common_mock_resp_dp.c
+++ b/src/tests/cmocka/common_mock_resp_dp.c
@@ -43,15 +43,11 @@ sss_dp_get_account_send(TALLOC_CTX *mem_ctx,
 errno_t
 sss_dp_get_account_recv(TALLOC_CTX *mem_ctx,
                         struct tevent_req *req,
-                        dbus_uint16_t *dp_err,
-                        dbus_uint32_t *dp_ret,
-                        const char **err_msg)
+                        dbus_uint32_t *err)
 {
     acct_cb_t cb;
 
-    *dp_err = sss_mock_type(dbus_uint16_t);
-    *dp_ret = sss_mock_type(dbus_uint32_t);
-    *err_msg = sss_mock_ptr_type(char *);
+    *err = sss_mock_type(dbus_uint32_t);
 
     cb = sss_mock_ptr_type(acct_cb_t);
     if (cb) {
@@ -76,15 +72,11 @@ sss_dp_resolver_get_send(TALLOC_CTX *mem_ctx,
 errno_t
 sss_dp_resolver_get_recv(TALLOC_CTX *mem_ctx,
                          struct tevent_req *req,
-                         dbus_uint16_t *dp_err,
-                         dbus_uint32_t *dp_ret,
-                         const char **err_msg)
+                         dbus_uint32_t *err)
 {
     resolver_cb_t cb;
 
-    *dp_err = sss_mock_type(dbus_uint16_t);
-    *dp_ret = sss_mock_type(dbus_uint32_t);
-    *err_msg = sss_mock_ptr_type(char *);
+    *err = sss_mock_type(dbus_uint32_t);
 
     cb = sss_mock_ptr_type(resolver_cb_t);
     if (cb) {
@@ -97,9 +89,7 @@ sss_dp_resolver_get_recv(TALLOC_CTX *mem_ctx,
 void mock_resolver_recv(uint16_t dp_err, uint32_t dp_ret, char *msg,
                         resolver_cb_t cb, void *pvt)
 {
-    will_return(sss_dp_resolver_get_recv, dp_err);
     will_return(sss_dp_resolver_get_recv, dp_ret);
-    will_return(sss_dp_resolver_get_recv, msg);
 
     will_return(sss_dp_resolver_get_recv, cb);
     if (cb) {
@@ -148,15 +138,11 @@ sss_dp_get_ssh_host_recv(TALLOC_CTX *mem_ctx,
 errno_t
 sss_dp_req_recv(TALLOC_CTX *mem_ctx,
                 struct tevent_req *req,
-                dbus_uint16_t *dp_err,
-                dbus_uint32_t *dp_ret,
-                char **err_msg)
+                dbus_uint32_t *err)
 {
     acct_cb_t cb;
 
-    *dp_err = sss_mock_type(dbus_uint16_t);
-    *dp_ret = sss_mock_type(dbus_uint32_t);
-    *err_msg = sss_mock_ptr_type(char *);
+    *err = sss_mock_type(dbus_uint32_t);
 
     cb = sss_mock_ptr_type(acct_cb_t);
     if (cb) {
@@ -166,12 +152,10 @@ sss_dp_req_recv(TALLOC_CTX *mem_ctx,
     return test_request_recv(req);
 }
 
-void mock_account_recv(uint16_t dp_err, uint32_t dp_ret, char *msg,
-                       acct_cb_t acct_cb, void *pvt)
+void mock_account_recv(uint32_t dp_ret, acct_cb_t acct_cb,
+                       void *pvt)
 {
-    will_return(sss_dp_get_account_recv, dp_err);
     will_return(sss_dp_get_account_recv, dp_ret);
-    will_return(sss_dp_get_account_recv, msg);
 
     will_return(sss_dp_get_account_recv, acct_cb);
     if (acct_cb) {
@@ -181,7 +165,7 @@ void mock_account_recv(uint16_t dp_err, uint32_t dp_ret, char *msg,
 
 void mock_account_recv_simple(void)
 {
-    return mock_account_recv(0, 0, NULL, NULL, NULL);
+    return mock_account_recv(0, NULL, NULL);
 }
 
 struct tevent_req *

--- a/src/tests/cmocka/test_krb5_wait_queue.c
+++ b/src/tests/cmocka/test_krb5_wait_queue.c
@@ -35,7 +35,6 @@ struct krb5_mocked_auth_state {
     time_t us_delay;
     int ret;
     int pam_status;
-    int dp_err;
 };
 
 static void krb5_mocked_auth_done(struct tevent_context *ev,
@@ -64,7 +63,6 @@ struct tevent_req *krb5_auth_send(TALLOC_CTX *mem_ctx,
     state->us_delay = sss_mock_type(time_t);
     state->ret = sss_mock_type(int);
     state->pam_status = sss_mock_type(int);
-    state->dp_err = sss_mock_type(int);
 
     tv = tevent_timeval_current_ofs(0, state->us_delay);
 
@@ -97,8 +95,7 @@ static void krb5_mocked_auth_done(struct tevent_context *ev,
 }
 
 int krb5_auth_recv(struct tevent_req *req,
-                   int *_pam_status,
-                   int *_dp_err)
+                   int *_pam_status)
 {
     struct krb5_mocked_auth_state *state;
 
@@ -106,10 +103,6 @@ int krb5_auth_recv(struct tevent_req *req,
 
     if (_pam_status != NULL) {
         *_pam_status = state->pam_status;
-    }
-
-    if (_dp_err != NULL) {
-        *_dp_err = state->dp_err;
     }
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
@@ -163,8 +156,7 @@ static void test_krb5_wait_mock(struct test_krb5_wait_queue *test_ctx,
                                 const char *username,
                                 time_t us_delay,
                                 int ret,
-                                int pam_status,
-                                int dp_err)
+                                int pam_status)
 {
     test_ctx->pd->user = discard_const(username);
 
@@ -172,13 +164,12 @@ static void test_krb5_wait_mock(struct test_krb5_wait_queue *test_ctx,
     will_return(krb5_auth_send, us_delay);
     will_return(krb5_auth_send, ret);
     will_return(krb5_auth_send, pam_status);
-    will_return(krb5_auth_send, dp_err);
 }
 
 static void test_krb5_wait_mock_success(struct test_krb5_wait_queue *test_ctx,
                                         const char *username)
 {
-    return test_krb5_wait_mock(test_ctx, username, 200, 0, 0, 0);
+    return test_krb5_wait_mock(test_ctx, username, 200, 0, 0);
 }
 
 static void test_krb5_wait_queue_single_done(struct tevent_req *req);
@@ -210,9 +201,8 @@ static void test_krb5_wait_queue_single_done(struct tevent_req *req)
         tevent_req_callback_data(req, struct test_krb5_wait_queue);
     errno_t ret;
     int pam_status;
-    int dp_err;
 
-    ret = krb5_auth_queue_recv(req, &pam_status, &dp_err);
+    ret = krb5_auth_queue_recv(req, &pam_status);
     talloc_free(req);
     assert_int_equal(ret, EOK);
 
@@ -253,9 +243,8 @@ static void test_krb5_wait_queue_multi_done(struct tevent_req *req)
         tevent_req_callback_data(req, struct test_krb5_wait_queue);
     errno_t ret;
     int pam_status;
-    int dp_err;
 
-    ret = krb5_auth_queue_recv(req, &pam_status, &dp_err);
+    ret = krb5_auth_queue_recv(req, &pam_status);
     talloc_free(req);
     assert_int_equal(ret, EOK);
 
@@ -279,7 +268,7 @@ static void test_krb5_wait_queue_fail_odd(void **state)
     test_ctx->num_auths = 10;
 
     for (i=0; i < test_ctx->num_auths; i++) {
-        test_krb5_wait_mock(test_ctx, "krb5_user", 0, i+1 % 2, PAM_SUCCESS, 0);
+        test_krb5_wait_mock(test_ctx, "krb5_user", 0, i+1 % 2, PAM_SUCCESS);
 
         req = krb5_auth_queue_send(test_ctx,
                                    test_ctx->tctx->ev,
@@ -300,9 +289,8 @@ static void test_krb5_wait_queue_fail_odd_done(struct tevent_req *req)
         tevent_req_callback_data(req, struct test_krb5_wait_queue);
     errno_t ret;
     int pam_status;
-    int dp_err;
 
-    ret = krb5_auth_queue_recv(req, &pam_status, &dp_err);
+    ret = krb5_auth_queue_recv(req, &pam_status);
     talloc_free(req);
     assert_int_equal(ret, test_ctx->num_finished_auths+1 % 2);
 

--- a/src/tests/cmocka/test_nss_srv.c
+++ b/src/tests/cmocka/test_nss_srv.c
@@ -857,7 +857,7 @@ void test_sss_nss_getpwnam_search(void **state)
     struct ldb_result *res;
 
     mock_input_user_or_group("testuser_search");
-    mock_account_recv(0, 0, NULL, test_sss_nss_getpwnam_search_acct_cb, sss_nss_test_ctx);
+    mock_account_recv(0, test_sss_nss_getpwnam_search_acct_cb, sss_nss_test_ctx);
     will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETPWNAM);
     mock_fill_user();
     set_cmd_cb(test_sss_nss_getpwnam_search_check);
@@ -936,7 +936,7 @@ void test_sss_nss_getpwnam_update(void **state)
     /* Mock client command */
     will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETPWNAM);
     /* Call this function when user is updated by the mock DP request */
-    mock_account_recv(0, 0, NULL, test_sss_nss_getpwnam_update_acct_cb, sss_nss_test_ctx);
+    mock_account_recv(0, test_sss_nss_getpwnam_update_acct_cb, sss_nss_test_ctx);
     /* Call this function to check what the responder returned to the client */
     set_cmd_cb(test_sss_nss_getpwnam_update_check);
     /* Mock output buffer */
@@ -1327,7 +1327,7 @@ void test_sss_nss_getpwuid_search(void **state)
     struct ldb_result *res;
 
     mock_input_id(sss_nss_test_ctx, getpwuid_srch.pw_uid);
-    mock_account_recv(0, 0, NULL, test_sss_nss_getpwuid_search_acct_cb, sss_nss_test_ctx);
+    mock_account_recv(0, test_sss_nss_getpwuid_search_acct_cb, sss_nss_test_ctx);
     will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETPWUID);
     mock_fill_user();
     set_cmd_cb(test_sss_nss_getpwuid_search_check);
@@ -1406,7 +1406,7 @@ void test_sss_nss_getpwuid_update(void **state)
     /* Mock client command */
     will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETPWUID);
     /* Call this function when id is updated by the mock DP request */
-    mock_account_recv(0, 0, NULL, test_sss_nss_getpwuid_update_acct_cb, sss_nss_test_ctx);
+    mock_account_recv(0, test_sss_nss_getpwuid_update_acct_cb, sss_nss_test_ctx);
     /* Call this function to check what the responder returned to the client */
     set_cmd_cb(test_sss_nss_getpwuid_update_check);
     /* Mock output buffer */
@@ -3354,7 +3354,7 @@ void test_sss_nss_initgr_search(void **state)
     struct ldb_result *res;
 
     mock_input_user_or_group("testinitgr_srch");
-    mock_account_recv(0, 0, NULL, test_sss_nss_initgr_search_acct_cb, sss_nss_test_ctx);
+    mock_account_recv(0, test_sss_nss_initgr_search_acct_cb, sss_nss_test_ctx);
     will_return(__wrap_sss_packet_get_cmd, SSS_NSS_INITGR);
     will_return_always(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
     set_cmd_cb(test_sss_nss_initgr_search_check);
@@ -3474,7 +3474,7 @@ void test_sss_nss_initgr_update(void **state)
     assert_int_equal(ret, EOK);
 
     mock_input_user_or_group("testinitgr_update");
-    mock_account_recv(0, 0, NULL, test_sss_nss_initgr_update_acct_cb, sss_nss_test_ctx);
+    mock_account_recv(0, test_sss_nss_initgr_update_acct_cb, sss_nss_test_ctx);
     will_return(__wrap_sss_packet_get_cmd, SSS_NSS_INITGR);
     will_return_always(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
     set_cmd_cb(test_sss_nss_initgr_update_check);
@@ -3594,7 +3594,7 @@ void test_sss_nss_initgr_update_two_expire_attributes(void **state)
     assert_int_equal(ret, EOK);
 
     mock_input_user_or_group("testinitgr_2attr");
-    mock_account_recv(0, 0, NULL,
+    mock_account_recv(0,
                       test_sss_nss_initgr_update_acct_2expire_attributes_cb,
                       sss_nss_test_ctx);
     will_return(__wrap_sss_packet_get_cmd, SSS_NSS_INITGR);
@@ -3991,7 +3991,7 @@ void test_sss_nss_getnamebysid_update(void **state)
     /* Mock client command */
     will_return(__wrap_sss_packet_get_cmd, SSS_NSS_GETNAMEBYSID);
     /* Call this function when user is updated by the mock DP request */
-    mock_account_recv(0, 0, NULL, test_sss_nss_getnamebysid_update_acct_cb,
+    mock_account_recv(0L, test_sss_nss_getnamebysid_update_acct_cb,
                       sss_nss_test_ctx);
     /* Call this function to check what the responder returned to the client */
     set_cmd_cb(test_sss_nss_getnamebysid_update_check);

--- a/src/tests/cmocka/test_pam_srv.c
+++ b/src/tests/cmocka/test_pam_srv.c
@@ -669,7 +669,7 @@ static void mock_input_pam_passkey(TALLOC_CTX *mem_ctx,
     }
 
     if (acct_cb != NULL) {
-        mock_account_recv(0, 0, NULL, acct_cb, discard_const(passkey));
+        mock_account_recv(0, acct_cb, discard_const(passkey));
     }
 }
 
@@ -843,7 +843,7 @@ static void mock_input_pam_cert(TALLOC_CTX *mem_ctx, const char *name,
     will_return(__wrap_sss_packet_get_body, buf_size);
 
     if (acct_cb != NULL) {
-        mock_account_recv(0, 0, NULL, acct_cb, discard_const(cert));
+        mock_account_recv(0, acct_cb, discard_const(cert));
     }
 
     if (name != NULL) {

--- a/src/util/util_errors.c
+++ b/src/util/util_errors.c
@@ -157,6 +157,7 @@ struct err_string error_to_str[] = {
     { "Certificate authority file not found"}, /* ERR_CA_DB_NOT_FOUND */
 
     { "Server failure"}, /* ERR_SERVER_FAILURE */
+    { "No more servers"}, /* ERR_NO_MORE_SERVERS */
 
     { "ERR_LAST" } /* ERR_LAST */
 };

--- a/src/util/util_errors.h
+++ b/src/util/util_errors.h
@@ -182,6 +182,7 @@ enum sssd_errors {
     ERR_CA_DB_NOT_FOUND,
 
     ERR_SERVER_FAILURE,
+    ERR_NO_MORE_SERVERS,
 
     ERR_LAST            /* ALWAYS LAST */
 };


### PR DESCRIPTION
The old provider code still implements sssd.dataprovider D-Bus interface (e.g. getAccountInfo, hostHandler, ...) that expects three return codes:

    "ret"

    "operation error"

    "dp error" (DP_ERR_*)

This is a relic from a time when SSSD did not have its own error codes and had to add more information to the output. This, however, can be done with custom error codes now. The new failover code does not use DP_ERR_* at all.

This PR returns only a single error code through as standard D-Bus reply (success) or D-Bus error (DP offline, operation error, ...).