### PR TITLE
man: Replace bool -> boolean across sssd man-pages

### DIFF
--- a/src/man/sss_rpcidmapd.5.xml
+++ b/src/man/sss_rpcidmapd.5.xml
@@ -66,7 +66,7 @@
             <variablelist>
                 <title>Configuration attributes</title>
                 <varlistentry>
-                    <term>memcache (bool)</term>
+                    <term>memcache (boolean)</term>
                     <listitem>
                         <para>
                             Indicates whether or not to use memcache

--- a/src/man/sssd-ad.5.xml
+++ b/src/man/sssd-ad.5.xml
@@ -1143,7 +1143,7 @@ ad_gpo_map_deny = +my_pam_service
                 </varlistentry>
 
                 <varlistentry>
-                    <term>ad_use_ldaps (bool)</term>
+                    <term>ad_use_ldaps (boolean)</term>
                     <listitem>
                         <para>
                             By default SSSD uses the plain LDAP port 389 and the
@@ -1270,7 +1270,7 @@ ad_gpo_map_deny = +my_pam_service
                 </varlistentry>
 
                 <varlistentry>
-                    <term>dyndns_update_ptr (bool)</term>
+                    <term>dyndns_update_ptr (boolean)</term>
                     <listitem>
                         <para>
                             Whether the PTR record should also be explicitly
@@ -1289,7 +1289,7 @@ ad_gpo_map_deny = +my_pam_service
                 </varlistentry>
 
                 <varlistentry>
-                    <term>dyndns_force_tcp (bool)</term>
+                    <term>dyndns_force_tcp (boolean)</term>
                     <listitem>
                         <para>
                             Whether the nsupdate utility should default to using

--- a/src/man/sssd-kcm.8.xml
+++ b/src/man/sssd-kcm.8.xml
@@ -286,7 +286,7 @@ systemctl restart sssd-kcm.service
                 </listitem>
             </varlistentry>
             <varlistentry condition="enable_kcm_renewal">
-                <term>tgt_renewal (bool)</term>
+                <term>tgt_renewal (boolean)</term>
                 <listitem>
                     <para>
                         Enables TGT renewals functionality.

--- a/src/man/sssd-ldap.5.xml
+++ b/src/man/sssd-ldap.5.xml
@@ -828,7 +828,7 @@
                 </varlistentry>
 
                 <varlistentry>
-                    <term>ldap_ignore_unreadable_references (bool)</term>
+                    <term>ldap_ignore_unreadable_references (boolean)</term>
                     <listitem>
                         <para>
                             Ignore unreadable LDAP entries referenced in
@@ -1336,7 +1336,7 @@ host/*
                 </varlistentry>
 
                 <varlistentry>
-                    <term>ldap_chpass_update_last_change (bool)</term>
+                    <term>ldap_chpass_update_last_change (boolean)</term>
                     <listitem>
                         <para>
                             Specifies whether to update the

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -170,7 +170,7 @@
                     </listitem>
                 </varlistentry>
                 <varlistentry>
-                    <term>debug_timestamps (bool)</term>
+                    <term>debug_timestamps (boolean)</term>
                     <listitem>
                         <para>
                             Add a timestamp to the debug messages.
@@ -183,7 +183,7 @@
                     </listitem>
                 </varlistentry>
                 <varlistentry>
-                    <term>debug_microseconds (bool)</term>
+                    <term>debug_microseconds (boolean)</term>
                     <listitem>
                         <para>
                             Add microseconds to the timestamp in debug messages.
@@ -196,7 +196,7 @@
                     </listitem>
                 </varlistentry>
                 <varlistentry>
-                    <term>debug_backtrace_enabled (bool)</term>
+                    <term>debug_backtrace_enabled (boolean)</term>
                     <listitem>
                         <para>
                             Enable debug backtrace.
@@ -922,7 +922,7 @@
                     </listitem>
                 </varlistentry>
                 <varlistentry>
-                    <term>filter_users_in_groups (bool)</term>
+                    <term>filter_users_in_groups (boolean)</term>
                     <listitem>
                         <para>
                             If you want filtered user still be group members
@@ -1538,7 +1538,7 @@ pam_account_locked_message = Account locked, please contact help desk.
                     </listitem>
                 </varlistentry>
                 <varlistentry condition="build_passkey">
-                    <term>pam_passkey_auth (bool)</term>
+                    <term>pam_passkey_auth (boolean)</term>
                     <listitem>
                         <para>
                             Enable passkey device based authentication.
@@ -1549,7 +1549,7 @@ pam_account_locked_message = Account locked, please contact help desk.
                     </listitem>
                 </varlistentry>
                 <varlistentry condition="build_passkey">
-                    <term>passkey_debug_libfido2 (bool)</term>
+                    <term>passkey_debug_libfido2 (boolean)</term>
                     <listitem>
                         <para>
                             Enable libfido2 library debug messages.
@@ -1560,7 +1560,7 @@ pam_account_locked_message = Account locked, please contact help desk.
                     </listitem>
                 </varlistentry>
                 <varlistentry>
-                    <term>pam_cert_auth (bool)</term>
+                    <term>pam_cert_auth (boolean)</term>
                     <listitem>
                         <para>
                             Enable certificate based Smartcard authentication.
@@ -2023,7 +2023,7 @@ pam_json_services = gdm-switchable-auth
             </para>
             <variablelist>
                 <varlistentry>
-                    <term>sudo_timed (bool)</term>
+                    <term>sudo_timed (boolean)</term>
                     <listitem>
                         <para>
                             Whether or not to evaluate the sudoNotBefore
@@ -2095,7 +2095,7 @@ pam_json_services = gdm-switchable-auth
             </para>
             <variablelist>
                 <varlistentry>
-                    <term>ssh_use_certificate_keys (bool)</term>
+                    <term>ssh_use_certificate_keys (boolean)</term>
                     <listitem>
                         <para>
                             If set to true the
@@ -2590,7 +2590,7 @@ pam_json_services = gdm-switchable-auth
                 </varlistentry>
 
                 <varlistentry>
-                    <term>enumerate (bool)</term>
+                    <term>enumerate (boolean)</term>
                     <listitem>
                         <para>
                             Determines if a domain can be enumerated,
@@ -2942,7 +2942,7 @@ pam_json_services = gdm-switchable-auth
                 </varlistentry>
 
                 <varlistentry>
-                    <term>cache_credentials (bool)</term>
+                    <term>cache_credentials (boolean)</term>
                     <listitem>
                         <para>
                             Determines if user credentials are also cached
@@ -3081,7 +3081,7 @@ pam_json_services = gdm-switchable-auth
                 </varlistentry>
 
                 <varlistentry>
-                    <term>use_fully_qualified_names (bool)</term>
+                    <term>use_fully_qualified_names (boolean)</term>
                     <listitem>
                         <para>
                             Use the full name and domain (as formatted by
@@ -3111,7 +3111,7 @@ pam_json_services = gdm-switchable-auth
                     </listitem>
                 </varlistentry>
                 <varlistentry>
-                    <term>ignore_group_members (bool)</term>
+                    <term>ignore_group_members (boolean)</term>
                     <listitem>
                         <para>
                             Do not return group members for group lookups.
@@ -3812,7 +3812,7 @@ pam_json_services = gdm-switchable-auth
                 </varlistentry>
 
                 <varlistentry>
-                    <term>dns_resolver_use_search_list (bool)</term>
+                    <term>dns_resolver_use_search_list (boolean)</term>
                     <listitem>
                         <para>
                             Normally, the DNS resolver searches the domain


### PR DESCRIPTION
This patch will replace keyword 'bool' by 'boolean' across the following sssd man-pages to maintain consitency. sssd.conf(5), sssd-ldap(5), sssd-ad(5), sssd-kcm(8), sss_rpcidmapd(5).

Resolves: https://github.com/SSSD/sssd/issues/8829