### PR TITLE
man: Add Default for vetoed_shells in sssd.conf(5)

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -1022,6 +1022,9 @@ fallback_homedir = /home/%u
                         <para>
                             Replace any instance of these shells with the shell_fallback
                         </para>
+                        <para>
+                            Default: Not set
+                        </para>
                     </listitem>
                 </varlistentry>
                 <varlistentry>


### PR DESCRIPTION
This patch add missing 'Default' value for vetoed_shells option in sssd.conf(5) man-page.