### PR TITLE
man: Replace ldap_opt_timout -> ldap_opt_timeout

### DIFF
--- a/src/man/sssd-ldap.5.xml
+++ b/src/man/sssd-ldap.5.xml
@@ -627,7 +627,7 @@
                             connections will always be closed immediately and
                             will never be reused if
                             <emphasis>ldap_connection_expire_timeout &lt;=
-                            ldap_opt_timout</emphasis>
+                            ldap_opt_timeout</emphasis>
                         </para>
                         <para>
                             This timeout can be extended of a random


### PR DESCRIPTION
This patch corrects the typo in sssd-ldap(5) man-page for option 'ldap_opt_timeout' within
'ldap_connection_expire_timeout' description.