### PR TITLE
man: Correct default for ldap_user_nds_login_expiration_time and ldap_host_object_class  options

### DIFF
--- a/src/man/sssd-ldap-attributes.5.xml
+++ b/src/man/sssd-ldap-attributes.5.xml
@@ -378,7 +378,7 @@
                             attribute determines if access is allowed or not.
                         </para>
                         <para>
-                            Default: loginDisabled
+                            Default: loginDisabled (rfc2307, rfc2307bis and IPA), not set (AD)
                         </para>
                     </listitem>
                 </varlistentry>
@@ -392,7 +392,7 @@
                             granted.
                         </para>
                         <para>
-                            Default: loginDisabled
+                            Default: loginExpirationTime (rfc2307, rfc2307bis and IPA), not set (AD)
                         </para>
                     </listitem>
                 </varlistentry>
@@ -406,7 +406,7 @@
                             when access is granted.
                         </para>
                         <para>
-                            Default: loginAllowedTimeMap
+                            Default: loginAllowedTimeMap (rfc2307, rfc2307bis and IPA), not set (AD)
                         </para>
                     </listitem>
                 </varlistentry>

--- a/src/man/sssd-ldap-attributes.5.xml
+++ b/src/man/sssd-ldap-attributes.5.xml
@@ -897,7 +897,7 @@
                             The object class of a host entry in LDAP.
                         </para>
                         <para>
-                            Default: ipService
+                            Default: ipHost
                         </para>
                     </listitem>
                 </varlistentry>


### PR DESCRIPTION
This patch corrects the 'Default' value for
`ldap_user_nds_login_expiration_time` and `ldap_host_object_class` 
options in sssd-ldap-attributes(5) man-page.