### PR TITLE
tests: fix sssctl analyze non-default log location SSH client check

### DIFF
--- a/src/tests/system/tests/test_sssctl_analyze.py
+++ b/src/tests/system/tests/test_sssctl_analyze.py
@@ -118,11 +118,15 @@ def test_sssctl_analyze__non_default_log_location(client: Client, ldap: LDAP):
 
     res = client.sssctl.analyze_request(command="list", logdir="/tmp/copy/")
     assert " id" in res.stdout or "coreutils" in res.stdout, "' id' or 'coreutils' not found in analyze list output"
-    assert "sshd" in res.stdout or "coreutils" in res.stdout, "sshd or coreutils not found in output"
 
     res = client.sssctl.analyze_request(command="list -v", logdir="/tmp/copy/")
     assert " id" in res.stdout or "coreutils" in res.stdout, "' id' or 'coreutils' not found in analyze list -v output"
-    assert "sshd" in res.stdout or "coreutils" in res.stdout, "sshd or coreutils not found in output"
+
+    for command in ("list --pam", "list -v --pam"):
+        res = client.sssctl.analyze_request(command=command, logdir="/tmp/copy/")
+        assert (
+            "sshd" in res.stdout or "systemd-logind" in res.stdout
+        ), "sshd or systemd-logind not found in analyze pam list output"
 
 
 @pytest.mark.importance("high")


### PR DESCRIPTION
- `sssctl analyze request list` shows NSS clients; on RHEL 8.10 SSH appears as `systemd-logind`, not `sshd`
- Check SSH login with `list --pam` instead, matching the multihost test