### PR TITLE
[backport: sssd-2-9] sssd-ipa man: Improvement in sssd-ipa(5) man-page

### DIFF
--- a/src/man/sssd-ipa.5.xml
+++ b/src/man/sssd-ipa.5.xml
@@ -636,7 +636,7 @@
                 </varlistentry>
 
                 <varlistentry>
-                    <term>ipa_hbac_selinux (integer)</term>
+                    <term>ipa_selinux_refresh (integer)</term>
                     <listitem>
                         <para>
                             The amount of time between lookups of the SELinux

--- a/src/man/sssd-ipa.5.xml
+++ b/src/man/sssd-ipa.5.xml
@@ -243,7 +243,7 @@
                 </varlistentry>
 
                 <varlistentry>
-                    <term>dyndns_update_ptr (bool)</term>
+                    <term>dyndns_update_ptr (boolean)</term>
                     <listitem>
                         <para>
                             Whether the PTR record should also be explicitly
@@ -268,7 +268,7 @@
                 </varlistentry>
 
                 <varlistentry>
-                    <term>dyndns_force_tcp (bool)</term>
+                    <term>dyndns_force_tcp (boolean)</term>
                     <listitem>
                         <para>
                             Whether the nsupdate utility should default to using

--- a/src/man/sssd-ipa.5.xml
+++ b/src/man/sssd-ipa.5.xml
@@ -138,11 +138,6 @@
                             <quote>dyndns_iface</quote> option.
                         </para>
                         <para>
-                            NOTE: On older systems (such as RHEL 5), for this
-                            behavior to work reliably, the default Kerberos
-                            realm must be set properly in /etc/krb5.conf
-                        </para>
-                        <para>
                             NOTE: While it is still possible to use the old
                             <emphasis>ipa_dyndns_update</emphasis> option, users
                             should migrate to using <emphasis>dyndns_update</emphasis>


### PR DESCRIPTION
This is manual backport of the commits from https://github.com/SSSD/sssd/pull/8822 to branch sssd-2-9