### PR TITLE
man: Correction of typo in pam_sss(8)

### DIFF
--- a/src/man/pam_sss.8.xml
+++ b/src/man/pam_sss.8.xml
@@ -433,7 +433,7 @@ auth sufficient pam_sss.so allow_missing_name
                     <para>
                         No authentication method was found by Kerberos.
                         This might happen if the user has a Smartcard assigned but
-                        the pkint plugin is not available on the client.
+                        the pkinit plugin is not available on the client.
                     </para>
                 </listitem>
             </varlistentry>

--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -1319,7 +1319,7 @@ void pam_reply(struct pam_auth_req *preq)
          * (PAM_BAD_ITEM), so let's try authentication against the Smartcard
          * PAM_NO_MODULE_DATA is returned by the krb5 backend if no
          * authentication method was found at all, this might happen if the
-         * user has a Smartcard assigned but the pkint plugin is not available
+         * user has a Smartcard assigned but the pkinit plugin is not available
          * on the client. */
         DEBUG(SSSDBG_IMPORTANT_INFO,
               "Backend cannot handle Smartcard authentication, "


### PR DESCRIPTION
This patch correct the typo in pam_sss(8) man-page as well as in the code comments within `pamsrv_cmd.c`
`pkint` -> `pkinit`