### PR TITLE
man: Remove duplicate sentence from intro sssd-kcm(8)

### DIFF
--- a/src/man/sssd-kcm.8.xml
+++ b/src/man/sssd-kcm.8.xml
@@ -212,7 +212,6 @@ systemctl restart sssd-kcm.service
             </programlisting>
         </para>
         <para>
-            The KCM service is configured in the <quote>kcm</quote>
             For a detailed syntax reference, refer to the <quote>FILE FORMAT</quote> section of the
             <citerefentry>
                 <refentrytitle>sssd.conf</refentrytitle>


### PR DESCRIPTION
This patch removes a duplicated sentence from sssd-kcm(8) man-page.