### PR TITLE
sdap: Fix memory leaks in sdap_copy_map and nss_protocol_sid

### DIFF
--- a/src/providers/ldap/sdap.c
+++ b/src/providers/ldap/sdap.c
@@ -63,6 +63,7 @@ int sdap_copy_map(TALLOC_CTX *memctx,
         map[i].opt_name = talloc_strdup(map, src_map[i].opt_name);
         map[i].sys_name = talloc_strdup(map, src_map[i].sys_name);
         if (map[i].opt_name == NULL || map[i].sys_name == NULL) {
+            talloc_zfree(map);
             return ENOMEM;
         }
 
@@ -70,6 +71,7 @@ int sdap_copy_map(TALLOC_CTX *memctx,
             map[i].def_name = talloc_strdup(map, src_map[i].def_name);
             map[i].name = talloc_strdup(map, src_map[i].def_name);
             if (map[i].def_name == NULL || map[i].name == NULL) {
+                talloc_zfree(map);
                 return ENOMEM;
             }
         } else {

--- a/src/responder/nss/nss_protocol_sid.c
+++ b/src/responder/nss/nss_protocol_sid.c
@@ -659,6 +659,7 @@ sss_nss_protocol_fill_name_list_all_domains(struct sss_nss_ctx *nss_ctx,
 
     id_types = talloc_array(cmd_ctx, enum sss_id_type, total);
     if (id_types == NULL) {
+        talloc_zfree(sz_names);
         return ENOMEM;
     }
 


### PR DESCRIPTION
     sdap_copy_map() allocates a map array via talloc_array() but returns                                                                                                                                          
     ENOMEM on two talloc_strdup() failure paths without freeing map,                                                                                                                                              
     causing a memory leak each time attribute map initialization fails                                                                                                                                            
     mid-iteration.                                                                                                                                                                                                
                                                                                                                                                                                                                   
     sss_nss_protocol_fill_name_list_all_domains() allocates sz_names                                                                                                                                              
     via talloc_array() and then allocates id_types. If the second                                                                                                                                                 
     allocation fails, sz_names is not freed before returning ENOMEM.                                                                                                                                              
                                                                                                                                                                                                                   
     Add talloc_zfree() calls on the error paths to properly release                                                                                                                                               
     previously allocated memory.                                                                                                                                                                                  
                                                                                                                                                                                                                   
     :fixes: Fixed memory leaks in sdap_copy_map() and                                                                                                                                                             
       sss_nss_protocol_fill_name_list_all_domains() where                                                                                                                                                         
       talloc_array results were not freed on subsequent allocation                                                                                                                                                
       failure. 