### PR TITLE
ci: serialize make distcheck

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,9 @@ jobs:
       working-directory: x86_64
       run: |
         source ../contrib/fedora/bashrc_sssd
-        make -j$PROCESSORS distcheck
+
+        # parallel distcheck is full of race conditions
+        make -j1 distcheck
 
     - uses: actions/upload-artifact@v7
       if: always()


### PR DESCRIPTION
I saw make distcheck fail recently with linker due to a race condition when libsss_util.so was not available for libsss_ldap.

I let AI handle it:

```
  Root cause: Parallel libtool relink race condition during make distcheck install phase

  The failure is on line 27479-27480:
  libsss_util.so: file not recognized: file format not recognized
  collect2: error: ld returned 1 exit status

  What happened — two libtool relink commands ran in parallel during make install:

  1. Line 27474 (at 27.133s): libtool starts relinking libsss_util.so, writing to _build/sub/.libs/libsss_util.so
  2. Line 27478 (at 27.229s, ~100ms later): libtool starts relinking libsss_ldap.so, which links against -lsss_util via -L_build/sub/.libs
  3. Line 27479 (at 27.240s, ~10ms later): the libsss_ldap linker tries to read libsss_util.so from .libs/ — but that file is still being written by the concurrent libsss_util relink, so the linker sees a partially-written
  (truncated/corrupt) .so file

```

---

Libtool relinks shared libraries during install. With parallel make,
install-sssdlibLTLIBRARIES and install-pkglibLTLIBRARIES run
concurrently, causing provider plugin relinks to read half-written
base library .so files (e.g. libsss_ldap reads libsss_util.so
mid-relink). Serialize the install targets to prevent this.

Assisted-By: Claude Code (Opus 4.6)
