### PR TITLE
tests: Update ds tests to rely less on hostname

### DIFF
--- a/src/tests/multihost/alltests/conftest.py
+++ b/src/tests/multihost/alltests/conftest.py
@@ -134,7 +134,7 @@ def setup_authselect(session_multihost):
 @pytest.fixture(scope='function')
 def ldap_posix_usergroup(session_multihost, request):
     """ Create single ldap posix user group """
-    ldap_uri = f'ldap://{session_multihost.master[0].sys_hostname}'
+    ldap_uri = f'ldap://{session_multihost.master[0].ip}'
     ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
     krb = krb5srv(session_multihost.master[0], 'EXAMPLE.TEST')
     id = random.randint(9, 99)
@@ -189,7 +189,7 @@ def localusers(session_multihost, request):
 @pytest.fixture(scope='function')
 def create_350_posix_users(session_multihost, request):
     """ Create posix user and groups """
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].sys_hostname)
+    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
     ds_rootdn = 'cn=Directory Manager'
     ds_rootpw = 'Secret123'
     ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
@@ -257,7 +257,7 @@ def backupsssdconf(session_multihost, request):
 @pytest.fixture(scope='function')
 def delete_groups_users(session_multihost, request):
     """Fixture for bz1817122"""
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].sys_hostname)
+    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
     ds_rootdn = 'cn=Directory Manager'
     ds_rootpw = 'Secret123'
     ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
@@ -286,7 +286,7 @@ def delete_groups_users(session_multihost, request):
 @pytest.fixture(scope="function")
 def set_dslimits(session_multihost, request):
     """ Modify nsslapd-sizelimit """
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].sys_hostname)
+    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
     ds_rootdn = 'cn=Directory Manager'
     ds_rootpw = 'Secret123'
     ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
@@ -325,7 +325,7 @@ def add_nisobject(session_multihost, request):
         session_multihost.master[0].run_command(start_nfs)
     except subprocess.CalledProcessError:
         pytest.fail("Unable to start nfs server")
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].sys_hostname)
+    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
     ds_rootdn = 'cn=Directory Manager'
     ds_rootpw = 'Secret123'
     ds_suffix = 'dc=example,dc=test'
@@ -371,7 +371,7 @@ def indirect_nismaps(session_multihost, request, create_etc_exports):
     nfs_server = session_multihost.master[0].external_hostname
     client_ip = session_multihost.client[0].ip
     server = sssdTools(session_multihost.master[0])
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].sys_hostname)
+    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
     ds_rootdn = 'cn=Directory Manager'
     ds_rootpw = 'Secret123'
     ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
@@ -439,7 +439,7 @@ def set_autofs_search_base(session_multihost, request):
 def set_ldap_uri(session_multihost, request):
     """ Replace ldaps uri with ldap uri """
     tools = sssdTools(session_multihost.client[0])
-    ldap_uri = 'ldap://%s' % session_multihost.master[0].sys_hostname
+    ldap_uri = 'ldap://%s' % session_multihost.master[0].ip
     ldap_params = {'ldap_uri': ldap_uri}
     tools.sssd_conf('domain/%s' % (ds_instance_name), ldap_params)
     session_multihost.client[0].service_sssd('restart')
@@ -456,7 +456,7 @@ def set_ldap_uri(session_multihost, request):
 @pytest.fixture(scope="function")
 def create_ssh_keys(session_multihost, request):
     """ Create ssh keys """
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].sys_hostname)
+    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
     ds_rootdn = 'cn=Directory Manager'
     ds_rootpw = 'Secret123'
     ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
@@ -533,7 +533,7 @@ def sssd_sudo_conf(session_multihost, request):
 @pytest.fixture(scope='function')
 def sudo_rule(session_multihost, request):
     """ Create sudoers ldap entries """
-    ldap_uri = f'ldap://{session_multihost.master[0].sys_hostname}'
+    ldap_uri = f'ldap://{session_multihost.master[0].ip}'
     sudo_ou = f'ou=sudoers,{ds_suffix}'
     ds_rootdn = 'cn=Directory Manager'
     ds_rootpw = 'Secret123'
@@ -577,7 +577,7 @@ testdata = [
 @pytest.fixture(ids=["sudoNotBefore", "sudoNotAfter"], params=testdata)
 def timed_sudoers(session_multihost, request):
     """ Creates a time sudoers ldap entries """
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].sys_hostname)
+    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
     sudo_ou = 'ou=sudoers, %s' % ds_suffix
     ds_rootdn = 'cn=Directory Manager'
     ds_rootpw = 'Secret123'
@@ -706,7 +706,7 @@ def posix_users_multidomain(session_multihost, multipleds):
     id_suffix = ['20', '30']
     for idx in range(2):
         host = session_multihost.master[idx]
-        ldap_uri = 'ldap://%s' % (host.sys_hostname)
+        ldap_uri = 'ldap://%s' % (host.ip)
         ds_rootdn = 'cn=Directory Manager'
         ds_rootpw = 'Secret123'
         ds_suffix = 'dc=example%d,dc=test' % idx
@@ -976,7 +976,7 @@ def setup_sssd_gssapi(session_multihost, setup_sssd,
     tools = sssdTools(session_multihost.client[0])
     domain_section = 'domain/%s' % ds_instance_name
     krb5_server = session_multihost.master[0].sys_hostname
-    ldap_uri = 'ldap://%s' % (krb5_server)
+    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
     ds_rootdn = 'cn=Directory Manager'
     ds_rootpw = 'Secret123'
     ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
@@ -1043,7 +1043,7 @@ def multihost(session_multihost, request):
 @pytest.fixture(scope='class')
 def create_posix_usersgroups(session_multihost):
     """ Create posix user and groups """
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].sys_hostname)
+    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
     ds_rootdn = 'cn=Directory Manager'
     ds_rootpw = 'Secret123'
     ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
@@ -1078,7 +1078,7 @@ def create_posix_usersgroups(session_multihost):
 def create_posix_usersgroups_failover(session_multihost):
     """ Create posix user and groups """
     for idx in range(2):
-        ldap_uri = 'ldap://%s' % (session_multihost.master[idx].sys_hostname)
+        ldap_uri = 'ldap://%s' % (session_multihost.master[idx].ip)
         ds_rootdn = 'cn=Directory Manager'
         ds_rootpw = 'Secret123'
         ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
@@ -1111,7 +1111,7 @@ def create_posix_usersgroups_failover(session_multihost):
 @pytest.fixture(scope='class')
 def create_posix_usersgroups_autoprivategroups(session_multihost):
     """ Create posix user and groups for autoprivategroup fixture"""
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].sys_hostname)
+    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
     ds_rootdn = 'cn=Directory Manager'
     ds_rootpw = 'Secret123'
     ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
@@ -1167,7 +1167,7 @@ def create_posix_usersgroups_autoprivategroups(session_multihost):
 @pytest.fixture(scope='class')
 def netgroups(session_multihost):
     """ Create netgroup users """
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].sys_hostname)
+    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
     ds_rootdn = 'cn=Directory Manager'
     ds_rootpw = 'Secret123'
     ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
@@ -1211,7 +1211,7 @@ def enable_autofs_schema(session_multihost, request):
     :param obj session_multihost: multihost object
     :param obj request: pytest request object
     """
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].sys_hostname)
+    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
     ds_rootdn = 'cn=Directory Manager'
     ds_rootpw = 'Secret123'
     ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
@@ -1311,7 +1311,7 @@ def create_host_user(session_multihost):
     """ Add host user for SASL with GSSAPI authentication
     :param obj session_multihost: multihost object
     """
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].sys_hostname)
+    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
     ds_rootdn = 'cn=Directory Manager'
     ds_rootpw = 'Secret123'
     ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
@@ -1331,7 +1331,7 @@ def create_host_user(session_multihost):
 @pytest.fixture(scope='class')
 def enable_password_check_syntax(session_multihost, request):
     """ Enable passwordCheckSyntax """
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].sys_hostname)
+    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
     ds_rootdn = 'cn=Directory Manager'
     ds_rootpw = 'Secret123'
     ldap_obj = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
@@ -1448,7 +1448,7 @@ def add_host_entry(session_multihost, request):
     Add host and network entries in Directory server to be used
     by sssd hostmap feature.
     """
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].sys_hostname)
+    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
     ds_rootdn = 'cn=Directory Manager'
     ds_rootpw = 'Secret123'
     ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)

--- a/src/tests/multihost/alltests/test_all_misc.py
+++ b/src/tests/multihost/alltests/test_all_misc.py
@@ -221,7 +221,7 @@ class TestMisc(object):
          https://bugzilla.redhat.com/show_bug.cgi?id=1660693
         """
         multihost.client[0].service_sssd('restart')
-        ldap_uri = 'ldap://%s' % (multihost.master[0].sys_hostname)
+        ldap_uri = 'ldap://%s' % (multihost.master[0].ip)
         ds_rootdn = 'cn=Directory Manager'
         ds_rootpw = 'Secret123'
         ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
@@ -273,7 +273,7 @@ class TestMisc(object):
                          'ldap_group_member': 'uniquemember'}
         client.sssd_conf(f'domain/{domain_name}', domain_params)
         multihost.client[0].service_sssd('restart')
-        ldap_uri = 'ldap://%s' % (multihost.master[0].sys_hostname)
+        ldap_uri = 'ldap://%s' % (multihost.master[0].ip)
         ds_rootdn = 'cn=Directory Manager'
         ds_rootpw = 'Secret123'
         ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
@@ -568,7 +568,7 @@ class TestMisc(object):
         client = multihost.client[0]
         multihost.client[0].run_command("modprobe sch_netem")
         log_nss = '/var/log/sssd/sssd_nss.log'
-        ldap_uri = 'ldap://%s' % (multihost.master[0].sys_hostname)
+        ldap_uri = 'ldap://%s' % (multihost.master[0].ip)
         ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
         ldap_inst.org_unit("Netgroup", ds_suffix)
         user_dn = f'cn=netgrp_nowait,ou=Netgroup,{ds_suffix}'

--- a/src/tests/multihost/alltests/test_automount.py
+++ b/src/tests/multihost/alltests/test_automount.py
@@ -254,7 +254,7 @@ class Testautofsresponder(object):
                                             "/etc/exports")
         start_nfs = 'systemctl start nfs-server'
         multihost.master[0].run_command(start_nfs)
-        ldap_uri = 'ldap://%s' % (multihost.master[0].sys_hostname)
+        ldap_uri = 'ldap://%s' % (multihost.master[0].ip)
         ds_rootdn = 'cn=Directory Manager'
         ds_rootpw = 'Secret123'
         ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)

--- a/src/tests/multihost/alltests/test_automount_from_bash.py
+++ b/src/tests/multihost/alltests/test_automount_from_bash.py
@@ -109,7 +109,7 @@ def create_users(multihost, request):
     client.run_command("cp -f /etc/nsswitch.conf /etc/nsswitch.conf.backup")
     client.run_command("cp -f /etc/sysconfig/autofs /etc/sysconfig/autofs_bkp")
     client.run_command("sed --follow-symlinks -i 's/automount:  files/automount:  sss files/g' /etc/nsswitch.conf")
-    ldap_uri = f'ldap://{multihost.master[0].sys_hostname}'
+    ldap_uri = f'ldap://{multihost.master[0].ip}'
     ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
     ldap_inst.org_unit("mount", ds_suffix)
     user_dn = f'nisMapName=auto.master,ou=mount,{ds_suffix}'
@@ -590,7 +590,7 @@ class TestAutoFs(object):
         assert f"{master_server}:/export/projects" in cmd.stdout_text
         find_logs(multihost, log_sssd, f"Searching for automount map entries with base [ou=mount,{ds_suffix}]")
         client.run_command("umount -v /folder1/folder2/projects")
-        ldap_uri = f'ldap://{multihost.master[0].sys_hostname}'
+        ldap_uri = f'ldap://{multihost.master[0].ip}'
         ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
         modify_gid = [(ldap.MOD_REPLACE, 'nisMapEntry',
                        f'-fstype=nfs,rw {master_server}:/export/projects_new'.encode('utf-8'))]
@@ -642,7 +642,7 @@ class TestAutoFs(object):
         client = multihost.client[0]
         log_sssd = f'/var/log/sssd/sssd_{ds_instance_name}.log'
         master_server = multihost.master[0].sys_hostname
-        ldap_uri = f'ldap://{multihost.master[0].sys_hostname}'
+        ldap_uri = f'ldap://{multihost.master[0].ip}'
         ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
         tools = sssdTools(multihost.client[0])
         tools.sssd_conf("domain/example1", {'entry_cache_autofs_timeout': "60"}, action='update')
@@ -706,7 +706,7 @@ class TestAutoFs(object):
         client = multihost.client[0]
         log_sssd = f'/var/log/sssd/sssd_{ds_instance_name}.log'
         master_server = multihost.master[0].sys_hostname
-        ldap_uri = f'ldap://{multihost.master[0].sys_hostname}'
+        ldap_uri = f'ldap://{multihost.master[0].ip}'
         ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
         tools = sssdTools(multihost.client[0])
         tools.sssd_conf("domain/example1", {'entry_cache_autofs_timeout': "60"}, action='update')
@@ -789,7 +789,7 @@ class TestAutoFs(object):
         client = multihost.client[0]
         master_server = multihost.master[0].sys_hostname
         log_sssd = f'/var/log/sssd/sssd_{ds_instance_name}.log'
-        ldap_uri = f'ldap://{multihost.master[0].sys_hostname}'
+        ldap_uri = f'ldap://{multihost.master[0].ip}'
         ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
         tools = sssdTools(multihost.client[0])
         tools.sssd_conf("domain/example1", {'entry_cache_autofs_timeout': "60"}, action='update')
@@ -885,7 +885,7 @@ class TestAutoFs(object):
         # maximum key name must be PATH MAX bz811987
         client = multihost.client[0]
         master_server = multihost.master[0].sys_hostname
-        ldap_uri = f'ldap://{multihost.master[0].sys_hostname}'
+        ldap_uri = f'ldap://{multihost.master[0].ip}'
         ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
         tools = sssdTools(multihost.client[0])
         tools.sssd_conf("domain/example1", {'entry_cache_autofs_timeout': "60"}, action='update')
@@ -930,7 +930,7 @@ class TestAutoFs(object):
         # SSSD frequently fails to return automount maps from LDAP bz967636
         client = multihost.client[0]
         master_server = multihost.master[0].sys_hostname
-        ldap_uri = f'ldap://{multihost.master[0].sys_hostname}'
+        ldap_uri = f'ldap://{multihost.master[0].ip}'
         ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
         # sssd automount maps from LDAP test BZ 967636
         client.run_command("service autofs restart")

--- a/src/tests/multihost/alltests/test_default_debug_level.py
+++ b/src/tests/multihost/alltests/test_default_debug_level.py
@@ -43,7 +43,7 @@ class TestDefaultDebugLevel(object):
         """
         client = multihost.client[0]
         tools = sssdTools(multihost.client[0])
-        ldap_uri = f'ldap://{multihost.master[0].sys_hostname}'
+        ldap_uri = f'ldap://{multihost.master[0].ip}'
         ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
         user_dn = f'uid=tempuser2,{ds_suffix}'
         user_info = {'cn': 'Temp user2'.encode('utf-8'),
@@ -156,7 +156,7 @@ class TestDefaultDebugLevel(object):
         """
         client = multihost.client[0]
         tools = sssdTools(multihost.client[0])
-        ldap_uri = f'ldap://{multihost.master[0].sys_hostname}'
+        ldap_uri = f'ldap://{multihost.master[0].ip}'
         ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
         user_dn = f'uid=mid_cacheuser,{ds_suffix}'
         user_info = {'cn': 'Midcache'.encode('utf-8'),

--- a/src/tests/multihost/alltests/test_hosts.py
+++ b/src/tests/multihost/alltests/test_hosts.py
@@ -254,7 +254,7 @@ class TestHostMaps(object):
           1. Should succeed
           2. Should succeed
         """
-        ldap_uri = 'ldap://%s' % (multihost.master[0].sys_hostname)
+        ldap_uri = 'ldap://%s' % (multihost.master[0].ip)
         ds_rootdn = 'cn=Directory Manager'
         ds_rootpw = 'Secret123'
         ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)

--- a/src/tests/multihost/alltests/test_krb_fips.py
+++ b/src/tests/multihost/alltests/test_krb_fips.py
@@ -252,7 +252,7 @@ class Testkrbfips(object):
         :title: krb5/fips: verify login fails when weak crypto is presented
         :id: cdd2ef0d-4921-40b3-b61e-0b271b2d5e00
         """
-        ldap_uri = 'ldap://%s' % (multihost.master[0].sys_hostname)
+        ldap_uri = 'ldap://%s' % (multihost.master[0].ip)
         ds_rootdn = 'cn=Directory Manager'
         ds_rootpw = 'Secret123'
         tools = sssdTools(multihost.client[0])

--- a/src/tests/multihost/alltests/test_ldap_password_policy.py
+++ b/src/tests/multihost/alltests/test_ldap_password_policy.py
@@ -45,7 +45,7 @@ def ldap_modify_ds(multihost, ldap_mode, dn_dn, element, value):
     element: Attribute of Dn which needs to change
     value: New Attribute value.
     """
-    ldap_uri = f'ldap://{multihost.master[0].sys_hostname}'
+    ldap_uri = f'ldap://{multihost.master[0].ip}'
     ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
     modify_gid = [(ldap_mode, element, value)]
     ldap_inst.modify_ldap(dn_dn, modify_gid)
@@ -55,7 +55,7 @@ def ldap_modify_ds(multihost, ldap_mode, dn_dn, element, value):
 def create_users_groups(multihost, request):
     """ Create user and restore """
     client = multihost.client[0]
-    ldap_uri = f'ldap://{multihost.master[0].sys_hostname}'
+    ldap_uri = f'ldap://{multihost.master[0].ip}'
     ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
     user_dn = 'uid=ppuser1,ou=People,dc=example,dc=test'
     user_info = {'cn': 'ppuser1'.encode('utf-8'),

--- a/src/tests/multihost/alltests/test_netgroup.py
+++ b/src/tests/multihost/alltests/test_netgroup.py
@@ -121,7 +121,7 @@ class TestNetgroup(object):
         getent_cmd = "getent netgroup netgroup_1"
         multihost.client[0].run_command(getent_cmd)
         shortname = multihost.client[0].sys_hostname.strip().split('.')[0]
-        ldap_uri = 'ldap://%s' % (multihost.master[0].sys_hostname)
+        ldap_uri = 'ldap://%s' % (multihost.master[0].ip)
         ds_rootdn = 'cn=Directory Manager'
         ds_rootpw = 'Secret123'
         ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)

--- a/src/tests/multihost/alltests/test_rfc2307.py
+++ b/src/tests/multihost/alltests/test_rfc2307.py
@@ -23,7 +23,7 @@ def usr_grp(multihost, obj_info, type):
         :return: None
         :exception: LdapException
     """
-    ldap_uri = f'ldap://{multihost.master[0].sys_hostname}'
+    ldap_uri = f'ldap://{multihost.master[0].ip}'
     ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
     krb = krb5srv(multihost.master[0], 'EXAMPLE.TEST')
     if type == 'user':

--- a/src/tests/multihost/alltests/test_sss_cache.py
+++ b/src/tests/multihost/alltests/test_sss_cache.py
@@ -44,7 +44,7 @@ class TestSssCache(object):
         assert "foo9@example1" in get_ent.stdout_text
         user_dn = 'uid=foo9,ou=People,dc=example,dc=test'
         group_dn = 'cn=ldapusers,ou=Groups,dc=example,dc=test'
-        ldap_uri = 'ldap://%s' % (multihost.master[0].sys_hostname)
+        ldap_uri = 'ldap://%s' % (multihost.master[0].ip)
         ds_rootdn = 'cn=Directory Manager'
         ds_rootpw = 'Secret123'
         ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)

--- a/src/tests/multihost/alltests/test_sudo.py
+++ b/src/tests/multihost/alltests/test_sudo.py
@@ -38,7 +38,7 @@ class TestSudo(object):
         tools = sssdTools(multihost.client[0])
         # remove sssd cache
         tools.remove_sss_cache('/var/lib/sss/db/')
-        ldap_uri = 'ldap://%s' % multihost.master[0].sys_hostname
+        ldap_uri = 'ldap://%s' % multihost.master[0].ip
         sssd_params = {'services': 'nss, pam, sudo'}
         tools.sssd_conf('sssd', sssd_params)
         ldap_params = {'ldap_uri': ldap_uri}
@@ -91,7 +91,7 @@ class TestSudo(object):
         multihost.client[0].service_sssd('stop')
         tools.remove_sss_cache('/var/lib/sss/db/')
         sudo_base = 'ou=sudoers,dc=example,dc=test'
-        sudo_uri = "ldap://%s" % multihost.master[0].sys_hostname
+        sudo_uri = "ldap://%s" % multihost.master[0].ip
         params = {'ldap_sudo_search_base': sudo_base,
                   'ldap_uri': sudo_uri, 'sudo_provider': "ldap"}
         domain_section = 'domain/%s' % ds_instance_name
@@ -147,7 +147,7 @@ class TestSudo(object):
         tools.remove_sss_cache('/var/lib/sss/db')
         tools.remove_sss_cache('/var/log/sssd')
         sudo_base = 'ou=sudoers,%s' % (ds_suffix)
-        sudo_uri = "ldap://%s" % multihost.master[0].sys_hostname
+        sudo_uri = "ldap://%s" % multihost.master[0].ip
         params = {'ldap_sudo_search_base': sudo_base,
                   'ldap_uri': sudo_uri,
                   'sudo_provider': "ldap",

--- a/src/tests/multihost/sssd/testlib/common/libdirsrv.py
+++ b/src/tests/multihost/sssd/testlib/common/libdirsrv.py
@@ -98,6 +98,21 @@ class DirSrv(object):
         Exceptions:
              subprocess.CalledProcessError:
         """
+        # Leftover instances (e.g. after a failed fixture) block dscreate.
+        check_inst = self.multihost.run_command(
+            ['/usr/bin/ls', self.dsinst_path], raiseonerr=False)
+        if check_inst.returncode == 0:
+            self.multihost.log.info(
+                'DS instance %s already exists; removing before setup'
+                % self.instance_name)
+            try:
+                # dsctl expects the short instance name (not slapd-*).
+                self.remove_ds(self.instance_name)
+            except subprocess.CalledProcessError:
+                self.multihost.log.info(
+                    "Failed to remove existing %s instance" % self.instance_name)
+                raise
+
         self.multihost.transport.put_file(ds_cfg_file, '/tmp/test.cfg')
         setup_cmd = 'dscreate -v from-file %s' % '/tmp/test.cfg'
         try:
@@ -344,7 +359,11 @@ class DirSrvWrap(object):
         self.dirsrv_obj = None
         self.ds_instance_name = None
         self.multihost = multihost_obj
+        # Hostname for dscreate full_machine_name / cert nicks on the SUT.
         self.ds_instance_host = self.multihost.sys_hostname
+        # IP for controller-side LDAP and port probes (lab FQDNs may not
+        # resolve on the pytest controller).
+        self.ds_connect_host = self.multihost.ip or self.ds_instance_host
         self.client_host = client_obj
         self.ds_instance_suffix = None
         self.ds_rootdn_pwd = None
@@ -475,7 +494,7 @@ class DirSrvWrap(object):
         sock_obj = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock_obj.settimeout(1)
         try:
-            sock_obj.connect((self.ds_instance_host, port))
+            sock_obj.connect((self.ds_connect_host, port))
         except socket.error as err:
             print("fail to connect to port %s due to error %r" % (port,
                                                                   err.errno))
@@ -487,21 +506,22 @@ class DirSrvWrap(object):
     def _validate_options(self):
         """verify if the instance directory already exists.
 
+        Leftover instances are removed in DirSrv.setup_ds(); log only here
+        so create_ds_instance can proceed to a clean recreate.
+
         Args:
             None
 
         Returns:
             None
-
-        Exceptions:
-            DirSrvException: if instance directory already exists
         """
         check_instance = ['/usr/bin/ls', '/etc/dirsrv/slapd-%s' %
                           self.ds_instance_name]
         output = self.multihost.run_command(check_instance, raiseonerr=False)
         if output.returncode == 0:
-            raise DirSrvException('%s Instance already exists' %
-                                  self.ds_instance_name)
+            self.multihost.log.info(
+                '%s instance already exists; setup_ds will replace it'
+                % self.ds_instance_name)
 
     def create_ds_instance(self,
                            inst_name,
@@ -544,7 +564,7 @@ class DirSrvWrap(object):
             except subprocess.CalledProcessError:
                 raise DirSrvException('Failed to setup Directory server')
             self.dirsrv_info[self.ds_instance_name] = self.dirsrv_obj.__dict__
-            ldap_uri = 'ldap://%s:%r' % (self.ds_instance_host,
+            ldap_uri = 'ldap://%s:%r' % (self.ds_connect_host,
                                          self.ds_ldap_port)
             try:
                 self.dirsrv_obj.enable_anonymous_search(ldap_uri)
@@ -593,7 +613,7 @@ class DirSrvWrap(object):
                 self.multihost.log.info('Added %s port to ldap_port_t' %
                                         self.ds_tls_port)
         try:
-            self.dirsrv_obj.enable_ssl('ldap://%s:%r' % (self.ds_instance_host,
+            self.dirsrv_obj.enable_ssl('ldap://%s:%r' % (self.ds_connect_host,
                                                          self.ds_ldap_port),
                                        self.ds_tls_port)
         except LdapException:


### PR DESCRIPTION
With AWS we might or might not have properly working dns with resolvable hostnames. Make sure to use ip address where possible.