### PR TITLE
fix request csr failed with authorityKeyIdentifier

### DIFF
--- a/src/tests/test_CA/intermediate_CA/SSSD_test_intermediate_CA.config
+++ b/src/tests/test_CA/intermediate_CA/SSSD_test_intermediate_CA.config
@@ -27,7 +27,6 @@ authorityKeyIdentifier = keyid, issuer
 
 [ v3_ca ]
 subjectKeyIdentifier   = hash
-authorityKeyIdentifier = keyid:always,issuer:always
 basicConstraints       = CA:true
 keyUsage               = critical, digitalSignature, cRLSign, keyCertSign
 


### PR DESCRIPTION
genarate csr should not include authorityKeyIdentifier in config file
https://github.com/SSSD/sssd/issues/8989