### PR TITLE
CI: update releases to run rpm-build and ci jobs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -42,7 +42,6 @@ jobs:
     packages:
       - upstream
     targets:
-      - fedora-all
       - centos-stream-10
 
   # Run TMT tests after COPR builds complete

--- a/contrib/ci/get-matrix.py
+++ b/contrib/ci/get-matrix.py
@@ -42,13 +42,13 @@ def get_fedora_releases(session, type, exclude=[]):
 def get_fedora_matrix():
     session = requests_session()
     fedora_stable = get_fedora_releases(session, 'current')
-    fedora_devel = get_fedora_releases(session, 'pending', exclude=['eln'])
-    fedora_frozen = get_fedora_releases(session, 'frozen', exclude=['eln'])
+
+    # Strip out non-working releases and only return known good ones
+    fedora_working = ['43']
+    fedora_stable = [v for v in fedora_stable if v in fedora_working]
 
     matrix = []
     matrix.extend(['fedora-{0}'.format(x) for x in fedora_stable])
-    matrix.extend(['fedora-{0}'.format(x) for x in fedora_devel])
-    matrix.extend(['fedora-{0}'.format(x) for x in fedora_frozen])
 
     return matrix
 


### PR DESCRIPTION
The sssd-2-12 branch no longer works with newer versions of openssl starting with Fedora 45.  As such, we do not need to test on that or attempt to build on it.

This modifies the packit config to remove Fedora from the rpm-build list and leave only c10s.

It also modifies the contrib get-matrix.py to only return known working versions of Fedora (43, 44).  So that after those are no longer supported, they should drop off the list here as well.