### PR TITLE
Multihost tests ldap fix

### DIFF
--- a/src/tests/multihost/alltests/conftest.py
+++ b/src/tests/multihost/alltests/conftest.py
@@ -1513,7 +1513,7 @@ def ns_account_lock(session_multihost, request):
     session_multihost.client[0].service_sssd('restart')
     # Add managed role
     master_e = session_multihost.master[0].ip
-    ldap_uri = f'ldap://{master_e}'
+    ldap_uri = f'ldaps://{master_e}'
     ds_rootdn = 'cn=Directory Manager'
     ds_rootpw = 'Secret123'
     ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
@@ -1548,7 +1548,7 @@ def ns_account_lock(session_multihost, request):
     def restoresssdconf():
         """ Restore sssd.conf """
         master_e = session_multihost.master[0].ip
-        ldap_uri = f'ldap://{master_e}'
+        ldap_uri = f'ldaps://{master_e}'
         ds_rootdn = 'cn=Directory Manager'
         ds_rootpw = 'Secret123'
         ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)

--- a/src/tests/multihost/alltests/test_config_merging.py
+++ b/src/tests/multihost/alltests/test_config_merging.py
@@ -33,7 +33,7 @@ class TestConfigMerge(object):
         content = "[%s]\nuse_fully_quailified_name = False" % section
         snippet_file = "/etc/sssd/conf.d/01_snippet.conf"
         multihost.client[0].put_file_contents(snippet_file, content)
-        multihost.client[0].run_command(f"chmod 640 {snippet_file}")
+        multihost.client[0].run_command(f"chmod 600 {snippet_file}")
         returncode = multihost.client[0].service_sssd('start')
         if returncode == 0:
             config_check = 'sssctl config-check'
@@ -64,7 +64,7 @@ class TestConfigMerge(object):
         file_content = "[%s]\nuse_fully_quailified_name = False" % dom_section
         snippet_file = "/etc/sssd/conf.d/._01_snippet.conf"
         multihost.client[0].put_file_contents(snippet_file, file_content)
-        multihost.client[0].run_command(f"chmod 640 {snippet_file}")
+        multihost.client[0].run_command(f"chmod 600 {snippet_file}")
         start = multihost.client[0].service_sssd('start')
         sssctl_cmd = 'sssctl config-check'
         if start == 0:
@@ -87,7 +87,7 @@ class TestConfigMerge(object):
                                                                 idx)
             snippet_file = "/etc/sssd/conf.d/%s_snippet.conf" % idx
             multihost.client[0].put_file_contents(snippet_file, content)
-            chmod = 'chmod 640 %s' % snippet_file
+            chmod = 'chmod 600 %s' % snippet_file
             multihost.client[0].run_command(chmod)
         start = multihost.client[0].service_sssd('start')
         cmd = multihost.client[0].run_command(['sssctl', 'config-check'])
@@ -115,7 +115,7 @@ class TestConfigMerge(object):
         file_content = "[%s]\nuse_fully_qualified_names = False" % dom_section
         snippet_file = "/etc/sssd/conf.d/01_snippet.conf.disable"
         multihost.client[0].put_file_contents(snippet_file, file_content)
-        cmd_chmod = 'chmod 640 %s' % snippet_file
+        cmd_chmod = 'chmod 600 %s' % snippet_file
         multihost.client[0].run_command(cmd_chmod, raiseonerr=False)
         start = multihost.client[0].service_sssd('start')
         if start == 0:

--- a/src/tests/multihost/alltests/test_krb_access_provider.py
+++ b/src/tests/multihost/alltests/test_krb_access_provider.py
@@ -244,7 +244,7 @@ class TestKrbAccessProvider():
             ssh.execute_command("id > /tmp/accessProvider_id_krb5_004.out 2>&1")
             ssh.execute_command(f"ssh -o StrictHostKeyChecking=no -o "
                                 f"PasswordAuthentication=no foo3@{client_ip} id >> "
-                                f"/tmp/accessProvider_id_krb5_004.out 2>&1")
+                                f"/tmp/accessProvider_id_krb5_004.out")
             ssh.close()
         except Exception:
             pytest.fail("Error in connection via ssh as foo4")

--- a/src/tests/multihost/alltests/test_krb_access_provider.py
+++ b/src/tests/multihost/alltests/test_krb_access_provider.py
@@ -182,11 +182,11 @@ class TestKrbAccessProvider():
             cmd = multihost.client[0].run_command(command, raiseonerr=False)
 
         ssh = check_login_client_bool(multihost, "foo3", "Secret123")
-        client_hostname = multihost.client[0].sys_hostname
+        client_ip = multihost.client[0].ip
         try:
             run_command_client(multihost, "foo4", "Secret123",
                                f"ssh -o StrictHostKeyChecking=no -o "
-                               f"PasswordAuthentication=no foo3@{client_hostname} "
+                               f"PasswordAuthentication=no foo3@{client_ip} "
                                f"id > /tmp/accessProvider_id_krb5_003.out 2>&1")
         except Exception:
             pytest.fail("Error in connection via ssh as foo4")
@@ -237,13 +237,13 @@ class TestKrbAccessProvider():
                    -D "cn=Directory Manager" -w "Secret123" uid=foo3,ou=People,dc=example,dc=test'
         cmd2 = multihost.client[0].run_command(ldap_cmd, raiseonerr=False)
         time.sleep(10)
-        client_hostname = multihost.client[0].sys_hostname
+        client_ip = multihost.client[0].ip
         try:
-            ssh = SSHClient(client_hostname, "foo4", "Secret123")
+            ssh = SSHClient(client_ip, "foo4", "Secret123")
             ssh.connect()
             ssh.execute_command("id > /tmp/accessProvider_id_krb5_004.out 2>&1")
             ssh.execute_command(f"ssh -o StrictHostKeyChecking=no -o "
-                                f"PasswordAuthentication=no foo3@{client_hostname} id >> "
+                                f"PasswordAuthentication=no foo3@{client_ip} id >> "
                                 f"/tmp/accessProvider_id_krb5_004.out 2>&1")
             ssh.close()
         except Exception:

--- a/src/tests/multihost/alltests/test_krb_fips.py
+++ b/src/tests/multihost/alltests/test_krb_fips.py
@@ -91,7 +91,7 @@ class Testkrbfips(object):
         multihost.client[0].service_sssd('restart')
         multihost.client[0].run_command("systemctl "
                                         "restart sssd-kcm")
-        ssh = SSHClient(multihost.client[0].sys_hostname, 'foo3', 'Secret123')
+        ssh = SSHClient(multihost.client[0].ip, 'foo3', 'Secret123')
         try:
             ssh.connect()
             ssh.execute_command('kdestroy -A -q')
@@ -316,7 +316,7 @@ class Testkrbfips(object):
         tcpdump_cmd = 'tcpdump -s0 host %s -w %s' % (ldap_host, pcapfile)
         multihost.client[0].run_command(tcpdump_cmd, bg=True)
         pkill = 'pkill tcpdump'
-        client = SSHClient(multihost.client[0].sys_hostname, user, 'Secret123')
+        client = SSHClient(multihost.client[0].ip, user, 'Secret123')
         try:
             client.connect()
         except Exception:

--- a/src/tests/multihost/alltests/test_ldap_extra_attrs.py
+++ b/src/tests/multihost/alltests/test_ldap_extra_attrs.py
@@ -244,7 +244,7 @@ class TestLdapExtraAttrs(object):
         client.run_command('gcc -lpthread /tmp/sssd_client_hang.c'
                            ' -o /tmp/client-hang')
         client.run_command("chown foo1 /tmp/client-hang")
-        ssh = SSHClient(multihost.client[0].sys_hostname, 'foo1', 'Secret123')
+        ssh = SSHClient(multihost.client[0].ip, 'foo1', 'Secret123')
         try:
             ssh.connect()
             ssh.execute_command('cd /tmp; ./client-hang > output')

--- a/src/tests/multihost/alltests/test_proxy.py
+++ b/src/tests/multihost/alltests/test_proxy.py
@@ -59,7 +59,7 @@ class TestsssdProxy(object):
         cat = 'cat /etc/sssd/sssd.conf'
         multihost.client[0].run_command(cat)
         multihost.client[0].service_sssd('start')
-        client = SSHClient(multihost.client[0].sys_hostname, user, 'Secret123')
+        client = SSHClient(multihost.client[0].ip, user, 'Secret123')
         try:
             client.connect()
         except Exception:

--- a/src/tests/multihost/alltests/test_sudo.py
+++ b/src/tests/multihost/alltests/test_sudo.py
@@ -55,7 +55,7 @@ class TestSudo(object):
             add_rule2 = "echo 'Defaults:%s !requiretty'"\
                         " >> /etc/sudoers.d/%s" % (user, user)
             multihost.client[0].run_command(add_rule2)
-            ssh = SSHClient(multihost.client[0].sys_hostname, user, 'Secret123')
+            ssh = SSHClient(multihost.client[0].ip, user, 'Secret123')
             try:
                 ssh.connect()
                 for _ in range(1, 10):
@@ -100,7 +100,7 @@ class TestSudo(object):
         sssd_params = {'services': 'nss, pam, sudo'}
         tools.sssd_conf(section, sssd_params, action='update')
         multihost.client[0].service_sssd('start')
-        ssh = SSHClient(multihost.client[0].sys_hostname, 'foo1@example.test', 'Secret123')
+        ssh = SSHClient(multihost.client[0].ip, 'foo1@example.test', 'Secret123')
         try:
             ssh.connect()
             id_out = ssh.execute_command('id')

--- a/src/tests/multihost/sssd/testlib/common/utils.py
+++ b/src/tests/multihost/sssd/testlib/common/utils.py
@@ -1219,6 +1219,8 @@ class LdapOperations(object):
         self.binddn = binddn
         self.bindpw = bindpw
         self.conn = ldap.initialize(self.uri)
+        self.conn.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
+        self.conn.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
         self.conn = self.bind()
         if isinstance(self.conn, tuple):
             raise LdapException("Failed to bind to ldap server, Error: %s"


### PR DESCRIPTION
Multihost tests fixes for resolving some CI issues in newer distros.   This includes LDAP -> LDAPS, some snippet permissions fixes, and switch a couple of SSH calls to use IP instead of hostnames.