### PR TITLE
man: Correct the ports for ad_use_ldaps option

### DIFF
--- a/src/man/sssd-ad.5.xml
+++ b/src/man/sssd-ad.5.xml
@@ -1147,9 +1147,9 @@ ad_gpo_map_deny = +my_pam_service
                     <listitem>
                         <para>
                             By default SSSD uses the plain LDAP port 389 and the
-                            Global Catalog port 3628. If this option is set to
+                            Global Catalog port 3268. If this option is set to
                             True SSSD will use the LDAPS port 636 and Global
-                            Catalog port 3629 with LDAPS protection. Since AD
+                            Catalog port 3269 with LDAPS protection. Since AD
                             does not allow to have multiple encryption layers on
                             a single connection and we still want to use
                             SASL/GSSAPI or SASL/GSS-SPNEGO for authentication


### PR DESCRIPTION
This patch replaces incorrect port numbers for ad_use_ldaps 
option in sssd-ad(5) by 3268 and 3269 respectively.