### PR TITLE
man: Improve description for dns_resolver_server_timeout

### DIFF
--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -3731,9 +3731,9 @@ pam_json_services = gdm-switchable-auth
                     <term>dns_resolver_server_timeout (integer)</term>
                     <listitem>
                         <para>
-                            Defines the amount of time (in milliseconds)
-                            SSSD would try to talk to DNS server before
-                            trying next DNS server.
+                            Defines the timeout duration (in milliseconds)
+                            SSSD waits for a DNS server to respond before
+                            moving to the next one.
                         </para>
                         <para>
                             The AD provider will use this option for the


### PR DESCRIPTION
This patch improves the description for `dns_resolver_server_timeout` 
option in sssd.conf(5) man-page.

Resolves: https://github.com/SSSD/sssd/issues/7340