### PR TITLE
test rewrite: legacy intg test_pam_responder.py - remaining batch

### DIFF
--- a/src/tests/system/tests/test_authentication.py
+++ b/src/tests/system/tests/test_authentication.py
@@ -7,11 +7,15 @@ SSSD Authentication Test Cases
 from __future__ import annotations
 
 import re
+import textwrap
+from inspect import cleandoc
 
 import pytest
 from sssd_test_framework.roles.client import Client
 from sssd_test_framework.roles.generic import GenericProvider
+from sssd_test_framework.roles.ipa import IPA
 from sssd_test_framework.roles.kdc import KDC
+from sssd_test_framework.roles.samba import Samba
 from sssd_test_framework.topology import KnownTopology, KnownTopologyGroup
 
 
@@ -409,3 +413,108 @@ def test_authentication__custom_password_prompt_is_shown_at_login(
     result = client.host.conn.run("su - user1 -c 'su - user1 -c whoami'", input="Secret123")
     assert "My custom prompt" in result.stderr, "Custom password prompt was not shown!"
     assert "user1" in result.stdout, "'user1' failed to log in!"
+
+
+@pytest.mark.importance("medium")
+@pytest.mark.authentication
+@pytest.mark.topology(KnownTopology.ALLREALMS)
+def test_authentication__pam_sss_domains_skips_non_matching_krb5_domains(
+    client: Client, samba: Samba, ipa: IPA, kdc: KDC
+):
+    """
+    :title: pam_sss.so 'domains' authenticates only against the listed Kerberos realm domain
+    :description:
+        Local users may authenticate via Kerberos against one of several configured realms
+        (Samba, IPA, or a standalone KDC). The same username exists in every realm with a
+        different password. Each PAM 'domains=' line restricts SSSD to that domain only, so
+        earlier lines fail with the wrong password and PAM falls through until the matching
+        domain succeeds (try-and-error via the domains option).
+    :setup:
+        1. Add a local user and create 'user1' in the Samba, IPA, and KDC realms with
+           different passwords
+        2. Configure three SSSD domains (samba, ipa, krb5) with id_provider=proxy/files and
+           auth_provider=krb5 using each provider's realm
+        3. Replace 'su-l' with three 'sufficient' pam_sss.so lines, each limited by 'domains='
+    :steps:
+        1. Authenticate as the local user via 'su -' using the Samba password and run klist
+        2. Authenticate as the local user via 'su -' using the IPA password and run klist
+        3. Authenticate as the local user via 'su -' using the KDC password and run klist
+    :expectedresults:
+        1. Authentication succeeds via 'domains=samba' and the TGT realm is the Samba realm
+        2. Authentication succeeds via 'domains=ipa' (after Samba fails) and the TGT realm is
+           the IPA realm
+        3. Authentication succeeds via 'domains=krb5' (after Samba and IPA fail) and the TGT
+           realm is the KDC realm
+    :customerscenario: True
+    """
+    client.local.user("user1").add(password="LocalSecret123")
+    samba.user("user1").add(password="SambaSecret123")
+    ipa.user("user1").add(password="IPASecret123")
+    kdc.principal("user1").add(password="KDCSecret123")
+
+    client.sssd.fs.write(
+        "/etc/krb5.conf",
+        textwrap.dedent(f"""
+            [libdefaults]
+            default_realm = {kdc.realm}
+            dns_lookup_realm = false
+            dns_lookup_kdc = false
+            ticket_lifetime = 24h
+            renew_lifetime = 7d
+            forwardable = yes
+
+            [realms]
+            {samba.realm} = {{
+              kdc = {samba.host.hostname}
+            }}
+            {ipa.realm} = {{
+              kdc = {ipa.host.hostname}
+            }}
+            {kdc.realm} = {{
+              kdc = {kdc.host.hostname}:88
+              admin_server = {kdc.host.hostname}:749
+            }}
+            """).lstrip(),
+        user="root",
+        group="root",
+        mode="0644",
+    )
+
+    for name, role in (("samba", samba), ("ipa", ipa), ("krb5", kdc)):
+        client.sssd.dom(name).update(
+            enabled="true",
+            id_provider="proxy",
+            proxy_lib_name="files",
+            auth_provider="krb5",
+            krb5_realm=role.realm,
+            krb5_server=role.host.hostname,
+        )
+    client.sssd.sssd["domains"] = "samba, ipa, krb5"
+    client.sssd.default_domain = "krb5"
+    client.sssd.start()
+
+    client.fs.backup("/etc/pam.d/su-l")
+    client.fs.write(
+        "/etc/pam.d/su-l",
+        cleandoc("""
+            auth        required    pam_env.so
+            auth        sufficient  pam_sss.so forward_pass domains=samba
+            auth        sufficient  pam_sss.so forward_pass domains=ipa
+            auth        sufficient  pam_sss.so forward_pass domains=krb5
+            auth        required    pam_deny.so
+            account     required    pam_sss.so
+            password    required    pam_sss.so
+            session     required    pam_sss.so
+            """),
+    )
+
+    for password, realm, domain in (
+        ("SambaSecret123", samba.realm, "samba"),
+        ("IPASecret123", ipa.realm, "ipa"),
+        ("KDCSecret123", kdc.realm, "krb5"),
+    ):
+        result = client.host.conn.run("su - user1 -c klist", input=password, raise_on_error=False)
+        assert result.rc == 0, f"Authentication with the {domain} password failed!"
+        assert (
+            f"krbtgt/{realm}@{realm}" in result.stdout
+        ), f"TGT should come from the {domain} realm ({realm}) when authenticating with that realm's password!"

--- a/src/tests/system/tests/test_smartcard.py
+++ b/src/tests/system/tests/test_smartcard.py
@@ -476,3 +476,155 @@ def test_smartcard__login_fails_when_cert_auth_required_without_card(client: Cli
     assert (
         "Authentication service cannot retrieve authentication info" in result.stderr
     ), "Authentication should have failed without a card!"
+
+
+@pytest.mark.importance("critical")
+@pytest.mark.topology(KnownTopology.Client)
+@pytest.mark.builtwith(client="virtualsmartcard")
+def test_smartcard__try_cert_auth_never_used_for_root(client: Client):
+    """
+    :title: try_cert_auth never routes root's own login through certificate authentication
+    :description:
+        pam_sss.so unconditionally refuses to handle the 'root' identity. When 'try_cert_auth'
+        is set, that refusal must surface as PAM_AUTHINFO_UNAVAIL (so the PAM stack falls back
+        to another module), not as a successful or user-unknown result. This is verified via
+        'sssctl user-checks' against a minimal 'auth required pam_sss.so try_cert_auth' service,
+        since there is no way to originate a fresh authentication attempt for the 'root' identity
+        itself via 'su'/'ssh' (root already owns the control connection).
+    :setup:
+        1. Create a local user and initialize a smart card mapped to the user
+        2. Install a minimal PAM service with 'pam_sss.so try_cert_auth'
+    :steps:
+        1. Run 'sssctl user-checks root' against that service
+    :expectedresults:
+        1. Authentication is reported unavailable, never routed through certificate auth
+    :customerscenario: True
+    """
+    client.local.user("user1").add()
+    client.smartcard.setup_local_card(client, "user1")
+    client.fs.write(
+        "/etc/pam.d/pam_sss_try_sc",
+        """
+        auth        required        pam_sss.so try_cert_auth
+        account     required        pam_sss.so
+        password    required        pam_sss.so
+        session     required        pam_sss.so
+        """,
+    )
+
+    result = client.sssctl.user_checks("root", action="auth", service="pam_sss_try_sc", auth_input=TOKEN_PIN)
+    assert (
+        "pam_authenticate for user [root]: Authentication service cannot retrieve authentication info" in result.stderr
+    ), f"root should never be routed through certificate authentication! stderr={result.stderr}"
+
+
+@pytest.mark.importance("high")
+@pytest.mark.topology(KnownTopology.Client)
+@pytest.mark.parametrize("username_input", ["", " "], ids=["empty_name", "whitespace_only_name"])
+@pytest.mark.builtwith(client="virtualsmartcard")
+def test_smartcard__certificate_owner_resolved_when_username_is_missing(client: Client, username_input: str):
+    """
+    :title: allow_missing_name resolves the certificate owner when no username is given
+    :setup:
+        1. Create a local user and initialize a smart card mapped to the user
+    :steps:
+        1. Authenticate against the 'smartcard-auth' service with an empty or
+           whitespace-only username and the smart card PIN
+    :expectedresults:
+        1. Authentication succeeds and is resolved to the certificate's mapped user
+    :customerscenario: True
+    """
+    client.local.user("user1").add()
+    client.smartcard.setup_local_card(client, "user1")
+    client.authselect.select("sssd", ["with-smartcard-required"])
+    client.sssd.pam["pam_p11_allowed_services"] = "+smartcard-auth"
+    client.sssd.restart()
+
+    result = client.sssctl.user_checks(username_input, action="auth", service="smartcard-auth", auth_input=TOKEN_PIN)
+    assert (
+        "pam_authenticate for user [user1]: Success" in result.stderr
+    ), f"Certificate owner was not resolved! stderr={result.stderr}"
+
+
+@pytest.mark.importance("medium")
+@pytest.mark.topology(KnownTopology.Client)
+@pytest.mark.builtwith(client="virtualsmartcard")
+def test_smartcard__certificate_owner_resolved_with_full_name_format(client: Client):
+    """
+    :title: allow_missing_name respects full_name_format when resolving the certificate owner
+    :setup:
+        1. Create a local user and initialize a smart card mapped to the user
+        2. Enable fully-qualified names with a custom 'full_name_format'
+    :steps:
+        1. Authenticate against the 'smartcard-auth' service with no username and the smart card PIN
+    :expectedresults:
+        1. Authentication succeeds and the resolved user name matches 'full_name_format'
+    :customerscenario: True
+    """
+    client.local.user("user1").add()
+    client.smartcard.setup_local_card(client, "user1")
+    client.authselect.select("sssd", ["with-smartcard-required"])
+    client.sssd.pam["pam_p11_allowed_services"] = "+smartcard-auth"
+    client.sssd.domain["use_fully_qualified_names"] = "True"
+    client.sssd.domain["full_name_format"] = "%2$s\\%1$s"
+    client.sssd.restart(clean=True)
+
+    result = client.sssctl.user_checks("", action="auth", service="smartcard-auth", auth_input=TOKEN_PIN)
+    assert (
+        "pam_authenticate for user [local\\user1]: Success" in result.stderr
+    ), f"Certificate owner was not resolved with full_name_format applied! stderr={result.stderr}"
+
+
+@pytest.mark.importance("medium")
+@pytest.mark.topology(KnownTopology.Client)
+@pytest.mark.parametrize("cert_selection", [1, 2])
+def test_smartcard__certificate_owner_resolved_with_two_tokens_and_missing_name(client: Client, cert_selection: int):
+    """
+    :title: allow_missing_name resolves the certificate owner when two tokens are present
+    :setup:
+        1. Create a local user
+        2. Reset the certificate CA trust store to a clean state
+        3. Initialize two SoftHSM tokens, each holding a certificate mapped to the user,
+           and trust both certificates in the CA trust store
+        4. Configure SSSD for smart card authentication and start services
+    :steps:
+        1. Authenticate against the 'smartcard-auth' service with no username, selecting
+           each certificate in turn
+    :expectedresults:
+        1. Authentication succeeds and is resolved to the certificate's mapped user for
+           either certificate selection
+    :customerscenario: True
+    """
+    username = "user1"
+    client.local.user(username).add()
+    client.host.fs.rm("/etc/sssd/pki/sssd_auth_ca_db.pem")
+
+    key1, cert1 = client.smartcard.generate_cert(key_path="/tmp/sc_token1.key", cert_path="/tmp/sc_token1.crt")
+    client.smartcard.initialize_card(label=TOKEN1_LABEL, user_pin=TOKEN_PIN, reset=True)
+    client.smartcard.add_key(key1, token_label=TOKEN1_LABEL, label=username)
+    client.smartcard.add_cert(cert1, token_label=TOKEN1_LABEL, label=username)
+    key2, cert2 = client.smartcard.generate_cert(key_path="/tmp/sc_token2.key", cert_path="/tmp/sc_token2.crt")
+    client.smartcard.initialize_card(label=TOKEN2_LABEL, user_pin=TOKEN_PIN, reset=False)
+    client.smartcard.add_key(key2, token_label=TOKEN2_LABEL, label=username)
+    client.smartcard.add_cert(cert2, token_label=TOKEN2_LABEL, label=username)
+
+    client.sssd.common.local()
+    client.sssd.section(f"certmap/local/{username}")["matchrule"] = "<SUBJECT>.*CN=Test Cert.*"
+    client.sssd.pam["pam_cert_auth"] = "True"
+    for cert in (cert1, cert2):
+        # dedent=False is required here: fs.append() strips trailing whitespace,
+        # by default which will corrupt the CA bundle.
+        client.host.fs.append(
+            "/etc/sssd/pki/sssd_auth_ca_db.pem", client.host.fs.read(cert).strip() + "\n", dedent=False
+        )
+    client.sssd.common.smartcard_with_softhsm(client.smartcard)
+    client.authselect.select("sssd", ["with-smartcard-required", "with-mkhomedir"])
+    client.sssd.pam["pam_p11_allowed_services"] = "+smartcard-auth"
+    client.sssd.restart()
+
+    result = client.sssctl.user_checks(
+        "", action="auth", service="smartcard-auth", auth_input=f"{cert_selection}\n{TOKEN_PIN}"
+    )
+    assert (
+        f"pam_authenticate for user [{username}]: Success" in result.stderr
+    ), f"Certificate owner was not resolved! stderr={result.stderr}"

--- a/src/tests/system/tests/test_smartcard.py
+++ b/src/tests/system/tests/test_smartcard.py
@@ -628,3 +628,75 @@ def test_smartcard__certificate_owner_resolved_with_two_tokens_and_missing_name(
     assert (
         f"pam_authenticate for user [{username}]: Success" in result.stderr
     ), f"Certificate owner was not resolved! stderr={result.stderr}"
+
+
+@pytest.mark.importance("high")
+@pytest.mark.topology(KnownTopology.Client)
+@pytest.mark.builtwith(client="virtualsmartcard")
+@pytest.mark.parametrize(
+    "local_auth_policy, auth_input, expected",
+    [
+        (None, None, "Password:"),
+        ("enable:smartcard", TOKEN_PIN, "pam_authenticate for user [user1]: Success"),
+    ],
+    ids=["password_fallback_when_smartcard_not_enabled", "smartcard_when_local_auth_policy_enables_it"],
+)
+def test_smartcard__proxy_auth_uses_password_or_smartcard_based_on_local_auth_policy(
+    client: Client, local_auth_policy: str | None, auth_input: str | None, expected: str
+):
+    """
+    :title: Proxy domain falls back to password unless local smartcard auth is enabled
+    :description:
+        With a smart card present, a proxy domain only offers password auth by default
+        (``local_auth_policy`` match). Enabling ``enable:smartcard`` switches the prompt
+        to the smart card PIN and authenticates with the certificate.
+    :setup:
+        1. Create a local user with a password
+        2. Enroll a smart card certificate mapped to the user
+        3. Install a minimal PAM service that only stacks ``pam_sss.so``
+    :steps:
+        1. Configure a proxy/files domain with ``pam_cert_auth`` and the parametrized
+           ``local_auth_policy``, then start SSSD
+        2. Authenticate via ``sssctl user-checks`` against that PAM service
+    :expectedresults:
+        1. SSSD starts with the requested local authentication policy
+        2. Without smartcard enabled a password prompt is shown; with
+           ``enable:smartcard`` authentication succeeds with the PIN
+    :customerscenario: True
+    :requirement: smartcard_authentication
+    """
+    client.local.user("user1").add(password="Secret123")
+
+    client.host.fs.rm("/etc/sssd/pki/sssd_auth_ca_db.pem")
+    key, cert = client.smartcard.generate_cert()
+    client.smartcard.initialize_card()
+    client.smartcard.add_key(key)
+    client.smartcard.add_cert(cert)
+    client.authselect.select("sssd", ["with-smartcard"])
+    client.svc.restart("virt_cacard.service")
+
+    client.fs.write(
+        "/etc/pam.d/pam_sss_service",
+        """
+        auth        required        pam_sss.so
+        account     required        pam_sss.so
+        password    required        pam_sss.so
+        session     required        pam_sss.so
+        """,
+    )
+
+    client.sssd.common.local()
+    if local_auth_policy is not None:
+        client.sssd.dom("local")["local_auth_policy"] = local_auth_policy
+    client.sssd.section("certmap/local/user1")["matchrule"] = "<SUBJECT>.*CN=Test Cert.*"
+    client.sssd.pam["pam_cert_auth"] = "True"
+    client.sssd.pam["pam_p11_allowed_services"] = "+pam_sss_service"
+    client.host.fs.append("/etc/sssd/pki/sssd_auth_ca_db.pem", client.host.fs.read(cert), dedent=False)
+    client.sssd.start()
+
+    result = client.host.conn.exec(
+        ["sssctl", "user-checks", "user1", "-a", "auth", "-s", "pam_sss_service"],
+        input=auth_input,
+        raise_on_error=False,
+    )
+    assert expected in result.stderr, f"Unexpected authentication prompt or result! stderr={result.stderr}"


### PR DESCRIPTION
Rewrite the remaining sssd/src/tests/intg/test_pam_responder.py cases to
test_smartcard.py, test_authentication.py

- test_try_sc_auth_root -> test_smartcard__try_cert_auth_never_used_for_root
- test_sc_auth_missing_name, test_sc_auth_missing_name_whitespace -> test_smartcard__certificate_owner_resolved_when_username_is_missing
- test_sc_auth_name_format -> test_smartcard__certificate_owner_resolved_with_full_name_format
- test_sc_auth_two_missing_name -> test_smartcard__certificate_owner_resolved_with_two_tokens_and_missing_name
- test_krb5_auth_domains -> test_authentication__pam_sss_domains_skips_non_matching_krb5_domains

Peeling out the reviewed test cases into it's own PR, from
https://github.com/SSSD/sssd/pull/8873

Requires the following framework change
https://github.com/SSSD/sssd-test-framework/pull/262

Co-authored-by: Cursor <cursoragent@cursor.com>
Model used: Claude Sonnet 5
