### PR TITLE
sudo: don't warn about search base when it was set by provider

### DIFF
--- a/src/providers/ldap/sdap.c
+++ b/src/providers/ldap/sdap.c
@@ -1341,29 +1341,44 @@ errno_t sdap_set_config_options_with_rootdse(struct sysdb_attrs *rootdse,
 
     /* Sudo */
     if (!sdom->sudo_search_bases) {
-        /* At some point make this option mandatory,
-         * i.e. disable sudo rules lookup if 'sudo_search_bases' not set.
-         */
-        DEBUG(SSSDBG_IMPORTANT_INFO,
-              "`ldap_sudo_search_base` is not set. SSSD will search the entire "
-              "directory tree (%s) for sudoRole objects. This may allow any "
-              "LDAP principal with write access to any subtree to inject "
-              "sudo rules granting arbitrary privileges. Set "
-              "`ldap_sudo_search_base` to restrict the search scope "
-              "(e.g., 'ou=sudoers,dc=example,dc=com').\n",
-              sdom->naming_context);
-       sss_log(SSS_LOG_ALERT,
-               "`ldap_sudo_search_base` is not set. SSSD will search the entire "
-               "directory tree (%s) for sudoRole objects. This may allow any "
-               "LDAP principal with write access to any subtree to inject "
-               "sudo rules granting arbitrary privileges. Set "
-               "`ldap_sudo_search_base` to restrict the search scope "
-               "(e.g., 'ou=sudoers,dc=example,dc=com').",
-               sdom->naming_context);
-       ret = sdap_set_search_base(opts, sdom,
-                                   SDAP_SUDO_SEARCH_BASE,
-                                   sdom->naming_context);
-        if (ret != EOK) goto done;
+        if (dp_opt_get_string(opts->basic, SDAP_SUDO_SEARCH_BASE) != NULL) {
+            /* The option string can be set while sdom->sudo_search_bases
+             * is still NULL when a provider sets SDAP_SUDO_SEARCH_BASE
+             * but parses it into its own context rather than into sdom.
+             * E.g. IPA sets it to "cn=sudo,<basedn>" in
+             * ipa_sudo_choose_schema() and parses it into sudo_ctx->sudo_sb
+             * in ipa_sudo_init_ipa_schema(), bypassing sdom entirely.
+             * In this case just parse the already-set option into sdom. */
+            ret = sdap_parse_search_base(opts,
+                                         sysdb_ctx_get_ldb(sdom->dom->sysdb),
+                                         opts->basic, SDAP_SUDO_SEARCH_BASE,
+                                         &sdom->sudo_search_bases);
+            if (ret != EOK) goto done;
+        } else {
+            /* At some point make this option mandatory,
+             * i.e. disable sudo rules lookup if 'sudo_search_bases' not set.
+             */
+            DEBUG(SSSDBG_IMPORTANT_INFO,
+                  "`ldap_sudo_search_base` is not set. SSSD will search the "
+                  "entire directory tree (%s) for sudoRole objects. This may "
+                  "allow any LDAP principal with write access to any subtree "
+                  "to inject sudo rules granting arbitrary privileges. Set "
+                  "`ldap_sudo_search_base` to restrict the search scope "
+                  "(e.g., 'ou=sudoers,dc=example,dc=com').\n",
+                  sdom->naming_context);
+            sss_log(SSS_LOG_ALERT,
+                    "`ldap_sudo_search_base` is not set. SSSD will search the "
+                    "entire directory tree (%s) for sudoRole objects. This may "
+                    "allow any LDAP principal with write access to any subtree "
+                    "to inject sudo rules granting arbitrary privileges. Set "
+                    "`ldap_sudo_search_base` to restrict the search scope "
+                    "(e.g., 'ou=sudoers,dc=example,dc=com').",
+                    sdom->naming_context);
+            ret = sdap_set_search_base(opts, sdom,
+                                       SDAP_SUDO_SEARCH_BASE,
+                                       sdom->naming_context);
+            if (ret != EOK) goto done;
+        }
     }
 
     /* Services */


### PR DESCRIPTION
Assisted-By: Claude Code (Opus 4.6)

Resolves: https://github.com/SSSD/sssd/issues/9030