### PR TITLE
cfg_rules: add pwfield to allowed_domain_options

### DIFF
--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -389,6 +389,7 @@ option = account_cache_expiration
 option = pwd_expiration_warning
 option = filter_users
 option = filter_groups
+option = pwfield
 option = dns_resolver_server_timeout
 option = dns_resolver_op_timeout
 option = dns_resolver_timeout

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -1229,16 +1229,26 @@ fallback_homedir = /home/%u
                             <quote>password</quote> field.
                         </para>
                         <para>
+                            This option can also be set per-domain, which
+                            overwrites the value in the <quote>[nss]</quote>
+                            section for that domain. This is particularly useful
+                            when using a proxy domain with
+                            <option>proxy_lib_name=files</option> and a
+                            <option>proxy_pam_target</option> other than
+                            <quote>sssd-shadowutils</quote>. In that case, SSSD
+                            returns <quote>*</quote> for the password field by
+                            default, which causes <command>pam_unix</command> to
+                            treat all accounts as locked. Setting
+                            <option>pwfield = x</option> in the domain section
+                            restores the expected behavior.
+                        </para>
+                        <para>
                             Default: <quote>*</quote>
                         </para>
                         <para>
-                            Note: This option can also be set per-domain which
-                            overwrites the value in [nss] section.
-                        </para>
-                        <para>
-                            Default: <quote>not set</quote> (remote domains),
-                            <quote>x</quote> (proxy domain with nss_files
-                            and sssd-shadowutils target)
+                            Default (per-domain): <quote>not set</quote> (remote
+                            domains), <quote>x</quote> (proxy domain with
+                            nss_files and sssd-shadowutils target)
                         </para>
                     </listitem>
                 </varlistentry>


### PR DESCRIPTION
## Problem

`pwfield` was made configurable per-domain in commit c778c36c5
(_CONFDB: Make pwfield configurable per-domain_, 2016), but
`cfg_rules.ini` was never updated. As a result, `sssctl config-check`
rejects `pwfield` in any `[domain/*]` section:

```
[rule/allowed_domain_options]: Attribute 'pwfield' is not allowed in
section 'domain/local'. Check for typos.
```

This surfaces in practice when a test or deployment sets `pwfield=x`
in a proxy domain with `proxy_lib_name=files` to work around the
`*`-vs-`x` issue documented in #5129. Even though SSSD reads and
respects the value at runtime (via `confdb.c`), the config validator
incorrectly rejects it.

## Fix

Add `pwfield` to `[rule/allowed_domain_options]` in `cfg_rules.ini`,
placing it alongside the other NSS override options (`filter_users`,
`filter_groups`).

## Testing

Verified that `sssctl config-check` no longer reports an error for
a `[domain/local]` section containing `pwfield=x`.

Resolves: #5129