### PR TITLE
cfg_rules: add pwfield to allowed_domain_options

### DIFF
--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -403,6 +403,7 @@ option = account_cache_expiration
 option = pwd_expiration_warning
 option = filter_users
 option = filter_groups
+option = pwfield
 option = dns_resolver_server_timeout
 option = dns_resolver_op_timeout
 option = dns_resolver_timeout


### PR DESCRIPTION
Backport of #9034 to sssd-2-9.

`pwfield` was made configurable per-domain in commit c778c36c5
(_CONFDB: Make pwfield configurable per-domain_, 2016), but
`cfg_rules.ini` was never updated. As a result, `sssctl config-check`
rejects `pwfield` in any `[domain/*]` section:

```
[rule/allowed_domain_options]: Attribute 'pwfield' is not allowed in
section 'domain/local'. Check for typos.
```

Add `pwfield` to `[rule/allowed_domain_options]` to match the
documented and implemented behavior.

Resolves: #5129