### PR TITLE
pam: validate auth_token_length in extract_authtok_v1()

### DIFF
--- a/src/responder/pam/pamsrv_cmd.c
+++ b/src/responder/pam/pamsrv_cmd.c
@@ -450,6 +450,11 @@ static int extract_authtok_v1(struct sss_auth_token *tok,
 
     SAFEALIGN_COPY_UINT32_CHECK(&auth_token_type, &body[*c], blen, c);
     SAFEALIGN_COPY_UINT32_CHECK(&auth_token_length, &body[*c], blen, c);
+
+    if (*c + auth_token_length > blen || SIZE_T_OVERFLOW(*c, auth_token_length)) {
+        return EINVAL;
+    }
+
     auth_token_data = body+(*c);
 
     switch (auth_token_type) {


### PR DESCRIPTION
The check mimics one existing in `extract_authtok_v2()`

:fixes: CVE-2026-68743

Assisted-By: Claude Code (Opus 4.6)

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=2510305