### PR TITLE
[sssd-2-9] cfg_rules: add pwfield to allowed_domain_options

### DIFF
--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -403,6 +403,7 @@ option = account_cache_expiration
 option = pwd_expiration_warning
 option = filter_users
 option = filter_groups
+option = pwfield
 option = dns_resolver_server_timeout
 option = dns_resolver_op_timeout
 option = dns_resolver_timeout

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -1293,14 +1293,25 @@ fallback_homedir = /home/%u
                             <quote>password</quote> field.
                         </para>
                         <para>
+                            This option can also be set per-domain, which
+                            overwrites the value in the <quote>[nss]</quote>
+                            section for that domain. This is particularly useful
+                            when using a proxy domain with
+                            <option>proxy_lib_name=files</option> and a
+                            <option>proxy_pam_target</option> other than
+                            <quote>sssd-shadowutils</quote>. In that case, SSSD
+                            returns <quote>*</quote> for the password field by
+                            default, which causes <command>pam_unix</command> to
+                            treat all accounts as locked. Setting
+                            <option>pwfield = x</option> in the domain section
+                            restores the expected behavior.
+                        </para>
+                        <para>
                             Default: <quote>*</quote>
                         </para>
                         <para>
-                            Note: This option can also be set per-domain which
-                            overwrites the value in [nss] section.
-                        </para>
-                        <para>
-                            Default: <quote>not set</quote> (remote domains),
+                            Default (per-domain): <quote>not set</quote> (remote
+                            domains),
                             <phrase condition="with_files_provider">
                                 <quote>x</quote> (the files domain),
                             </phrase>


### PR DESCRIPTION
Backport of #9034 to sssd-2-9.

Conflict in `src/man/sssd.conf.5.xml` was resolved manually: preserved `<phrase condition="with_files_provider">` which exists in sssd-2-9 but was removed in master (see commit `827a9bffa Delete 'files provider'`).

Closes #9037.