### PR TITLE
sysdb: preserve memberships when renaming verified groups

### DIFF
--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -2850,6 +2850,17 @@ static errno_t sysdb_store_group_attrs(struct sss_domain_info *domain,
                                        uint64_t cache_timeout,
                                        time_t now);
 
+static bool sysdb_group_identity_matches(struct ldb_message *cached_group,
+                                         struct sysdb_attrs *attrs);
+
+static errno_t sysdb_rename_group(struct sss_domain_info *domain,
+                                  struct ldb_message *cached_group,
+                                  const char *name,
+                                  gid_t gid,
+                                  struct sysdb_attrs *attrs,
+                                  uint64_t cache_timeout,
+                                  time_t now);
+
 int sysdb_store_group(struct sss_domain_info *domain,
                       const char *name,
                       gid_t gid,
@@ -2964,6 +2975,115 @@ done:
     return ret;
 }
 
+static bool sysdb_group_identity_matches(struct ldb_message *cached_group,
+                                         struct sysdb_attrs *attrs)
+{
+    static const char *stable_attrs[] = { SYSDB_SID_STR, SYSDB_UUID, NULL };
+    const char *cached_value;
+    const char *incoming_value;
+    bool compared = false;
+    int i;
+    errno_t ret;
+
+    for (i = 0; stable_attrs[i] != NULL; i++) {
+        cached_value = ldb_msg_find_attr_as_string(cached_group,
+                                                   stable_attrs[i], NULL);
+        ret = sysdb_attrs_get_string(attrs, stable_attrs[i],
+                                     &incoming_value);
+        if (cached_value == NULL || ret != EOK) {
+            continue;
+        }
+
+        compared = true;
+        if (strcmp(cached_value, incoming_value) != 0) {
+            return false;
+        }
+    }
+
+    if (compared) {
+        return true;
+    }
+
+    cached_value = ldb_msg_find_attr_as_string(cached_group, SYSDB_ORIG_DN,
+                                                NULL);
+    ret = sysdb_attrs_get_string(attrs, SYSDB_ORIG_DN, &incoming_value);
+    return cached_value != NULL && ret == EOK
+        && strcmp(cached_value, incoming_value) == 0;
+}
+
+static errno_t sysdb_rename_group(struct sss_domain_info *domain,
+                                  struct ldb_message *cached_group,
+                                  const char *name,
+                                  gid_t gid,
+                                  struct sysdb_attrs *attrs,
+                                  uint64_t cache_timeout,
+                                  time_t now)
+{
+    TALLOC_CTX *tmp_ctx;
+    struct ldb_message_element *name_el;
+    struct sysdb_attrs *name_attrs;
+    struct ldb_dn *new_dn;
+    errno_t ret;
+    errno_t tret;
+    int lret;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    ret = sysdb_attrs_get_el_ext(attrs, SYSDB_NAME, false, &name_el);
+    if (ret == ENOENT) {
+        ret = sysdb_attrs_add_string(attrs, SYSDB_NAME, name);
+    }
+    if (ret != EOK) {
+        goto done;
+    }
+
+    new_dn = sysdb_group_dn(tmp_ctx, domain, name);
+    if (new_dn == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    lret = ldb_rename(domain->sysdb->ldb, cached_group->dn, new_dn);
+    ret = sysdb_error_to_errno(lret);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "Could not rename cached group: %d\n", ret);
+        goto done;
+    }
+
+    /* The open transaction can expose the new RDN before the stored name
+     * attribute changes, making the generic no-op check suppress this write. */
+    name_attrs = sysdb_new_attrs(tmp_ctx);
+    if (name_attrs == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+    ret = sysdb_attrs_add_string(name_attrs, SYSDB_NAME, name);
+    if (ret != EOK) {
+        goto done;
+    }
+    ret = sysdb_set_cache_entry_attr(domain->sysdb->ldb, new_dn,
+                                     name_attrs, SYSDB_MOD_REP);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Could not update the renamed group name: %d\n", ret);
+        goto done;
+    }
+
+    tret = sysdb_delete_ts_entry(domain->sysdb, cached_group->dn);
+    if (tret != EOK) {
+        DEBUG(SSSDBG_MINOR_FAILURE,
+              "Could not remove the old group timestamp entry: %d\n", tret);
+    }
+
+    ret = sysdb_store_group_attrs(domain, name, gid, attrs,
+                                  cache_timeout, now);
+done:
+    talloc_zfree(tmp_ctx);
+    return ret;
+}
 
 static errno_t sysdb_store_new_group(struct sss_domain_info *domain,
                                      const char *name,
@@ -2972,6 +3092,11 @@ static errno_t sysdb_store_new_group(struct sss_domain_info *domain,
                                      uint64_t cache_timeout,
                                      time_t now)
 {
+    static const char *identity_attrs[] = {
+        SYSDB_SID_STR, SYSDB_UUID, SYSDB_ORIG_DN, NULL
+    };
+    TALLOC_CTX *tmp_ctx;
+    struct ldb_message *cached_group;
     errno_t ret;
 
     /* group doesn't exist, turn into adding a group */
@@ -2981,6 +3106,26 @@ static errno_t sysdb_store_new_group(struct sss_domain_info *domain,
          * same GID, remove it and try to add the basic group again
          */
         DEBUG(SSSDBG_TRACE_LIBS, "sysdb_add_group failed: [EEXIST].\n");
+        if (gid != 0) {
+            tmp_ctx = talloc_new(NULL);
+            if (tmp_ctx == NULL) {
+                return ENOMEM;
+            }
+
+            ret = sysdb_search_group_by_gid(tmp_ctx, domain, gid,
+                                            identity_attrs, &cached_group);
+            if (ret == EOK
+                    && sysdb_group_identity_matches(cached_group, attrs)) {
+                DEBUG(SSSDBG_TRACE_LIBS,
+                      "Renaming a cached group with a verified identity.\n");
+                ret = sysdb_rename_group(domain, cached_group, name, gid,
+                                         attrs, cache_timeout, now);
+                talloc_zfree(tmp_ctx);
+                return ret;
+            }
+
+            talloc_zfree(tmp_ctx);
+        }
         ret = sysdb_delete_group(domain, NULL, gid);
         if (ret == ENOENT) {
             /* Not found by GID, return the original EEXIST,

--- a/src/ldb_modules/memberof.c
+++ b/src/ldb_modules/memberof.c
@@ -17,6 +17,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <stdint.h>
 #include <string.h>
 #include <dhash.h>
 
@@ -168,8 +169,8 @@ struct mbof_rename_ctx {
     struct mbof_ctx *ctx;
 
     struct ldb_message **entries;
-    int num_entries;
-    int current_entry;
+    size_t num_entries;
+    size_t current_entry;
 };
 static struct mbof_ctx *mbof_init(struct ldb_module *module,
                                   struct ldb_request *req)
@@ -1404,6 +1405,10 @@ static int mbof_rename_search_callback(struct ldb_request *req,
 
     switch (ares->type) {
     case LDB_REPLY_ENTRY:
+        if (rename_ctx->num_entries == SIZE_MAX) {
+            return ldb_module_done(ctx->req, NULL, NULL,
+                                   LDB_ERR_OPERATIONS_ERROR);
+        }
         entries = talloc_realloc(rename_ctx, rename_ctx->entries,
                                  struct ldb_message *,
                                  rename_ctx->num_entries + 1);

--- a/src/ldb_modules/memberof.c
+++ b/src/ldb_modules/memberof.c
@@ -164,6 +164,13 @@ struct mbof_mod_ctx {
     bool terminate;
 };
 
+struct mbof_rename_ctx {
+    struct mbof_ctx *ctx;
+
+    struct ldb_message **entries;
+    int num_entries;
+    int current_entry;
+};
 static struct mbof_ctx *mbof_init(struct ldb_module *module,
                                   struct ldb_request *req)
 {
@@ -1274,6 +1281,412 @@ static int mbof_add_muop_callback(struct ldb_request *req,
     return LDB_SUCCESS;
 }
 
+
+
+
+/* rename operation */
+
+/*
+ * A rename only changes the DN used to label a member/memberof edge. Unlike a
+ * delete, it does not change the membership graph, so update those labels
+ * directly instead of recalculating all transitive memberships.
+ */
+
+static int mbof_rename_search_callback(struct ldb_request *req,
+                                       struct ldb_reply *ares);
+static int mbof_rename_callback(struct ldb_request *req,
+                                struct ldb_reply *ares);
+static int mbof_rename_mod_callback(struct ldb_request *req,
+                                    struct ldb_reply *ares);
+static int mbof_rename_next_mod(struct mbof_rename_ctx *rename_ctx);
+static int mbof_rename_make_mod(struct mbof_rename_ctx *rename_ctx,
+                                struct ldb_message *entry,
+                                struct ldb_message **_mod_msg);
+static int mbof_rename_replace_values(struct mbof_rename_ctx *rename_ctx,
+                                      struct ldb_message *mod_msg,
+                                      const struct ldb_message_element *src);
+
+static int memberof_rename(struct ldb_module *module,
+                           struct ldb_request *req)
+{
+    static const char *attrs[] = { DB_MEMBER, DB_MEMBEROF, NULL };
+    struct ldb_context *ldb = ldb_module_get_ctx(module);
+    struct mbof_rename_ctx *rename_ctx;
+    struct mbof_ctx *ctx;
+    struct ldb_request *search;
+    const char *old_dn;
+    char *clean_dn;
+    char *expression;
+    errno_t sret;
+    int ret;
+
+    if (getenv("SSSD_UPGRADE_DB")) {
+        /* do not do anything during upgrade */
+        return ldb_next_request(module, req);
+    }
+
+    if (ldb_dn_is_special(req->op.rename.olddn)
+            || ldb_dn_is_special(req->op.rename.newdn)) {
+        /* do not manipulate control entries */
+        return ldb_next_request(module, req);
+    }
+
+    ctx = mbof_init(module, req);
+    if (ctx == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    rename_ctx = talloc_zero(ctx, struct mbof_rename_ctx);
+    if (rename_ctx == NULL) {
+        talloc_free(ctx);
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    rename_ctx->ctx = ctx;
+
+    old_dn = ldb_dn_get_linearized(req->op.rename.olddn);
+    if (old_dn == NULL) {
+        talloc_free(ctx);
+        return LDB_ERR_INVALID_DN_SYNTAX;
+    }
+
+    sret = sss_filter_sanitize_dn(rename_ctx, old_dn, &clean_dn);
+    if (sret != EOK) {
+        talloc_free(ctx);
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    expression = talloc_asprintf(rename_ctx, "(|(%s=%s)(%s=%s))",
+                                 DB_MEMBER, clean_dn,
+                                 DB_MEMBEROF, clean_dn);
+    talloc_zfree(clean_dn);
+    if (expression == NULL) {
+        talloc_free(ctx);
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    ret = ldb_build_search_req(&search, ldb, rename_ctx,
+                               NULL, LDB_SCOPE_SUBTREE,
+                               expression, attrs, NULL,
+                               rename_ctx, mbof_rename_search_callback,
+                               req);
+    if (ret != LDB_SUCCESS) {
+        talloc_free(ctx);
+        return ret;
+    }
+
+    return ldb_request(ldb, search);
+}
+
+static int mbof_rename_search_callback(struct ldb_request *req,
+                                       struct ldb_reply *ares)
+{
+    struct mbof_rename_ctx *rename_ctx;
+    struct mbof_ctx *ctx;
+    struct ldb_context *ldb;
+    struct ldb_request *rename_req;
+    struct ldb_message **entries;
+    int ret;
+
+    rename_ctx = talloc_get_type(req->context, struct mbof_rename_ctx);
+    ctx = rename_ctx->ctx;
+    ldb = ldb_module_get_ctx(ctx->module);
+
+    if (ares == NULL) {
+        return ldb_module_done(ctx->req, NULL, NULL,
+                               LDB_ERR_OPERATIONS_ERROR);
+    }
+    if (ares->error != LDB_SUCCESS) {
+        return ldb_module_done(ctx->req,
+                               ares->controls,
+                               ares->response,
+                               ares->error);
+    }
+
+    switch (ares->type) {
+    case LDB_REPLY_ENTRY:
+        entries = talloc_realloc(rename_ctx, rename_ctx->entries,
+                                 struct ldb_message *,
+                                 rename_ctx->num_entries + 1);
+        if (entries == NULL) {
+            return ldb_module_done(ctx->req, NULL, NULL,
+                                   LDB_ERR_OPERATIONS_ERROR);
+        }
+        rename_ctx->entries = entries;
+
+        entries[rename_ctx->num_entries] = talloc_steal(entries,
+                                                         ares->message);
+        if (entries[rename_ctx->num_entries] == NULL) {
+            return ldb_module_done(ctx->req, NULL, NULL,
+                                   LDB_ERR_OPERATIONS_ERROR);
+        }
+        rename_ctx->num_entries++;
+        break;
+
+    case LDB_REPLY_REFERRAL:
+        /* ignore */
+        break;
+
+    case LDB_REPLY_DONE:
+        ret = ldb_build_rename_req(&rename_req, ldb, rename_ctx,
+                                   ctx->req->op.rename.olddn,
+                                   ctx->req->op.rename.newdn,
+                                   ctx->req->controls,
+                                   rename_ctx, mbof_rename_callback,
+                                   ctx->req);
+        talloc_zfree(ares);
+        if (ret != LDB_SUCCESS) {
+            return ldb_module_done(ctx->req, NULL, NULL, ret);
+        }
+
+        return ldb_next_request(ctx->module, rename_req);
+    }
+
+    talloc_zfree(ares);
+    return LDB_SUCCESS;
+}
+
+static int mbof_rename_callback(struct ldb_request *req,
+                                struct ldb_reply *ares)
+{
+    struct mbof_rename_ctx *rename_ctx;
+    struct mbof_ctx *ctx;
+    struct ldb_context *ldb;
+    int ret;
+
+    rename_ctx = talloc_get_type(req->context, struct mbof_rename_ctx);
+    ctx = rename_ctx->ctx;
+    ldb = ldb_module_get_ctx(ctx->module);
+
+    if (ares == NULL) {
+        return ldb_module_done(ctx->req, NULL, NULL,
+                               LDB_ERR_OPERATIONS_ERROR);
+    }
+    if (ares->error != LDB_SUCCESS) {
+        return ldb_module_done(ctx->req,
+                               ares->controls,
+                               ares->response,
+                               ares->error);
+    }
+    if (ares->type != LDB_REPLY_DONE) {
+        talloc_zfree(ares);
+        ldb_set_errstring(ldb, "Invalid reply type!");
+        return ldb_module_done(ctx->req, NULL, NULL,
+                               LDB_ERR_OPERATIONS_ERROR);
+    }
+
+    ctx->ret_ctrls = talloc_steal(ctx, ares->controls);
+    ctx->ret_resp = talloc_steal(ctx, ares->response);
+    talloc_zfree(ares);
+
+    ret = mbof_rename_next_mod(rename_ctx);
+    if (ret != LDB_SUCCESS) {
+        return ldb_module_done(ctx->req, NULL, NULL, ret);
+    }
+
+    return LDB_SUCCESS;
+}
+
+static int mbof_rename_replace_values(struct mbof_rename_ctx *rename_ctx,
+                                      struct ldb_message *mod_msg,
+                                      const struct ldb_message_element *src)
+{
+    struct mbof_ctx *ctx = rename_ctx->ctx;
+    struct ldb_message_element *dst;
+    const char *old_dn;
+    const char *new_dn;
+    const char *value;
+    bool changed = false;
+    bool duplicate;
+    unsigned int i;
+    unsigned int j;
+    int ret;
+
+    old_dn = ldb_dn_get_linearized(ctx->req->op.rename.olddn);
+    new_dn = ldb_dn_get_linearized(ctx->req->op.rename.newdn);
+    if (old_dn == NULL || new_dn == NULL) {
+        return LDB_ERR_INVALID_DN_SYNTAX;
+    }
+
+    for (i = 0; i < src->num_values; i++) {
+        if (sss_linearized_dn_match((const char *)src->values[i].data,
+                                    old_dn)) {
+            changed = true;
+            break;
+        }
+    }
+    if (!changed) {
+        return LDB_SUCCESS;
+    }
+
+    ret = ldb_msg_add_empty(mod_msg, src->name, LDB_FLAG_MOD_REPLACE, &dst);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+
+    dst->values = talloc_array(dst, struct ldb_val, src->num_values);
+    if (dst->values == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    for (i = 0; i < src->num_values; i++) {
+        value = (const char *)src->values[i].data;
+        if (sss_linearized_dn_match(value, old_dn)) {
+            value = new_dn;
+        }
+
+        duplicate = false;
+        for (j = 0; j < dst->num_values; j++) {
+            if (sss_linearized_dn_match(value,
+                                        (const char *)dst->values[j].data)) {
+                duplicate = true;
+                break;
+            }
+        }
+        if (duplicate) {
+            continue;
+        }
+
+        dst->values[dst->num_values].data =
+            (uint8_t *)talloc_strdup(dst->values, value);
+        if (dst->values[dst->num_values].data == NULL) {
+            return LDB_ERR_OPERATIONS_ERROR;
+        }
+        dst->values[dst->num_values].length = strlen(value);
+        dst->num_values++;
+    }
+
+    return LDB_SUCCESS;
+}
+
+static int mbof_rename_make_mod(struct mbof_rename_ctx *rename_ctx,
+                                struct ldb_message *entry,
+                                struct ldb_message **_mod_msg)
+{
+    struct mbof_ctx *ctx = rename_ctx->ctx;
+    struct ldb_message_element *el;
+    struct ldb_message *mod_msg;
+    const char *entry_dn;
+    const char *old_dn;
+    int ret;
+
+    *_mod_msg = NULL;
+
+    old_dn = ldb_dn_get_linearized(ctx->req->op.rename.olddn);
+    entry_dn = ldb_dn_get_linearized(entry->dn);
+    if (old_dn == NULL || entry_dn == NULL) {
+        return LDB_ERR_INVALID_DN_SYNTAX;
+    }
+
+    mod_msg = ldb_msg_new(rename_ctx);
+    if (mod_msg == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    if (sss_linearized_dn_match(entry_dn, old_dn)) {
+        mod_msg->dn = ctx->req->op.rename.newdn;
+    } else {
+        mod_msg->dn = entry->dn;
+    }
+
+    el = ldb_msg_find_element(entry, DB_MEMBER);
+    if (el != NULL) {
+        ret = mbof_rename_replace_values(rename_ctx, mod_msg, el);
+        if (ret != LDB_SUCCESS) {
+            talloc_free(mod_msg);
+            return ret;
+        }
+    }
+
+    el = ldb_msg_find_element(entry, DB_MEMBEROF);
+    if (el != NULL) {
+        ret = mbof_rename_replace_values(rename_ctx, mod_msg, el);
+        if (ret != LDB_SUCCESS) {
+            talloc_free(mod_msg);
+            return ret;
+        }
+    }
+
+    if (mod_msg->num_elements == 0) {
+        talloc_free(mod_msg);
+        return LDB_SUCCESS;
+    }
+
+    *_mod_msg = mod_msg;
+    return LDB_SUCCESS;
+}
+
+static int mbof_rename_next_mod(struct mbof_rename_ctx *rename_ctx)
+{
+    struct mbof_ctx *ctx = rename_ctx->ctx;
+    struct ldb_context *ldb = ldb_module_get_ctx(ctx->module);
+    struct ldb_request *mod_req;
+    struct ldb_message *mod_msg;
+    int ret;
+
+    while (rename_ctx->current_entry < rename_ctx->num_entries) {
+        ret = mbof_rename_make_mod(rename_ctx,
+                                   rename_ctx->entries[rename_ctx->current_entry],
+                                   &mod_msg);
+        rename_ctx->current_entry++;
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+        if (mod_msg == NULL) {
+            continue;
+        }
+
+        ret = ldb_build_mod_req(&mod_req, ldb, rename_ctx,
+                                mod_msg, NULL,
+                                rename_ctx, mbof_rename_mod_callback,
+                                ctx->req);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+
+        return ldb_next_request(ctx->module, mod_req);
+    }
+
+    return ldb_module_done(ctx->req, ctx->ret_ctrls, ctx->ret_resp,
+                           LDB_SUCCESS);
+}
+
+static int mbof_rename_mod_callback(struct ldb_request *req,
+                                    struct ldb_reply *ares)
+{
+    struct mbof_rename_ctx *rename_ctx;
+    struct mbof_ctx *ctx;
+    struct ldb_context *ldb;
+    int ret;
+
+    rename_ctx = talloc_get_type(req->context, struct mbof_rename_ctx);
+    ctx = rename_ctx->ctx;
+    ldb = ldb_module_get_ctx(ctx->module);
+
+    if (ares == NULL) {
+        return ldb_module_done(ctx->req, NULL, NULL,
+                               LDB_ERR_OPERATIONS_ERROR);
+    }
+    if (ares->error != LDB_SUCCESS) {
+        return ldb_module_done(ctx->req,
+                               ares->controls,
+                               ares->response,
+                               ares->error);
+    }
+    if (ares->type != LDB_REPLY_DONE) {
+        talloc_zfree(ares);
+        ldb_set_errstring(ldb, "Invalid reply type!");
+        return ldb_module_done(ctx->req, NULL, NULL,
+                               LDB_ERR_OPERATIONS_ERROR);
+    }
+
+    talloc_zfree(ares);
+    ret = mbof_rename_next_mod(rename_ctx);
+    if (ret != LDB_SUCCESS) {
+        return ldb_module_done(ctx->req, NULL, NULL, ret);
+    }
+
+    return LDB_SUCCESS;
+}
 
 
 
@@ -4654,6 +5067,7 @@ const struct ldb_module_ops ldb_memberof_module_ops = {
     .add = memberof_add,
     .modify = memberof_mod,
     .del = memberof_del,
+    .rename = memberof_rename,
 };
 
 int ldb_init_module(const char *version)

--- a/src/tests/sysdb-tests.c
+++ b/src/tests/sysdb-tests.c
@@ -3975,6 +3975,27 @@ START_TEST(test_sysdb_get_real_name)
 }
 END_TEST
 
+static bool test_message_has_value(struct ldb_message *msg,
+                                   const char *attr,
+                                   const char *value)
+{
+    struct ldb_message_element *el;
+    unsigned int i;
+
+    el = ldb_msg_find_element(msg, attr);
+    if (el == NULL) {
+        return false;
+    }
+
+    for (i = 0; i < el->num_values; i++) {
+        if (strcmp((const char *)el->values[i].data, value) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 START_TEST(test_group_rename)
 {
     struct sysdb_test_ctx *test_ctx;
@@ -4048,6 +4069,189 @@ START_TEST(test_group_rename)
     ck_assert_msg(res->count == 0, "Unexpectedly found the original user\n");
 
 done:
+    talloc_free(test_ctx);
+}
+END_TEST
+
+START_TEST(test_group_rename_preserves_memberships)
+{
+    const char *membership_attrs[] = {
+        SYSDB_NAME, SYSDB_MEMBER, SYSDB_MEMBEROF, NULL
+    };
+    const gid_t parent_gid = 38100;
+    const gid_t old_gid = 38101;
+    const gid_t child_gid = 38102;
+    const uid_t user_uid = 38103;
+    struct sysdb_test_ctx *test_ctx;
+    struct sysdb_attrs *old_attrs;
+    struct sysdb_attrs *new_attrs;
+    struct ldb_dn *parent_dn;
+    struct ldb_dn *old_dn;
+    struct ldb_dn *new_dn;
+    struct ldb_dn *child_dn;
+    struct ldb_message *msg;
+    struct ldb_result *res;
+    const char *parent;
+    const char *old_name;
+    const char *new_name;
+    const char *child;
+    const char *user;
+    const char *parent_dn_str;
+    const char *old_dn_str;
+    const char *new_dn_str;
+    const char *child_dn_str;
+    const char *entry_name;
+    bool found_old = false;
+    bool found_new = false;
+    unsigned int i;
+    errno_t ret;
+
+    ret = setup_sysdb_tests(&test_ctx);
+    ck_assert_msg(ret == EOK, "Could not set up the test");
+
+    parent = sss_create_internal_fqname(test_ctx, "rename-parent",
+                                        test_ctx->domain->name);
+    old_name = sss_create_internal_fqname(test_ctx, "rename-old",
+                                          test_ctx->domain->name);
+    new_name = sss_create_internal_fqname(test_ctx, "rename-new",
+                                          test_ctx->domain->name);
+    child = sss_create_internal_fqname(test_ctx, "rename-child",
+                                       test_ctx->domain->name);
+    user = sss_create_internal_fqname(test_ctx, "rename-user",
+                                      test_ctx->domain->name);
+    ck_assert_msg(parent != NULL && old_name != NULL && new_name != NULL
+                  && child != NULL && user != NULL,
+                  "sss_create_internal_fqname failed");
+
+    old_attrs = sysdb_new_attrs(test_ctx);
+    ck_assert_msg(old_attrs != NULL, "sysdb_new_attrs failed");
+    ret = sysdb_attrs_add_string(old_attrs, SYSDB_SID_STR,
+                                 "S-1-5-21-123-456-789-111");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_string failed");
+
+    new_attrs = sysdb_new_attrs(test_ctx);
+    ck_assert_msg(new_attrs != NULL, "sysdb_new_attrs failed");
+    ret = sysdb_attrs_add_string(new_attrs, SYSDB_SID_STR,
+                                 "S-1-5-21-123-456-789-111");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_string failed");
+
+    ret = sysdb_store_user(test_ctx->domain, user, NULL, user_uid, 0,
+                           "Rename User", "/home/rename-user", "/bin/sh",
+                           NULL, NULL, NULL, -1, 0);
+    ck_assert_msg(ret == EOK, "Could not add test user");
+
+    ret = sysdb_store_group(test_ctx->domain, parent, parent_gid, NULL, 0, 0);
+    ck_assert_msg(ret == EOK, "Could not add parent group");
+    ret = sysdb_store_group(test_ctx->domain, old_name, old_gid,
+                            old_attrs, 0, 0);
+    ck_assert_msg(ret == EOK, "Could not add original group");
+    ret = sysdb_store_group(test_ctx->domain, child, child_gid, NULL, 0, 0);
+    ck_assert_msg(ret == EOK, "Could not add child group");
+
+    ret = sysdb_add_group_member(test_ctx->domain, parent, old_name,
+                                 SYSDB_MEMBER_GROUP, false);
+    ck_assert_msg(ret == EOK, "Could not add renamed group to parent");
+    ret = sysdb_add_group_member(test_ctx->domain, old_name, child,
+                                 SYSDB_MEMBER_GROUP, false);
+    ck_assert_msg(ret == EOK, "Could not add child to renamed group");
+    ret = sysdb_add_group_member(test_ctx->domain, child, user,
+                                 SYSDB_MEMBER_USER, false);
+    ck_assert_msg(ret == EOK, "Could not add user to child group");
+
+    parent_dn = sysdb_group_dn(test_ctx, test_ctx->domain, parent);
+    old_dn = sysdb_group_dn(test_ctx, test_ctx->domain, old_name);
+    new_dn = sysdb_group_dn(test_ctx, test_ctx->domain, new_name);
+    child_dn = sysdb_group_dn(test_ctx, test_ctx->domain, child);
+    ck_assert_msg(parent_dn != NULL && old_dn != NULL && new_dn != NULL
+                  && child_dn != NULL, "sysdb_group_dn failed");
+    parent_dn_str = ldb_dn_get_linearized(parent_dn);
+    old_dn_str = ldb_dn_get_linearized(old_dn);
+    new_dn_str = ldb_dn_get_linearized(new_dn);
+    child_dn_str = ldb_dn_get_linearized(child_dn);
+    ck_assert_msg(parent_dn_str != NULL && old_dn_str != NULL
+                  && new_dn_str != NULL && child_dn_str != NULL,
+                  "ldb_dn_get_linearized failed");
+
+    ret = sysdb_store_group(test_ctx->domain, new_name, old_gid,
+                            new_attrs, 0, 0);
+    ck_assert_msg(ret == EOK, "Could not rename the group");
+
+    ret = sysdb_getgrnam(test_ctx, test_ctx->domain, old_name, &res);
+    ck_assert_msg(ret == EOK, "Could not look up the old group name");
+    ck_assert_int_eq(res->count, 0);
+
+    ret = sysdb_search_group_by_name(test_ctx, test_ctx->domain, new_name,
+                                     membership_attrs, &msg);
+    ck_assert_msg(ret == EOK, "Could not look up the renamed group");
+    ck_assert_msg(test_message_has_value(msg, SYSDB_MEMBER,
+                                         child_dn_str),
+                  "Renamed group lost its direct child");
+    ck_assert_msg(test_message_has_value(msg, SYSDB_MEMBEROF,
+                                         parent_dn_str),
+                  "Renamed group lost its parent");
+    talloc_zfree(msg);
+
+    ret = sysdb_search_group_by_name(test_ctx, test_ctx->domain, parent,
+                                     membership_attrs, &msg);
+    ck_assert_msg(ret == EOK, "Could not look up the parent group");
+    ck_assert_msg(test_message_has_value(msg, SYSDB_MEMBER,
+                                         new_dn_str),
+                  "Parent still refers to the old group DN");
+    ck_assert_msg(!test_message_has_value(msg, SYSDB_MEMBER,
+                                          old_dn_str),
+                  "Parent retained the old group DN");
+    talloc_zfree(msg);
+
+    ret = sysdb_search_group_by_name(test_ctx, test_ctx->domain, child,
+                                     membership_attrs, &msg);
+    ck_assert_msg(ret == EOK, "Could not look up the child group");
+    ck_assert_msg(test_message_has_value(msg, SYSDB_MEMBEROF,
+                                         new_dn_str),
+                  "Child did not receive the new group DN");
+    ck_assert_msg(test_message_has_value(msg, SYSDB_MEMBEROF,
+                                         parent_dn_str),
+                  "Child lost its inherited parent group");
+    ck_assert_msg(!test_message_has_value(msg, SYSDB_MEMBEROF,
+                                          old_dn_str),
+                  "Child retained the old group DN");
+    talloc_zfree(msg);
+
+    ret = sysdb_search_user_by_name(test_ctx, test_ctx->domain, user,
+                                    membership_attrs, &msg);
+    ck_assert_msg(ret == EOK, "Could not look up the test user");
+    ck_assert_msg(test_message_has_value(msg, SYSDB_MEMBEROF,
+                                         new_dn_str),
+                  "User did not receive the new group DN");
+    ck_assert_msg(test_message_has_value(msg, SYSDB_MEMBEROF,
+                                         child_dn_str),
+                  "User lost the child group");
+    ck_assert_msg(test_message_has_value(msg, SYSDB_MEMBEROF,
+                                         parent_dn_str),
+                  "User lost the inherited parent group");
+    ck_assert_msg(!test_message_has_value(msg, SYSDB_MEMBEROF,
+                                          old_dn_str),
+                  "User retained the old group DN");
+    talloc_zfree(msg);
+
+    ret = sysdb_initgroups(test_ctx, test_ctx->domain, user, &res);
+    ck_assert_msg(ret == EOK, "sysdb_initgroups failed");
+    ck_assert_int_eq(res->count, 4);
+    for (i = 0; i < res->count; i++) {
+        entry_name = ldb_msg_find_attr_as_string(res->msgs[i], SYSDB_NAME,
+                                                 NULL);
+        if (entry_name == NULL) {
+            continue;
+        }
+        if (strcmp(entry_name, old_name) == 0) {
+            found_old = true;
+        }
+        if (strcmp(entry_name, new_name) == 0) {
+            found_new = true;
+        }
+    }
+    ck_assert_msg(!found_old, "initgroups returned the old group name");
+    ck_assert_msg(found_new, "initgroups did not return the renamed group");
+
     talloc_free(test_ctx);
 }
 END_TEST
@@ -8038,6 +8242,7 @@ Suite *create_sysdb_suite(void)
 
     /* Test user and group renames */
     tcase_add_test(tc_sysdb, test_group_rename);
+    tcase_add_test(tc_sysdb, test_group_rename_preserves_memberships);
     tcase_add_test(tc_sysdb, test_user_rename);
 
     /* Test GetUserAttr with subdomain user */


### PR DESCRIPTION
## Problem

When a group arrives under a new name with a GID already present in the
cache, SSSD deletes and recreates the existing group.

If both entries represent the same directory identity, replacement is
unnecessary. Deleting the cached group also causes the memberOf plugin to
synchronously rebuild membership references across the cached graph. With
large or deeply nested membership data, this work can exceed the backend
watchdog deadline and block user logins.

A raw LDB rename is not sufficient because existing `member` and `memberOf`
values continue to reference the old DN.

## Solution

- Teach the memberOf plugin to update `member` and `memberOf` references when
  an entry is renamed.
- Bound rename search-result growth and guard against allocation-size
  overflow.
- When an incoming same-GID group has the same stable identity as the cached
  group, rename the existing entry instead of deleting and recreating it.
- Verify identity using SID or UUID, falling back to `originalDN`.
- Remove the obsolete timestamp-cache key and store the incoming attributes
  under the renamed entry.
- Add regression coverage for direct membership, nested membership, reverse
  membership, and initgroups results.

## Scope

This fixes the verified same-GID delete/re-add trigger described in #9049.

It does not include the broader transactional memberOf graph derivation or
the NSS mmap cache-warming optimization. Those changes will be proposed
separately.

## Validation

- `git diff --check` passes.
- The equivalent implementation has been exercised in the RHEL 9 and RHEL 10
  investigation branches.
- Build and focused sysdb testing of the exact master-rebased series will be
  completed before the PR is marked ready for review.

Refs #9049