### PR TITLE
memberof: derive membership graphs once per transaction

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4959,6 +4959,8 @@ endif
 
 memberof_la_SOURCES = \
     src/ldb_modules/memberof.c \
+    src/ldb_modules/memberof_transaction.c \
+    src/ldb_modules/memberof_transaction.h \
     src/util/util.c \
     src/util/util_ext.c \
     $(NULL)

--- a/src/db/sysdb_ops.c
+++ b/src/db/sysdb_ops.c
@@ -2850,6 +2850,17 @@ static errno_t sysdb_store_group_attrs(struct sss_domain_info *domain,
                                        uint64_t cache_timeout,
                                        time_t now);
 
+static bool sysdb_group_identity_matches(struct ldb_message *cached_group,
+                                         struct sysdb_attrs *attrs);
+
+static errno_t sysdb_rename_group(struct sss_domain_info *domain,
+                                  struct ldb_message *cached_group,
+                                  const char *name,
+                                  gid_t gid,
+                                  struct sysdb_attrs *attrs,
+                                  uint64_t cache_timeout,
+                                  time_t now);
+
 int sysdb_store_group(struct sss_domain_info *domain,
                       const char *name,
                       gid_t gid,
@@ -2964,6 +2975,115 @@ done:
     return ret;
 }
 
+static bool sysdb_group_identity_matches(struct ldb_message *cached_group,
+                                         struct sysdb_attrs *attrs)
+{
+    static const char *stable_attrs[] = { SYSDB_SID_STR, SYSDB_UUID, NULL };
+    const char *cached_value;
+    const char *incoming_value;
+    bool compared = false;
+    int i;
+    errno_t ret;
+
+    for (i = 0; stable_attrs[i] != NULL; i++) {
+        cached_value = ldb_msg_find_attr_as_string(cached_group,
+                                                   stable_attrs[i], NULL);
+        ret = sysdb_attrs_get_string(attrs, stable_attrs[i],
+                                     &incoming_value);
+        if (cached_value == NULL || ret != EOK) {
+            continue;
+        }
+
+        compared = true;
+        if (strcmp(cached_value, incoming_value) != 0) {
+            return false;
+        }
+    }
+
+    if (compared) {
+        return true;
+    }
+
+    cached_value = ldb_msg_find_attr_as_string(cached_group, SYSDB_ORIG_DN,
+                                                NULL);
+    ret = sysdb_attrs_get_string(attrs, SYSDB_ORIG_DN, &incoming_value);
+    return cached_value != NULL && ret == EOK
+        && strcmp(cached_value, incoming_value) == 0;
+}
+
+static errno_t sysdb_rename_group(struct sss_domain_info *domain,
+                                  struct ldb_message *cached_group,
+                                  const char *name,
+                                  gid_t gid,
+                                  struct sysdb_attrs *attrs,
+                                  uint64_t cache_timeout,
+                                  time_t now)
+{
+    TALLOC_CTX *tmp_ctx;
+    struct ldb_message_element *name_el;
+    struct sysdb_attrs *name_attrs;
+    struct ldb_dn *new_dn;
+    errno_t ret;
+    errno_t tret;
+    int lret;
+
+    tmp_ctx = talloc_new(NULL);
+    if (tmp_ctx == NULL) {
+        return ENOMEM;
+    }
+
+    ret = sysdb_attrs_get_el_ext(attrs, SYSDB_NAME, false, &name_el);
+    if (ret == ENOENT) {
+        ret = sysdb_attrs_add_string(attrs, SYSDB_NAME, name);
+    }
+    if (ret != EOK) {
+        goto done;
+    }
+
+    new_dn = sysdb_group_dn(tmp_ctx, domain, name);
+    if (new_dn == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    lret = ldb_rename(domain->sysdb->ldb, cached_group->dn, new_dn);
+    ret = sysdb_error_to_errno(lret);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE, "Could not rename cached group: %d\n", ret);
+        goto done;
+    }
+
+    /* The open transaction can expose the new RDN before the stored name
+     * attribute changes, making the generic no-op check suppress this write. */
+    name_attrs = sysdb_new_attrs(tmp_ctx);
+    if (name_attrs == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+    ret = sysdb_attrs_add_string(name_attrs, SYSDB_NAME, name);
+    if (ret != EOK) {
+        goto done;
+    }
+    ret = sysdb_set_cache_entry_attr(domain->sysdb->ldb, new_dn,
+                                     name_attrs, SYSDB_MOD_REP);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Could not update the renamed group name: %d\n", ret);
+        goto done;
+    }
+
+    tret = sysdb_delete_ts_entry(domain->sysdb, cached_group->dn);
+    if (tret != EOK) {
+        DEBUG(SSSDBG_MINOR_FAILURE,
+              "Could not remove the old group timestamp entry: %d\n", tret);
+    }
+
+    ret = sysdb_store_group_attrs(domain, name, gid, attrs,
+                                  cache_timeout, now);
+done:
+    talloc_zfree(tmp_ctx);
+    return ret;
+}
 
 static errno_t sysdb_store_new_group(struct sss_domain_info *domain,
                                      const char *name,
@@ -2972,6 +3092,11 @@ static errno_t sysdb_store_new_group(struct sss_domain_info *domain,
                                      uint64_t cache_timeout,
                                      time_t now)
 {
+    static const char *identity_attrs[] = {
+        SYSDB_SID_STR, SYSDB_UUID, SYSDB_ORIG_DN, NULL
+    };
+    TALLOC_CTX *tmp_ctx;
+    struct ldb_message *cached_group;
     errno_t ret;
 
     /* group doesn't exist, turn into adding a group */
@@ -2981,6 +3106,26 @@ static errno_t sysdb_store_new_group(struct sss_domain_info *domain,
          * same GID, remove it and try to add the basic group again
          */
         DEBUG(SSSDBG_TRACE_LIBS, "sysdb_add_group failed: [EEXIST].\n");
+        if (gid != 0) {
+            tmp_ctx = talloc_new(NULL);
+            if (tmp_ctx == NULL) {
+                return ENOMEM;
+            }
+
+            ret = sysdb_search_group_by_gid(tmp_ctx, domain, gid,
+                                            identity_attrs, &cached_group);
+            if (ret == EOK
+                    && sysdb_group_identity_matches(cached_group, attrs)) {
+                DEBUG(SSSDBG_TRACE_LIBS,
+                      "Renaming a cached group with a verified identity.\n");
+                ret = sysdb_rename_group(domain, cached_group, name, gid,
+                                         attrs, cache_timeout, now);
+                talloc_zfree(tmp_ctx);
+                return ret;
+            }
+
+            talloc_zfree(tmp_ctx);
+        }
         ret = sysdb_delete_group(domain, NULL, gid);
         if (ret == ENOENT) {
             /* Not found by GID, return the original EEXIST,

--- a/src/ldb_modules/memberof.c
+++ b/src/ldb_modules/memberof.c
@@ -17,6 +17,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <stdint.h>
 #include <string.h>
 #include <dhash.h>
 
@@ -168,8 +169,8 @@ struct mbof_rename_ctx {
     struct mbof_ctx *ctx;
 
     struct ldb_message **entries;
-    int num_entries;
-    int current_entry;
+    size_t num_entries;
+    size_t current_entry;
 };
 static struct mbof_ctx *mbof_init(struct ldb_module *module,
                                   struct ldb_request *req)
@@ -1404,6 +1405,10 @@ static int mbof_rename_search_callback(struct ldb_request *req,
 
     switch (ares->type) {
     case LDB_REPLY_ENTRY:
+        if (rename_ctx->num_entries == SIZE_MAX) {
+            return ldb_module_done(ctx->req, NULL, NULL,
+                                   LDB_ERR_OPERATIONS_ERROR);
+        }
         entries = talloc_realloc(rename_ctx, rename_ctx->entries,
                                  struct ldb_message *,
                                  rename_ctx->num_entries + 1);

--- a/src/ldb_modules/memberof.c
+++ b/src/ldb_modules/memberof.c
@@ -23,6 +23,7 @@
 
 #include "ldb_module.h"
 #include "util/util.h"
+#include "ldb_modules/memberof_transaction.h"
 
 #define DB_MEMBER "member"
 #define DB_GHOST "ghost"
@@ -526,6 +527,10 @@ static int memberof_add(struct ldb_module *module, struct ldb_request *req)
     struct mbof_dn_array *parents;
     struct ldb_dn *valdn;
     int i, ret;
+
+    if (memberof_tx_enabled(module)) {
+        return memberof_tx_add(module, req);
+    }
 
     if (ldb_dn_is_special(req->op.add.message->dn)) {
 
@@ -1321,6 +1326,10 @@ static int memberof_rename(struct ldb_module *module,
     errno_t sret;
     int ret;
 
+    if (memberof_tx_enabled(module)) {
+        return memberof_tx_rename(module, req);
+    }
+
     if (getenv("SSSD_UPGRADE_DB")) {
         /* do not do anything during upgrade */
         return ldb_next_request(module, req);
@@ -1826,6 +1835,10 @@ static int memberof_del(struct ldb_module *module, struct ldb_request *req)
     struct mbof_ctx *ctx;
     int ret;
     errno_t sret;
+
+    if (memberof_tx_enabled(module)) {
+        return memberof_tx_delete(module, req);
+    }
 
     if (ldb_dn_is_special(req->op.del.dn)) {
         /* do not manipulate our control entries */
@@ -3370,6 +3383,10 @@ static int memberof_mod(struct ldb_module *module, struct ldb_request *req)
     struct ldb_context *ldb = ldb_module_get_ctx(module);
     struct ldb_request *search;
     int ret;
+
+    if (memberof_tx_enabled(module)) {
+        return memberof_tx_modify(module, req);
+    }
 
     if (getenv("SSSD_UPGRADE_DB")) {
         /* do not do anything during upgrade */
@@ -5185,6 +5202,9 @@ static int memberof_init(struct ldb_module *module)
     ret = ldb_schema_attribute_add(ldb, DB_MEMBEROF, 0, LDB_SYNTAX_DN);
     if (ret != 0) return LDB_ERR_OPERATIONS_ERROR;
 
+    ret = memberof_tx_init(module);
+    if (ret != LDB_SUCCESS) return ret;
+
     return ldb_next_init(module);
 }
 
@@ -5195,6 +5215,10 @@ const struct ldb_module_ops ldb_memberof_module_ops = {
     .modify = memberof_mod,
     .del = memberof_del,
     .rename = memberof_rename,
+    .start_transaction = memberof_tx_start,
+    .prepare_commit = memberof_tx_prepare_commit,
+    .end_transaction = memberof_tx_end,
+    .del_transaction = memberof_tx_cancel,
 };
 
 int ldb_init_module(const char *version)

--- a/src/ldb_modules/memberof.c
+++ b/src/ldb_modules/memberof.c
@@ -164,6 +164,13 @@ struct mbof_mod_ctx {
     bool terminate;
 };
 
+struct mbof_rename_ctx {
+    struct mbof_ctx *ctx;
+
+    struct ldb_message **entries;
+    int num_entries;
+    int current_entry;
+};
 static struct mbof_ctx *mbof_init(struct ldb_module *module,
                                   struct ldb_request *req)
 {
@@ -1274,6 +1281,412 @@ static int mbof_add_muop_callback(struct ldb_request *req,
     return LDB_SUCCESS;
 }
 
+
+
+
+/* rename operation */
+
+/*
+ * A rename only changes the DN used to label a member/memberof edge. Unlike a
+ * delete, it does not change the membership graph, so update those labels
+ * directly instead of recalculating all transitive memberships.
+ */
+
+static int mbof_rename_search_callback(struct ldb_request *req,
+                                       struct ldb_reply *ares);
+static int mbof_rename_callback(struct ldb_request *req,
+                                struct ldb_reply *ares);
+static int mbof_rename_mod_callback(struct ldb_request *req,
+                                    struct ldb_reply *ares);
+static int mbof_rename_next_mod(struct mbof_rename_ctx *rename_ctx);
+static int mbof_rename_make_mod(struct mbof_rename_ctx *rename_ctx,
+                                struct ldb_message *entry,
+                                struct ldb_message **_mod_msg);
+static int mbof_rename_replace_values(struct mbof_rename_ctx *rename_ctx,
+                                      struct ldb_message *mod_msg,
+                                      const struct ldb_message_element *src);
+
+static int memberof_rename(struct ldb_module *module,
+                           struct ldb_request *req)
+{
+    static const char *attrs[] = { DB_MEMBER, DB_MEMBEROF, NULL };
+    struct ldb_context *ldb = ldb_module_get_ctx(module);
+    struct mbof_rename_ctx *rename_ctx;
+    struct mbof_ctx *ctx;
+    struct ldb_request *search;
+    const char *old_dn;
+    char *clean_dn;
+    char *expression;
+    errno_t sret;
+    int ret;
+
+    if (getenv("SSSD_UPGRADE_DB")) {
+        /* do not do anything during upgrade */
+        return ldb_next_request(module, req);
+    }
+
+    if (ldb_dn_is_special(req->op.rename.olddn)
+            || ldb_dn_is_special(req->op.rename.newdn)) {
+        /* do not manipulate control entries */
+        return ldb_next_request(module, req);
+    }
+
+    ctx = mbof_init(module, req);
+    if (ctx == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    rename_ctx = talloc_zero(ctx, struct mbof_rename_ctx);
+    if (rename_ctx == NULL) {
+        talloc_free(ctx);
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    rename_ctx->ctx = ctx;
+
+    old_dn = ldb_dn_get_linearized(req->op.rename.olddn);
+    if (old_dn == NULL) {
+        talloc_free(ctx);
+        return LDB_ERR_INVALID_DN_SYNTAX;
+    }
+
+    sret = sss_filter_sanitize_dn(rename_ctx, old_dn, &clean_dn);
+    if (sret != EOK) {
+        talloc_free(ctx);
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    expression = talloc_asprintf(rename_ctx, "(|(%s=%s)(%s=%s))",
+                                 DB_MEMBER, clean_dn,
+                                 DB_MEMBEROF, clean_dn);
+    talloc_zfree(clean_dn);
+    if (expression == NULL) {
+        talloc_free(ctx);
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    ret = ldb_build_search_req(&search, ldb, rename_ctx,
+                               NULL, LDB_SCOPE_SUBTREE,
+                               expression, attrs, NULL,
+                               rename_ctx, mbof_rename_search_callback,
+                               req);
+    if (ret != LDB_SUCCESS) {
+        talloc_free(ctx);
+        return ret;
+    }
+
+    return ldb_request(ldb, search);
+}
+
+static int mbof_rename_search_callback(struct ldb_request *req,
+                                       struct ldb_reply *ares)
+{
+    struct mbof_rename_ctx *rename_ctx;
+    struct mbof_ctx *ctx;
+    struct ldb_context *ldb;
+    struct ldb_request *rename_req;
+    struct ldb_message **entries;
+    int ret;
+
+    rename_ctx = talloc_get_type(req->context, struct mbof_rename_ctx);
+    ctx = rename_ctx->ctx;
+    ldb = ldb_module_get_ctx(ctx->module);
+
+    if (ares == NULL) {
+        return ldb_module_done(ctx->req, NULL, NULL,
+                               LDB_ERR_OPERATIONS_ERROR);
+    }
+    if (ares->error != LDB_SUCCESS) {
+        return ldb_module_done(ctx->req,
+                               ares->controls,
+                               ares->response,
+                               ares->error);
+    }
+
+    switch (ares->type) {
+    case LDB_REPLY_ENTRY:
+        entries = talloc_realloc(rename_ctx, rename_ctx->entries,
+                                 struct ldb_message *,
+                                 rename_ctx->num_entries + 1);
+        if (entries == NULL) {
+            return ldb_module_done(ctx->req, NULL, NULL,
+                                   LDB_ERR_OPERATIONS_ERROR);
+        }
+        rename_ctx->entries = entries;
+
+        entries[rename_ctx->num_entries] = talloc_steal(entries,
+                                                         ares->message);
+        if (entries[rename_ctx->num_entries] == NULL) {
+            return ldb_module_done(ctx->req, NULL, NULL,
+                                   LDB_ERR_OPERATIONS_ERROR);
+        }
+        rename_ctx->num_entries++;
+        break;
+
+    case LDB_REPLY_REFERRAL:
+        /* ignore */
+        break;
+
+    case LDB_REPLY_DONE:
+        ret = ldb_build_rename_req(&rename_req, ldb, rename_ctx,
+                                   ctx->req->op.rename.olddn,
+                                   ctx->req->op.rename.newdn,
+                                   ctx->req->controls,
+                                   rename_ctx, mbof_rename_callback,
+                                   ctx->req);
+        talloc_zfree(ares);
+        if (ret != LDB_SUCCESS) {
+            return ldb_module_done(ctx->req, NULL, NULL, ret);
+        }
+
+        return ldb_next_request(ctx->module, rename_req);
+    }
+
+    talloc_zfree(ares);
+    return LDB_SUCCESS;
+}
+
+static int mbof_rename_callback(struct ldb_request *req,
+                                struct ldb_reply *ares)
+{
+    struct mbof_rename_ctx *rename_ctx;
+    struct mbof_ctx *ctx;
+    struct ldb_context *ldb;
+    int ret;
+
+    rename_ctx = talloc_get_type(req->context, struct mbof_rename_ctx);
+    ctx = rename_ctx->ctx;
+    ldb = ldb_module_get_ctx(ctx->module);
+
+    if (ares == NULL) {
+        return ldb_module_done(ctx->req, NULL, NULL,
+                               LDB_ERR_OPERATIONS_ERROR);
+    }
+    if (ares->error != LDB_SUCCESS) {
+        return ldb_module_done(ctx->req,
+                               ares->controls,
+                               ares->response,
+                               ares->error);
+    }
+    if (ares->type != LDB_REPLY_DONE) {
+        talloc_zfree(ares);
+        ldb_set_errstring(ldb, "Invalid reply type!");
+        return ldb_module_done(ctx->req, NULL, NULL,
+                               LDB_ERR_OPERATIONS_ERROR);
+    }
+
+    ctx->ret_ctrls = talloc_steal(ctx, ares->controls);
+    ctx->ret_resp = talloc_steal(ctx, ares->response);
+    talloc_zfree(ares);
+
+    ret = mbof_rename_next_mod(rename_ctx);
+    if (ret != LDB_SUCCESS) {
+        return ldb_module_done(ctx->req, NULL, NULL, ret);
+    }
+
+    return LDB_SUCCESS;
+}
+
+static int mbof_rename_replace_values(struct mbof_rename_ctx *rename_ctx,
+                                      struct ldb_message *mod_msg,
+                                      const struct ldb_message_element *src)
+{
+    struct mbof_ctx *ctx = rename_ctx->ctx;
+    struct ldb_message_element *dst;
+    const char *old_dn;
+    const char *new_dn;
+    const char *value;
+    bool changed = false;
+    bool duplicate;
+    unsigned int i;
+    unsigned int j;
+    int ret;
+
+    old_dn = ldb_dn_get_linearized(ctx->req->op.rename.olddn);
+    new_dn = ldb_dn_get_linearized(ctx->req->op.rename.newdn);
+    if (old_dn == NULL || new_dn == NULL) {
+        return LDB_ERR_INVALID_DN_SYNTAX;
+    }
+
+    for (i = 0; i < src->num_values; i++) {
+        if (sss_linearized_dn_match((const char *)src->values[i].data,
+                                    old_dn)) {
+            changed = true;
+            break;
+        }
+    }
+    if (!changed) {
+        return LDB_SUCCESS;
+    }
+
+    ret = ldb_msg_add_empty(mod_msg, src->name, LDB_FLAG_MOD_REPLACE, &dst);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+
+    dst->values = talloc_array(dst, struct ldb_val, src->num_values);
+    if (dst->values == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    for (i = 0; i < src->num_values; i++) {
+        value = (const char *)src->values[i].data;
+        if (sss_linearized_dn_match(value, old_dn)) {
+            value = new_dn;
+        }
+
+        duplicate = false;
+        for (j = 0; j < dst->num_values; j++) {
+            if (sss_linearized_dn_match(value,
+                                        (const char *)dst->values[j].data)) {
+                duplicate = true;
+                break;
+            }
+        }
+        if (duplicate) {
+            continue;
+        }
+
+        dst->values[dst->num_values].data =
+            (uint8_t *)talloc_strdup(dst->values, value);
+        if (dst->values[dst->num_values].data == NULL) {
+            return LDB_ERR_OPERATIONS_ERROR;
+        }
+        dst->values[dst->num_values].length = strlen(value);
+        dst->num_values++;
+    }
+
+    return LDB_SUCCESS;
+}
+
+static int mbof_rename_make_mod(struct mbof_rename_ctx *rename_ctx,
+                                struct ldb_message *entry,
+                                struct ldb_message **_mod_msg)
+{
+    struct mbof_ctx *ctx = rename_ctx->ctx;
+    struct ldb_message_element *el;
+    struct ldb_message *mod_msg;
+    const char *entry_dn;
+    const char *old_dn;
+    int ret;
+
+    *_mod_msg = NULL;
+
+    old_dn = ldb_dn_get_linearized(ctx->req->op.rename.olddn);
+    entry_dn = ldb_dn_get_linearized(entry->dn);
+    if (old_dn == NULL || entry_dn == NULL) {
+        return LDB_ERR_INVALID_DN_SYNTAX;
+    }
+
+    mod_msg = ldb_msg_new(rename_ctx);
+    if (mod_msg == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    if (sss_linearized_dn_match(entry_dn, old_dn)) {
+        mod_msg->dn = ctx->req->op.rename.newdn;
+    } else {
+        mod_msg->dn = entry->dn;
+    }
+
+    el = ldb_msg_find_element(entry, DB_MEMBER);
+    if (el != NULL) {
+        ret = mbof_rename_replace_values(rename_ctx, mod_msg, el);
+        if (ret != LDB_SUCCESS) {
+            talloc_free(mod_msg);
+            return ret;
+        }
+    }
+
+    el = ldb_msg_find_element(entry, DB_MEMBEROF);
+    if (el != NULL) {
+        ret = mbof_rename_replace_values(rename_ctx, mod_msg, el);
+        if (ret != LDB_SUCCESS) {
+            talloc_free(mod_msg);
+            return ret;
+        }
+    }
+
+    if (mod_msg->num_elements == 0) {
+        talloc_free(mod_msg);
+        return LDB_SUCCESS;
+    }
+
+    *_mod_msg = mod_msg;
+    return LDB_SUCCESS;
+}
+
+static int mbof_rename_next_mod(struct mbof_rename_ctx *rename_ctx)
+{
+    struct mbof_ctx *ctx = rename_ctx->ctx;
+    struct ldb_context *ldb = ldb_module_get_ctx(ctx->module);
+    struct ldb_request *mod_req;
+    struct ldb_message *mod_msg;
+    int ret;
+
+    while (rename_ctx->current_entry < rename_ctx->num_entries) {
+        ret = mbof_rename_make_mod(rename_ctx,
+                                   rename_ctx->entries[rename_ctx->current_entry],
+                                   &mod_msg);
+        rename_ctx->current_entry++;
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+        if (mod_msg == NULL) {
+            continue;
+        }
+
+        ret = ldb_build_mod_req(&mod_req, ldb, rename_ctx,
+                                mod_msg, NULL,
+                                rename_ctx, mbof_rename_mod_callback,
+                                ctx->req);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+
+        return ldb_next_request(ctx->module, mod_req);
+    }
+
+    return ldb_module_done(ctx->req, ctx->ret_ctrls, ctx->ret_resp,
+                           LDB_SUCCESS);
+}
+
+static int mbof_rename_mod_callback(struct ldb_request *req,
+                                    struct ldb_reply *ares)
+{
+    struct mbof_rename_ctx *rename_ctx;
+    struct mbof_ctx *ctx;
+    struct ldb_context *ldb;
+    int ret;
+
+    rename_ctx = talloc_get_type(req->context, struct mbof_rename_ctx);
+    ctx = rename_ctx->ctx;
+    ldb = ldb_module_get_ctx(ctx->module);
+
+    if (ares == NULL) {
+        return ldb_module_done(ctx->req, NULL, NULL,
+                               LDB_ERR_OPERATIONS_ERROR);
+    }
+    if (ares->error != LDB_SUCCESS) {
+        return ldb_module_done(ctx->req,
+                               ares->controls,
+                               ares->response,
+                               ares->error);
+    }
+    if (ares->type != LDB_REPLY_DONE) {
+        talloc_zfree(ares);
+        ldb_set_errstring(ldb, "Invalid reply type!");
+        return ldb_module_done(ctx->req, NULL, NULL,
+                               LDB_ERR_OPERATIONS_ERROR);
+    }
+
+    talloc_zfree(ares);
+    ret = mbof_rename_next_mod(rename_ctx);
+    if (ret != LDB_SUCCESS) {
+        return ldb_module_done(ctx->req, NULL, NULL, ret);
+    }
+
+    return LDB_SUCCESS;
+}
 
 
 
@@ -4654,6 +5067,7 @@ const struct ldb_module_ops ldb_memberof_module_ops = {
     .add = memberof_add,
     .modify = memberof_mod,
     .del = memberof_del,
+    .rename = memberof_rename,
 };
 
 int ldb_init_module(const char *version)

--- a/src/ldb_modules/memberof.c
+++ b/src/ldb_modules/memberof.c
@@ -4357,18 +4357,88 @@ struct mbof_member {
     bool orig_has_memberof;
     bool orig_has_memberuid;
     struct ldb_message_element *orig_members;
+    hash_table_t *orig_memberofs;
+    hash_table_t *orig_memuids;
 
     struct mbof_member **members;
 
     hash_table_t *memberofs;
 
     struct ldb_message_element *memuids;
+    hash_table_t *memuid_set;
 
     enum { MBOF_GROUP_TO_DO = 0,
            MBOF_GROUP_DONE,
            MBOF_USER,
            MBOF_ITER_ERROR } status;
 };
+
+static int mbof_hash_values(TALLOC_CTX *mem_ctx,
+                            const struct ldb_message_element *el,
+                            hash_table_t **_table)
+{
+    hash_table_t *table;
+    hash_value_t value;
+    hash_key_t key;
+    unsigned int i;
+    int ret;
+
+    *_table = NULL;
+    if (el == NULL || el->num_values == 0) {
+        return LDB_SUCCESS;
+    }
+
+    ret = hash_create_ex(el->num_values, &table, 0, 0, 0, 0,
+                         hash_alloc, hash_free, mem_ctx, NULL, NULL);
+    if (ret != HASH_SUCCESS) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    value.type = HASH_VALUE_UNDEF;
+    for (i = 0; i < el->num_values; i++) {
+        key.type = HASH_KEY_STRING;
+        key.str = (char *)el->values[i].data;
+        if (hash_has_key(table, &key)) {
+            continue;
+        }
+
+        ret = hash_enter(table, &key, &value);
+        if (ret != HASH_SUCCESS) {
+            return LDB_ERR_OPERATIONS_ERROR;
+        }
+    }
+
+    *_table = table;
+    return LDB_SUCCESS;
+}
+
+static bool mbof_hash_equal(hash_table_t *left, hash_table_t *right)
+{
+    hash_key_t *keys;
+    unsigned long count;
+    unsigned long i;
+    int ret;
+
+    if (left == NULL || hash_count(left) == 0) {
+        return right == NULL || hash_count(right) == 0;
+    }
+    if (right == NULL || hash_count(left) != hash_count(right)) {
+        return false;
+    }
+
+    ret = hash_keys(left, &count, &keys);
+    if (ret != HASH_SUCCESS) {
+        return false;
+    }
+
+    for (i = 0; i < count; i++) {
+        if (!hash_has_key(right, &keys[i])) {
+            return false;
+        }
+    }
+
+    return true;
+}
 
 struct mbof_rcmp_context {
     struct ldb_module *module;
@@ -4496,6 +4566,13 @@ static int mbof_rcmp_usr_callback(struct ldb_request *req,
 
         if (ldb_msg_find_element(ares->message, DB_MEMBEROF)) {
             usr->orig_has_memberof = true;
+            ret = mbof_hash_values(usr,
+                                   ldb_msg_find_element(ares->message,
+                                                        DB_MEMBEROF),
+                                   &usr->orig_memberofs);
+            if (ret != LDB_SUCCESS) {
+                return ldb_module_done(ctx->req, NULL, NULL, ret);
+            }
         }
 
         DLIST_ADD(ctx->user_list, usr);
@@ -4602,10 +4679,24 @@ static int mbof_rcmp_grp_callback(struct ldb_request *req,
 
         if (ldb_msg_find_element(ares->message, DB_MEMBEROF)) {
             grp->orig_has_memberof = true;
+            ret = mbof_hash_values(grp,
+                                   ldb_msg_find_element(ares->message,
+                                                        DB_MEMBEROF),
+                                   &grp->orig_memberofs);
+            if (ret != LDB_SUCCESS) {
+                return ldb_module_done(ctx->req, NULL, NULL, ret);
+            }
         }
 
         if (ldb_msg_find_element(ares->message, DB_MEMBERUID)) {
             grp->orig_has_memberuid = true;
+            ret = mbof_hash_values(grp,
+                                   ldb_msg_find_element(ares->message,
+                                                        DB_MEMBERUID),
+                                   &grp->orig_memuids);
+            if (ret != LDB_SUCCESS) {
+                return ldb_module_done(ctx->req, NULL, NULL, ret);
+            }
         }
 
         ret = mbof_steal_msg_el(grp, DB_MEMBER,
@@ -4863,6 +4954,9 @@ static bool mbof_member_iter(hash_entry_t *item, void *user_data)
 static int mbof_add_memuid(struct mbof_member *grp, const char *user)
 {
     struct ldb_val *vals;
+    hash_value_t value;
+    hash_key_t key;
+    int ret;
     int n;
 
     if (!grp->memuids) {
@@ -4875,6 +4969,18 @@ static int mbof_add_memuid(struct mbof_member *grp, const char *user)
         if (!grp->memuids->name) {
             return LDB_ERR_OPERATIONS_ERROR;
         }
+
+        ret = hash_create_ex(0, &grp->memuid_set, 0, 0, 0, 0,
+                             hash_alloc, hash_free, grp, NULL, NULL);
+        if (ret != HASH_SUCCESS) {
+            return LDB_ERR_OPERATIONS_ERROR;
+        }
+    }
+
+    key.type = HASH_KEY_STRING;
+    key.str = discard_const(user);
+    if (hash_has_key(grp->memuid_set, &key)) {
+        return LDB_SUCCESS;
     }
 
     n = grp->memuids->num_values;
@@ -4891,6 +4997,12 @@ static int mbof_add_memuid(struct mbof_member *grp, const char *user)
     grp->memuids->values = vals;
     grp->memuids->num_values = n + 1;
 
+    value.type = HASH_VALUE_UNDEF;
+    ret = hash_enter(grp->memuid_set, &key, &value);
+    if (ret != HASH_SUCCESS) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
     return LDB_SUCCESS;
 }
 
@@ -4906,6 +5018,7 @@ static int mbof_rcmp_update(struct mbof_rcmp_context *ctx)
     int flags;
     int ret, i;
 
+next_entry:
     /* we process all users first and then all groups */
     if (ctx->user_list) {
         /* take the next entry and remove it from the list */
@@ -4932,7 +5045,9 @@ static int mbof_rcmp_update(struct mbof_rcmp_context *ctx)
     msg->dn = x->dn;
 
     /* process memberof */
-    if (x->memberofs) {
+    if (mbof_hash_equal(x->memberofs, x->orig_memberofs)) {
+        /* no change */
+    } else if (x->memberofs) {
         ret = hash_keys(x->memberofs, &count, &keys);
         if (ret != HASH_SUCCESS) {
             ret = LDB_ERR_OPERATIONS_ERROR;
@@ -4969,7 +5084,9 @@ static int mbof_rcmp_update(struct mbof_rcmp_context *ctx)
     }
 
     /* process memberuid */
-    if (x->memuids) {
+    if (mbof_hash_equal(x->memuid_set, x->orig_memuids)) {
+        /* no change */
+    } else if (x->memuids) {
         if (x->orig_has_memberuid) {
             flags = LDB_FLAG_MOD_REPLACE;
         } else {
@@ -4986,6 +5103,11 @@ static int mbof_rcmp_update(struct mbof_rcmp_context *ctx)
         if (ret != LDB_SUCCESS) {
             goto done;
         }
+    }
+
+    if (msg->num_elements == 0) {
+        talloc_zfree(msg);
+        goto next_entry;
     }
 
     ret = ldb_build_mod_req(&req, ldb, ctx, msg, NULL,

--- a/src/ldb_modules/memberof_transaction.c
+++ b/src/ldb_modules/memberof_transaction.c
@@ -113,6 +113,38 @@ struct tx_snapshot_group {
 static int tx_graph_flush(struct ldb_module *module,
                           struct tx_journal *journal);
 
+static int tx_size_add(size_t left, size_t right, size_t *result)
+{
+    if (right > SIZE_MAX - left) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    *result = left + right;
+    return LDB_SUCCESS;
+}
+
+static int tx_next_capacity(size_t current, size_t element_size,
+                            size_t *next)
+{
+    size_t capacity;
+
+    if (current == 0) {
+        capacity = 8;
+    } else {
+        if (current > SIZE_MAX / 2) {
+            return LDB_ERR_OPERATIONS_ERROR;
+        }
+        capacity = current * 2;
+    }
+
+    if (element_size != 0 && capacity > SIZE_MAX / element_size) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    *next = capacity;
+    return LDB_SUCCESS;
+}
+
 static void *tx_hash_alloc(size_t size, void *pvt)
 {
     return talloc_size(pvt, size);
@@ -265,9 +297,10 @@ static int tx_set_add(struct tx_set *set, const char *key_string,
     }
 
     if (set->count == set->capacity) {
-        capacity = set->capacity == 0 ? 8 : set->capacity * 2;
-        if (capacity < set->capacity) {
-            return LDB_ERR_OPERATIONS_ERROR;
+        ret = tx_next_capacity(set->capacity,
+                               sizeof(set->ordered[0]), &capacity);
+        if (ret != LDB_SUCCESS) {
+            return ret;
         }
         ordered = talloc_realloc(set->storage, set->ordered,
                                  struct tx_set_entry *, capacity);
@@ -480,7 +513,12 @@ static int tx_snapshot_set_values(struct ldb_message *message,
     struct ldb_dn *dn = message->dn;
     TALLOC_CTX *tmp_ctx;
     size_t i;
+    size_t allocation_size;
     int ret;
+
+    if (count > UINT_MAX || (count != 0 && values == NULL)) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
 
     tmp_ctx = talloc_new(message);
     if (tmp_ctx == NULL) {
@@ -493,8 +531,13 @@ static int tx_snapshot_set_values(struct ldb_message *message,
             return LDB_ERR_OPERATIONS_ERROR;
         }
         for (i = 0; i < count; i++) {
-            copies[i].data = talloc_zero_size(copies,
-                                              values[i].length + 1);
+            if ((values[i].length != 0 && values[i].data == NULL)
+                    || tx_size_add(values[i].length, 1,
+                                   &allocation_size) != LDB_SUCCESS) {
+                talloc_free(tmp_ctx);
+                return LDB_ERR_OPERATIONS_ERROR;
+            }
+            copies[i].data = talloc_zero_size(copies, allocation_size);
             if (copies[i].data == NULL) {
                 talloc_free(tmp_ctx);
                 return LDB_ERR_OPERATIONS_ERROR;
@@ -517,7 +560,7 @@ static int tx_snapshot_set_values(struct ldb_message *message,
         return ret;
     }
     element->values = talloc_steal(message, copies);
-    element->num_values = count;
+    element->num_values = (unsigned int)count;
     talloc_free(tmp_ctx);
     return LDB_SUCCESS;
 }
@@ -529,6 +572,7 @@ static int tx_snapshot_apply_element(struct ldb_message *message,
     struct ldb_val *values;
     TALLOC_CTX *tmp_ctx;
     size_t current_count;
+    size_t allocation_count;
     size_t count = 0;
     size_t i;
     unsigned int j;
@@ -544,14 +588,18 @@ static int tx_snapshot_apply_element(struct ldb_message *message,
                                       change->num_values);
 
     case LDB_FLAG_MOD_ADD:
+        ret = tx_size_add(current_count, change->num_values,
+                          &allocation_count);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
         tmp_ctx = talloc_new(message);
         if (tmp_ctx == NULL) {
             return LDB_ERR_OPERATIONS_ERROR;
         }
         values = talloc_array(tmp_ctx, struct ldb_val,
-                              current_count + change->num_values);
-        if (values == NULL
-                && current_count + change->num_values != 0) {
+                              allocation_count);
+        if (values == NULL && allocation_count != 0) {
             talloc_free(tmp_ctx);
             return LDB_ERR_OPERATIONS_ERROR;
         }
@@ -632,6 +680,7 @@ static int tx_snapshot_add(struct tx_journal *journal,
     struct ldb_message **messages;
     struct ldb_message *message;
     const char *key;
+    size_t new_count;
     int ret;
 
     if (tx_snapshot_lookup(journal, source->dn) != NULL) {
@@ -641,10 +690,15 @@ static int tx_snapshot_add(struct tx_journal *journal,
     if (message == NULL) {
         return LDB_ERR_OPERATIONS_ERROR;
     }
+    ret = tx_size_add(journal->snapshot->count, 1, &new_count);
+    if (ret != LDB_SUCCESS || new_count > UINT_MAX) {
+        talloc_free(message);
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
     messages = talloc_realloc(journal->snapshot,
                               journal->snapshot->msgs,
                               struct ldb_message *,
-                              journal->snapshot->count + 1);
+                              new_count);
     if (messages == NULL) {
         return LDB_ERR_OPERATIONS_ERROR;
     }
@@ -1724,11 +1778,13 @@ static int tx_append_node(TALLOC_CTX *mem_ctx,
 {
     struct tx_node **new_array;
     size_t new_capacity;
+    int ret;
 
     if (*count == *capacity) {
-        new_capacity = *capacity == 0 ? 8 : *capacity * 2;
-        if (new_capacity < *capacity) {
-            return LDB_ERR_OPERATIONS_ERROR;
+        ret = tx_next_capacity(*capacity, sizeof((*array)[0]),
+                               &new_capacity);
+        if (ret != LDB_SUCCESS) {
+            return ret;
         }
         new_array = talloc_realloc(mem_ctx, *array,
                                    struct tx_node *, new_capacity);
@@ -1752,11 +1808,13 @@ static int tx_append_component(TALLOC_CTX *mem_ctx,
 {
     struct tx_component **new_array;
     size_t new_capacity;
+    int ret;
 
     if (*count == *capacity) {
-        new_capacity = *capacity == 0 ? 8 : *capacity * 2;
-        if (new_capacity < *capacity) {
-            return LDB_ERR_OPERATIONS_ERROR;
+        ret = tx_next_capacity(*capacity, sizeof((*array)[0]),
+                               &new_capacity);
+        if (ret != LDB_SUCCESS) {
+            return ret;
         }
         new_array = talloc_realloc(mem_ctx, *array,
                                    struct tx_component *, new_capacity);

--- a/src/ldb_modules/memberof_transaction.c
+++ b/src/ldb_modules/memberof_transaction.c
@@ -81,6 +81,7 @@ struct tx_rename {
 
 struct tx_journal {
     bool dirty;
+    bool failed;
     bool migration_checked;
     bool migration_marker_exists;
     bool migration_complete;
@@ -1348,51 +1349,35 @@ static int tx_complete_noop(struct ldb_request *req)
     return ldb_module_done(req, NULL, NULL, LDB_SUCCESS);
 }
 
-int memberof_tx_add(struct ldb_module *module, struct ldb_request *req)
-{
-    struct tx_private *private_data;
+enum tx_forward_operation {
+    TX_FORWARD_ADD,
+    TX_FORWARD_MODIFY,
+    TX_FORWARD_DELETE,
+    TX_FORWARD_RENAME
+};
+
+struct tx_forward_ctx {
+    struct ldb_module *module;
+    struct ldb_request *request;
     struct tx_journal *journal;
-    const char *dn_string;
+    enum tx_forward_operation operation;
+};
+
+static int tx_journal_error(struct tx_journal *journal, int ret)
+{
+    journal->failed = true;
+    return ret;
+}
+
+static int tx_apply_forwarded_add(struct tx_forward_ctx *ctx)
+{
+    struct ldb_request *req = ctx->request;
+    struct tx_journal *journal = ctx->journal;
     const char *key;
-    bool identity;
     int ret;
 
-    ret = tx_require_journal(module, &private_data, &journal);
-    if (ret != LDB_SUCCESS) {
-        return ret;
-    }
-    if (private_data->flushing || getenv("SSSD_UPGRADE_DB") != NULL) {
-        return ldb_next_request(module, req);
-    }
-
-    if (ldb_dn_is_special(req->op.add.message->dn)) {
-        dn_string = ldb_dn_get_linearized(req->op.add.message->dn);
-        if (dn_string != NULL && strcmp(dn_string, TX_REBUILD_DN) == 0) {
-            ret = tx_mark_dirty(module, journal);
-            if (ret != LDB_SUCCESS) {
-                return ret;
-            }
-            return tx_complete_noop(req);
-        }
-        return ldb_next_request(module, req);
-    }
-    ret = tx_snapshot_ensure(module, journal);
-    if (ret != LDB_SUCCESS) {
-        return ret;
-    }
-
-    ret = tx_check_readonly(module, req->op.add.message);
-    if (ret != LDB_SUCCESS) {
-        return ret;
-    }
-    ret = tx_validate_members(module, req->op.add.message);
-    if (ret != LDB_SUCCESS) {
-        return ret;
-    }
-
-    identity = tx_message_is_identity(req->op.add.message);
-    if (identity) {
-        ret = tx_mark_dirty(module, journal);
+    if (tx_message_is_identity(req->op.add.message)) {
+        ret = tx_mark_dirty(ctx->module, journal);
         if (ret != LDB_SUCCESS) {
             return ret;
         }
@@ -1410,62 +1395,31 @@ int memberof_tx_add(struct ldb_module *module, struct ldb_request *req)
     if (ret != LDB_SUCCESS) {
         return ret;
     }
-    ret = tx_snapshot_add(journal, req->op.add.message);
-    if (ret != LDB_SUCCESS) {
-        return ret;
-    }
-
-    return ldb_next_request(module, req);
+    return tx_snapshot_add(journal, req->op.add.message);
 }
 
-int memberof_tx_modify(struct ldb_module *module, struct ldb_request *req)
+static int tx_apply_forwarded_modify(struct tx_forward_ctx *ctx)
 {
-    struct tx_private *private_data;
-    struct tx_journal *journal;
+    struct ldb_request *req = ctx->request;
+    struct tx_private *private_data = tx_get_private(ctx->module);
+    struct tx_journal *journal = ctx->journal;
     struct ldb_message *identity;
     bool changes_graph;
     bool is_identity;
-    bool relevant;
     bool was_identity;
     int ret;
 
-    ret = tx_require_journal(module, &private_data, &journal);
-    if (ret != LDB_SUCCESS) {
-        return ret;
-    }
-    if (private_data->flushing || getenv("SSSD_UPGRADE_DB") != NULL) {
-        return ldb_next_request(module, req);
-    }
-    if (ldb_dn_is_special(req->op.mod.message->dn)) {
-        return ldb_next_request(module, req);
+    if (private_data == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
     }
 
-    ret = tx_check_readonly(module, req->op.mod.message);
-    if (ret != LDB_SUCCESS) {
-        return ret;
-    }
-    ret = tx_validate_members(module, req->op.mod.message);
-    if (ret != LDB_SUCCESS) {
-        return ret;
-    }
-
-    relevant = tx_modify_affects_graph(req->op.mod.message);
-    if (!relevant) {
-        /* Initgroups can commit thousands of metadata-only cache updates. */
-        return ldb_next_request(module, req);
-    }
-
-    ret = tx_snapshot_ensure(module, journal);
-    if (ret != LDB_SUCCESS) {
-        return ret;
-    }
     identity = tx_snapshot_lookup(journal, req->op.mod.message->dn);
     if (identity == NULL) {
-        return ldb_next_request(module, req);
+        return LDB_SUCCESS;
     }
     was_identity = tx_message_is_identity(identity);
 
-    ret = tx_load_migration_state(module, private_data, journal);
+    ret = tx_load_migration_state(ctx->module, private_data, journal);
     if (ret != LDB_SUCCESS) {
         return ret;
     }
@@ -1481,23 +1435,300 @@ int memberof_tx_modify(struct ldb_module *module, struct ldb_request *req)
     }
     is_identity = tx_message_is_identity(identity);
     if (!was_identity && !is_identity) {
-        return ldb_next_request(module, req);
+        return LDB_SUCCESS;
     }
 
     ret = tx_record_request_ghosts(journal, req, false);
     if (ret != LDB_SUCCESS) {
         return ret;
     }
+    if (!journal->migration_complete || changes_graph) {
+        return tx_mark_dirty(ctx->module, journal);
+    }
 
-    relevant = !journal->migration_complete || changes_graph;
-    if (relevant) {
-        ret = tx_mark_dirty(module, journal);
+    return LDB_SUCCESS;
+}
+
+static int tx_apply_forwarded_delete(struct tx_forward_ctx *ctx)
+{
+    struct ldb_request *req = ctx->request;
+    struct tx_journal *journal = ctx->journal;
+    struct ldb_message *identity;
+    const char *key;
+    int ret;
+
+    identity = tx_snapshot_lookup(journal, req->op.del.dn);
+    if (identity == NULL) {
+        return LDB_SUCCESS;
+    }
+
+    if (tx_message_is_identity(identity)) {
+        ret = tx_mark_dirty(ctx->module, journal);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+        key = tx_dn_key(req->op.del.dn);
+        if (key == NULL) {
+            return LDB_ERR_INVALID_DN_SYNTAX;
+        }
+        ret = tx_set_add(&journal->deleted_dns, key, key);
         if (ret != LDB_SUCCESS) {
             return ret;
         }
     }
 
-    return ldb_next_request(module, req);
+    return tx_snapshot_remove(journal, req->op.del.dn);
+}
+
+static int tx_apply_forwarded_rename(struct tx_forward_ctx *ctx)
+{
+    struct ldb_request *req = ctx->request;
+    struct tx_journal *journal = ctx->journal;
+    struct ldb_message *identity;
+    const char *new_key;
+    int ret;
+
+    identity = tx_snapshot_lookup(journal, req->op.rename.olddn);
+    if (identity == NULL) {
+        return LDB_SUCCESS;
+    }
+
+    if (tx_message_is_identity(identity)) {
+        ret = tx_mark_dirty(ctx->module, journal);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+        ret = tx_record_rename(journal, req->op.rename.olddn,
+                               req->op.rename.newdn);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+    }
+
+    new_key = tx_dn_key(req->op.rename.newdn);
+    if (new_key == NULL) {
+        return LDB_ERR_INVALID_DN_SYNTAX;
+    }
+    ret = tx_set_remove(&journal->deleted_dns, new_key);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    return tx_snapshot_rename(journal, req->op.rename.olddn,
+                              req->op.rename.newdn);
+}
+
+static int tx_apply_forwarded_request(struct tx_forward_ctx *ctx)
+{
+    switch (ctx->operation) {
+    case TX_FORWARD_ADD:
+        return tx_apply_forwarded_add(ctx);
+    case TX_FORWARD_MODIFY:
+        return tx_apply_forwarded_modify(ctx);
+    case TX_FORWARD_DELETE:
+        return tx_apply_forwarded_delete(ctx);
+    case TX_FORWARD_RENAME:
+        return tx_apply_forwarded_rename(ctx);
+    }
+
+    return LDB_ERR_OPERATIONS_ERROR;
+}
+
+static int tx_forward_callback(struct ldb_request *req,
+                               struct ldb_reply *reply)
+{
+    struct tx_forward_ctx *ctx;
+    struct ldb_context *ldb;
+    int ret;
+
+    ctx = talloc_get_type(req->context, struct tx_forward_ctx);
+    ldb = ldb_module_get_ctx(ctx->module);
+
+    if (reply == NULL) {
+        ctx->journal->failed = true;
+        return ldb_module_done(ctx->request, NULL, NULL,
+                               LDB_ERR_OPERATIONS_ERROR);
+    }
+    if (reply->error != LDB_SUCCESS) {
+        return ldb_module_done(ctx->request, reply->controls,
+                               reply->response, reply->error);
+    }
+    if (reply->type != LDB_REPLY_DONE) {
+        ctx->journal->failed = true;
+        talloc_zfree(reply);
+        ldb_set_errstring(ldb, "Invalid reply type for a write request");
+        return ldb_module_done(ctx->request, NULL, NULL,
+                               LDB_ERR_OPERATIONS_ERROR);
+    }
+
+    ret = tx_apply_forwarded_request(ctx);
+    if (ret != LDB_SUCCESS) {
+        ctx->journal->failed = true;
+        return ldb_module_done(ctx->request, reply->controls,
+                               reply->response, ret);
+    }
+
+    return ldb_module_done(ctx->request, reply->controls,
+                           reply->response, LDB_SUCCESS);
+}
+
+static int tx_forward_request(struct ldb_module *module,
+                              struct ldb_request *req,
+                              struct tx_journal *journal,
+                              enum tx_forward_operation operation)
+{
+    struct tx_forward_ctx *ctx;
+    struct ldb_request *down_req;
+    struct ldb_context *ldb = ldb_module_get_ctx(module);
+    int ret;
+
+    ctx = talloc_zero(req, struct tx_forward_ctx);
+    if (ctx == NULL) {
+        return tx_journal_error(journal, LDB_ERR_OPERATIONS_ERROR);
+    }
+    ctx->module = module;
+    ctx->request = req;
+    ctx->journal = journal;
+    ctx->operation = operation;
+
+    switch (operation) {
+    case TX_FORWARD_ADD:
+        ret = ldb_build_add_req(&down_req, ldb, ctx,
+                                req->op.add.message, req->controls,
+                                ctx, tx_forward_callback, req);
+        break;
+    case TX_FORWARD_MODIFY:
+        ret = ldb_build_mod_req(&down_req, ldb, ctx,
+                                req->op.mod.message, req->controls,
+                                ctx, tx_forward_callback, req);
+        break;
+    case TX_FORWARD_DELETE:
+        ret = ldb_build_del_req(&down_req, ldb, ctx,
+                                req->op.del.dn, req->controls,
+                                ctx, tx_forward_callback, req);
+        break;
+    case TX_FORWARD_RENAME:
+        ret = ldb_build_rename_req(&down_req, ldb, ctx,
+                                   req->op.rename.olddn,
+                                   req->op.rename.newdn,
+                                   req->controls,
+                                   ctx, tx_forward_callback, req);
+        break;
+    default:
+        ret = LDB_ERR_OPERATIONS_ERROR;
+        break;
+    }
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+
+    ret = ldb_next_request(module, down_req);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    return LDB_SUCCESS;
+}
+
+int memberof_tx_add(struct ldb_module *module, struct ldb_request *req)
+{
+    struct tx_private *private_data;
+    struct tx_journal *journal;
+    const char *dn_string;
+    bool identity;
+    int ret;
+
+    ret = tx_require_journal(module, &private_data, &journal);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    if (private_data->flushing || getenv("SSSD_UPGRADE_DB") != NULL) {
+        return ldb_next_request(module, req);
+    }
+
+    if (ldb_dn_is_special(req->op.add.message->dn)) {
+        dn_string = ldb_dn_get_linearized(req->op.add.message->dn);
+        if (dn_string != NULL && strcmp(dn_string, TX_REBUILD_DN) == 0) {
+            ret = tx_mark_dirty(module, journal);
+            if (ret != LDB_SUCCESS) {
+                return tx_journal_error(journal, ret);
+            }
+            return tx_complete_noop(req);
+        }
+        return ldb_next_request(module, req);
+    }
+    ret = tx_snapshot_ensure(module, journal);
+    if (ret != LDB_SUCCESS) {
+        return tx_journal_error(journal, ret);
+    }
+
+    ret = tx_check_readonly(module, req->op.add.message);
+    if (ret != LDB_SUCCESS) {
+        return tx_journal_error(journal, ret);
+    }
+    ret = tx_validate_members(module, req->op.add.message);
+    if (ret != LDB_SUCCESS) {
+        return tx_journal_error(journal, ret);
+    }
+
+    identity = tx_message_is_identity(req->op.add.message);
+    if (identity) {
+        ret = tx_load_migration_state(module, private_data, journal);
+        if (ret != LDB_SUCCESS) {
+            return tx_journal_error(journal, ret);
+        }
+    }
+
+    return tx_forward_request(module, req, journal, TX_FORWARD_ADD);
+}
+
+int memberof_tx_modify(struct ldb_module *module, struct ldb_request *req)
+{
+    struct tx_private *private_data;
+    struct tx_journal *journal;
+    struct ldb_message *identity;
+    bool relevant;
+    int ret;
+
+    ret = tx_require_journal(module, &private_data, &journal);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    if (private_data->flushing || getenv("SSSD_UPGRADE_DB") != NULL) {
+        return ldb_next_request(module, req);
+    }
+    if (ldb_dn_is_special(req->op.mod.message->dn)) {
+        return ldb_next_request(module, req);
+    }
+
+    ret = tx_check_readonly(module, req->op.mod.message);
+    if (ret != LDB_SUCCESS) {
+        return tx_journal_error(journal, ret);
+    }
+    ret = tx_validate_members(module, req->op.mod.message);
+    if (ret != LDB_SUCCESS) {
+        return tx_journal_error(journal, ret);
+    }
+
+    relevant = tx_modify_affects_graph(req->op.mod.message);
+    if (!relevant) {
+        /* Initgroups can commit thousands of metadata-only cache updates. */
+        return ldb_next_request(module, req);
+    }
+
+    ret = tx_snapshot_ensure(module, journal);
+    if (ret != LDB_SUCCESS) {
+        return tx_journal_error(journal, ret);
+    }
+    identity = tx_snapshot_lookup(journal, req->op.mod.message->dn);
+    if (identity == NULL) {
+        return ldb_next_request(module, req);
+    }
+
+    ret = tx_load_migration_state(module, private_data, journal);
+    if (ret != LDB_SUCCESS) {
+        return tx_journal_error(journal, ret);
+    }
+
+    return tx_forward_request(module, req, journal, TX_FORWARD_MODIFY);
 }
 
 int memberof_tx_delete(struct ldb_module *module, struct ldb_request *req)
@@ -1505,7 +1736,6 @@ int memberof_tx_delete(struct ldb_module *module, struct ldb_request *req)
     struct tx_private *private_data;
     struct tx_journal *journal;
     struct ldb_message *identity;
-    const char *key;
     bool is_identity;
     int ret;
 
@@ -1521,7 +1751,7 @@ int memberof_tx_delete(struct ldb_module *module, struct ldb_request *req)
     }
     ret = tx_snapshot_ensure(module, journal);
     if (ret != LDB_SUCCESS) {
-        return ret;
+        return tx_journal_error(journal, ret);
     }
     identity = tx_snapshot_lookup(journal, req->op.del.dn);
     if (identity == NULL) {
@@ -1530,25 +1760,13 @@ int memberof_tx_delete(struct ldb_module *module, struct ldb_request *req)
 
     is_identity = tx_message_is_identity(identity);
     if (is_identity) {
-        ret = tx_mark_dirty(module, journal);
+        ret = tx_load_migration_state(module, private_data, journal);
         if (ret != LDB_SUCCESS) {
-            return ret;
+            return tx_journal_error(journal, ret);
         }
-        key = tx_dn_key(req->op.del.dn);
-        if (key == NULL) {
-            return LDB_ERR_INVALID_DN_SYNTAX;
-        }
-        ret = tx_set_add(&journal->deleted_dns, key, key);
-        if (ret != LDB_SUCCESS) {
-            return ret;
-        }
-    }
-    ret = tx_snapshot_remove(journal, req->op.del.dn);
-    if (ret != LDB_SUCCESS) {
-        return ret;
     }
 
-    return ldb_next_request(module, req);
+    return tx_forward_request(module, req, journal, TX_FORWARD_DELETE);
 }
 
 int memberof_tx_rename(struct ldb_module *module, struct ldb_request *req)
@@ -1556,7 +1774,6 @@ int memberof_tx_rename(struct ldb_module *module, struct ldb_request *req)
     struct tx_private *private_data;
     struct tx_journal *journal;
     struct ldb_message *identity;
-    const char *new_key;
     bool is_identity;
     int ret;
 
@@ -1573,7 +1790,7 @@ int memberof_tx_rename(struct ldb_module *module, struct ldb_request *req)
     }
     ret = tx_snapshot_ensure(module, journal);
     if (ret != LDB_SUCCESS) {
-        return ret;
+        return tx_journal_error(journal, ret);
     }
     identity = tx_snapshot_lookup(journal, req->op.rename.olddn);
     if (identity == NULL) {
@@ -1582,31 +1799,13 @@ int memberof_tx_rename(struct ldb_module *module, struct ldb_request *req)
 
     is_identity = tx_message_is_identity(identity);
     if (is_identity) {
-        ret = tx_mark_dirty(module, journal);
+        ret = tx_load_migration_state(module, private_data, journal);
         if (ret != LDB_SUCCESS) {
-            return ret;
+            return tx_journal_error(journal, ret);
         }
-        ret = tx_record_rename(journal, req->op.rename.olddn,
-                               req->op.rename.newdn);
-        if (ret != LDB_SUCCESS) {
-            return ret;
-        }
-    }
-    new_key = tx_dn_key(req->op.rename.newdn);
-    if (new_key == NULL) {
-        return LDB_ERR_INVALID_DN_SYNTAX;
-    }
-    ret = tx_set_remove(&journal->deleted_dns, new_key);
-    if (ret != LDB_SUCCESS) {
-        return ret;
-    }
-    ret = tx_snapshot_rename(journal, req->op.rename.olddn,
-                             req->op.rename.newdn);
-    if (ret != LDB_SUCCESS) {
-        return ret;
     }
 
-    return ldb_next_request(module, req);
+    return tx_forward_request(module, req, journal, TX_FORWARD_RENAME);
 }
 
 int memberof_tx_start(struct ldb_module *module)
@@ -1654,6 +1853,12 @@ int memberof_tx_prepare_commit(struct ldb_module *module)
     if (journal == NULL) {
         return LDB_ERR_OPERATIONS_ERROR;
     }
+    if (journal->failed) {
+        ldb_set_errstring(ldb_module_get_ctx(module),
+                          "Cannot commit after a failed memberof write");
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
     if (journal->dirty) {
         private_data->flushing = true;
         ret = tx_graph_flush(module, journal);

--- a/src/ldb_modules/memberof_transaction.c
+++ b/src/ldb_modules/memberof_transaction.c
@@ -1,0 +1,2738 @@
+/*
+   Transactional membership graph maintenance for the SSSD sysdb.
+
+   Direct group "member" edges are source data. Reverse memberships,
+   memberUid, and inherited ghost users are materialized once when the outer
+   LDB transaction is prepared. This prevents one recursive database walk for
+   every removed edge during a large group replacement.
+*/
+
+#include <stdbool.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+#include <dhash.h>
+
+#include "ldb_module.h"
+#include "util/util.h"
+#include "ldb_modules/memberof_transaction.h"
+
+#define TX_DB_MEMBER "member"
+#define TX_DB_GHOST "ghost"
+#define TX_DB_GHOST_DIRECT "ghostDirect"
+#define TX_DB_MEMBEROF "memberof"
+#define TX_DB_MEMBERUID "memberuid"
+#define TX_DB_NAME "name"
+#define TX_DB_OC "objectCategory"
+#define TX_DB_USER_CLASS "user"
+#define TX_DB_GROUP_CLASS "group"
+#define TX_DB_CACHE_EXPIRE "dataExpireTimestamp"
+
+#define TX_REBUILD_DN "@MEMBEROF-REBUILD"
+#define TX_MIGRATION_DN "@MEMBEROF-TRANSACTIONAL"
+#define TX_MIGRATION_ATTR "@GHOST-DIRECT-VERSION"
+#define TX_MIGRATION_VERSION "1"
+
+/* Expiration and other cache metadata do not participate in the graph. */
+static const char *tx_graph_attrs[] = {
+    TX_DB_OC, TX_DB_NAME, TX_DB_MEMBER,
+    TX_DB_MEMBEROF, TX_DB_MEMBERUID,
+    TX_DB_GHOST, TX_DB_GHOST_DIRECT, NULL
+};
+
+struct tx_set_entry {
+    const char *key;
+    const char *output;
+};
+
+struct tx_set {
+    TALLOC_CTX *owner;
+    TALLOC_CTX *storage;
+    hash_table_t *table;
+    struct tx_set_entry **ordered;
+    size_t count;
+    size_t capacity;
+};
+
+struct tx_legacy_ghost {
+    struct tx_set direct;
+    bool ambiguous;
+};
+
+struct tx_ghost_op {
+    struct tx_ghost_op *next;
+    struct ldb_dn *dn;
+    unsigned int flags;
+    struct ldb_val *values;
+    unsigned int num_values;
+};
+
+struct tx_rename {
+    struct tx_rename *next;
+    struct tx_rename *prev;
+    struct ldb_dn *old_dn;
+    struct ldb_dn *new_dn;
+    const char *old_key;
+    const char *new_key;
+};
+
+struct tx_journal {
+    bool dirty;
+    bool migration_checked;
+    bool migration_marker_exists;
+    bool migration_complete;
+    bool migration_written;
+
+    hash_table_t *legacy_ghosts;
+    struct tx_ghost_op *ghost_ops;
+    struct tx_ghost_op *last_ghost_op;
+    struct tx_rename *renames;
+    struct tx_rename *last_rename;
+    struct tx_set deleted_dns;
+    struct ldb_result *snapshot;
+    hash_table_t *snapshot_map;
+};
+
+struct tx_private {
+    bool enabled;
+    bool flushing;
+    bool migration_persisted;
+    struct tx_journal *journal;
+};
+
+struct tx_snapshot_group {
+    struct ldb_message *msg;
+    const char *key;
+    struct tx_set public_ghosts;
+    struct tx_set direct_ghosts;
+};
+
+static int tx_graph_flush(struct ldb_module *module,
+                          struct tx_journal *journal);
+
+static void *tx_hash_alloc(size_t size, void *pvt)
+{
+    return talloc_size(pvt, size);
+}
+
+static void tx_hash_free(void *ptr, void *pvt)
+{
+    talloc_free(ptr);
+}
+
+static int tx_hash_create(TALLOC_CTX *mem_ctx, unsigned long size,
+                          hash_table_t **_table)
+{
+    int hret;
+
+    hret = hash_create_ex(size, _table, 0, 0, 0, 0,
+                          tx_hash_alloc, tx_hash_free,
+                          mem_ctx, NULL, NULL);
+    return hret == HASH_SUCCESS ? LDB_SUCCESS : LDB_ERR_OPERATIONS_ERROR;
+}
+
+static int tx_hash_put_ptr(hash_table_t *table, const char *key_string,
+                           void *ptr)
+{
+    hash_value_t value;
+    hash_key_t key;
+    int hret;
+
+    key.type = HASH_KEY_STRING;
+    key.str = discard_const(key_string);
+    value.type = HASH_VALUE_PTR;
+    value.ptr = ptr;
+
+    hret = hash_enter(table, &key, &value);
+    return hret == HASH_SUCCESS ? LDB_SUCCESS : LDB_ERR_OPERATIONS_ERROR;
+}
+
+static void *tx_hash_get_ptr(hash_table_t *table, const char *key_string)
+{
+    hash_value_t value;
+    hash_key_t key;
+    int hret;
+
+    if (table == NULL || key_string == NULL) {
+        return NULL;
+    }
+
+    key.type = HASH_KEY_STRING;
+    key.str = discard_const(key_string);
+    hret = hash_lookup(table, &key, &value);
+    if (hret != HASH_SUCCESS || value.type != HASH_VALUE_PTR) {
+        return NULL;
+    }
+
+    return value.ptr;
+}
+
+static int tx_hash_delete_key(hash_table_t *table, const char *key_string)
+{
+    hash_key_t key;
+    int hret;
+
+    if (table == NULL || key_string == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    key.type = HASH_KEY_STRING;
+    key.str = discard_const(key_string);
+    hret = hash_delete(table, &key);
+    return hret == HASH_SUCCESS ? LDB_SUCCESS
+                                : LDB_ERR_OPERATIONS_ERROR;
+}
+
+static void tx_set_init(struct tx_set *set, TALLOC_CTX *owner)
+{
+    set->owner = owner;
+}
+
+static int tx_set_ensure(struct tx_set *set, unsigned long size)
+{
+    int ret;
+
+    if (set->table != NULL) {
+        return LDB_SUCCESS;
+    }
+
+    set->storage = talloc_new(set->owner);
+    if (set->storage == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    ret = tx_hash_create(set->storage, size, &set->table);
+    if (ret != LDB_SUCCESS) {
+        talloc_zfree(set->storage);
+    }
+
+    return ret;
+}
+
+static void tx_set_clear(struct tx_set *set)
+{
+    talloc_zfree(set->storage);
+    set->table = NULL;
+    set->ordered = NULL;
+    set->count = 0;
+    set->capacity = 0;
+}
+
+static unsigned long tx_set_count(const struct tx_set *set)
+{
+    return set->count;
+}
+
+static bool tx_set_has(const struct tx_set *set, const char *key_string)
+{
+    hash_key_t key;
+
+    if (set->table == NULL || key_string == NULL) {
+        return false;
+    }
+
+    key.type = HASH_KEY_STRING;
+    key.str = discard_const(key_string);
+    return hash_has_key(set->table, &key);
+}
+
+static int tx_set_add(struct tx_set *set, const char *key_string,
+                      const char *output)
+{
+    struct tx_set_entry **ordered;
+    struct tx_set_entry *entry;
+    hash_value_t value;
+    hash_key_t key;
+    size_t capacity;
+    int ret;
+
+    if (key_string == NULL || output == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    ret = tx_set_ensure(set, 0);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+
+    key.type = HASH_KEY_STRING;
+    key.str = discard_const(key_string);
+    if (hash_has_key(set->table, &key)) {
+        return LDB_SUCCESS;
+    }
+
+    if (set->count == set->capacity) {
+        capacity = set->capacity == 0 ? 8 : set->capacity * 2;
+        if (capacity < set->capacity) {
+            return LDB_ERR_OPERATIONS_ERROR;
+        }
+        ordered = talloc_realloc(set->storage, set->ordered,
+                                 struct tx_set_entry *, capacity);
+        if (ordered == NULL) {
+            return LDB_ERR_OPERATIONS_ERROR;
+        }
+        set->ordered = ordered;
+        set->capacity = capacity;
+    }
+
+    entry = talloc_zero(set->storage, struct tx_set_entry);
+    if (entry == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    entry->key = talloc_strdup(entry, key_string);
+    entry->output = talloc_strdup(entry, output);
+    if (entry->key == NULL || entry->output == NULL) {
+        talloc_free(entry);
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    key.str = discard_const(entry->key);
+    value.type = HASH_VALUE_PTR;
+    value.ptr = entry;
+    ret = hash_enter(set->table, &key, &value);
+    if (ret != HASH_SUCCESS) {
+        talloc_free(entry);
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    set->ordered[set->count++] = entry;
+    return LDB_SUCCESS;
+}
+
+static int tx_set_remove(struct tx_set *set, const char *key_string)
+{
+    struct tx_set_entry *entry;
+    hash_value_t value;
+    hash_key_t key;
+    size_t i;
+    int hret;
+
+    if (set->table == NULL || key_string == NULL) {
+        return LDB_SUCCESS;
+    }
+
+    key.type = HASH_KEY_STRING;
+    key.str = discard_const(key_string);
+    if (!hash_has_key(set->table, &key)) {
+        return LDB_SUCCESS;
+    }
+
+    hret = hash_lookup(set->table, &key, &value);
+    if (hret != HASH_SUCCESS || value.type != HASH_VALUE_PTR) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    entry = value.ptr;
+    for (i = 0; i < set->count; i++) {
+        if (set->ordered[i] == entry) {
+            break;
+        }
+    }
+    if (i == set->count) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    hret = hash_delete(set->table, &key);
+    if (hret != HASH_SUCCESS) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    set->count--;
+    if (i != set->count) {
+        memmove(&set->ordered[i], &set->ordered[i + 1],
+                (set->count - i) * sizeof(set->ordered[0]));
+    }
+    talloc_free(entry);
+    return LDB_SUCCESS;
+}
+
+static int tx_set_union(struct tx_set *dest, const struct tx_set *source)
+{
+    size_t i;
+    int ret;
+
+    for (i = 0; i < source->count; i++) {
+        ret = tx_set_add(dest, source->ordered[i]->key,
+                         source->ordered[i]->output);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+    }
+
+    return LDB_SUCCESS;
+}
+
+static int tx_set_copy(struct tx_set *dest, const struct tx_set *source)
+{
+    tx_set_clear(dest);
+    return tx_set_union(dest, source);
+}
+
+static const char *tx_dn_key(struct ldb_dn *dn)
+{
+    if (dn == NULL || !ldb_dn_validate(dn)) {
+        return NULL;
+    }
+
+    return ldb_dn_get_casefold(dn);
+}
+
+static bool tx_message_is_class(const struct ldb_message *message,
+                                const char *object_class)
+{
+    struct ldb_message_element *el;
+    unsigned int i;
+
+    el = ldb_msg_find_element(message, TX_DB_OC);
+    if (el == NULL) {
+        return false;
+    }
+
+    for (i = 0; i < el->num_values; i++) {
+        if (strcasecmp((const char *)el->values[i].data,
+                       object_class) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool tx_message_is_identity(const struct ldb_message *message)
+{
+    return tx_message_is_class(message, TX_DB_USER_CLASS)
+        || tx_message_is_class(message, TX_DB_GROUP_CLASS);
+}
+
+static int tx_snapshot_ensure(struct ldb_module *module,
+                              struct tx_journal *journal)
+{
+    struct ldb_context *ldb = ldb_module_get_ctx(module);
+    const char *key;
+    unsigned int i;
+    int ret;
+
+    if (journal->snapshot != NULL) {
+        return LDB_SUCCESS;
+    }
+
+    ret = ldb_search(ldb, journal, &journal->snapshot,
+                     NULL, LDB_SCOPE_SUBTREE, tx_graph_attrs, NULL);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+
+    ret = tx_hash_create(journal, journal->snapshot->count,
+                         &journal->snapshot_map);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    for (i = 0; i < journal->snapshot->count; i++) {
+        key = tx_dn_key(journal->snapshot->msgs[i]->dn);
+        if (key == NULL) {
+            return LDB_ERR_INVALID_DN_SYNTAX;
+        }
+        ret = tx_hash_put_ptr(journal->snapshot_map, key,
+                              journal->snapshot->msgs[i]);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+    }
+
+    return LDB_SUCCESS;
+}
+
+static struct ldb_message *tx_snapshot_lookup(struct tx_journal *journal,
+                                              struct ldb_dn *dn)
+{
+    return tx_hash_get_ptr(journal->snapshot_map, tx_dn_key(dn));
+}
+
+static bool tx_value_equal(const struct ldb_val *left,
+                           const struct ldb_val *right)
+{
+    return left->length == right->length
+        && memcmp(left->data, right->data, left->length) == 0;
+}
+
+static bool tx_values_have(const struct ldb_val *values, size_t count,
+                           const struct ldb_val *value)
+{
+    size_t i;
+
+    for (i = 0; i < count; i++) {
+        if (tx_value_equal(&values[i], value)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static int tx_snapshot_set_values(struct ldb_message *message,
+                                  const char *name,
+                                  const struct ldb_val *values,
+                                  size_t count)
+{
+    struct ldb_message_element *element;
+    struct ldb_val *copies = NULL;
+    struct ldb_dn *dn = message->dn;
+    TALLOC_CTX *tmp_ctx;
+    size_t i;
+    int ret;
+
+    tmp_ctx = talloc_new(message);
+    if (tmp_ctx == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    if (count != 0) {
+        copies = talloc_zero_array(tmp_ctx, struct ldb_val, count);
+        if (copies == NULL) {
+            talloc_free(tmp_ctx);
+            return LDB_ERR_OPERATIONS_ERROR;
+        }
+        for (i = 0; i < count; i++) {
+            copies[i].data = talloc_zero_size(copies,
+                                              values[i].length + 1);
+            if (copies[i].data == NULL) {
+                talloc_free(tmp_ctx);
+                return LDB_ERR_OPERATIONS_ERROR;
+            }
+            memcpy(copies[i].data, values[i].data, values[i].length);
+            copies[i].length = values[i].length;
+        }
+    }
+
+    ldb_msg_remove_attr(message, name);
+    message->dn = dn;
+    if (count == 0) {
+        talloc_free(tmp_ctx);
+        return LDB_SUCCESS;
+    }
+
+    ret = ldb_msg_add_empty(message, name, 0, &element);
+    if (ret != LDB_SUCCESS) {
+        talloc_free(tmp_ctx);
+        return ret;
+    }
+    element->values = talloc_steal(message, copies);
+    element->num_values = count;
+    talloc_free(tmp_ctx);
+    return LDB_SUCCESS;
+}
+
+static int tx_snapshot_apply_element(struct ldb_message *message,
+                                     const struct ldb_message_element *change)
+{
+    struct ldb_message_element *current;
+    struct ldb_val *values;
+    TALLOC_CTX *tmp_ctx;
+    size_t current_count;
+    size_t count = 0;
+    size_t i;
+    unsigned int j;
+    int ret;
+
+    current = ldb_msg_find_element(message, change->name);
+    current_count = current == NULL ? 0 : current->num_values;
+    switch (change->flags & LDB_FLAG_MOD_MASK) {
+    case 0:
+    case LDB_FLAG_MOD_REPLACE:
+        return tx_snapshot_set_values(message, change->name,
+                                      change->values,
+                                      change->num_values);
+
+    case LDB_FLAG_MOD_ADD:
+        tmp_ctx = talloc_new(message);
+        if (tmp_ctx == NULL) {
+            return LDB_ERR_OPERATIONS_ERROR;
+        }
+        values = talloc_array(tmp_ctx, struct ldb_val,
+                              current_count + change->num_values);
+        if (values == NULL
+                && current_count + change->num_values != 0) {
+            talloc_free(tmp_ctx);
+            return LDB_ERR_OPERATIONS_ERROR;
+        }
+        for (i = 0; i < current_count; i++) {
+            values[count++] = current->values[i];
+        }
+        for (j = 0; j < change->num_values; j++) {
+            if (!tx_values_have(values, count, &change->values[j])) {
+                values[count++] = change->values[j];
+            }
+        }
+        ret = tx_snapshot_set_values(message, change->name, values, count);
+        talloc_free(tmp_ctx);
+        return ret;
+
+    case LDB_FLAG_MOD_DELETE:
+        if (current == NULL || change->num_values == 0) {
+            return tx_snapshot_set_values(message, change->name, NULL, 0);
+        }
+        tmp_ctx = talloc_new(message);
+        if (tmp_ctx == NULL) {
+            return LDB_ERR_OPERATIONS_ERROR;
+        }
+        values = talloc_array(tmp_ctx, struct ldb_val, current_count);
+        if (values == NULL && current_count != 0) {
+            talloc_free(tmp_ctx);
+            return LDB_ERR_OPERATIONS_ERROR;
+        }
+        for (i = 0; i < current_count; i++) {
+            if (!tx_values_have(change->values, change->num_values,
+                                &current->values[i])) {
+                values[count++] = current->values[i];
+            }
+        }
+        ret = tx_snapshot_set_values(message, change->name, values, count);
+        talloc_free(tmp_ctx);
+        return ret;
+
+    default:
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+}
+
+static bool tx_snapshot_tracks_attr(const char *name)
+{
+    return strcasecmp(name, TX_DB_OC) == 0
+        || strcasecmp(name, TX_DB_NAME) == 0
+        || strcasecmp(name, TX_DB_MEMBER) == 0
+        || strcasecmp(name, TX_DB_GHOST) == 0;
+}
+
+static int tx_snapshot_modify(struct tx_journal *journal,
+                              const struct ldb_message *change)
+{
+    struct ldb_message *message;
+    unsigned int i;
+    int ret;
+
+    message = tx_snapshot_lookup(journal, change->dn);
+    if (message == NULL) {
+        return LDB_SUCCESS;
+    }
+    for (i = 0; i < change->num_elements; i++) {
+        if (!tx_snapshot_tracks_attr(change->elements[i].name)) {
+            continue;
+        }
+        ret = tx_snapshot_apply_element(message, &change->elements[i]);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+    }
+    return LDB_SUCCESS;
+}
+
+static int tx_snapshot_add(struct tx_journal *journal,
+                           const struct ldb_message *source)
+{
+    struct ldb_message **messages;
+    struct ldb_message *message;
+    const char *key;
+    int ret;
+
+    if (tx_snapshot_lookup(journal, source->dn) != NULL) {
+        return LDB_ERR_ENTRY_ALREADY_EXISTS;
+    }
+    message = ldb_msg_copy(journal->snapshot, source);
+    if (message == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    messages = talloc_realloc(journal->snapshot,
+                              journal->snapshot->msgs,
+                              struct ldb_message *,
+                              journal->snapshot->count + 1);
+    if (messages == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    journal->snapshot->msgs = messages;
+    key = tx_dn_key(message->dn);
+    if (key == NULL) {
+        return LDB_ERR_INVALID_DN_SYNTAX;
+    }
+    ret = tx_hash_put_ptr(journal->snapshot_map, key, message);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    journal->snapshot->msgs[journal->snapshot->count++] = message;
+    return LDB_SUCCESS;
+}
+
+static int tx_snapshot_remove(struct tx_journal *journal, struct ldb_dn *dn)
+{
+    struct ldb_message *message;
+    const char *key;
+    unsigned int i;
+    int ret;
+
+    message = tx_snapshot_lookup(journal, dn);
+    if (message == NULL) {
+        return LDB_ERR_NO_SUCH_OBJECT;
+    }
+    key = tx_dn_key(dn);
+    ret = tx_hash_delete_key(journal->snapshot_map, key);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    for (i = 0; i < journal->snapshot->count; i++) {
+        if (journal->snapshot->msgs[i] == message) {
+            break;
+        }
+    }
+    if (i == journal->snapshot->count) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    journal->snapshot->count--;
+    if (i != journal->snapshot->count) {
+        memmove(&journal->snapshot->msgs[i],
+                &journal->snapshot->msgs[i + 1],
+                (journal->snapshot->count - i)
+                    * sizeof(journal->snapshot->msgs[0]));
+    }
+    talloc_free(message);
+    return LDB_SUCCESS;
+}
+
+static int tx_snapshot_rename(struct tx_journal *journal,
+                              struct ldb_dn *old_dn,
+                              struct ldb_dn *new_dn)
+{
+    struct ldb_message *message;
+    struct ldb_dn *copy;
+    const char *old_key;
+    const char *new_key;
+    int ret;
+
+    message = tx_snapshot_lookup(journal, old_dn);
+    if (message == NULL) {
+        return LDB_ERR_NO_SUCH_OBJECT;
+    }
+    copy = ldb_dn_copy(message, new_dn);
+    if (copy == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    old_key = tx_dn_key(old_dn);
+    ret = tx_hash_delete_key(journal->snapshot_map, old_key);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    message->dn = copy;
+    new_key = tx_dn_key(message->dn);
+    if (new_key == NULL) {
+        return LDB_ERR_INVALID_DN_SYNTAX;
+    }
+    return tx_hash_put_ptr(journal->snapshot_map, new_key, message);
+}
+
+static int tx_snapshot_public_ghosts(struct tx_snapshot_group *group)
+{
+    struct ldb_message_element *el;
+    unsigned int i;
+    int ret;
+
+    tx_set_init(&group->public_ghosts, group);
+    tx_set_init(&group->direct_ghosts, group);
+
+    el = ldb_msg_find_element(group->msg, TX_DB_GHOST);
+    if (el == NULL) {
+        return LDB_SUCCESS;
+    }
+
+    for (i = 0; i < el->num_values; i++) {
+        ret = tx_set_add(&group->public_ghosts,
+                         (const char *)el->values[i].data,
+                         (const char *)el->values[i].data);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+    }
+
+    return tx_set_copy(&group->direct_ghosts, &group->public_ghosts);
+}
+
+static int tx_check_migration_marker(struct ldb_module *module,
+                                     TALLOC_CTX *mem_ctx,
+                                     bool *_exists,
+                                     bool *_complete)
+{
+    static const char *attrs[] = { TX_MIGRATION_ATTR, NULL };
+    struct ldb_context *ldb = ldb_module_get_ctx(module);
+    struct ldb_result *result = NULL;
+    struct ldb_dn *dn;
+    const char *version;
+    int ret;
+
+    *_exists = false;
+    *_complete = false;
+    dn = ldb_dn_new(mem_ctx, ldb, TX_MIGRATION_DN);
+    if (dn == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    ret = ldb_search(ldb, mem_ctx, &result, dn, LDB_SCOPE_BASE,
+                     attrs, NULL);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    if (result->count == 0) {
+        return LDB_SUCCESS;
+    }
+    if (result->count != 1) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    *_exists = true;
+    version = ldb_msg_find_attr_as_string(result->msgs[0],
+                                           TX_MIGRATION_ATTR, NULL);
+    *_complete = version != NULL
+              && strcmp(version, TX_MIGRATION_VERSION) == 0;
+    return LDB_SUCCESS;
+}
+
+static int tx_capture_legacy_ghosts(struct ldb_module *module,
+                                    struct tx_journal *journal)
+{
+    struct ldb_context *ldb = ldb_module_get_ctx(module);
+    struct tx_snapshot_group **groups = NULL;
+    struct tx_snapshot_group *group;
+    struct tx_snapshot_group *child;
+    struct ldb_message_element *members;
+    struct ldb_result *result = journal->snapshot;
+    struct tx_legacy_ghost *record;
+    TALLOC_CTX *tmp_ctx;
+    hash_table_t *group_map = NULL;
+    struct ldb_dn *member_dn;
+    const char *key;
+    size_t num_groups = 0;
+    size_t group_index = 0;
+    size_t k;
+    unsigned int i;
+    unsigned int j;
+    int ret;
+
+    if (journal->migration_checked) {
+        return LDB_SUCCESS;
+    }
+    journal->migration_checked = true;
+
+    tmp_ctx = talloc_new(journal);
+    if (tmp_ctx == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    ret = tx_check_migration_marker(module, tmp_ctx,
+                                    &journal->migration_marker_exists,
+                                    &journal->migration_complete);
+    if (ret != LDB_SUCCESS || journal->migration_complete) {
+        talloc_free(tmp_ctx);
+        return ret;
+    }
+
+    if (result == NULL) {
+        talloc_free(tmp_ctx);
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    for (i = 0; i < result->count; i++) {
+        if (tx_message_is_class(result->msgs[i], TX_DB_GROUP_CLASS)) {
+            num_groups++;
+        }
+    }
+
+    ret = tx_hash_create(journal, num_groups, &journal->legacy_ghosts);
+    if (ret != LDB_SUCCESS) {
+        talloc_free(tmp_ctx);
+        return ret;
+    }
+    ret = tx_hash_create(tmp_ctx, num_groups, &group_map);
+    if (ret != LDB_SUCCESS) {
+        talloc_free(tmp_ctx);
+        return ret;
+    }
+
+    groups = talloc_zero_array(tmp_ctx, struct tx_snapshot_group *,
+                               num_groups);
+    if (groups == NULL && num_groups != 0) {
+        talloc_free(tmp_ctx);
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    for (i = 0; i < result->count; i++) {
+        if (!tx_message_is_class(result->msgs[i], TX_DB_GROUP_CLASS)) {
+            continue;
+        }
+        group = talloc_zero(tmp_ctx, struct tx_snapshot_group);
+        if (group == NULL) {
+            ret = LDB_ERR_OPERATIONS_ERROR;
+            goto done;
+        }
+        groups[group_index++] = group;
+        group->msg = result->msgs[i];
+        group->key = tx_dn_key(group->msg->dn);
+        if (group->key == NULL) {
+            ret = LDB_ERR_INVALID_DN_SYNTAX;
+            goto done;
+        }
+
+        ret = tx_snapshot_public_ghosts(group);
+        if (ret != LDB_SUCCESS) {
+            goto done;
+        }
+        ret = tx_hash_put_ptr(group_map, group->key, group);
+        if (ret != LDB_SUCCESS) {
+            goto done;
+        }
+    }
+
+    for (i = 0; i < num_groups; i++) {
+        group = groups[i];
+        members = ldb_msg_find_element(group->msg, TX_DB_MEMBER);
+        if (members == NULL) {
+            continue;
+        }
+
+        for (j = 0; j < members->num_values; j++) {
+            member_dn = ldb_dn_from_ldb_val(tmp_ctx, ldb,
+                                            &members->values[j]);
+            key = tx_dn_key(member_dn);
+            child = tx_hash_get_ptr(group_map, key);
+            if (child == NULL || child->public_ghosts.table == NULL) {
+                continue;
+            }
+
+            for (k = 0; k < child->public_ghosts.count; k++) {
+                key = child->public_ghosts.ordered[k]->key;
+                if (tx_set_has(&group->direct_ghosts, key)) {
+                    record = tx_hash_get_ptr(journal->legacy_ghosts,
+                                             group->key);
+                    if (record == NULL) {
+                        record = talloc_zero(journal,
+                                             struct tx_legacy_ghost);
+                        if (record == NULL) {
+                            ret = LDB_ERR_OPERATIONS_ERROR;
+                            goto done;
+                        }
+                        tx_set_init(&record->direct, record);
+                        record->ambiguous = true;
+                        ret = tx_hash_put_ptr(journal->legacy_ghosts,
+                                              group->key, record);
+                        if (ret != LDB_SUCCESS) {
+                            goto done;
+                        }
+                    } else {
+                        record->ambiguous = true;
+                    }
+                }
+
+                ret = tx_set_remove(&group->direct_ghosts, key);
+                if (ret != LDB_SUCCESS) {
+                    goto done;
+                }
+            }
+        }
+    }
+
+    for (i = 0; i < num_groups; i++) {
+        group = groups[i];
+        record = tx_hash_get_ptr(journal->legacy_ghosts, group->key);
+        if (record == NULL) {
+            record = talloc_zero(journal, struct tx_legacy_ghost);
+            if (record == NULL) {
+                ret = LDB_ERR_OPERATIONS_ERROR;
+                goto done;
+            }
+            tx_set_init(&record->direct, record);
+            ret = tx_hash_put_ptr(journal->legacy_ghosts,
+                                  group->key, record);
+            if (ret != LDB_SUCCESS) {
+                goto done;
+            }
+        }
+
+        ret = tx_set_copy(&record->direct, &group->direct_ghosts);
+        if (ret != LDB_SUCCESS) {
+            goto done;
+        }
+    }
+
+    ret = LDB_SUCCESS;
+
+done:
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+static struct tx_private *tx_get_private(struct ldb_module *module)
+{
+    return talloc_get_type(ldb_module_get_private(module),
+                           struct tx_private);
+}
+
+bool memberof_tx_enabled(struct ldb_module *module)
+{
+    struct tx_private *private_data = tx_get_private(module);
+
+    return private_data != NULL && private_data->enabled;
+}
+
+int memberof_tx_init(struct ldb_module *module)
+{
+    struct tx_private *private_data;
+
+    private_data = talloc_zero(module, struct tx_private);
+    if (private_data == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    private_data->enabled = getenv("SSSD_MEMBEROF_LEGACY") == NULL;
+    ldb_module_set_private(module, private_data);
+    return LDB_SUCCESS;
+}
+
+static int tx_require_journal(struct ldb_module *module,
+                              struct tx_private **_private,
+                              struct tx_journal **_journal)
+{
+    struct tx_private *private_data = tx_get_private(module);
+
+    if (private_data == NULL || private_data->journal == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    *_private = private_data;
+    *_journal = private_data->journal;
+    return LDB_SUCCESS;
+}
+
+static int tx_mark_dirty(struct ldb_module *module,
+                         struct tx_journal *journal)
+{
+    struct tx_private *private_data;
+    int ret;
+
+    ret = tx_snapshot_ensure(module, journal);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    if (!journal->dirty) {
+        ret = tx_capture_legacy_ghosts(module, journal);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+        if (journal->migration_complete) {
+            private_data = tx_get_private(module);
+            if (private_data != NULL) {
+                private_data->migration_persisted = true;
+            }
+        }
+    }
+
+    journal->dirty = true;
+    return LDB_SUCCESS;
+}
+
+static bool tx_has_attr(const struct ldb_message *message, const char *name)
+{
+    return ldb_msg_find_element(message, name) != NULL;
+}
+
+static bool tx_modify_affects_graph(const struct ldb_message *message)
+{
+    return tx_has_attr(message, TX_DB_MEMBER)
+        || tx_has_attr(message, TX_DB_GHOST)
+        || tx_has_attr(message, TX_DB_NAME)
+        || tx_has_attr(message, TX_DB_OC);
+}
+
+static bool tx_element_has_value(const struct ldb_message_element *element,
+                                 const struct ldb_val *value)
+{
+    unsigned int i;
+
+    if (element == NULL) {
+        return false;
+    }
+    for (i = 0; i < element->num_values; i++) {
+        if (element->values[i].length == value->length
+                && memcmp(element->values[i].data, value->data,
+                          value->length) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool tx_element_changes(const struct ldb_message_element *current,
+                               const struct ldb_message_element *change)
+{
+    unsigned int i;
+
+    switch (change->flags & LDB_FLAG_MOD_MASK) {
+    case 0:
+    case LDB_FLAG_MOD_REPLACE:
+        if (current == NULL) {
+            return change->num_values != 0;
+        }
+        return ldb_msg_element_compare(
+            discard_const_p(struct ldb_message_element, current),
+            discard_const_p(struct ldb_message_element, change)) != 0;
+
+    case LDB_FLAG_MOD_ADD:
+        for (i = 0; i < change->num_values; i++) {
+            if (!tx_element_has_value(current, &change->values[i])) {
+                return true;
+            }
+        }
+        return false;
+
+    case LDB_FLAG_MOD_DELETE:
+        if (current == NULL) {
+            return false;
+        }
+        if (change->num_values == 0) {
+            return current->num_values != 0;
+        }
+        for (i = 0; i < change->num_values; i++) {
+            if (tx_element_has_value(current, &change->values[i])) {
+                return true;
+            }
+        }
+        return false;
+
+    default:
+        return true;
+    }
+}
+
+static bool tx_modify_changes_graph(const struct ldb_message *current,
+                                    const struct ldb_message *change)
+{
+    const struct ldb_message_element *old_element;
+    const struct ldb_message_element *new_element;
+    unsigned int i;
+
+    for (i = 0; i < change->num_elements; i++) {
+        new_element = &change->elements[i];
+        if (strcasecmp(new_element->name, TX_DB_MEMBER) == 0
+                || strcasecmp(new_element->name, TX_DB_NAME) == 0
+                || strcasecmp(new_element->name, TX_DB_OC) == 0) {
+            old_element = ldb_msg_find_element(current, new_element->name);
+        } else if (strcasecmp(new_element->name, TX_DB_GHOST) == 0) {
+            old_element = ldb_msg_find_element(current,
+                                               TX_DB_GHOST_DIRECT);
+        } else {
+            continue;
+        }
+
+        if (tx_element_changes(old_element, new_element)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static int tx_load_migration_state(struct ldb_module *module,
+                                   struct tx_private *private_data,
+                                   struct tx_journal *journal)
+{
+    int ret;
+
+    ret = tx_capture_legacy_ghosts(module, journal);
+    if (ret == LDB_SUCCESS && journal->migration_complete) {
+        private_data->migration_persisted = true;
+    }
+    return ret;
+}
+
+static int tx_check_readonly(struct ldb_module *module,
+                             const struct ldb_message *message)
+{
+    struct ldb_context *ldb = ldb_module_get_ctx(module);
+
+    if (tx_has_attr(message, TX_DB_MEMBEROF)
+            || tx_has_attr(message, TX_DB_MEMBERUID)
+            || tx_has_attr(message, TX_DB_GHOST_DIRECT)) {
+        ldb_debug(ldb, LDB_DEBUG_ERROR,
+                  "Transactional memberOf derived attributes are readonly");
+        return LDB_ERR_UNWILLING_TO_PERFORM;
+    }
+
+    return LDB_SUCCESS;
+}
+
+static int tx_validate_members(struct ldb_module *module,
+                               const struct ldb_message *message)
+{
+    struct ldb_context *ldb = ldb_module_get_ctx(module);
+    struct ldb_message_element *members;
+    TALLOC_CTX *tmp_ctx;
+    struct ldb_dn *dn;
+    unsigned int i;
+
+    members = ldb_msg_find_element(message, TX_DB_MEMBER);
+    if (members == NULL || members->num_values == 0) {
+        return LDB_SUCCESS;
+    }
+
+    tmp_ctx = talloc_new(module);
+    if (tmp_ctx == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    for (i = 0; i < members->num_values; i++) {
+        dn = ldb_dn_from_ldb_val(tmp_ctx, ldb, &members->values[i]);
+        if (dn == NULL || !ldb_dn_validate(dn)) {
+            ldb_debug(ldb, LDB_DEBUG_ERROR, "Invalid member DN: [%s]",
+                      (const char *)members->values[i].data);
+            talloc_free(tmp_ctx);
+            return LDB_ERR_INVALID_DN_SYNTAX;
+        }
+    }
+
+    talloc_free(tmp_ctx);
+    return LDB_SUCCESS;
+}
+
+static int tx_record_ghosts(struct tx_journal *journal,
+                            struct ldb_dn *dn,
+                            const struct ldb_message *message,
+                            bool is_add)
+{
+    struct ldb_message_element *el;
+    struct tx_ghost_op *op;
+    unsigned int i;
+
+    el = ldb_msg_find_element(message, TX_DB_GHOST);
+    if (el == NULL) {
+        return LDB_SUCCESS;
+    }
+
+    op = talloc_zero(journal, struct tx_ghost_op);
+    if (op == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    op->dn = ldb_dn_copy(op, dn);
+    if (op->dn == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    op->flags = is_add ? LDB_FLAG_MOD_REPLACE
+                       : (el->flags & LDB_FLAG_MOD_MASK);
+    op->num_values = el->num_values;
+    if (el->num_values != 0) {
+        op->values = talloc_zero_array(op, struct ldb_val, el->num_values);
+        if (op->values == NULL) {
+            return LDB_ERR_OPERATIONS_ERROR;
+        }
+
+        for (i = 0; i < el->num_values; i++) {
+            op->values[i].data = (uint8_t *)talloc_strndup(
+                op->values, (const char *)el->values[i].data,
+                el->values[i].length);
+            if (op->values[i].data == NULL) {
+                return LDB_ERR_OPERATIONS_ERROR;
+            }
+            op->values[i].length = el->values[i].length;
+        }
+    }
+
+    if (journal->last_ghost_op == NULL) {
+        journal->ghost_ops = op;
+    } else {
+        journal->last_ghost_op->next = op;
+    }
+    journal->last_ghost_op = op;
+    return LDB_SUCCESS;
+}
+
+static int tx_record_request_ghosts(struct tx_journal *journal,
+                                    struct ldb_request *req,
+                                    bool is_add)
+{
+    const struct ldb_message *source;
+
+    source = is_add ? req->op.add.message : req->op.mod.message;
+    return tx_record_ghosts(journal, source->dn, source, is_add);
+}
+
+static int tx_record_rename(struct tx_journal *journal,
+                            struct ldb_dn *old_dn,
+                            struct ldb_dn *new_dn)
+{
+    struct tx_rename *rename;
+
+    rename = talloc_zero(journal, struct tx_rename);
+    if (rename == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    rename->old_dn = ldb_dn_copy(rename, old_dn);
+    rename->new_dn = ldb_dn_copy(rename, new_dn);
+    if (rename->old_dn == NULL || rename->new_dn == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    rename->old_key = tx_dn_key(rename->old_dn);
+    rename->new_key = tx_dn_key(rename->new_dn);
+    if (rename->old_key == NULL || rename->new_key == NULL) {
+        return LDB_ERR_INVALID_DN_SYNTAX;
+    }
+
+    if (journal->last_rename == NULL) {
+        journal->renames = rename;
+    } else {
+        journal->last_rename->next = rename;
+        rename->prev = journal->last_rename;
+    }
+    journal->last_rename = rename;
+    return LDB_SUCCESS;
+}
+
+static int tx_complete_noop(struct ldb_request *req)
+{
+    return ldb_module_done(req, NULL, NULL, LDB_SUCCESS);
+}
+
+int memberof_tx_add(struct ldb_module *module, struct ldb_request *req)
+{
+    struct tx_private *private_data;
+    struct tx_journal *journal;
+    const char *dn_string;
+    const char *key;
+    bool identity;
+    int ret;
+
+    ret = tx_require_journal(module, &private_data, &journal);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    if (private_data->flushing || getenv("SSSD_UPGRADE_DB") != NULL) {
+        return ldb_next_request(module, req);
+    }
+
+    if (ldb_dn_is_special(req->op.add.message->dn)) {
+        dn_string = ldb_dn_get_linearized(req->op.add.message->dn);
+        if (dn_string != NULL && strcmp(dn_string, TX_REBUILD_DN) == 0) {
+            ret = tx_mark_dirty(module, journal);
+            if (ret != LDB_SUCCESS) {
+                return ret;
+            }
+            return tx_complete_noop(req);
+        }
+        return ldb_next_request(module, req);
+    }
+    ret = tx_snapshot_ensure(module, journal);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+
+    ret = tx_check_readonly(module, req->op.add.message);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    ret = tx_validate_members(module, req->op.add.message);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+
+    identity = tx_message_is_identity(req->op.add.message);
+    if (identity) {
+        ret = tx_mark_dirty(module, journal);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+        ret = tx_record_request_ghosts(journal, req, true);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+    }
+
+    key = tx_dn_key(req->op.add.message->dn);
+    if (key == NULL) {
+        return LDB_ERR_INVALID_DN_SYNTAX;
+    }
+    ret = tx_set_remove(&journal->deleted_dns, key);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    ret = tx_snapshot_add(journal, req->op.add.message);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+
+    return ldb_next_request(module, req);
+}
+
+int memberof_tx_modify(struct ldb_module *module, struct ldb_request *req)
+{
+    struct tx_private *private_data;
+    struct tx_journal *journal;
+    struct ldb_message *identity;
+    bool changes_graph;
+    bool is_identity;
+    bool relevant;
+    bool was_identity;
+    int ret;
+
+    ret = tx_require_journal(module, &private_data, &journal);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    if (private_data->flushing || getenv("SSSD_UPGRADE_DB") != NULL) {
+        return ldb_next_request(module, req);
+    }
+    if (ldb_dn_is_special(req->op.mod.message->dn)) {
+        return ldb_next_request(module, req);
+    }
+
+    ret = tx_check_readonly(module, req->op.mod.message);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    ret = tx_validate_members(module, req->op.mod.message);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+
+    relevant = tx_modify_affects_graph(req->op.mod.message);
+    if (!relevant) {
+        /* Initgroups can commit thousands of metadata-only cache updates. */
+        return ldb_next_request(module, req);
+    }
+
+    ret = tx_snapshot_ensure(module, journal);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    identity = tx_snapshot_lookup(journal, req->op.mod.message->dn);
+    if (identity == NULL) {
+        return ldb_next_request(module, req);
+    }
+    was_identity = tx_message_is_identity(identity);
+
+    ret = tx_load_migration_state(module, private_data, journal);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    changes_graph = true;
+    if (journal->migration_complete) {
+        changes_graph = tx_modify_changes_graph(identity,
+                                                 req->op.mod.message);
+    }
+
+    ret = tx_snapshot_modify(journal, req->op.mod.message);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    is_identity = tx_message_is_identity(identity);
+    if (!was_identity && !is_identity) {
+        return ldb_next_request(module, req);
+    }
+
+    ret = tx_record_request_ghosts(journal, req, false);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+
+    relevant = !journal->migration_complete || changes_graph;
+    if (relevant) {
+        ret = tx_mark_dirty(module, journal);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+    }
+
+    return ldb_next_request(module, req);
+}
+
+int memberof_tx_delete(struct ldb_module *module, struct ldb_request *req)
+{
+    struct tx_private *private_data;
+    struct tx_journal *journal;
+    struct ldb_message *identity;
+    const char *key;
+    bool is_identity;
+    int ret;
+
+    ret = tx_require_journal(module, &private_data, &journal);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    if (private_data->flushing || getenv("SSSD_UPGRADE_DB") != NULL) {
+        return ldb_next_request(module, req);
+    }
+    if (ldb_dn_is_special(req->op.del.dn)) {
+        return ldb_next_request(module, req);
+    }
+    ret = tx_snapshot_ensure(module, journal);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    identity = tx_snapshot_lookup(journal, req->op.del.dn);
+    if (identity == NULL) {
+        return ldb_next_request(module, req);
+    }
+
+    is_identity = tx_message_is_identity(identity);
+    if (is_identity) {
+        ret = tx_mark_dirty(module, journal);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+        key = tx_dn_key(req->op.del.dn);
+        if (key == NULL) {
+            return LDB_ERR_INVALID_DN_SYNTAX;
+        }
+        ret = tx_set_add(&journal->deleted_dns, key, key);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+    }
+    ret = tx_snapshot_remove(journal, req->op.del.dn);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+
+    return ldb_next_request(module, req);
+}
+
+int memberof_tx_rename(struct ldb_module *module, struct ldb_request *req)
+{
+    struct tx_private *private_data;
+    struct tx_journal *journal;
+    struct ldb_message *identity;
+    const char *new_key;
+    bool is_identity;
+    int ret;
+
+    ret = tx_require_journal(module, &private_data, &journal);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    if (private_data->flushing || getenv("SSSD_UPGRADE_DB") != NULL) {
+        return ldb_next_request(module, req);
+    }
+    if (ldb_dn_is_special(req->op.rename.olddn)
+            || ldb_dn_is_special(req->op.rename.newdn)) {
+        return ldb_next_request(module, req);
+    }
+    ret = tx_snapshot_ensure(module, journal);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    identity = tx_snapshot_lookup(journal, req->op.rename.olddn);
+    if (identity == NULL) {
+        return ldb_next_request(module, req);
+    }
+
+    is_identity = tx_message_is_identity(identity);
+    if (is_identity) {
+        ret = tx_mark_dirty(module, journal);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+        ret = tx_record_rename(journal, req->op.rename.olddn,
+                               req->op.rename.newdn);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+    }
+    new_key = tx_dn_key(req->op.rename.newdn);
+    if (new_key == NULL) {
+        return LDB_ERR_INVALID_DN_SYNTAX;
+    }
+    ret = tx_set_remove(&journal->deleted_dns, new_key);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    ret = tx_snapshot_rename(journal, req->op.rename.olddn,
+                             req->op.rename.newdn);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+
+    return ldb_next_request(module, req);
+}
+
+int memberof_tx_start(struct ldb_module *module)
+{
+    struct tx_private *private_data = tx_get_private(module);
+    struct tx_journal *journal;
+    int ret;
+
+    if (private_data == NULL || !private_data->enabled) {
+        return ldb_next_start_trans(module);
+    }
+    if (private_data->journal != NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    journal = talloc_zero(private_data, struct tx_journal);
+    if (journal == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    tx_set_init(&journal->deleted_dns, journal);
+    journal->migration_complete = private_data->migration_persisted;
+    journal->migration_checked = private_data->migration_persisted;
+
+    /* Write hooks snapshot after start succeeds but before forwarding a write. */
+    ret = ldb_next_start_trans(module);
+    if (ret != LDB_SUCCESS) {
+        talloc_free(journal);
+        return ret;
+    }
+
+    private_data->journal = journal;
+    return LDB_SUCCESS;
+}
+
+int memberof_tx_prepare_commit(struct ldb_module *module)
+{
+    struct tx_private *private_data = tx_get_private(module);
+    struct tx_journal *journal;
+    int ret;
+
+    if (private_data == NULL || !private_data->enabled) {
+        return ldb_next_prepare_commit(module);
+    }
+    journal = private_data->journal;
+    if (journal == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    if (journal->dirty) {
+        private_data->flushing = true;
+        ret = tx_graph_flush(module, journal);
+        private_data->flushing = false;
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+    }
+
+    return ldb_next_prepare_commit(module);
+}
+
+int memberof_tx_end(struct ldb_module *module)
+{
+    struct tx_private *private_data = tx_get_private(module);
+    struct tx_journal *journal;
+    int ret;
+
+    if (private_data == NULL || !private_data->enabled) {
+        return ldb_next_end_trans(module);
+    }
+    journal = private_data->journal;
+    if (journal == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    ret = ldb_next_end_trans(module);
+    if (ret == LDB_SUCCESS && journal->migration_written) {
+        private_data->migration_persisted = true;
+    }
+    private_data->journal = NULL;
+    talloc_free(journal);
+    return ret;
+}
+
+int memberof_tx_cancel(struct ldb_module *module)
+{
+    struct tx_private *private_data = tx_get_private(module);
+    struct tx_journal *journal;
+    int ret;
+
+    if (private_data == NULL || !private_data->enabled) {
+        return ldb_next_del_trans(module);
+    }
+    journal = private_data->journal;
+
+    ret = ldb_next_del_trans(module);
+    private_data->journal = NULL;
+    talloc_free(journal);
+    return ret;
+}
+
+struct tx_node;
+
+struct tx_component {
+    struct tx_node **members;
+    size_t num_members;
+    size_t members_capacity;
+    struct tx_component **children;
+    size_t num_children;
+    size_t children_capacity;
+    size_t indegree;
+    struct tx_component *last_edge_parent;
+    struct tx_set ancestors;
+};
+
+struct tx_node {
+    struct ldb_message *msg;
+    const char *key;
+    const char *linearized_dn;
+    const char *name;
+    bool is_group;
+    bool visited;
+    bool member_changed;
+    bool ghost_ambiguous;
+
+    struct tx_node **children;
+    size_t num_children;
+    size_t children_capacity;
+    struct tx_node **parents;
+    size_t num_parents;
+    size_t parents_capacity;
+    struct tx_component *component;
+
+    struct tx_set normalized_members;
+    struct tx_set memberof;
+    struct tx_set memberuid;
+    struct tx_set direct_ghosts;
+    struct tx_set ghosts;
+};
+
+struct tx_graph {
+    struct ldb_context *ldb;
+    struct tx_journal *journal;
+    struct ldb_result *result;
+    hash_table_t *node_map;
+
+    struct tx_node **nodes;
+    size_t num_nodes;
+    struct tx_node **groups;
+    size_t num_groups;
+    struct tx_node **users;
+    size_t num_users;
+
+    struct tx_component **components;
+    size_t num_components;
+    size_t components_capacity;
+    size_t changed_entries;
+    size_t changed_attributes;
+};
+
+struct tx_dfs_frame {
+    struct tx_node *node;
+    size_t next_child;
+};
+
+static int tx_append_node(TALLOC_CTX *mem_ctx,
+                          struct tx_node ***array,
+                          size_t *count,
+                          size_t *capacity,
+                          struct tx_node *node)
+{
+    struct tx_node **new_array;
+    size_t new_capacity;
+
+    if (*count == *capacity) {
+        new_capacity = *capacity == 0 ? 8 : *capacity * 2;
+        if (new_capacity < *capacity) {
+            return LDB_ERR_OPERATIONS_ERROR;
+        }
+        new_array = talloc_realloc(mem_ctx, *array,
+                                   struct tx_node *, new_capacity);
+        if (new_array == NULL) {
+            return LDB_ERR_OPERATIONS_ERROR;
+        }
+        *array = new_array;
+        *capacity = new_capacity;
+    }
+
+    (*array)[*count] = node;
+    (*count)++;
+    return LDB_SUCCESS;
+}
+
+static int tx_append_component(TALLOC_CTX *mem_ctx,
+                               struct tx_component ***array,
+                               size_t *count,
+                               size_t *capacity,
+                               struct tx_component *component)
+{
+    struct tx_component **new_array;
+    size_t new_capacity;
+
+    if (*count == *capacity) {
+        new_capacity = *capacity == 0 ? 8 : *capacity * 2;
+        if (new_capacity < *capacity) {
+            return LDB_ERR_OPERATIONS_ERROR;
+        }
+        new_array = talloc_realloc(mem_ctx, *array,
+                                   struct tx_component *, new_capacity);
+        if (new_array == NULL) {
+            return LDB_ERR_OPERATIONS_ERROR;
+        }
+        *array = new_array;
+        *capacity = new_capacity;
+    }
+
+    (*array)[*count] = component;
+    (*count)++;
+    return LDB_SUCCESS;
+}
+
+static struct ldb_dn *tx_resolve_rename(struct tx_journal *journal,
+                                        struct ldb_dn *input,
+                                        bool *changed)
+{
+    struct tx_rename *rename;
+    struct ldb_dn *current = input;
+    const char *key;
+
+    *changed = false;
+    for (rename = journal->renames;
+         rename != NULL;
+         rename = rename->next) {
+        key = tx_dn_key(current);
+        if (key == NULL) {
+            return NULL;
+        }
+        if (strcmp(key, rename->old_key) == 0) {
+            current = rename->new_dn;
+            *changed = true;
+        }
+    }
+
+    return current;
+}
+
+static struct tx_legacy_ghost *
+tx_find_legacy_ghost(struct tx_journal *journal, const char *current_key)
+{
+    struct tx_legacy_ghost *record;
+    struct tx_rename *rename;
+    const char *key = current_key;
+
+    record = tx_hash_get_ptr(journal->legacy_ghosts, key);
+    if (record != NULL) {
+        return record;
+    }
+
+    for (rename = journal->last_rename;
+         rename != NULL;
+         rename = rename->prev) {
+        if (strcmp(key, rename->new_key) == 0) {
+            key = rename->old_key;
+        }
+        record = tx_hash_get_ptr(journal->legacy_ghosts, key);
+        if (record != NULL) {
+            return record;
+        }
+    }
+
+    return NULL;
+}
+
+static int tx_graph_add_nodes(struct tx_graph *graph)
+{
+    struct tx_node *node;
+    struct ldb_message *msg;
+    unsigned int i;
+    int ret;
+
+    ret = tx_hash_create(graph, graph->result->count, &graph->node_map);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+
+    graph->nodes = talloc_zero_array(graph, struct tx_node *,
+                                     graph->result->count);
+    graph->groups = talloc_zero_array(graph, struct tx_node *,
+                                      graph->result->count);
+    graph->users = talloc_zero_array(graph, struct tx_node *,
+                                     graph->result->count);
+    if ((graph->nodes == NULL || graph->groups == NULL
+            || graph->users == NULL) && graph->result->count != 0) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    for (i = 0; i < graph->result->count; i++) {
+        msg = graph->result->msgs[i];
+        if (!tx_message_is_identity(msg)) {
+            continue;
+        }
+        node = talloc_zero(graph, struct tx_node);
+        if (node == NULL) {
+            return LDB_ERR_OPERATIONS_ERROR;
+        }
+        node->msg = msg;
+        node->key = tx_dn_key(msg->dn);
+        node->linearized_dn = ldb_dn_get_linearized(msg->dn);
+        node->name = ldb_msg_find_attr_as_string(msg, TX_DB_NAME, NULL);
+        node->is_group = tx_message_is_class(msg, TX_DB_GROUP_CLASS);
+        if (node->key == NULL || node->linearized_dn == NULL) {
+            return LDB_ERR_INVALID_DN_SYNTAX;
+        }
+
+        tx_set_init(&node->normalized_members, node);
+        tx_set_init(&node->memberof, node);
+        tx_set_init(&node->memberuid, node);
+        tx_set_init(&node->direct_ghosts, node);
+        tx_set_init(&node->ghosts, node);
+
+        graph->nodes[graph->num_nodes++] = node;
+        if (node->is_group) {
+            graph->groups[graph->num_groups++] = node;
+        } else {
+            graph->users[graph->num_users++] = node;
+        }
+
+        ret = tx_hash_put_ptr(graph->node_map, node->key, node);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+    }
+
+    return LDB_SUCCESS;
+}
+
+static int tx_graph_add_edges(struct tx_graph *graph)
+{
+    struct ldb_message_element *members;
+    struct tx_node *parent;
+    struct tx_node *child;
+    struct ldb_dn *raw_dn;
+    struct ldb_dn *resolved_dn;
+    const char *raw_value;
+    const char *resolved_key;
+    const char *output;
+    bool renamed;
+    size_t i;
+    unsigned int j;
+    int ret;
+
+    for (i = 0; i < graph->num_groups; i++) {
+        parent = graph->groups[i];
+        members = ldb_msg_find_element(parent->msg, TX_DB_MEMBER);
+        if (members == NULL) {
+            continue;
+        }
+
+        for (j = 0; j < members->num_values; j++) {
+            raw_value = (const char *)members->values[j].data;
+            raw_dn = ldb_dn_from_ldb_val(parent, graph->ldb,
+                                         &members->values[j]);
+            if (raw_dn == NULL || !ldb_dn_validate(raw_dn)) {
+                ldb_debug(graph->ldb, LDB_DEBUG_ERROR,
+                          "Ignoring invalid cached member DN [%s]",
+                          raw_value);
+                continue;
+            }
+
+            resolved_dn = tx_resolve_rename(graph->journal, raw_dn,
+                                             &renamed);
+            resolved_key = tx_dn_key(resolved_dn);
+            if (resolved_dn == NULL || resolved_key == NULL) {
+                return LDB_ERR_INVALID_DN_SYNTAX;
+            }
+
+            if (tx_set_has(&graph->journal->deleted_dns, resolved_key)) {
+                parent->member_changed = true;
+                continue;
+            }
+
+            child = tx_hash_get_ptr(graph->node_map, resolved_key);
+            if (child == parent) {
+                parent->member_changed = true;
+                continue;
+            }
+
+            output = renamed ? ldb_dn_get_linearized(resolved_dn) : raw_value;
+            if (output == NULL) {
+                return LDB_ERR_INVALID_DN_SYNTAX;
+            }
+            if (tx_set_has(&parent->normalized_members, resolved_key)) {
+                parent->member_changed = true;
+                continue;
+            }
+            ret = tx_set_add(&parent->normalized_members,
+                             resolved_key, output);
+            if (ret != LDB_SUCCESS) {
+                return ret;
+            }
+            if (renamed) {
+                parent->member_changed = true;
+            }
+
+            if (child == NULL) {
+                continue;
+            }
+            ret = tx_append_node(parent, &parent->children,
+                                 &parent->num_children,
+                                 &parent->children_capacity, child);
+            if (ret != LDB_SUCCESS) {
+                return ret;
+            }
+            ret = tx_append_node(child, &child->parents,
+                                 &child->num_parents,
+                                 &child->parents_capacity, parent);
+            if (ret != LDB_SUCCESS) {
+                return ret;
+            }
+        }
+    }
+
+    return LDB_SUCCESS;
+}
+
+static int tx_graph_components(struct tx_graph *graph)
+{
+    struct tx_dfs_frame *frames;
+    struct tx_component **queue;
+    struct tx_component *component;
+    struct tx_component *parent_component;
+    struct tx_component *child_component;
+    struct tx_node **order;
+    struct tx_node **stack;
+    struct tx_node *node;
+    struct tx_node *child;
+    struct tx_node *parent;
+    size_t order_count = 0;
+    size_t frame_count;
+    size_t stack_count;
+    size_t queue_head = 0;
+    size_t queue_tail = 0;
+    size_t i;
+    size_t j;
+    int ret;
+
+    if (graph->num_groups == 0) {
+        return LDB_SUCCESS;
+    }
+
+    order = talloc_zero_array(graph, struct tx_node *, graph->num_groups);
+    stack = talloc_zero_array(graph, struct tx_node *, graph->num_groups);
+    frames = talloc_zero_array(graph, struct tx_dfs_frame,
+                               graph->num_groups);
+    queue = talloc_zero_array(graph, struct tx_component *,
+                              graph->num_groups);
+    if (order == NULL || stack == NULL || frames == NULL
+            || queue == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    /* Iterative first Kosaraju pass: group DFS finishing order. */
+    for (i = 0; i < graph->num_groups; i++) {
+        node = graph->groups[i];
+        if (node->visited) {
+            continue;
+        }
+
+        frame_count = 1;
+        frames[0].node = node;
+        frames[0].next_child = 0;
+        node->visited = true;
+
+        while (frame_count != 0) {
+            struct tx_dfs_frame *frame = &frames[frame_count - 1];
+            child = NULL;
+            while (frame->next_child < frame->node->num_children) {
+                child = frame->node->children[frame->next_child++];
+                if (child->is_group && !child->visited) {
+                    break;
+                }
+                child = NULL;
+            }
+
+            if (child != NULL) {
+                child->visited = true;
+                frames[frame_count].node = child;
+                frames[frame_count].next_child = 0;
+                frame_count++;
+                continue;
+            }
+
+            order[order_count++] = frame->node;
+            frame_count--;
+        }
+    }
+
+    /* Reverse pass assigns strongly connected components. */
+    for (i = order_count; i > 0; i--) {
+        node = order[i - 1];
+        if (node->component != NULL) {
+            continue;
+        }
+
+        component = talloc_zero(graph, struct tx_component);
+        if (component == NULL) {
+            return LDB_ERR_OPERATIONS_ERROR;
+        }
+        ret = tx_append_component(graph, &graph->components,
+                                  &graph->num_components,
+                                  &graph->components_capacity, component);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+        tx_set_init(&component->ancestors, component);
+        stack_count = 1;
+        stack[0] = node;
+        node->component = component;
+
+        while (stack_count != 0) {
+            child = stack[--stack_count];
+            ret = tx_append_node(component, &component->members,
+                                 &component->num_members,
+                                 &component->members_capacity, child);
+            if (ret != LDB_SUCCESS) {
+                return ret;
+            }
+
+            for (j = 0; j < child->num_parents; j++) {
+                parent = child->parents[j];
+                if (!parent->is_group || parent->component != NULL) {
+                    continue;
+                }
+                parent->component = component;
+                stack[stack_count++] = parent;
+            }
+        }
+    }
+
+    /* Build the condensed DAG. */
+    for (i = 0; i < graph->num_components; i++) {
+        component = graph->components[i];
+        for (j = 0; j < component->num_members; j++) {
+            node = component->members[j];
+            for (size_t k = 0; k < node->num_children; k++) {
+                child = node->children[k];
+                if (!child->is_group
+                        || child->component == component) {
+                    continue;
+                }
+                if (child->component->last_edge_parent == component) {
+                    continue;
+                }
+                child->component->last_edge_parent = component;
+                ret = tx_append_component(component,
+                                           &component->children,
+                                           &component->num_children,
+                                           &component->children_capacity,
+                                           child->component);
+                if (ret != LDB_SUCCESS) {
+                    return ret;
+                }
+                child->component->indegree++;
+            }
+        }
+    }
+
+    for (i = 0; i < graph->num_components; i++) {
+        if (graph->components[i]->indegree == 0) {
+            queue[queue_tail++] = graph->components[i];
+        }
+    }
+
+    while (queue_head < queue_tail) {
+        parent_component = queue[queue_head++];
+
+        /* Keep the legacy root-to-leaf order for derived memberships. */
+        for (j = 0; j < parent_component->num_members; j++) {
+            node = parent_component->members[j];
+            ret = tx_set_add(&parent_component->ancestors,
+                             node->key, node->linearized_dn);
+            if (ret != LDB_SUCCESS) {
+                return ret;
+            }
+        }
+
+        for (i = 0; i < parent_component->num_children; i++) {
+            child_component = parent_component->children[i];
+            ret = tx_set_union(&child_component->ancestors,
+                               &parent_component->ancestors);
+            if (ret != LDB_SUCCESS) {
+                return ret;
+            }
+            if (--child_component->indegree == 0) {
+                queue[queue_tail++] = child_component;
+            }
+        }
+    }
+
+    if (queue_tail != graph->num_components) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    return LDB_SUCCESS;
+}
+
+static int tx_load_direct_ghosts(struct tx_graph *graph,
+                                 struct tx_node *group)
+{
+    struct tx_legacy_ghost *legacy;
+    struct ldb_message_element *el;
+    unsigned int i;
+    int ret;
+
+    if (!graph->journal->migration_complete) {
+        legacy = tx_find_legacy_ghost(graph->journal, group->key);
+        if (legacy == NULL) {
+            return LDB_SUCCESS;
+        }
+        group->ghost_ambiguous = legacy->ambiguous;
+        return tx_set_copy(&group->direct_ghosts, &legacy->direct);
+    }
+
+    el = ldb_msg_find_element(group->msg, TX_DB_GHOST_DIRECT);
+    if (el == NULL) {
+        return LDB_SUCCESS;
+    }
+    for (i = 0; i < el->num_values; i++) {
+        ret = tx_set_add(&group->direct_ghosts,
+                         (const char *)el->values[i].data,
+                         (const char *)el->values[i].data);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+    }
+
+    return LDB_SUCCESS;
+}
+
+static int tx_apply_ghost_value(struct tx_set *set,
+                                const struct ldb_val *value,
+                                bool add)
+{
+    char *string;
+    int ret;
+
+    string = talloc_strndup(set->owner, (const char *)value->data,
+                            value->length);
+    if (string == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    if (add) {
+        ret = tx_set_add(set, string, string);
+    } else {
+        ret = tx_set_remove(set, string);
+    }
+    talloc_free(string);
+    return ret;
+}
+
+static int tx_apply_ghost_ops(struct tx_graph *graph)
+{
+    struct tx_ghost_op *op;
+    struct tx_node *group;
+    struct ldb_dn *resolved_dn;
+    const char *key;
+    bool renamed;
+    unsigned int i;
+    int ret;
+
+    for (op = graph->journal->ghost_ops; op != NULL; op = op->next) {
+        resolved_dn = tx_resolve_rename(graph->journal, op->dn, &renamed);
+        (void)renamed;
+        key = tx_dn_key(resolved_dn);
+        group = tx_hash_get_ptr(graph->node_map, key);
+        if (group == NULL || !group->is_group) {
+            continue;
+        }
+
+        switch (op->flags) {
+        case LDB_FLAG_MOD_ADD:
+            for (i = 0; i < op->num_values; i++) {
+                ret = tx_apply_ghost_value(&group->direct_ghosts,
+                                           &op->values[i], true);
+                if (ret != LDB_SUCCESS) {
+                    return ret;
+                }
+            }
+            break;
+
+        case LDB_FLAG_MOD_DELETE:
+            if (op->num_values == 0) {
+                tx_set_clear(&group->direct_ghosts);
+                break;
+            }
+            for (i = 0; i < op->num_values; i++) {
+                ret = tx_apply_ghost_value(&group->direct_ghosts,
+                                           &op->values[i], false);
+                if (ret != LDB_SUCCESS) {
+                    return ret;
+                }
+            }
+            break;
+
+        case LDB_FLAG_MOD_REPLACE:
+        case 0:
+            tx_set_clear(&group->direct_ghosts);
+            for (i = 0; i < op->num_values; i++) {
+                ret = tx_apply_ghost_value(&group->direct_ghosts,
+                                           &op->values[i], true);
+                if (ret != LDB_SUCCESS) {
+                    return ret;
+                }
+            }
+            break;
+
+        default:
+            return LDB_ERR_PROTOCOL_ERROR;
+        }
+    }
+
+    return LDB_SUCCESS;
+}
+
+static int tx_graph_derive(struct tx_graph *graph)
+{
+    struct tx_node *node;
+    struct tx_node *parent;
+    struct tx_node *group;
+    struct tx_set_entry *entry;
+    const char *output;
+    size_t i;
+    size_t j;
+    size_t k;
+    size_t p;
+    int ret;
+
+    ret = tx_graph_components(graph);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+
+    for (i = 0; i < graph->num_groups; i++) {
+        node = graph->groups[i];
+        ret = tx_set_copy(&node->memberof, &node->component->ancestors);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+        ret = tx_set_remove(&node->memberof, node->key);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+        ret = tx_load_direct_ghosts(graph, node);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+    }
+
+    for (i = 0; i < graph->num_users; i++) {
+        node = graph->users[i];
+        for (j = 0; j < node->num_parents; j++) {
+            parent = node->parents[j];
+            ret = tx_set_union(&node->memberof,
+                               &parent->component->ancestors);
+            if (ret != LDB_SUCCESS) {
+                return ret;
+            }
+        }
+    }
+
+    ret = tx_apply_ghost_ops(graph);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+
+    /* A user's ancestor groups are exactly the groups needing memberUid. */
+    for (i = 0; i < graph->num_users; i++) {
+        node = graph->users[i];
+        if (node->name == NULL || node->memberof.table == NULL) {
+            continue;
+        }
+        for (k = 0; k < node->memberof.count; k++) {
+            entry = node->memberof.ordered[k];
+            group = tx_hash_get_ptr(graph->node_map, entry->key);
+            if (group == NULL || !group->is_group) {
+                return LDB_ERR_OPERATIONS_ERROR;
+            }
+            ret = tx_set_add(&group->memberuid, node->name, node->name);
+            if (ret != LDB_SUCCESS) {
+                return ret;
+            }
+        }
+    }
+
+    /* Direct ghosts are inherited by the group itself and every ancestor. */
+    for (i = 0; i < graph->num_groups; i++) {
+        node = graph->groups[i];
+        if (node->direct_ghosts.table == NULL) {
+            continue;
+        }
+        for (k = 0; k < node->direct_ghosts.count; k++) {
+            entry = node->direct_ghosts.ordered[k];
+            output = entry->output;
+            ret = tx_set_add(&node->ghosts, entry->key, output);
+            if (ret != LDB_SUCCESS) {
+                return ret;
+            }
+
+            if (node->memberof.table == NULL) {
+                continue;
+            }
+            for (p = 0; p < node->memberof.count; p++) {
+                group = tx_hash_get_ptr(graph->node_map,
+                                        node->memberof.ordered[p]->key);
+                if (group == NULL || !group->is_group) {
+                    return LDB_ERR_OPERATIONS_ERROR;
+                }
+                ret = tx_set_add(&group->ghosts, entry->key, output);
+                if (ret != LDB_SUCCESS) {
+                    return ret;
+                }
+            }
+        }
+    }
+
+    return LDB_SUCCESS;
+}
+
+static int tx_element_set(TALLOC_CTX *mem_ctx,
+                          struct ldb_context *ldb,
+                          const struct ldb_message_element *element,
+                          bool dn_values,
+                          struct tx_set *set)
+{
+    struct ldb_dn *dn;
+    const char *key;
+    const char *value;
+    unsigned int i;
+    int ret;
+
+    tx_set_init(set, mem_ctx);
+    if (element == NULL) {
+        return LDB_SUCCESS;
+    }
+
+    for (i = 0; i < element->num_values; i++) {
+        value = (const char *)element->values[i].data;
+        if (dn_values) {
+            dn = ldb_dn_from_ldb_val(mem_ctx, ldb, &element->values[i]);
+            key = tx_dn_key(dn);
+            if (key == NULL) {
+                return LDB_ERR_INVALID_DN_SYNTAX;
+            }
+        } else {
+            key = value;
+        }
+
+        ret = tx_set_add(set, key, value);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+    }
+
+    return LDB_SUCCESS;
+}
+
+static bool tx_sets_equal(const struct tx_set *left,
+                          const struct tx_set *right)
+{
+    size_t i;
+
+    if (tx_set_count(left) != tx_set_count(right)) {
+        return false;
+    }
+    if (left->table == NULL) {
+        return true;
+    }
+
+    for (i = 0; i < left->count; i++) {
+        if (!tx_set_has(right, left->ordered[i]->key)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static int tx_add_difference_mod(struct ldb_message *modification,
+                                 const char *attribute,
+                                 int flags,
+                                 const struct tx_set *candidates,
+                                 const struct tx_set *excluded)
+{
+    struct ldb_message_element *element;
+    const char *output;
+    size_t count = 0;
+    size_t i;
+    size_t j = 0;
+    int ret;
+
+    for (i = 0; i < candidates->count; i++) {
+        if (!tx_set_has(excluded, candidates->ordered[i]->key)) {
+            count++;
+        }
+    }
+    if (count == 0) {
+        return LDB_SUCCESS;
+    }
+    if (count > UINT_MAX) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    ret = ldb_msg_add_empty(modification, attribute, flags, &element);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    element->values = talloc_zero_array(modification, struct ldb_val, count);
+    if (element->values == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+
+    for (i = 0; i < candidates->count; i++) {
+        if (tx_set_has(excluded, candidates->ordered[i]->key)) {
+            continue;
+        }
+        output = candidates->ordered[i]->output;
+        element->values[j].data = (uint8_t *)talloc_strdup(
+            element->values, output);
+        if (element->values[j].data == NULL) {
+            return LDB_ERR_OPERATIONS_ERROR;
+        }
+        element->values[j].length = strlen(output);
+        j++;
+    }
+    element->num_values = count;
+    return LDB_SUCCESS;
+}
+
+static int tx_add_set_mod(struct tx_graph *graph,
+                          struct ldb_message *modification,
+                          struct tx_node *node,
+                          const char *attribute,
+                          const struct tx_set *new_values,
+                          bool dn_values)
+{
+    struct ldb_message_element *old_element;
+    struct tx_set old_values = { 0 };
+    TALLOC_CTX *tmp_ctx;
+    int ret;
+
+    old_element = ldb_msg_find_element(node->msg, attribute);
+    tmp_ctx = talloc_new(modification);
+    if (tmp_ctx == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    ret = tx_element_set(tmp_ctx, graph->ldb, old_element,
+                         dn_values, &old_values);
+    if (ret != LDB_SUCCESS) {
+        talloc_free(tmp_ctx);
+        return ret;
+    }
+
+    if (tx_sets_equal(&old_values, new_values)) {
+        talloc_free(tmp_ctx);
+        return LDB_SUCCESS;
+    }
+
+    if (tx_set_count(new_values) == 0) {
+        ret = ldb_msg_add_empty(modification, attribute,
+                                LDB_FLAG_MOD_DELETE, NULL);
+        if (ret == LDB_SUCCESS) {
+            graph->changed_attributes++;
+        }
+        talloc_free(tmp_ctx);
+        return ret;
+    }
+
+    ret = tx_add_difference_mod(modification, attribute,
+                                LDB_FLAG_MOD_DELETE,
+                                &old_values, new_values);
+    if (ret != LDB_SUCCESS) {
+        talloc_free(tmp_ctx);
+        return ret;
+    }
+    ret = tx_add_difference_mod(modification, attribute,
+                                LDB_FLAG_MOD_ADD,
+                                new_values, &old_values);
+    if (ret != LDB_SUCCESS) {
+        talloc_free(tmp_ctx);
+        return ret;
+    }
+
+    graph->changed_attributes++;
+    talloc_free(tmp_ctx);
+    return LDB_SUCCESS;
+}
+
+static int tx_add_expire_mod(struct tx_graph *graph,
+                             struct ldb_message *modification,
+                             struct tx_node *node)
+{
+    int ret;
+
+    if (!node->ghost_ambiguous) {
+        return LDB_SUCCESS;
+    }
+
+    /* The migration marker makes this unconditional replacement one-time. */
+    ret = ldb_msg_add_empty(modification, TX_DB_CACHE_EXPIRE,
+                            LDB_FLAG_MOD_REPLACE, NULL);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    ret = ldb_msg_add_string(modification, TX_DB_CACHE_EXPIRE, "1");
+    if (ret == LDB_SUCCESS) {
+        graph->changed_attributes++;
+    }
+    return ret;
+}
+
+static int tx_graph_write_nodes(struct tx_graph *graph)
+{
+    struct ldb_message *modification;
+    struct tx_node *node;
+    size_t i;
+    int ret;
+
+    for (i = 0; i < graph->num_nodes; i++) {
+        node = graph->nodes[i];
+        modification = ldb_msg_new(graph);
+        if (modification == NULL) {
+            return LDB_ERR_OPERATIONS_ERROR;
+        }
+        modification->dn = node->msg->dn;
+
+        if (node->is_group && node->member_changed) {
+            ret = tx_add_set_mod(graph, modification, node,
+                                 TX_DB_MEMBER,
+                                 &node->normalized_members, true);
+            if (ret != LDB_SUCCESS) {
+                return ret;
+            }
+        }
+
+        ret = tx_add_set_mod(graph, modification, node,
+                             TX_DB_MEMBEROF, &node->memberof, true);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+
+        if (node->is_group) {
+            ret = tx_add_set_mod(graph, modification, node,
+                                 TX_DB_MEMBERUID, &node->memberuid, false);
+            if (ret != LDB_SUCCESS) {
+                return ret;
+            }
+            ret = tx_add_set_mod(graph, modification, node,
+                                 TX_DB_GHOST, &node->ghosts, false);
+            if (ret != LDB_SUCCESS) {
+                return ret;
+            }
+            ret = tx_add_set_mod(graph, modification, node,
+                                 TX_DB_GHOST_DIRECT,
+                                 &node->direct_ghosts, false);
+            if (ret != LDB_SUCCESS) {
+                return ret;
+            }
+            ret = tx_add_expire_mod(graph, modification, node);
+            if (ret != LDB_SUCCESS) {
+                return ret;
+            }
+        }
+
+        if (modification->num_elements == 0) {
+            talloc_free(modification);
+            continue;
+        }
+
+        ret = ldb_modify(graph->ldb, modification);
+        if (ret != LDB_SUCCESS) {
+            ldb_debug(graph->ldb, LDB_DEBUG_ERROR,
+                      "Transactional memberOf update failed for [%s]: %s",
+                      node->linearized_dn, ldb_errstring(graph->ldb));
+            return ret;
+        }
+        graph->changed_entries++;
+        talloc_free(modification);
+    }
+
+    return LDB_SUCCESS;
+}
+
+static int tx_write_migration_marker(struct tx_graph *graph)
+{
+    struct ldb_message *message;
+    int ret;
+
+    if (graph->journal->migration_complete) {
+        return LDB_SUCCESS;
+    }
+
+    message = ldb_msg_new(graph);
+    if (message == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    message->dn = ldb_dn_new(message, graph->ldb, TX_MIGRATION_DN);
+    if (message->dn == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    if (graph->journal->migration_marker_exists) {
+        ret = ldb_msg_add_empty(message, TX_MIGRATION_ATTR,
+                                LDB_FLAG_MOD_REPLACE, NULL);
+        if (ret != LDB_SUCCESS) {
+            return ret;
+        }
+    }
+    ret = ldb_msg_add_string(message, TX_MIGRATION_ATTR,
+                             TX_MIGRATION_VERSION);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+
+    if (graph->journal->migration_marker_exists) {
+        ret = ldb_modify(graph->ldb, message);
+    } else {
+        ret = ldb_add(graph->ldb, message);
+    }
+    if (ret == LDB_SUCCESS) {
+        graph->journal->migration_written = true;
+    }
+    return ret;
+}
+
+static int tx_graph_flush(struct ldb_module *module,
+                          struct tx_journal *journal)
+{
+    struct tx_graph *graph;
+    size_t edge_count = 0;
+    size_t i;
+    int ret;
+
+    graph = talloc_zero(journal, struct tx_graph);
+    if (graph == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    graph->ldb = ldb_module_get_ctx(module);
+    graph->journal = journal;
+    graph->result = journal->snapshot;
+    if (graph->result == NULL) {
+        ret = LDB_ERR_OPERATIONS_ERROR;
+        goto done;
+    }
+
+    ret = tx_graph_add_nodes(graph);
+    if (ret != LDB_SUCCESS) {
+        goto done;
+    }
+    ret = tx_graph_add_edges(graph);
+    if (ret != LDB_SUCCESS) {
+        goto done;
+    }
+    ret = tx_graph_derive(graph);
+    if (ret != LDB_SUCCESS) {
+        goto done;
+    }
+    ret = tx_graph_write_nodes(graph);
+    if (ret != LDB_SUCCESS) {
+        goto done;
+    }
+    ret = tx_write_migration_marker(graph);
+    if (ret != LDB_SUCCESS) {
+        goto done;
+    }
+    for (i = 0; i < graph->num_groups; i++) {
+        edge_count += graph->groups[i]->num_children;
+    }
+    ldb_debug(graph->ldb, LDB_DEBUG_TRACE,
+              "Transactional memberOf flush: %zu nodes, %zu direct edges, "
+              "%zu entries and %zu attributes changed",
+              graph->num_nodes, edge_count,
+              graph->changed_entries, graph->changed_attributes);
+done:
+    talloc_free(graph);
+    return ret;
+}

--- a/src/ldb_modules/memberof_transaction.h
+++ b/src/ldb_modules/memberof_transaction.h
@@ -1,0 +1,21 @@
+#ifndef SSSD_MEMBEROF_TRANSACTION_H_
+#define SSSD_MEMBEROF_TRANSACTION_H_
+
+#include <stdbool.h>
+
+#include "ldb_module.h"
+
+bool memberof_tx_enabled(struct ldb_module *module);
+int memberof_tx_init(struct ldb_module *module);
+
+int memberof_tx_add(struct ldb_module *module, struct ldb_request *req);
+int memberof_tx_modify(struct ldb_module *module, struct ldb_request *req);
+int memberof_tx_delete(struct ldb_module *module, struct ldb_request *req);
+int memberof_tx_rename(struct ldb_module *module, struct ldb_request *req);
+
+int memberof_tx_start(struct ldb_module *module);
+int memberof_tx_prepare_commit(struct ldb_module *module);
+int memberof_tx_end(struct ldb_module *module);
+int memberof_tx_cancel(struct ldb_module *module);
+
+#endif /* SSSD_MEMBEROF_TRANSACTION_H_ */

--- a/src/tests/sysdb-tests.c
+++ b/src/tests/sysdb-tests.c
@@ -56,6 +56,11 @@
 #define MBO_GROUP_BASE 28500
 #define NUM_GHOSTS 10
 
+#define TX_MBO_MARKER_DN "@MEMBEROF-TRANSACTIONAL"
+#define TX_MBO_MARKER_ATTR "@GHOST-DIRECT-VERSION"
+#define TX_MBO_GHOST_DIRECT "ghostDirect"
+#define TX_MBO_SCALE_MEMBERS 3500
+
 #define TEST_AUTOFS_MAP_BASE 29500
 
 struct sysdb_test_ctx {
@@ -3996,6 +4001,230 @@ static bool test_message_has_value(struct ldb_message *msg,
     return false;
 }
 
+static int test_tx_marker_set(struct sysdb_test_ctx *test_ctx,
+                              const char *version)
+{
+    static const char *attrs[] = { TX_MBO_MARKER_ATTR, NULL };
+    struct ldb_context *ldb = test_ctx->sysdb->ldb;
+    struct ldb_result *res = NULL;
+    struct ldb_message *msg;
+    struct ldb_dn *dn;
+    TALLOC_CTX *tmp_ctx;
+    bool in_transaction = false;
+    bool exists;
+    int ret;
+
+    tmp_ctx = talloc_new(test_ctx);
+    if (tmp_ctx == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    dn = ldb_dn_new(tmp_ctx, ldb, TX_MBO_MARKER_DN);
+    if (dn == NULL) {
+        ret = LDB_ERR_OPERATIONS_ERROR;
+        goto done;
+    }
+    ret = ldb_search(ldb, tmp_ctx, &res, dn, LDB_SCOPE_BASE, attrs, NULL);
+    if (ret != LDB_SUCCESS) {
+        goto done;
+    }
+    if (res->count > 1) {
+        ret = LDB_ERR_OPERATIONS_ERROR;
+        goto done;
+    }
+    exists = res->count == 1;
+
+    msg = ldb_msg_new(tmp_ctx);
+    if (msg == NULL) {
+        ret = LDB_ERR_OPERATIONS_ERROR;
+        goto done;
+    }
+    msg->dn = ldb_dn_copy(msg, dn);
+    if (msg->dn == NULL) {
+        ret = LDB_ERR_OPERATIONS_ERROR;
+        goto done;
+    }
+    if (exists) {
+        ret = ldb_msg_add_empty(msg, TX_MBO_MARKER_ATTR,
+                                LDB_FLAG_MOD_REPLACE, NULL);
+        if (ret != LDB_SUCCESS) {
+            goto done;
+        }
+    }
+    ret = ldb_msg_add_string(msg, TX_MBO_MARKER_ATTR, version);
+    if (ret != LDB_SUCCESS) {
+        goto done;
+    }
+
+    ret = ldb_transaction_start(ldb);
+    if (ret != LDB_SUCCESS) {
+        goto done;
+    }
+    in_transaction = true;
+    ret = exists ? ldb_modify(ldb, msg) : ldb_add(ldb, msg);
+    if (ret != LDB_SUCCESS) {
+        goto done;
+    }
+    ret = ldb_transaction_commit(ldb);
+    if (ret == LDB_SUCCESS) {
+        in_transaction = false;
+    }
+
+done:
+    if (in_transaction) {
+        ldb_transaction_cancel(ldb);
+    }
+    talloc_free(tmp_ctx);
+    return ret;
+}
+
+static int test_tx_marker_get(TALLOC_CTX *mem_ctx,
+                              struct sysdb_test_ctx *test_ctx,
+                              const char **_version)
+{
+    static const char *attrs[] = { TX_MBO_MARKER_ATTR, NULL };
+    struct ldb_context *ldb = test_ctx->sysdb->ldb;
+    struct ldb_result *res = NULL;
+    struct ldb_dn *dn;
+    const char *version;
+    int ret;
+
+    *_version = NULL;
+    dn = ldb_dn_new(mem_ctx, ldb, TX_MBO_MARKER_DN);
+    if (dn == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    ret = ldb_search(ldb, mem_ctx, &res, dn, LDB_SCOPE_BASE, attrs, NULL);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    if (res->count != 1) {
+        return LDB_ERR_NO_SUCH_OBJECT;
+    }
+    version = ldb_msg_find_attr_as_string(res->msgs[0],
+                                          TX_MBO_MARKER_ATTR, NULL);
+    if (version == NULL) {
+        return LDB_ERR_NO_SUCH_ATTRIBUTE;
+    }
+    *_version = talloc_strdup(mem_ctx, version);
+    return *_version == NULL ? LDB_ERR_OPERATIONS_ERROR : LDB_SUCCESS;
+}
+
+static struct ldb_message *
+test_tx_identity_message(TALLOC_CTX *mem_ctx,
+                         struct ldb_dn *dn,
+                         const char *name,
+                         const char *category)
+{
+    struct ldb_message *msg;
+    int ret;
+
+    msg = ldb_msg_new(mem_ctx);
+    if (msg == NULL) {
+        return NULL;
+    }
+    msg->dn = ldb_dn_copy(msg, dn);
+    if (msg->dn == NULL) {
+        talloc_free(msg);
+        return NULL;
+    }
+    ret = ldb_msg_add_string(msg, SYSDB_NAME, name);
+    if (ret == LDB_SUCCESS) {
+        ret = ldb_msg_add_string(msg, SYSDB_OBJECTCATEGORY, category);
+    }
+    if (ret != LDB_SUCCESS) {
+        talloc_free(msg);
+        return NULL;
+    }
+
+    return msg;
+}
+
+static int test_tx_add_member_values(struct ldb_message *msg,
+                                     struct ldb_dn **members,
+                                     size_t num_members,
+                                     int flags)
+{
+    struct ldb_message_element *el;
+    const char *value;
+    size_t i;
+    int ret;
+
+    ret = ldb_msg_add_empty(msg, SYSDB_MEMBER, flags, &el);
+    if (ret != LDB_SUCCESS || num_members == 0) {
+        return ret;
+    }
+    el->values = talloc_zero_array(msg, struct ldb_val, num_members);
+    if (el->values == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    for (i = 0; i < num_members; i++) {
+        value = ldb_dn_get_linearized(members[i]);
+        if (value == NULL) {
+            return LDB_ERR_INVALID_DN_SYNTAX;
+        }
+        el->values[i].data = (uint8_t *)talloc_strdup(el->values, value);
+        if (el->values[i].data == NULL) {
+            return LDB_ERR_OPERATIONS_ERROR;
+        }
+        el->values[i].length = strlen(value);
+    }
+    el->num_values = num_members;
+    return LDB_SUCCESS;
+}
+
+static int test_tx_modify_members(TALLOC_CTX *mem_ctx,
+                                  struct ldb_context *ldb,
+                                  struct ldb_dn *group_dn,
+                                  struct ldb_dn **members,
+                                  size_t num_members,
+                                  int flags)
+{
+    struct ldb_message *msg;
+    int ret;
+
+    msg = ldb_msg_new(mem_ctx);
+    if (msg == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    msg->dn = ldb_dn_copy(msg, group_dn);
+    if (msg->dn == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    ret = test_tx_add_member_values(msg, members, num_members, flags);
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+    return ldb_modify(ldb, msg);
+}
+
+static int test_tx_modify_ghost(TALLOC_CTX *mem_ctx,
+                                struct ldb_context *ldb,
+                                struct ldb_dn *group_dn,
+                                const char *ghost,
+                                int flags)
+{
+    struct ldb_message *msg;
+    int ret;
+
+    msg = ldb_msg_new(mem_ctx);
+    if (msg == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    msg->dn = ldb_dn_copy(msg, group_dn);
+    if (msg->dn == NULL) {
+        return LDB_ERR_OPERATIONS_ERROR;
+    }
+    ret = ldb_msg_add_empty(msg, SYSDB_GHOST, flags, NULL);
+    if (ret == LDB_SUCCESS && ghost != NULL) {
+        ret = ldb_msg_add_string(msg, SYSDB_GHOST, ghost);
+    }
+    if (ret != LDB_SUCCESS) {
+        return ret;
+    }
+
+    return ldb_modify(ldb, msg);
+}
+
 START_TEST(test_group_rename)
 {
     struct sysdb_test_ctx *test_ctx;
@@ -4251,6 +4480,571 @@ START_TEST(test_group_rename_preserves_memberships)
     }
     ck_assert_msg(!found_old, "initgroups returned the old group name");
     ck_assert_msg(found_new, "initgroups did not return the renamed group");
+
+    talloc_free(test_ctx);
+}
+END_TEST
+
+START_TEST(test_transactional_memberof_empty_transactions)
+{
+    struct sysdb_test_ctx *test_ctx;
+    size_t i;
+    int lret;
+    errno_t ret;
+
+    if (getenv("SSSD_MEMBEROF_LEGACY") != NULL) {
+        return;
+    }
+
+    ret = setup_sysdb_tests(&test_ctx);
+    ck_assert_msg(ret == EOK, "Could not set up the empty transaction test");
+
+    for (i = 0; i < 16; i++) {
+        lret = ldb_transaction_start(test_ctx->sysdb->ldb);
+        ck_assert_int_eq(lret, LDB_SUCCESS);
+        lret = ldb_transaction_cancel(test_ctx->sysdb->ldb);
+        ck_assert_int_eq(lret, LDB_SUCCESS);
+
+        lret = ldb_transaction_start(test_ctx->sysdb->ldb);
+        ck_assert_int_eq(lret, LDB_SUCCESS);
+        lret = ldb_transaction_commit(test_ctx->sysdb->ldb);
+        ck_assert_int_eq(lret, LDB_SUCCESS);
+    }
+
+    talloc_free(test_ctx);
+}
+END_TEST
+
+START_TEST(test_transactional_memberof_marker_rollback)
+{
+    struct sysdb_test_ctx *test_ctx;
+    struct ldb_context *ldb;
+    struct ldb_message *msg;
+    struct ldb_dn *group_dn;
+    struct ldb_dn *marker_dn;
+    const char *group_name;
+    const char *version;
+    int lret;
+    errno_t ret;
+
+    if (getenv("SSSD_MEMBEROF_LEGACY") != NULL) {
+        return;
+    }
+
+    ret = setup_sysdb_tests(&test_ctx);
+    ck_assert_msg(ret == EOK, "Could not set up the test");
+    lret = test_tx_marker_set(test_ctx, "0");
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+    talloc_free(test_ctx);
+
+    ret = setup_sysdb_tests(&test_ctx);
+    ck_assert_msg(ret == EOK, "Could not reopen the test database");
+    ldb = test_ctx->sysdb->ldb;
+    group_name = sss_create_internal_fqname(test_ctx, "tx-rollback-group",
+                                            test_ctx->domain->name);
+    ck_assert_msg(group_name != NULL, "Could not create rollback group name");
+    group_dn = sysdb_group_dn(test_ctx, test_ctx->domain, group_name);
+    marker_dn = ldb_dn_new(test_ctx, ldb, TX_MBO_MARKER_DN);
+    ck_assert_msg(group_dn != NULL, "Could not create rollback group DN");
+    ck_assert_msg(marker_dn != NULL, "Could not create marker DN");
+
+    lret = ldb_transaction_start(ldb);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+    msg = test_tx_identity_message(test_ctx, group_dn, group_name,
+                                   SYSDB_GROUP_CLASS);
+    if (msg == NULL) {
+        ldb_transaction_cancel(ldb);
+        ck_abort_msg("Could not create rollback test group");
+    }
+    lret = ldb_add(ldb, msg);
+    if (lret != LDB_SUCCESS) {
+        ldb_transaction_cancel(ldb);
+        ck_abort_msg("Could not add rollback test group: %d", lret);
+    }
+    lret = ldb_delete(ldb, marker_dn);
+    if (lret != LDB_SUCCESS) {
+        ldb_transaction_cancel(ldb);
+        ck_abort_msg("Could not stage marker deletion: %d", lret);
+    }
+
+    /* The missing marker makes prepare_commit fail after the group add. */
+    lret = ldb_transaction_commit(ldb);
+    ck_assert_msg(lret != LDB_SUCCESS,
+                  "Marker deletion did not fail prepare_commit");
+    talloc_free(test_ctx);
+
+    ret = setup_sysdb_tests(&test_ctx);
+    ck_assert_msg(ret == EOK, "Could not reopen after rollback");
+    group_name = sss_create_internal_fqname(test_ctx, "tx-rollback-group",
+                                            test_ctx->domain->name);
+    ck_assert_msg(group_name != NULL, "Could not recreate rollback group name");
+    ret = sysdb_search_group_by_name(test_ctx, test_ctx->domain, group_name,
+                                     NULL, &msg);
+    ck_assert_int_eq(ret, ENOENT);
+
+    lret = test_tx_marker_get(test_ctx, test_ctx, &version);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+    ck_assert_str_eq(version, "0");
+
+    ret = sysdb_store_group(test_ctx->domain, group_name, 38200, NULL, 0, 0);
+    ck_assert_msg(ret == EOK, "Could not upgrade the migration marker");
+    lret = test_tx_marker_get(test_ctx, test_ctx, &version);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+    ck_assert_str_eq(version, "1");
+
+    ret = sysdb_delete_group(test_ctx->domain, group_name, 0);
+    ck_assert_msg(ret == EOK, "Could not remove rollback test group");
+    talloc_free(test_ctx);
+}
+END_TEST
+
+START_TEST(test_transactional_memberof_operation_replay)
+{
+    static const char *group_attrs[] = {
+        SYSDB_MEMBER, SYSDB_MEMBERUID, NULL
+    };
+    static const char *user_attrs[] = { SYSDB_MEMBEROF, NULL };
+    struct sysdb_test_ctx *test_ctx;
+    struct ldb_context *ldb;
+    struct ldb_message *msg;
+    struct ldb_result *res = NULL;
+    struct ldb_dn *user_a_dn;
+    struct ldb_dn *user_b_dn;
+    struct ldb_dn *temp_dn;
+    struct ldb_dn *group_dn;
+    struct ldb_dn *member[1];
+    const char *user_a;
+    const char *user_b;
+    const char *temp_user;
+    const char *group;
+    const char *user_b_dn_str;
+    const char *group_dn_str;
+    int lret;
+    errno_t ret;
+
+    if (getenv("SSSD_MEMBEROF_LEGACY") != NULL) {
+        return;
+    }
+
+    ret = setup_sysdb_tests(&test_ctx);
+    ck_assert_msg(ret == EOK, "Could not set up the replay test");
+    ldb = test_ctx->sysdb->ldb;
+    user_a = sss_create_internal_fqname(test_ctx, "tx-replay-a",
+                                        test_ctx->domain->name);
+    user_b = sss_create_internal_fqname(test_ctx, "tx-replay-b",
+                                        test_ctx->domain->name);
+    temp_user = sss_create_internal_fqname(test_ctx, "tx-replay-temp",
+                                           test_ctx->domain->name);
+    group = sss_create_internal_fqname(test_ctx, "tx-replay-group",
+                                       test_ctx->domain->name);
+    ck_assert_msg(user_a != NULL && user_b != NULL && temp_user != NULL
+                  && group != NULL, "Could not create replay names");
+
+    user_a_dn = sysdb_user_dn(test_ctx, test_ctx->domain, user_a);
+    user_b_dn = sysdb_user_dn(test_ctx, test_ctx->domain, user_b);
+    temp_dn = sysdb_user_dn(test_ctx, test_ctx->domain, temp_user);
+    group_dn = sysdb_group_dn(test_ctx, test_ctx->domain, group);
+    ck_assert_msg(user_a_dn != NULL && user_b_dn != NULL && temp_dn != NULL
+                  && group_dn != NULL, "Could not create replay DNs");
+    user_b_dn_str = ldb_dn_get_linearized(user_b_dn);
+    group_dn_str = ldb_dn_get_linearized(group_dn);
+    ck_assert_msg(user_b_dn_str != NULL && group_dn_str != NULL,
+                  "Could not linearize replay DNs");
+
+    lret = ldb_transaction_start(ldb);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+
+    msg = test_tx_identity_message(test_ctx, user_a_dn, user_a,
+                                   SYSDB_USER_CLASS);
+    lret = msg == NULL ? LDB_ERR_OPERATIONS_ERROR : ldb_add(ldb, msg);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+
+    msg = test_tx_identity_message(test_ctx, group_dn, group,
+                                   SYSDB_GROUP_CLASS);
+    member[0] = user_a_dn;
+    lret = msg == NULL ? LDB_ERR_OPERATIONS_ERROR
+                       : test_tx_add_member_values(msg, member, 1, 0);
+    if (lret == LDB_SUCCESS) {
+        lret = ldb_add(ldb, msg);
+    }
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+
+    msg = test_tx_identity_message(test_ctx, user_b_dn, user_b,
+                                   SYSDB_USER_CLASS);
+    lret = msg == NULL ? LDB_ERR_OPERATIONS_ERROR : ldb_add(ldb, msg);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+
+    member[0] = user_a_dn;
+    lret = test_tx_modify_members(test_ctx, ldb, group_dn, member, 1,
+                                  LDB_FLAG_MOD_DELETE);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+    member[0] = user_b_dn;
+    lret = test_tx_modify_members(test_ctx, ldb, group_dn, member, 1,
+                                  LDB_FLAG_MOD_ADD);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+
+    lret = ldb_delete(ldb, user_b_dn);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+    msg = test_tx_identity_message(test_ctx, user_b_dn, user_b,
+                                   SYSDB_USER_CLASS);
+    lret = msg == NULL ? LDB_ERR_OPERATIONS_ERROR : ldb_add(ldb, msg);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+    lret = ldb_rename(ldb, user_b_dn, temp_dn);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+    lret = ldb_rename(ldb, temp_dn, user_b_dn);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+
+    lret = ldb_transaction_commit(ldb);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+
+    lret = ldb_search(ldb, test_ctx, &res, group_dn, LDB_SCOPE_BASE,
+                      group_attrs, NULL);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+    ck_assert_int_eq(res->count, 1);
+    ck_assert_msg(test_message_has_value(res->msgs[0], SYSDB_MEMBER,
+                                         user_b_dn_str),
+                  "Replay group lost its final direct member");
+    ck_assert_msg(test_message_has_value(res->msgs[0], SYSDB_MEMBERUID,
+                                         user_b),
+                  "Replay group has an incorrect memberUid");
+    talloc_zfree(res);
+
+    lret = ldb_search(ldb, test_ctx, &res, user_b_dn, LDB_SCOPE_BASE,
+                      user_attrs, NULL);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+    ck_assert_int_eq(res->count, 1);
+    ck_assert_msg(test_message_has_value(res->msgs[0], SYSDB_MEMBEROF,
+                                         group_dn_str),
+                  "Re-added user lost its final membership");
+    talloc_zfree(res);
+
+    lret = ldb_search(ldb, test_ctx, &res, user_a_dn, LDB_SCOPE_BASE,
+                      user_attrs, NULL);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+    ck_assert_int_eq(res->count, 1);
+    ck_assert_msg(!test_message_has_value(res->msgs[0], SYSDB_MEMBEROF,
+                                          group_dn_str),
+                  "Removed user retained a stale membership");
+
+    talloc_free(test_ctx);
+}
+END_TEST
+
+START_TEST(test_transactional_memberof_ghost_writes)
+{
+    static const char *attrs[] = {
+        SYSDB_GHOST, TX_MBO_GHOST_DIRECT, NULL
+    };
+    const char *old_ghost = "tx-ghost-old@example.test";
+    const char *new_ghost = "tx-ghost-new@example.test";
+    const char *missing_ghost = "tx-ghost-missing@example.test";
+    struct sysdb_test_ctx *test_ctx;
+    struct ldb_context *ldb;
+    struct ldb_message *msg;
+    struct ldb_result *res = NULL;
+    struct ldb_dn *child_dn;
+    struct ldb_dn *parent_dn;
+    struct ldb_dn *member[1];
+    const char *child;
+    const char *parent;
+    int lret;
+    errno_t ret;
+
+    if (getenv("SSSD_MEMBEROF_LEGACY") != NULL) {
+        return;
+    }
+
+    ret = setup_sysdb_tests(&test_ctx);
+    ck_assert_msg(ret == EOK, "Could not set up the ghost-write test");
+    ldb = test_ctx->sysdb->ldb;
+    child = sss_create_internal_fqname(test_ctx, "tx-ghost-child",
+                                       test_ctx->domain->name);
+    parent = sss_create_internal_fqname(test_ctx, "tx-ghost-parent",
+                                        test_ctx->domain->name);
+    ck_assert_msg(child != NULL && parent != NULL,
+                  "Could not create ghost-write group names");
+    child_dn = sysdb_group_dn(test_ctx, test_ctx->domain, child);
+    parent_dn = sysdb_group_dn(test_ctx, test_ctx->domain, parent);
+    ck_assert_msg(child_dn != NULL && parent_dn != NULL,
+                  "Could not create ghost-write group DNs");
+
+    lret = ldb_transaction_start(ldb);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+    msg = test_tx_identity_message(test_ctx, child_dn, child,
+                                   SYSDB_GROUP_CLASS);
+    lret = msg == NULL ? LDB_ERR_OPERATIONS_ERROR
+                       : ldb_msg_add_string(msg, SYSDB_GHOST, old_ghost);
+    if (lret == LDB_SUCCESS) {
+        lret = ldb_add(ldb, msg);
+    }
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+
+    msg = test_tx_identity_message(test_ctx, parent_dn, parent,
+                                   SYSDB_GROUP_CLASS);
+    member[0] = child_dn;
+    lret = msg == NULL ? LDB_ERR_OPERATIONS_ERROR
+                       : test_tx_add_member_values(msg, member, 1, 0);
+    if (lret == LDB_SUCCESS) {
+        lret = ldb_add(ldb, msg);
+    }
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+    lret = ldb_transaction_commit(ldb);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+
+    lret = ldb_transaction_start(ldb);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+    lret = test_tx_modify_ghost(test_ctx, ldb, child_dn, new_ghost,
+                                LDB_FLAG_MOD_REPLACE);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+    lret = ldb_transaction_commit(ldb);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+
+    lret = ldb_search(ldb, test_ctx, &res, child_dn, LDB_SCOPE_BASE,
+                      attrs, NULL);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+    ck_assert_int_eq(res->count, 1);
+    ck_assert_msg(test_message_has_value(res->msgs[0], SYSDB_GHOST,
+                                         new_ghost),
+                  "Child did not retain the replacement ghost");
+    ck_assert_msg(test_message_has_value(res->msgs[0],
+                                         TX_MBO_GHOST_DIRECT, new_ghost),
+                  "Child did not retain direct ghost provenance");
+    ck_assert_msg(!test_message_has_value(res->msgs[0], SYSDB_GHOST,
+                                          old_ghost),
+                  "Child retained the replaced ghost");
+    talloc_zfree(res);
+
+    lret = ldb_search(ldb, test_ctx, &res, parent_dn, LDB_SCOPE_BASE,
+                      attrs, NULL);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+    ck_assert_int_eq(res->count, 1);
+    ck_assert_msg(test_message_has_value(res->msgs[0], SYSDB_GHOST,
+                                         new_ghost),
+                  "Parent did not inherit the replacement ghost");
+    ck_assert_msg(!test_message_has_value(res->msgs[0], SYSDB_GHOST,
+                                          old_ghost),
+                  "Parent retained the replaced inherited ghost");
+    ck_assert_msg(!test_message_has_value(res->msgs[0],
+                                          TX_MBO_GHOST_DIRECT, new_ghost),
+                  "Parent incorrectly recorded an inherited ghost as direct");
+    talloc_zfree(res);
+
+    lret = ldb_transaction_start(ldb);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+    lret = test_tx_modify_ghost(test_ctx, ldb, child_dn, missing_ghost,
+                                LDB_FLAG_MOD_DELETE);
+    ck_assert_msg(lret != LDB_SUCCESS,
+                  "Deleting an absent ghost unexpectedly succeeded");
+    lret = ldb_transaction_cancel(ldb);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+
+    lret = ldb_search(ldb, test_ctx, &res, child_dn, LDB_SCOPE_BASE,
+                      attrs, NULL);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+    ck_assert_int_eq(res->count, 1);
+    ck_assert_msg(test_message_has_value(res->msgs[0], SYSDB_GHOST,
+                                         new_ghost),
+                  "Rejected ghost write changed the child");
+    ck_assert_msg(!test_message_has_value(res->msgs[0], SYSDB_GHOST,
+                                          missing_ghost),
+                  "Rejected ghost write added an unexpected value");
+
+    talloc_free(test_ctx);
+}
+END_TEST
+
+START_TEST(test_transactional_memberof_large_replace)
+{
+    static const char *group_attrs[] = {
+        SYSDB_MEMBER, SYSDB_MEMBERUID, NULL
+    };
+    static const char *user_attrs[] = { SYSDB_MEMBEROF, NULL };
+    struct sysdb_test_ctx *test_ctx;
+    struct ldb_context *ldb;
+    struct ldb_message_element *el;
+    struct ldb_message *msg;
+    struct ldb_dn **user_dns;
+    struct ldb_dn *group_dn;
+    TALLOC_CTX *tmp_ctx;
+    char **user_names;
+    const char *group_name;
+    const char *group_dn_str;
+    size_t i;
+    int lret;
+    errno_t ret;
+
+    if (getenv("SSSD_MEMBEROF_LEGACY") != NULL) {
+        return;
+    }
+
+    ret = setup_sysdb_tests(&test_ctx);
+    ck_assert_msg(ret == EOK, "Could not set up the scale test");
+    ldb = test_ctx->sysdb->ldb;
+    user_names = talloc_zero_array(test_ctx, char *, TX_MBO_SCALE_MEMBERS);
+    user_dns = talloc_zero_array(test_ctx, struct ldb_dn *,
+                                 TX_MBO_SCALE_MEMBERS);
+    ck_assert_msg(user_names != NULL, "Could not allocate scale user names");
+    ck_assert_msg(user_dns != NULL, "Could not allocate scale user DNs");
+
+    for (i = 0; i < TX_MBO_SCALE_MEMBERS; i++) {
+        user_names[i] = test_asprintf_fqname(user_names, test_ctx->domain,
+                                             "tx-scale-user-%04zu", i);
+        ck_assert_msg(user_names[i] != NULL,
+                      "Could not create scale user name %zu", i);
+        user_dns[i] = sysdb_user_dn(user_dns, test_ctx->domain,
+                                    user_names[i]);
+        ck_assert_msg(user_dns[i] != NULL,
+                      "Could not create scale user DN %zu", i);
+    }
+    group_name = sss_create_internal_fqname(test_ctx, "tx-scale-group",
+                                            test_ctx->domain->name);
+    ck_assert_msg(group_name != NULL, "Could not create scale group name");
+    group_dn = sysdb_group_dn(test_ctx, test_ctx->domain, group_name);
+    ck_assert_msg(group_dn != NULL, "Could not create scale group DN");
+    group_dn_str = ldb_dn_get_linearized(group_dn);
+    ck_assert_msg(group_dn_str != NULL, "Could not linearize scale group DN");
+
+    lret = ldb_transaction_start(ldb);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+    for (i = 0; i < TX_MBO_SCALE_MEMBERS; i++) {
+        tmp_ctx = talloc_new(test_ctx);
+        if (tmp_ctx == NULL) {
+            ldb_transaction_cancel(ldb);
+            ck_abort_msg("Out of memory creating scale users");
+        }
+        msg = test_tx_identity_message(tmp_ctx, user_dns[i],
+                                       user_names[i], SYSDB_USER_CLASS);
+        lret = msg == NULL ? LDB_ERR_OPERATIONS_ERROR : ldb_add(ldb, msg);
+        talloc_free(tmp_ctx);
+        if (lret != LDB_SUCCESS) {
+            ldb_transaction_cancel(ldb);
+            ck_abort_msg("Could not add scale user %zu: %d", i, lret);
+        }
+    }
+
+    msg = test_tx_identity_message(test_ctx, group_dn, group_name,
+                                   SYSDB_GROUP_CLASS);
+    if (msg == NULL) {
+        ldb_transaction_cancel(ldb);
+        ck_abort_msg("Could not create scale group");
+    }
+    lret = test_tx_add_member_values(msg, user_dns, TX_MBO_SCALE_MEMBERS, 0);
+    if (lret == LDB_SUCCESS) {
+        lret = ldb_add(ldb, msg);
+    }
+    if (lret != LDB_SUCCESS) {
+        ldb_transaction_cancel(ldb);
+        ck_abort_msg("Could not add scale group: %d", lret);
+    }
+    lret = ldb_transaction_commit(ldb);
+    if (lret != LDB_SUCCESS) {
+        ldb_transaction_cancel(ldb);
+        ck_abort_msg("Could not commit scale graph: %d", lret);
+    }
+
+    ret = sysdb_search_group_by_name(test_ctx, test_ctx->domain, group_name,
+                                     group_attrs, &msg);
+    ck_assert_int_eq(ret, EOK);
+    el = ldb_msg_find_element(msg, SYSDB_MEMBER);
+    ck_assert_msg(el != NULL, "Scale group has no member attribute");
+    ck_assert_int_eq(el->num_values, TX_MBO_SCALE_MEMBERS);
+    el = ldb_msg_find_element(msg, SYSDB_MEMBERUID);
+    ck_assert_msg(el != NULL, "Scale group has no memberUid attribute");
+    ck_assert_int_eq(el->num_values, TX_MBO_SCALE_MEMBERS);
+    talloc_zfree(msg);
+
+    msg = ldb_msg_new(test_ctx);
+    ck_assert_msg(msg != NULL, "Could not allocate scale replacement");
+    msg->dn = ldb_dn_copy(msg, group_dn);
+    ck_assert_msg(msg->dn != NULL, "Could not copy scale group DN");
+    lret = test_tx_add_member_values(msg, user_dns, 4,
+                                     LDB_FLAG_MOD_REPLACE);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+
+    lret = ldb_transaction_start(ldb);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+    for (i = 0; i < TX_MBO_SCALE_MEMBERS; i++) {
+        struct ldb_message *overlay;
+
+        tmp_ctx = talloc_new(test_ctx);
+        if (tmp_ctx == NULL) {
+            ldb_transaction_cancel(ldb);
+            ck_abort_msg("Out of memory creating overlay update");
+        }
+        overlay = ldb_msg_new(tmp_ctx);
+        if (overlay != NULL) {
+            overlay->dn = ldb_dn_copy(overlay, user_dns[i]);
+        }
+        lret = overlay == NULL || overlay->dn == NULL
+             ? LDB_ERR_OPERATIONS_ERROR
+             : ldb_msg_add_empty(overlay, SYSDB_CACHE_EXPIRE,
+                                 LDB_FLAG_MOD_REPLACE, NULL);
+        if (lret == LDB_SUCCESS) {
+            lret = ldb_msg_add_string(overlay, SYSDB_CACHE_EXPIRE,
+                                      "123456789");
+        }
+        if (lret == LDB_SUCCESS) {
+            lret = ldb_modify(ldb, overlay);
+        }
+        talloc_free(tmp_ctx);
+        if (lret != LDB_SUCCESS) {
+            ldb_transaction_cancel(ldb);
+            ck_abort_msg("Could not stage overlay update %zu: %d", i,
+                         lret);
+        }
+    }
+    lret = ldb_modify(ldb, msg);
+    if (lret != LDB_SUCCESS) {
+        ldb_transaction_cancel(ldb);
+        ck_abort_msg("Could not stage large replacement: %d", lret);
+    }
+    lret = ldb_transaction_commit(ldb);
+    if (lret != LDB_SUCCESS) {
+        ldb_transaction_cancel(ldb);
+        ck_abort_msg("Could not commit large replacement: %d", lret);
+    }
+
+    ret = sysdb_search_group_by_name(test_ctx, test_ctx->domain, group_name,
+                                     group_attrs, &msg);
+    ck_assert_int_eq(ret, EOK);
+    el = ldb_msg_find_element(msg, SYSDB_MEMBER);
+    ck_assert_msg(el != NULL, "Replaced group has no member attribute");
+    ck_assert_int_eq(el->num_values, 4);
+    el = ldb_msg_find_element(msg, SYSDB_MEMBERUID);
+    ck_assert_msg(el != NULL, "Replaced group has no memberUid attribute");
+    ck_assert_int_eq(el->num_values, 4);
+    talloc_zfree(msg);
+
+    ret = sysdb_search_user_by_name(test_ctx, test_ctx->domain,
+                                    user_names[0], user_attrs, &msg);
+    ck_assert_int_eq(ret, EOK);
+    ck_assert_msg(test_message_has_value(msg, SYSDB_MEMBEROF, group_dn_str),
+                  "Retained user lost its group");
+    talloc_zfree(msg);
+
+    ret = sysdb_search_user_by_name(test_ctx, test_ctx->domain,
+                                    user_names[TX_MBO_SCALE_MEMBERS - 1],
+                                    user_attrs, &msg);
+    ck_assert_int_eq(ret, EOK);
+    ck_assert_msg(!test_message_has_value(msg, SYSDB_MEMBEROF, group_dn_str),
+                  "Removed user retained its group");
+    talloc_zfree(msg);
+
+    lret = ldb_transaction_start(ldb);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+    lret = ldb_delete(ldb, group_dn);
+    for (i = 0; lret == LDB_SUCCESS && i < TX_MBO_SCALE_MEMBERS; i++) {
+        lret = ldb_delete(ldb, user_dns[i]);
+    }
+    if (lret != LDB_SUCCESS) {
+        ldb_transaction_cancel(ldb);
+        ck_abort_msg("Could not stage scale cleanup: %d", lret);
+    }
+    lret = ldb_transaction_commit(ldb);
+    if (lret != LDB_SUCCESS) {
+        ldb_transaction_cancel(ldb);
+        ck_abort_msg("Could not commit scale cleanup: %d", lret);
+    }
 
     talloc_free(test_ctx);
 }
@@ -8437,6 +9231,20 @@ Suite *create_sysdb_suite(void)
     tcase_add_loop_test(tc_memberof, test_sysdb_remove_local_group_by_gid,
                         MBO_GROUP_BASE , MBO_GROUP_BASE + 10);
     suite_add_tcase(s, tc_memberof);
+
+    TCase *tc_transactional = tcase_create("Transactional memberof Tests");
+    tcase_set_timeout(tc_transactional, 300);
+    tcase_add_test(tc_transactional,
+                   test_transactional_memberof_empty_transactions);
+    tcase_add_test(tc_transactional,
+                   test_transactional_memberof_marker_rollback);
+    tcase_add_test(tc_transactional,
+                   test_transactional_memberof_operation_replay);
+    tcase_add_test(tc_transactional,
+                   test_transactional_memberof_ghost_writes);
+    tcase_add_test(tc_transactional,
+                   test_transactional_memberof_large_replace);
+    suite_add_tcase(s, tc_transactional);
 
     TCase *tc_subdomain = tcase_create("SYSDB sub-domain Tests");
 

--- a/src/tests/sysdb-tests.c
+++ b/src/tests/sysdb-tests.c
@@ -4853,6 +4853,99 @@ START_TEST(test_transactional_memberof_ghost_writes)
 }
 END_TEST
 
+START_TEST(test_transactional_memberof_failed_writes_preserve_journal)
+{
+    static const char *group_attrs[] = { SYSDB_MEMBER, NULL };
+    struct sysdb_test_ctx *test_ctx;
+    struct ldb_context *ldb;
+    struct ldb_message *msg;
+    struct ldb_dn *present_dn;
+    struct ldb_dn *missing_dn;
+    struct ldb_dn *group_dn;
+    struct ldb_dn *member[1];
+    const char *present_user;
+    const char *missing_user;
+    const char *group;
+    const char *missing_dn_str;
+    const char *present_dn_str;
+    int lret;
+    errno_t ret;
+
+    if (getenv("SSSD_MEMBEROF_LEGACY") != NULL) {
+        return;
+    }
+
+    ret = setup_sysdb_tests(&test_ctx);
+    ck_assert_msg(ret == EOK, "Could not set up the failed-write test");
+    ldb = test_ctx->sysdb->ldb;
+    present_user = sss_create_internal_fqname(test_ctx, "tx-fail-present",
+                                               test_ctx->domain->name);
+    missing_user = sss_create_internal_fqname(test_ctx, "tx-fail-missing",
+                                               test_ctx->domain->name);
+    group = sss_create_internal_fqname(test_ctx, "tx-fail-group",
+                                        test_ctx->domain->name);
+    ck_assert_msg(present_user != NULL && missing_user != NULL
+                  && group != NULL, "Could not create failed-write names");
+
+    ret = sysdb_store_user(test_ctx->domain, present_user, NULL, 38301, 0,
+                           "Present User", "/home/tx-fail-present", "/bin/sh",
+                           NULL, NULL, NULL, -1, 0);
+    ck_assert_int_eq(ret, EOK);
+    ret = sysdb_store_user(test_ctx->domain, missing_user, NULL, 38302, 0,
+                           "Missing User", "/home/tx-fail-missing", "/bin/sh",
+                           NULL, NULL, NULL, -1, 0);
+    ck_assert_int_eq(ret, EOK);
+    ret = sysdb_store_group(test_ctx->domain, group, 38300, NULL, 0, 0);
+    ck_assert_int_eq(ret, EOK);
+    ret = sysdb_add_group_member(test_ctx->domain, group, present_user,
+                                 SYSDB_MEMBER_USER, false);
+    ck_assert_int_eq(ret, EOK);
+
+    present_dn = sysdb_user_dn(test_ctx, test_ctx->domain, present_user);
+    missing_dn = sysdb_user_dn(test_ctx, test_ctx->domain, missing_user);
+    group_dn = sysdb_group_dn(test_ctx, test_ctx->domain, group);
+    ck_assert_msg(present_dn != NULL && missing_dn != NULL && group_dn != NULL,
+                  "Could not create failed-write DNs");
+    present_dn_str = ldb_dn_get_linearized(present_dn);
+    missing_dn_str = ldb_dn_get_linearized(missing_dn);
+    ck_assert_msg(present_dn_str != NULL && missing_dn_str != NULL,
+                  "Could not linearize the member DNs");
+
+    lret = ldb_transaction_start(ldb);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+    member[0] = missing_dn;
+    lret = test_tx_modify_members(test_ctx, ldb, group_dn, member, 1,
+                                  LDB_FLAG_MOD_DELETE);
+    ck_assert_msg(lret != LDB_SUCCESS,
+                  "Deleting an absent member unexpectedly succeeded");
+
+    member[0] = present_dn;
+    lret = test_tx_modify_members(test_ctx, ldb, group_dn, member, 1,
+                                  LDB_FLAG_MOD_ADD);
+    ck_assert_msg(lret != LDB_SUCCESS,
+                  "Adding a duplicate member unexpectedly succeeded");
+
+    member[0] = missing_dn;
+    lret = test_tx_modify_members(test_ctx, ldb, group_dn, member, 1,
+                                  LDB_FLAG_MOD_ADD);
+    ck_assert_int_eq(lret, LDB_SUCCESS);
+
+    lret = ldb_transaction_commit(ldb);
+    ck_assert_msg(lret == LDB_SUCCESS,
+                  "Expected write errors poisoned a valid transaction");
+
+    ret = sysdb_search_group_by_name(test_ctx, test_ctx->domain, group,
+                                     group_attrs, &msg);
+    ck_assert_int_eq(ret, EOK);
+    ck_assert_msg(test_message_has_value(msg, SYSDB_MEMBER, present_dn_str),
+                  "Failed delete removed the existing member");
+    ck_assert_msg(test_message_has_value(msg, SYSDB_MEMBER, missing_dn_str),
+                  "Successful write after expected failures was not staged");
+
+    talloc_free(test_ctx);
+}
+END_TEST
+
 START_TEST(test_transactional_memberof_large_replace)
 {
     static const char *group_attrs[] = {
@@ -9242,6 +9335,8 @@ Suite *create_sysdb_suite(void)
                    test_transactional_memberof_operation_replay);
     tcase_add_test(tc_transactional,
                    test_transactional_memberof_ghost_writes);
+    tcase_add_test(tc_transactional,
+                   test_transactional_memberof_failed_writes_preserve_journal);
     tcase_add_test(tc_transactional,
                    test_transactional_memberof_large_replace);
     suite_add_tcase(s, tc_transactional);

--- a/src/tests/sysdb-tests.c
+++ b/src/tests/sysdb-tests.c
@@ -3975,6 +3975,27 @@ START_TEST(test_sysdb_get_real_name)
 }
 END_TEST
 
+static bool test_message_has_value(struct ldb_message *msg,
+                                   const char *attr,
+                                   const char *value)
+{
+    struct ldb_message_element *el;
+    unsigned int i;
+
+    el = ldb_msg_find_element(msg, attr);
+    if (el == NULL) {
+        return false;
+    }
+
+    for (i = 0; i < el->num_values; i++) {
+        if (strcmp((const char *)el->values[i].data, value) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 START_TEST(test_group_rename)
 {
     struct sysdb_test_ctx *test_ctx;
@@ -4048,6 +4069,189 @@ START_TEST(test_group_rename)
     ck_assert_msg(res->count == 0, "Unexpectedly found the original user\n");
 
 done:
+    talloc_free(test_ctx);
+}
+END_TEST
+
+START_TEST(test_group_rename_preserves_memberships)
+{
+    const char *membership_attrs[] = {
+        SYSDB_NAME, SYSDB_MEMBER, SYSDB_MEMBEROF, NULL
+    };
+    const gid_t parent_gid = 38100;
+    const gid_t old_gid = 38101;
+    const gid_t child_gid = 38102;
+    const uid_t user_uid = 38103;
+    struct sysdb_test_ctx *test_ctx;
+    struct sysdb_attrs *old_attrs;
+    struct sysdb_attrs *new_attrs;
+    struct ldb_dn *parent_dn;
+    struct ldb_dn *old_dn;
+    struct ldb_dn *new_dn;
+    struct ldb_dn *child_dn;
+    struct ldb_message *msg;
+    struct ldb_result *res;
+    const char *parent;
+    const char *old_name;
+    const char *new_name;
+    const char *child;
+    const char *user;
+    const char *parent_dn_str;
+    const char *old_dn_str;
+    const char *new_dn_str;
+    const char *child_dn_str;
+    const char *entry_name;
+    bool found_old = false;
+    bool found_new = false;
+    unsigned int i;
+    errno_t ret;
+
+    ret = setup_sysdb_tests(&test_ctx);
+    ck_assert_msg(ret == EOK, "Could not set up the test");
+
+    parent = sss_create_internal_fqname(test_ctx, "rename-parent",
+                                        test_ctx->domain->name);
+    old_name = sss_create_internal_fqname(test_ctx, "rename-old",
+                                          test_ctx->domain->name);
+    new_name = sss_create_internal_fqname(test_ctx, "rename-new",
+                                          test_ctx->domain->name);
+    child = sss_create_internal_fqname(test_ctx, "rename-child",
+                                       test_ctx->domain->name);
+    user = sss_create_internal_fqname(test_ctx, "rename-user",
+                                      test_ctx->domain->name);
+    ck_assert_msg(parent != NULL && old_name != NULL && new_name != NULL
+                  && child != NULL && user != NULL,
+                  "sss_create_internal_fqname failed");
+
+    old_attrs = sysdb_new_attrs(test_ctx);
+    ck_assert_msg(old_attrs != NULL, "sysdb_new_attrs failed");
+    ret = sysdb_attrs_add_string(old_attrs, SYSDB_SID_STR,
+                                 "S-1-5-21-123-456-789-111");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_string failed");
+
+    new_attrs = sysdb_new_attrs(test_ctx);
+    ck_assert_msg(new_attrs != NULL, "sysdb_new_attrs failed");
+    ret = sysdb_attrs_add_string(new_attrs, SYSDB_SID_STR,
+                                 "S-1-5-21-123-456-789-111");
+    ck_assert_msg(ret == EOK, "sysdb_attrs_add_string failed");
+
+    ret = sysdb_store_user(test_ctx->domain, user, NULL, user_uid, 0,
+                           "Rename User", "/home/rename-user", "/bin/sh",
+                           NULL, NULL, NULL, -1, 0);
+    ck_assert_msg(ret == EOK, "Could not add test user");
+
+    ret = sysdb_store_group(test_ctx->domain, parent, parent_gid, NULL, 0, 0);
+    ck_assert_msg(ret == EOK, "Could not add parent group");
+    ret = sysdb_store_group(test_ctx->domain, old_name, old_gid,
+                            old_attrs, 0, 0);
+    ck_assert_msg(ret == EOK, "Could not add original group");
+    ret = sysdb_store_group(test_ctx->domain, child, child_gid, NULL, 0, 0);
+    ck_assert_msg(ret == EOK, "Could not add child group");
+
+    ret = sysdb_add_group_member(test_ctx->domain, parent, old_name,
+                                 SYSDB_MEMBER_GROUP, false);
+    ck_assert_msg(ret == EOK, "Could not add renamed group to parent");
+    ret = sysdb_add_group_member(test_ctx->domain, old_name, child,
+                                 SYSDB_MEMBER_GROUP, false);
+    ck_assert_msg(ret == EOK, "Could not add child to renamed group");
+    ret = sysdb_add_group_member(test_ctx->domain, child, user,
+                                 SYSDB_MEMBER_USER, false);
+    ck_assert_msg(ret == EOK, "Could not add user to child group");
+
+    parent_dn = sysdb_group_dn(test_ctx, test_ctx->domain, parent);
+    old_dn = sysdb_group_dn(test_ctx, test_ctx->domain, old_name);
+    new_dn = sysdb_group_dn(test_ctx, test_ctx->domain, new_name);
+    child_dn = sysdb_group_dn(test_ctx, test_ctx->domain, child);
+    ck_assert_msg(parent_dn != NULL && old_dn != NULL && new_dn != NULL
+                  && child_dn != NULL, "sysdb_group_dn failed");
+    parent_dn_str = ldb_dn_get_linearized(parent_dn);
+    old_dn_str = ldb_dn_get_linearized(old_dn);
+    new_dn_str = ldb_dn_get_linearized(new_dn);
+    child_dn_str = ldb_dn_get_linearized(child_dn);
+    ck_assert_msg(parent_dn_str != NULL && old_dn_str != NULL
+                  && new_dn_str != NULL && child_dn_str != NULL,
+                  "ldb_dn_get_linearized failed");
+
+    ret = sysdb_store_group(test_ctx->domain, new_name, old_gid,
+                            new_attrs, 0, 0);
+    ck_assert_msg(ret == EOK, "Could not rename the group");
+
+    ret = sysdb_getgrnam(test_ctx, test_ctx->domain, old_name, &res);
+    ck_assert_msg(ret == EOK, "Could not look up the old group name");
+    ck_assert_int_eq(res->count, 0);
+
+    ret = sysdb_search_group_by_name(test_ctx, test_ctx->domain, new_name,
+                                     membership_attrs, &msg);
+    ck_assert_msg(ret == EOK, "Could not look up the renamed group");
+    ck_assert_msg(test_message_has_value(msg, SYSDB_MEMBER,
+                                         child_dn_str),
+                  "Renamed group lost its direct child");
+    ck_assert_msg(test_message_has_value(msg, SYSDB_MEMBEROF,
+                                         parent_dn_str),
+                  "Renamed group lost its parent");
+    talloc_zfree(msg);
+
+    ret = sysdb_search_group_by_name(test_ctx, test_ctx->domain, parent,
+                                     membership_attrs, &msg);
+    ck_assert_msg(ret == EOK, "Could not look up the parent group");
+    ck_assert_msg(test_message_has_value(msg, SYSDB_MEMBER,
+                                         new_dn_str),
+                  "Parent still refers to the old group DN");
+    ck_assert_msg(!test_message_has_value(msg, SYSDB_MEMBER,
+                                          old_dn_str),
+                  "Parent retained the old group DN");
+    talloc_zfree(msg);
+
+    ret = sysdb_search_group_by_name(test_ctx, test_ctx->domain, child,
+                                     membership_attrs, &msg);
+    ck_assert_msg(ret == EOK, "Could not look up the child group");
+    ck_assert_msg(test_message_has_value(msg, SYSDB_MEMBEROF,
+                                         new_dn_str),
+                  "Child did not receive the new group DN");
+    ck_assert_msg(test_message_has_value(msg, SYSDB_MEMBEROF,
+                                         parent_dn_str),
+                  "Child lost its inherited parent group");
+    ck_assert_msg(!test_message_has_value(msg, SYSDB_MEMBEROF,
+                                          old_dn_str),
+                  "Child retained the old group DN");
+    talloc_zfree(msg);
+
+    ret = sysdb_search_user_by_name(test_ctx, test_ctx->domain, user,
+                                    membership_attrs, &msg);
+    ck_assert_msg(ret == EOK, "Could not look up the test user");
+    ck_assert_msg(test_message_has_value(msg, SYSDB_MEMBEROF,
+                                         new_dn_str),
+                  "User did not receive the new group DN");
+    ck_assert_msg(test_message_has_value(msg, SYSDB_MEMBEROF,
+                                         child_dn_str),
+                  "User lost the child group");
+    ck_assert_msg(test_message_has_value(msg, SYSDB_MEMBEROF,
+                                         parent_dn_str),
+                  "User lost the inherited parent group");
+    ck_assert_msg(!test_message_has_value(msg, SYSDB_MEMBEROF,
+                                          old_dn_str),
+                  "User retained the old group DN");
+    talloc_zfree(msg);
+
+    ret = sysdb_initgroups(test_ctx, test_ctx->domain, user, &res);
+    ck_assert_msg(ret == EOK, "sysdb_initgroups failed");
+    ck_assert_int_eq(res->count, 4);
+    for (i = 0; i < res->count; i++) {
+        entry_name = ldb_msg_find_attr_as_string(res->msgs[i], SYSDB_NAME,
+                                                 NULL);
+        if (entry_name == NULL) {
+            continue;
+        }
+        if (strcmp(entry_name, old_name) == 0) {
+            found_old = true;
+        }
+        if (strcmp(entry_name, new_name) == 0) {
+            found_new = true;
+        }
+    }
+    ck_assert_msg(!found_old, "initgroups returned the old group name");
+    ck_assert_msg(found_new, "initgroups did not return the renamed group");
+
     talloc_free(test_ctx);
 }
 END_TEST
@@ -8038,6 +8242,7 @@ Suite *create_sysdb_suite(void)
 
     /* Test user and group renames */
     tcase_add_test(tc_sysdb, test_group_rename);
+    tcase_add_test(tc_sysdb, test_group_rename_preserves_memberships);
     tcase_add_test(tc_sysdb, test_user_rename);
 
     /* Test GetUserAttr with subdomain user */


### PR DESCRIPTION
## Problem

The memberOf plugin currently performs recursive reverse-membership searches
and derived-attribute writes while processing individual graph changes.

Dense caches and large group replacements can therefore trigger repeated
graph walks and large numbers of redundant writes within one transaction.
This can keep the backend occupied beyond its watchdog deadline and block
identity and login requests.

## Solution

Introduce a transaction-scoped membership graph engine that:

- snapshots graph-relevant cache data on the first relevant write;
- journals direct membership, ghost, delete, and rename changes;
- stages journal changes only after the lower LDB write succeeds;
- condenses membership cycles using strongly connected components;
- derives ancestor, `memberUid`, and ghost sets once at prepare-commit;
- writes only derived attributes whose values changed;
- bypasses graph setup for metadata-only cache updates;
- retains a legacy operational fallback during migration.

Expected lower-layer errors, such as duplicate member additions and removal of
absent members, leave the graph journal unchanged and do not poison the
transaction. An internal graph failure after a successful database write
still prevents commit because the database and journal can no longer be
safely reconciled.

Allocation growth, value cardinality, and integer conversions are explicitly
bounded before allocating or copying directory-controlled values.

## Tests

Add focused coverage for:

- repeated empty transaction lifecycles;
- transaction cancellation and migration-marker rollback;
- add, modify, delete, and rename replay in one transaction;
- direct and inherited ghost provenance;
- cycle handling;
- metadata-only updates;
- reducing a 3,500-member group to four members;
- duplicate additions and absent deletions followed by a valid update;
- direct member, reverse `memberOf`, and derived `memberUid` results.

## Scope

This addresses the repeated membership-graph work and large-group replacement
path described in #9049.

It depends on the rename support proposed in #9050. It does not include the
separate NSS mmap cache-warming optimization.

## Validation

- The equivalent transactional implementation has been built and exercised
  on the RHEL 9 and RHEL 10 investigation branches.
- Focused sysdb and NSS tests passed on those branches.
- Build, focused transaction tests, and the supervised reproducer will be run
  against the exact master-rebased series before marking this PR ready.

Refs #9049
Depends on #9050