### PR TITLE
nss: warm the group mmap cache during initgroups

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2525,7 +2525,8 @@ nss_srv_tests_LDFLAGS = \
     -Wl,-wrap,sss_packet_get_body \
     -Wl,-wrap,sss_packet_get_cmd \
     -Wl,-wrap,sss_cmd_send_empty \
-    -Wl,-wrap,sss_cmd_done
+    -Wl,-wrap,sss_cmd_done \
+    -Wl,-wrap,sss_mmap_cache_gr_store
 nss_srv_tests_LDADD = \
     $(LIBADD_DL) \
     $(CMOCKA_LIBS) \

--- a/src/responder/nss/nss_protocol_grent.c
+++ b/src/responder/nss/nss_protocol_grent.c
@@ -337,12 +337,59 @@ static bool is_group_filtered(struct sss_nc_ctx *ncache,
     return false;
 }
 
+static void
+sss_nss_protocol_cache_initgr_group(TALLOC_CTX **mem_ctx,
+                                    struct sss_nss_ctx *nss_ctx,
+                                    struct sss_nss_cmd_ctx *cmd_ctx,
+                                    struct sss_domain_info *domain,
+                                    struct ldb_message *msg)
+{
+    struct sized_string *name;
+    struct sized_string pwfield;
+    uint32_t gid;
+    errno_t ret;
+
+    /* With group members ignored, initgroups already has every field needed
+     * for a complete group memory-cache entry. Cache the same snapshot so
+     * callers do not have to resolve every returned GID separately. */
+    if (!domain->ignore_group_members
+            || nss_ctx->grp_mc_ctx == NULL
+            || (cmd_ctx->flags & SSS_NSS_EX_FLAG_INVALIDATE_CACHE) != 0) {
+        return;
+    }
+
+    if (*mem_ctx == NULL) {
+        *mem_ctx = talloc_new(NULL);
+        if (*mem_ctx == NULL) {
+            return;
+        }
+    } else {
+        talloc_free_children(*mem_ctx);
+    }
+
+    ret = sss_nss_get_grent(*mem_ctx, nss_ctx, domain, msg, &gid, &name);
+    if (ret != EOK) {
+        return;
+    }
+
+    to_sized_string(&pwfield, sss_nss_get_pwfield(nss_ctx, domain));
+    ret = sss_mmap_cache_gr_store(&nss_ctx->grp_mc_ctx, name, &pwfield,
+                                  gid, 0, "", 0);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Failed to store initgroups group %s (%s) in mem-cache "
+              "[%d]: %s!\n",
+              name->str, domain->name, ret, sss_strerror(ret));
+    }
+}
+
 errno_t
 sss_nss_protocol_fill_initgr(struct sss_nss_ctx *nss_ctx,
                              struct sss_nss_cmd_ctx *cmd_ctx,
                              struct sss_packet *packet,
                              struct cache_req_result *result)
 {
+    TALLOC_CTX *tmp_ctx;
     struct sss_domain_info *domain;
     struct sss_domain_info *grp_dom;
     struct ldb_message *user;
@@ -372,6 +419,9 @@ sss_nss_protocol_fill_initgr(struct sss_nss_ctx *nss_ctx,
     if (ret != EOK) {
         return ret;
     }
+
+    tmp_ctx = NULL;
+
     sss_packet_get_body(packet, &body, &body_len);
     rp = 2 * sizeof(uint32_t);
 
@@ -435,6 +485,9 @@ sss_nss_protocol_fill_initgr(struct sss_nss_ctx *nss_ctx,
         SAFEALIGN_COPY_UINT32(&body[rp], &gid, &rp);
         num_results++;
 
+        sss_nss_protocol_cache_initgr_group(&tmp_ctx, nss_ctx, cmd_ctx,
+                                            grp_dom, msg);
+
         /* Do not add the GID of the original primary group if the user is
          * already an explicit member of the group. */
         if (orig_gid == gid) {
@@ -465,6 +518,7 @@ sss_nss_protocol_fill_initgr(struct sss_nss_ctx *nss_ctx,
                   "Failed to store initgroups %s (%s) in mem-cache [%d]: %s!\n",
                   rawname.str, domain->name, ret, sss_strerror(ret));
             sss_packet_set_size(packet, 0);
+            talloc_free(tmp_ctx);
             return ret;
         }
     }
@@ -472,6 +526,8 @@ sss_nss_protocol_fill_initgr(struct sss_nss_ctx *nss_ctx,
     sss_packet_get_body(packet, &body, &body_len);
     SAFEALIGN_COPY_UINT32(body, &num_results, NULL);
     SAFEALIGN_SETMEM_UINT32(body + sizeof(uint32_t), 0, NULL); /* reserved */
+
+    talloc_free(tmp_ctx);
 
     return EOK;
 }

--- a/src/tests/cmocka/test_nss_srv.c
+++ b/src/tests/cmocka/test_nss_srv.c
@@ -87,6 +87,16 @@ const char *global_full_attrs[]  = { ORIG_ATTRS, EXTRA_ATTRS, NULL };
 
 struct sss_nss_test_ctx *sss_nss_test_ctx;
 
+struct group_mmap_store {
+    char name[256];
+    gid_t gid;
+};
+
+static bool capture_group_mmap_stores;
+static size_t group_mmap_store_count;
+static struct group_mmap_store group_mmap_stores[2];
+static char group_mmap_ctx_sentinel;
+
 /* Mock NSS structure */
 struct sss_nss_ctx *
 mock_nctx(TALLOC_CTX *mem_ctx)
@@ -180,6 +190,34 @@ int __wrap_sss_cmd_send_empty(struct cli_ctx *cctx, TALLOC_CTX *freectx)
 {
     sss_nss_test_ctx->tctx->done = true;
     sss_nss_test_ctx->tctx->error = ENOENT;
+    return EOK;
+}
+
+int __wrap_sss_mmap_cache_gr_store(struct sss_mc_ctx **_mcc,
+                                   const struct sized_string *name,
+                                   const struct sized_string *pw,
+                                   gid_t gid, size_t memnum,
+                                   const char *membuf, size_t memsize)
+{
+    struct group_mmap_store *store;
+
+    assert_true(capture_group_mmap_stores);
+    assert_non_null(_mcc);
+    assert_ptr_equal(*_mcc,
+                     (struct sss_mc_ctx *)&group_mmap_ctx_sentinel);
+    assert_non_null(name);
+    assert_non_null(pw);
+    assert_string_equal(pw->str, "*");
+    assert_int_equal(memnum, 0);
+    assert_non_null(membuf);
+    assert_int_equal(memsize, 0);
+    assert_true(group_mmap_store_count < N_ELEMENTS(group_mmap_stores));
+    assert_true(name->len <= sizeof(group_mmap_stores[0].name));
+
+    store = &group_mmap_stores[group_mmap_store_count++];
+    memcpy(store->name, name->str, name->len);
+    store->gid = gid;
+
     return EOK;
 }
 
@@ -3160,6 +3198,8 @@ struct group testinitgr_gr2 = {
 
 void test_sss_nss_initgroups(void **state)
 {
+    struct sss_mc_ctx *old_grp_mc_ctx;
+    bool old_ignore_group_members;
     errno_t ret;
     struct sysdb_attrs *attrs;
 
@@ -3201,6 +3241,15 @@ void test_sss_nss_initgroups(void **state)
                              SYSDB_MEMBER_USER);
     assert_int_equal(ret, EOK);
 
+    old_ignore_group_members =
+        sss_nss_test_ctx->tctx->dom->ignore_group_members;
+    old_grp_mc_ctx = sss_nss_test_ctx->nctx->grp_mc_ctx;
+    sss_nss_test_ctx->tctx->dom->ignore_group_members = true;
+    sss_nss_test_ctx->nctx->grp_mc_ctx =
+        (struct sss_mc_ctx *)&group_mmap_ctx_sentinel;
+    capture_group_mmap_stores = true;
+    group_mmap_store_count = 0;
+
     mock_input_user_or_group("testinitgr");
     will_return(__wrap_sss_packet_get_cmd, SSS_NSS_INITGR);
     will_return_always(__wrap_sss_packet_get_body, WRAP_CALL_REAL);
@@ -3213,7 +3262,19 @@ void test_sss_nss_initgroups(void **state)
 
     /* Wait until the test finishes with EOK */
     ret = test_ev_loop(sss_nss_test_ctx->tctx);
+    capture_group_mmap_stores = false;
+    sss_nss_test_ctx->tctx->dom->ignore_group_members =
+        old_ignore_group_members;
+    sss_nss_test_ctx->nctx->grp_mc_ctx = old_grp_mc_ctx;
     assert_int_equal(ret, EOK);
+
+    assert_int_equal(group_mmap_store_count, 2);
+    assert_string_equal(group_mmap_stores[0].name,
+                        testinitgr_gr1.gr_name);
+    assert_int_equal(group_mmap_stores[0].gid, testinitgr_gr1.gr_gid);
+    assert_string_equal(group_mmap_stores[1].name,
+                        testinitgr_gr2.gr_name);
+    assert_int_equal(group_mmap_stores[1].gid, testinitgr_gr2.gr_gid);
 }
 
 /* Test that searching for a nonexistent user yields ENOENT.


### PR DESCRIPTION
## Problem

With `ignore_group_members` enabled, an initgroups response already contains
the name and GID needed for a memberless group memory-cache entry.

However, the NSS responder currently caches only the initgroups result. It
does not populate the group mmap cache for the groups returned by that
request. Callers may therefore resolve each returned GID separately,
repeating responder and cache work during login and VPN-sensitive
authentication paths.

## Solution

While constructing an initgroups response:

- store each returned group in the group mmap cache;
- use an empty member list, consistent with `ignore_group_members`;
- skip warming when group members are not ignored;
- skip warming when cache invalidation was explicitly requested;
- reuse one temporary talloc context across the result loop.

Failure to warm an individual group remains non-fatal and does not change the
initgroups response.

## Tests

Wrap `sss_mmap_cache_gr_store()` in the NSS responder unit test and verify
that:

- both initgroups groups are written to the mmap cache;
- the expected names and GIDs are stored;
- no synthetic group members are added.

## Scope

This is an independent NSS responder optimization. It does not depend on the
verified-group rename or transactional memberOf changes in #9050 and #9051,
and it is not required for the #9049 watchdog fix.

## Validation

- The equivalent change is present in the tested RHEL 9 and RHEL 10
  investigation branches.
- NSS responder tests passed on those branches.
- The exact master-based branch will be built and its focused NSS tests run
  before marking this PR ready for review.

Related: #9049