### PR TITLE
Set ipv6_first as default lookup_family_order

### DIFF
--- a/src/man/po/bg.po
+++ b/src/man/po/bg.po
@@ -4128,7 +4128,7 @@ msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
+msgid "Default: ipv6_first"
 msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>

--- a/src/man/po/br.po
+++ b/src/man/po/br.po
@@ -4146,7 +4146,7 @@ msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
+msgid "Default: ipv6_first"
 msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>

--- a/src/man/po/ca.po
+++ b/src/man/po/ca.po
@@ -4521,8 +4521,8 @@ msgstr "ipv6_only: Intenta resoldre només noms màquina a adreces IPv6."
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
-msgstr "Per defecte: ipv4_first"
+msgid "Default: ipv6_first"
+msgstr "Per defecte: ipv6_first"
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>
 #: sssd.conf.5.xml:3598

--- a/src/man/po/cs.po
+++ b/src/man/po/cs.po
@@ -4183,7 +4183,7 @@ msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
+msgid "Default: ipv6_first"
 msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>

--- a/src/man/po/de.po
+++ b/src/man/po/de.po
@@ -4686,8 +4686,8 @@ msgstr "ipv6_only: versucht, nur Rechnernamen zu IPv6-Adressen aufzulösen"
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
-msgstr "Voreinstellung: ipv4_first"
+msgid "Default: ipv6_first"
+msgstr "Voreinstellung: ipv6_first"
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>
 #: sssd.conf.5.xml:3598

--- a/src/man/po/es.po
+++ b/src/man/po/es.po
@@ -5163,8 +5163,8 @@ msgstr "ipv6_only: Sólo intenta resolver nombres de host a direcciones IPv6."
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
-msgstr "Predeterminado: ipv4_first"
+msgid "Default: ipv6_first"
+msgstr "Predeterminado: ipv6_first"
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>
 #: sssd.conf.5.xml:3598

--- a/src/man/po/eu.po
+++ b/src/man/po/eu.po
@@ -4117,7 +4117,7 @@ msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
+msgid "Default: ipv6_first"
 msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>

--- a/src/man/po/fi.po
+++ b/src/man/po/fi.po
@@ -4166,7 +4166,7 @@ msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
+msgid "Default: ipv6_first"
 msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>

--- a/src/man/po/fr.po
+++ b/src/man/po/fr.po
@@ -4728,8 +4728,8 @@ msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
-msgstr "Par défaut : ipv4_first"
+msgid "Default: ipv6_first"
+msgstr "Par défaut : ipv6_first"
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>
 #: sssd.conf.5.xml:3598

--- a/src/man/po/hu.po
+++ b/src/man/po/hu.po
@@ -4128,7 +4128,7 @@ msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
+msgid "Default: ipv6_first"
 msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>

--- a/src/man/po/id.po
+++ b/src/man/po/id.po
@@ -4128,7 +4128,7 @@ msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
+msgid "Default: ipv6_first"
 msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>

--- a/src/man/po/it.po
+++ b/src/man/po/it.po
@@ -5208,8 +5208,8 @@ msgstr "ipv6_only: tenta di risolvere i nomi host solo in indirizzi IPv6."
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
-msgstr "Predefinito: ipv4_first"
+msgid "Default: ipv6_first"
+msgstr "Predefinito: ipv6_first"
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>
 #: sssd.conf.5.xml:3598

--- a/src/man/po/ja.po
+++ b/src/man/po/ja.po
@@ -4495,8 +4495,8 @@ msgstr "ipv6_only: ホスト名を IPv6 アドレスに名前解決すること�
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
-msgstr "初期値: ipv4_first"
+msgid "Default: ipv6_first"
+msgstr "初期値: ipv6_first"
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>
 #: sssd.conf.5.xml:3598

--- a/src/man/po/ka.po
+++ b/src/man/po/ka.po
@@ -4116,7 +4116,7 @@ msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3579
-msgid "Default: ipv4_first"
+msgid "Default: ipv6_first"
 msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>

--- a/src/man/po/ko.po
+++ b/src/man/po/ko.po
@@ -4268,8 +4268,8 @@ msgstr "ipv6_only: 호스트이름을 IPv6 주소로만 확인을 시도합니�
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3416
-msgid "Default: ipv4_first"
-msgstr "기본값: ipv4_first"
+msgid "Default: ipv6_first"
+msgstr "기본값: ipv6_first"
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>
 #: sssd.conf.5.xml:3422 sssd.conf.5.xml:3461

--- a/src/man/po/lv.po
+++ b/src/man/po/lv.po
@@ -4141,7 +4141,7 @@ msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
+msgid "Default: ipv6_first"
 msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>

--- a/src/man/po/nb_NO.po
+++ b/src/man/po/nb_NO.po
@@ -4128,7 +4128,7 @@ msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
+msgid "Default: ipv6_first"
 msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>

--- a/src/man/po/nl.po
+++ b/src/man/po/nl.po
@@ -4195,7 +4195,7 @@ msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
+msgid "Default: ipv6_first"
 msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>

--- a/src/man/po/pl.po
+++ b/src/man/po/pl.po
@@ -4061,7 +4061,7 @@ msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3528
-msgid "Default: ipv4_first"
+msgid "Default: ipv6_first"
 msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>

--- a/src/man/po/pt.po
+++ b/src/man/po/pt.po
@@ -5125,8 +5125,8 @@ msgstr "ipv6_only: Apenas tenta resolver nomes-de-máquinas em endereços IPv6."
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
-msgstr "Predefinição: ipv4_first"
+msgid "Default: ipv6_first"
+msgstr "Predefinição: ipv6_first"
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>
 #: sssd.conf.5.xml:3598

--- a/src/man/po/pt_BR.po
+++ b/src/man/po/pt_BR.po
@@ -4114,7 +4114,7 @@ msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
+msgid "Default: ipv6_first"
 msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>

--- a/src/man/po/ru.po
+++ b/src/man/po/ru.po
@@ -5164,8 +5164,8 @@ msgstr "ipv6_only: пытаться разрешать имена узлов т�
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
-msgstr "По умолчанию: ipv4_first"
+msgid "Default: ipv6_first"
+msgstr "По умолчанию: ipv6_first"
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>
 #: sssd.conf.5.xml:3598

--- a/src/man/po/sssd-docs.pot
+++ b/src/man/po/sssd-docs.pot
@@ -4126,7 +4126,7 @@ msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
+msgid "Default: ipv6_first"
 msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>

--- a/src/man/po/sv.po
+++ b/src/man/po/sv.po
@@ -5076,8 +5076,8 @@ msgstr "ipv6_only: Försök endast slå upp värdnamn som IPv6-adresser."
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
-msgstr "Standard: ipv4_first"
+msgid "Default: ipv6_first"
+msgstr "Standard: ipv6_first"
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>
 #: sssd.conf.5.xml:3598

--- a/src/man/po/tg.po
+++ b/src/man/po/tg.po
@@ -4127,7 +4127,7 @@ msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
+msgid "Default: ipv6_first"
 msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>

--- a/src/man/po/tr.po
+++ b/src/man/po/tr.po
@@ -4128,7 +4128,7 @@ msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
+msgid "Default: ipv6_first"
 msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>

--- a/src/man/po/uk.po
+++ b/src/man/po/uk.po
@@ -5198,8 +5198,8 @@ msgstr "ipv6_only: намагатися визначити назви вузлі
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
-msgstr "Типове значення: ipv4_first"
+msgid "Default: ipv6_first"
+msgstr "Типове значення: ipv6_first"
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>
 #: sssd.conf.5.xml:3598

--- a/src/man/po/zh_CN.po
+++ b/src/man/po/zh_CN.po
@@ -4125,7 +4125,7 @@ msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3592
-msgid "Default: ipv4_first"
+msgid "Default: ipv6_first"
 msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>

--- a/src/man/po/zh_TW.po
+++ b/src/man/po/zh_TW.po
@@ -4177,7 +4177,7 @@ msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><listitem><para>
 #: sssd.conf.5.xml:3660
-msgid "Default: ipv4_first"
+msgid "Default: ipv6_first"
 msgstr ""
 
 #. type: Content of: <reference><refentry><refsect1><para><variablelist><varlistentry><term>

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -3732,7 +3732,7 @@ pam_json_services = gdm-switchable-auth
                             ipv6_only: Only attempt to resolve hostnames to IPv6 addresses.
                         </para>
                         <para>
-                            Default: ipv4_first
+                            Default: ipv6_first
                         </para>
                     </listitem>
                 </varlistentry>

--- a/src/providers/data_provider_fo.c
+++ b/src/providers/data_provider_fo.c
@@ -881,7 +881,7 @@ void _be_fo_set_port_status(struct be_ctx *ctx,
 
 /* Resolver back end interface */
 static struct dp_option dp_res_default_opts[] = {
-    { "lookup_family_order", DP_OPT_STRING, { "ipv4_first" }, NULL_STRING },
+    { "lookup_family_order", DP_OPT_STRING, { "ipv6_first" }, NULL_STRING },
     { "dns_resolver_timeout", DP_OPT_NUMBER, { .number = 6 }, NULL_NUMBER },
     { "dns_resolver_op_timeout", DP_OPT_NUMBER, { .number = 3 }, NULL_NUMBER },
     { "dns_resolver_server_timeout", DP_OPT_NUMBER, { .number = 1000 }, NULL_NUMBER },


### PR DESCRIPTION
See #9053

V6 the specifically replacing protocol, so this should be the default.

This also makes it easier for people who want to remove V4 from their networks to know from their telemetry that their traffic does not actually require it.