### PR TITLE
ci: Swap flake and isort for ruff and reorder jobs

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -9,6 +9,70 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  files-changed:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      system_tests: ${{ steps.filter.outputs.system_tests }}
+    steps:
+    - uses: actions/checkout@v7
+    - uses: dorny/paths-filter@v4
+      id: filter
+      with:
+        # Include this workflow so edits to the CI job itself still run the checks.
+        filters: |
+          system_tests:
+            - 'src/tests/system/**'
+            - '.github/workflows/static-code-analysis.yml'
+
+  python-system-tests:
+    needs: files-changed
+    # ruff/black/mypy on src/tests/system, not the runtime suite. Skip on
+    # push/PR unless those files or this workflow changed; nightly still runs.
+    if: github.event_name == 'schedule' || needs.files-changed.outputs.system_tests == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/setup-python@v7
+      with:
+        python-version: '3.x'
+
+    - name: Checkout repository
+      uses: actions/checkout@v7
+
+    - name: Setup virtual environment
+      working-directory: ./src/tests/system
+      run: |
+        sudo apt-get update
+
+        # Install dependencies for python-ldap
+        sudo apt-get install -y libsasl2-dev python3-dev libldap2-dev libssl-dev libssh-dev
+
+        pip3 install virtualenv
+        python3 -m venv .venv
+        source .venv/bin/activate
+        pip3 install -r ./requirements.txt
+        # ruff replaces flake8, pycodestyle, and isort; black kept (ruff lint is Black-compatible)
+        pip3 install ruff mypy black
+
+    - name: ruff
+      if: always()
+      working-directory: ./src/tests/system
+      run: source .venv/bin/activate && ruff check .
+
+    - name: black
+      if: always()
+      working-directory: ./src/tests/system
+      run: source .venv/bin/activate && black --check --diff .
+
+    - name: mypy
+      if: always()
+      working-directory: ./src/tests/system
+      run: source .venv/bin/activate && mypy --install-types --non-interactive tests
+
   codeql:
     runs-on: ubuntu-latest
     permissions:

--- a/src/tests/system/pyproject.toml
+++ b/src/tests/system/pyproject.toml
@@ -9,10 +9,16 @@ ignore_missing_imports = true
 module = "ldap.*"
 ignore_missing_imports = true
 
-[tool.isort]
-line_length = 119
-profile = "black"
-add_imports = "from __future__ import annotations"
+[tool.ruff]
+line-length = 119
+exclude = [".venv"]
+
+[tool.ruff.lint]
+# E/W ≈ pycodestyle, F ≈ pyflakes/flake8, I ≈ isort; defaults are Black-compatible
+select = ["E", "W", "F", "I"]
+
+[tool.ruff.lint.isort]
+required-imports = ["from __future__ import annotations"]
 
 [tool.black]
 line-length = 119

--- a/src/tests/system/setup.cfg
+++ b/src/tests/system/setup.cfg
@@ -1,12 +1,2 @@
 [metadata]
 description-file = readme.md
-
-[flake8]
-max-line-length = 119
-ignore = E203,W503
-exclude = .venv
-
-[pycodestyle]
-max-line-length = 119
-ignore = E203,W503
-exclude = .venv


### PR DESCRIPTION
Ruff provides the same checks but runs a native code that is faster. It could be used also instead of black but current codebase would need to be reformatted first as ruff and black have different opinions on some cases.
Do not run python-system-tests when tests/system were not changed. Run python-system-tests before codeql (which is building sssd) to get its results much faster.