### PR TITLE
Spec: pin gdm-pam-extensions-devel to less than 51

### DIFF
--- a/contrib/sssd.spec.in
+++ b/contrib/sssd.spec.in
@@ -80,7 +80,7 @@ BuildRequires: docbook-style-xsl
 BuildRequires: doxygen
 BuildRequires: findutils
 BuildRequires: gcc
-BuildRequires: gdm-pam-extensions-devel
+BuildRequires: gdm-pam-extensions-devel < 1:51
 BuildRequires: gettext-devel
 BuildRequires: jansson-devel
 BuildRequires: libcap-devel


### PR DESCRIPTION
The newer version of gdm-pam-extensions-devel changes some MACROS from what is currently used in pam_sss.c. For now, starting with pinning the version in the spec file.   When the macros are fixed, the version pin will have to be removed.