### PR TITLE
krb5: restart krb5_child for Smartcard authentication

### DIFF
--- a/src/providers/krb5/krb5_auth.c
+++ b/src/providers/krb5/krb5_auth.c
@@ -866,6 +866,14 @@ static void krb5_auth_resolve_done(struct tevent_req *subreq)
         kr->is_offline = false;
     }
 
+    /* Restart krb5_child for Smartcard authentication in case a different
+     * certificate was selected by the user */
+    if (kr->pd->cmd == SSS_PAM_AUTHENTICATE && IS_SC_AUTHTOK(kr->pd->authtok)
+                && kr->pd->child_pid != 0) {
+        soft_terminate_krb5_child(state, kr->pd, kr->krb5_ctx);
+        kr->pd->child_pid = 0;
+    }
+
     subreq = handle_child_send(state, state->ev, kr);
     if (subreq == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "handle_child_send failed.\n");


### PR DESCRIPTION
In contrast to other authentication methods for PKINIT some information about the used Smartcard and certificate are already needed for the pre-authentication step to trigger the MIT Kerberos PKINIT module to get back the information if PKINIT is possible or not and if the Smartcard can be used for authentication. If krb5_child is kept running between the pre-authentication and the authentication step the information given during pre-authentication is used if Smartcard authentication was selected.

As long as only a single certificate is available there is no issue. But if there are multiple certificates which all apply to the given mapping and matching rules for the user trying to log in and the user can choose a certificate for authentication the authentication might fail if the certificate use during pre-authentication and the one selected by the user differ. Before the change to keep krb5_child running for all authentication methods this was not an issue since the fresh instance started during the authentication step was using the certificate selected by the user.

With this patch krb5_child is restart during the authentication step is Smartcard authentication was selected.

Reviewed-by: Iker Pedrosa <ipedrosa@redhat.com>
Reviewed-by: Justin Stephenson <jstephen@redhat.com>
(cherry picked from commit f3a36bec2a6c9fe11076c8f4673775a0d4221ad1)