### PR TITLE
tests: migrate multihost/alltests/test_default_debug_level.py

### DIFF
--- a/src/tests/system/tests/test_cache.py
+++ b/src/tests/system/tests/test_cache.py
@@ -433,3 +433,48 @@ def test_cache__both_ldap_user_email_and_extra_attribute_email_are_stored(client
     assert user_dict["description"] == ["gecos1"], "attribute 'description' was not correct"
     assert user_dict["mail"] == ["user1@example.test"], "attribute 'mail' was not correct"
     assert user_dict["email"] == ["user1@example.test"], "attribute 'email' was not correct"
+
+
+@pytest.mark.integration
+@pytest.mark.importance("high")
+@pytest.mark.ticket(bz=785898)
+@pytest.mark.topology(KnownTopology.LDAP)
+def test_cache__entry_cache_nowait_percentage_triggers_background_refresh(client: Client, provider: LDAP):
+    """
+    :title: entry_cache_nowait_percentage triggers midway background cache refresh
+    :setup:
+        1. Create user "user1"
+        2. Configure SSSD and set 'entry_cache_timeout to 60', 'entry_cache_nowait_percentage to 50',
+           and 'memcache_timeout to 1'
+        3. Start SSSD
+        4. Lookup user to populate the cache
+    :steps:
+        1. Truncate the domain log
+        2. Wait 35 seconds past the 50% nowait threshold and lookup user
+        3. Wait 5 seconds and read the domain log
+    :expectedresults:
+        1. Domain log is empty after truncation
+        2. User is returned from cache
+        3. Domain log contains "Got request for"
+    :customerscenario: True
+    :requirement: SSSD - Default debug level
+    """
+    provider.user("user1").add(password="Secret123")
+
+    client.sssd.domain["entry_cache_timeout"] = "60"
+    client.sssd.nss["entry_cache_nowait_percentage"] = "50"
+    client.sssd.nss["memcache_timeout"] = "1"
+    client.sssd.start()
+
+    assert client.tools.getent.passwd("user1") is not None, "Initial user lookup failed"
+
+    client.host.conn.run(f"truncate -s 0 {client.sssd.logs.domain()}")
+
+    time.sleep(35)
+
+    assert client.tools.getent.passwd("user1") is not None, "User lookup after midpoint failed"
+
+    time.sleep(5)
+
+    log = client.fs.read(client.sssd.logs.domain())
+    assert "Got request for" in log, "Background midpoint cache refresh was not triggered"

--- a/src/tests/system/tests/test_cache.py
+++ b/src/tests/system/tests/test_cache.py
@@ -439,42 +439,45 @@ def test_cache__both_ldap_user_email_and_extra_attribute_email_are_stored(client
 @pytest.mark.importance("high")
 @pytest.mark.ticket(bz=785898)
 @pytest.mark.topology(KnownTopology.LDAP)
-def test_cache__entry_cache_nowait_percentage_triggers_background_refresh(client: Client, provider: LDAP):
+def test_cache__nowait_percentage_serves_cache_then_refreshes_in_background(client: Client, provider: LDAP):
     """
-    :title: entry_cache_nowait_percentage triggers midway background cache refresh
+    :title: entry_cache_nowait_percentage serves a cached entry and refreshes it in the background
+    :description:
+        With 'entry_cache_nowait_percentage' set, SSSD returns a cached entry immediately (no wait) but
+        silently triggers a background refresh once the entry reaches that percentage of
+        'entry_cache_timeout', keeping the cache warm without making the client wait on the provider.
     :setup:
         1. Create user "user1"
-        2. Configure SSSD and set 'entry_cache_timeout to 60', 'entry_cache_nowait_percentage to 50',
+        2. Configure SSSD and set 'entry_cache_timeout to 20', 'entry_cache_nowait_percentage to 50',
            and 'memcache_timeout to 1'
         3. Start SSSD
         4. Lookup user to populate the cache
     :steps:
         1. Truncate the domain log
-        2. Wait 35 seconds past the 50% nowait threshold and lookup user
-        3. Wait 5 seconds and read the domain log
+        2. Repeatedly lookup user within the nowait window until the background refresh is logged
     :expectedresults:
         1. Domain log is empty after truncation
-        2. User is returned from cache
-        3. Domain log contains "Got request for"
+        2. Domain log contains "Got request for", the background refresh reached the provider before expiry
     :customerscenario: True
     :requirement: SSSD - Default debug level
     """
     provider.user("user1").add(password="Secret123")
 
-    client.sssd.domain["entry_cache_timeout"] = "60"
+    client.sssd.domain["entry_cache_timeout"] = "20"
     client.sssd.nss["entry_cache_nowait_percentage"] = "50"
     client.sssd.nss["memcache_timeout"] = "1"
     client.sssd.start()
 
-    assert client.tools.getent.passwd("user1") is not None, "Initial user lookup failed"
+    assert client.tools.getent.passwd("user1") is not None, "Initial user lookup failed!"
 
     client.host.conn.run(f"truncate -s 0 {client.sssd.logs.domain()}")
 
-    time.sleep(35)
+    refreshed = False
+    for _ in range(9):
+        time.sleep(2)
+        assert client.tools.getent.passwd("user1") is not None, "User lookup failed!"
+        if "Got request for" in client.fs.read(client.sssd.logs.domain()):
+            refreshed = True
+            break
 
-    assert client.tools.getent.passwd("user1") is not None, "User lookup after midpoint failed"
-
-    time.sleep(5)
-
-    log = client.fs.read(client.sssd.logs.domain())
-    assert "Got request for" in log, "Background midpoint cache refresh was not triggered"
+    assert refreshed, "Background midpoint cache refresh was not triggered!"

--- a/src/tests/system/tests/test_ldap.py
+++ b/src/tests/system/tests/test_ldap.py
@@ -840,3 +840,53 @@ def test_ldap__resolver_provider_lookup_services_by_port(client: Client, ldap: L
         assert protocol in result.protocol, f"Service '{protocol}' was not found!"
     else:
         raise AssertionError("No service entry found!")
+
+
+@pytest.mark.importance("medium")
+@pytest.mark.ticket(bz=785908)
+@pytest.mark.topology(KnownTopology.LDAP)
+def test_ldap__search_base_limits_rfc2307bis_posixgroup_scope(client: Client, ldap: LDAP):
+    """
+    :title: ldap_search_base limits group scope for rfc2307bis/groupOfNames schema
+    :setup:
+        1. Create ou=qagroup outside the intended search base
+        2. Create users tempuser2 and tempuser3
+        3. Create Group11 in ou=qagroup with member tempuser3
+        4. Create Group22 in ou=groups with member tempuser3
+        5. Create Group222 in ou=qagroup with member Group11
+        6. Create Group111 in ou=groups with members Group222, Group22, tempuser2
+        7. Configure SSSD with 'ldap_schema = rfc2307bis', 'ldap_group_object_class = groupOfNames',
+           'ldap_search_base = ou=groups', and 'enumerate = True'
+        8. Start SSSD
+    :steps:
+        1. Lookup Group111 in ou=groups
+        2. Lookup Group22 in ou=groups
+        3. Lookup Group222 in ou=qagroup
+        4. Lookup Group11 in ou=qagroup
+    :expectedresults:
+        1. Group111 is found
+        2. Group22 is found
+        3. Group222 is not found, outside ldap_search_base
+        4. Group11 is not found, outside ldap_search_base
+    :customerscenario: True
+    :requirement: SSSD - Default debug level
+    """
+    ou_qa = ldap.ou("qagroup").add()
+    user2 = ldap.user("tempuser2").add(uid=121298, gid=10000, password="Secret123")
+    user3 = ldap.user("tempuser3").add(uid=121297, gid=10000, password="Secret123")
+
+    grp11 = ldap.group("Group11", basedn=ou_qa, rfc2307bis=True).add(gid=222011, members=[user3])
+    grp22 = ldap.group("Group22", rfc2307bis=True).add(gid=222022, members=[user3])
+    grp222 = ldap.group("Group222", basedn=ou_qa, rfc2307bis=True).add(gid=222000, members=[grp11])
+    ldap.group("Group111", rfc2307bis=True).add(gid=111000, members=[grp222, grp22, user2])
+
+    client.sssd.domain["ldap_schema"] = "rfc2307bis"
+    client.sssd.domain["ldap_group_object_class"] = "groupOfNames"
+    client.sssd.dom("test")["ldap_search_base"] = f"ou=groups,{ldap.ldap.naming_context}"
+    client.sssd.domain["enumerate"] = "True"
+    client.sssd.start()
+
+    assert client.tools.getent.group("Group111") is not None, "Group111 was not found!"
+    assert client.tools.getent.group("Group22") is not None, "Group22 was not found!"
+    assert client.tools.getent.group("Group222") is None, "Group222 should not be visible outside search base"
+    assert client.tools.getent.group("Group11") is None, "Group11 should not be visible outside search base"

--- a/src/tests/system/tests/test_ldap.py
+++ b/src/tests/system/tests/test_ldap.py
@@ -847,46 +847,35 @@ def test_ldap__resolver_provider_lookup_services_by_port(client: Client, ldap: L
 @pytest.mark.topology(KnownTopology.LDAP)
 def test_ldap__search_base_limits_rfc2307bis_posixgroup_scope(client: Client, ldap: LDAP):
     """
-    :title: ldap_search_base limits group scope for rfc2307bis/groupOfNames schema
+    :title: ldap_search_base limits group scope for rfc2307bis and groupOfNames schema
+    :description:
+        When ldap_search_base is set, groups stored outside that base must not be resolved,
+        even when they are nested members of a group that is inside the base.
     :setup:
-        1. Create ou=qagroup outside the intended search base
-        2. Create users tempuser2 and tempuser3
-        3. Create Group11 in ou=qagroup with member tempuser3
-        4. Create Group22 in ou=groups with member tempuser3
-        5. Create Group222 in ou=qagroup with member Group11
-        6. Create Group111 in ou=groups with members Group222, Group22, tempuser2
-        7. Configure SSSD with 'ldap_schema = rfc2307bis', 'ldap_group_object_class = groupOfNames',
-           'ldap_search_base = ou=groups', and 'enumerate = True'
-        8. Start SSSD
+        1. Create groups inside and outside the configured ldap_search_base, nested across the boundary
+        2. Configure SSSD with rfc2307bis schema, groupOfNames object class and a limited ldap_search_base
+        3. Start SSSD
     :steps:
-        1. Lookup Group111 in ou=groups
-        2. Lookup Group22 in ou=groups
-        3. Lookup Group222 in ou=qagroup
-        4. Lookup Group11 in ou=qagroup
+        1. Lookup groups that are inside the search base
+        2. Lookup groups that are outside the search base
     :expectedresults:
-        1. Group111 is found
-        2. Group22 is found
-        3. Group222 is not found, outside ldap_search_base
-        4. Group11 is not found, outside ldap_search_base
+        1. Groups inside the search base are found
+        2. Groups outside the search base are not found
     :customerscenario: True
     :requirement: SSSD - Default debug level
     """
-    ou_qa = ldap.ou("qagroup").add()
-    user2 = ldap.user("tempuser2").add(uid=121298, gid=10000, password="Secret123")
-    user3 = ldap.user("tempuser3").add(uid=121297, gid=10000, password="Secret123")
+    outside_ou = ldap.ou("qagroup").add()
+    user = ldap.user("tempuser").add()
 
-    grp11 = ldap.group("Group11", basedn=ou_qa, rfc2307bis=True).add(gid=222011, members=[user3])
-    grp22 = ldap.group("Group22", rfc2307bis=True).add(gid=222022, members=[user3])
-    grp222 = ldap.group("Group222", basedn=ou_qa, rfc2307bis=True).add(gid=222000, members=[grp11])
-    ldap.group("Group111", rfc2307bis=True).add(gid=111000, members=[grp222, grp22, user2])
+    outside_group = ldap.group("outside_group", basedn=outside_ou, rfc2307bis=True).add(members=[user])
+    ldap.group("inside_group", rfc2307bis=True).add(members=[outside_group])
 
     client.sssd.domain["ldap_schema"] = "rfc2307bis"
     client.sssd.domain["ldap_group_object_class"] = "groupOfNames"
     client.sssd.dom("test")["ldap_search_base"] = f"ou=groups,{ldap.ldap.naming_context}"
-    client.sssd.domain["enumerate"] = "True"
     client.sssd.start()
 
-    assert client.tools.getent.group("Group111") is not None, "Group111 was not found!"
-    assert client.tools.getent.group("Group22") is not None, "Group22 was not found!"
-    assert client.tools.getent.group("Group222") is None, "Group222 should not be visible outside search base"
-    assert client.tools.getent.group("Group11") is None, "Group11 should not be visible outside search base"
+    assert client.tools.getent.group("inside_group") is not None, "inside_group was not found!"
+    assert (
+        client.tools.getent.group("outside_group") is None
+    ), "outside_group should not be visible outside search base!"


### PR DESCRIPTION
Migrates the two remaining legacy multihost tests from multihost/alltests/test_default_debug_level.py

Co-authored-by: Cursor [cursoragent@cursor.com](mailto:cursoragent@cursor.com)
Model used: Claude Opus 4.8