### PR TITLE
Remove obsolete entry_cache_computer_timeout option

### DIFF
--- a/src/confdb/confdb.c
+++ b/src/confdb/confdb.c
@@ -1475,17 +1475,6 @@ static errno_t confdb_init_domain_timeouts(struct confdb_ctx *cdb,
         goto done;
     }
 
-    /* Override the computer timeout, if specified */
-    ret = get_entry_as_uint32(res->msgs[0], &domain->computer_timeout,
-                              CONFDB_DOMAIN_COMPUTER_CACHE_TIMEOUT,
-                              entry_cache_timeout);
-    if (ret != EOK) {
-        DEBUG(SSSDBG_FATAL_FAILURE,
-              "Invalid value for [%s]\n",
-              CONFDB_DOMAIN_COMPUTER_CACHE_TIMEOUT);
-        goto done;
-    }
-
     /* Override the resolver timeout, if specified */
     ret = get_entry_as_uint32(res->msgs[0], &domain->resolver_timeout,
                               CONFDB_DOMAIN_RESOLVER_CACHE_TIMEOUT,

--- a/src/confdb/confdb.h
+++ b/src/confdb/confdb.h
@@ -246,7 +246,6 @@
 #define CONFDB_DOMAIN_AUTOFS_CACHE_TIMEOUT "entry_cache_autofs_timeout"
 #define CONFDB_DOMAIN_SUDO_CACHE_TIMEOUT "entry_cache_sudo_timeout"
 #define CONFDB_DOMAIN_SSH_HOST_CACHE_TIMEOUT "entry_cache_ssh_host_timeout"
-#define CONFDB_DOMAIN_COMPUTER_CACHE_TIMEOUT "entry_cache_computer_timeout"
 #define CONFDB_DOMAIN_RESOLVER_CACHE_TIMEOUT "entry_cache_resolver_timeout"
 #define CONFDB_DOMAIN_PWD_EXPIRATION_WARNING "pwd_expiration_warning"
 #define CONFDB_DOMAIN_REFRESH_EXPIRED_INTERVAL "refresh_expired_interval"
@@ -394,7 +393,6 @@ struct sss_domain_info {
     uint32_t autofsmap_timeout;
     uint32_t sudo_timeout;
     uint32_t ssh_host_timeout;
-    uint32_t computer_timeout;
     uint32_t resolver_timeout;
 
     uint32_t refresh_expired_interval;

--- a/src/config/cfg_rules.ini
+++ b/src/config/cfg_rules.ini
@@ -429,7 +429,6 @@ option = entry_cache_service_timeout
 option = entry_cache_autofs_timeout
 option = entry_cache_sudo_timeout
 option = entry_cache_ssh_host_timeout
-option = entry_cache_computer_timeout
 option = entry_cache_resolver_timeout
 option = refresh_expired_interval
 option = refresh_expired_interval_offset

--- a/src/man/sssd.conf.5.xml
+++ b/src/man/sssd.conf.5.xml
@@ -2832,19 +2832,6 @@ pam_json_services = gdm-switchable-auth
                 </varlistentry>
 
                 <varlistentry>
-                    <term>entry_cache_computer_timeout (integer)</term>
-                    <listitem>
-                        <para>
-                            How many seconds to keep the local computer
-                            entry before asking the backend again
-                        </para>
-                        <para>
-                            Default: entry_cache_timeout
-                        </para>
-                    </listitem>
-                </varlistentry>
-
-                <varlistentry>
                     <term>offline_timeout (integer)</term>
                     <listitem>
                         <para>


### PR DESCRIPTION
This patch removes option `entry_cache_computer_timeout` and all its references from the code (from sssd.conf.5.xml, cfg_rules.ini, confdb.c, confdb.h) since it is not used anymore. `entry_cache_computer_timeout` parameter was originally introduced with a2e7f68 but its usage was later removed with c02e09a.