### PR TITLE
man: fix TENNANT-ID typo in sssd-idp(5) example

### DIFF
--- a/src/man/sssd-idp.5.xml
+++ b/src/man/sssd-idp.5.xml
@@ -277,9 +277,9 @@ id_provider = idp
 idp_type = entra_id
 idp_client_id = 12345678-abcd-0101-efef-ba9876543210
 idp_client_secret = YOUR-CLIENT-SCERET
-idp_token_endpoint = https://login.microsoftonline.com/TENNANT-ID/oauth2/v2.0/token
+idp_token_endpoint = https://login.microsoftonline.com/TENANT-ID/oauth2/v2.0/token
 idp_userinfo_endpoint = https://graph.microsoft.com/v1.0/me
-idp_device_auth_endpoint = https://login.microsoftonline.com/TENNANT-ID/oauth2/v2.0/devicecode
+idp_device_auth_endpoint = https://login.microsoftonline.com/TENANT-ID/oauth2/v2.0/devicecode
 idp_id_scope = https://graph.microsoft.com/.default
 idp_auth_scope = openid profile email
 </programlisting>


### PR DESCRIPTION
Resolves: https://redhat.atlassian.net/browse/RHEL-245973

The idp_token_endpoint and idp_device_auth_endpoint placeholder URLs in the Entra ID EXAMPLE block contain TENNANT-ID instead of TENANT-ID.

Documentation only, no functional change.

Diff: src/man/sssd-idp.5.xml, 2 lines changed (both TENNANT-ID occurrences)