### PR TITLE
test_kcm: use config_apply instead of start to avoid proxy domain auth issue

### DIFF
--- a/src/tests/system/tests/test_kcm.py
+++ b/src/tests/system/tests/test_kcm.py
@@ -109,6 +109,8 @@ def test_kcm__ccache_holds_multiple_and_all_types_of_principals(client: Client, 
     client.local.user("tuser").add(password="Secret123")
 
     client.sssd.common.kcm(kdc)
+    client.sssd.kcm["ccache_storage"] = ccache_storage
+    client.sssd.config_apply()
 
     with client.ssh("tuser", "Secret123") as ssh:
         with client.auth.kerberos(ssh) as krb:

--- a/src/tests/system/tests/test_kcm.py
+++ b/src/tests/system/tests/test_kcm.py
@@ -108,7 +108,7 @@ def test_kcm__ccache_holds_multiple_and_all_types_of_principals(client: Client, 
     kdc.principal("host/myhost").add(password=None)
     client.local.user("tuser").add(password="Secret123")
 
-    client.sssd.common.kcm(kdc)
+    client.sssd.common.kcm(kdc, local_domain=False)
     client.sssd.kcm["ccache_storage"] = ccache_storage
     client.sssd.start()
 

--- a/src/tests/system/tests/test_kcm.py
+++ b/src/tests/system/tests/test_kcm.py
@@ -108,9 +108,7 @@ def test_kcm__ccache_holds_multiple_and_all_types_of_principals(client: Client, 
     kdc.principal("host/myhost").add(password=None)
     client.local.user("tuser").add(password="Secret123")
 
-    client.sssd.common.kcm(kdc, local_domain=False)
-    client.sssd.kcm["ccache_storage"] = ccache_storage
-    client.sssd.start()
+    client.sssd.common.kcm(kdc)
 
     with client.ssh("tuser", "Secret123") as ssh:
         with client.auth.kerberos(ssh) as krb:


### PR DESCRIPTION
## Problem

`test_kcm__ccache_holds_multiple_and_all_types_of_principals` fails on RHEL 9.6
with `SSHAuthenticationError` when the client image ships with
`passwd: sss files systemd` in `/etc/nsswitch.conf`.

The root cause is that `client.sssd.start()` starts SSSD with a proxy+files
domain (`id_provider=proxy`, `proxy_lib_name=files`,
`proxy_pam_target=system-auth`). When `sss` appears before `files` in
`nsswitch.conf`, SSSD returns `*` in the password field for NSS lookups.
`pam_unix` sees `*` and treats the account as locked, causing SSH
authentication to fail.

## Fix

Replace `client.sssd.start()` with `client.sssd.config_apply()` so that:

- `sssd.conf` is written with the correct `ccache_storage` setting (preserving
  the `memory`/`secdb` parametrization)
- `sssd.service` is **not** started → the proxy+files domain is never active
- `sssd-kcm` starts on demand via systemd socket activation when `kinit` first
  connects to the KCM socket

This approach is consistent with the observation that KCM functionality does
not require the full SSSD daemon to be running.

## Testing

Verified on RHEL 9.6 (`sssd-2.9.4`) with `passwd: sss files systemd` in
`/etc/nsswitch.conf`:

- **Before**: `test_kcm__ccache_holds_multiple_and_all_types_of_principals`
  fails with `SSHAuthenticationError` for both `memory` and `secdb`
- **After**: 2 passed (memory + secdb)

Closes: https://github.com/SSSD/sssd-test-framework/pull/265

Suggested-by: Sumit Bose <sbose@redhat.com>