### PR TITLE
man: fix doubled "are" in sssd-ldap(5)

### DIFF
--- a/src/man/sssd-ldap.5.xml
+++ b/src/man/sssd-ldap.5.xml
@@ -156,7 +156,7 @@
                             The namingContexts attribute must have a
                             single value with the DN of the search base of the
                             LDAP server to make this work. Multiple values are
-                            are not supported.
+                            not supported.
                         </para>
                     </listitem>
                 </varlistentry>


### PR DESCRIPTION

The ldap_search_base default paragraph in sssd-ldap(5) contains a doubled
word: "Multiple values are are not supported."

Documentation only, no functional change.