### PR TITLE
man: fix YOUR-CLIENT-SCERET typo in sssd-idp(5)

### DIFF
--- a/src/man/sssd-idp.5.xml
+++ b/src/man/sssd-idp.5.xml
@@ -276,7 +276,7 @@
 id_provider = idp
 idp_type = entra_id
 idp_client_id = 12345678-abcd-0101-efef-ba9876543210
-idp_client_secret = YOUR-CLIENT-SCERET
+idp_client_secret = YOUR-CLIENT-SECRET
 idp_token_endpoint = https://login.microsoftonline.com/TENANT-ID/oauth2/v2.0/token
 idp_userinfo_endpoint = https://graph.microsoft.com/v1.0/me
 idp_device_auth_endpoint = https://login.microsoftonline.com/TENANT-ID/oauth2/v2.0/devicecode
@@ -288,7 +288,7 @@ idp_auth_scope = openid profile email
 idp_type = keycloak:https://master.keycloak.test:8443/auth/admin/realms/master/
 id_provider = idp
 idp_client_id = myclient
-idp_client_secret = YOUR-CLIENT-SCERET
+idp_client_secret = YOUR-CLIENT-SECRET
 idp_token_endpoint = https://master.keycloak.test:8443/auth/realms/master/protocol/openid-connect/token
 idp_userinfo_endpoint = https://master.keycloak.test:8443/auth/realms/master/protocol/openid-connect/userinfo
 idp_device_auth_endpoint = https://master.keycloak.test:8443/auth/realms/master/protocol/openid-connect/auth/device


### PR DESCRIPTION
Resolves: https://redhat.atlassian.net/browse/RHEL-246729

The idp_client_secret placeholder in both EXAMPLE blocks of
sssd-idp(5) is misspelled YOUR-CLIENT-SCERET (missing C).

The [sssd.io](http://sssd.io/) IdP intro already uses the correct spelling YOUR-CLIENT-SECRET:
https://sssd.io/docs/idp/idp-introduction.html