### PR TITLE
failover: allow to kinit for ldap connections

### DIFF
--- a/src/krb5_plugin/sssd_krb5_locator_plugin.c
+++ b/src/krb5_plugin/sssd_krb5_locator_plugin.c
@@ -63,6 +63,8 @@
 #define SSSD_KRB5_LOCATOR_DEBUG "SSSD_KRB5_LOCATOR_DEBUG"
 #define SSSD_KRB5_LOCATOR_DISABLE "SSSD_KRB5_LOCATOR_DISABLE"
 #define SSSD_KRB5_LOCATOR_IGNORE_DNS_FAILURES "SSSD_KRB5_LOCATOR_IGNORE_DNS_FAILURES"
+#define SSSD_KRB5_LOCATOR_KDC_ADDRESS "SSSD_KRB5_LOCATOR_KDC_ADDRESS"
+#define SSSD_KRB5_LOCATOR_KPASSWD_ADDRESS "SSSD_KRB5_LOCATOR_KPASSWD_ADDRESS"
 #define DEBUG_KEY "[sssd_krb5_locator] "
 #define PLUGIN_DEBUG(format, ...) do { \
     if (ctx->debug) { \
@@ -79,6 +81,8 @@ struct sssd_ctx {
     char *sssd_realm;
     struct addr_port *kdc_addr;
     struct addr_port *kpasswd_addr;
+    struct addr_port *kdc_addr_override;
+    struct addr_port *kpasswd_addr_override;
     bool debug;
     bool disabled;
     bool kpasswdinfo_used;
@@ -314,9 +318,23 @@ static int get_krb5info(const char *realm, struct sssd_ctx *ctx,
 
     switch (svc) {
         case locate_service_kdc:
+            if (ctx->kdc_addr_override != NULL) {
+                PLUGIN_DEBUG("Using KDC address from environment variable.\n");
+                ret = copy_addr_port_list(ctx->kdc_addr_override, false,
+                                          &(ctx->kdc_addr));
+                return ret;
+            }
+
             name_tmpl = KDCINFO_TMPL;
             break;
         case locate_service_kpasswd:
+            if (ctx->kpasswd_addr_override != NULL) {
+                PLUGIN_DEBUG("Using kpasswd address from environment variable.\n");
+                ret = copy_addr_port_list(ctx->kpasswd_addr_override, false,
+                                          &(ctx->kpasswd_addr));
+                return ret;
+            }
+
             name_tmpl = KPASSWDINFO_TMPL;
             break;
         default:
@@ -393,6 +411,31 @@ done:
     return ret;
 }
 
+static struct addr_port *
+parse_address_from_env(struct sssd_ctx *ctx, const char *var_name)
+{
+    struct addr_port *addr = NULL;
+    const char *dummy;
+    int ret;
+
+    dummy = getenv(var_name);
+    if (dummy == NULL) {
+        /* No env var given, that is fine. */
+        return NULL;
+    }
+
+    ret = buf_to_addr_port_list(ctx, (const uint8_t *)dummy, strlen(dummy),
+                                &addr);
+    if (ret != EOK) {
+        PLUGIN_DEBUG("Failed to parse address from environment variable "
+                     "[%s=%s], ignoring.\n", var_name, dummy);
+        return NULL;
+    }
+
+    PLUGIN_DEBUG("Using address override [%s=%s].\n", var_name, dummy);
+    return addr;
+}
+
 krb5_error_code sssd_krb5_locator_init(krb5_context context,
                                        void **private_data)
 {
@@ -428,6 +471,9 @@ krb5_error_code sssd_krb5_locator_init(krb5_context context,
         PLUGIN_DEBUG("SSSD KRB5 locator plugin ignores DNS resolving errors.\n");
     }
 
+    ctx->kdc_addr_override = parse_address_from_env(ctx, SSSD_KRB5_LOCATOR_KDC_ADDRESS);
+    ctx->kpasswd_addr_override = parse_address_from_env(ctx, SSSD_KRB5_LOCATOR_KPASSWD_ADDRESS);
+
     *private_data = ctx;
 
     return 0;
@@ -444,6 +490,8 @@ void sssd_krb5_locator_close(void *private_data)
 
     free_addr_port_list(&(ctx->kdc_addr));
     free_addr_port_list(&(ctx->kpasswd_addr));
+    free_addr_port_list(&(ctx->kdc_addr_override));
+    free_addr_port_list(&(ctx->kpasswd_addr_override));
     free(ctx->sssd_realm);
     free(ctx);
 
@@ -490,6 +538,7 @@ krb5_error_code sssd_krb5_locator_lookup(void *private_data,
             return KRB5_PLUGIN_NO_HANDLE;
         }
 
+        free_addr_port_list(&(ctx->kdc_addr));
         ret = get_krb5info(realm, ctx, locate_service_kdc);
         if (ret != EOK) {
             PLUGIN_DEBUG("get_krb5info failed.\n");
@@ -504,16 +553,16 @@ krb5_error_code sssd_krb5_locator_lookup(void *private_data,
         ret = get_krb5info(realm, ctx, locate_service_kpasswd);
         if (ret != EOK) {
             PLUGIN_DEBUG("reading kpasswd address failed, "
-                         "using kdc address.\n");
+                            "using kdc address.\n");
             free_addr_port_list(&(ctx->kpasswd_addr));
             ret = copy_addr_port_list(ctx->kdc_addr, true,
-                                      &(ctx->kpasswd_addr));
-            if (ret != EOK) {
-                PLUGIN_DEBUG("copying address list failed.\n");
-                return KRB5_PLUGIN_NO_HANDLE;
-            }
+                                        &(ctx->kpasswd_addr));
         } else {
             ctx->kpasswdinfo_used = true;
+        }
+        if (ret != EOK) {
+            PLUGIN_DEBUG("Failed to get kpasswd addresses.\n");
+            return KRB5_PLUGIN_NO_HANDLE;
         }
     }
 

--- a/src/krb5_plugin/sssd_krb5_locator_plugin.c
+++ b/src/krb5_plugin/sssd_krb5_locator_plugin.c
@@ -172,13 +172,13 @@ done:
 }
 
 static int buf_to_addr_port_list(struct sssd_ctx *ctx,
-                                 uint8_t *buf, size_t buf_size,
+                                 const uint8_t *buf, size_t buf_size,
                                  struct addr_port **list)
 {
     struct addr_port *l = NULL;
     int ret;
-    uint8_t *p;
-    uint8_t *pn;
+    const uint8_t *p;
+    const uint8_t *pn;
     size_t c;
     size_t len;
     size_t addr_len;
@@ -221,7 +221,7 @@ static int buf_to_addr_port_list(struct sssd_ctx *ctx,
         }
 
         free(tmp);
-        tmp = strndup((char *) p, len);
+        tmp = strndup((const char *) p, len);
         if (tmp == NULL) {
             ret = ENOMEM;
             goto done;

--- a/src/man/sssd_krb5_locator_plugin.8.xml
+++ b/src/man/sssd_krb5_locator_plugin.8.xml
@@ -102,6 +102,18 @@
             in kdcinfo file. By default plugin returns KRB5_PLUGIN_NO_HANDLE
             to the caller immediately on first DNS resolving failure.
         </para>
+        <para>
+            If the environment variable SSSD_KRB5_LOCATOR_KDC_ADDRESS is set
+            to a KDC address the plugin will use this address instead of
+            reading the kdcinfo file. The address format is the same as in the
+            kdcinfo file (see above).
+        </para>
+        <para>
+            If the environment variable SSSD_KRB5_LOCATOR_KPASSWD_ADDRESS is
+            set to a kpasswd server address the plugin will use this address
+            instead of reading the kpasswdinfo file. The address format is the
+            same as in the kpasswdinfo file (see above).
+        </para>
     </refsect1>
 
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="include/seealso.xml" />

--- a/src/providers/ad/ad_gpo.c
+++ b/src/providers/ad/ad_gpo.c
@@ -4817,7 +4817,7 @@ ad_gpo_process_cse_send(TALLOC_CTX *mem_ctx,
         goto immediately;
     }
 
-    ret = sss_child_start(state, ev, GPO_CHILD, NULL, false,
+    ret = sss_child_start(state, ev, GPO_CHILD, NULL, false, NULL,
                           GPO_CHILD_LOG_FILE, AD_GPO_CHILD_OUT_FILENO,
                           /* no SIGCHLD cb */ NULL, NULL,
                           timeout,

--- a/src/providers/ad/ad_machine_pw_renewal.c
+++ b/src/providers/ad/ad_machine_pw_renewal.c
@@ -228,7 +228,7 @@ ad_machine_account_password_renewal_send(TALLOC_CTX *mem_ctx,
     }
 
     ret = sss_child_start(state, ev,
-                          renewal_data->prog_path, extra_args, true,
+                          renewal_data->prog_path, extra_args, true, NULL,
                           /* no log file */ NULL, STDERR_FILENO,
                           /* no SIGCHLD cb */ NULL, NULL,
                           (unsigned)(be_ptask_get_timeout(be_ptask)),

--- a/src/providers/be_dyndns.c
+++ b/src/providers/be_dyndns.c
@@ -1222,7 +1222,7 @@ nsupdate_child_send(TALLOC_CTX *mem_ctx,
     state->child_status = ETIMEDOUT;
 
     ret = sss_child_start(state, ev,
-                          NSUPDATE_PATH, args, true,
+                          NSUPDATE_PATH, args, true, NULL,
                           NULL, STDERR_FILENO,
                           nsupdate_child_handler, req,
                           DYNDNS_TIMEOUT,

--- a/src/providers/failover/failover.c
+++ b/src/providers/failover/failover.c
@@ -213,6 +213,26 @@ sss_failover_set_active_server(struct sss_failover_ctx *fctx,
     }
 }
 
+bool
+sss_failover_active_server_is_working(struct sss_failover_ctx *fctx)
+{
+    if (fctx->active_server == NULL) {
+        return false;
+    }
+
+    return sss_failover_server_is_working(fctx->active_server);
+}
+
+bool
+sss_failover_active_server_maybe_working(struct sss_failover_ctx *fctx)
+{
+    if (fctx->active_server == NULL) {
+        return false;
+    }
+
+    return sss_failover_server_maybe_working(fctx->active_server);
+}
+
 struct sss_failover_server *
 sss_failover_get_active_server(TALLOC_CTX *mem_ctx,
                                struct sss_failover_ctx *fctx)

--- a/src/providers/failover/failover.c
+++ b/src/providers/failover/failover.c
@@ -214,6 +214,13 @@ sss_failover_set_active_server(struct sss_failover_ctx *fctx,
 }
 
 bool
+sss_failover_active_server_cmp(struct sss_failover_ctx *fctx,
+                               struct sss_failover_server *server)
+{
+    return fctx->active_server == server;
+}
+
+bool
 sss_failover_active_server_is_working(struct sss_failover_ctx *fctx)
 {
     if (fctx->active_server == NULL) {

--- a/src/providers/failover/failover.c
+++ b/src/providers/failover/failover.c
@@ -206,6 +206,11 @@ sss_failover_set_active_server(struct sss_failover_ctx *fctx,
 
     DEBUG(SSSDBG_TRACE_FUNC, "Setting new active server %s\n", server->name);
     fctx->active_server = talloc_reference(fctx, server);
+    if (fctx->active_server == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!\n");
+        sss_failover_set_connection(fctx, NULL);
+        return;
+    }
 }
 
 void
@@ -230,6 +235,16 @@ sss_failover_set_connection(struct sss_failover_ctx *fctx, void *connection)
         return;
     }
 
+    if (fctx->active_server == NULL) {
+        /* This may be a bug in the code or OOM scenario that we can't detect in
+         * caller to simplify the API. Let's be defensive here. */
+        DEBUG(SSSDBG_OP_FAILURE,
+              "Trying to set connection without an active server, setting to NULL\n");
+        fctx->connection = NULL;
+        fctx->state = SSS_FAILOVER_STATE_DISCONNECTED;
+        return;
+    }
+
     DEBUG(SSSDBG_TRACE_FUNC, "Setting new connection %p\n", connection);
     fctx->connection = talloc_steal(fctx, connection);
     fctx->state = SSS_FAILOVER_STATE_CONNECTED;
@@ -238,9 +253,17 @@ sss_failover_set_connection(struct sss_failover_ctx *fctx, void *connection)
 void *
 sss_failover_get_connection(TALLOC_CTX *mem_ctx, struct sss_failover_ctx *fctx)
 {
+    void *conn;
+
     if (fctx->connection == NULL) {
         return NULL;
     }
 
-    return talloc_reference(mem_ctx, fctx->connection);
+    conn = talloc_reference(mem_ctx, fctx->connection);
+    if (conn == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!\n");
+        return NULL;
+    }
+
+    return conn;
 }

--- a/src/providers/failover/failover.c
+++ b/src/providers/failover/failover.c
@@ -137,6 +137,7 @@ sss_failover_init(TALLOC_CTX *mem_ctx,
 
     /* We are not connected to any server yet. */
     fctx->active_server = NULL;
+    fctx->state = SSS_FAILOVER_STATE_DISCONNECTED;
 
     fctx->vtable = talloc_zero(fctx, struct sss_failover_vtable);
     if (fctx->vtable == NULL) {
@@ -165,6 +166,21 @@ done:
 }
 
 void
+sss_failover_mark_offline(struct sss_failover_ctx *fctx)
+{
+    sss_failover_set_active_server(fctx, NULL);
+
+    DEBUG(SSSDBG_OP_FAILURE, "Failover [%s] is going offline\n", fctx->name);
+    fctx->state = SSS_FAILOVER_STATE_OFFLINE;
+}
+
+bool
+sss_failover_is_offline(struct sss_failover_ctx *fctx)
+{
+    return fctx->state == SSS_FAILOVER_STATE_OFFLINE;
+}
+
+void
 sss_failover_set_active_server(struct sss_failover_ctx *fctx,
                                struct sss_failover_server *server)
 {
@@ -178,6 +194,14 @@ sss_failover_set_active_server(struct sss_failover_ctx *fctx,
               fctx->active_server->name);
 
         talloc_unlink(fctx, fctx->active_server);
+    }
+
+    if (server == NULL) {
+        DEBUG(SSSDBG_TRACE_FUNC,
+              "Setting active server to NULL (we are not connected)\n");
+        sss_failover_set_connection(fctx, NULL);
+        fctx->active_server = NULL;
+        return;
     }
 
     DEBUG(SSSDBG_TRACE_FUNC, "Setting new active server %s\n", server->name);
@@ -199,8 +223,16 @@ sss_failover_set_connection(struct sss_failover_ctx *fctx, void *connection)
         talloc_unlink(fctx, fctx->connection);
     }
 
+    if (connection == NULL) {
+        DEBUG(SSSDBG_TRACE_FUNC, "Removing connection\n");
+        fctx->connection = NULL;
+        fctx->state = SSS_FAILOVER_STATE_DISCONNECTED;
+        return;
+    }
+
     DEBUG(SSSDBG_TRACE_FUNC, "Setting new connection %p\n", connection);
     fctx->connection = talloc_steal(fctx, connection);
+    fctx->state = SSS_FAILOVER_STATE_CONNECTED;
 }
 
 void *

--- a/src/providers/failover/failover.c
+++ b/src/providers/failover/failover.c
@@ -339,3 +339,10 @@ sss_failover_connection_get_ref(TALLOC_CTX *mem_ctx, struct sss_failover_ctx *fc
 
     return conn;
 }
+
+bool
+sss_failover_connection_cmp(struct sss_failover_ctx *fctx,
+                            void *conn)
+{
+    return fctx->connection == conn;
+}

--- a/src/providers/failover/failover.c
+++ b/src/providers/failover/failover.c
@@ -281,14 +281,20 @@ sss_failover_set_connection(struct sss_failover_ctx *fctx, void *connection)
                   ref_count - 1);
         }
 
-        /* If this is the last parent, the connection will be gracefully
-         * terminated via talloc destructor. Otherwise it will wait until the
-         * refcount drops to zero. */
-        talloc_unlink(fctx, fctx->connection);
-
         /* Old connection is removed. At this point we are not connected. */
         fctx->connection = NULL;
         fctx->state = SSS_FAILOVER_STATE_DISCONNECTED;
+
+        /* Notify backend that this connection is dropped. */
+        if (fctx->vtable->disconnected.cb != NULL) {
+            fctx->vtable->disconnected.cb(fctx, ptr,
+                                          fctx->vtable->disconnected.data);
+        }
+
+        /* If this is the last parent, the connection will be gracefully
+         * terminated via talloc destructor. Otherwise it will wait until the
+         * refcount drops to zero. */
+        talloc_unlink(fctx, ptr);
     }
 
     if (connection == NULL) {

--- a/src/providers/failover/failover.c
+++ b/src/providers/failover/failover.c
@@ -216,6 +216,10 @@ sss_failover_set_active_server(struct sss_failover_ctx *fctx,
 void
 sss_failover_set_connection(struct sss_failover_ctx *fctx, void *connection)
 {
+    if (fctx->connection == NULL && connection == NULL) {
+        return;
+    }
+
     if (fctx->connection != NULL) {
         if (connection == fctx->connection) {
             /* it is the same connection, nothing to do */

--- a/src/providers/failover/failover.c
+++ b/src/providers/failover/failover.c
@@ -255,36 +255,52 @@ sss_failover_get_active_server(TALLOC_CTX *mem_ctx,
 void
 sss_failover_set_connection(struct sss_failover_ctx *fctx, void *connection)
 {
-    if (fctx->connection == NULL && connection == NULL) {
+    size_t ref_count;
+    void *ptr;
+
+    if (connection == fctx->connection) {
+        /* It is the same connection, nothing to do. This also covers the case
+         * where both are set to NULL. */
         return;
     }
 
-    if (fctx->connection != NULL) {
-        if (connection == fctx->connection) {
-            /* it is the same connection, nothing to do */
-            return;
-        }
+    ptr = fctx->connection;
 
+    if (fctx->connection != NULL) {
         DEBUG(SSSDBG_TRACE_FUNC, "Releasing old connection %p\n",
               fctx->connection);
 
+        ref_count = talloc_reference_count(fctx->connection);
+        if (ref_count == 0) {
+            DEBUG(SSSDBG_TRACE_FUNC, "The connection is no longer used, it "
+                                     "will be freed immediately\n");
+        } else {
+            DEBUG(SSSDBG_TRACE_FUNC,
+                  "The connection is still used at %zu places, it will be "
+                  "freed once it reaches 0\n",
+                  ref_count - 1);
+        }
+
+        /* If this is the last parent, the connection will be gracefully
+         * terminated via talloc destructor. Otherwise it will wait until the
+         * refcount drops to zero. */
         talloc_unlink(fctx, fctx->connection);
+
+        /* Old connection is removed. At this point we are not connected. */
+        fctx->connection = NULL;
+        fctx->state = SSS_FAILOVER_STATE_DISCONNECTED;
     }
 
     if (connection == NULL) {
-        DEBUG(SSSDBG_TRACE_FUNC, "Removing connection\n");
-        fctx->connection = NULL;
-        fctx->state = SSS_FAILOVER_STATE_DISCONNECTED;
+        DEBUG(SSSDBG_TRACE_FUNC, "Connection %p was dropped\n", ptr);
         return;
     }
 
     if (fctx->active_server == NULL) {
         /* This may be a bug in the code or OOM scenario that we can't detect in
          * caller to simplify the API. Let's be defensive here. */
-        DEBUG(SSSDBG_OP_FAILURE,
-              "Trying to set connection without an active server, setting to NULL\n");
-        fctx->connection = NULL;
-        fctx->state = SSS_FAILOVER_STATE_DISCONNECTED;
+        DEBUG(SSSDBG_OP_FAILURE, "Trying to set connection without an active "
+                                 "server, connection was dropped\n");
         return;
     }
 

--- a/src/providers/failover/failover.c
+++ b/src/providers/failover/failover.c
@@ -374,3 +374,23 @@ sss_failover_connection_cmp(struct sss_failover_ctx *fctx,
 {
     return fctx->connection == conn;
 }
+
+void
+sss_failover_connection_op_start(struct sss_failover_ctx *fctx,
+                                 void *connection)
+{
+    if (fctx->vtable->conn_op_start.cb != NULL) {
+        fctx->vtable->conn_op_start.cb(fctx, connection,
+                                       fctx->vtable->conn_op_start.data);
+    }
+}
+
+void
+sss_failover_connection_op_done(struct sss_failover_ctx *fctx,
+                                void *connection)
+{
+    if (fctx->vtable->conn_op_done.cb != NULL) {
+        fctx->vtable->conn_op_done.cb(fctx, connection,
+                                      fctx->vtable->conn_op_done.data);
+    }
+}

--- a/src/providers/failover/failover.c
+++ b/src/providers/failover/failover.c
@@ -213,6 +213,18 @@ sss_failover_active_server_set(struct sss_failover_ctx *fctx,
     }
 }
 
+void
+sss_failover_active_server_remove(struct sss_failover_ctx *fctx,
+                                  struct sss_failover_server *server)
+{
+    /* We want to only remove the server if it is still the active one. */
+    if (!sss_failover_active_server_cmp(fctx, server)) {
+        return;
+    }
+
+    sss_failover_active_server_set(fctx, NULL);
+}
+
 struct sss_failover_server *
 sss_failover_active_server_get_ref(TALLOC_CTX *mem_ctx,
                                    struct sss_failover_ctx *fctx)
@@ -320,6 +332,18 @@ sss_failover_connection_set(struct sss_failover_ctx *fctx, void *connection)
     DEBUG(SSSDBG_TRACE_FUNC, "Setting new connection %p\n", connection);
     fctx->connection = talloc_steal(fctx, connection);
     fctx->state = SSS_FAILOVER_STATE_CONNECTED;
+}
+
+void
+sss_failover_connection_remove(struct sss_failover_ctx *fctx,
+                               void *conn)
+{
+    /* We want to only remove the connection if it is still the active one. */
+    if (!sss_failover_connection_cmp(fctx, conn)) {
+        return;
+    }
+
+    sss_failover_connection_set(fctx, NULL);
 }
 
 void *

--- a/src/providers/failover/failover.c
+++ b/src/providers/failover/failover.c
@@ -199,7 +199,7 @@ sss_failover_active_server_set(struct sss_failover_ctx *fctx,
     if (server == NULL) {
         DEBUG(SSSDBG_TRACE_FUNC,
               "Setting active server to NULL (we are not connected)\n");
-        sss_failover_set_connection(fctx, NULL);
+        sss_failover_connection_set(fctx, NULL);
         fctx->active_server = NULL;
         return;
     }
@@ -208,7 +208,7 @@ sss_failover_active_server_set(struct sss_failover_ctx *fctx,
     fctx->active_server = talloc_reference(fctx, server);
     if (fctx->active_server == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!\n");
-        sss_failover_set_connection(fctx, NULL);
+        sss_failover_connection_set(fctx, NULL);
         return;
     }
 }
@@ -260,7 +260,7 @@ sss_failover_active_server_maybe_working(struct sss_failover_ctx *fctx)
 }
 
 void
-sss_failover_set_connection(struct sss_failover_ctx *fctx, void *connection)
+sss_failover_connection_set(struct sss_failover_ctx *fctx, void *connection)
 {
     size_t ref_count;
     void *ptr;
@@ -323,7 +323,7 @@ sss_failover_set_connection(struct sss_failover_ctx *fctx, void *connection)
 }
 
 void *
-sss_failover_get_connection(TALLOC_CTX *mem_ctx, struct sss_failover_ctx *fctx)
+sss_failover_connection_get_ref(TALLOC_CTX *mem_ctx, struct sss_failover_ctx *fctx)
 {
     void *conn;
 

--- a/src/providers/failover/failover.c
+++ b/src/providers/failover/failover.c
@@ -213,6 +213,25 @@ sss_failover_set_active_server(struct sss_failover_ctx *fctx,
     }
 }
 
+struct sss_failover_server *
+sss_failover_get_active_server(TALLOC_CTX *mem_ctx,
+                               struct sss_failover_ctx *fctx)
+{
+    void *srv;
+
+    if (fctx->active_server == NULL) {
+        return NULL;
+    }
+
+    srv = talloc_reference(mem_ctx, fctx->active_server);
+    if (srv == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!\n");
+        return NULL;
+    }
+
+    return srv;
+}
+
 void
 sss_failover_set_connection(struct sss_failover_ctx *fctx, void *connection)
 {

--- a/src/providers/failover/failover.c
+++ b/src/providers/failover/failover.c
@@ -168,7 +168,7 @@ done:
 void
 sss_failover_mark_offline(struct sss_failover_ctx *fctx)
 {
-    sss_failover_set_active_server(fctx, NULL);
+    sss_failover_active_server_set(fctx, NULL);
 
     DEBUG(SSSDBG_OP_FAILURE, "Failover [%s] is going offline\n", fctx->name);
     fctx->state = SSS_FAILOVER_STATE_OFFLINE;
@@ -181,7 +181,7 @@ sss_failover_is_offline(struct sss_failover_ctx *fctx)
 }
 
 void
-sss_failover_set_active_server(struct sss_failover_ctx *fctx,
+sss_failover_active_server_set(struct sss_failover_ctx *fctx,
                                struct sss_failover_server *server)
 {
     if (fctx->active_server != NULL) {
@@ -213,6 +213,25 @@ sss_failover_set_active_server(struct sss_failover_ctx *fctx,
     }
 }
 
+struct sss_failover_server *
+sss_failover_active_server_get_ref(TALLOC_CTX *mem_ctx,
+                                   struct sss_failover_ctx *fctx)
+{
+    void *srv;
+
+    if (fctx->active_server == NULL) {
+        return NULL;
+    }
+
+    srv = talloc_reference(mem_ctx, fctx->active_server);
+    if (srv == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!\n");
+        return NULL;
+    }
+
+    return srv;
+}
+
 bool
 sss_failover_active_server_cmp(struct sss_failover_ctx *fctx,
                                struct sss_failover_server *server)
@@ -238,25 +257,6 @@ sss_failover_active_server_maybe_working(struct sss_failover_ctx *fctx)
     }
 
     return sss_failover_server_maybe_working(fctx->active_server);
-}
-
-struct sss_failover_server *
-sss_failover_get_active_server(TALLOC_CTX *mem_ctx,
-                               struct sss_failover_ctx *fctx)
-{
-    void *srv;
-
-    if (fctx->active_server == NULL) {
-        return NULL;
-    }
-
-    srv = talloc_reference(mem_ctx, fctx->active_server);
-    if (srv == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!\n");
-        return NULL;
-    }
-
-    return srv;
 }
 
 void

--- a/src/providers/failover/failover.c
+++ b/src/providers/failover/failover.c
@@ -194,6 +194,10 @@ sss_failover_active_server_set(struct sss_failover_ctx *fctx,
               fctx->active_server->name);
 
         talloc_unlink(fctx, fctx->active_server);
+
+        /* Also remove the connection associated with this server. */
+        sss_failover_connection_set(fctx, NULL);
+        fctx->active_server = NULL;
     }
 
     if (server == NULL) {

--- a/src/providers/failover/failover.h
+++ b/src/providers/failover/failover.h
@@ -156,6 +156,22 @@ bool
 sss_failover_is_offline(struct sss_failover_ctx *fctx);
 
 /**
+ * @brief Return true if active server is set and working.
+ *
+ * @param fctx
+ */
+bool
+sss_failover_active_server_is_working(struct sss_failover_ctx *fctx);
+
+/**
+ * @brief Return true if active server is set and in a non-error state.
+ *
+ * @param fctx
+ */
+bool
+sss_failover_active_server_maybe_working(struct sss_failover_ctx *fctx);
+
+/**
  * @brief Set active server.
  *
  * This is a noop if @server and @fctx->active_server is identical.

--- a/src/providers/failover/failover.h
+++ b/src/providers/failover/failover.h
@@ -260,4 +260,24 @@ bool
 sss_failover_connection_cmp(struct sss_failover_ctx *fctx,
                             void *conn);
 
+/**
+ * @brief New operation is using the connection.
+ *
+ * @param fctx
+ * @param connection
+ */
+void
+sss_failover_connection_op_start(struct sss_failover_ctx *fctx,
+                                 void *connection);
+
+/**
+ * @brief Operation that used the connection is finished.
+ *
+ * @param fctx
+ * @param connection
+ */
+void
+sss_failover_connection_op_done(struct sss_failover_ctx *fctx,
+                                void *connection);
+
 #endif /* _FAILOVER_H_ */

--- a/src/providers/failover/failover.h
+++ b/src/providers/failover/failover.h
@@ -156,6 +156,16 @@ bool
 sss_failover_is_offline(struct sss_failover_ctx *fctx);
 
 /**
+ * @brief Return true if the server is the same as currently active server.
+ *
+ * @param fctx
+ * @param server
+ */
+bool
+sss_failover_active_server_cmp(struct sss_failover_ctx *fctx,
+                               struct sss_failover_server *server);
+
+/**
  * @brief Return true if active server is set and working.
  *
  * @param fctx

--- a/src/providers/failover/failover.h
+++ b/src/providers/failover/failover.h
@@ -209,7 +209,7 @@ sss_failover_active_server_maybe_working(struct sss_failover_ctx *fctx);
  * This is a noop if @connection and @fctx->connection is identical.
  */
 void
-sss_failover_set_connection(struct sss_failover_ctx *fctx, void *connection);
+sss_failover_connection_set(struct sss_failover_ctx *fctx, void *connection);
 
 /**
  * @brief Get connection.
@@ -221,6 +221,6 @@ sss_failover_set_connection(struct sss_failover_ctx *fctx, void *connection);
  * @return void*
  */
 void *
-sss_failover_get_connection(TALLOC_CTX *mem_ctx, struct sss_failover_ctx *fctx);
+sss_failover_connection_get_ref(TALLOC_CTX *mem_ctx, struct sss_failover_ctx *fctx);
 
 #endif /* _FAILOVER_H_ */

--- a/src/providers/failover/failover.h
+++ b/src/providers/failover/failover.h
@@ -165,6 +165,19 @@ sss_failover_set_active_server(struct sss_failover_ctx *fctx,
                                struct sss_failover_server *server);
 
 /**
+ * @brief Get active server.
+ *
+ * The output is talloc_reference to the active server attached to mem_ctx.
+ *
+ * @param mem_ctx
+ * @param fctx
+ * @return struct sss_failover_server*
+ */
+struct sss_failover_server *
+sss_failover_get_active_server(TALLOC_CTX *mem_ctx,
+                               struct sss_failover_ctx *fctx);
+
+/**
  * @brief Set new connection, release old one.
  *
  * This is a noop if @connection and @fctx->connection is identical.

--- a/src/providers/failover/failover.h
+++ b/src/providers/failover/failover.h
@@ -67,6 +67,20 @@ struct sss_failover_options {
     unsigned int negative_dns_srv_ttl;
 };
 
+enum sss_failover_state {
+    /* Not connected to any server, but this is not an error. There was no
+     * connection attempt yet or the active server was gracefully
+     * disconnected. */
+    SSS_FAILOVER_STATE_DISCONNECTED,
+
+    /* Connected and online. There is a working connection. */
+    SSS_FAILOVER_STATE_CONNECTED,
+
+    /* There is no working connection and no more servers to try. All servers
+     * are down. */
+    SSS_FAILOVER_STATE_OFFLINE
+};
+
 struct sss_failover_ctx {
     struct tevent_context *ev;
     char *name;
@@ -94,6 +108,9 @@ struct sss_failover_ctx {
     /* Currently active server. */
     struct sss_failover_server *active_server;
 
+    /* Current failover connection state. */
+    enum sss_failover_state state;
+
     /* Backend specific established connection. */
     void *connection;
 
@@ -118,6 +135,25 @@ sss_failover_init(TALLOC_CTX *mem_ctx,
                   const char *name,
                   struct resolv_ctx *resolver_ctx,
                   enum restrict_family family_order);
+
+/**
+ * @brief Mark the failover as offline - there are no available servers.
+ *
+ * This will clear the active server and set fctx state to
+ * SSS_FAILOVER_STATE_OFFLINE.
+ *
+ * @param fctx
+ */
+void
+sss_failover_mark_offline(struct sss_failover_ctx *fctx);
+
+/**
+ * @brief Return true if failover is offline.
+ *
+ * @param fctx
+ */
+bool
+sss_failover_is_offline(struct sss_failover_ctx *fctx);
 
 /**
  * @brief Set active server.

--- a/src/providers/failover/failover.h
+++ b/src/providers/failover/failover.h
@@ -165,6 +165,20 @@ sss_failover_active_server_set(struct sss_failover_ctx *fctx,
                                struct sss_failover_server *server);
 
 /**
+ * @brief Remove current active server if it is the same as @server.
+ *
+ * This compares active_server to @server and if they are identical,
+ * active_server is set to NULL. The current connection is also dropped and
+ * set to NULL.
+ *
+ * @param fctx
+ * @param server
+ */
+void
+sss_failover_active_server_remove(struct sss_failover_ctx *fctx,
+                                  struct sss_failover_server *server);
+
+/**
  * @brief Get active server.
  *
  * The output is talloc_reference to the active server attached to mem_ctx.
@@ -210,6 +224,19 @@ sss_failover_active_server_maybe_working(struct sss_failover_ctx *fctx);
  */
 void
 sss_failover_connection_set(struct sss_failover_ctx *fctx, void *connection);
+
+/**
+ * @brief Remove current connection if it is the same as @conn.
+ *
+ * This compares current connection to @conn and if they are identical,
+ * connection is set to NULL.
+ *
+ * @param fctx
+ * @param conn
+ */
+void
+sss_failover_connection_remove(struct sss_failover_ctx *fctx,
+                               void *conn);
 
 /**
  * @brief Get connection.

--- a/src/providers/failover/failover.h
+++ b/src/providers/failover/failover.h
@@ -156,6 +156,28 @@ bool
 sss_failover_is_offline(struct sss_failover_ctx *fctx);
 
 /**
+ * @brief Set active server.
+ *
+ * This is a noop if @server and @fctx->active_server is identical.
+ */
+void
+sss_failover_active_server_set(struct sss_failover_ctx *fctx,
+                               struct sss_failover_server *server);
+
+/**
+ * @brief Get active server.
+ *
+ * The output is talloc_reference to the active server attached to mem_ctx.
+ *
+ * @param mem_ctx
+ * @param fctx
+ * @return struct sss_failover_server*
+ */
+struct sss_failover_server *
+sss_failover_active_server_get_ref(TALLOC_CTX *mem_ctx,
+                                   struct sss_failover_ctx *fctx);
+
+/**
  * @brief Return true if the server is the same as currently active server.
  *
  * @param fctx
@@ -180,28 +202,6 @@ sss_failover_active_server_is_working(struct sss_failover_ctx *fctx);
  */
 bool
 sss_failover_active_server_maybe_working(struct sss_failover_ctx *fctx);
-
-/**
- * @brief Set active server.
- *
- * This is a noop if @server and @fctx->active_server is identical.
- */
-void
-sss_failover_set_active_server(struct sss_failover_ctx *fctx,
-                               struct sss_failover_server *server);
-
-/**
- * @brief Get active server.
- *
- * The output is talloc_reference to the active server attached to mem_ctx.
- *
- * @param mem_ctx
- * @param fctx
- * @return struct sss_failover_server*
- */
-struct sss_failover_server *
-sss_failover_get_active_server(TALLOC_CTX *mem_ctx,
-                               struct sss_failover_ctx *fctx);
 
 /**
  * @brief Set new connection, release old one.

--- a/src/providers/failover/failover.h
+++ b/src/providers/failover/failover.h
@@ -223,4 +223,14 @@ sss_failover_connection_set(struct sss_failover_ctx *fctx, void *connection);
 void *
 sss_failover_connection_get_ref(TALLOC_CTX *mem_ctx, struct sss_failover_ctx *fctx);
 
+/**
+ * @brief Return true if the connection is the same as the current connection.
+ *
+ * @param fctx
+ * @param conn
+ */
+bool
+sss_failover_connection_cmp(struct sss_failover_ctx *fctx,
+                            void *conn);
+
 #endif /* _FAILOVER_H_ */

--- a/src/providers/failover/failover_refresh_candidates.c
+++ b/src/providers/failover/failover_refresh_candidates.c
@@ -178,11 +178,18 @@ sss_failover_ping_recv(TALLOC_CTX *mem_ctx,
                        struct sss_failover_server **_server)
 {
     struct sss_failover_ping_state *state;
+    struct sss_failover_server *server;
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     state = tevent_req_data(req, struct sss_failover_ping_state);
-    *_server = talloc_reference(mem_ctx, state->server);
+    server = talloc_reference(mem_ctx, state->server);
+    if (server == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!\n");
+        return ENOMEM;
+    }
+
+    *_server = server;
 
     return EOK;
 }

--- a/src/providers/failover/failover_refresh_candidates.c
+++ b/src/providers/failover/failover_refresh_candidates.c
@@ -695,6 +695,12 @@ sss_failover_refresh_candidates_done(struct tevent_req *subreq)
     state->fctx->candidates->servers = talloc_steal(state->fctx->candidates,
                                                     candidates);
 
+    if (state->fctx->vtable->new_candidates.cb != NULL) {
+        state->fctx->vtable->new_candidates.cb(
+            state->fctx, state->fctx->candidates->servers,
+            state->fctx->vtable->new_candidates.data);
+    }
+
 done:
     if (ret != EOK) {
         tevent_req_error(req, ret);

--- a/src/providers/failover/failover_server.c
+++ b/src/providers/failover/failover_server.c
@@ -278,6 +278,12 @@ done:
 }
 
 bool
+sss_failover_server_is_working(struct sss_failover_server *srv)
+{
+    return srv->state == SSS_FAILOVER_SERVER_STATE_WORKING;
+}
+
+bool
 sss_failover_server_maybe_working(struct sss_failover_server *srv)
 {
     switch (srv->state) {

--- a/src/providers/failover/failover_server.h
+++ b/src/providers/failover/failover_server.h
@@ -140,6 +140,11 @@ struct sss_failover_server *
 sss_failover_server_clone(TALLOC_CTX *mem_ctx,
                           const struct sss_failover_server *srv);
 
+/**
+ * @brief Return true if the server is marked as working.
+ */
+bool
+sss_failover_server_is_working(struct sss_failover_server *srv);
 
 /**
  * @brief Return true if server state suggest that the server may work.

--- a/src/providers/failover/failover_transaction.c
+++ b/src/providers/failover/failover_transaction.c
@@ -274,6 +274,9 @@ sss_failover_transaction_kinit_done(struct tevent_req *subreq)
         sss_failover_mark_offline(state->fctx->kinit_ctx);
         sss_failover_mark_offline(state->fctx);
 
+        /* Return ERR_OFFLINE to the caller. */
+        ret = ERR_OFFLINE;
+
         goto done;
     } else if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
@@ -347,6 +350,9 @@ sss_failover_transaction_connect_done(struct tevent_req *subreq)
         DEBUG(SSSDBG_OP_FAILURE,
               "There are no more servers to try, cancelling operation\n");
         sss_failover_mark_offline(state->fctx);
+
+        /* Return ERR_OFFLINE to the caller. */
+        ret = ERR_OFFLINE;
         goto done;
     } else if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,

--- a/src/providers/failover/failover_transaction.c
+++ b/src/providers/failover/failover_transaction.c
@@ -58,6 +58,7 @@ struct sss_failover_transaction_state {
      * connected_callback is fired. */
     struct tevent_req *connected_req;
     tevent_req_fn connected_callback;
+    void *connection;
 
     /* Single transaction attempt. If successful, the main transaction request
      * is finished. Otherwise, we try next server. */
@@ -82,14 +83,17 @@ sss_failover_transaction_finish_connection(
     connected_state = tevent_req_data(state->connected_req,
                             struct sss_failover_transaction_connected_state);
 
-    DEBUG(SSSDBG_TRACE_FUNC, "Connected to %s, connection %p\n",
-          server->name, connection);
+    DEBUG(SSSDBG_TRACE_FUNC, "Connected to %s, connection %p\n", server->name,
+          connection);
 
     connected_state->connection = talloc_reference(connected_state, connection);
     if (connected_state->connection == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!\n");
         return ENOMEM;
     }
+
+    /* New operation starts once we call tevent_req_done. */
+    sss_failover_connection_op_start(state->fctx, connection);
 
     /* We are connected. Now continue with connected_callback. */
     tevent_req_done(state->connected_req);
@@ -120,6 +124,22 @@ sss_failover_transaction_attempt_done(struct tevent_req *attempt_req);
 
 static void
 sss_failover_transaction_done(struct tevent_req *subreq);
+
+static void
+sss_failover_transaction_ex_cleanup(struct tevent_req *req,
+                                    enum tevent_req_state req_state)
+{
+    struct sss_failover_transaction_state *state;
+
+    state = tevent_req_data(req, struct sss_failover_transaction_state);
+
+    /* If the transaction is freed with ongoing attempt in progress, we need to
+     * make sure to notify the connection that it is no longer used by this
+     * operation. */
+    if (state->connection != NULL) {
+        sss_failover_connection_op_done(state->fctx, state->connection);
+    }
+}
 
 errno_t
 sss_failover_transaction_ex_send(TALLOC_CTX *mem_ctx,
@@ -157,9 +177,11 @@ sss_failover_transaction_ex_send(TALLOC_CTX *mem_ctx,
     state->caller_data_size = talloc_get_size(state->caller_data);
     state->caller_data_type = talloc_get_name(state->caller_data);
     state->connected_callback = connected_callback;
+    state->connection = NULL;
     state->attempts = 0;
 
     tevent_req_set_callback(req, sss_failover_transaction_done, caller_req);
+    tevent_req_set_cleanup_fn(req, sss_failover_transaction_ex_cleanup);
 
     ret = sss_failover_transaction_restart(req);
     if (ret != EOK) {
@@ -237,7 +259,6 @@ sss_failover_transaction_next(struct tevent_req *req)
 {
     struct sss_failover_transaction_state *state;
     errno_t ret;
-    void *connection;
 
     state = tevent_req_data(req, struct sss_failover_transaction_state);
 
@@ -249,8 +270,8 @@ sss_failover_transaction_next(struct tevent_req *req)
 
     /* We can reuse existing connection. Let's see if there is one. */
     if (state->reuse_connection && sss_failover_active_server_is_working(state->fctx)) {
-        connection = sss_failover_connection_get_ref(state, state->fctx);
-        if (connection != NULL) {
+        state->connection = sss_failover_connection_get_ref(state, state->fctx);
+        if (state->connection != NULL) {
             DEBUG(SSSDBG_TRACE_FUNC, "Reusing active connection\n");
             state->current_server = sss_failover_active_server_get_ref(state,
                                                                    state->fctx);
@@ -259,7 +280,7 @@ sss_failover_transaction_next(struct tevent_req *req)
             }
 
             return sss_failover_transaction_finish_connection(
-                state, state->current_server, connection);
+                state, state->current_server, state->connection);
         }
     }
 
@@ -374,7 +395,6 @@ sss_failover_transaction_connect_done(struct tevent_req *subreq)
 {
     struct sss_failover_transaction_state *state;
     struct tevent_req *req;
-    void *connection;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
@@ -384,7 +404,7 @@ sss_failover_transaction_connect_done(struct tevent_req *subreq)
      * to an active, connected server. */
     ret = sss_failover_vtable_op_connect_recv(state, subreq,
                                               &state->current_server,
-                                              &connection);
+                                              &state->connection);
     talloc_zfree(subreq);
     if (ret == ERR_NO_MORE_SERVERS) {
         DEBUG(SSSDBG_OP_FAILURE,
@@ -404,13 +424,14 @@ sss_failover_transaction_connect_done(struct tevent_req *subreq)
     /* Remember the server if we can reuse the connection. */
     if (state->reuse_connection) {
         sss_failover_active_server_set(state->fctx, state->current_server);
-        sss_failover_connection_set(state->fctx, connection);
+        sss_failover_connection_set(state->fctx, state->connection);
+        state->connection = sss_failover_connection_get_ref(state, state->fctx);
     }
 
     /* We are done. Finish the connection callback. */
     ret = sss_failover_transaction_finish_connection(state,
                                                      state->current_server,
-                                                     connection);
+                                                     state->connection);
 
 done:
     if (ret != EOK) {
@@ -432,6 +453,13 @@ static void sss_failover_transaction_attempt_done(struct tevent_req *attempt_req
     req = tevent_req_callback_data(attempt_req, struct tevent_req);
     state = tevent_req_data(req, struct sss_failover_transaction_state);
     attempt_state = _tevent_req_data(attempt_req);
+
+    if (state->connection != NULL) {
+        /* The operation on this connection is over. */
+        sss_failover_connection_op_done(state->fctx, state->connection);
+        talloc_unlink(state, state->connection);
+        state->connection = NULL;
+    }
 
     /* Copy the transaction_req state back to the caller_req state. We can not
      * free the transaction state as there is no way to move possible new data
@@ -516,7 +544,6 @@ _sss_failover_transaction_connected_recv(TALLOC_CTX *mem_ctx,
                                         struct tevent_req *req)
 {
     struct sss_failover_transaction_connected_state *state;
-    void *conn;
 
     state = tevent_req_data(req,
                             struct sss_failover_transaction_connected_state);
@@ -526,11 +553,6 @@ _sss_failover_transaction_connected_recv(TALLOC_CTX *mem_ctx,
         return NULL;
     }
 
-    conn = talloc_reference(mem_ctx, state->connection);
-    if (conn == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory\n");
-        return NULL;
-    }
-
-    return conn;
+    /* It is a talloc_reference so we have to use reparent. */
+    return talloc_reparent(state, mem_ctx, state->connection);
 }

--- a/src/providers/failover/failover_transaction.c
+++ b/src/providers/failover/failover_transaction.c
@@ -356,7 +356,6 @@ sss_failover_transaction_connect(struct tevent_req *req)
     DEBUG(SSSDBG_TRACE_FUNC, "Trying to establish connection\n");
 
     subreq = sss_failover_vtable_op_connect_send(state, state->ev, state->fctx,
-                                                 state->reuse_connection,
                                                  state->authenticate_connection,
                                                  state->read_rootdse,
                                                  state->force_tls,

--- a/src/providers/failover/failover_transaction.c
+++ b/src/providers/failover/failover_transaction.c
@@ -72,6 +72,32 @@ struct sss_failover_transaction_state {
 };
 
 static errno_t
+sss_failover_transaction_finish_connection(
+    struct sss_failover_transaction_state *state,
+    struct sss_failover_server *server,
+    void *connection)
+{
+    struct sss_failover_transaction_connected_state *connected_state;
+
+    connected_state = tevent_req_data(state->connected_req,
+                            struct sss_failover_transaction_connected_state);
+
+    DEBUG(SSSDBG_TRACE_FUNC, "Connected to %s, connection %p\n",
+          server->name, connection);
+
+    connected_state->connection = talloc_reference(connected_state, connection);
+    if (connected_state->connection == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!\n");
+        return ENOMEM;
+    }
+
+    /* We are connected. Now continue with connected_callback. */
+    tevent_req_done(state->connected_req);
+
+    return EOK;
+}
+
+static errno_t
 sss_failover_transaction_restart(struct tevent_req *req);
 
 static errno_t
@@ -211,6 +237,7 @@ sss_failover_transaction_next(struct tevent_req *req)
 {
     struct sss_failover_transaction_state *state;
     errno_t ret;
+    void *connection;
 
     state = tevent_req_data(req, struct sss_failover_transaction_state);
 
@@ -218,6 +245,22 @@ sss_failover_transaction_next(struct tevent_req *req)
     if (state->current_server != NULL) {
         talloc_unlink(state, state->current_server);
         state->current_server = NULL;
+    }
+
+    /* We can reuse existing connection. Let's see if there is one. */
+    if (state->reuse_connection && state->fctx->active_server != NULL) {
+        connection = sss_failover_get_connection(state, state->fctx);
+        if (connection != NULL) {
+            DEBUG(SSSDBG_TRACE_FUNC, "Reusing active connection\n");
+            state->current_server = sss_failover_get_active_server(state,
+                                                                   state->fctx);
+            if (state->current_server == NULL) {
+                return ENOMEM;
+            }
+
+            return sss_failover_transaction_finish_connection(
+                state, state->current_server, connection);
+        }
     }
 
     DEBUG(SSSDBG_TRACE_FUNC, "Trying to find a working server\n");
@@ -331,15 +374,12 @@ static void
 sss_failover_transaction_connect_done(struct tevent_req *subreq)
 {
     struct sss_failover_transaction_state *state;
-    struct sss_failover_transaction_connected_state *connected_state;
     struct tevent_req *req;
     void *connection;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sss_failover_transaction_state);
-    connected_state = tevent_req_data(state->connected_req,
-                            struct sss_failover_transaction_connected_state);
 
     /* If successful, state->current_server is additional talloc_reference
      * to an active, connected server. */
@@ -362,24 +402,16 @@ sss_failover_transaction_connect_done(struct tevent_req *subreq)
         goto done;
     }
 
-    DEBUG(SSSDBG_TRACE_FUNC, "Connected to %s, connection %p\n",
-          state->current_server->name, connection);
-
     /* Remember the server if we can reuse the connection. */
     if (state->reuse_connection) {
         sss_failover_set_active_server(state->fctx, state->current_server);
         sss_failover_set_connection(state->fctx, connection);
     }
 
-    connected_state->connection = talloc_reference(connected_state, connection);
-    if (connected_state->connection == NULL) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!\n");
-        ret = ENOMEM;
-        goto done;
-    }
-
-    /* We are connected. Now continue with connected_callback. */
-    tevent_req_done(state->connected_req);
+    /* We are done. Finish the connection callback. */
+    ret = sss_failover_transaction_finish_connection(state,
+                                                     state->current_server,
+                                                     connection);
 
 done:
     if (ret != EOK) {
@@ -416,6 +448,13 @@ static void sss_failover_transaction_attempt_done(struct tevent_req *attempt_req
             /* Try next server. */
             if (treq_error == ERR_SERVER_FAILURE) {
                 sss_failover_server_mark_offline(state->current_server);
+
+                /* Remove the active server as it is not working anymore. This
+                 * also drops the connection. */
+                if (state->current_server == state->fctx->active_server) {
+                    sss_failover_set_active_server(state->fctx, NULL);
+                }
+
                 sss_failover_transaction_restart(req);
                 return;
             }

--- a/src/providers/failover/failover_transaction.c
+++ b/src/providers/failover/failover_transaction.c
@@ -248,7 +248,7 @@ sss_failover_transaction_next(struct tevent_req *req)
     }
 
     /* We can reuse existing connection. Let's see if there is one. */
-    if (state->reuse_connection && state->fctx->active_server != NULL) {
+    if (state->reuse_connection && sss_failover_active_server_is_working(state->fctx)) {
         connection = sss_failover_get_connection(state, state->fctx);
         if (connection != NULL) {
             DEBUG(SSSDBG_TRACE_FUNC, "Reusing active connection\n");

--- a/src/providers/failover/failover_transaction.c
+++ b/src/providers/failover/failover_transaction.c
@@ -252,7 +252,7 @@ sss_failover_transaction_next(struct tevent_req *req)
         connection = sss_failover_get_connection(state, state->fctx);
         if (connection != NULL) {
             DEBUG(SSSDBG_TRACE_FUNC, "Reusing active connection\n");
-            state->current_server = sss_failover_get_active_server(state,
+            state->current_server = sss_failover_active_server_get_ref(state,
                                                                    state->fctx);
             if (state->current_server == NULL) {
                 return ENOMEM;
@@ -403,7 +403,7 @@ sss_failover_transaction_connect_done(struct tevent_req *subreq)
 
     /* Remember the server if we can reuse the connection. */
     if (state->reuse_connection) {
-        sss_failover_set_active_server(state->fctx, state->current_server);
+        sss_failover_active_server_set(state->fctx, state->current_server);
         sss_failover_set_connection(state->fctx, connection);
     }
 
@@ -451,7 +451,7 @@ static void sss_failover_transaction_attempt_done(struct tevent_req *attempt_req
                 /* Remove the active server as it is not working anymore. This
                  * also drops the connection. */
                 if (state->current_server == state->fctx->active_server) {
-                    sss_failover_set_active_server(state->fctx, NULL);
+                    sss_failover_active_server_set(state->fctx, NULL);
                 }
 
                 sss_failover_transaction_restart(req);

--- a/src/providers/failover/failover_transaction.c
+++ b/src/providers/failover/failover_transaction.c
@@ -249,7 +249,7 @@ sss_failover_transaction_next(struct tevent_req *req)
 
     /* We can reuse existing connection. Let's see if there is one. */
     if (state->reuse_connection && sss_failover_active_server_is_working(state->fctx)) {
-        connection = sss_failover_get_connection(state, state->fctx);
+        connection = sss_failover_connection_get_ref(state, state->fctx);
         if (connection != NULL) {
             DEBUG(SSSDBG_TRACE_FUNC, "Reusing active connection\n");
             state->current_server = sss_failover_active_server_get_ref(state,
@@ -404,7 +404,7 @@ sss_failover_transaction_connect_done(struct tevent_req *subreq)
     /* Remember the server if we can reuse the connection. */
     if (state->reuse_connection) {
         sss_failover_active_server_set(state->fctx, state->current_server);
-        sss_failover_set_connection(state->fctx, connection);
+        sss_failover_connection_set(state->fctx, connection);
     }
 
     /* We are done. Finish the connection callback. */

--- a/src/providers/failover/failover_transaction.c
+++ b/src/providers/failover/failover_transaction.c
@@ -124,6 +124,7 @@ sss_failover_transaction_ex_send(TALLOC_CTX *mem_ctx,
     state->reuse_connection = reuse_connection;
     state->authenticate_connection = authenticate_connection;
     state->read_rootdse = read_rootdse;
+    state->force_tls = force_tls;
 
     state->caller_req = caller_req;
     state->caller_data = _tevent_req_data(caller_req);

--- a/src/providers/failover/failover_transaction.c
+++ b/src/providers/failover/failover_transaction.c
@@ -36,7 +36,7 @@ sss_failover_transaction_send(TALLOC_CTX *mem_ctx,
 }
 
 struct sss_failover_transaction_connected_state {
-    struct sss_failover_ctx *fctx;
+    void *connection;
 };
 
 struct sss_failover_transaction_state {
@@ -69,7 +69,6 @@ struct sss_failover_transaction_state {
     /* Connection information. */
     struct sss_failover_server *current_server;
     time_t kinit_expiration_time;
-    void *connection;
 };
 
 static errno_t
@@ -165,7 +164,6 @@ sss_failover_transaction_restart(struct tevent_req *req)
         ret = ENOMEM;
         goto done;
     }
-    connected_state->fctx = state->fctx;
 
     /* Create attempt req, this is used by the user as a replacement for
      * caller_req. The user will seamlessly call
@@ -269,6 +267,13 @@ sss_failover_transaction_kinit_done(struct tevent_req *subreq)
     if (ret == ERR_NO_MORE_SERVERS) {
         DEBUG(SSSDBG_OP_FAILURE,
               "There are no more servers to try, cancelling operation\n");
+
+        /* We need kinit to succeed to connect to the server. Let's mark the
+         * main (LDAP) connection as offline as well and reconnect when kinit is
+         * successful. */
+        sss_failover_mark_offline(state->fctx->kinit_ctx);
+        sss_failover_mark_offline(state->fctx);
+
         goto done;
     } else if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
@@ -322,12 +327,15 @@ static void
 sss_failover_transaction_connect_done(struct tevent_req *subreq)
 {
     struct sss_failover_transaction_state *state;
+    struct sss_failover_transaction_connected_state *connected_state;
     struct tevent_req *req;
     void *connection;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sss_failover_transaction_state);
+    connected_state = tevent_req_data(state->connected_req,
+                            struct sss_failover_transaction_connected_state);
 
     /* If successful, state->current_server is additional talloc_reference
      * to an active, connected server. */
@@ -338,6 +346,7 @@ sss_failover_transaction_connect_done(struct tevent_req *subreq)
     if (ret == ERR_NO_MORE_SERVERS) {
         DEBUG(SSSDBG_OP_FAILURE,
               "There are no more servers to try, cancelling operation\n");
+        sss_failover_mark_offline(state->fctx);
         goto done;
     } else if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
@@ -349,8 +358,18 @@ sss_failover_transaction_connect_done(struct tevent_req *subreq)
     DEBUG(SSSDBG_TRACE_FUNC, "Connected to %s, connection %p\n",
           state->current_server->name, connection);
 
-    sss_failover_set_active_server(state->fctx, state->current_server);
-    sss_failover_set_connection(state->fctx, connection);
+    /* Remember the server if we can reuse the connection. */
+    if (state->reuse_connection) {
+        sss_failover_set_active_server(state->fctx, state->current_server);
+        sss_failover_set_connection(state->fctx, connection);
+    }
+
+    connected_state->connection = talloc_reference(connected_state, connection);
+    if (connected_state->connection == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!\n");
+        ret = ENOMEM;
+        goto done;
+    }
 
     /* We are connected. Now continue with connected_callback. */
     tevent_req_done(state->connected_req);
@@ -453,15 +472,21 @@ _sss_failover_transaction_connected_recv(TALLOC_CTX *mem_ctx,
                                         struct tevent_req *req)
 {
     struct sss_failover_transaction_connected_state *state;
-    void *connection;
+    void *conn;
 
     state = tevent_req_data(req,
                             struct sss_failover_transaction_connected_state);
 
-    connection = sss_failover_get_connection(mem_ctx, state->fctx);
-    if (connection == NULL) {
+    if (state->connection == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Bug: connection should not be NULL!\n");
+        return NULL;
     }
 
-    return connection;
+    conn = talloc_reference(mem_ctx, state->connection);
+    if (conn == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory\n");
+        return NULL;
+    }
+
+    return conn;
 }

--- a/src/providers/failover/failover_transaction.c
+++ b/src/providers/failover/failover_transaction.c
@@ -450,9 +450,8 @@ static void sss_failover_transaction_attempt_done(struct tevent_req *attempt_req
 
                 /* Remove the active server as it is not working anymore. This
                  * also drops the connection. */
-                if (state->current_server == state->fctx->active_server) {
-                    sss_failover_active_server_set(state->fctx, NULL);
-                }
+                sss_failover_active_server_remove(state->fctx,
+                                                  state->current_server);
 
                 sss_failover_transaction_restart(req);
                 return;

--- a/src/providers/failover/failover_transaction.h
+++ b/src/providers/failover/failover_transaction.h
@@ -29,6 +29,8 @@
  * operation. Neither the caller nor the operation has to deal with any failover
  * mechanics.
  *
+ * ERR_OFFLINE is returned if there are no available servers.
+ *
  * The result of the operation can be received by
  * @sss_failover_transaction_recv.
  */

--- a/src/providers/failover/failover_vtable.c
+++ b/src/providers/failover/failover_vtable.c
@@ -44,3 +44,12 @@ sss_failover_vtable_set_kinit(struct sss_failover_ctx *fctx,
     fctx->vtable->kinit.recv = recv_fn;
     fctx->vtable->kinit.data = data;
 }
+
+void
+sss_failover_vtable_set_disconnected(struct sss_failover_ctx *fctx,
+                                     sss_failover_vtable_disconnected_t cb,
+                                     void *data)
+{
+    fctx->vtable->disconnected.cb = cb;
+    fctx->vtable->disconnected.data = data;
+}

--- a/src/providers/failover/failover_vtable.c
+++ b/src/providers/failover/failover_vtable.c
@@ -24,6 +24,15 @@
 #include "util/util.h"
 
 void
+sss_failover_vtable_set_new_candidates(struct sss_failover_ctx *fctx,
+                                       sss_failover_vtable_new_candidates_t cb,
+                                       void *data)
+{
+    fctx->vtable->new_candidates.cb = cb;
+    fctx->vtable->new_candidates.data = data;
+}
+
+void
 sss_failover_vtable_set_kinit(struct sss_failover_ctx *fctx,
                               sss_failover_vtable_kinit_send_t send_fn,
                               sss_failover_vtable_kinit_recv_t recv_fn,

--- a/src/providers/failover/failover_vtable.c
+++ b/src/providers/failover/failover_vtable.c
@@ -24,17 +24,6 @@
 #include "util/util.h"
 
 void
-sss_failover_vtable_set_connect(struct sss_failover_ctx *fctx,
-                                sss_failover_vtable_connect_send_t send_fn,
-                                sss_failover_vtable_connect_recv_t recv_fn,
-                                void *data)
-{
-    fctx->vtable->connect.send = send_fn;
-    fctx->vtable->connect.recv = recv_fn;
-    fctx->vtable->connect.data = data;
-}
-
-void
 sss_failover_vtable_set_kinit(struct sss_failover_ctx *fctx,
                               sss_failover_vtable_kinit_send_t send_fn,
                               sss_failover_vtable_kinit_recv_t recv_fn,
@@ -43,6 +32,17 @@ sss_failover_vtable_set_kinit(struct sss_failover_ctx *fctx,
     fctx->vtable->kinit.send = send_fn;
     fctx->vtable->kinit.recv = recv_fn;
     fctx->vtable->kinit.data = data;
+}
+
+void
+sss_failover_vtable_set_connect(struct sss_failover_ctx *fctx,
+                                sss_failover_vtable_connect_send_t send_fn,
+                                sss_failover_vtable_connect_recv_t recv_fn,
+                                void *data)
+{
+    fctx->vtable->connect.send = send_fn;
+    fctx->vtable->connect.recv = recv_fn;
+    fctx->vtable->connect.data = data;
 }
 
 void

--- a/src/providers/failover/failover_vtable.c
+++ b/src/providers/failover/failover_vtable.c
@@ -47,9 +47,27 @@ sss_failover_vtable_set_kinit(struct sss_failover_ctx *fctx,
 
 void
 sss_failover_vtable_set_disconnected(struct sss_failover_ctx *fctx,
-                                     sss_failover_vtable_disconnected_t cb,
-                                     void *data)
+                                      sss_failover_vtable_disconnected_t cb,
+                                      void *data)
 {
     fctx->vtable->disconnected.cb = cb;
     fctx->vtable->disconnected.data = data;
+}
+
+void
+sss_failover_vtable_set_conn_op_start(struct sss_failover_ctx *fctx,
+                                      sss_failover_vtable_conn_op_start_t cb,
+                                      void *data)
+{
+    fctx->vtable->conn_op_start.cb = cb;
+    fctx->vtable->conn_op_start.data = data;
+}
+
+void
+sss_failover_vtable_set_conn_op_done(struct sss_failover_ctx *fctx,
+                                     sss_failover_vtable_conn_op_done_t cb,
+                                     void *data)
+{
+    fctx->vtable->conn_op_done.cb = cb;
+    fctx->vtable->conn_op_done.data = data;
 }

--- a/src/providers/failover/failover_vtable.h
+++ b/src/providers/failover/failover_vtable.h
@@ -67,6 +67,11 @@ typedef errno_t
                                       struct tevent_req *req,
                                       void **_connection);
 
+typedef void
+(*sss_failover_vtable_disconnected_t)(struct sss_failover_ctx *fctx,
+                                      void *connection,
+                                      void *pvt);
+
 
 struct sss_failover_vtable_connect {
     sss_failover_vtable_connect_send_t send;
@@ -74,9 +79,22 @@ struct sss_failover_vtable_connect {
     void *data;
 };
 
+struct sss_failover_vtable_disconnected {
+    sss_failover_vtable_disconnected_t cb;
+    void *data;
+};
+
 struct sss_failover_vtable {
+    /* Obtain TGT for the host. */
     struct sss_failover_vtable_kinit kinit;
+
+    /* Establish connection. */
     struct sss_failover_vtable_connect connect;
+
+    /* Connection is dropped. There may still be active references. This is just
+     * an information hook, actually disconnect should be done by talloc
+     * destructor. */
+    struct sss_failover_vtable_disconnected disconnected;
 };
 
 void
@@ -90,5 +108,10 @@ sss_failover_vtable_set_kinit(struct sss_failover_ctx *fctx,
                               sss_failover_vtable_kinit_send_t send_fn,
                               sss_failover_vtable_kinit_recv_t recv_fn,
                               void *data);
+
+void
+sss_failover_vtable_set_disconnected(struct sss_failover_ctx *fctx,
+                                     sss_failover_vtable_disconnected_t cb,
+                                     void *data);
 
 #endif /* _FAILOVER_VTABLE_H_ */

--- a/src/providers/failover/failover_vtable.h
+++ b/src/providers/failover/failover_vtable.h
@@ -72,6 +72,16 @@ typedef void
                                       void *connection,
                                       void *pvt);
 
+typedef void
+(*sss_failover_vtable_conn_op_start_t)(struct sss_failover_ctx *fctx,
+                                      void *connection,
+                                      void *pvt);
+
+typedef void
+(*sss_failover_vtable_conn_op_done_t)(struct sss_failover_ctx *fctx,
+                                      void *connection,
+                                      void *pvt);
+
 
 struct sss_failover_vtable_connect {
     sss_failover_vtable_connect_send_t send;
@@ -81,6 +91,16 @@ struct sss_failover_vtable_connect {
 
 struct sss_failover_vtable_disconnected {
     sss_failover_vtable_disconnected_t cb;
+    void *data;
+};
+
+struct sss_failover_vtable_conn_op_start {
+    sss_failover_vtable_conn_op_start_t cb;
+    void *data;
+};
+
+struct sss_failover_vtable_conn_op_done {
+    sss_failover_vtable_conn_op_done_t cb;
     void *data;
 };
 
@@ -95,6 +115,12 @@ struct sss_failover_vtable {
      * an information hook, actually disconnect should be done by talloc
      * destructor. */
     struct sss_failover_vtable_disconnected disconnected;
+
+    /* Connection is used by new operation. */
+    struct sss_failover_vtable_conn_op_start conn_op_start;
+
+    /* Operation using the connection finished. */
+    struct sss_failover_vtable_conn_op_done conn_op_done;
 };
 
 void
@@ -112,6 +138,16 @@ sss_failover_vtable_set_kinit(struct sss_failover_ctx *fctx,
 void
 sss_failover_vtable_set_disconnected(struct sss_failover_ctx *fctx,
                                      sss_failover_vtable_disconnected_t cb,
+                                     void *data);
+
+void
+sss_failover_vtable_set_conn_op_start(struct sss_failover_ctx *fctx,
+                                      sss_failover_vtable_conn_op_start_t cb,
+                                      void *data);
+
+void
+sss_failover_vtable_set_conn_op_done(struct sss_failover_ctx *fctx,
+                                     sss_failover_vtable_conn_op_done_t cb,
                                      void *data);
 
 #endif /* _FAILOVER_VTABLE_H_ */

--- a/src/providers/failover/failover_vtable.h
+++ b/src/providers/failover/failover_vtable.h
@@ -38,7 +38,6 @@ typedef struct tevent_req *
                                     struct tevent_context *ev,
                                     struct sss_failover_ctx *fctx,
                                     struct sss_failover_server *server,
-                                    bool addr_changed,
                                     void *pvt);
 
 typedef errno_t
@@ -57,8 +56,6 @@ typedef struct tevent_req *
                                       struct tevent_context *ev,
                                       struct sss_failover_ctx *fctx,
                                       struct sss_failover_server *server,
-                                      bool addr_changed,
-                                      bool reuse_connection,
                                       bool authenticate_connection,
                                       bool read_rootdse,
                                       enum sss_failover_transaction_tls force_tls,

--- a/src/providers/failover/failover_vtable.h
+++ b/src/providers/failover/failover_vtable.h
@@ -41,12 +41,6 @@ typedef errno_t
                                     struct tevent_req *,
                                     time_t *_expiration_time);
 
-struct sss_failover_vtable_kinit {
-    sss_failover_vtable_kinit_send_t send;
-    sss_failover_vtable_kinit_recv_t recv;
-    void *data;
-};
-
 typedef struct tevent_req *
 (*sss_failover_vtable_connect_send_t)(TALLOC_CTX *mem_ctx,
                                       struct tevent_context *ev,
@@ -78,6 +72,11 @@ typedef void
                                       void *connection,
                                       void *pvt);
 
+struct sss_failover_vtable_kinit {
+    sss_failover_vtable_kinit_send_t send;
+    sss_failover_vtable_kinit_recv_t recv;
+    void *data;
+};
 
 struct sss_failover_vtable_connect {
     sss_failover_vtable_connect_send_t send;
@@ -120,16 +119,16 @@ struct sss_failover_vtable {
 };
 
 void
-sss_failover_vtable_set_connect(struct sss_failover_ctx *fctx,
-                                sss_failover_vtable_connect_send_t send_fn,
-                                sss_failover_vtable_connect_recv_t recv_fn,
-                                void *data);
-
-void
 sss_failover_vtable_set_kinit(struct sss_failover_ctx *fctx,
                               sss_failover_vtable_kinit_send_t send_fn,
                               sss_failover_vtable_kinit_recv_t recv_fn,
                               void *data);
+
+void
+sss_failover_vtable_set_connect(struct sss_failover_ctx *fctx,
+                                sss_failover_vtable_connect_send_t send_fn,
+                                sss_failover_vtable_connect_recv_t recv_fn,
+                                void *data);
 
 void
 sss_failover_vtable_set_disconnected(struct sss_failover_ctx *fctx,

--- a/src/providers/failover/failover_vtable.h
+++ b/src/providers/failover/failover_vtable.h
@@ -29,6 +29,11 @@
 struct sss_failover_ctx;
 enum sss_failover_transaction_tls;
 
+typedef void
+(*sss_failover_vtable_new_candidates_t)(struct sss_failover_ctx *fctx,
+                                        struct sss_failover_server **servers,
+                                        void *pvt);
+
 typedef struct tevent_req *
 (*sss_failover_vtable_kinit_send_t)(TALLOC_CTX *mem_ctx,
                                     struct tevent_context *ev,
@@ -72,12 +77,16 @@ typedef void
                                       void *connection,
                                       void *pvt);
 
+struct sss_failover_vtable_new_candidates {
+    sss_failover_vtable_new_candidates_t cb;
+    void *data;
+};
+
 struct sss_failover_vtable_kinit {
     sss_failover_vtable_kinit_send_t send;
     sss_failover_vtable_kinit_recv_t recv;
     void *data;
 };
-
 struct sss_failover_vtable_connect {
     sss_failover_vtable_connect_send_t send;
     sss_failover_vtable_connect_recv_t recv;
@@ -100,6 +109,9 @@ struct sss_failover_vtable_conn_op_done {
 };
 
 struct sss_failover_vtable {
+    /* New list of candidate server is available. */
+    struct sss_failover_vtable_new_candidates new_candidates;
+
     /* Obtain TGT for the host. */
     struct sss_failover_vtable_kinit kinit;
 
@@ -117,6 +129,11 @@ struct sss_failover_vtable {
     /* Operation using the connection finished. */
     struct sss_failover_vtable_conn_op_done conn_op_done;
 };
+
+void
+sss_failover_vtable_set_new_candidates(struct sss_failover_ctx *fctx,
+                                       sss_failover_vtable_new_candidates_t cb,
+                                       void *data);
 
 void
 sss_failover_vtable_set_kinit(struct sss_failover_ctx *fctx,

--- a/src/providers/failover/failover_vtable.h
+++ b/src/providers/failover/failover_vtable.h
@@ -29,10 +29,6 @@
 struct sss_failover_ctx;
 enum sss_failover_transaction_tls;
 
-struct sss_failover_vtable_kinit_output_data {
-    time_t expiration_time;
-};
-
 typedef struct tevent_req *
 (*sss_failover_vtable_kinit_send_t)(TALLOC_CTX *mem_ctx,
                                     struct tevent_context *ev,

--- a/src/providers/failover/failover_vtable_op.c
+++ b/src/providers/failover/failover_vtable_op.c
@@ -164,8 +164,18 @@ sss_failover_vtable_op_send(TALLOC_CTX *mem_ctx,
 
     switch (state->operation) {
     case SSS_FAILOVER_VTABLE_OP_KINIT:
+        if (fctx->vtable->kinit.send == NULL || fctx->vtable->kinit.recv == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE, "Operation kinit is not supported\n");
+            ret = ENOTSUP;
+            goto done;
+        }
+        break;
     case SSS_FAILOVER_VTABLE_OP_CONNECT:
-        /* Correct operation. */
+        if (fctx->vtable->connect.send == NULL || fctx->vtable->connect.recv == NULL) {
+            DEBUG(SSSDBG_OP_FAILURE, "Operation connect is not supported\n");
+            ret = ENOTSUP;
+            goto done;
+        }
         break;
     default:
         DEBUG(SSSDBG_CRIT_FAILURE, "Invalid operation: [%d]\n", state->operation);

--- a/src/providers/failover/failover_vtable_op.c
+++ b/src/providers/failover/failover_vtable_op.c
@@ -461,9 +461,7 @@ static void sss_failover_vtable_op_done(struct tevent_req *subreq)
         sss_failover_server_mark_working(state->current_server);
 
         /* Remember this server. */
-        talloc_unlink(state->fctx, state->fctx->active_server);
-        state->fctx->active_server = talloc_reference(state->fctx,
-                                                      state->current_server);
+        sss_failover_set_active_server(state->fctx, state->current_server);
         break;
     case ENOMEM:
         /* There is no reason to retry if we our out of memory. */

--- a/src/providers/failover/failover_vtable_op.c
+++ b/src/providers/failover/failover_vtable_op.c
@@ -81,21 +81,13 @@ enum sss_failover_vtable_op {
 /**
  * @brief Issue vtable operation against specific server.
  *
- * The operation should check the @server state and shortcut if possible (for
- * example if the server is already connected and working). @addr_changed is
- * true if the server hostname resolved to different address then what is stored
- * (it was previously unresolved, or the DNS record has changed). The operation
- * should take this information into consideration (e.g. reconnect to the server
- * with new address).
- *
  * The server state can be unknown, reachable or working. The server address
  * is guaranteed to be resolved.
  */
 typedef struct tevent_req *
 (*sss_failover_vtable_op_send_t)(TALLOC_CTX *mem_ctx,
                                  struct sss_failover_ctx *fctx,
-                                 struct sss_failover_server *server,
-                                 bool addr_changed);
+                                 struct sss_failover_server *server);
 
 /**
  * @brief Receive operation result and point to its private data.
@@ -110,7 +102,6 @@ typedef errno_t
 struct sss_failover_vtable_op_args {
     union {
         struct {
-            bool reuse_connection;
             bool authenticate_connection;
             bool read_rootdse;
             enum sss_failover_transaction_tls force_tls;
@@ -156,8 +147,7 @@ static void
 sss_failover_vtable_op_server_resolved(struct tevent_req *subreq);
 
 static struct tevent_req *
-sss_failover_vtable_op_subreq_send(struct sss_failover_vtable_op_state *state,
-                                   bool addr_changed);
+sss_failover_vtable_op_subreq_send(struct sss_failover_vtable_op_state *state);
 
 static errno_t
 sss_failover_vtable_op_subreq_recv(TALLOC_CTX *mem_ctx,
@@ -294,8 +284,6 @@ sss_failover_vtable_op_server_next(struct tevent_req *req)
                 state->current_server->name);
     }
 
-    /* TODO shortcut if already connected */
-
     /* First resolve the hostname. */
     DEBUG(SSSDBG_TRACE_FUNC, "Resolving hostname of %s\n",
           state->current_server->name);
@@ -375,13 +363,12 @@ sss_failover_vtable_op_server_resolved(struct tevent_req *subreq)
 {
     struct sss_failover_vtable_op_state *state;
     struct tevent_req *req;
-    bool addr_changed;
     errno_t ret;
 
     req = tevent_req_callback_data(subreq, struct tevent_req);
     state = tevent_req_data(req, struct sss_failover_vtable_op_state);
 
-    ret = sss_failover_server_resolve_recv(subreq, &addr_changed);
+    ret = sss_failover_server_resolve_recv(subreq, NULL);
     talloc_zfree(subreq);
     if (ret != EOK) {
         DEBUG(SSSDBG_OP_FAILURE,
@@ -395,7 +382,7 @@ sss_failover_vtable_op_server_resolved(struct tevent_req *subreq)
     /* Trigger the operation. */
     DEBUG(SSSDBG_TRACE_FUNC, "Name resolved, starting vtable operation\n");
 
-    subreq = sss_failover_vtable_op_subreq_send(state, addr_changed);
+    subreq = sss_failover_vtable_op_subreq_send(state);
     if (subreq == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!\n");
         ret = ENOMEM;
@@ -412,18 +399,16 @@ done:
 }
 
 static struct tevent_req *
-sss_failover_vtable_op_subreq_send(struct sss_failover_vtable_op_state *state,
-                                   bool addr_changed)
+sss_failover_vtable_op_subreq_send(struct sss_failover_vtable_op_state *state)
 {
     switch (state->operation) {
     case SSS_FAILOVER_VTABLE_OP_KINIT:
         return state->fctx->vtable->kinit.send(
-            state, state->ev, state->fctx, state->current_server, addr_changed,
+            state, state->ev, state->fctx, state->current_server,
             state->fctx->vtable->kinit.data);
     case SSS_FAILOVER_VTABLE_OP_CONNECT:
         return state->fctx->vtable->connect.send(
-            state, state->ev, state->fctx, state->current_server, addr_changed,
-            state->args->input.connect.reuse_connection,
+            state, state->ev, state->fctx, state->current_server,
             state->args->input.connect.authenticate_connection,
             state->args->input.connect.read_rootdse,
             state->args->input.connect.force_tls,
@@ -569,7 +554,6 @@ struct tevent_req *
 sss_failover_vtable_op_connect_send(TALLOC_CTX *mem_ctx,
                                     struct tevent_context *ev,
                                     struct sss_failover_ctx *fctx,
-                                    bool reuse_connection,
                                     bool authenticate_connection,
                                     bool read_rootdse,
                                     enum sss_failover_transaction_tls force_tls,
@@ -582,7 +566,6 @@ sss_failover_vtable_op_connect_send(TALLOC_CTX *mem_ctx,
         return NULL;
     }
 
-    args->input.connect.reuse_connection = reuse_connection;
     args->input.connect.authenticate_connection = authenticate_connection;
     args->input.connect.read_rootdse = read_rootdse;
     args->input.connect.force_tls = force_tls;

--- a/src/providers/failover/failover_vtable_op.c
+++ b/src/providers/failover/failover_vtable_op.c
@@ -324,7 +324,6 @@ sss_failover_vtable_op_refresh_candidates(struct tevent_req *req)
     if (state->candidates_refreshed) {
         /* We already refreshed the candidates. */
         DEBUG(SSSDBG_TRACE_FUNC, "Refresh did not find any working server\n");
-        sss_failover_mark_offline(state->fctx);
         return ERR_NO_MORE_SERVERS;
     }
 
@@ -471,9 +470,6 @@ static void sss_failover_vtable_op_done(struct tevent_req *subreq)
     case EOK:
         /* The operation was successful. */
         sss_failover_server_mark_working(state->current_server);
-
-        /* Remember this server. */
-        sss_failover_set_active_server(state->fctx, state->current_server);
         break;
     case ENOMEM:
         /* There is no reason to retry if we our out of memory. */

--- a/src/providers/failover/failover_vtable_op.c
+++ b/src/providers/failover/failover_vtable_op.c
@@ -56,7 +56,13 @@ sss_failover_vtable_op_pick_server(TALLOC_CTX *mem_ctx,
         }
 
         if (sss_failover_server_maybe_working(server)) {
-            return talloc_reference(mem_ctx, server);
+            server = talloc_reference(mem_ctx, server);
+            if (server == NULL) {
+                DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!\n");
+                return NULL;
+            }
+
+            return server;
         }
     }
 
@@ -498,12 +504,20 @@ sss_failover_vtable_op_recv(TALLOC_CTX *mem_ctx,
                             struct sss_failover_vtable_op_args **_args)
 {
     struct sss_failover_vtable_op_state *state = NULL;
+    struct sss_failover_server *server;
+
     state = tevent_req_data(req, struct sss_failover_vtable_op_state);
 
     TEVENT_REQ_RETURN_ON_ERROR(req);
 
     if (_server != NULL) {
-        *_server = talloc_reference(mem_ctx, state->current_server);
+        server = talloc_reference(mem_ctx, state->current_server);
+        if (server == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!\n");
+            return ENOMEM;
+        }
+
+        *_server = server;
     }
 
     if (_args != NULL) {

--- a/src/providers/failover/failover_vtable_op.c
+++ b/src/providers/failover/failover_vtable_op.c
@@ -313,6 +313,7 @@ sss_failover_vtable_op_refresh_candidates(struct tevent_req *req)
     if (state->candidates_refreshed) {
         /* We already refreshed the candidates. */
         DEBUG(SSSDBG_TRACE_FUNC, "Refresh did not find any working server\n");
+        sss_failover_mark_offline(state->fctx);
         return ERR_NO_MORE_SERVERS;
     }
 

--- a/src/providers/failover/failover_vtable_op.c
+++ b/src/providers/failover/failover_vtable_op.c
@@ -38,6 +38,11 @@ sss_failover_vtable_op_pick_server(TALLOC_CTX *mem_ctx,
 
     /* Total count of elements. */
     count = talloc_array_length(fctx->candidates->servers) - 1;
+    if (count == 0) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Candidates servers count can not be zero\n");
+        return NULL;
+    }
 
     start = sss_rand() % count;
     for (size_t i = 0; i < count; i++) {

--- a/src/providers/failover/failover_vtable_op.c
+++ b/src/providers/failover/failover_vtable_op.c
@@ -251,7 +251,11 @@ sss_failover_vtable_op_server_next(struct tevent_req *req)
         if (state->fctx->active_server != NULL
             && sss_failover_server_maybe_working(state->fctx->active_server)) {
             /* Try active server first. */
-            state->current_server = state->fctx->active_server;
+            state->current_server = talloc_reference(state, state->fctx->active_server);
+            if (state->current_server == NULL) {
+                DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!\n");
+                return ENOMEM;
+            }
             DEBUG(SSSDBG_TRACE_FUNC, "Trying current active server: %s\n",
                   state->current_server->name);
         } else {
@@ -280,6 +284,7 @@ sss_failover_vtable_op_server_next(struct tevent_req *req)
                                                      state->fctx);
         }
 
+        talloc_unlink(state, state->current_server);
         state->current_server = sss_failover_vtable_op_pick_server(state, state->fctx);
         if (state->current_server == NULL) {
             /* No candidates are available. Wait for new ones. */

--- a/src/providers/failover/failover_vtable_op.c
+++ b/src/providers/failover/failover_vtable_op.c
@@ -248,8 +248,7 @@ sss_failover_vtable_op_server_next(struct tevent_req *req)
 
     if (state->current_server == NULL) {
         /* Select first server to try.*/
-        if (state->fctx->active_server != NULL
-            && sss_failover_server_maybe_working(state->fctx->active_server)) {
+        if (sss_failover_active_server_maybe_working(state->fctx)) {
             /* Try active server first. */
             state->current_server = sss_failover_get_active_server(state, state->fctx);
             if (state->current_server == NULL) {

--- a/src/providers/failover/failover_vtable_op.c
+++ b/src/providers/failover/failover_vtable_op.c
@@ -251,7 +251,7 @@ sss_failover_vtable_op_server_next(struct tevent_req *req)
         if (state->fctx->active_server != NULL
             && sss_failover_server_maybe_working(state->fctx->active_server)) {
             /* Try active server first. */
-            state->current_server = talloc_reference(state, state->fctx->active_server);
+            state->current_server = sss_failover_get_active_server(state, state->fctx);
             if (state->current_server == NULL) {
                 DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!\n");
                 return ENOMEM;

--- a/src/providers/failover/failover_vtable_op.c
+++ b/src/providers/failover/failover_vtable_op.c
@@ -219,7 +219,7 @@ sss_failover_vtable_op_server_next(struct tevent_req *req)
         /* Select first server to try.*/
         if (sss_failover_active_server_maybe_working(state->fctx)) {
             /* Try active server first. */
-            state->current_server = sss_failover_get_active_server(state, state->fctx);
+            state->current_server = sss_failover_active_server_get_ref(state, state->fctx);
             if (state->current_server == NULL) {
                 DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!\n");
                 return ENOMEM;

--- a/src/providers/failover/failover_vtable_op.c
+++ b/src/providers/failover/failover_vtable_op.c
@@ -78,27 +78,6 @@ enum sss_failover_vtable_op {
     SSS_FAILOVER_VTABLE_OP_CONNECT,
 };
 
-/**
- * @brief Issue vtable operation against specific server.
- *
- * The server state can be unknown, reachable or working. The server address
- * is guaranteed to be resolved.
- */
-typedef struct tevent_req *
-(*sss_failover_vtable_op_send_t)(TALLOC_CTX *mem_ctx,
-                                 struct sss_failover_ctx *fctx,
-                                 struct sss_failover_server *server);
-
-/**
- * @brief Receive operation result and point to its private data.
- *
- * The private data is then stored on the server structure by caller.
- */
-typedef errno_t
-(*sss_failover_vtable_op_recv_t)(TALLOC_CTX *mem_ctx,
-                                 struct tevent_req *,
-                                 void **_op_private_data);
-
 struct sss_failover_vtable_op_args {
     union {
         struct {

--- a/src/providers/failover/failover_vtable_op.h
+++ b/src/providers/failover/failover_vtable_op.h
@@ -88,7 +88,6 @@ sss_failover_vtable_op_kinit_recv(TALLOC_CTX *mem_ctx,
  * @param mem_ctx
  * @param ev
  * @param fctx
- * @param reuse_connection
  * @param authenticate_connection
  * @param read_rootdse
  * @param force_tls
@@ -99,7 +98,6 @@ struct tevent_req *
 sss_failover_vtable_op_connect_send(TALLOC_CTX *mem_ctx,
                                     struct tevent_context *ev,
                                     struct sss_failover_ctx *fctx,
-                                    bool reuse_connection,
                                     bool authenticate_connection,
                                     bool read_rootdse,
                                     enum sss_failover_transaction_tls force_tls,

--- a/src/providers/failover/ldap/failover_ldap.h
+++ b/src/providers/failover/ldap/failover_ldap.h
@@ -37,7 +37,6 @@ sss_failover_ldap_kinit_send(TALLOC_CTX *mem_ctx,
                              struct tevent_context *ev,
                              struct sss_failover_ctx *fctx,
                              struct sss_failover_server *server,
-                             bool addr_changed,
                              void *pvt);
 
 errno_t
@@ -50,8 +49,6 @@ sss_failover_ldap_connect_send(TALLOC_CTX *mem_ctx,
                                struct tevent_context *ev,
                                struct sss_failover_ctx *fctx,
                                struct sss_failover_server *server,
-                               bool addr_changed,
-                               bool reuse_connection,
                                bool authenticate_connection,
                                bool read_rootdse,
                                enum sss_failover_transaction_tls force_tls,

--- a/src/providers/failover/ldap/failover_ldap.h
+++ b/src/providers/failover/ldap/failover_ldap.h
@@ -26,6 +26,12 @@
 #include "providers/failover/failover_server.h"
 #include "util/util.h"
 
+/**
+ * @brief LDAP connection.
+ *
+ * The connection is terminated via a talloc destructor when the last reference
+ * to the instance is dropped.
+ */
 struct sss_failover_ldap_connection {
     struct sss_failover_server *server;
     struct sdap_server_opts *srv_opts;

--- a/src/providers/failover/ldap/failover_ldap.h
+++ b/src/providers/failover/ldap/failover_ldap.h
@@ -23,6 +23,7 @@
 
 #include "config.h"
 #include "resolv/async_resolv.h"
+#include "providers/failover/failover.h"
 #include "providers/failover/failover_server.h"
 #include "util/util.h"
 
@@ -33,6 +34,7 @@
  * to the instance is dropped.
  */
 struct sss_failover_ldap_connection {
+    struct sss_failover_ctx *fctx;
     struct sss_failover_server *server;
     struct sdap_server_opts *srv_opts;
     struct sdap_handle *sh;

--- a/src/providers/failover/ldap/failover_ldap.h
+++ b/src/providers/failover/ldap/failover_ldap.h
@@ -27,6 +27,7 @@
 #include "util/util.h"
 
 struct sss_failover_ldap_connection {
+    struct sss_failover_server *server;
     struct sdap_server_opts *srv_opts;
     struct sdap_handle *sh;
     char *uri;

--- a/src/providers/failover/ldap/failover_ldap.h
+++ b/src/providers/failover/ldap/failover_ldap.h
@@ -39,6 +39,10 @@ struct sss_failover_ldap_connection {
     struct sdap_server_opts *srv_opts;
     struct sdap_handle *sh;
     char *uri;
+    time_t idle_timeout;
+
+    int op_count;
+    time_t idle_since;
 };
 
 struct tevent_req *
@@ -68,5 +72,15 @@ errno_t
 sss_failover_ldap_connect_recv(TALLOC_CTX *mem_ctx,
                                struct tevent_req *req,
                                void **_connection);
+
+void
+sss_failover_ldap_connect_op_start(struct sss_failover_ctx *fctx,
+                                   void *connection,
+                                   void *pvt);
+
+void
+sss_failover_ldap_connect_op_done(struct sss_failover_ctx *fctx,
+                                  void *connection,
+                                  void *pvt);
 
 #endif /* _FAILOVER_LDAP_H_ */

--- a/src/providers/failover/ldap/failover_ldap_connect.c
+++ b/src/providers/failover/ldap/failover_ldap_connect.c
@@ -32,6 +32,7 @@ struct sss_failover_ldap_connect_state {
     struct tevent_context *ev;
     struct sss_failover_ctx *fctx;
     time_t op_timeout;
+    time_t idle_timeout;
 
     struct sss_failover_ldap_connection *connection;
 };
@@ -99,6 +100,71 @@ sss_failover_ldap_connection_setup_expiration(
     return EOK;
 }
 
+static errno_t
+sss_failover_ldap_connection_setup_idle(
+    struct tevent_context *ev,
+    struct sss_failover_ldap_connection *connection,
+    time_t idle_timeout);
+
+static void
+sss_failover_ldap_connection_idle(struct tevent_context *ev,
+                                  struct tevent_timer *te,
+                                  struct timeval current_time,
+                                  void *pvt)
+{
+    struct sss_failover_ldap_connection *connection;
+    errno_t ret;
+
+    connection = talloc_get_type(pvt, struct sss_failover_ldap_connection);
+
+    if (connection->idle_since != 0 && connection->idle_since + connection->idle_timeout <= time(NULL)) {
+        DEBUG(SSSDBG_TRACE_ALL,
+              "Connection %p has reached idle timeout, releasing it\n", connection);
+        sss_failover_connection_remove(connection->fctx, connection);
+        return;
+    }
+
+    /* Not idle enough. */
+    ret = sss_failover_ldap_connection_setup_idle(ev, connection,
+                                                  connection->idle_timeout);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Unable to setup connection idle handler, "
+                                   "idle timeout will not work\n");
+    }
+}
+
+static errno_t
+sss_failover_ldap_connection_setup_idle(
+    struct tevent_context *ev,
+    struct sss_failover_ldap_connection *connection,
+    time_t idle_timeout)
+{
+    struct tevent_timer *te;
+    struct timeval tv = {0};
+
+    if (idle_timeout <= 0) {
+        DEBUG(SSSDBG_TRACE_FUNC, "Connection idle timeout is disabled\n");
+        return EOK;
+    }
+
+    if (connection->idle_since == 0) {
+        tv = tevent_timeval_current_ofs(idle_timeout, 0);
+    } else {
+        tv = tevent_timeval_set(connection->idle_since + idle_timeout, 0);
+    }
+
+    DEBUG(SSSDBG_TRACE_ALL,
+          "Scheduling connection idle timer to run at %"SPRItime"\n", tv.tv_sec);
+
+    te = tevent_add_timer(ev, connection, tv, sss_failover_ldap_connection_idle,
+                          connection);
+    if (te == NULL) {
+        return ENOMEM;
+    }
+
+    return EOK;
+}
+
 static void sss_failover_ldap_connect_done(struct tevent_req *subreq);
 
 struct tevent_req *
@@ -131,6 +197,7 @@ sss_failover_ldap_connect_send(TALLOC_CTX *mem_ctx,
     state->ev = ev;
     state->fctx = fctx;
     state->op_timeout = dp_opt_get_int(opts->basic, SDAP_OPT_TIMEOUT);
+    state->idle_timeout = dp_opt_get_int(opts->basic, SDAP_IDLE_TIMEOUT);
 
     state->connection = talloc_zero(state, struct sss_failover_ldap_connection);
     if (state->connection == NULL) {
@@ -140,6 +207,9 @@ sss_failover_ldap_connect_send(TALLOC_CTX *mem_ctx,
     }
 
     state->connection->fctx = fctx;
+    state->connection->op_count = 0;
+    state->connection->idle_timeout = state->idle_timeout;
+    state->connection->idle_since = time(NULL);
 
     state->connection->server = talloc_reference(state->connection, server);
     if (state->connection->server == NULL) {
@@ -224,6 +294,14 @@ sss_failover_ldap_connect_done(struct tevent_req *subreq)
         goto done;
     }
 
+    ret = sss_failover_ldap_connection_setup_idle(state->ev, state->connection,
+                                                  state->idle_timeout);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Unable to setup connection idle handler\n");
+        goto done;
+    }
+
 done:
     if (ret != EOK) {
         tevent_req_error(req, ret);
@@ -248,4 +326,40 @@ sss_failover_ldap_connect_recv(TALLOC_CTX *mem_ctx,
     }
 
     return EOK;
+}
+
+void
+sss_failover_ldap_connect_op_start(struct sss_failover_ctx *fctx,
+                                   void *connection,
+                                   void *pvt)
+{
+    struct sss_failover_ldap_connection *conn;
+
+    conn = talloc_get_type_abort(connection,
+                                 struct sss_failover_ldap_connection);
+
+    conn->op_count++;
+    conn->idle_since = 0;
+}
+
+void
+sss_failover_ldap_connect_op_done(struct sss_failover_ctx *fctx,
+                                  void *connection,
+                                  void *pvt)
+{
+    struct sss_failover_ldap_connection *conn;
+
+    conn = talloc_get_type_abort(connection,
+                                 struct sss_failover_ldap_connection);
+
+    conn->op_count--;
+    if (conn->op_count == 0) {
+        conn->idle_since = time(NULL);
+        return;
+    }
+
+    if (conn->op_count < 0) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Bug: op_count < 0, idle timeout will not work correctly\n");
+    }
 }

--- a/src/providers/failover/ldap/failover_ldap_connect.c
+++ b/src/providers/failover/ldap/failover_ldap_connect.c
@@ -31,6 +31,19 @@ struct sss_failover_ldap_connect_state {
     struct sss_failover_ldap_connection *connection;
 };
 
+static int
+sss_failover_ldap_connection_destructor(void *ctx)
+{
+    struct sss_failover_ldap_connection *conn;
+
+    conn = talloc_get_type(ctx, struct sss_failover_ldap_connection);
+
+    /* This will trigger sdap_handle destructor and terminates the connection. */
+    talloc_zfree(conn->sh);
+
+    return 0;
+}
+
 static void sss_failover_ldap_connect_done(struct tevent_req *subreq);
 
 struct tevent_req *
@@ -80,6 +93,9 @@ sss_failover_ldap_connect_send(TALLOC_CTX *mem_ctx,
         ret = ENOMEM;
         goto done;
     }
+
+    talloc_set_destructor(state->connection,
+                          sss_failover_ldap_connection_destructor);
 
     switch (force_tls) {
     case SSS_FAILOVER_TRANSACTION_TLS_DEFAULT:

--- a/src/providers/failover/ldap/failover_ldap_connect.c
+++ b/src/providers/failover/ldap/failover_ldap_connect.c
@@ -38,8 +38,6 @@ sss_failover_ldap_connect_send(TALLOC_CTX *mem_ctx,
                                struct tevent_context *ev,
                                struct sss_failover_ctx *fctx,
                                struct sss_failover_server *server,
-                               bool addr_changed,
-                               bool reuse_connection,
                                bool authenticate_connection,
                                bool read_rootdse,
                                enum sss_failover_transaction_tls force_tls,
@@ -52,8 +50,6 @@ sss_failover_ldap_connect_send(TALLOC_CTX *mem_ctx,
     struct tevent_req *req;
     enum connect_tls tls;
     errno_t ret;
-
-    /* TODO handle active connection */
 
     opts = talloc_get_type_abort(pvt, struct sdap_options);
 

--- a/src/providers/failover/ldap/failover_ldap_connect.c
+++ b/src/providers/failover/ldap/failover_ldap_connect.c
@@ -67,6 +67,13 @@ sss_failover_ldap_connect_send(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
+    state->connection->server = talloc_reference(state->connection, server);
+    if (state->connection->server == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
     state->connection->uri = talloc_strdup(state->connection, server->uri);
     if (state->connection->uri == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory\n");

--- a/src/providers/failover/ldap/failover_ldap_connect.c
+++ b/src/providers/failover/ldap/failover_ldap_connect.c
@@ -17,6 +17,7 @@
 
 #include <talloc.h>
 #include <tevent.h>
+#include <time.h>
 #include <errno.h>
 
 #include "config.h"
@@ -28,20 +29,74 @@
 #include "util/util.h"
 
 struct sss_failover_ldap_connect_state {
+    struct tevent_context *ev;
+    struct sss_failover_ctx *fctx;
+    time_t op_timeout;
+
     struct sss_failover_ldap_connection *connection;
 };
 
 static int
-sss_failover_ldap_connection_destructor(void *ctx)
+sss_failover_ldap_connection_destructor(struct sss_failover_ldap_connection *conn)
 {
-    struct sss_failover_ldap_connection *conn;
-
-    conn = talloc_get_type(ctx, struct sss_failover_ldap_connection);
-
     /* This will trigger sdap_handle destructor and terminates the connection. */
     talloc_zfree(conn->sh);
 
     return 0;
+}
+
+static void
+sss_failover_ldap_connection_expired(struct tevent_context *ev,
+                                     struct tevent_timer *te,
+                                     struct timeval current_time,
+                                     void *pvt)
+{
+    struct sss_failover_ldap_connection *connection;
+
+    connection = talloc_get_type(pvt, struct sss_failover_ldap_connection);
+
+    DEBUG(SSSDBG_TRACE_FUNC, "Connection %p to server %s expired\n", connection,
+          connection->server->name);
+
+    /* Remove connection from the failover context. This will force failover to
+     * reconnect and terminate the connection when all references to it are
+     * dropped. */
+    sss_failover_connection_remove(connection->fctx, connection);
+}
+
+static errno_t
+sss_failover_ldap_connection_setup_expiration(
+    struct tevent_context *ev,
+    struct sss_failover_ldap_connection *connection,
+    time_t expire_time,
+    time_t op_timeout)
+{
+    struct tevent_timer *te;
+    struct timeval tv = {0};
+    time_t schedule;
+
+    /* Expiration is disabled. */
+    if (expire_time <= 0) {
+        return EOK;
+    }
+
+    schedule = expire_time - op_timeout;
+    if (schedule <= time(NULL)) {
+        DEBUG(SSSDBG_TRACE_ALL, "Not starting expire timer because connection "
+                                "is already expired\n");
+        return EOK;
+    }
+
+    tv.tv_sec = schedule;
+
+    te = tevent_add_timer(ev, connection, tv,
+                          sss_failover_ldap_connection_expired, connection);
+    if (te == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!\n");
+        return ENOMEM;
+    }
+
+    return EOK;
 }
 
 static void sss_failover_ldap_connect_done(struct tevent_req *subreq);
@@ -73,12 +128,18 @@ sss_failover_ldap_connect_send(TALLOC_CTX *mem_ctx,
         return NULL;
     }
 
+    state->ev = ev;
+    state->fctx = fctx;
+    state->op_timeout = dp_opt_get_int(opts->basic, SDAP_OPT_TIMEOUT);
+
     state->connection = talloc_zero(state, struct sss_failover_ldap_connection);
     if (state->connection == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory\n");
         ret = ENOMEM;
         goto done;
     }
+
+    state->connection->fctx = fctx;
 
     state->connection->server = talloc_reference(state->connection, server);
     if (state->connection->server == NULL) {
@@ -153,6 +214,15 @@ sss_failover_ldap_connect_done(struct tevent_req *subreq)
 
     talloc_steal(state->connection, state->connection->sh);
     talloc_steal(state->connection, state->connection->srv_opts);
+
+    ret = sss_failover_ldap_connection_setup_expiration(state->ev,
+                state->connection, state->connection->sh->expire_time,
+                state->op_timeout);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE,
+              "Unable to setup connection expiration handler\n");
+        goto done;
+    }
 
 done:
     if (ret != EOK) {

--- a/src/providers/failover/ldap/failover_ldap_kinit.c
+++ b/src/providers/failover/ldap/failover_ldap_kinit.c
@@ -56,7 +56,6 @@ sss_failover_ldap_kinit_send(TALLOC_CTX *mem_ctx,
                              struct tevent_context *ev,
                              struct sss_failover_ctx *fctx,
                              struct sss_failover_server *server,
-                             bool addr_changed,
                              void *pvt)
 {
     struct sss_failover_ldap_kinit_state *state;

--- a/src/providers/failover/ldap/failover_ldap_kinit.c
+++ b/src/providers/failover/ldap/failover_ldap_kinit.c
@@ -78,8 +78,6 @@ sss_failover_ldap_kinit_send(TALLOC_CTX *mem_ctx,
         return NULL;
     }
 
-    /* TODO do not acquire TGT if we already have a valid one */
-
     opts = talloc_get_type_abort(pvt, struct sdap_options);
 
     sss_failover_ldap_kinit_options(opts, &keytab, &realm, &principal,

--- a/src/providers/failover/ldap/failover_ldap_kinit.c
+++ b/src/providers/failover/ldap/failover_ldap_kinit.c
@@ -66,6 +66,7 @@ sss_failover_ldap_kinit_send(TALLOC_CTX *mem_ctx,
     const char *principal;
     const char *realm;
     bool canonicalize;
+    char *kdc_address;
     int timeout;
     int lifetime;
     errno_t ret;
@@ -98,8 +99,16 @@ sss_failover_ldap_kinit_send(TALLOC_CTX *mem_ctx,
 
     /* TODO write kdcinfo */
 
-    subreq = sdap_get_tgt_send(state, ev, realm, principal, keytab, lifetime,
-                               timeout);
+    kdc_address = talloc_asprintf(state, "%s:%" PRIu16, server->addr->human,
+                                  server->port);
+    if (kdc_address == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!\n");
+        ret = ENOMEM;
+        goto done;
+    }
+
+    subreq = sdap_get_tgt_send(state, ev, kdc_address, realm, principal, keytab,
+                               lifetime, timeout);
     if (subreq == NULL) {
         DEBUG(SSSDBG_CRIT_FAILURE, "Out of memory!\n");
         ret = ENOMEM;

--- a/src/providers/failover/ldap/failover_ldap_kinit.c
+++ b/src/providers/failover/ldap/failover_ldap_kinit.c
@@ -95,8 +95,6 @@ sss_failover_ldap_kinit_send(TALLOC_CTX *mem_ctx,
           keytab != NULL ? keytab : "default", principal, realm, lifetime,
           server->name);
 
-    /* TODO write kdcinfo */
-
     kdc_address = talloc_asprintf(state, "%s:%" PRIu16, server->addr->human,
                                   server->port);
     if (kdc_address == NULL) {

--- a/src/providers/failover/ldap/failover_ldap_kinit.c
+++ b/src/providers/failover/ldap/failover_ldap_kinit.c
@@ -140,7 +140,7 @@ sss_failover_ldap_kinit_done(struct tevent_req *subreq)
     ret = sdap_get_tgt_recv(subreq, state, &result, &kerr, &ccname,
                             &state->expiration_time);
     talloc_zfree(subreq);
-    if (ret != EOK) {
+    if (ret != EOK && ret != ETIMEDOUT) {
         goto done;
     }
 

--- a/src/providers/failover/readme.md
+++ b/src/providers/failover/readme.md
@@ -141,7 +141,7 @@ errno_t my_operation_recv(TALLOC_CTX *mem_ctx,
 * `ERR_SERVER_FAILURE` - Returning this error withing a failover transaction
   will retry the transaction with another server
 
-* `ERR_NO_MORE_SERVERS` - This is returned from the transaction if there are no
+* `ERR_OFFLINE` - This is returned from the transaction if there are no
   more servers to try
 
 ## Internals

--- a/src/providers/idp/oidc_child_handler.c
+++ b/src/providers/idp/oidc_child_handler.c
@@ -113,7 +113,7 @@ struct tevent_req *handle_oidc_child_send(TALLOC_CTX *mem_ctx,
     /* Create new child. */
     ret = sss_child_start(state, ev,
                           OIDC_CHILD, idp_req->oidc_child_extra_args, false,
-                          OIDC_CHILD_LOG_FILE, STDOUT_FILENO,
+                          NULL, OIDC_CHILD_LOG_FILE, STDOUT_FILENO,
                           sss_child_handle_exited, NULL,
                           dp_opt_get_int(idp_req->idp_options, IDP_REQ_TIMEOUT),
                           sss_child_handle_timeout,

--- a/src/providers/ipa/ipa_selinux.c
+++ b/src/providers/ipa/ipa_selinux.c
@@ -594,7 +594,7 @@ static struct tevent_req *selinux_child_send(TALLOC_CTX *mem_ctx,
     }
 
     ret = sss_child_start(state, ev,
-                          SELINUX_CHILD, NULL, false,
+                          SELINUX_CHILD, NULL, false, NULL,
                           SELINUX_CHILD_LOG_FILE, STDOUT_FILENO,
                           selinux_child_done, req,
                           0, NULL, NULL, false,

--- a/src/providers/krb5/krb5_child_handler.c
+++ b/src/providers/krb5/krb5_child_handler.c
@@ -447,7 +447,7 @@ static errno_t start_krb5_child(struct tevent_req *req)
     }
 
     ret = sss_child_start(child_state, ev,
-                          KRB5_CHILD, krb5_child_extra_args, false,
+                          KRB5_CHILD, krb5_child_extra_args, false, NULL,
                           KRB5_CHILD_LOG_FILE, STDOUT_FILENO,
                           sss_child_handle_exited, NULL,
                           dp_opt_get_int(kr->krb5_ctx->opts, KRB5_AUTH_TIMEOUT),

--- a/src/providers/ldap/sdap_async_connection.c
+++ b/src/providers/ldap/sdap_async_connection.c
@@ -1229,7 +1229,7 @@ static void sdap_kinit_kdc_resolved(struct tevent_req *subreq)
 
     DEBUG(SSSDBG_TRACE_LIBS, "KDC resolved, attempting to get TGT...\n");
 
-    tgtreq = sdap_get_tgt_send(state, state->ev, state->realm,
+    tgtreq = sdap_get_tgt_send(state, state->ev, NULL, state->realm,
                                state->principal, state->keytab,
                                state->lifetime, state->timeout);
     if (!tgtreq) {

--- a/src/providers/ldap/sdap_async_private.h
+++ b/src/providers/ldap/sdap_async_private.h
@@ -94,6 +94,7 @@ const char *sdap_get_server_peer_str_safe(struct sdap_handle *sh);
 
 struct tevent_req *sdap_get_tgt_send(TALLOC_CTX *mem_ctx,
                                      struct tevent_context *ev,
+                                     const char *kdc_address,
                                      const char *realm_str,
                                      const char *princ_str,
                                      const char *keytab_name,

--- a/src/providers/ldap/sdap_child_helpers.c
+++ b/src/providers/ldap/sdap_child_helpers.c
@@ -234,7 +234,7 @@ errno_t sdap_select_principal_from_keytab_sync(TALLOC_CTX *mem_ctx,
         goto done;
     }
 
-    ret = sss_child_start(mem_ctx, NULL, LDAP_CHILD, NULL, false,
+    ret = sss_child_start(mem_ctx, NULL, LDAP_CHILD, NULL, false, NULL,
                           LDAP_CHILD_LOG_FILE, STDOUT_FILENO,
                           NULL, NULL,
                           0, NULL, NULL, false, &io);
@@ -322,7 +322,7 @@ struct tevent_req *sdap_get_tgt_send(TALLOC_CTX *mem_ctx,
         goto fail;
     }
 
-    ret = sss_child_start(state, state->ev, LDAP_CHILD, NULL, false,
+    ret = sss_child_start(state, state->ev, LDAP_CHILD, NULL, false, NULL,
                           LDAP_CHILD_LOG_FILE, STDOUT_FILENO,
                           child_callback, req,
                           timeout, get_tgt_timeout_handler, req, false,

--- a/src/providers/ldap/sdap_child_helpers.c
+++ b/src/providers/ldap/sdap_child_helpers.c
@@ -295,6 +295,7 @@ static void sdap_get_tgt_done(struct tevent_req *subreq);
 
 struct tevent_req *sdap_get_tgt_send(TALLOC_CTX *mem_ctx,
                                      struct tevent_context *ev,
+                                     const char *kdc_address,
                                      const char *realm_str,
                                      const char *princ_str,
                                      const char *keytab_name,
@@ -304,6 +305,7 @@ struct tevent_req *sdap_get_tgt_send(TALLOC_CTX *mem_ctx,
     struct tevent_req *req, *subreq;
     struct sdap_get_tgt_state *state;
     struct io_buffer *buf;
+    const char *extra_env[] = {NULL, NULL, NULL}; /* name, value, NULL */
     int ret;
 
     req = tevent_req_create(mem_ctx, &state, struct sdap_get_tgt_state);
@@ -322,7 +324,12 @@ struct tevent_req *sdap_get_tgt_send(TALLOC_CTX *mem_ctx,
         goto fail;
     }
 
-    ret = sss_child_start(state, state->ev, LDAP_CHILD, NULL, false, NULL,
+    if (kdc_address != NULL) {
+        extra_env[0] = "SSSD_KRB5_LOCATOR_KDC_ADDRESS";
+        extra_env[1] = kdc_address;
+    }
+
+    ret = sss_child_start(state, state->ev, LDAP_CHILD, NULL, false, extra_env,
                           LDAP_CHILD_LOG_FILE, STDOUT_FILENO,
                           child_callback, req,
                           timeout, get_tgt_timeout_handler, req, false,

--- a/src/providers/minimal/minimal_init.c
+++ b/src/providers/minimal/minimal_init.c
@@ -350,6 +350,14 @@ sssm_minimal_init_failover(TALLOC_CTX *mem_ctx,
                                     sss_failover_ldap_connect_recv,
                                     opts);
 
+    sss_failover_vtable_set_conn_op_start(fctx,
+                                          sss_failover_ldap_connect_op_start,
+                                          NULL);
+
+    sss_failover_vtable_set_conn_op_done(fctx,
+                                         sss_failover_ldap_connect_op_done,
+                                         NULL);
+
     ret = EOK;
 
 done:

--- a/src/responder/ifp/ifp_users.c
+++ b/src/responder/ifp/ifp_users.c
@@ -1144,7 +1144,8 @@ ifp_users_find_by_valid_cert_send(TALLOC_CTX *mem_ctx,
     }
 
     ret = sss_child_start(state, state->ev, P11_CHILD_PATH,
-                          state->extra_args, false, state->logfile,
+                          state->extra_args, false, NULL,
+                          state->logfile,
                           -1, /* ifp cares only about exit code, so no 'io' */
                           ifp_users_find_by_valid_cert_step, req,
                           state->timeout,

--- a/src/responder/pam/pamsrv_p11.c
+++ b/src/responder/pam/pamsrv_p11.c
@@ -903,7 +903,7 @@ struct tevent_req *pam_check_cert_send(TALLOC_CTX *mem_ctx,
     state->ev = ev;
 
     ret = sss_child_start(state, ev,
-                          P11_CHILD_PATH, extra_args, false,
+                          P11_CHILD_PATH, extra_args, false, NULL,
                           P11_CHILD_LOG_FILE, STDOUT_FILENO,
                           NULL, NULL,
                           (unsigned)(timeout),

--- a/src/responder/pam/pamsrv_passkey.c
+++ b/src/responder/pam/pamsrv_passkey.c
@@ -1018,7 +1018,7 @@ static errno_t passkey_child_exec(struct tevent_req *req)
     state->child_status = ETIMEDOUT;
 
     ret = sss_child_start(state, state->ev,
-                          PASSKEY_CHILD_PATH, state->extra_args, false,
+                          PASSKEY_CHILD_PATH, state->extra_args, false, NULL,
                           state->logfile, STDOUT_FILENO,
                           (state->kerberos_pa) ? NULL : pam_passkey_auth_done, req,
                           state->timeout,

--- a/src/responder/ssh/ssh_cert_to_ssh_key.c
+++ b/src/responder/ssh/ssh_cert_to_ssh_key.c
@@ -167,7 +167,8 @@ static errno_t cert_to_ssh_key_step(struct tevent_req *req)
     state->extra_args[0] = state->certs[state->iter];
 
     ret = sss_child_start(state, state->ev, P11_CHILD_PATH,
-                          state->extra_args, false, state->logfile,
+                          state->extra_args, false, NULL,
+                          state->logfile,
                           -1, /* ssh cares only about exit code, so no 'io' */
                           cert_to_ssh_key_done, req,
                           (unsigned)(state->timeout),

--- a/src/tests/cmocka/dummy_child.c
+++ b/src/tests/cmocka/dummy_child.c
@@ -127,6 +127,23 @@ int main(int argc, const char *argv[])
                       len, written);
                 _exit(1);
             }
+        } else if (strcasecmp(action, "check_extra_env") == 0) {
+            const char *var1 = getenv("TEST_ENV_VAR1");
+            const char *var2 = getenv("TEST_ENV_VAR2");
+
+            if (var1 == NULL || strcmp(var1, "foo") != 0) {
+                DEBUG(SSSDBG_CRIT_FAILURE,
+                      "TEST_ENV_VAR1 not set correctly, got: %s\n",
+                      var1 ? var1 : "(null)");
+                _exit(1);
+            }
+
+            if (var2 == NULL || strcmp(var2, "bar") != 0) {
+                DEBUG(SSSDBG_CRIT_FAILURE,
+                      "TEST_ENV_VAR2 not set correctly, got: %s\n",
+                      var2 ? var2 : "(null)");
+                _exit(1);
+            }
         }
     }
 

--- a/src/tests/cmocka/test_child_common.c
+++ b/src/tests/cmocka/test_child_common.c
@@ -38,6 +38,7 @@ void exec_child_ex(TALLOC_CTX *mem_ctx,
                    int *pipefd_to_child, int *pipefd_from_child,
                    const char *binary, const char *logfile,
                    const char *extra_argv[], bool extra_args_only,
+                   const char *extra_env[],
                    int child_in_fd, int child_out_fd);
 
 
@@ -106,7 +107,7 @@ void test_exec_child(void **state)
                       child_tctx->pipefd_to_child,
                       child_tctx->pipefd_from_child,
                       CHILD_DIR"/"TEST_BIN, NULL,
-                      NULL, false,
+                      NULL, false, NULL,
                       STDIN_FILENO, STDOUT_FILENO);
     } else {
             do {
@@ -179,7 +180,7 @@ static void extra_args_test(struct child_test_ctx *child_tctx,
                       child_tctx->pipefd_to_child,
                       child_tctx->pipefd_from_child,
                       CHILD_DIR"/"TEST_BIN, NULL, extra_args,
-                      extra_args_only,
+                      extra_args_only, NULL,
                       STDIN_FILENO, STDOUT_FILENO);
     } else {
             do {
@@ -262,7 +263,7 @@ void test_exec_child_handler(void **state)
                       child_tctx->pipefd_to_child,
                       child_tctx->pipefd_from_child,
                       CHILD_DIR"/"TEST_BIN, NULL,
-                      NULL, false,
+                      NULL, false, NULL,
                       STDIN_FILENO, STDOUT_FILENO);
     }
 
@@ -314,7 +315,7 @@ void test_exec_child_echo(void **state,
         exec_child_ex(child_tctx,
                       child_tctx->pipefd_to_child,
                       child_tctx->pipefd_from_child,
-                      CHILD_DIR"/"TEST_BIN, NULL, NULL, false,
+                      CHILD_DIR"/"TEST_BIN, NULL, NULL, false, NULL,
                       STDIN_FILENO, 3);
     }
 
@@ -497,7 +498,7 @@ void test_sss_child(void **state)
                       child_tctx->pipefd_to_child,
                       child_tctx->pipefd_from_child,
                       CHILD_DIR"/"TEST_BIN, NULL,
-                      NULL, false,
+                      NULL, false, NULL,
                       STDIN_FILENO, STDOUT_FILENO);
     }
 
@@ -524,6 +525,51 @@ void sss_child_cb(int pid, int wait_status, void *pvt)
     child_ctx->test_ctx->done = true;
 }
 
+void test_exec_child_extra_env(void **state)
+{
+    struct child_test_ctx *child_tctx = talloc_get_type(*state,
+                                                        struct child_test_ctx);
+    pid_t child_pid;
+    errno_t ret;
+    int status;
+
+    const char *extra_env[] = {
+        "TEST_ENV_VAR1", "foo",
+        "TEST_ENV_VAR2", "bar",
+        NULL
+    };
+
+    setenv("TEST_CHILD_ACTION", "check_extra_env", 1);
+
+    child_pid = fork();
+    assert_int_not_equal(child_pid, -1);
+    if (child_pid == 0) {
+        exec_child_ex(child_tctx,
+                      child_tctx->pipefd_to_child,
+                      child_tctx->pipefd_from_child,
+                      CHILD_DIR"/"TEST_BIN, NULL,
+                      NULL, false, extra_env,
+                      STDIN_FILENO, STDOUT_FILENO);
+    } else {
+        do {
+            errno = 0;
+            ret = waitpid(child_pid, &status, 0);
+        } while (ret == -1 && errno == EINTR);
+
+        if (ret > 0) {
+            ret = EIO;
+            if (WIFEXITED(status)) {
+                ret = WEXITSTATUS(status);
+                assert_int_equal(ret, 0);
+            }
+        } else {
+            DEBUG(SSSDBG_FUNC_DATA,
+                "Failed to wait for children %d\n", child_pid);
+            ret = EIO;
+        }
+    }
+}
+
 int main(int argc, const char *argv[])
 {
     int rv;
@@ -540,6 +586,9 @@ int main(int argc, const char *argv[])
                                         child_test_setup,
                                         child_test_teardown),
         cmocka_unit_test_setup_teardown(test_exec_child_extra_args,
+                                        child_test_setup,
+                                        child_test_teardown),
+        cmocka_unit_test_setup_teardown(test_exec_child_extra_env,
                                         child_test_setup,
                                         child_test_teardown),
         cmocka_unit_test_setup_teardown(test_exec_child_handler,

--- a/src/tests/cmocka/test_failover_server.c
+++ b/src/tests/cmocka/test_failover_server.c
@@ -466,6 +466,43 @@ static void test_sss_failover_server_state_management(void **state)
     talloc_free(srv);
 }
 
+/* Test: sss_failover_server_is_working returns true only for WORKING state */
+static void test_sss_failover_server_is_working(void **state)
+{
+    TALLOC_CTX *test_ctx = (TALLOC_CTX*)*state;
+    struct sss_failover_server *srv;
+
+    srv = sss_failover_server_new(test_ctx, "server.ipa.test",
+                                  "ldap://server.ipa.test", 389, 10, 100);
+    assert_non_null(srv);
+
+    /* Initial state UNKNOWN: not working */
+    assert_int_equal(srv->state, SSS_FAILOVER_SERVER_STATE_UNKNOWN);
+    assert_false(sss_failover_server_is_working(srv));
+
+    /* REACHABLE: not working */
+    sss_failover_server_mark_reachable(srv);
+    assert_false(sss_failover_server_is_working(srv));
+
+    /* WORKING: working */
+    sss_failover_server_mark_working(srv);
+    assert_true(sss_failover_server_is_working(srv));
+
+    /* OFFLINE: not working */
+    sss_failover_server_mark_offline(srv);
+    assert_false(sss_failover_server_is_working(srv));
+
+    /* UNKNOWN again: not working */
+    sss_failover_server_mark_unknown(srv);
+    assert_false(sss_failover_server_is_working(srv));
+
+    /* RESOLVER_ERROR: not working */
+    sss_failover_server_mark_resolver_error(srv);
+    assert_false(sss_failover_server_is_working(srv));
+
+    talloc_free(srv);
+}
+
 /* Test: Compare two equal servers */
 static void test_sss_failover_server_equal__same(void **state)
 {
@@ -557,6 +594,8 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_sss_failover_server_clone__null_server,
                                         setup, teardown),
         cmocka_unit_test_setup_teardown(test_sss_failover_server_state_management,
+                                        setup, teardown),
+        cmocka_unit_test_setup_teardown(test_sss_failover_server_is_working,
                                         setup, teardown),
         cmocka_unit_test_setup_teardown(test_sss_failover_server_equal__same,
                                         setup, teardown),

--- a/src/tests/cmocka/test_sssd_krb5_locator_plugin.c
+++ b/src/tests/cmocka/test_sssd_krb5_locator_plugin.c
@@ -55,6 +55,10 @@ static int setup(void **state)
 {
     struct test_state *ts = NULL;
 
+    /* Make sure we don't leak the variables. */
+    unsetenv("SSSD_KRB5_LOCATOR_KDC_ADDRESS");
+    unsetenv("SSSD_KRB5_LOCATOR_KPASSWD_ADDRESS");
+
     assert_true(leak_check_setup());
 
     ts = talloc(global_talloc_context, struct test_state);
@@ -73,6 +77,10 @@ static int setup(void **state)
 static int teardown(void **state)
 {
     struct test_state *ts = talloc_get_type_abort(*state, struct test_state);
+
+    /* Make sure we don't leak the variables. */
+    unsetenv("SSSD_KRB5_LOCATOR_KDC_ADDRESS");
+    unsetenv("SSSD_KRB5_LOCATOR_KPASSWD_ADDRESS");
 
     assert_non_null(ts);
 
@@ -736,6 +744,177 @@ void test_kpasswd_and_master_kdc(void **state)
     krb5_free_context(ctx);
 }
 
+void test_kdc_addr_override(void **state)
+{
+    krb5_context ctx;
+    krb5_error_code kerr;
+    void *priv;
+    struct serverlist list = SERVERLIST_INIT;
+    struct module_callback_data cbdata = { 0 };
+    int ret;
+    char host[NI_MAXHOST];
+    char service[NI_MAXSERV];
+
+    cbdata.list = &list;
+
+    setenv("SSSD_KRB5_LOCATOR_KDC_ADDRESS", TEST_IP_1, 1);
+
+    kerr = krb5_init_context(&ctx);
+    assert_int_equal(kerr, 0);
+
+    kerr = sssd_krb5_locator_init(ctx, &priv);
+    assert_int_equal(kerr, 0);
+
+    kerr = sssd_krb5_locator_lookup(priv, locate_service_kdc, TEST_REALM,
+                                    SOCK_DGRAM, AF_INET, module_callback,
+                                    &cbdata);
+    assert_int_equal(kerr, 0);
+    assert_int_equal(list.nservers, 1);
+    assert_non_null(list.servers);
+    ret = getnameinfo((struct sockaddr *) &list.servers[0].addr,
+                      list.servers[0].addrlen,
+                      host, sizeof(host), service, sizeof(service),
+                      NI_NUMERICHOST|NI_NUMERICSERV);
+    assert_int_equal(ret, 0);
+    assert_string_equal(TEST_IP_1, host);
+    assert_string_equal("88", service);
+
+    k5_free_serverlist(&list);
+
+    sssd_krb5_locator_close(priv);
+    krb5_free_context(ctx);
+    unsetenv("SSSD_KRB5_LOCATOR_KDC_ADDRESS");
+}
+
+void test_kdc_addr_override_with_port(void **state)
+{
+    krb5_context ctx;
+    krb5_error_code kerr;
+    void *priv;
+    struct serverlist list = SERVERLIST_INIT;
+    struct module_callback_data cbdata = { 0 };
+    int ret;
+    char host[NI_MAXHOST];
+    char service[NI_MAXSERV];
+
+    cbdata.list = &list;
+
+    setenv("SSSD_KRB5_LOCATOR_KDC_ADDRESS", TEST_IP_1_WITH_SERVICE, 1);
+
+    kerr = krb5_init_context(&ctx);
+    assert_int_equal(kerr, 0);
+
+    kerr = sssd_krb5_locator_init(ctx, &priv);
+    assert_int_equal(kerr, 0);
+
+    kerr = sssd_krb5_locator_lookup(priv, locate_service_kdc, TEST_REALM,
+                                    SOCK_DGRAM, AF_INET, module_callback,
+                                    &cbdata);
+    assert_int_equal(kerr, 0);
+    assert_int_equal(list.nservers, 1);
+    assert_non_null(list.servers);
+    ret = getnameinfo((struct sockaddr *) &list.servers[0].addr,
+                      list.servers[0].addrlen,
+                      host, sizeof(host), service, sizeof(service),
+                      NI_NUMERICHOST|NI_NUMERICSERV);
+    assert_int_equal(ret, 0);
+    assert_string_equal(TEST_IP_1, host);
+    assert_string_equal(TEST_SERVICE_1, service);
+
+    k5_free_serverlist(&list);
+
+    sssd_krb5_locator_close(priv);
+    krb5_free_context(ctx);
+    unsetenv("SSSD_KRB5_LOCATOR_KDC_ADDRESS");
+}
+
+void test_kpasswd_addr_override(void **state)
+{
+    krb5_context ctx;
+    krb5_error_code kerr;
+    void *priv;
+    int fd;
+    struct serverlist list = SERVERLIST_INIT;
+    struct module_callback_data cbdata = { 0 };
+    ssize_t s;
+    int ret;
+    char host[NI_MAXHOST];
+    char service[NI_MAXSERV];
+
+    cbdata.list = &list;
+
+    setenv("SSSD_KRB5_LOCATOR_KPASSWD_ADDRESS", TEST_IPV6_1, 1);
+
+    kerr = krb5_init_context(&ctx);
+    assert_int_equal(kerr, 0);
+
+    kerr = sssd_krb5_locator_init(ctx, &priv);
+    assert_int_equal(kerr, 0);
+
+    /* Create kdcinfo so the KDC lookup succeeds */
+    mkdir(TEST_PUBCONF_PATH, 0777);
+    fd = open(TEST_PUBCONF_PATH"/kdcinfo."TEST_REALM, O_CREAT|O_RDWR, 0777);
+    assert_int_not_equal(fd, -1);
+    s = write(fd, TEST_IP_1, sizeof(TEST_IP_1));
+    assert_int_equal(s, sizeof(TEST_IP_1));
+    close(fd);
+
+    /* KDC lookup should use kdcinfo file */
+    kerr = sssd_krb5_locator_lookup(priv, locate_service_kdc, TEST_REALM,
+                                    SOCK_DGRAM, AF_INET, module_callback,
+                                    &cbdata);
+    assert_int_equal(kerr, 0);
+    assert_int_equal(list.nservers, 1);
+    ret = getnameinfo((struct sockaddr *) &list.servers[0].addr,
+                      list.servers[0].addrlen,
+                      host, sizeof(host), service, sizeof(service),
+                      NI_NUMERICHOST|NI_NUMERICSERV);
+    assert_int_equal(ret, 0);
+    assert_string_equal(TEST_IP_1, host);
+    assert_string_equal("88", service);
+
+    k5_free_serverlist(&list);
+
+    /* kpasswd lookup should use the override address */
+    kerr = sssd_krb5_locator_lookup(priv, locate_service_kpasswd, TEST_REALM,
+                                    SOCK_DGRAM, AF_INET6, module_callback,
+                                    &cbdata);
+    assert_int_equal(kerr, 0);
+    assert_int_equal(list.nservers, 1);
+    ret = getnameinfo((struct sockaddr *) &list.servers[0].addr,
+                      list.servers[0].addrlen,
+                      host, sizeof(host), service, sizeof(service),
+                      NI_NUMERICHOST|NI_NUMERICSERV);
+    assert_int_equal(ret, 0);
+    assert_string_equal(TEST_IPV6_1_PURE, host);
+    assert_string_equal("464", service);
+
+    k5_free_serverlist(&list);
+
+    /* locate_service_master_kdc should use the default KDC port 88 and not
+     * the one set in the kpasswd override. */
+    kerr = sssd_krb5_locator_lookup(priv, locate_service_master_kdc, TEST_REALM,
+                                    SOCK_DGRAM, AF_INET6, module_callback,
+                                    &cbdata);
+    assert_int_equal(kerr, 0);
+    assert_int_equal(list.nservers, 1);
+    ret = getnameinfo((struct sockaddr *) &list.servers[0].addr,
+                      list.servers[0].addrlen,
+                      host, sizeof(host), service, sizeof(service),
+                      NI_NUMERICHOST|NI_NUMERICSERV);
+    assert_int_equal(ret, 0);
+    assert_string_equal(TEST_IPV6_1_PURE, host);
+    assert_string_equal("88", service);
+
+    k5_free_serverlist(&list);
+
+    unlink(TEST_PUBCONF_PATH"/kdcinfo."TEST_REALM);
+    rmdir(TEST_PUBCONF_PATH);
+    sssd_krb5_locator_close(priv);
+    krb5_free_context(ctx);
+    unsetenv("SSSD_KRB5_LOCATOR_KPASSWD_ADDRESS");
+}
+
 int main(int argc, const char *argv[])
 {
     poptContext pc;
@@ -761,6 +940,12 @@ int main(int argc, const char *argv[])
         cmocka_unit_test_setup_teardown(test_service,
                                         setup, teardown),
         cmocka_unit_test_setup_teardown(test_kpasswd_and_master_kdc,
+                                        setup, teardown),
+        cmocka_unit_test_setup_teardown(test_kdc_addr_override,
+                                        setup, teardown),
+        cmocka_unit_test_setup_teardown(test_kdc_addr_override_with_port,
+                                        setup, teardown),
+        cmocka_unit_test_setup_teardown(test_kpasswd_addr_override,
                                         setup, teardown),
     };
 

--- a/src/util/child_common.h
+++ b/src/util/child_common.h
@@ -68,11 +68,14 @@ typedef void (*sss_child_sigchld_callback_t)(int child_status,
  * There is also a watch attached to SIGCHLD 'pvt' so callback won't be called
  * if 'pvt' was freed. But basic handling - waitpid() - is still performed
  * automatically.
+ *
+ * extra_env format: {"NAME1", "value1", "NAME2", "value2", NULL}
  */
 errno_t sss_child_start(TALLOC_CTX *mem_ctx,
                         struct tevent_context *ev,
                         const char *binary,
                         const char *extra_args[], bool extra_args_only,
+                        const char *extra_env[],  /* extra environment variables */
                         const char *logfile,
                         int child_out_fd,  /* FD that binary uses to write response to */
                         sss_child_sigchld_callback_t cb,  /* SIGCHLD handler */

--- a/src/util/child_handlers.c
+++ b/src/util/child_handlers.c
@@ -701,6 +701,7 @@ errno_t sss_child_start(TALLOC_CTX *mem_ctx,
                         struct tevent_context *ev,
                         const char *binary,
                         const char *extra_args[], bool extra_args_only,
+                        const char *extra_env[],
                         const char *logfile,
                         int child_out_fd,
                         sss_child_sigchld_callback_t cb, void *pvt,
@@ -752,7 +753,7 @@ errno_t sss_child_start(TALLOC_CTX *mem_ctx,
         exec_child_ex(tmp_ctx,
                       pipefd_to_child, pipefd_from_child,
                       binary, logfile,
-                      extra_args, extra_args_only, NULL,
+                      extra_args, extra_args_only, extra_env,
                       STDIN_FILENO, child_out_fd);
 
         /* We should never get here */

--- a/src/util/child_handlers.c
+++ b/src/util/child_handlers.c
@@ -419,11 +419,47 @@ static void log_child_command(TALLOC_CTX *mem_ctx, const char *binary,
     }
 }
 
+/* extra_env format: {"NAME1", "value1", "NAME2", "value2", NULL} */
+static errno_t child_setenv(const char *extra_env[])
+{
+    const char *name;
+    const char *value;
+    errno_t ret;
+    size_t i;
+
+    if (extra_env == NULL) {
+        return EOK;
+    }
+
+    for (i = 0; extra_env[i] != NULL; i += 2) {
+        name = extra_env[i];
+        value = extra_env[i + 1];
+
+        if (value == NULL) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Missing value for environment variable: %s\n", name);
+            return EINVAL;
+        }
+
+        ret = setenv(name, value, 1);
+        if (ret != 0) {
+            ret = errno;
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "setenv failed for %s [%d]: %s\n",
+                  name, ret, strerror(ret));
+            return ret;
+        }
+    }
+
+    return EOK;
+}
+
 /* Isn't static because it is used in unit test */
 void exec_child_ex(TALLOC_CTX *mem_ctx,
                    int *pipefd_to_child, int *pipefd_from_child,
                    const char *binary, const char *logfile,
                    const char *extra_argv[], bool extra_args_only,
+                   const char *extra_env[],
                    int child_in_fd, int child_out_fd)
 {
     int ret;
@@ -471,6 +507,12 @@ void exec_child_ex(TALLOC_CTX *mem_ctx,
                              &argv);
     if (ret != EOK) {
         DEBUG(SSSDBG_CRIT_FAILURE, "prepare_child_argv() failed.\n");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = child_setenv(extra_env);
+    if (ret != EOK) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "child_setenv() failed.\n");
         exit(EXIT_FAILURE);
     }
 
@@ -710,7 +752,7 @@ errno_t sss_child_start(TALLOC_CTX *mem_ctx,
         exec_child_ex(tmp_ctx,
                       pipefd_to_child, pipefd_from_child,
                       binary, logfile,
-                      extra_args, extra_args_only,
+                      extra_args, extra_args_only, NULL,
                       STDIN_FILENO, child_out_fd);
 
         /* We should never get here */


### PR DESCRIPTION
This pull request depends on:
- https://github.com/SSSD/sssd/pull/8982
- https://github.com/SSSD/sssd/pull/9135

The code in this pull request is actually only these four commits:

- failover: use specific KDC server
- failover: kinit is not repeated for existing connection
- failover: add new_candidates callback
- failover: do not write kdcinfo as part of ldap kinit

---

This pull request implements a new new_candidates callback that can be used to populated kdcinfo and kpasswdinfo files for krb5/ipa/ad authentication providers. The provider-specific callback is not yet implmented (this will be done in other pull request).

It also implements kinit for ldap connection that does not use kdcinfo file but rather provides an address of a specific KDC server that should be used. This allows us to fully control the failover process for Kerberos operations and it can mark the correct server as offline. Previously, we relied on having multiple servers in kdcinfo file (which is helpful to external clients such as running kinit on command line), but it does not relay the information on which server is down and which server was actually used. In new failover, we can correctly track this information and perform failover on our own terms, sharing the logic with ldap connection.

