### PR TITLE
pam_sss: cast to GdmPamExtensionMessage in binary prompt macro

### DIFF
--- a/src/sss_client/pam_sss.c
+++ b/src/sss_client/pam_sss.c
@@ -2239,8 +2239,9 @@ static int auth_selection_conversation_gdm(pam_handle_t *pamh,
 
     GDM_PAM_EXTENSION_CUSTOM_JSON_REQUEST_INIT(request, "auth-mechanisms", 1,
                                                pi->json_auth_msg);
-    GDM_PAM_EXTENSION_MESSAGE_TO_BINARY_PROMPT_MESSAGE(request,
-                                                       &prompt_message);
+    GDM_PAM_EXTENSION_MESSAGE_TO_BINARY_PROMPT_MESSAGE(
+                                        (GdmPamExtensionMessage *)request,
+                                        &prompt_message);
     prompt_messages[0] = &prompt_message;
 
     ret = conv->conv(1, prompt_messages, &reply, conv->appdata_ptr);
@@ -2343,8 +2344,9 @@ static int prompt_multi_cert_gdm(pam_handle_t *pamh, struct pam_items *pi)
         request->list.items[c++].text = prompt;
     }
 
-    GDM_PAM_EXTENSION_MESSAGE_TO_BINARY_PROMPT_MESSAGE(request,
-                                                       &prompt_message);
+    GDM_PAM_EXTENSION_MESSAGE_TO_BINARY_PROMPT_MESSAGE(
+                                        (GdmPamExtensionMessage *)request,
+                                        &prompt_message);
     prompt_messages[0] = &prompt_message;
 
     ret = conv->conv(1, prompt_messages, &reply, conv->appdata_ptr);


### PR DESCRIPTION
GDM's PAM extension headers were rewritten to replace the uppercase function-like macros with static inline functions. The re-added backwards-compatible GDM_PAM_EXTENSION_MESSAGE_TO_BINARY_PROMPT_MESSAGE macro forwards its argument to the strongly-typed
gdm_pam_extension_message_to_binary_prompt_message(GdmPamExtensionMessage *) without a cast, whereas the original macro cast it to void *.

Cast the request to GdmPamExtensionMessage * at the call sites so the code is correct regardless of header variant used.

Assisted-By: Claude Code (Opus 4.8)