### PR TITLE
Man page sssd_ad improvements

### DIFF
--- a/src/man/sssd-ad.5.xml
+++ b/src/man/sssd-ad.5.xml
@@ -1514,8 +1514,6 @@ ldap_account_expire_policy = ad
             because these attributes are included in the default Active
             Directory schema.
         </para>
-        <para>
-        </para>
     </refsect1>
 
 	<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="include/seealso.xml" />

--- a/src/man/sssd-ad.5.xml
+++ b/src/man/sssd-ad.5.xml
@@ -1258,10 +1258,9 @@ ad_gpo_map_deny = +my_pam_service
                             How often should the back end perform periodic DNS update in
                             addition to the automatic update performed when the back end
                             goes online.
-                            This option is optional and applicable only when dyndns_update
-                            is true. Note that the lowest possible value is 60 seconds in-case
-                            if value is provided less than 60, parameter will assume lowest
-                            value only.
+                            This is optional and applicable only when dyndns_update
+                            is true. Note that the minimum value is 60 seconds, any
+                            specified value below this threshold will default to 60.
                         </para>
                         <para>
                             Default: 86400 (24 hours)

--- a/src/man/sssd-ad.5.xml
+++ b/src/man/sssd-ad.5.xml
@@ -1106,7 +1106,7 @@ ad_gpo_map_deny = +my_pam_service
                             <command>realm</command> will be used. Since
                             the helper is started as the user SSSD is running
                             as there might be the chance that the renewal will
-                            fail if this user does not has permissions to
+                            fail if this user does not have permissions to
                             modify the keytab file where the machine account
                             credentials are stored. This will typically be the
                             case for <command>adcli</command>.


### PR DESCRIPTION
- Improve description for dyndns_refresh_interval
- Remove empty <para></para> from sssd-ad.5.xml
- Correct the minor typo in sssd-ad.5.xml