### PR TITLE
ci: Fix duplicated python-system-tests in static-code-analysis.yml

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -113,57 +113,6 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4
 
-  python-system-tests:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-    - uses: actions/setup-python@v7
-      with:
-        python-version: '3.x'
-
-    - name: Checkout repository
-      uses: actions/checkout@v7
-
-    - name: Setup virtual environment
-      working-directory: ./src/tests/system
-      run: |
-        sudo apt-get update
-
-        # Install dependencies for python-ldap
-        sudo apt-get install -y libsasl2-dev python3-dev libldap2-dev libssl-dev libssh-dev
-
-        pip3 install virtualenv
-        python3 -m venv .venv
-        source .venv/bin/activate
-        pip3 install -r ./requirements.txt
-        pip3 install flake8 pycodestyle isort mypy black
-
-    - name: flake8
-      if: always()
-      working-directory: ./src/tests/system
-      run: source .venv/bin/activate && flake8 .
-
-    - name: pycodestyle
-      if: always()
-      working-directory: ./src/tests/system
-      run: source .venv/bin/activate && pycodestyle .
-
-    - name: isort
-      if: always()
-      working-directory: ./src/tests/system
-      run: source .venv/bin/activate && isort --check-only .
-
-    - name: black
-      if: always()
-      working-directory: ./src/tests/system
-      run: source .venv/bin/activate && black --check --diff .
-
-    - name: mypy
-      if: always()
-      working-directory: ./src/tests/system
-      run: source .venv/bin/activate && mypy --install-types --non-interactive tests
-
   pre-commit:
     runs-on: ubuntu-latest
     permissions:

--- a/src/tests/system/pyproject.toml
+++ b/src/tests/system/pyproject.toml
@@ -17,6 +17,9 @@ exclude = [".venv"]
 # E/W ≈ pycodestyle, F ≈ pyflakes/flake8, I ≈ isort; defaults are Black-compatible
 select = ["E", "W", "F", "I"]
 
+[tool.ruff.lint.pycodestyle]
+max-line-length = 119
+
 [tool.ruff.lint.isort]
 required-imports = ["from __future__ import annotations"]
 

--- a/src/tests/system/tests/test_passkey.py
+++ b/src/tests/system/tests/test_passkey.py
@@ -737,12 +737,9 @@ def test_passkey__su_with_12_mappings(
     assert rc == 0, "Authentication failed"
     assert "Ticket cache" in output, "Failed to get the TGT"
     assert (
-        not (
-            "No Kerberos TGT granted as the server does not support this method. "
-            "Your single-sign on(SSO) experience will be affected"
-        )
-        in output
-    ), "Get the console message about TGT"
+        "No Kerberos TGT granted as the server does not support this method. "
+        "Your single-sign on(SSO) experience will be affected"
+    ) not in output, "Get the console message about TGT"
 
 
 @pytest.mark.importance("critical")
@@ -783,13 +780,10 @@ def test_passkey__su_no_pin_set(
 
     assert rc == 0, "Authentication failed"
     assert "Ticket cache" in output, "Failed to get the TGT"
-    assert not (
-        (
-            "No Kerberos TGT granted as the server does not support this method. "
-            "Your single-sign on(SSO) experience will be affected"
-        )
-        in output
-    ), "Got the console message about No Kerberos TGT granted"
+    assert (
+        "No Kerberos TGT granted as the server does not support this method. "
+        "Your single-sign on(SSO) experience will be affected"
+    ) not in output, "Got the console message about No Kerberos TGT granted"
 
 
 @pytest.mark.importance("medium")
@@ -837,12 +831,9 @@ def test_passkey__prompt_options(
     assert rc == 0, "Authentication failed"
     assert "Ticket cache" in output, "Failed to get the TGT"
     assert (
-        not (
-            "No Kerberos TGT granted as the server does not support this method."
-            "Your single-sign on(SSO) experience will be affected"
-        )
-        in output
-    ), "Got the console message about No Kerberos TGT granted"
+        "No Kerberos TGT granted as the server does not support this method."
+        "Your single-sign on(SSO) experience will be affected"
+    ) not in output, "Got the console message about No Kerberos TGT granted"
 
 
 @pytest.mark.importance("critical")
@@ -883,9 +874,6 @@ def test_passkey__su_fallback_to_password(
     assert rc == 0, "Authentication failed"
     assert "Ticket cache" in output, "Failed to get the TGT"
     assert (
-        not (
-            "No Kerberos TGT granted as the server does not support this method."
-            " Your single-sign on(SSO) experience will be affected"
-        )
-        in output
-    ), "Got the console message about No Kerberos TGT granted"
+        "No Kerberos TGT granted as the server does not support this method."
+        " Your single-sign on(SSO) experience will be affected"
+    ) not in output, "Got the console message about No Kerberos TGT granted"


### PR DESCRIPTION
The item got duplicated due to incorrect conflict resolution during rebase.
Set max-line-length for ruff as it has the setting in multiple places.
Fix E713 [*] Test for membership should be `not in` in passkey tests.