### PR TITLE
tests: mark test_kcm__tgt_renewal_updates_ticket_as_configured as flaky

### DIFF
--- a/src/tests/system/tests/test_kcm.py
+++ b/src/tests/system/tests/test_kcm.py
@@ -350,6 +350,7 @@ def test_kcm__kdestroy_nocache_throws_no_error(client: Client, kdc: KDC, ccache_
                 assert False, f"Destroying cache raised an error: {e}"
 
 
+@pytest.mark.flaky(max_runs=5)
 @pytest.mark.importance("critical")
 @pytest.mark.authentication
 @pytest.mark.topology(KnownTopology.Client)


### PR DESCRIPTION
The feature works well, but the test sometimes fail due to timing
issues.
