### PR TITLE
Man: Remove note about obsolete option ipa_dyndns_iface

### DIFF
--- a/src/man/sssd-ad.5.xml
+++ b/src/man/sssd-ad.5.xml
@@ -1213,12 +1213,6 @@ ad_gpo_map_deny = +my_pam_service
                             details about patterns.
                         </para>
                         <para>
-                            NOTE: While it is still possible to use the old
-                            <emphasis>ipa_dyndns_iface</emphasis> option, users
-                            should migrate to using <emphasis>dyndns_iface</emphasis>
-                            in their config file.
-                        </para>
-                        <para>
                             Default: Use the IP addresses of the interface which
                             is used for AD LDAP connection
                         </para>


### PR DESCRIPTION
This patch removes note about obsolete option `ipa_dyndns_iface` from description of `dyndns_iface` option in sssd-ad(5) man-page. ipa_dyndns_iface option was already removed from sssd code with commit a38790f.