### PR TITLE
ci: workaround PR CI issues on ubuntu-24-04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         tag: ${{ fromJson(needs.prepare.outputs.matrix).intgcheck }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     steps:
@@ -98,7 +98,7 @@ jobs:
       fail-fast: false
       matrix:
         tag: ${{ fromJson(needs.prepare.outputs.matrix).multihost }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     steps:
@@ -117,7 +117,7 @@ jobs:
         set -ex -o pipefail
 
         sudo apt-get update
-        sudo apt-get install -y linux-modules-extra-$(uname -r)
+        sudo apt-get install -y linux-modules-$(uname -r)
 
         sudo modprobe vhci-hcd
 

--- a/src/tests/system/tests/test_ldap_krb5.py
+++ b/src/tests/system/tests/test_ldap_krb5.py
@@ -161,14 +161,10 @@ def test_ldap_krb5__keytab_selects_correct_principal_with_multiple_realms(
         4. Start SSSD
     :steps:
         1. Trigger user lookup
-        2. Truncate ldap_child.log
-        3. Trigger user lookup again
-        4. Read ldap_child.log for selected principal
+        2. Read ldap_child.log for selected principal
     :expectedresults:
-        1. First user lookup completes
-        2. ldap_child.log is truncated
-        3. Second user lookup completes
-        4. Wrong nfs principal is not selected; correct host principal is in the log
+        1. User lookup completes
+        2. Wrong nfs principal is not selected; correct host principal is in the log
     :customerscenario: True
     """
     provider.user("puser1").add(uid=1001, gid=1001, password="12345678")
@@ -197,22 +193,18 @@ def test_ldap_krb5__keytab_selects_correct_principal_with_multiple_realms(
     client.sssd.domain["ldap_sasl_mech"] = "GSSAPI"
     client.sssd.domain["ldap_krb5_keytab"] = "/etc/krb5.keytab"
     client.sssd.domain["debug_level"] = "0xFFF0"
-
-    client.sssd.restart(clean=True)
-
-    client.tools.id("puser1")
-
-    client.host.conn.run("truncate -s 0 /var/log/sssd/ldap_child.log", raise_on_error=False)
+    client.sssd.start()
 
     client.tools.id("puser1")
+
+    # `id` can return before ldap_child finishes appending to ldap_child.log.
+    time.sleep(2)
 
     ldap_child_log = "/var/log/sssd/ldap_child.log"
     wrong_pattern = f"nfs/{client.host.hostname}@TEST.EXAMPLE.COM"
     correct_pattern = f"host/{client.host.hostname}@{kdc.realm}"
     selected_ok = f"Selected principal: {correct_pattern}"
 
-    # `id` can return before ldap_child finishes appending to ldap_child.log.
-    time.sleep(2)
     log_content = client.fs.read(ldap_child_log)
 
     assert f"Selected principal: {wrong_pattern}" not in log_content, f"SSSD incorrectly selected {wrong_pattern}!"


### PR DESCRIPTION
ci: use ubuntu-26-04 runner to workaroud issues on ubuntu-24-04

ubuntu-24-04 started having issues with podman containers, switching
to ubuntu-26-04 seems to workaround it. At the time of this commit
ubuntu-24-04 is still ubuntu-latest, while ubuntu-26-04 is in preview
state.

See: https://github.com/actions/runner-images/issues/14604#issuecomment-5478535669

---

ubuntu-26-04 had its own problems when tshark (running as root) is accessing pcap file owned by tcpdump in /tmp and docker-compose command is not available there. But this is possible to workaround.

---

Requires:
* https://github.com/SSSD/sssd-ci-containers/pull/214
* https://github.com/SSSD/sssd-test-framework/pull/271

Green run with the changes from sssd-ci-containers and sssd-test-framework:
* https://github.com/SSSD/sssd/actions/runs/33491749812?pr=9183

