### PR TITLE
Man: Improvement in max_ccache_size parameter

### DIFF
--- a/src/man/sssd-kcm.8.xml
+++ b/src/man/sssd-kcm.8.xml
@@ -276,8 +276,8 @@ systemctl restart sssd-kcm.service
                 <term>max_ccache_size (integer)</term>
                 <listitem>
                     <para>
-                        How big can a credential cache be per ccache. Each
-                        service ticket accounts into this quota.
+                        How big a credential cache be per ccache. Each
+                        service ticket counts toward this quota.
                     </para>
                     <para>
                         Default: 65536


### PR DESCRIPTION
This patch improves description of max_ccache_size option in sssd-kcm(8) man-page.