### PR TITLE
fix(docs): repair malformed quote tag in Spanish sssd-ifp.5 translation

### DIFF
--- a/src/man/po/es.po
+++ b/src/man/po/es.po
@@ -18102,7 +18102,7 @@ msgstr ""
 "Es posible añadir otro atributo a este conjunto usando <quote>+attr_name</"
 "quote> o eliminarlo explícitamente usando <quote>-attr_name</quote>. "
 "Atributos añadidos serán hechos disponibles en el segmento <quote>"
-"extraAttributes>/quote>. Por ejemplo, para permitir <quote>telephoneNumber</"
+"extraAttributes</quote>. Por ejemplo, para permitir <quote>telephoneNumber</"
 "quote> pero denegar <quote>loginShell</quote>, se usaría la siguiente "
 "configuración: <placeholder type=\"programlisting\" id=\"0\"/>"
 


### PR DESCRIPTION
Skip Testing Farm's default Copr RPM install on the host for `/plans/passkey`. SSSD is installed in test containers via `dnf copr enable`, so the host install is unnecessary and was failing guest
setup (`libipa_hbac ... not a rpm`).

Assisted-by: Cursor