### PR TITLE
fix(test): run DS LDAP setup on the SUT for mrack compatibility

### DIFF
--- a/src/tests/multihost/alltests/conftest.py
+++ b/src/tests/multihost/alltests/conftest.py
@@ -134,8 +134,8 @@ def setup_authselect(session_multihost):
 @pytest.fixture(scope='function')
 def ldap_posix_usergroup(session_multihost, request):
     """ Create single ldap posix user group """
-    ldap_uri = f'ldap://{session_multihost.master[0].ip}'
-    ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+    ldap_inst = LdapOperations.for_ds_host(session_multihost.master[0],
+                                         ds_rootdn, ds_rootpw)
     krb = krb5srv(session_multihost.master[0], 'EXAMPLE.TEST')
     id = random.randint(9, 99)
     user_info = {'cn': f'usr_{id}',
@@ -189,10 +189,8 @@ def localusers(session_multihost, request):
 @pytest.fixture(scope='function')
 def create_350_posix_users(session_multihost, request):
     """ Create posix user and groups """
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
-    ds_rootdn = 'cn=Directory Manager'
-    ds_rootpw = 'Secret123'
-    ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+    ldap_inst = LdapOperations.for_ds_host(session_multihost.master[0],
+                                         ds_rootdn, ds_rootpw)
     krb = krb5srv(session_multihost.master[0], 'EXAMPLE.TEST')
     for i in range(1, 351):
         user_info = {'cn': 'doo%d' % i,
@@ -257,10 +255,8 @@ def backupsssdconf(session_multihost, request):
 @pytest.fixture(scope='function')
 def delete_groups_users(session_multihost, request):
     """Fixture for bz1817122"""
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
-    ds_rootdn = 'cn=Directory Manager'
-    ds_rootpw = 'Secret123'
-    ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+    ldap_inst = LdapOperations.for_ds_host(session_multihost.master[0],
+                                         ds_rootdn, ds_rootpw)
 
     def restoresssdconf():
         """Delete users, ous and groups"""
@@ -286,10 +282,8 @@ def delete_groups_users(session_multihost, request):
 @pytest.fixture(scope="function")
 def set_dslimits(session_multihost, request):
     """ Modify nsslapd-sizelimit """
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
-    ds_rootdn = 'cn=Directory Manager'
-    ds_rootpw = 'Secret123'
-    ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+    ldap_inst = LdapOperations.for_ds_host(session_multihost.master[0],
+                                         ds_rootdn, ds_rootpw)
     configdn = 'cn=config,cn=ldbm database,cn=plugins,cn=config'
     mod_limit = [(ldap.MOD_REPLACE, 'nsslapd-lookthroughlimit', [b'10'])]
     (ret, _) = ldap_inst.modify_ldap(configdn, mod_limit)
@@ -325,11 +319,9 @@ def add_nisobject(session_multihost, request):
         session_multihost.master[0].run_command(start_nfs)
     except subprocess.CalledProcessError:
         pytest.fail("Unable to start nfs server")
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
-    ds_rootdn = 'cn=Directory Manager'
-    ds_rootpw = 'Secret123'
+    ldap_inst = LdapOperations.for_ds_host(session_multihost.master[0],
+                                         ds_rootdn, ds_rootpw)
     ds_suffix = 'dc=example,dc=test'
-    ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
     ret = ldap_inst.add_map(request.param, 'auto.direct',
                             nfs_server, request.param, ds_suffix)
     assert ret == 'Success'
@@ -371,10 +363,8 @@ def indirect_nismaps(session_multihost, request, create_etc_exports):
     nfs_server = session_multihost.master[0].external_hostname
     client_ip = session_multihost.client[0].ip
     server = sssdTools(session_multihost.master[0])
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
-    ds_rootdn = 'cn=Directory Manager'
-    ds_rootpw = 'Secret123'
-    ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+    ldap_inst = LdapOperations.for_ds_host(session_multihost.master[0],
+                                         ds_rootdn, ds_rootpw)
     server.export_nfs_fs(['/projects'], client_ip)
     for i in range(1, 20):
         map_keys = ['foo%d' % (i)]
@@ -456,10 +446,8 @@ def set_ldap_uri(session_multihost, request):
 @pytest.fixture(scope="function")
 def create_ssh_keys(session_multihost, request):
     """ Create ssh keys """
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
-    ds_rootdn = 'cn=Directory Manager'
-    ds_rootpw = 'Secret123'
-    ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+    ldap_inst = LdapOperations.for_ds_host(session_multihost.master[0],
+                                         ds_rootdn, ds_rootpw)
     keygen_cmd = "ssh-keygen -q -t rsa -b 2048 -N '' -f /tmp/id_rsa -C ''"
     session_multihost.client[0].run_command(keygen_cmd)
     get_pub_key = 'cat /tmp/id_rsa.pub'
@@ -533,11 +521,9 @@ def sssd_sudo_conf(session_multihost, request):
 @pytest.fixture(scope='function')
 def sudo_rule(session_multihost, request):
     """ Create sudoers ldap entries """
-    ldap_uri = f'ldap://{session_multihost.master[0].ip}'
+    ldap_inst = LdapOperations.for_ds_host(session_multihost.master[0],
+                                         ds_rootdn, ds_rootpw)
     sudo_ou = f'ou=sudoers,{ds_suffix}'
-    ds_rootdn = 'cn=Directory Manager'
-    ds_rootpw = 'Secret123'
-    ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
     try:
         ldap_inst.org_unit('sudoers', ds_suffix)
     except LdapException:
@@ -577,11 +563,9 @@ testdata = [
 @pytest.fixture(ids=["sudoNotBefore", "sudoNotAfter"], params=testdata)
 def timed_sudoers(session_multihost, request):
     """ Creates a time sudoers ldap entries """
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
+    ldap_inst = LdapOperations.for_ds_host(session_multihost.master[0],
+                                         ds_rootdn, ds_rootpw)
     sudo_ou = 'ou=sudoers, %s' % ds_suffix
-    ds_rootdn = 'cn=Directory Manager'
-    ds_rootpw = 'Secret123'
-    ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
     try:
         ldap_inst.org_unit('sudoers', ds_suffix)
     except LdapException:
@@ -706,11 +690,8 @@ def posix_users_multidomain(session_multihost, multipleds):
     id_suffix = ['20', '30']
     for idx in range(2):
         host = session_multihost.master[idx]
-        ldap_uri = 'ldap://%s' % (host.ip)
-        ds_rootdn = 'cn=Directory Manager'
-        ds_rootpw = 'Secret123'
+        ldap_inst = LdapOperations.for_ds_host(host, ds_rootdn, ds_rootpw)
         ds_suffix = 'dc=example%d,dc=test' % idx
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
         for i in range(20):
             uid = "{:02d}".format(i)
             user_info = {'cn': '%suser%d' % (suffix[idx], i),
@@ -976,10 +957,8 @@ def setup_sssd_gssapi(session_multihost, setup_sssd,
     tools = sssdTools(session_multihost.client[0])
     domain_section = 'domain/%s' % ds_instance_name
     krb5_server = session_multihost.master[0].sys_hostname
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
-    ds_rootdn = 'cn=Directory Manager'
-    ds_rootpw = 'Secret123'
-    ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+    ldap_inst = LdapOperations.for_ds_host(session_multihost.master[0],
+                                         ds_rootdn, ds_rootpw)
     domain_params = {'auth_provider': 'krb5',
                      'ldap_sasl_mech': 'GSSAPI',
                      'krb5_realm': 'EXAMPLE.TEST',
@@ -1043,10 +1022,8 @@ def multihost(session_multihost, request):
 @pytest.fixture(scope='class')
 def create_posix_usersgroups(session_multihost):
     """ Create posix user and groups """
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
-    ds_rootdn = 'cn=Directory Manager'
-    ds_rootpw = 'Secret123'
-    ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+    ldap_inst = LdapOperations.for_ds_host(session_multihost.master[0],
+                                         ds_rootdn, ds_rootpw)
     krb = krb5srv(session_multihost.master[0], 'EXAMPLE.TEST')
     for i in range(10):
         user_info = {'cn': 'foo%d' % i,
@@ -1078,10 +1055,8 @@ def create_posix_usersgroups(session_multihost):
 def create_posix_usersgroups_failover(session_multihost):
     """ Create posix user and groups """
     for idx in range(2):
-        ldap_uri = 'ldap://%s' % (session_multihost.master[idx].ip)
-        ds_rootdn = 'cn=Directory Manager'
-        ds_rootpw = 'Secret123'
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+        ldap_inst = LdapOperations.for_ds_host(session_multihost.master[idx],
+                                             ds_rootdn, ds_rootpw)
         for i in range(10):
             user_info = {'cn': 'foo%d' % i,
                          'uid': 'foo%d' % i,
@@ -1111,10 +1086,8 @@ def create_posix_usersgroups_failover(session_multihost):
 @pytest.fixture(scope='class')
 def create_posix_usersgroups_autoprivategroups(session_multihost):
     """ Create posix user and groups for autoprivategroup fixture"""
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
-    ds_rootdn = 'cn=Directory Manager'
-    ds_rootpw = 'Secret123'
-    ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+    ldap_inst = LdapOperations.for_ds_host(session_multihost.master[0],
+                                         ds_rootdn, ds_rootpw)
     for i in range(10):
         user_info = {'cn': 'foobar%d' % i,
                      'uid': 'foobar%d' % i,
@@ -1167,10 +1140,8 @@ def create_posix_usersgroups_autoprivategroups(session_multihost):
 @pytest.fixture(scope='class')
 def netgroups(session_multihost):
     """ Create netgroup users """
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
-    ds_rootdn = 'cn=Directory Manager'
-    ds_rootpw = 'Secret123'
-    ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+    ldap_inst = LdapOperations.for_ds_host(session_multihost.master[0],
+                                         ds_rootdn, ds_rootpw)
     ldap_inst.org_unit('Netgroups', ds_suffix)
     for idx in range(10):
         nisNetgroupTriple = "(,foo%d, %s)" % (idx, krb_realm)
@@ -1211,10 +1182,8 @@ def enable_autofs_schema(session_multihost, request):
     :param obj session_multihost: multihost object
     :param obj request: pytest request object
     """
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
-    ds_rootdn = 'cn=Directory Manager'
-    ds_rootpw = 'Secret123'
-    ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+    ldap_inst = LdapOperations.for_ds_host(session_multihost.master[0],
+                                         ds_rootdn, ds_rootpw)
     ldap_inst.autofs_nis_schema(ds_suffix)
 
 
@@ -1311,10 +1280,8 @@ def create_host_user(session_multihost):
     """ Add host user for SASL with GSSAPI authentication
     :param obj session_multihost: multihost object
     """
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
-    ds_rootdn = 'cn=Directory Manager'
-    ds_rootpw = 'Secret123'
-    ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+    ldap_inst = LdapOperations.for_ds_host(session_multihost.master[0],
+                                         ds_rootdn, ds_rootpw)
     user_info = {'cn': 'host/%s' % session_multihost.client[0].sys_hostname,
                  'uid': 'host/%s' % session_multihost.client[0].sys_hostname,
                  'uidNumber': '9003',
@@ -1331,10 +1298,8 @@ def create_host_user(session_multihost):
 @pytest.fixture(scope='class')
 def enable_password_check_syntax(session_multihost, request):
     """ Enable passwordCheckSyntax """
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
-    ds_rootdn = 'cn=Directory Manager'
-    ds_rootpw = 'Secret123'
-    ldap_obj = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+    ldap_obj = LdapOperations.for_ds_host(session_multihost.master[0],
+                                        ds_rootdn, ds_rootpw)
     mod_dn1 = 'cn=config'
     add_pass_check = [(ldap.MOD_ADD, 'passwordCheckSyntax', [b'on'])]
     (ret, _) = ldap_obj.modify_ldap(mod_dn1, add_pass_check)
@@ -1448,10 +1413,8 @@ def add_host_entry(session_multihost, request):
     Add host and network entries in Directory server to be used
     by sssd hostmap feature.
     """
-    ldap_uri = 'ldap://%s' % (session_multihost.master[0].ip)
-    ds_rootdn = 'cn=Directory Manager'
-    ds_rootpw = 'Secret123'
-    ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+    ldap_inst = LdapOperations.for_ds_host(session_multihost.master[0],
+                                         ds_rootdn, ds_rootpw)
     user_info = {'cn': 'node1'.encode('utf-8'),
                  'objectClass': [b'top', b'ipHost', b'device'],
                  'ipHostNumber': '192.168.1.1'.encode('utf-8')}
@@ -1512,11 +1475,8 @@ def ns_account_lock(session_multihost, request):
     client.sssd_conf('nss', domain_params)
     session_multihost.client[0].service_sssd('restart')
     # Add managed role
-    master_e = session_multihost.master[0].ip
-    ldap_uri = f'ldaps://{master_e}'
-    ds_rootdn = 'cn=Directory Manager'
-    ds_rootpw = 'Secret123'
-    ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+    ldap_inst = LdapOperations.for_ds_host(session_multihost.master[0],
+                                         ds_rootdn, ds_rootpw, use_ssl=True)
     user_info = {'cn': 'managed'.encode('utf-8'),
                  'objectClass': [b'top', b'LdapSubEntry',
                                  b'nsRoleDefinition',
@@ -1547,11 +1507,9 @@ def ns_account_lock(session_multihost, request):
 
     def restoresssdconf():
         """ Restore sssd.conf """
-        master_e = session_multihost.master[0].ip
-        ldap_uri = f'ldaps://{master_e}'
-        ds_rootdn = 'cn=Directory Manager'
-        ds_rootpw = 'Secret123'
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+        ldap_inst = LdapOperations.for_ds_host(session_multihost.master[0],
+                                             ds_rootdn, ds_rootpw,
+                                             use_ssl=True)
         user_dn = 'uid=foo1,ou=People,dc=example,dc=test'
         role_dn = "cn=managed,ou=people,dc=example,dc=test"
         del_member = [(ldap.MOD_DELETE, 'nsRoleDN', role_dn.encode('utf-8'))]

--- a/src/tests/multihost/alltests/test_all_misc.py
+++ b/src/tests/multihost/alltests/test_all_misc.py
@@ -222,9 +222,8 @@ class TestMisc(object):
         """
         multihost.client[0].service_sssd('restart')
         ldap_uri = 'ldap://%s' % (multihost.master[0].ip)
-        ds_rootdn = 'cn=Directory Manager'
-        ds_rootpw = 'Secret123'
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+        ldap_inst = LdapOperations.for_ds_host(multihost.master[0],
+                                            ds_rootdn, ds_rootpw)
         user_info = {'cn': 'user_exp4'.encode('utf-8'),
                      'objectClass': [b'top', b'person',
                                      b'inetOrgPerson',
@@ -274,9 +273,8 @@ class TestMisc(object):
         client.sssd_conf(f'domain/{domain_name}', domain_params)
         multihost.client[0].service_sssd('restart')
         ldap_uri = 'ldap://%s' % (multihost.master[0].ip)
-        ds_rootdn = 'cn=Directory Manager'
-        ds_rootpw = 'Secret123'
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+        ldap_inst = LdapOperations.for_ds_host(multihost.master[0],
+                                            ds_rootdn, ds_rootpw)
         user_info = {
             'ou': 'Unit1'.encode('utf-8'),
             'objectClass': [b'top', b'organizationalUnit']}
@@ -568,8 +566,8 @@ class TestMisc(object):
         client = multihost.client[0]
         multihost.client[0].run_command("modprobe sch_netem")
         log_nss = '/var/log/sssd/sssd_nss.log'
-        ldap_uri = 'ldap://%s' % (multihost.master[0].ip)
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+        ldap_inst = LdapOperations.for_ds_host(multihost.master[0],
+                                            ds_rootdn, ds_rootpw)
         ldap_inst.org_unit("Netgroup", ds_suffix)
         user_dn = f'cn=netgrp_nowait,ou=Netgroup,{ds_suffix}'
         user_info = {'cn': 'netgrp_nowait'.encode('utf-8'),

--- a/src/tests/multihost/alltests/test_automount.py
+++ b/src/tests/multihost/alltests/test_automount.py
@@ -255,9 +255,8 @@ class Testautofsresponder(object):
         start_nfs = 'systemctl start nfs-server'
         multihost.master[0].run_command(start_nfs)
         ldap_uri = 'ldap://%s' % (multihost.master[0].ip)
-        ds_rootdn = 'cn=Directory Manager'
-        ds_rootpw = 'Secret123'
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+        ldap_inst = LdapOperations.for_ds_host(multihost.master[0],
+                                            ds_rootdn, ds_rootpw)
         for ou_ou in ['auto.master', 'auto.direct', 'auto.home']:
             user_info = {'ou': f'{ou_ou}'.encode('utf-8'),
                          'objectClass': [b'top', b'automountMap']}

--- a/src/tests/multihost/alltests/test_automount_from_bash.py
+++ b/src/tests/multihost/alltests/test_automount_from_bash.py
@@ -109,8 +109,7 @@ def create_users(multihost, request):
     client.run_command("cp -f /etc/nsswitch.conf /etc/nsswitch.conf.backup")
     client.run_command("cp -f /etc/sysconfig/autofs /etc/sysconfig/autofs_bkp")
     client.run_command("sed --follow-symlinks -i 's/automount:  files/automount:  sss files/g' /etc/nsswitch.conf")
-    ldap_uri = f'ldap://{multihost.master[0].ip}'
-    ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+    ldap_inst = LdapOperations.for_ds_host(multihost.master[0], ds_rootdn, ds_rootpw)
     ldap_inst.org_unit("mount", ds_suffix)
     user_dn = f'nisMapName=auto.master,ou=mount,{ds_suffix}'
     user_info = {'nisMapName': 'auto.master'.encode('utf-8'),
@@ -590,8 +589,8 @@ class TestAutoFs(object):
         assert f"{master_server}:/export/projects" in cmd.stdout_text
         find_logs(multihost, log_sssd, f"Searching for automount map entries with base [ou=mount,{ds_suffix}]")
         client.run_command("umount -v /folder1/folder2/projects")
-        ldap_uri = f'ldap://{multihost.master[0].ip}'
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+        ldap_inst = LdapOperations.for_ds_host(multihost.master[0],
+                                            ds_rootdn, ds_rootpw)
         modify_gid = [(ldap.MOD_REPLACE, 'nisMapEntry',
                        f'-fstype=nfs,rw {master_server}:/export/projects_new'.encode('utf-8'))]
         ldap_inst.modify_ldap(f'cn=/folder1/folder2/projects,nisMapName=auto.direct,ou=mount,{ds_suffix}', modify_gid)
@@ -642,8 +641,8 @@ class TestAutoFs(object):
         client = multihost.client[0]
         log_sssd = f'/var/log/sssd/sssd_{ds_instance_name}.log'
         master_server = multihost.master[0].sys_hostname
-        ldap_uri = f'ldap://{multihost.master[0].ip}'
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+        ldap_inst = LdapOperations.for_ds_host(multihost.master[0],
+                                            ds_rootdn, ds_rootpw)
         tools = sssdTools(multihost.client[0])
         tools.sssd_conf("domain/example1", {'entry_cache_autofs_timeout': "60"}, action='update')
         tools.clear_sssd_cache()
@@ -706,8 +705,8 @@ class TestAutoFs(object):
         client = multihost.client[0]
         log_sssd = f'/var/log/sssd/sssd_{ds_instance_name}.log'
         master_server = multihost.master[0].sys_hostname
-        ldap_uri = f'ldap://{multihost.master[0].ip}'
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+        ldap_inst = LdapOperations.for_ds_host(multihost.master[0],
+                                            ds_rootdn, ds_rootpw)
         tools = sssdTools(multihost.client[0])
         tools.sssd_conf("domain/example1", {'entry_cache_autofs_timeout': "60"}, action='update')
         tools.clear_sssd_cache()
@@ -789,8 +788,8 @@ class TestAutoFs(object):
         client = multihost.client[0]
         master_server = multihost.master[0].sys_hostname
         log_sssd = f'/var/log/sssd/sssd_{ds_instance_name}.log'
-        ldap_uri = f'ldap://{multihost.master[0].ip}'
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+        ldap_inst = LdapOperations.for_ds_host(multihost.master[0],
+                                            ds_rootdn, ds_rootpw)
         tools = sssdTools(multihost.client[0])
         tools.sssd_conf("domain/example1", {'entry_cache_autofs_timeout': "60"}, action='update')
         tools.clear_sssd_cache()
@@ -885,8 +884,8 @@ class TestAutoFs(object):
         # maximum key name must be PATH MAX bz811987
         client = multihost.client[0]
         master_server = multihost.master[0].sys_hostname
-        ldap_uri = f'ldap://{multihost.master[0].ip}'
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+        ldap_inst = LdapOperations.for_ds_host(multihost.master[0],
+                                            ds_rootdn, ds_rootpw)
         tools = sssdTools(multihost.client[0])
         tools.sssd_conf("domain/example1", {'entry_cache_autofs_timeout': "60"}, action='update')
         tools.clear_sssd_cache()
@@ -930,8 +929,8 @@ class TestAutoFs(object):
         # SSSD frequently fails to return automount maps from LDAP bz967636
         client = multihost.client[0]
         master_server = multihost.master[0].sys_hostname
-        ldap_uri = f'ldap://{multihost.master[0].ip}'
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+        ldap_inst = LdapOperations.for_ds_host(multihost.master[0],
+                                            ds_rootdn, ds_rootpw)
         # sssd automount maps from LDAP test BZ 967636
         client.run_command("service autofs restart")
         user_dn = f'nisMapName=auto.share,ou=mount,{ds_suffix}'

--- a/src/tests/multihost/alltests/test_default_debug_level.py
+++ b/src/tests/multihost/alltests/test_default_debug_level.py
@@ -43,8 +43,8 @@ class TestDefaultDebugLevel(object):
         """
         client = multihost.client[0]
         tools = sssdTools(multihost.client[0])
-        ldap_uri = f'ldap://{multihost.master[0].ip}'
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+        ldap_inst = LdapOperations.for_ds_host(multihost.master[0],
+                                            ds_rootdn, ds_rootpw)
         user_dn = f'uid=tempuser2,{ds_suffix}'
         user_info = {'cn': 'Temp user2'.encode('utf-8'),
                      'loginshell': '/bin/bash'.encode('utf-8'),
@@ -156,8 +156,8 @@ class TestDefaultDebugLevel(object):
         """
         client = multihost.client[0]
         tools = sssdTools(multihost.client[0])
-        ldap_uri = f'ldap://{multihost.master[0].ip}'
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+        ldap_inst = LdapOperations.for_ds_host(multihost.master[0],
+                                            ds_rootdn, ds_rootpw)
         user_dn = f'uid=mid_cacheuser,{ds_suffix}'
         user_info = {'cn': 'Midcache'.encode('utf-8'),
                      'loginshell': '/bin/bash'.encode('utf-8'),

--- a/src/tests/multihost/alltests/test_hosts.py
+++ b/src/tests/multihost/alltests/test_hosts.py
@@ -255,9 +255,8 @@ class TestHostMaps(object):
           2. Should succeed
         """
         ldap_uri = 'ldap://%s' % (multihost.master[0].ip)
-        ds_rootdn = 'cn=Directory Manager'
-        ds_rootpw = 'Secret123'
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+        ldap_inst = LdapOperations.for_ds_host(multihost.master[0],
+                                            ds_rootdn, ds_rootpw)
         user_info = {'cn': ['node4'.encode('utf-8'),
                             'node4.example.test'.encode('utf-8')],
                      'objectClass': [b'top', b'ipHost', b'device'],

--- a/src/tests/multihost/alltests/test_krb_fips.py
+++ b/src/tests/multihost/alltests/test_krb_fips.py
@@ -252,14 +252,8 @@ class Testkrbfips(object):
         :title: krb5/fips: verify login fails when weak crypto is presented
         :id: cdd2ef0d-4921-40b3-b61e-0b271b2d5e00
         """
-        ldap_uri = 'ldap://%s' % (multihost.master[0].ip)
-        ds_rootdn = 'cn=Directory Manager'
-        ds_rootpw = 'Secret123'
-        tools = sssdTools(multihost.client[0])
-        domain_name = tools.get_domain_section_name()
-        tools.clear_sssd_cache()
-        user = 'cracker@%s' % domain_name
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+        ldap_inst = LdapOperations.for_ds_host(multihost.master[0],
+                                            ds_rootdn, ds_rootpw)
         krb = krb5srv(multihost.master[0], 'EXAMPLE.TEST')
         user_info = {'cn': 'cracker',
                      'uid': 'cracker',

--- a/src/tests/multihost/alltests/test_ldap_password_policy.py
+++ b/src/tests/multihost/alltests/test_ldap_password_policy.py
@@ -45,8 +45,7 @@ def ldap_modify_ds(multihost, ldap_mode, dn_dn, element, value):
     element: Attribute of Dn which needs to change
     value: New Attribute value.
     """
-    ldap_uri = f'ldap://{multihost.master[0].ip}'
-    ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+    ldap_inst = LdapOperations.for_ds_host(multihost.master[0], ds_rootdn, ds_rootpw)
     modify_gid = [(ldap_mode, element, value)]
     ldap_inst.modify_ldap(dn_dn, modify_gid)
 
@@ -55,8 +54,7 @@ def ldap_modify_ds(multihost, ldap_mode, dn_dn, element, value):
 def create_users_groups(multihost, request):
     """ Create user and restore """
     client = multihost.client[0]
-    ldap_uri = f'ldap://{multihost.master[0].ip}'
-    ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+    ldap_inst = LdapOperations.for_ds_host(multihost.master[0], ds_rootdn, ds_rootpw)
     user_dn = 'uid=ppuser1,ou=People,dc=example,dc=test'
     user_info = {'cn': 'ppuser1'.encode('utf-8'),
                  'sn': 'ppuser1'.encode('utf-8'),

--- a/src/tests/multihost/alltests/test_netgroup.py
+++ b/src/tests/multihost/alltests/test_netgroup.py
@@ -121,10 +121,8 @@ class TestNetgroup(object):
         getent_cmd = "getent netgroup netgroup_1"
         multihost.client[0].run_command(getent_cmd)
         shortname = multihost.client[0].sys_hostname.strip().split('.')[0]
-        ldap_uri = 'ldap://%s' % (multihost.master[0].ip)
-        ds_rootdn = 'cn=Directory Manager'
-        ds_rootpw = 'Secret123'
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+        ldap_inst = LdapOperations.for_ds_host(multihost.master[0],
+                                            ds_rootdn, ds_rootpw)
         netgroup_dn = 'cn=netgroup_1,ou=Netgroups,%s' % (ds_suffix)
         nisNetgroupTriple = "(%s,foo1,%s)" % (shortname, ds_suffix)
         modify_netgroup = [(ldap.MOD_REPLACE, 'nisNetgroupTriple',

--- a/src/tests/multihost/alltests/test_ns_account_lock.py
+++ b/src/tests/multihost/alltests/test_ns_account_lock.py
@@ -141,7 +141,6 @@ class TestNsAccountLock(object):
         """
         clean_sys(multihost)
         client = sssdTools(multihost.client[0])
-        ldap_uri = f'ldap://{multihost.master[0].ip}'
         ds_rootdn = 'cn=Directory Manager'
         ds_rootpw = 'Secret123'
         manage_user_roles(multihost, "cn=managed", "lock", "role")
@@ -151,7 +150,8 @@ class TestNsAccountLock(object):
         lock_check(multihost, "foo1")
         # User added to the above inactive managed role
         clean_sys(multihost)
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+        ldap_inst = LdapOperations.for_ds_host(multihost.master[0],
+                                            ds_rootdn, ds_rootpw)
         user_dn = 'uid=foo2,ou=People,dc=example,dc=test'
         role_dn = "cn=managed,ou=people,dc=example,dc=test"
         add_member = [(ldap.MOD_ADD, 'nsRoleDN', role_dn.encode('utf-8'))]
@@ -163,7 +163,8 @@ class TestNsAccountLock(object):
         lock_check(multihost, "foo2")
         # User removed from the above inactive managed role
         clean_sys(multihost)
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+        ldap_inst = LdapOperations.for_ds_host(multihost.master[0],
+                                            ds_rootdn, ds_rootpw)
         user_dn = 'uid=foo2,ou=People,dc=example,dc=test'
         role_dn = "cn=managed,ou=people,dc=example,dc=test"
         add_member = [(ldap.MOD_DELETE, 'nsRoleDN', role_dn.encode('utf-8'))]
@@ -197,10 +198,10 @@ class TestNsAccountLock(object):
         """
         clean_sys(multihost)
         client = sssdTools(multihost.client[0])
-        ldap_uri = f'ldap://{multihost.master[0].ip}'
         ds_rootdn = 'cn=Directory Manager'
         ds_rootpw = 'Secret123'
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+        ldap_inst = LdapOperations.for_ds_host(multihost.master[0],
+                                            ds_rootdn, ds_rootpw)
         user_dn = 'uid=foo3,ou=People,dc=example,dc=test'
         role_dn = "filtered"
         add_member = [(ldap.MOD_ADD, 'o', role_dn.encode('utf-8'))]
@@ -221,7 +222,8 @@ class TestNsAccountLock(object):
         lock_check(multihost, "foo4")
         # User removed from the above inactive filtered role
         clean_sys(multihost)
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+        ldap_inst = LdapOperations.for_ds_host(multihost.master[0],
+                                            ds_rootdn, ds_rootpw)
         user_dn = 'uid=foo3,ou=People,dc=example,dc=test'
         role_dn = "filtered"
         add_member = [(ldap.MOD_DELETE, 'o', role_dn.encode('utf-8'))]
@@ -253,11 +255,10 @@ class TestNsAccountLock(object):
         """
         clean_sys(multihost)
         client = sssdTools(multihost.client[0])
-        master_e = multihost.master[0].ip
-        ldap_uri = f'ldap://{master_e}'
         ds_rootdn = 'cn=Directory Manager'
         ds_rootpw = 'Secret123'
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+        ldap_inst = LdapOperations.for_ds_host(multihost.master[0],
+                                            ds_rootdn, ds_rootpw)
         user_info = {
             'cn': 'nested'.encode('utf-8'),
             'objectClass': [b'top',
@@ -283,7 +284,8 @@ class TestNsAccountLock(object):
         lock_check(multihost, "foo4")
         # Nested role has both the above roles and activated
         clean_sys(multihost)
-        ldap_inst = LdapOperations(ldap_uri, ds_rootdn, ds_rootpw)
+        ldap_inst = LdapOperations.for_ds_host(multihost.master[0],
+                                            ds_rootdn, ds_rootpw)
         manage_user_roles(multihost, "cn=nested", "unlock", "role")
         check_login_client(multihost, "foo1@example1", 'Secret123')
         check_login_client(multihost, "foo4@example1", 'Secret123')

--- a/src/tests/multihost/sssd/testlib/common/libdirsrv.py
+++ b/src/tests/multihost/sssd/testlib/common/libdirsrv.py
@@ -7,12 +7,9 @@ except ImportError:
     import configparser as ConfigParser
 import tempfile
 import subprocess
-import socket
 import time
-import ldap
 from sssd.testlib.common.exceptions import DirSrvException
 from sssd.testlib.common.exceptions import LdapException
-from sssd.testlib.common.utils import LdapOperations
 
 DS_USER = 'dirsrv'
 DS_GROUP = 'dirsrv'
@@ -255,36 +252,76 @@ class DirSrv(object):
         else:
             self.multihost.log.info('DS instance started successfully')
 
-    def enable_anonymous_search(self, binduri):
+    def _local_ldap_uri(self):
+        """LDAP URI for operations executed on the DS host itself."""
+        return 'ldap://127.0.0.1:%s' % self.dsldap_port
+
+    def _wait_for_local_ldap(self, timeout=60):
+        """Wait until slapd accepts connections on localhost."""
+        check_cmd = [
+            'bash', '-c',
+            'ldapsearch -x -H %s -s base -b "" "(objectclass=*)" '
+            '>/dev/null 2>&1' % self._local_ldap_uri()]
+        for _ in range(timeout):
+            result = self.multihost.run_command(check_cmd, raiseonerr=False)
+            if result.returncode == 0:
+                return
+            time.sleep(1)
+        raise LdapException(
+            'LDAP server not reachable at %s' % self._local_ldap_uri())
+
+    def _ldapmodify(self, ldif_content):
+        """Apply an LDIF change via ldapmodify on the DS host."""
+        ldif_file = tempfile.NamedTemporaryFile(mode='w', suffix='.ldif',
+                                                delete=False)
+        remote_ldif = '/tmp/sssd_ds_%d.ldif' % os.getpid()
+        try:
+            ldif_file.write(ldif_content)
+            ldif_file.close()
+            self.multihost.transport.put_file(ldif_file.name, remote_ldif)
+            cmd = ['ldapmodify', '-x', '-D', self.dsrootdn,
+                   '-w', self.dsrootdn_pwd, '-H', self._local_ldap_uri(),
+                   '-f', remote_ldif]
+            self.multihost.run_command(cmd)
+        except subprocess.CalledProcessError as err:
+            raise LdapException('ldapmodify failed: %s' % err)
+        finally:
+            os.unlink(ldif_file.name)
+
+    def enable_anonymous_search(self, binduri=None):
         """Enable anonymous search access to basedn
         Args:
-            binduri (str): LDAP uri to bind with
+            binduri (str): Unused; kept for compatibility. Changes are applied
+                on the DS host via localhost.
         Returns:
             boold: True if ACI is added
         Exceptions:
             LdapException
         """
-        ldap_obj = LdapOperations(uri=binduri, binddn=self.dsrootdn,
-                                  bindpw=self.dsrootdn_pwd)
-        # Enable Anonymous access aci
-        allow_anonymous = "(targetattr!=\"userPassword || aci\")" \
-                          "(version 3.0; acl \"Enable anonymous access\";" \
-                          "allow (read, search, compare)" \
-                          "userdn=\"ldap:///anyone\";)"
-        add_aci = [(ldap.MOD_ADD, 'aci', [allow_anonymous.encode('utf-8')])]
-        (ret, return_value) = ldap_obj.modify_ldap(self.dsinstance_suffix,
-                                                   add_aci)
-        if not return_value:
+        self._wait_for_local_ldap()
+        allow_anonymous = (
+            '(targetattr!="userPassword || aci")'
+            '(version 3.0; acl "Enable anonymous access";'
+            'allow (read, search, compare)'
+            'userdn="ldap:///anyone";)'
+        )
+        ldif = """dn: %s
+changetype: modify
+add: aci
+aci: %s
+""" % (self.dsinstance_suffix, allow_anonymous)
+        try:
+            self._ldapmodify(ldif)
+        except LdapException:
             raise LdapException("Failed to enable anonymous access aci")
-        else:
-            print("Enabled Anonymous access aci to %s" %
-                  self.dsinstance_suffix)
+        print("Enabled Anonymous access aci to %s" % self.dsinstance_suffix)
 
-    def enable_ssl(self, binduri, tls_port):
+    def enable_ssl(self, binduri=None, tls_port=None):
         """sets TLS Port and enabled TLS on Directory Server.
 
         Args:
-            binduri (str): LDAP uri to bind with
+            binduri (str): Unused; kept for compatibility. Changes are applied
+                on the DS host via localhost.
             tls_port (str): TLS port to be setup
 
         Returns:
@@ -293,46 +330,34 @@ class DirSrv(object):
         Exceptions:
             LdapException
         """
-        ldap_obj = LdapOperations(uri=binduri, binddn=self.dsrootdn,
-                                  bindpw=self.dsrootdn_pwd)
-        # Enable TLS
-        mod_dn1 = 'cn=encryption,cn=config'
-        add_tls = [(ldap.MOD_ADD, 'nsTLS1', [b'on'])]
-        (ret, return_value) = ldap_obj.modify_ldap(mod_dn1, add_tls)
-        if not return_value:
-            raise LdapException('Failed to enable TLS, Error:%s' % (ret))
-        else:
-            print('Enabled nsTLS1=on')
-        mod_dn2 = 'cn=RSA,cn=encryption,cn=config'
-        mod_security = [(ldap.MOD_REPLACE, 'nsSSLPersonalitySSL',
-                         [b'Server-Cert-%s' %
-                          ((self.dsinstance_host.encode()))])]
-        (ret, return_value) = ldap_obj.modify_ldap(mod_dn2, mod_security)
-        if not return_value:
-            raise LdapException('Failed to set Server-Cert nick:%s' % (ret))
-        else:
-            print('Enabled Server-Cert nick')
+        self._wait_for_local_ldap()
+        cert_nick = 'Server-Cert-%s' % self.dsinstance_host
+        ldif = """dn: cn=encryption,cn=config
+changetype: modify
+add: nsTLS1
+nsTLS1: on
 
-        # Enable security
-        mod_dn3 = 'cn=config'
-        enable_security = [(ldap.MOD_REPLACE, 'nsslapd-security', [b'on'])]
-        (ret, return_value) = ldap_obj.modify_ldap(mod_dn3, enable_security)
-        if not return_value:
-            raise LdapException(
-                'Failed to enable nsslapd-security, Error:%s' % (ret))
-        else:
-            print('Enabled nsslapd-security')
+dn: cn=RSA,cn=encryption,cn=config
+changetype: modify
+replace: nsSSLPersonalitySSL
+nsSSLPersonalitySSL: %s
 
-        # set the appropriate TLS port
-        mod_dn4 = 'cn=config'
-        enable_ssl_port = [(ldap.MOD_REPLACE, 'nsslapd-securePort',
-                            str(tls_port).encode())]
-        (ret, return_value) = ldap_obj.modify_ldap(mod_dn4, enable_ssl_port)
-        if not return_value:
-            raise LdapException(
-                'Failed to set nsslapd-securePort, Error:%s' % (ret))
-        else:
-            print('Enabled nsslapd-securePort=%r' % tls_port)
+dn: cn=config
+changetype: modify
+replace: nsslapd-security
+nsslapd-security: on
+-
+replace: nsslapd-securePort
+nsslapd-securePort: %s
+""" % (cert_nick, tls_port)
+        try:
+            self._ldapmodify(ldif)
+        except LdapException as err:
+            raise LdapException('Failed to enable TLS: %s' % err)
+        print('Enabled nsTLS1=on')
+        print('Enabled Server-Cert nick')
+        print('Enabled nsslapd-security')
+        print('Enabled nsslapd-securePort=%r' % tls_port)
 
 
 class DirSrvWrap(object):
@@ -361,9 +386,12 @@ class DirSrvWrap(object):
         self.multihost = multihost_obj
         # Hostname for dscreate full_machine_name / cert nicks on the SUT.
         self.ds_instance_host = self.multihost.sys_hostname
-        # IP for controller-side LDAP and port probes (lab FQDNs may not
-        # resolve on the pytest controller).
-        self.ds_connect_host = self.multihost.ip or self.ds_instance_host
+        # Address other test hosts use in ldap_uri (client -> DS).
+        if (self.multihost.external_hostname and
+                self.multihost.external_hostname != self.ds_instance_host):
+            self.ds_ldap_host = self.multihost.external_hostname
+        else:
+            self.ds_ldap_host = self.multihost.ip or self.ds_instance_host
         self.client_host = client_obj
         self.ds_instance_suffix = None
         self.ds_rootdn_pwd = None
@@ -483,25 +511,25 @@ class DirSrvWrap(object):
             return sorted_available_ports[0]
 
     def _check_remote_port(self, port):
-        """check if the port on the remote host is free.
+        """check if the port on the remote host is in use.
+
+        The check runs on the DS host itself so it works when the pytest
+        controller cannot reach LDAP ports (for example on mrack).
 
         Args:
             port (int): check if port is available
 
         Returns:
-            bool: True if port is free else False.
+            bool: True if port is in use else False.
         """
-        sock_obj = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock_obj.settimeout(1)
-        try:
-            sock_obj.connect((self.ds_connect_host, port))
-        except socket.error as err:
-            print("fail to connect to port %s due to error %r" % (port,
-                                                                  err.errno))
-            return False
-        else:
-            sock_obj.close()
-            return True
+        check_cmd = [
+            'bash', '-c',
+            'ss -H -lnt "( sport = :%d )" | grep -q .' % int(port)]
+        result = self.multihost.run_command(check_cmd, raiseonerr=False)
+        if result.returncode != 0:
+            print("port %s is not in use on %s" % (port,
+                                                   self.ds_instance_host))
+        return result.returncode == 0
 
     def _validate_options(self):
         """verify if the instance directory already exists.
@@ -564,10 +592,8 @@ class DirSrvWrap(object):
             except subprocess.CalledProcessError:
                 raise DirSrvException('Failed to setup Directory server')
             self.dirsrv_info[self.ds_instance_name] = self.dirsrv_obj.__dict__
-            ldap_uri = 'ldap://%s:%r' % (self.ds_connect_host,
-                                         self.ds_ldap_port)
             try:
-                self.dirsrv_obj.enable_anonymous_search(ldap_uri)
+                self.dirsrv_obj.enable_anonymous_search()
             except LdapException:
                 raise DirSrvException("Failed to enable anonymous search")
             if self.ssl:
@@ -613,9 +639,7 @@ class DirSrvWrap(object):
                 self.multihost.log.info('Added %s port to ldap_port_t' %
                                         self.ds_tls_port)
         try:
-            self.dirsrv_obj.enable_ssl('ldap://%s:%r' % (self.ds_connect_host,
-                                                         self.ds_ldap_port),
-                                       self.ds_tls_port)
+            self.dirsrv_obj.enable_ssl(tls_port=self.ds_tls_port)
         except LdapException:
             return "Error", 1
 

--- a/src/tests/multihost/sssd/testlib/common/utils.py
+++ b/src/tests/multihost/sssd/testlib/common/utils.py
@@ -1214,10 +1214,34 @@ class LdapOperations(object):
         conn: ldap bind object (already  initialized)
     """
 
-    def __init__(self, uri, binddn, bindpw, port=None):
-        self.uri = uri if not port else '%s:%s' % (uri, port)
+    _LDAP_MOD_NAMES = {
+        ldap.MOD_ADD: 'add',
+        ldap.MOD_DELETE: 'delete',
+        ldap.MOD_REPLACE: 'replace',
+    }
+
+    @classmethod
+    def for_ds_host(cls, host, binddn, bindpw, port=None, use_ssl=False):
+        """Run LDAP operations on a DS host via SSH (localhost on the SUT)."""
+        if use_ssl:
+            port = port or 636
+            scheme = 'ldaps'
+        else:
+            port = port or 389
+            scheme = 'ldap'
+        uri = '%s://127.0.0.1:%s' % (scheme, port)
+        return cls(uri, binddn, bindpw, multihost=host)
+
+    def __init__(self, uri, binddn, bindpw, port=None, multihost=None):
         self.binddn = binddn
         self.bindpw = bindpw
+        self.multihost = multihost
+        if multihost is not None:
+            self.uri = uri if not port else '%s:%s' % (uri, port)
+            self.conn = None
+            self._wait_for_local_ldap()
+            return
+        self.uri = uri if not port else '%s:%s' % (uri, port)
         self.conn = ldap.initialize(self.uri)
         self.conn.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
         self.conn.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
@@ -1225,6 +1249,95 @@ class LdapOperations(object):
         if isinstance(self.conn, tuple):
             raise LdapException("Failed to bind to ldap server, Error: %s"
                                 % self.conn[0])
+
+    def _is_remote(self):
+        return self.multihost is not None
+
+    def _ldap_cli_opts(self):
+        opts = ['-x', '-D', self.binddn, '-w', self.bindpw, '-H', self.uri]
+        if self.uri.startswith('ldaps://'):
+            opts.extend(['-o', 'tls_reqcert=never'])
+        return opts
+
+    def _wait_for_local_ldap(self, timeout=60):
+        check_cmd = [
+            'bash', '-c',
+            'ldapsearch %s -s base -b "" "(objectclass=*)" >/dev/null 2>&1' % (
+                ' '.join(shlex.quote(arg) for arg in self._ldap_cli_opts()))
+        ]
+        for _ in range(timeout):
+            result = self.multihost.run_command(check_cmd, raiseonerr=False)
+            if result.returncode == 0:
+                return
+            time.sleep(1)
+        raise LdapException('LDAP server not reachable at %s' % self.uri)
+
+    def _decode_attr_value(self, val):
+        if isinstance(val, bytes):
+            return val.decode('utf-8')
+        return str(val)
+
+    def _entry_to_add_ldif(self, ldap_dn, entry):
+        lines = ['dn: %s' % ldap_dn]
+        for attr, values in entry.items():
+            if isinstance(values, list):
+                for val in values:
+                    lines.append('%s: %s' % (attr, self._decode_attr_value(val)))
+            else:
+                lines.append('%s: %s' % (attr, self._decode_attr_value(values)))
+        lines.append('')
+        return '\n'.join(lines)
+
+    def _modlist_to_ldif(self, ldap_dn, modify_list):
+        lines = ['dn: %s' % ldap_dn, 'changetype: modify']
+        for op, attr, values in modify_list:
+            lines.append('%s: %s' % (self._LDAP_MOD_NAMES[op], attr))
+            if values is None:
+                continue
+            if isinstance(values, list):
+                for val in values:
+                    lines.append('%s: %s' % (attr, self._decode_attr_value(val)))
+            else:
+                lines.append('%s: %s' % (attr, self._decode_attr_value(values)))
+        lines.append('')
+        return '\n'.join(lines)
+
+    def _run_ldif(self, ldif_content, tool):
+        ldif_file = tempfile.NamedTemporaryFile(mode='w', suffix='.ldif',
+                                                delete=False)
+        remote_ldif = '/tmp/sssd_ldap_%d.ldif' % os.getpid()
+        try:
+            ldif_file.write(ldif_content)
+            ldif_file.close()
+            self.multihost.transport.put_file(ldif_file.name, remote_ldif)
+            cmd = [tool] + self._ldap_cli_opts() + ['-f', remote_ldif]
+            self.multihost.run_command(cmd)
+        except subprocess.CalledProcessError as err:
+            err_text = '%s %s' % (
+                getattr(err, 'stderr', '') or '',
+                getattr(err, 'stdout', '') or '')
+            raise LdapException('%s failed: %s' % (tool, err_text or err))
+        finally:
+            os.unlink(ldif_file.name)
+            self.multihost.run_command(['rm', '-f', remote_ldif],
+                                       raiseonerr=False)
+
+    def _handle_modify_cli_error(self, err):
+        err_text = str(err)
+        if 'No such attribute' in err_text:
+            return "Fail", False
+        if 'No such object' in err_text:
+            return self._parseException(ldap.NO_SUCH_OBJECT({'desc': err_text}))
+        if 'Object class violation' in err_text:
+            return self._parseException(
+                ldap.OBJECT_CLASS_VIOLATION({'desc': err_text}))
+        if 'Type or value exists' in err_text or 'Already exists' in err_text:
+            return self._parseException(
+                ldap.TYPE_OR_VALUE_EXISTS({'desc': err_text}))
+        if 'Unwilling To Perform' in err_text:
+            return self._parseException(
+                ldap.UNWILLING_TO_PERFORM({'desc': err_text}))
+        raise err
 
     def bind(self):
         """ Bind to ldap server
@@ -1247,6 +1360,15 @@ class LdapOperations(object):
             :param str dn: Entry dn to be added
         """
         print("Adding entry: %s" % (ldap_dn))
+        if self._is_remote():
+            try:
+                self._run_ldif(self._entry_to_add_ldif(ldap_dn, entry),
+                               'ldapadd')
+            except LdapException as err:
+                if 'Already exists' in str(err):
+                    raise ldap.ALREADY_EXISTS({'desc': str(err)})
+                raise
+            return "Success", True
         ldif = modlist.addModlist(entry)
         self.conn.add_s(ldap_dn, ldif)
         return "Success", True
@@ -1262,6 +1384,10 @@ class LdapOperations(object):
            :return tupele: "Success", return_value
            :Exception: ldap exception
         """
+        if self._is_remote():
+            cmd = ['ldapdelete'] + self._ldap_cli_opts() + [ldap_dn]
+            self.multihost.run_command(cmd)
+            return "Success", True
         ret = self.conn.delete_s(ldap_dn)
         return "Success", ret
 
@@ -1276,6 +1402,34 @@ class LdapOperations(object):
                          ldap.SCOPE_SUBTREE
             :return tuple: Success/Fail, bool(True,False)
         """
+        if self._is_remote():
+            scope_name = {
+                ldap.SCOPE_BASE: 'base',
+                ldap.SCOPE_ONELEVEL: 'one',
+                ldap.SCOPE_SUBTREE: 'sub',
+            }[scope]
+            attr_args = []
+            if attributes:
+                attr_args = list(attributes)
+            cmd = ['ldapsearch', '-LLL'] + self._ldap_cli_opts() + [
+                '-b', basedn, '-s', scope_name, criteria] + attr_args
+            result = self.multihost.run_command(cmd)
+            parser = ldif.LDIFRecordList(StringIO(result.stdout_text))
+            parser.parse()
+            result_set = []
+            for _, entry in parser.all_records:
+                encoded = {}
+                for attr, values in entry.items():
+                    if isinstance(values, list):
+                        encoded[attr] = [
+                            val.encode('utf-8') if isinstance(val, str) else val
+                            for val in values]
+                    elif isinstance(values, str):
+                        encoded[attr] = values.encode('utf-8')
+                    else:
+                        encoded[attr] = values
+                result_set.append(encoded)
+            return result_set
 
         self.conn.set_option(ldap.OPT_REFERRALS, 0)
         result = self.conn.search_s(basedn, ldap.SCOPE_SUBTREE,
@@ -1285,6 +1439,13 @@ class LdapOperations(object):
 
     def modify_ldap(self, ldap_dn, modify_list):
         """ Modify ldap dn """
+        if self._is_remote():
+            try:
+                self._run_ldif(self._modlist_to_ldif(ldap_dn, modify_list),
+                               'ldapmodify')
+            except LdapException as err:
+                return self._handle_modify_cli_error(err)
+            return 'Success', True
         try:
             self.conn.modify_s(ldap_dn, modify_list)
         except ldap.NO_SUCH_ATTRIBUTE:


### PR DESCRIPTION
Directory Server setup failed on mrack during the `setupds` fixture because `enable_anonymous_search` and `enable_ssl` bound to LDAP from the pytest controller. On mrack, the controller can SSH to test VMs but cannot reach LDAP ports 389/636, which produced `Can't contact LDAP server` and `Failed to enable anonymous search` in tests.

This change runs post-setup LDAP configuration on the DS host itself using `ldapmodify` against `ldap://127.0.0.1:<port>`, and checks port availability with `ss` on the remote host instead of probing from the controller.

- Add `_local_ldap_uri`, `_wait_for_local_ldap`, and `_ldapmodify` helpers in `DirSrv` to apply LDIF changes over SSH on the SUT.
- Refactor `enable_anonymous_search` and `enable_ssl` to use host-local LDAP instead of controller-side `LdapOperations`.
- Update `_check_remote_port` to detect listening ports on the DS host via `ss`.
- Set `ds_ldap_host` to `external_hostname` when available (OpenStack), otherwise fall back to the host IP for client-to-DS `ldap_uri` usage.