### PR TITLE
Test: add sssd conf backup to test_0002_1736796

### DIFF
--- a/src/tests/multihost/alltests/test_services.py
+++ b/src/tests/multihost/alltests/test_services.py
@@ -36,7 +36,7 @@ class TestServices(object):
         assert cmd.stdout_text.find('/etc/systemd/system') == -1
 
     @pytest.mark.tier1
-    def test_0002_1736796(self, multihost, localusers):
+    def test_0002_1736796(self, multihost, localusers, backupsssdconf):
         """
         :title: config: "default_domain_suffix" should not
          cause files domain entries to be qualified, this can break sudo access


### PR DESCRIPTION
The multihost alltests/test_services.py code is failing due to a corrupted sssd.conf created in an earlier test case.  Adding backup fixture to test case so that the sssd.conf is backed up before the test modifies the file and restores it afterwards.