### PR TITLE
SDAP: Parse each attribute of an entry in message order

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3190,6 +3190,10 @@ sdap_tests_LDFLAGS = \
     -Wl,-wrap,ldap_value_free_len \
     -Wl,-wrap,ldap_first_attribute \
     -Wl,-wrap,ldap_next_attribute \
+    -Wl,-wrap,ldap_get_dn_ber \
+    -Wl,-wrap,ldap_get_attribute_ber \
+    -Wl,-wrap,ber_memfree \
+    -Wl,-wrap,ber_free \
     $(NULL)
 sdap_tests_LDADD = \
     $(CMOCKA_LIBS) \

--- a/src/external/ldap.m4
+++ b/src/external/ldap.m4
@@ -69,6 +69,8 @@ AC_CHECK_FUNCS([ldap_control_create ldap_init_fd \
                 ldap_parse_derefresponse_control \
                 ldap_derefresponse_free \
                 ldap_is_ldapc_url])
+AC_CHECK_FUNCS([ldap_get_dn_ber ldap_get_attribute_ber], [],
+               [AC_MSG_ERROR([The OpenLDAP version found does not provide $ac_func])])
 AC_CHECK_MEMBERS([struct ldap_conncb.lc_arg],
                  [AC_RUN_IFELSE(
                    [AC_LANG_PROGRAM(

--- a/src/providers/ldap/sdap.c
+++ b/src/providers/ldap/sdap.c
@@ -406,6 +406,7 @@ static bool objectclass_matched_ber(struct sdap_attr_map *map,
 static uint8_t *sss_base64_enc_ber(TALLOC_CTX *mem_ctx,
                                    const struct berval attr_val);
 static bool attribute_has_values(const struct berval *setof_attr_val);
+static bool berval_has_zero_byte(const struct berval bv);
 
 int sdap_parse_entry(TALLOC_CTX *memctx,
                      struct sdap_handle *sh, struct sdap_msg *sm,
@@ -452,6 +453,12 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
         goto done;
     }
 
+    if (berval_has_zero_byte(bv)) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "DN contains a zero byte\n");
+        ret = EINVAL;
+        goto done;
+    }
+
     DEBUG_CONDITIONAL(SSSDBG_TRACE_LIBS, "OriginalDN: [%.*s].\n",
                       (int)bv.bv_len, bv.bv_val);
     PROBE(SDAP_PARSE_ENTRY, "OriginalDN", bv.bv_val, bv.bv_len);
@@ -482,6 +489,13 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
            has been consumed". */
         if (bv.bv_val == NULL)
             break;
+
+        if (berval_has_zero_byte(bv)) {
+            DEBUG(SSSDBG_CRIT_FAILURE,
+                  "Attribute description contains a zero byte\n");
+            ret = EINVAL;
+            goto done;
+        }
 
         /* The attribute description points into the decoded message and
            is not guaranteed to be terminated, while sdap_parse_range()
@@ -694,6 +708,12 @@ static bool objectclass_matched_ber(struct sdap_attr_map *map,
 static bool attribute_has_values(const struct berval *setof_attr_val)
 {
     return setof_attr_val != NULL && setof_attr_val[0].bv_val != NULL;
+}
+
+/* True if BV contains a zero byte, which an LDAPString never does.  */
+static bool berval_has_zero_byte(const struct berval bv)
+{
+    return memchr(bv.bv_val, '\0', bv.bv_len) != NULL;
 }
 
 /* utility function to apply sss_base64_encode to a struct berval */

--- a/src/providers/ldap/sdap.c
+++ b/src/providers/ldap/sdap.c
@@ -407,6 +407,7 @@ static uint8_t *sss_base64_enc_ber(TALLOC_CTX *mem_ctx,
                                    const struct berval attr_val);
 static bool attribute_has_values(const struct berval *setof_attr_val);
 static bool berval_has_zero_byte(const struct berval bv);
+static int berval_precision(const struct berval bv);
 
 int sdap_parse_entry(TALLOC_CTX *memctx,
                      struct sdap_handle *sh, struct sdap_msg *sm,
@@ -460,7 +461,7 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
     }
 
     DEBUG_CONDITIONAL(SSSDBG_TRACE_LIBS, "OriginalDN: [%.*s].\n",
-                      (int)bv.bv_len, bv.bv_val);
+                      berval_precision(bv), bv.bv_val);
     PROBE(SDAP_PARSE_ENTRY, "OriginalDN", bv.bv_val, bv.bv_len);
     ret = sysdb_attrs_add_mem(attrs, SYSDB_ORIG_DN, bv.bv_val, bv.bv_len);
     if (ret)
@@ -523,7 +524,7 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
                     /* ok it's an entry of the right type */
                     DEBUG_CONDITIONAL(SSSDBG_TRACE_LIBS,
                                       "objectClass '%.*s' matched\n",
-                                      (int)setof_attr_val[i].bv_len,
+                                      berval_precision(setof_attr_val[i]),
                                       setof_attr_val[i].bv_val);
                     object_class_matched = true;
                     break;
@@ -531,7 +532,7 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
 
                 DEBUG_CONDITIONAL(SSSDBG_TRACE_LIBS,
                                   "objectClass '%.*s' did not match\n",
-                                  (int)setof_attr_val[i].bv_len,
+                                  berval_precision(setof_attr_val[i]),
                                   setof_attr_val[i].bv_val);
             }
 
@@ -708,6 +709,12 @@ static bool objectclass_matched_ber(struct sdap_attr_map *map,
 static bool attribute_has_values(const struct berval *setof_attr_val)
 {
     return setof_attr_val != NULL && setof_attr_val[0].bv_val != NULL;
+}
+
+/* The length of BV as a printf precision, which is an int.  */
+static int berval_precision(const struct berval bv)
+{
+    return bv.bv_len > INT_MAX ? INT_MAX : (int)bv.bv_len;
 }
 
 /* True if BV contains a zero byte, which an LDAPString never does.  */

--- a/src/providers/ldap/sdap.c
+++ b/src/providers/ldap/sdap.c
@@ -401,6 +401,12 @@ int sdap_get_map(TALLOC_CTX *memctx,
 
 static bool objectclass_matched(struct sdap_attr_map *map,
                                 const char *objcl, int len);
+static bool objectclass_matched_ber(struct sdap_attr_map *map,
+                                    const struct berval attr_val);
+static uint8_t *sss_base64_enc_ber(TALLOC_CTX *mem_ctx,
+                                   const struct berval attr_val);
+static bool attribute_has_values(const struct berval *setof_attr_val);
+
 int sdap_parse_entry(TALLOC_CTX *memctx,
                      struct sdap_handle *sh, struct sdap_msg *sm,
                      struct sdap_attr_map *map, int attrs_num,
@@ -409,26 +415,21 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
 {
     struct sysdb_attrs *attrs;
     BerElement *ber = NULL;
-    struct berval **vals;
+    struct berval bv, *bvals = NULL;
+    const struct berval *setof_attr_val;
+    const char *attr_name;
     struct ldb_val v;
-    char *str;
-    int lerrno;
+    int lerrno = 0;
     int i, ret, ai;
     int base_attr_idx = 0;
     const char *name = NULL;
-    bool store;
     bool base64;
+    bool object_class_matched = false;
     char *base_attr;
     uint32_t range_offset;
     TALLOC_CTX *tmp_ctx = talloc_new(NULL);
-    if (!tmp_ctx) return ENOMEM;
 
-    lerrno = 0;
-    ret = ldap_set_option(sh->ldap, LDAP_OPT_RESULT_CODE, &lerrno);
-    if (ret != LDAP_OPT_SUCCESS) {
-        DEBUG(SSSDBG_MINOR_FAILURE, "ldap_set_option failed [%s], ignored.\n",
-              sss_ldap_err2string(ret));
-    }
+    if (!tmp_ctx) return ENOMEM;
 
     attrs = sysdb_new_attrs(tmp_ctx);
     if (!attrs) {
@@ -436,65 +437,104 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
         goto done;
     }
 
-    str = ldap_get_dn(sh->ldap, sm->msg);
-    if (!str) {
-        ldap_get_option(sh->ldap, LDAP_OPT_RESULT_CODE, &lerrno);
-        DEBUG(SSSDBG_CRIT_FAILURE, "ldap_get_dn failed: %d(%s)\n",
+    lerrno = ldap_get_dn_ber(sh->ldap, sm->msg, &ber, &bv);
+    if (lerrno != LDAP_SUCCESS) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "ldap_get_dn_ber failed: %d(%s)\n",
               lerrno, sss_ldap_err2string(lerrno));
         ret = EIO;
         goto done;
     }
 
-    DEBUG_CONDITIONAL(SSSDBG_TRACE_LIBS, "OriginalDN: [%s].\n", str);
-    PROBE(SDAP_PARSE_ENTRY, "OriginalDN", str, strlen(str));
-    ret = sysdb_attrs_add_string(attrs, SYSDB_ORIG_DN, str);
-    ldap_memfree(str);
-    if (ret) goto done;
+    /* The RootDSE has the empty DN, so only a missing value is an error.  */
+    if (bv.bv_val == NULL) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "ldap_get_dn_ber returned no DN\n");
+        ret = EIO;
+        goto done;
+    }
 
-    if (map) {
-        vals = ldap_get_values_len(sh->ldap, sm->msg, "objectClass");
-        if (!vals) {
+    DEBUG_CONDITIONAL(SSSDBG_TRACE_LIBS, "OriginalDN: [%.*s].\n",
+                      (int)bv.bv_len, bv.bv_val);
+    PROBE(SDAP_PARSE_ENTRY, "OriginalDN", bv.bv_val, bv.bv_len);
+    ret = sysdb_attrs_add_mem(attrs, SYSDB_ORIG_DN, bv.bv_val, bv.bv_len);
+    if (ret)
+        goto done;
+
+    /* If there is no map, skip the objectClass matching logic. */
+    object_class_matched = !map;
+
+    for (;;) {
+        if (bvals) {
+            ber_memfree(bvals);
+            bvals = NULL;
+        }
+        lerrno = ldap_get_attribute_ber(sh->ldap, sm->msg, ber, &bv, &bvals);
+        if (lerrno != LDAP_SUCCESS) {
             DEBUG(SSSDBG_CRIT_FAILURE,
-                  "Unknown entry type, no objectClasses found!\n");
-            ret = EINVAL;
+                  "ldap_get_attribute_ber failed: %d(%s)\n",
+                  lerrno, sss_ldap_err2string(lerrno));
+            ret = EIO;
             goto done;
         }
 
-        for (i = 0; vals[i]; i++) {
-            if (objectclass_matched(map, vals[i]->bv_val, vals[i]->bv_len)) {
-                /* ok it's an entry of the right type */
-                break;
+        setof_attr_val = bvals;
+
+        /* A NULL bv.bv_val w/ LDAP_SUCCESS indicates that "all data
+           has been consumed". */
+        if (bv.bv_val == NULL)
+            break;
+
+        /* The attribute description points into the decoded message and
+           is not guaranteed to be terminated, while sdap_parse_range()
+           and the comparisons against the map require a C string.  */
+        attr_name = talloc_strndup(tmp_ctx, bv.bv_val, bv.bv_len);
+        if (attr_name == NULL) {
+            ret = ENOMEM;
+            goto done;
+        }
+
+        DEBUG_CONDITIONAL(SSSDBG_TRACE_LIBS, "processing attribute [%s]\n",
+                          attr_name);
+
+        if (!attribute_has_values(setof_attr_val)) {
+            DEBUG_CONDITIONAL(SSSDBG_TRACE_LIBS,
+                              "Attribute [%s] has no values, skipping.\n",
+                              attr_name);
+            continue;
+        }
+
+        if (!object_class_matched
+                && strcasecmp(attr_name, "objectClass") == 0) {
+            for (i = 0; setof_attr_val[i].bv_val; i++) {
+                if (objectclass_matched_ber(map, setof_attr_val[i])) {
+                    /* ok it's an entry of the right type */
+                    DEBUG_CONDITIONAL(SSSDBG_TRACE_LIBS,
+                                      "objectClass '%.*s' matched\n",
+                                      (int)setof_attr_val[i].bv_len,
+                                      setof_attr_val[i].bv_val);
+                    object_class_matched = true;
+                    break;
+                }
+
+                DEBUG_CONDITIONAL(SSSDBG_TRACE_LIBS,
+                                  "objectClass '%.*s' did not match\n",
+                                  (int)setof_attr_val[i].bv_len,
+                                  setof_attr_val[i].bv_val);
             }
-        }
-        if (!vals[i]) {
-            DEBUG(SSSDBG_CRIT_FAILURE, "objectClass not matching: %s\n",
-                  map[0].name);
-            ldap_value_free_len(vals);
-            ret = EINVAL;
-            goto done;
-        }
-        ldap_value_free_len(vals);
-    }
 
-    str = ldap_first_attribute(sh->ldap, sm->msg, &ber);
-    if (!str) {
-        ldap_get_option(sh->ldap, LDAP_OPT_RESULT_CODE, &lerrno);
-        DEBUG(lerrno == LDAP_SUCCESS
-              ? SSSDBG_TRACE_LIBS
-              : SSSDBG_MINOR_FAILURE,
-              "Entry has no attributes [%d(%s)]!?\n",
-               lerrno, sss_ldap_err2string(lerrno));
-        if (map) {
-            ret = EINVAL;
-            goto done;
+            /* An entry may repeat an attribute description, so a later
+               objectClass attribute can still match and the entry is
+               only rejected once the whole message has been parsed.
+               The values are then handled like any other attribute, as
+               a map extended through ldap_user_extra_attrs may store
+               objectClass itself.  */
         }
-    }
-    while (str) {
-        base64 = false;
 
-        ret = sdap_parse_range(tmp_ctx, str, &base_attr, &range_offset,
+        ret = sdap_parse_range(tmp_ctx, attr_name, &base_attr, &range_offset,
                                disable_range_retrieval);
         switch(ret) {
+        case ECANCELED:
+            continue;
+
         case EAGAIN:
             /* This attribute contained range values and needs more to
              * be retrieved
@@ -503,131 +543,98 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
              * For now, we'll continue below and treat it as regular values.
              */
             /* FALLTHROUGH */
-        case ECANCELED:
-            /* FALLTHROUGH */
         case EOK:
             break;
         default:
             DEBUG(SSSDBG_CRIT_FAILURE,
-                  "Could not determine if attribute [%s] was ranged\n", str);
+                  "Could not determine if attribute [%s] was ranged\n",
+                  attr_name);
             goto done;
         }
 
-        if (ret == ECANCELED) {
-            store = false;
-        } else if (map) {
+        base64 = false;
+
+        name = base_attr;
+        if (map) {
             for (i = 1; i < attrs_num; i++) {
                 /* check if this attr is valid with the chosen schema */
-                if (!map[i].name) continue;
+                if (!map[i].name)
+                    continue;
+
                 /* check if it is an attr we are interested in */
-                if (strcasecmp(base_attr, map[i].name) == 0) break;
+                if (strcasecmp(base_attr, map[i].name) == 0) {
+                    name = map[i].sys_name;
+                    base_attr_idx = i;
+                    if (strcmp(name, SYSDB_SSH_PUBKEY) == 0) {
+                        base64 = true;
+                    }
+
+                    break;
+                }
             }
-            /* interesting attr */
-            if (i < attrs_num) {
-                store = true;
-                name = map[i].sys_name;
-                base_attr_idx = i;
-                if (strcmp(name, SYSDB_SSH_PUBKEY) == 0) {
-                    base64 = true;
-                }
-            } else {
-                store = false;
-            }
-        } else {
-            name = base_attr;
-            store = true;
-        }
 
-        if (store) {
-            vals = ldap_get_values_len(sh->ldap, sm->msg, str);
-            if (!vals) {
-                ldap_get_option(sh->ldap, LDAP_OPT_RESULT_CODE, &lerrno);
-                if (lerrno != LDAP_SUCCESS) {
-                    DEBUG(SSSDBG_CRIT_FAILURE,
-                          "ldap_get_values_len() failed: %d(%s)\n",
-                          lerrno, sss_ldap_err2string(lerrno));
-                    ret = EIO;
-                    goto done;
-                }
-
-                DEBUG(SSSDBG_TRACE_LIBS,
-                      "Attribute [%s] has no values, skipping.\n", str);
-
-            } else {
-                if (!vals[0]) {
-                    DEBUG(SSSDBG_CRIT_FAILURE,
-                          "Missing value after ldap_get_values() ??\n");
-                    ldap_value_free_len(vals);
-                    ret = EINVAL;
-                    goto done;
-                }
-                for (i = 0; vals[i]; i++) {
-                    if (vals[i]->bv_len == 0) {
-                        DEBUG(SSSDBG_TRACE_LIBS,
-                              "Value of attribute [%s] is empty. "
-                               "Skipping this value.\n", str);
-                        continue;
-                    }
-                    if (base64) {
-                        v.data = (uint8_t *) sss_base64_encode(attrs,
-                                 (uint8_t *) vals[i]->bv_val, vals[i]->bv_len);
-                        if (!v.data) {
-                            ldap_value_free_len(vals);
-                            ret = ENOMEM;
-                            goto done;
-                        }
-                        v.length = strlen((const char *)v.data);
-                    } else {
-                        v.data = (uint8_t *)vals[i]->bv_val;
-                        v.length = vals[i]->bv_len;
-                    }
-                    PROBE(SDAP_PARSE_ENTRY, str, v.data, v.length);
-
-                    if (map) {
-                        /* The same LDAP attr might be used for more sysdb
-                         * attrs in case there is a map. Find all that match
-                         * and copy the value
-                         */
-                        for (ai = base_attr_idx; ai < attrs_num; ai++) {
-                            /* check if this attr is valid with the chosen
-                             * schema */
-                            if (!map[ai].name) continue;
-
-                            /* check if it is an attr we are interested in */
-                            if (strcasecmp(base_attr, map[ai].name) == 0) {
-                                ret = sysdb_attrs_add_val(attrs,
-                                                          map[ai].sys_name,
-                                                          &v);
-                                if (ret) {
-                                    ldap_value_free_len(vals);
-                                    goto done;
-                                }
-                            }
-                        }
-                    } else {
-                        /* No map, just store the attribute */
-                        ret = sysdb_attrs_add_val(attrs, name, &v);
-                        if (ret) {
-                            ldap_value_free_len(vals);
-                            goto done;
-                        }
-                    }
-                }
-                ldap_value_free_len(vals);
+            if (i == attrs_num) {
+                DEBUG_CONDITIONAL(SSSDBG_TRACE_LIBS,
+                                  "Attribute [%s] not in map, skipping.\n",
+                                  attr_name);
+                continue;
             }
         }
 
-        ldap_memfree(str);
-        str = ldap_next_attribute(sh->ldap, sm->msg, ber);
+        for (i = 0; setof_attr_val[i].bv_val != NULL; i++ ) {
+            if (setof_attr_val[i].bv_len == 0) {
+                DEBUG_CONDITIONAL(SSSDBG_TRACE_LIBS,
+                                  "%s[%d] is zero-length, skipping.\n",
+                                  attr_name, i);
+                continue;
+            }
+
+            if (base64) {
+                v.data = sss_base64_enc_ber(attrs, setof_attr_val[i]);
+                if (!v.data) {
+                    ret = ENOMEM;
+                    goto done;
+                }
+                v.length = strlen((const char *)v.data);
+            } else {
+                v.data = (uint8_t *)setof_attr_val[i].bv_val;
+                v.length = setof_attr_val[i].bv_len;
+            }
+
+            PROBE(SDAP_PARSE_ENTRY, attr_name, v.data, v.length);
+
+            if (map) {
+                /* The same LDAP attr might be used for more sysdb
+                 * attrs in case there is a map. Find all that match
+                 * and copy the value
+                 */
+                for (ai = base_attr_idx; ai < attrs_num; ai++) {
+                    /* check if this attr is valid with the chosen
+                     * schema */
+                    if (!map[ai].name) continue;
+
+                    /* check if it is an attr we are interested in */
+                    if (strcasecmp(base_attr, map[ai].name) == 0) {
+                        ret = sysdb_attrs_add_val(attrs,
+                                                  map[ai].sys_name,
+                                                  &v);
+                        if (ret)
+                            goto done;
+                    }
+                }
+            } else {
+                /* No map, just store the attribute */
+                ret = sysdb_attrs_add_val(attrs, name, &v);
+                if (ret)
+                    goto done;
+            }
+        }
     }
-    ber_free(ber, 0);
-    ber = NULL;
 
-    ldap_get_option(sh->ldap, LDAP_OPT_RESULT_CODE, &lerrno);
-    if (lerrno) {
-        DEBUG(SSSDBG_CRIT_FAILURE, "ldap_get_option() failed: %d(%s)\n",
-              lerrno, sss_ldap_err2string(lerrno));
-        ret = EIO;
+    if (!object_class_matched) {
+        DEBUG(SSSDBG_CRIT_FAILURE, "objectClass not matching: %s\n",
+              map[0].name);
+        ret = EINVAL;
         goto done;
     }
 
@@ -636,6 +643,7 @@ int sdap_parse_entry(TALLOC_CTX *memctx,
     ret = EOK;
 
 done:
+    if (bvals) ber_memfree(bvals);
     if (ber) ber_free(ber, 0);
     talloc_free(tmp_ctx);
     return ret;
@@ -660,6 +668,30 @@ static bool objectclass_matched(struct sdap_attr_map *map,
     }
 
     return false;
+}
+
+/* utility function to apply objectclass_matched to a struct berval */
+static bool objectclass_matched_ber(struct sdap_attr_map *map,
+                                    const struct berval attr_val)
+{
+    return objectclass_matched(map, (char*)attr_val.bv_val, attr_val.bv_len);
+}
+
+/* True if SETOF_ATTR_VAL, as returned by ldap_get_attribute_ber(), holds
+   at least one value.  An attribute that carries no values leaves the
+   value array unset, so SETOF_ATTR_VAL is NULL rather than empty.  */
+static bool attribute_has_values(const struct berval *setof_attr_val)
+{
+    return setof_attr_val != NULL && setof_attr_val[0].bv_val != NULL;
+}
+
+/* utility function to apply sss_base64_encode to a struct berval */
+static uint8_t *sss_base64_enc_ber(TALLOC_CTX *mem_ctx,
+                                   const struct berval attr_val)
+{
+    return (uint8_t *)sss_base64_encode(mem_ctx,
+                                        (const unsigned char *)attr_val.bv_val,
+                                        attr_val.bv_len);
 }
 
 /* Parses an LDAPDerefRes into sdap_deref_attrs structure */

--- a/src/providers/ldap/sdap.c
+++ b/src/providers/ldap/sdap.c
@@ -649,21 +649,28 @@ done:
     return ret;
 }
 
+/* True if the first LEN bytes of OBJCL are the whole of the class NAME,
+   ignoring case.  */
+static bool class_name_equals(const char *name, const char *objcl, int len)
+{
+    return strncasecmp(name, objcl, len) == 0 && name[len] == '\0';
+}
+
 static bool objectclass_matched(struct sdap_attr_map *map,
                                 const char *objcl, int len)
 {
     if (len == 0) {
-        len = strlen(objcl) + 1;
+        len = strlen(objcl);
     }
 
-    if (strncasecmp(map[0].name, objcl, len) == 0) {
+    if (class_name_equals(map[0].name, objcl, len)) {
         return true;
     }
     /* first element is always object class, and for groups also the
      * second element (SDAP_OC_GROUP_ALT) in the array */
     if (strcmp(map[SDAP_OC_GROUP_ALT].sys_name, SYSDB_GROUP_CLASS) == 0
         && map[SDAP_OC_GROUP_ALT].name != NULL
-        && strncasecmp(map[SDAP_OC_GROUP_ALT].name, objcl, len) == 0) {
+        && class_name_equals(map[SDAP_OC_GROUP_ALT].name, objcl, len)) {
         return true;
     }
 
@@ -674,6 +681,10 @@ static bool objectclass_matched(struct sdap_attr_map *map,
 static bool objectclass_matched_ber(struct sdap_attr_map *map,
                                     const struct berval attr_val)
 {
+    if (attr_val.bv_len == 0) {
+        return false;
+    }
+
     return objectclass_matched(map, (char*)attr_val.bv_val, attr_val.bv_len);
 }
 

--- a/src/tests/cmocka/test_sdap.c
+++ b/src/tests/cmocka/test_sdap.c
@@ -1068,6 +1068,39 @@ void test_parse_objectclass_extra_attr(void **state)
     talloc_free(attrs);
 }
 
+void test_parse_oc_prefix(void **state)
+{
+    int ret;
+    struct sysdb_attrs *attrs;
+    struct parse_test_ctx *test_ctx = talloc_get_type_abort(*state,
+                                                      struct parse_test_ctx);
+    struct mock_ldap_entry test_rfc2307_user;
+    struct sdap_attr_map *map;
+
+    /* A strict prefix of the class name in the map is not a match */
+    const char *oc_values[] = { "posix", NULL };
+    const char *uid_values[] = { "tuser1", NULL };
+    struct mock_ldap_attr test_rfc2307_user_attrs[] = {
+        { .name = "objectClass", .values = oc_values },
+        { .name = "uid", .values = uid_values },
+        { NULL, NULL }
+    };
+
+    test_rfc2307_user.dn = "cn=testuser,dc=example,dc=com";
+    test_rfc2307_user.attrs = test_rfc2307_user_attrs;
+    set_entry_parse(&test_rfc2307_user);
+
+    ret = sdap_copy_map(test_ctx, rfc2307_user_map, SDAP_OPTS_USER, &map);
+    assert_int_equal(ret, ERR_OK);
+
+    ret = sdap_parse_entry(test_ctx, &test_ctx->sh, &test_ctx->sm,
+                           map, SDAP_OPTS_USER,
+                           &attrs, false);
+    assert_int_equal(ret, EINVAL);
+
+    talloc_free(map);
+}
+
 void test_parse_no_dn(void **state)
 {
     int ret;
@@ -1660,6 +1693,9 @@ int main(int argc, const char *argv[])
                                         parse_entry_test_setup,
                                         parse_entry_test_teardown),
         cmocka_unit_test_setup_teardown(test_parse_bad_oc,
+                                        parse_entry_test_setup,
+                                        parse_entry_test_teardown),
+        cmocka_unit_test_setup_teardown(test_parse_oc_prefix,
                                         parse_entry_test_setup,
                                         parse_entry_test_teardown),
         cmocka_unit_test_setup_teardown(test_parse_no_dn,

--- a/src/tests/cmocka/test_sdap.c
+++ b/src/tests/cmocka/test_sdap.c
@@ -757,6 +757,317 @@ void test_parse_no_oc(void **state)
 /* Negative test - the entry has no DN. Just make sure
  * we don't crash and detect the failure.
  */
+void test_parse_repeated_attr(void **state)
+{
+    int ret;
+    struct sysdb_attrs *attrs;
+    struct parse_test_ctx *test_ctx = talloc_get_type_abort(*state,
+                                                      struct parse_test_ctx);
+    struct mock_ldap_entry test_rfc2307_user;
+    struct sdap_attr_map *map;
+    struct ldb_message_element *el;
+    unsigned char *decoded_key;
+    size_t key_len;
+
+    const char *oc_values[] = { "posixAccount", NULL };
+    const char *uid_values[] = { "tuser1", NULL };
+    const char *ssh_values1[] = { "key1", NULL };
+    const char *ssh_values2[] = { "key2", NULL };
+    /* A multi-valued attribute split into repeated single-valued
+     * attributes of the same description, as Google Secure LDAP sends
+     * user-defined attributes */
+    struct mock_ldap_attr test_rfc2307_user_attrs[] = {
+        { .name = "objectClass", .values = oc_values },
+        { .name = "uid", .values = uid_values },
+        { .name = "sshPublicKey", .values = ssh_values1 },
+        { .name = "sshPublicKey", .values = ssh_values2 },
+        { NULL, NULL }
+    };
+
+    test_rfc2307_user.dn = "cn=testuser,dc=example,dc=com";
+    test_rfc2307_user.attrs = test_rfc2307_user_attrs;
+    set_entry_parse(&test_rfc2307_user);
+
+    ret = sdap_copy_map(test_ctx, rfc2307_user_map, SDAP_OPTS_USER, &map);
+    assert_int_equal(ret, ERR_OK);
+
+    ret = sdap_parse_entry(test_ctx, &test_ctx->sh, &test_ctx->sm,
+                           map, SDAP_OPTS_USER,
+                           &attrs, false);
+    assert_int_equal(ret, ERR_OK);
+
+    assert_int_equal(attrs->num, 3);
+    assert_entry_has_attr(attrs, SYSDB_NAME, "tuser1");
+
+    /* Both instances must contribute a value */
+    ret = sysdb_attrs_get_el_ext(attrs, SYSDB_SSH_PUBKEY, false, &el);
+    assert_int_equal(ret, ERR_OK);
+    assert_int_equal(el->num_values, 2);
+
+    decoded_key = sss_base64_decode(test_ctx,
+                                    (const char *)el->values[0].data,
+                                    &key_len);
+    assert_non_null(decoded_key);
+    assert_memory_equal(decoded_key, "key1", key_len);
+    talloc_free(decoded_key);
+
+    decoded_key = sss_base64_decode(test_ctx,
+                                    (const char *)el->values[1].data,
+                                    &key_len);
+    assert_non_null(decoded_key);
+    assert_memory_equal(decoded_key, "key2", key_len);
+    talloc_free(decoded_key);
+
+    talloc_free(map);
+    talloc_free(attrs);
+}
+
+void test_parse_attr_no_values(void **state)
+{
+    int ret;
+    struct sysdb_attrs *attrs;
+    struct parse_test_ctx *test_ctx = talloc_get_type_abort(*state,
+                                                      struct parse_test_ctx);
+    struct mock_ldap_entry test_rfc2307_user;
+    struct sdap_attr_map *map;
+
+    const char *oc_values[] = { "posixAccount", NULL };
+    const char *gecos_values[] = { "Test User", NULL };
+    /* A type without values, as returned for a typesOnly search or a
+     * value the server withholds */
+    struct mock_ldap_attr test_rfc2307_user_attrs[] = {
+        { .name = "objectClass", .values = oc_values },
+        { .name = "uid", .values = NULL },
+        { .name = "gecos", .values = gecos_values },
+        { NULL, NULL }
+    };
+
+    test_rfc2307_user.dn = "cn=testuser,dc=example,dc=com";
+    test_rfc2307_user.attrs = test_rfc2307_user_attrs;
+    set_entry_parse(&test_rfc2307_user);
+
+    ret = sdap_copy_map(test_ctx, rfc2307_user_map, SDAP_OPTS_USER, &map);
+    assert_int_equal(ret, ERR_OK);
+
+    ret = sdap_parse_entry(test_ctx, &test_ctx->sh, &test_ctx->sm,
+                           map, SDAP_OPTS_USER,
+                           &attrs, false);
+    assert_int_equal(ret, ERR_OK);
+
+    assert_int_equal(attrs->num, 2);
+    assert_entry_has_no_attr(attrs, SYSDB_NAME);
+    assert_entry_has_attr(attrs, SYSDB_GECOS, "Test User");
+
+    talloc_free(map);
+    talloc_free(attrs);
+}
+
+void test_parse_range_disabled(void **state)
+{
+    int ret;
+    struct sysdb_attrs *attrs;
+    struct parse_test_ctx *test_ctx = talloc_get_type_abort(*state,
+                                                      struct parse_test_ctx);
+    struct mock_ldap_entry test_rfc2307_group;
+    struct sdap_attr_map *map;
+
+    const char *oc_values[] = { "posixGroup", NULL };
+    const char *member_values[] = { "tuser1", "tuser2", NULL };
+    const char *cn_values[] = { "tgroup", NULL };
+    /* A ranged attribute precedes the rest of the entry, as Active
+     * Directory sends it for large groups */
+    struct mock_ldap_attr test_rfc2307_group_attrs[] = {
+        { .name = "objectClass", .values = oc_values },
+        { .name = "memberUid;range=0-1", .values = member_values },
+        { .name = "cn", .values = cn_values },
+        { NULL, NULL }
+    };
+
+    test_rfc2307_group.dn = "cn=tgroup,dc=example,dc=com";
+    test_rfc2307_group.attrs = test_rfc2307_group_attrs;
+    set_entry_parse(&test_rfc2307_group);
+
+    ret = sdap_copy_map(test_ctx, rfc2307_group_map, SDAP_OPTS_GROUP, &map);
+    assert_int_equal(ret, ERR_OK);
+
+    /* With range retrieval disabled the ranged attribute is skipped */
+    ret = sdap_parse_entry(test_ctx, &test_ctx->sh, &test_ctx->sm,
+                           map, SDAP_OPTS_GROUP,
+                           &attrs, true);
+    assert_int_equal(ret, ERR_OK);
+
+    assert_int_equal(attrs->num, 2);
+    assert_entry_has_no_attr(attrs, SYSDB_MEMBER);
+    assert_entry_has_attr(attrs, SYSDB_NAME, "tgroup");
+
+    talloc_free(map);
+    talloc_free(attrs);
+}
+
+void test_parse_range_unmapped(void **state)
+{
+    int ret;
+    struct sysdb_attrs *attrs;
+    struct parse_test_ctx *test_ctx = talloc_get_type_abort(*state,
+                                                      struct parse_test_ctx);
+    struct mock_ldap_entry test_rfc2307_user;
+    struct sdap_attr_map *map;
+
+    const char *oc_values[] = { "posixAccount", NULL };
+    const char *extra_values[] = { "extra1", "extra2", NULL };
+    const char *uid_values[] = { "tuser1", NULL };
+    /* A ranged attribute that is not in the map precedes the rest of
+     * the entry */
+    struct mock_ldap_attr test_rfc2307_user_attrs[] = {
+        { .name = "objectClass", .values = oc_values },
+        { .name = "extra;range=0-1", .values = extra_values },
+        { .name = "uid", .values = uid_values },
+        { NULL, NULL }
+    };
+
+    test_rfc2307_user.dn = "cn=testuser,dc=example,dc=com";
+    test_rfc2307_user.attrs = test_rfc2307_user_attrs;
+    set_entry_parse(&test_rfc2307_user);
+
+    ret = sdap_copy_map(test_ctx, rfc2307_user_map, SDAP_OPTS_USER, &map);
+    assert_int_equal(ret, ERR_OK);
+
+    ret = sdap_parse_entry(test_ctx, &test_ctx->sh, &test_ctx->sm,
+                           map, SDAP_OPTS_USER,
+                           &attrs, false);
+    assert_int_equal(ret, ERR_OK);
+
+    assert_int_equal(attrs->num, 2);
+    assert_entry_has_no_attr(attrs, "extra");
+    assert_entry_has_attr(attrs, SYSDB_NAME, "tuser1");
+
+    talloc_free(map);
+    talloc_free(attrs);
+}
+
+void test_parse_empty_dn(void **state)
+{
+    int ret;
+    struct sysdb_attrs *attrs;
+    struct parse_test_ctx *test_ctx = talloc_get_type_abort(*state,
+                                                      struct parse_test_ctx);
+    struct mock_ldap_entry test_rootdse;
+    struct sdap_attr_map *map;
+
+    const char *oc_values[] = { "posixAccount", NULL };
+    const char *uid_values[] = { "tuser1", NULL };
+    struct mock_ldap_attr test_rootdse_attrs[] = {
+        { .name = "objectClass", .values = oc_values },
+        { .name = "uid", .values = uid_values },
+        { NULL, NULL }
+    };
+
+    /* The RootDSE is the one entry with an empty DN */
+    test_rootdse.dn = "";
+    test_rootdse.attrs = test_rootdse_attrs;
+    set_entry_parse(&test_rootdse);
+
+    ret = sdap_copy_map(test_ctx, rfc2307_user_map, SDAP_OPTS_USER, &map);
+    assert_int_equal(ret, ERR_OK);
+
+    ret = sdap_parse_entry(test_ctx, &test_ctx->sh, &test_ctx->sm,
+                           map, SDAP_OPTS_USER,
+                           &attrs, false);
+    assert_int_equal(ret, ERR_OK);
+
+    assert_int_equal(attrs->num, 2);
+    assert_entry_has_attr(attrs, SYSDB_ORIG_DN, "");
+    assert_entry_has_attr(attrs, SYSDB_NAME, "tuser1");
+
+    talloc_free(map);
+    talloc_free(attrs);
+}
+
+void test_parse_objectclass_case(void **state)
+{
+    int ret;
+    struct sysdb_attrs *attrs;
+    struct parse_test_ctx *test_ctx = talloc_get_type_abort(*state,
+                                                      struct parse_test_ctx);
+    struct mock_ldap_entry test_rfc2307_user;
+    struct sdap_attr_map *map;
+
+    const char *oc_values[] = { "posixAccount", NULL };
+    const char *uid_values[] = { "tuser1", NULL };
+    /* Attribute descriptions are case-insensitive; a server may return
+     * the description in a different case than the request used */
+    struct mock_ldap_attr test_rfc2307_user_attrs[] = {
+        { .name = "objectclass", .values = oc_values },
+        { .name = "uid", .values = uid_values },
+        { NULL, NULL }
+    };
+
+    test_rfc2307_user.dn = "cn=testuser,dc=example,dc=com";
+    test_rfc2307_user.attrs = test_rfc2307_user_attrs;
+    set_entry_parse(&test_rfc2307_user);
+
+    ret = sdap_copy_map(test_ctx, rfc2307_user_map, SDAP_OPTS_USER, &map);
+    assert_int_equal(ret, ERR_OK);
+
+    ret = sdap_parse_entry(test_ctx, &test_ctx->sh, &test_ctx->sm,
+                           map, SDAP_OPTS_USER,
+                           &attrs, false);
+    assert_int_equal(ret, ERR_OK);
+
+    assert_int_equal(attrs->num, 2);
+    assert_entry_has_attr(attrs, SYSDB_NAME, "tuser1");
+
+    talloc_free(map);
+    talloc_free(attrs);
+}
+
+void test_parse_objectclass_extra_attr(void **state)
+{
+    int ret;
+    struct sysdb_attrs *attrs;
+    struct parse_test_ctx *test_ctx = talloc_get_type_abort(*state,
+                                                      struct parse_test_ctx);
+    struct mock_ldap_entry test_rfc2307_user;
+    struct sdap_attr_map *map;
+    struct ldb_message_element *el;
+    char *extra_attrs[] = { discard_const("ocs:objectClass"), NULL };
+    size_t map_size;
+
+    const char *oc_values[] = { "top", "posixAccount", "customPerson", NULL };
+    const char *uid_values[] = { "tuser1", NULL };
+    struct mock_ldap_attr test_rfc2307_user_attrs[] = {
+        { .name = "objectClass", .values = oc_values },
+        { .name = "uid", .values = uid_values },
+        { NULL, NULL }
+    };
+
+    test_rfc2307_user.dn = "cn=testuser,dc=example,dc=com";
+    test_rfc2307_user.attrs = test_rfc2307_user_attrs;
+    set_entry_parse(&test_rfc2307_user);
+
+    ret = sdap_copy_map(test_ctx, rfc2307_user_map, SDAP_OPTS_USER, &map);
+    assert_int_equal(ret, ERR_OK);
+
+    /* objectClass itself can be requested through ldap_user_extra_attrs */
+    ret = sdap_extend_map(test_ctx, map, SDAP_OPTS_USER, extra_attrs,
+                          &map, &map_size);
+    assert_int_equal(ret, ERR_OK);
+    assert_int_equal(map_size, SDAP_OPTS_USER + 1);
+
+    ret = sdap_parse_entry(test_ctx, &test_ctx->sh, &test_ctx->sm,
+                           map, map_size,
+                           &attrs, false);
+    assert_int_equal(ret, ERR_OK);
+
+    assert_entry_has_attr(attrs, SYSDB_NAME, "tuser1");
+    ret = sysdb_attrs_get_el_ext(attrs, "ocs", false, &el);
+    assert_int_equal(ret, ERR_OK);
+    assert_int_equal(el->num_values, 3);
+
+    talloc_free(map);
+    talloc_free(attrs);
+}
+
 void test_parse_no_dn(void **state)
 {
     int ret;
@@ -1321,6 +1632,27 @@ int main(int argc, const char *argv[])
                                         parse_entry_test_setup,
                                         parse_entry_test_teardown),
         cmocka_unit_test_setup_teardown(test_parse_secondary_oc,
+                                        parse_entry_test_setup,
+                                        parse_entry_test_teardown),
+        cmocka_unit_test_setup_teardown(test_parse_repeated_attr,
+                                        parse_entry_test_setup,
+                                        parse_entry_test_teardown),
+        cmocka_unit_test_setup_teardown(test_parse_attr_no_values,
+                                        parse_entry_test_setup,
+                                        parse_entry_test_teardown),
+        cmocka_unit_test_setup_teardown(test_parse_range_disabled,
+                                        parse_entry_test_setup,
+                                        parse_entry_test_teardown),
+        cmocka_unit_test_setup_teardown(test_parse_range_unmapped,
+                                        parse_entry_test_setup,
+                                        parse_entry_test_teardown),
+        cmocka_unit_test_setup_teardown(test_parse_empty_dn,
+                                        parse_entry_test_setup,
+                                        parse_entry_test_teardown),
+        cmocka_unit_test_setup_teardown(test_parse_objectclass_case,
+                                        parse_entry_test_setup,
+                                        parse_entry_test_teardown),
+        cmocka_unit_test_setup_teardown(test_parse_objectclass_extra_attr,
                                         parse_entry_test_setup,
                                         parse_entry_test_teardown),
         /* Negative tests */

--- a/src/tests/cmocka/test_sdap.c
+++ b/src/tests/cmocka/test_sdap.c
@@ -121,6 +121,18 @@ char *__wrap_ldap_get_dn(LDAP *ld, LDAPMessage *entry)
     return discard_const(ldap_entry->dn);
 }
 
+int __wrap_ldap_get_dn_ber(LDAP *ld, LDAPMessage *entry,
+                           BerElement **berout, BerValue *dn)
+{
+    struct mock_ldap_entry *ldap_entry = mock_ldap_entry_get();
+    dn->bv_val = discard_const(ldap_entry->dn);
+    dn->bv_len = ldap_entry->dn ? strlen(ldap_entry->dn) : 0;
+
+    *berout = (BerElement *)-1;
+    will_return(mock_ldap_entry_iter, 0);
+    return LDAP_SUCCESS;
+}
+
 void __wrap_ldap_memfree(void *p)
 {
     return;
@@ -209,6 +221,62 @@ char *__wrap_ldap_next_attribute(LDAP *ld,
         will_return(mock_ldap_entry_iter, idx + 1);
     }
     return val;
+}
+
+void __wrap_ber_memfree(void *p)
+{
+    talloc_free(p);
+}
+
+void __wrap_ber_free(void *p, int cnt)
+{
+    if (p)
+        mock_ldap_entry_iter();  /* make will_return happy */
+}
+
+int __wrap_ldap_get_attribute_ber(LDAP *ld,
+                                  LDAPMessage *entry,
+                                  BerElement *ber,
+                                  BerValue *attr,
+                                  BerVarray *vals)
+{
+    struct mock_ldap_entry *ldap_entry = mock_ldap_entry_get();
+    int idx = mock_ldap_entry_iter();
+    const char **attrvals;
+    struct berval *bvals;
+    char *val;
+    size_t count, i;
+
+    val = discard_const(ldap_entry->attrs[idx].name);
+    attr->bv_val = val;
+    attr->bv_len = val ? strlen(val) : 0;
+    will_return(mock_ldap_entry_iter, idx + 1);
+    if (!val)
+        return LDAP_SUCCESS;
+
+    attrvals = ldap_entry->attrs[idx].values;
+    /* ldap_get_attribute_ber() leaves the array unset for a type
+     * without values */
+    if (attrvals == NULL) {
+        *vals = NULL;
+        return LDAP_SUCCESS;
+    }
+
+    count = 0;
+    for (i = 0; attrvals[i]; i++) {
+        count++;
+    }
+
+    bvals = talloc_zero_array(global_talloc_context,
+                              struct berval,
+                              count + 1);
+    for (i = 0; attrvals[i]; i++) {
+        bvals[i].bv_val = discard_const(attrvals[i]);
+        bvals[i].bv_len = strlen(attrvals[i]);
+    }
+    *vals = bvals;
+
+    return LDAP_SUCCESS;
 }
 
 /* Mock parsing search base without overlinking the test */

--- a/src/tests/cmocka/test_sdap.c
+++ b/src/tests/cmocka/test_sdap.c
@@ -42,6 +42,13 @@ struct mock_ldap_entry {
 
 struct mock_ldap_entry *global_ldap_entry;
 
+/* When set, returned verbatim in place of the entry's DN or of the
+ * description of attribute mock_attr_override_idx, so a test can hand
+ * the parser bytes that a C string cannot carry */
+static const struct berval *mock_dn_override;
+static const struct berval *mock_attr_override;
+static int mock_attr_override_idx;
+
 static int mock_ldap_entry_iter(void)
 {
     return sss_mock_type(int);
@@ -125,8 +132,12 @@ int __wrap_ldap_get_dn_ber(LDAP *ld, LDAPMessage *entry,
                            BerElement **berout, BerValue *dn)
 {
     struct mock_ldap_entry *ldap_entry = mock_ldap_entry_get();
-    dn->bv_val = discard_const(ldap_entry->dn);
-    dn->bv_len = ldap_entry->dn ? strlen(ldap_entry->dn) : 0;
+    if (mock_dn_override != NULL) {
+        *dn = *mock_dn_override;
+    } else {
+        dn->bv_val = discard_const(ldap_entry->dn);
+        dn->bv_len = ldap_entry->dn ? strlen(ldap_entry->dn) : 0;
+    }
 
     *berout = (BerElement *)-1;
     will_return(mock_ldap_entry_iter, 0);
@@ -248,8 +259,12 @@ int __wrap_ldap_get_attribute_ber(LDAP *ld,
     size_t count, i;
 
     val = discard_const(ldap_entry->attrs[idx].name);
-    attr->bv_val = val;
-    attr->bv_len = val ? strlen(val) : 0;
+    if (mock_attr_override != NULL && idx == mock_attr_override_idx) {
+        *attr = *mock_attr_override;
+    } else {
+        attr->bv_val = val;
+        attr->bv_len = val ? strlen(val) : 0;
+    }
     will_return(mock_ldap_entry_iter, idx + 1);
     if (!val)
         return LDAP_SUCCESS;
@@ -1101,6 +1116,58 @@ void test_parse_oc_prefix(void **state)
     talloc_free(map);
 }
 
+void test_parse_zero_byte(void **state)
+{
+    int ret;
+    struct sysdb_attrs *attrs;
+    struct parse_test_ctx *test_ctx = talloc_get_type_abort(*state,
+                                                      struct parse_test_ctx);
+    struct mock_ldap_entry test_rfc2307_user;
+    struct sdap_attr_map *map;
+    const struct berval dn_with_zero = {
+        .bv_val = discard_const("cn=testuser\0,dc=example,dc=com"),
+        .bv_len = 30
+    };
+    const struct berval desc_with_zero = {
+        .bv_val = discard_const("uid\0Number"),
+        .bv_len = 10
+    };
+
+    const char *oc_values[] = { "posixAccount", NULL };
+    const char *uid_values[] = { "tuser1", NULL };
+    struct mock_ldap_attr test_rfc2307_user_attrs[] = {
+        { .name = "objectClass", .values = oc_values },
+        { .name = "uid", .values = uid_values },
+        { NULL, NULL }
+    };
+
+    test_rfc2307_user.dn = "cn=testuser,dc=example,dc=com";
+    test_rfc2307_user.attrs = test_rfc2307_user_attrs;
+    set_entry_parse(&test_rfc2307_user);
+
+    ret = sdap_copy_map(test_ctx, rfc2307_user_map, SDAP_OPTS_USER, &map);
+    assert_int_equal(ret, ERR_OK);
+
+    /* A zero byte inside the DN */
+    mock_dn_override = &dn_with_zero;
+    ret = sdap_parse_entry(test_ctx, &test_ctx->sh, &test_ctx->sm,
+                           map, SDAP_OPTS_USER,
+                           &attrs, false);
+    mock_dn_override = NULL;
+    assert_int_equal(ret, EINVAL);
+
+    /* A zero byte inside the description of the second attribute */
+    mock_attr_override = &desc_with_zero;
+    mock_attr_override_idx = 1;
+    ret = sdap_parse_entry(test_ctx, &test_ctx->sh, &test_ctx->sm,
+                           map, SDAP_OPTS_USER,
+                           &attrs, false);
+    mock_attr_override = NULL;
+    assert_int_equal(ret, EINVAL);
+
+    talloc_free(map);
+}
+
 void test_parse_no_dn(void **state)
 {
     int ret;
@@ -1696,6 +1763,9 @@ int main(int argc, const char *argv[])
                                         parse_entry_test_setup,
                                         parse_entry_test_teardown),
         cmocka_unit_test_setup_teardown(test_parse_oc_prefix,
+                                        parse_entry_test_setup,
+                                        parse_entry_test_teardown),
+        cmocka_unit_test_setup_teardown(test_parse_zero_byte,
                                         parse_entry_test_setup,
                                         parse_entry_test_teardown),
         cmocka_unit_test_setup_teardown(test_parse_no_dn,


### PR DESCRIPTION
Resubmission of #7116, rebased on master and reworked after review.
We are using this in production.

Problem: sdap_parse_entry() walks descriptions positionally but fetches
values by name, so a server that sends a multi-valued attribute as
repeated single-valued attributes (Google Secure LDAP, custom schema
fields) yields the first value once per instance. Verified live: with
ldap_user_ssh_public_key mapped to such a field, ldb rejects the
duplicate value and the user cannot be cached at all.

Fix: read the message once with ldap_get_dn_ber()/ldap_get_attribute_ber()
(exported by libldap since 2002, now required by configure). Verified
against Google Secure LDAP with a three-valued field: all values
returned; full `make check` passes.

Review points from #7116:
- Octet strings as C strings: descriptions and values are now used with
  explicit lengths (liblber's in-place terminator is an implementation
  detail we no longer rely on).
- objectClass fast-path: rejection is deferred to the end of the entry,
  since objectClass may itself be repeated; comparison is
  case-insensitive as with ldap_get_values_len().
- "no value": ldap_get_attribute_ber() leaves the array unset for a type
  without values; handled and tested.
- goto/naming/declarations: addressed.
- Regression testing without an external server: the cmocka mocks feed
  the parser a synthetic message; seven new cases cover repeated
  descriptions, empty value sets, empty DN (RootDSE), ranged attributes,
  lower-case objectClass and objectClass via extra attributes.

Also: per-attribute traces no longer log values (they reached the
backtrace buffer and thus the log on any failure), plus three small
hardening commits (exact object-class match, reject zero bytes in
DN/description, capped printf precision) — none exploitable, as their
messages state.

Out of scope, noted for follow-up: sdap_async.c:2164/:3088 still select
the objectClass map via ldap_get_values_len() (first instance only).