### PR TITLE
[backport: sssd-2-9] Man page sssd_ad improvements

### DIFF
--- a/src/man/sssd-ad.5.xml
+++ b/src/man/sssd-ad.5.xml
@@ -1496,8 +1496,6 @@ ldap_account_expire_policy = ad
             because these attributes are included in the default Active
             Directory schema.
         </para>
-        <para>
-        </para>
     </refsect1>
 
 	<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="include/seealso.xml" />

--- a/src/man/sssd-ad.5.xml
+++ b/src/man/sssd-ad.5.xml
@@ -1240,10 +1240,9 @@ ad_gpo_map_deny = +my_pam_service
                             How often should the back end perform periodic DNS update in
                             addition to the automatic update performed when the back end
                             goes online.
-                            This option is optional and applicable only when dyndns_update
-                            is true. Note that the lowest possible value is 60 seconds in-case
-                            if value is provided less than 60, parameter will assume lowest
-                            value only.
+                            This is optional and applicable only when dyndns_update
+                            is true. Note that the minimum value is 60 seconds, any
+                            specified value below this threshold will default to 60.
                         </para>
                         <para>
                             Default: 86400 (24 hours)


### PR DESCRIPTION
This is manual backport of the commits from https://github.com/SSSD/sssd/pull/9168 to branch sssd-2-9 including commits:
- Improve description for dyndns_refresh_interval
- Remove empty from sssd-ad.5.xml