### PR TITLE
ci: Install libssh-devel for the passkey TMT plan

### DIFF
--- a/plans/passkey.fmf
+++ b/plans/passkey.fmf
@@ -23,6 +23,7 @@ prepare:
         - expect
         - gcc
         - git
+        - libssh-devel
         - openldap-devel
         - podman
         - podman-compose


### PR DESCRIPTION
The test requirements pull in ansible-pylibssh through pytest-mh.  PyPI provides wheels up to Python 3.14, so on Fedora 45 and Rawhide, which ship 3.15, pip builds it from source and fails for lack of libssh/libssh.h, and the plan errors out in its prepare step on every pull request.  The GitHub workflow installs libssh-dev for the same reason.

Add libssh-devel to the plan's general dependencies.